### PR TITLE
Avoid off-by-one charge amount due to floating point truncation

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -228,7 +228,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$source = $this->get_source_from_request();
 
 				// Create intention.
-				$intent = $this->payments_api_client->create_intention( intval( (float) $amount * 100 ), 'usd' );
+				$intent = $this->payments_api_client->create_intention( round( (float) $amount * 100 ), 'usd' );
 
 				// TODO: We could attempt to confirm the intention when creating it instead?
 				// Try to confirm the intention & capture the charge (if 3DS is not required).


### PR DESCRIPTION
Round charge amount instead of truncating, to prevent 1 cent disparity with certain values – such as $8.20: `intval( 8.20 * 100 ) === 819` cents (as described [here](https://www.php.net/manual/en/function.intval.php#112039)).