### PR TITLE
Add basic Docker setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ contributors.md
 
 # Screenshots for e2e tests failures
 /screenshots/
+
+# Volumes mounted by Docker containers
+docker/data
+docker/wordpress

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,3 +53,27 @@ new WordPressExternalDependenciesPlugin( {
 ```
 
 When running webpack `index.deps.json` will be created, listing all the needed dependencies. More info can be found here: https://wordpress.org/gutenberg/handbook/designers-developers/developers/packages/packages-dependency-extraction-webpack-plugin/.
+
+## Docker Local Setup
+
+Docker can be used to setup a local development environment:
+
+* Ensure Docker is installed ([Docker Desktop](https://www.docker.com/products/docker-desktop) is a good option for developers)
+* Follow the steps above in the Development section to build the project's JavaScript
+* From the root of this project, run `docker-compose up -d`
+* Once <http://localhost:8082> displays the WordPress install screen, run `./bin/docker-setup.sh`
+* The fully configured site can now be accessed on <http://localhost:8082>
+* The prompt to run the setup wizard can be dismissed unless there is something specific you would like to configure
+
+To shutdown:
+
+* Use `docker-compose down` to stop the running containers
+* The state of the environment will be persisted in `docker/wordpress` and `docker/data`. To restart the environment simply run `docker-compose up` again. To start afresh, delete these folders and let `docker-compose up` re-create them.
+
+IDE setup:
+
+* Adding `docker/wordpress` to your IDE's PHP include path will allow it to provide hinting for WordPress functions etc.
+* The WordPress container has xdebug setup. Add the following path mappings to your IDE so it can find the correct code:
+
+   * `<project folder>/ -> /var/www/html/wp-content/plugins/woocommerce-payments`
+   * `<project folder>/docker/wordpress -> /var/www/html`

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env sh
+
+# Exit if any command fails.
+set -e
+
+# --user xfs forces the wordpress:cli container to use a user with the same ID as the main wordpress container. See:
+# https://hub.docker.com/_/wordpress#running-as-an-arbitrary-user
+cli()
+{
+	docker run -it --rm --user xfs --volumes-from woocommerce_payments_wordpress --network container:woocommerce_payments_wordpress wordpress:cli "$@" > /dev/null
+}
+
+echo
+echo "Setting up environment..."
+echo
+
+echo "Pulling the WordPress CLI docker image..."
+docker pull wordpress:cli > /dev/null
+
+echo "Setting up WordPress..."
+cli wp core install --path=/var/www/html --url=localhost:8082 --title="WooCommerce Payments Dev" --admin_name=admin --admin_password=admin --admin_email=admin@example.com --skip-email
+
+echo "Updating WordPress to the latest version..."
+cli wp core update --quiet
+
+echo "Updating the WordPress database..."
+cli wp core update-db --quiet
+
+echo "Installing and activating WooCommerce..."
+cli wp plugin install woocommerce --activate
+
+echo "Installing and activating Storefront theme..."
+cli wp theme install storefront --activate
+
+echo "Adding basic WooCommerce settings..."
+cli wp option set woocommerce_store_address "60 29th Street"
+cli wp option set woocommerce_store_address_2 "#343"
+cli wp option set woocommerce_store_city "San Francisco"
+cli wp option set woocommerce_default_country "US:CA"
+cli wp option set woocommerce_store_postcode "94110"
+cli wp option set woocommerce_currency "USD"
+cli wp option set woocommerce_product_type "both"
+cli wp option set woocommerce_allow_tracking "no"
+
+echo "Importing WooCommerce shop pages..."
+cli wp wc --user=admin tool run install_pages
+
+echo "Installing and activating the WordPress Importer plugin..."
+cli wp plugin install wordpress-importer --activate
+
+echo "Importing some sample data..."
+cli wp import wp-content/plugins/woocommerce/sample-data/sample_products.xml --authors=skip
+
+echo "Activating the WooCommerce Payments plugin..."
+cli wp plugin activate woocommerce-payments
+
+echo "Setting up WooCommerce Payments..."
+cli wp option add woocommerce_woocommerce_payments_settings --format=json '{"enabled":"yes"}'
+
+echo
+echo "SUCCESS! You should now be able to access http://localhost:8082/wp-admin/"
+echo "You can login by using the username and password both as 'admin'"

--- a/default.env
+++ b/default.env
@@ -1,0 +1,13 @@
+# WordPress
+WORDPRESS_DB_HOST=db:3306
+WORDPRESS_DB_USER=wordpress
+WORDPRESS_DB_PASSWORD=wordpress
+WORDPRESS_DB_NAME=wordpress
+WORDPRESS_DEBUG=1
+ABSPATH=/usr/src/wordpress/
+
+# Database
+MYSQL_ROOT_PASSWORD=wordpress
+MYSQL_DATABASE=wordpress
+MYSQL_USER=wordpress
+MYSQL_PASSWORD=wordpress

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+
+services:
+  wordpress:
+    build: ./docker/wordpress_xdebug
+    image: wordpress-xdebug
+    container_name: woocommerce_payments_wordpress
+    restart: always
+    depends_on:
+      - db
+    links:
+      - db:mysql
+    ports:
+      - "8082:80"
+    env_file:
+      - default.env
+    volumes:
+      - ./docker/wordpress:/var/www/html/
+      - .:/var/www/html/wp-content/plugins/woocommerce-payments
+  db:
+    container_name: woocommerce_payments_mysql
+    image: mysql:5.7
+    ports:
+      - "3306:3306"
+    env_file:
+      - default.env
+    volumes:
+      - ./docker/data:/var/lib/mysql

--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -1,0 +1,4 @@
+FROM wordpress
+RUN pecl install xdebug-2.6.1 \
+	&& docker-php-ext-enable xdebug
+COPY custom.ini $PHP_INI_DIR/conf.d/

--- a/docker/wordpress_xdebug/custom.ini
+++ b/docker/wordpress_xdebug/custom.ini
@@ -1,0 +1,3 @@
+xdebug.remote_enable = 1
+xdebug.remote_host = host.docker.internal
+


### PR DESCRIPTION
All the talk of PHP, WordPress and WooCommerce versions got me thinking about easy to create and destroy environments again. Thought I'd push up what I have so far by way of Docker setup in case it's of use to anyone.

I would be interested in merging this and having it as the main supported way of configuring a development environment, but figured this PR was a good way to start the discussion.

To use:

* Install Docker Desktop
* Run `docker-compose up` from this project's folder
* In another console run `./bin/docker-setup.sh`
* Open the site at the URL reported by the setup script
* ~~Complete WooCommerce setup~~
* ~~Import some test data as required~~
* ~~Enable the WooCommerce Payments Gateway~~

To shutdown:

* `ctrl`+`c` out of the `docker-compose` session
* Alternatively, start up with `docker-compose up -d` then use
  `docker-compose down` to stop

The state of the environment will be persisted in `docker/wordpress` and`docker/data`. To restart the environment simply run `docker-compose up` again. To start afresh, delete these folders and let `docker-compose up` re-create them.

To Do:

* [x] Automated the final 3 steps of the setup.

Could be handled in another PR:
* Auto-detect a free port instead of hardcoding
* Look into what can be done in terms of exposing the environment publicly (for example, if WP.com needs to contact our dev site)
* The unit test setup could be moved into Docker
* Allow configurable versions of WordPress and plugins to aid version testing
