### PR TITLE
Add REST endpoint to retrieve transactions

### DIFF
--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -58,8 +58,8 @@ class WC_Payments_Admin {
 	 * Register the CSS and JS scripts
 	 */
 	public function register_payments_scripts() {
-		$script_src_url = plugins_url( 'dist/index.js', WCPAY_PLUGIN_FILE );
-		$script_deps_path = WCPAY_ABSPATH . 'dist/index.deps.json';
+		$script_src_url      = plugins_url( 'dist/index.js', WCPAY_PLUGIN_FILE );
+		$script_deps_path    = WCPAY_ABSPATH . 'dist/index.deps.json';
 		$script_dependencies = file_exists( $script_deps_path )
 			? json_decode( file_get_contents( $script_deps_path ) )
 			: array();

--- a/includes/admin/class-wc-rest-payments-transactions-controller.php
+++ b/includes/admin/class-wc-rest-payments-transactions-controller.php
@@ -1,12 +1,15 @@
 <?php
 /**
- * …
+ * Class WC_REST_Payments_Transactions_Controller
  *
  * @package WooCommerce\Payments\Admin
  */
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * REST controller for transactions.
+ */
 class WC_REST_Payments_Transactions_Controller extends WP_REST_Controller {
 
 	/**
@@ -30,18 +33,33 @@ class WC_REST_Payments_Transactions_Controller extends WP_REST_Controller {
 	 */
 	private $api_client;
 
+	/**
+	 * WC_REST_Payments_Transactions_Controller constructor.
+	 *
+	 * @param WC_Payments_API_Client $api_client - WooCommerce Payments API client.
+	 */
 	public function __construct( WC_Payments_API_Client $api_client ) {
 		$this->api_client = $api_client;
 	}
 
+	/**
+	 * Configure REST API routes.
+	 */
 	public function register_routes() {
-		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
-			'methods'             => WP_REST_Server::READABLE,
-			'callback'            => array( $this, 'get_transactions' ),
-			'permission_callback' => array( $this, 'check_permission' ),
-		) );
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_transactions' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
 	}
 
+	/**
+	 * Retrieve transactions to respond with via API.
+	 */
 	public function get_transactions() {
 		return rest_ensure_response( $this->api_client->list_transactions() );
 	}

--- a/includes/admin/class-wc-rest-payments-transactions-controller.php
+++ b/includes/admin/class-wc-rest-payments-transactions-controller.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * …
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+class WC_REST_Payments_Transactions_Controller extends WP_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Endpoint path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'payments/transactions';
+
+	/**
+	 * Client for making requests to the WooCommerce Payments API
+	 *
+	 * @var WC_Payments_API_Client
+	 */
+	private $api_client;
+
+	public function __construct( WC_Payments_API_Client $api_client ) {
+		$this->api_client = $api_client;
+	}
+
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => array( $this, 'get_transactions' ),
+			'permission_callback' => array( $this, 'check_permission' ),
+		) );
+	}
+
+	public function get_transactions() {
+		return rest_ensure_response( $this->api_client->list_transactions() );
+	}
+
+	/**
+	 * Verify access.
+	 */
+	public function check_permission() {
+		return current_user_can( 'manage_woocommerce' );
+	}
+}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -134,11 +134,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
-
-		// Add account ID to the payments.
-		$this->payments_api_client->set_account_id(
-			$this->get_option( 'stripe_account_id' )
-		);
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -54,6 +54,8 @@ class WC_Payments {
 			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin.php';
 			new WC_Payments_Admin();
 		}
