### PR TITLE
Initial pagination for transactions list

### DIFF
--- a/client/transactions-list.js
+++ b/client/transactions-list.js
@@ -27,6 +27,7 @@ const headers = [
 
 export default () => {
 	const [ transactions, setTransactions ] = useState( [] );
+	const [ totalRows, setTotalRows ] = useState( 0 );
 	const [ loading, setLoading ] = useState( false );
 	const [ query, setQuery ] = useState( { page: 1, per_page: 25 } );
 
@@ -36,6 +37,7 @@ export default () => {
 			const { data } = response;
 			if ( data ) {
 				setTransactions( data );
+				setTotalRows( response.total_count );
 			} else {
 				console.error( response );
 			}
@@ -72,7 +74,7 @@ export default () => {
 			headers={ headers }
 			rows={ rows }
 			rowsPerPage={ query.per_page }
-			totalRows={ Infinity } // TODO set to number of total transactions.
+			totalRows={ totalRows }
 			query={ { page: query.page, per_page: query.per_page } }
 			onQueryChange={ param => value => {
 				if ( param === 'page' ) {

--- a/includes/admin/class-wc-rest-payments-transactions-controller.php
+++ b/includes/admin/class-wc-rest-payments-transactions-controller.php
@@ -59,9 +59,17 @@ class WC_REST_Payments_Transactions_Controller extends WP_REST_Controller {
 
 	/**
 	 * Retrieve transactions to respond with via API.
+	 *
+	 * @param WP_REST_Request $request The current matched request object.
 	 */
-	public function get_transactions() {
-		return rest_ensure_response( $this->api_client->list_transactions() );
+	public function get_transactions( $request ) {
+		$params = array(
+			'limit'          => $request['per_page'],
+			'ending_before'  => $request['before'],
+			'starting_after' => $request['after'],
+		);
+
+		return rest_ensure_response( $this->api_client->list_transactions( $params ) );
 	}
 
 	/**

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -120,9 +120,11 @@ class WC_Payments_API_Client {
 	 *
 	 * @return array
 	 * @throws Exception - Exception thrown on request failure.
+	 *
+	 * @param array $params - Details of the retrieval request.
 	 */
-	public function list_transactions() {
-		return $this->request( array(), self::TRANSACTIONS_API, self::GET );
+	public function list_transactions( $params = array() ) {
+		return $this->request( $params, self::TRANSACTIONS_API, self::GET );
 	}
 
 	/**


### PR DESCRIPTION
Branches off of https://github.com/Automattic/woocommerce-payments/pull/89

This change adds pagination arguments to the transaction request, and a bit of logic to adapt the pagination UI to the API in a basic (temporary) way.

<img width="912" alt="Screen Shot 2019-06-10 at 11 09 37 AM" src="https://user-images.githubusercontent.com/1867547/59205192-68a8c600-8b70-11e9-9f89-1d7bc472f4f2.png">

The state handler here only allows moving one page at a time or back to page 1, due to API's sequential pagination mechanism. Also, the total number of rows is currently unavailable through the API, so the view cannot display a total number of pages.

This is only an exploration and does not necessarily represent the best way forward – the overall pagination strategy is subject to discussion in paJDYF-8l-p2.