### PR TITLE
Minimum WordPress plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # WooCommerce Payments
+
+This is a feature plugin for accepting payments via a WooCommerce-branded payment gateway.

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Plugin Name: WooCommerce Payments
+ * Plugin URI: https://github.com/Automattic/woocommerce-payments
+ * Description: Feature plugin for accepting payments via a WooCommerce-branded payment gateway.
+ * Author: Automattic
+ * Author URI: https://woocommerce.com/
+ * Text Domain: woocommerce-payments
+ * Domain Path: /languages
+ * Version: 0.1.0
+ */


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/8

To test, go to Plugins page, find "WooCommerce Payments", activate, and verify plugin metadata.