### PR TITLE
Initial dashboard transactions table

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ When enqueuing the app JavaScript, `wordpress` and `woocommerce` dependencies ar
 
 We add each package as a dev dependency in `package.json`, though, since it enables auto-completion in our IDEs.
 
-Dependencies not handled by `@wordpress/dependency-extraction-webpack-plugin` should be handled in `webpack.config` using the functions `requestToExternal` and `requestToDependency`, for example:
+Dependencies not handled by `@wordpress/dependency-extraction-webpack-plugin` should be handled in `webpack.config` using the functions `requestToExternal` and `requestToHandle`, for example:
 
 ```
 new WordPressExternalDependenciesPlugin( {
@@ -44,7 +44,7 @@ new WordPressExternalDependenciesPlugin( {
             return [ 'wc', 'components' ];
         }
     },
-    requestToDependency( request ) {
+    requestToHandle( request ) {
         if ( request === '@woocommerce/components' ) {
             return 'wc-components';
         }

--- a/client/index.js
+++ b/client/index.js
@@ -9,9 +9,9 @@ import { addFilter } from '@wordpress/hooks';
  */
 import './style.scss';
 import { HelloWorld } from 'hello-world';
+import TransactionsPage from './transactions-list';
 
 const DepositsPage = () => <HelloWorld>Hello from the deposits page</HelloWorld>;
-const TransactionsPage = () => <HelloWorld>Hello from the transactions page</HelloWorld>;
 const DisputesPage = () => <HelloWorld>Hello from the disputes page</HelloWorld>;
 
 addFilter( 'woocommerce_admin_pages_list', 'woocommerce-payments', pages => {

--- a/client/style.scss
+++ b/client/style.scss
@@ -1,3 +1,0 @@
-.woocommerce-payments__section {
-    background: lightcoral;
-}

--- a/client/transactions-list.js
+++ b/client/transactions-list.js
@@ -19,13 +19,18 @@ const headers = [
 ];
 
 export default () => {
-	const [ response, setResponse ] = useState( null );
+	const [ transactions, setTransactions ] = useState( [] );
+	const [ loading, setLoading ] = useState( false );
 
 	useEffect( () => {
-		apiFetch( { path: '/wc/v3/payments/transactions' } ).then( setResponse );
+		setLoading( true );
+		apiFetch( { path: '/wc/v3/payments/transactions' } ).then( ( { data } ) => {
+			setTransactions( data );
+			setLoading( false );
+		} );
 	}, [] );
 
-	const rows = response && response.data.map( ( { type, status, description, amount, fee, created, available_on } ) => [
+	const rows = transactions.map( ( { type, status, description, amount, fee, created, available_on } ) => [
 		{ value: created * 1000, display: dateI18n( 'Y-m-d H:i', moment( created * 1000 ) ) },
 		{ value: type, display: type[ 0 ].toUpperCase() + type.slice( 1 ) },
 		{ value: status, display: status[ 0 ].toUpperCase() + status.slice( 1 ) },
@@ -38,11 +43,11 @@ export default () => {
 	return (
 		<TableCard
 			title="Transactions"
-			isLoading={ ! response }
+			isLoading={ loading }
 			rowsPerPage={ 10 }
 			totalRows={ 10 }
 			headers={ headers }
-			rows={ rows || [] }
+			rows={ rows }
 		/>
 	);
 };

--- a/client/transactions-list.js
+++ b/client/transactions-list.js
@@ -24,8 +24,14 @@ export default () => {
 
 	useEffect( () => {
 		setLoading( true );
-		apiFetch( { path: '/wc/v3/payments/transactions' } ).then( ( { data } ) => {
-			setTransactions( data );
+		apiFetch( { path: '/wc/v3/payments/transactions' } ).then( ( response ) => {
+			const { data } = response;
+			if ( data ) {
+				setTransactions( data );
+			} else {
+				console.error( response );
+			}
+
 			setLoading( false );
 		} );
 	}, [] );

--- a/client/transactions-list.js
+++ b/client/transactions-list.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { dateI18n } from '@wordpress/date';
+import moment from 'moment';
+import { formatCurrency } from '@woocommerce/currency';
+import { TableCard } from '@woocommerce/components';
+
+const headers = [
+	{ key: 'type', label: 'Type', isLeftAligned: true },
+	{ key: 'status', label: 'Status', isLeftAligned: true },
+	{ key: 'description', label: 'Description', hiddenByDefault: true, isLeftAligned: true },
+	{ key: 'amount', label: 'Amount' },
+	{ key: 'fee', label: 'Fee' },
+	{ key: 'created', label: 'Created on' },
+	{ key: 'available_on', label: 'Available on' },
+];
+
+export default () => {
+	const [ response, setResponse ] = useState( null );
+
+	useEffect( () => {
+		apiFetch( { path: '/wc/v3/payments/transactions' } ).then( setResponse );
+	}, [] );
+
+	const rows = response && response.data.map( ( { type, status, description, amount, fee, created, available_on } ) => [
+		{ value: type, display: type[ 0 ].toUpperCase() + type.slice( 1 ) },
+		{ value: status, display: status[ 0 ].toUpperCase() + status.slice( 1 ) },
+		{ value: description, display: description },
+		{ value: amount / 100, display: formatCurrency( amount / 100 ) },
+		{ value: fee / 100, display: formatCurrency( fee / 100 ) },
+		{ value: created * 1000, display: dateI18n( 'Y-m-d H:i', moment( created * 1000 ) ) },
+		{ value: available_on * 1000, display: dateI18n( 'Y-m-d H:i', moment( available_on * 1000 ) ) },
+	] );
+
+	return (
+		<TableCard
+			title="Transactions"
+			isLoading={ ! response }
+			rowsPerPage={ 10 }
+			totalRows={ 10 }
+			headers={ headers }
+			rows={ rows || [] }
+		/>
+	);
+};

--- a/client/transactions-list.js
+++ b/client/transactions-list.js
@@ -9,12 +9,12 @@ import { formatCurrency } from '@woocommerce/currency';
 import { TableCard } from '@woocommerce/components';
 
 const headers = [
-	{ key: 'type', label: 'Type', isLeftAligned: true },
-	{ key: 'status', label: 'Status', isLeftAligned: true },
+	{ key: 'created', label: 'Date / Time', isLeftAligned: true },
+	{ key: 'type', label: 'Type' },
+	{ key: 'status', label: 'Status', hiddenByDefault: true },
 	{ key: 'description', label: 'Description', hiddenByDefault: true, isLeftAligned: true },
 	{ key: 'amount', label: 'Amount' },
 	{ key: 'fee', label: 'Fee' },
-	{ key: 'created', label: 'Created on' },
 	{ key: 'available_on', label: 'Available on' },
 ];
 
@@ -26,12 +26,12 @@ export default () => {
 	}, [] );
 
 	const rows = response && response.data.map( ( { type, status, description, amount, fee, created, available_on } ) => [
+		{ value: created * 1000, display: dateI18n( 'Y-m-d H:i', moment( created * 1000 ) ) },
 		{ value: type, display: type[ 0 ].toUpperCase() + type.slice( 1 ) },
 		{ value: status, display: status[ 0 ].toUpperCase() + status.slice( 1 ) },
 		{ value: description, display: description },
 		{ value: amount / 100, display: formatCurrency( amount / 100 ) },
 		{ value: fee / 100, display: formatCurrency( fee / 100 ) },
-		{ value: created * 1000, display: dateI18n( 'Y-m-d H:i', moment( created * 1000 ) ) },
 		{ value: available_on * 1000, display: dateI18n( 'Y-m-d H:i', moment( available_on * 1000 ) ) },
 	] );
 

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -118,7 +118,7 @@ class WC_Payments_Admin {
 		wp_register_style(
 			'WCPAY_DASH_APP',
 			plugins_url( 'dist/index.css', WCPAY_PLUGIN_FILE ),
-			array(),
+			array( 'wc-components' ),
 			filemtime( WCPAY_ABSPATH . 'dist/index.css' )
 		);
 	}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,15 +42,19 @@ const webpackConfig = {
 		new WordPressExternalDependenciesPlugin( {
 			injectPolyfill: true,
 			requestToExternal( request ) {
-				const match = request.match( /@woocommerce\/(.+)/ );
-				if ( match ) {
-					return [ 'wc', match[ 1 ] ];
+				switch ( request ) {
+					case '@woocommerce/components':
+						return [ 'wc', 'components' ];
+					case '@woocommerce/currency':
+						return [ 'wc', 'currency' ];
 				}
 			},
 			requestToHandle( request ) {
-				const match = request.match( /@woocommerce\/(.+)/ );
-				if ( match ) {
-					return `wc-${ match[ 1 ] }`;
+				switch ( request ) {
+					case '@woocommerce/components':
+						return 'wc-components';
+					case '@woocommerce/currency':
+						return 'wc-currency';
 				}
 			},
 		} ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,13 +42,15 @@ const webpackConfig = {
 		new WordPressExternalDependenciesPlugin( {
 			injectPolyfill: true,
 			requestToExternal( request ) {
-				if (  request === '@woocommerce/components'  ) {
-					return [ 'wc', 'components' ];
+				const match = request.match( /@woocommerce\/(.+)/ );
+				if ( match ) {
+					return [ 'wc', match[ 1 ] ];
 				}
 			},
 			requestToHandle( request ) {
-				if ( request === '@woocommerce/components' ) {
-					return 'wc-components';
+				const match = request.match( /@woocommerce\/(.+)/ );
+				if ( match ) {
+					return `wc-${ match[ 1 ] }`;
 				}
 			},
 		} ),


### PR DESCRIPTION
<s>Branches off of https://github.com/Automattic/woocommerce-payments/pull/88</s>

Adds an initial table of transactions (note: including payouts) to the Payments dashboard screen, showing the 10 latest at the moment, with a sample set of columns displayed. The navigation and data fetching (among other things) are rudimentary and will change.

<img width="1097" alt="Screen Shot 2019-06-06 at 11 05 40 AM" src="https://user-images.githubusercontent.com/1867547/59046065-443aaa00-884f-11e9-82b1-18b0fea4947a.png">

Generalizes the webpack config to use externally loaded version of all `@woocommerce/*` packages – any reason not to do it this way? – but it hard-codes a style dependency on `wc-components` (following example [here](https://github.com/woocommerce/woocommerce-admin/blob/135a0bec8e5632c74fd8eb4ccb466c9e61901039/includes/class-wc-admin-loader.php#L300)).