### PR TITLE
Add checkout payment form

### DIFF
--- a/assets/js/wc-payment-checkout.js
+++ b/assets/js/wc-payment-checkout.js
@@ -1,0 +1,60 @@
+// Setup the Stripe elements when the checkout page is updated.
+jQuery( document.body ).on( 'updated_checkout', function() {
+	var stripe   = new Stripe( wc_payment_config.publishableKey );
+	var elements = stripe.elements();
+
+	// Create a card element.
+	var cardElement = elements.create( 'card', {
+		hidePostalCode: true
+	} );
+	cardElement.mount( '#wc-payment-card-element' );
+
+	// Update the validation state based on the element's state.
+	cardElement.addEventListener( 'change', function(event) {
+		var displayError = document.getElementById( 'wc-payment-errors' );
+		if (event.error) {
+			displayError.textContent = event.error.message;
+		} else {
+			displayError.textContent = '';
+		}
+	} );
+
+	// Create payment token on submission.
+	var tokenGenerated;
+	jQuery( 'form.checkout' ).on( 'checkout_place_order_woocommerce_payments', function() {
+		// We'll resubmit the form after populating our token, so if this is the second time this event is firing we
+		// should let the form submission happen.
+		if ( tokenGenerated ) {
+			return;
+		}
+
+		stripe.createToken( cardElement )
+			.then( function( result ) {
+				var token = result.token;
+				var error = result.error;
+
+				if ( error ) {
+					throw error;
+				}
+
+				return token;
+			} )
+			.then( function( token ) {
+				var id = token.id;
+
+				// Flag that the token has been successfully generated so that we can allow the form submission next
+				// time.
+				tokenGenerated = true;
+
+				// Populate form with the token.
+				var paymentTokenInput   = document.getElementById( 'wc-payment-token' );
+				paymentTokenInput.value = id;
+
+				// Re-submit the form.
+				jQuery( '.woocommerce-checkout' ).submit();
+			} );
+
+		// Prevent form submission so that we can fire it once a token has been generated.
+		return false;
+	} );
+} );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -29,6 +29,27 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	private $payments_api_client;
 
 	/**
+	 * Is test mode active?
+	 *
+	 * @var bool
+	 */
+	public $testmode;
+
+	/**
+	 * API access secret key
+	 *
+	 * @var string
+	 */
+	public $secret_key;
+
+	/**
+	 * API access publishable key
+	 *
+	 * @var string
+	 */
+	public $publishable_key;
+
+	/**
 	 * Returns the URL of the configuration screen for this gateway, for use in internal links.
 	 *
 	 * @return string URL of the configuration screen for this gateway
@@ -51,33 +72,82 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$this->method_title       = __( 'WooCommerce Payments', 'woocommerce-payments' );
 		$this->method_description = __( 'Accept payments via a WooCommerce-branded payment gateway', 'woocommerce-payments' );
 
+		// Define setting fields.
 		$this->form_fields = array(
-			'enabled'     => array(
+			'enabled'              => array(
 				'title'       => __( 'Enable/Disable', 'woocommerce-payments' ),
 				'label'       => __( 'Enable WooCommerce Payments', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
 				'description' => '',
 				'default'     => 'no',
 			),
-			'title'       => array(
+			'title'                => array(
 				'title'       => __( 'Title', 'woocommerce-payments' ),
 				'type'        => 'text',
 				'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce-payments' ),
 				'default'     => __( 'Credit Card (WooCommerce Payments)', 'woocommerce-payments' ),
 				'desc_tip'    => true,
 			),
-			'description' => array(
+			'description'          => array(
 				'title'       => __( 'Description', 'woocommerce-payments' ),
 				'type'        => 'text',
 				'description' => __( 'This controls the description which the user sees during checkout.', 'woocommerce-payments' ),
 				'default'     => __( 'Pay with your credit card via WooCommerce Payments.', 'woocommerce-payments' ),
 				'desc_tip'    => true,
 			),
+			'testmode'             => array(
+				'title'       => __( 'Test mode', 'woocommerce-payments' ),
+				'label'       => __( 'Enable Test Mode', 'woocommerce-payments' ),
+				'type'        => 'checkbox',
+				'description' => __( 'Place the payment gateway in test mode using test API keys.', 'woocommerce-payments' ),
+				'default'     => 'yes',
+				'desc_tip'    => true,
+			),
+			'test_publishable_key' => array(
+				'title'       => __( 'Test Publishable Key', 'woocommerce-payments' ),
+				'type'        => 'password',
+				'description' => __( 'Get your API keys from your Stripe account.', 'woocommerce-payments' ),
+				'default'     => '',
+				'desc_tip'    => true,
+			),
+			'test_secret_key'      => array(
+				'title'       => __( 'Test Secret Key', 'woocommerce-payments' ),
+				'type'        => 'password',
+				'description' => __( 'Get your API keys from your Stripe account.', 'woocommerce-payments' ),
+				'default'     => '',
+				'desc_tip'    => true,
+			),
+			'publishable_key'      => array(
+				'title'       => __( 'Live Publishable Key', 'woocommerce-payments' ),
+				'type'        => 'password',
+				'description' => __( 'Get your API keys from your Stripe account.', 'woocommerce-payments' ),
+				'default'     => '',
+				'desc_tip'    => true,
+			),
+			'secret_key'           => array(
+				'title'       => __( 'Live Secret Key', 'woocommerce-payments' ),
+				'type'        => 'password',
+				'description' => __( 'Get your API keys from your Stripe account.', 'woocommerce-payments' ),
+				'default'     => '',
+				'desc_tip'    => true,
+			),
 		);
+
+		// Load the settings.
 		$this->init_settings();
 
+		// Extract values we want to use in this class from the settings.
 		$this->title       = $this->get_option( 'title' );
 		$this->description = $this->get_option( 'description' );
+
+		$this->testmode        = ( ! empty( $this->settings['testmode'] ) && 'yes' === $this->settings['testmode'] ) ? true : false;
+		$this->publishable_key = ! empty( $this->settings['publishable_key'] ) ? $this->settings['publishable_key'] : '';
+		$this->secret_key      = ! empty( $this->settings['secret_key'] ) ? $this->settings['secret_key'] : '';
+
+		if ( $this->testmode ) {
+			$this->publishable_key = ! empty( $this->settings['test_publishable_key'] ) ? $this->settings['test_publishable_key'] : '';
+			$this->secret_key      = ! empty( $this->settings['test_secret_key'] ) ? $this->settings['test_secret_key'] : '';
+		}
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 	}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -154,8 +154,38 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 	/**
 	 * Renders the Credit Card input fields needed to get the user's payment information on the checkout page.
+	 *
+	 * We also add the JavaScript which drives the UI.
 	 */
 	public function payment_fields() {
+		// Add JavaScript for the payment form.
+		$js_config = array(
+			'publishableKey' => $this->publishable_key,
+		);
+
+		// Register Stripe's JavaScript using the same ID as the Stripe Gateway plugin. This prevents this JS being
+		// loaded twice in the event a site has both plugins enabled. We still run the risk of different plugins
+		// loading different versions however.
+		wp_register_script(
+			'stripe',
+			'https://js.stripe.com/v3/',
+			array(),
+			'3.0',
+			true
+		);
+
+		wp_register_script(
+			'wc-payment-checkout',
+			plugins_url( 'assets/js/wc-payment-checkout.js', WCPAY_PLUGIN_FILE ),
+			array( 'stripe', 'wc-checkout' ),
+			filemtime( WCPAY_ABSPATH . 'assets/js/wc-payment-checkout.js' ),
+			true
+		);
+
+		wp_localize_script( 'wc-payment-checkout', 'wc_payment_config', $js_config );
+		wp_enqueue_script( 'wc-payment-checkout' );
+
+		// Output the form HTML.
 		// TODO: Style this up. Formatting, escaping double line breaks etc.
 		?>
 		<p><?php echo wp_kses_post( $this->get_description() ); ?></p>

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -156,8 +156,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * Renders the Credit Card input fields needed to get the user's payment information on the checkout page.
 	 */
 	public function payment_fields() {
-		// TODO: Revisit properly escaping this once showing payment fields is implemented.
-		echo $this->get_description(); // PHPCS:Ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		// TODO: Style this up. Formatting, escaping double line breaks etc.
+		?>
+		<p><?php echo wp_kses_post( $this->get_description() ); ?></p>
+		<div id="wc-payment-card-element"></div>
+		<div id="wc-payment-errors" role="alert"></div>
+		<input id="wc-payment-token" type="hidden" name="wc-payment-token" />
+		<?php
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -15,6 +15,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Payments {
 
 	/**
+	 * Instance of WC_Payment_Gateway_WCPay, created in init function.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private static $gateway;
+
+	/**
 	 * Entry point to the initialization logic.
 	 */
 	public static function init() {
@@ -24,6 +31,9 @@ class WC_Payments {
 		}
 
 		include_once dirname( __FILE__ ) . '/class-wc-payment-gateway-wcpay.php';
+
+		self::$gateway = self::create_gateway();
+
 		add_filter( 'plugin_action_links_' . plugin_basename( WCPAY_PLUGIN_FILE ), array( __CLASS__, 'add_plugin_links' ) );
 		add_filter( 'woocommerce_payment_gateways', array( __CLASS__, 'register_gateway' ) );
 
@@ -158,7 +168,8 @@ class WC_Payments {
 	 * @return array The list of payment gateways that will be available, including WooCommerce Payments' Gateway class.
 	 */
 	public static function register_gateway( $gateways ) {
-		$gateways[] = self::create_gateway();
+		$gateways[] = self::$gateway;
+
 		return $gateways;
 	}
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,6 +5,7 @@
     <!-- Exclude paths -->
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/assets/*</exclude-pattern>
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="4.7" />


### PR DESCRIPTION
First pass at implementing a payment form for this gateway. It's based on the minimal payments API branch which is still to be merged in, but I thought I'd get this up now anyway.

Closes #11.

Some parts that I'm not too sure on:

* ~~Stripe.js can be loaded twice if the Stripe extension is also active. This causes warnings in the console, and could cause conflicts where different versions are loaded. How do we want to handle this, if at all?~~ Created issue #53 
* ~~What browsers are we targeting? I'm assuming as old as reasonably possible for this part?~~ Follow WordPress Core policy: https://make.wordpress.org/core/handbook/best-practices/browser-support/
* ~~Are we planning to use any build or transpiling steps?~~ Handle in a separate issue (https://github.com/Automattic/woocommerce-payments/issues/54)

* Things to create new issues for:

   * [x] ~~Define a plugin version and use this to version the JavaScript when calling `wp_register_script`~~ Let's follow the same convention used in WC Admin (#49)
   * [x] Create or wire-up an existing logger for sending messages to the server's logs (https://github.com/Automattic/woocommerce-payments/issues/9)
   * [x] ~~Create plugin specific exception classes so that we can be smarter about what we create notices and log messages for (thinking about the logic in `process_payments` here).~~ There are some TODO notes in the code for this.
   * [x] ~~Card details get lost in the event form validation fails. I think I saw an issue for this on another gateway?~~ Behaviour is consistent with the existing Stripe extension.
   * [x] Properly style the UI (https://github.com/Automattic/woocommerce-payments/issues/57)
   * [x] ~~The JavaScript is very basic. It'll be worth looking through what we have in the Stripe gateway and seeing what should be implemented here as well. Can create an issue for each piece of functionality.~~ This should fall out of work on other issues

## To Test
* Add a product to your basket
* Proceed to the checkout and select "Credit Card (WooCommerce Payments)"
* Enter a test credit card (e.g. 4242 4242 4242 4242 with any expiry and CVC)
* Open your browser's network monitor and then click the "Place Order" button
* The request to `/?wc-ajax=checkout` should contain a post variable `wc-payment-token` populated with a token value.
* In the admin dashboard, the order notes should show a payment using WooCommerce Payments and a randomly generated transaction ID.