### PR TITLE
Exclude new JavaScript folders from PHP code sniffing

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,9 +3,12 @@
 	<description>WooCommerce dev PHP_CodeSniffer ruleset.</description>
 
     <!-- Exclude paths -->
+	<exclude-pattern>*/client/*</exclude-pattern>
+	<exclude-pattern>*/dist/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/assets/*</exclude-pattern>
+	<exclude-pattern>*/webpack.config.js</exclude-pattern>
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="4.7" />


### PR DESCRIPTION
When running PHPCS from the command line (`composer run phpcs .` or `./vendor/bin/phpcs -p .`) some JavaScript files are being picked up causing failures.

We don't want to use PHPCS on JavaScript files, so this PR simply excludes these new folders and files using the XML config.

I'm not 100% sure why this isn't causing issues on Travis runs, perhaps because we only run the sniffs on changed files?

Other options:

* Create a new folder for all PHP code and only run PHPCS on that folder
* Run with the `--extensions=php` flag. Perhaps adding this to the scripts section of `composer.json`