### PR TITLE
Add a dummy payment gateway

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -4,10 +4,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
+/**
+ * Gateway class for WooCommerce Payments
+ */
 class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
+	/**
+	 * Internal ID of the payment gateway.
+	 * @type string
+	 */
 	const GATEWAY_ID = 'woocommerce_payments';
 
+	/**
+	 * @return string URL of the configuration screen for this gateway
+	 */
 	public static function get_settings_url() {
 		return admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . self::GATEWAY_ID );
 	}
@@ -50,10 +60,19 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 	}
 
+	/**
+	 * Renders the Credit Card input fields needed to get the user's payment information on the checkout page.
+	 */
 	public function payment_fields() {
 		echo $this->get_description();
 	}
 
+	/**
+	 * Process the payment for a given order.
+	 * @param int $order_id Order ID to process the payment for.
+	 *
+	 * @return array|null
+	 */
 	public function process_payment( $order_id ) {
 		$order = wc_get_order( $order_id );
 		$amount = $order->get_total();

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -4,8 +4,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
+/**
+ * Main class for the WooCommerce Payments extension. Its responsibility is to initialize the extension.
+ */
 class WC_Payments {
 
+	/**
+	 * Entry point to the initialization logic.
+	 * @param $plugin_name string The extension's plugin name. It will be "woocommerce-payments/woocommerce-payments.php" unless the user renamed the plugin directory.
+	 */
 	public static function init( $plugin_name ) {
 		// TODO: (#7) bail if WooCommerce / WordPress / Gutenberg / WC-Admin versions required are not present
 
@@ -14,6 +21,14 @@ class WC_Payments {
 		add_filter( 'woocommerce_payment_gateways', array( __CLASS__, 'register_gateway' ) );
 	}
 
+	/**
+	 * Adds links to the plugin's row in the "Plugins" Wp-Admin page.
+	 * @see https://codex.wordpress.org/Plugin_API/Filter_Reference/plugin_action_links_(plugin_file_name)
+	 *
+	 * @param $links array The existing list of links that will be rendered.
+	 *
+	 * @return array The list of links that will be rendered, after adding some links specific to this plugin.
+	 */
 	public static function add_plugin_links( $links ) {
 		$plugin_links = array(
 			'<a href="' . esc_attr( WC_Payment_Gateway_WCPay::get_settings_url() ) . '">' . esc_html__( 'Settings', 'woocommerce-payments' ) . '</a>',
@@ -22,6 +37,12 @@ class WC_Payments {
 		return array_merge( $plugin_links, $links );
 	}
 
+	/**
+	 * Adds the WooCommerce Payments' gateway class to the list of installed payment gateways.
+	 * @param $gateways array Existing list of gateway classes that will be available for the merchant to configure.
+	 *
+	 * @return array The list of payment gateways that will be available, including WooCommerce Payments' Gateway class.
+	 */
 	public static function register_gateway( $gateways ) {
 		$gateways[] = 'WC_Payment_Gateway_WCPay';
 		return $gateways;

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -14,6 +14,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+/**
+ * Initialize the extension. Note that this gets called on the "plugins_loaded" filter,
+ * so WooCommerce classes are guaranteed to exist at this point (if WooCommerce is enabled).
+ */
 function wcpay_init() {
 	include_once dirname( __FILE__ ) . '/includes/class-wc-payments.php';
 	WC_Payments::init( plugin_basename( __FILE__ ) );


### PR DESCRIPTION
Fixes #4 

If you agree with the classes/file structure, I'll add documentation. If not, please say why :)

Adds some basic scaffolding. Here are the relevant parts.

In `Plugins`, our glorious plugin now has a "Settings" shortcut that takes you to the WCPay settings screen:
![Screenshot 2019-03-10 at 19 41 02](https://user-images.githubusercontent.com/1715800/54090664-66b34900-436e-11e9-8f45-466bbe250c1f.png)

You can enable/disable the payment method, change its title, and description. Those fields work and are respected when displaying the checkout page:
![Screenshot 2019-03-10 at 19 41 28](https://user-images.githubusercontent.com/1715800/54090668-6adf6680-436e-11e9-90fc-ba89199bbde3.png)

You can select the payment method in the checkout, it will show the name/description you configured:
![Screenshot 2019-03-10 at 19 39 24](https://user-images.githubusercontent.com/1715800/54090684-97937e00-436e-11e9-861f-fd87f742ae40.png)

Instead of any actual work, the payment is "simulated" so it always succeeds. An order note is created with the total order amount and a fake "transaction ID":
![Screenshot 2019-03-10 at 19 40 36](https://user-images.githubusercontent.com/1715800/54090693-bb56c400-436e-11e9-8c63-0d563cc70926.png)