+
+		add_action( 'rest_api_init', array( __CLASS__, 'init_rest_api' ) );
 	}
 
 	/**
@@ -199,5 +201,14 @@ class WC_Payments {
 		$payments_api_client = new WC_Payments_API_Client( 'WooCommerce Payments/0.1.0' );
 
 		return $payments_api_client;
+	}
+
+	/**
+	 * Initialize the REST API controllers.
+	 */
+	public static function init_rest_api() {
+		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-transactions-controller.php';
+		$transactions_controller = new WC_REST_Payments_Transactions_Controller( self::$api_client );
+		$transactions_controller->register_routes();
 	}
 }

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -22,6 +22,13 @@ class WC_Payments {
 	private static $gateway;
 
 	/**
+	 * Instance of WC_Payments_API_Client, created in init function.
+	 *
+	 * @var WC_Payments_API_Client
+	 */
+	private static $api_client;
+
+	/**
 	 * Entry point to the initialization logic.
 	 */
 	public static function init() {
@@ -30,11 +37,16 @@ class WC_Payments {
 			return;
 		}
 
-		include_once dirname( __FILE__ ) . '/class-wc-payment-gateway-wcpay.php';
-
-		self::$gateway = self::create_gateway();
-
 		add_filter( 'plugin_action_links_' . plugin_basename( WCPAY_PLUGIN_FILE ), array( __CLASS__, 'add_plugin_links' ) );
+
+		self::$api_client = self::create_api_client();
+
+		include_once dirname( __FILE__ ) . '/class-wc-payment-gateway-wcpay.php';
+		self::$gateway = new WC_Payment_Gateway_WCPay( self::$api_client );
+
+		// Add account ID to the payments.
+		self::$api_client->set_account_id( self::$gateway->get_option( 'stripe_account_id' ) );
+
 		add_filter( 'woocommerce_payment_gateways', array( __CLASS__, 'register_gateway' ) );
 
 		// Add admin screens.
@@ -174,11 +186,11 @@ class WC_Payments {
 	}
 
 	/**
-	 * Create the payment gateway instance
+	 * Create the API client.
 	 *
-	 * @return WC_Payment_Gateway_WCPay
+	 * @return WC_Payments_API_Client
 	 */
-	public static function create_gateway() {
+	public static function create_api_client() {
 		require_once dirname( __FILE__ ) . '/wc-payment-api/models/class-wc-payments-api-charge.php';
 		require_once dirname( __FILE__ ) . '/wc-payment-api/models/class-wc-payments-api-intention.php';
 		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-api-client.php';
@@ -186,8 +198,6 @@ class WC_Payments {
 		// TODO: Don't hard code user agent string.
 		$payments_api_client = new WC_Payments_API_Client( 'WooCommerce Payments/0.1.0' );
 
-		$gateway = new WC_Payment_Gateway_WCPay( $payments_api_client );
-
-		return $gateway;
+		return $payments_api_client;
 	}
 }

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -17,8 +17,9 @@ class WC_Payments_API_Client {
 	const POST = 'POST';
 	const GET  = 'GET';
 
-	const CHARGES_API    = 'charges';
-	const INTENTIONS_API = 'intentions';
+	const CHARGES_API      = 'charges';
+	const INTENTIONS_API   = 'intentions';
+	const TRANSACTIONS_API = 'balance/history';
 
 	/**
 	 * User agent string to report in requests.
@@ -112,6 +113,16 @@ class WC_Payments_API_Client {
 		);
 
 		return $this->deserialize_intention_object_from_array( $response_array );
+	}
+
+	/**
+	 * List transactions
+	 *
+	 * @return array
+	 * @throws Exception - Exception thrown on request failure.
+	 */
+	public function list_transactions() {
+		return $this->request( array(), self::TRANSACTIONS_API, self::GET );
 	}
 
 	/**

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -19,7 +19,7 @@ class WC_Payments_API_Client {
 
 	const CHARGES_API      = 'charges';
 	const INTENTIONS_API   = 'intentions';
-	const TRANSACTIONS_API = 'balance/history';
+	const TRANSACTIONS_API = 'transactions';
 
 	/**
 	 * User agent string to report in requests.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -143,7 +143,7 @@ class WC_Payments_API_Client {
 		$request['account_id'] = $this->account_id;
 
 		// Build the URL we want to send the URL to.
-		$url = self::ENDPOINT . '/' . $api;
+		$url  = self::ENDPOINT . '/' . $api;
 		$body = null;
 
 		if ( self::GET === $method ) {

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -133,13 +133,18 @@ class WC_Payments_API_Client {
 
 		// Build the URL we want to send the URL to.
 		$url = self::ENDPOINT . '/' . $api;
+		$body = null;
 
-		// Encode the request body as JSON.
-		$body = wp_json_encode( $request );
-		if ( ! $body ) {
-			throw new Exception(
-				__( 'Unable to encode body for request to WooCommerce Payments API.', 'woocommerce-payments' )
-			);
+		if ( self::GET === $method ) {
+			$url .= '?' . http_build_query( $request );
+		} else {
+			// Encode the request body as JSON.
+			$body = wp_json_encode( $request );
+			if ( ! $body ) {
+				throw new Exception(
+					__( 'Unable to encode body for request to WooCommerce Payments API.', 'woocommerce-payments' )
+				);
+			}
 		}
 
 		// Create standard headers.


### PR DESCRIPTION
Partially addresses https://github.com/Automattic/woocommerce-payments/issues/64

Depends on https://github.com/Automattic/woocommerce-payments-server/pull/18

Adds a REST API endpoint for listing (the 10 latest) balance transactions: events that affect the balance, including payouts.

Feedback welcome on slight structural refactor of main class in https://github.com/Automattic/woocommerce-payments/commit/6fdab7c0a667300e93d37d44ea97d79491124512 (…and on anything else). Is having a separate/extended API client for the merchant dashboard (that need not be loaded for site front-end requests) worth considering, or would there be little benefit?

Note: https://github.com/Automattic/woocommerce-payments/issues/87 tracks bypassing the WP site for such client-server communications, but we may want to keep a REST API either way for the benefit of other clients.