### PR TITLE
Add refund support

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -287,7 +287,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return bool|WP_Error - Whether the refund went through, or an error.
 	 */
 	public function process_refund( $order_id, $amount = null, $reason = '' ) {
-		$order     = wc_get_order( $order_id );
+		$order = wc_get_order( $order_id );
+
+		if ( ! $order ) {
+			return false;
+		}
+
 		$charge_id = $order->get_meta( '_charge_id', true );
 
 		if ( is_null( $amount ) ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -296,16 +296,17 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$refund = $this->payments_api_client->refund_charge( $charge_id, round( (float) $amount * 100 ) );
 		}
 
-		if ( ! empty( $refund['error'] ) ) {
+		if ( is_wp_error( $refund ) ) {
 			// TODO log error.
 			$note = sprintf(
-				/* translators: %1: the successfully charged amount */
-				__( 'A refund of %1$s failed to complete.', 'woocommerce-payments' ),
-				wc_price( $amount )
+				/* translators: %1: the successfully charged amount, %2: error message */
+				__( 'A refund of %1$s failed to complete: %2$s', 'woocommerce-payments' ),
+				wc_price( $amount ),
+				$refund->get_error_message()
 			);
 			$order->add_order_note( $note );
 
-			return false;
+			return $refund;
 		}
 
 		$note = sprintf(

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -64,7 +64,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$this->has_fields         = true;
 		$this->method_title       = __( 'WooCommerce Payments', 'woocommerce-payments' );
 		$this->method_description = __( 'Accept payments via a WooCommerce-branded payment gateway', 'woocommerce-payments' );
-		$this->supports = array(
+		$this->supports           = array(
 			'products',
 			'refunds',
 		);
@@ -280,6 +280,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	/**
 	 * Refund a charge.
 	 *
+	 * @param  int    $order_id - the Order ID to process the refund for.
+	 * @param  float  $amount   - the amount to refund.
+	 * @param  string $reason   - the reason for refunding.
+	 *
 	 * @return bool - Whether refund went through.
 	 */
 	public function process_refund( $order_id, $amount = null, $reason = '' ) {
@@ -294,7 +298,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		if ( ! empty( $refund['error'] ) ) {
 			// TODO log error.
-
 			$note = sprintf(
 				/* translators: %1: the successfully charged amount */
 				__( 'A refund of %1$s failed to complete.', 'woocommerce-payments' ),

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -284,7 +284,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @param  float  $amount   - the amount to refund.
 	 * @param  string $reason   - the reason for refunding.
 	 *
-	 * @return bool - Whether refund went through.
+	 * @return bool|WP_Error - Whether the refund went through, or an error.
 	 */
 	public function process_refund( $order_id, $amount = null, $reason = '' ) {
 		$order     = wc_get_order( $order_id );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -216,6 +216,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					$transaction_id
 				);
 				$order->add_order_note( $note );
+
+				$order->update_meta_data( '_charge_id', $intent->get_charge_id() );
+				$order->save();
 			}
 
 			$order->payment_complete( $transaction_id );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -309,11 +309,20 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return $refund;
 		}
 
-		$note = sprintf(
-			/* translators: %1: the successfully charged amount */
-			__( 'A refund of %1$s was successfully processed using WooCommerce Payments.', 'woocommerce-payments' ),
-			wc_price( $amount )
-		);
+		if ( empty( $reason ) ) {
+			$note = sprintf(
+				/* translators: %1: the successfully charged amount */
+				__( 'A refund of %1$s was successfully processed using WooCommerce Payments.', 'woocommerce-payments' ),
+				wc_price( $amount )
+			);
+		} else {
+			$note = sprintf(
+				/* translators: %1: the successfully charged amount, %2: reason */
+				__( 'A refund of %1$s was successfully processed using WooCommerce Payments. Reason: %2$s', 'woocommerce-payments' ),
+				wc_price( $amount ),
+				$reason
+			);
+		}
 		$order->add_order_note( $note );
 
 		return true;

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -271,9 +271,10 @@ class WC_Payments_API_Client {
 
 		// Check the response code and handle any errors.
 		$response_code = wp_remote_retrieve_response_code( $response );
-		if ( 200 !== $response_code ) {
-			// TODO: Handle non-200 codes better.
-			throw new Exception( __( 'Server Error.', 'woocommerce-payments' ) );
+		if ( 500 <= $response_code ) {
+			throw new Exception( __( 'Server error. Please try again.', 'woocommerce-payments' ) );
+		} elseif ( 400 <= $response_code ) {
+			return new WP_Error( $response_body['code'], $response_body['message'] );
 		}
 
 		return $response_body;

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -19,6 +19,7 @@ class WC_Payments_API_Client {
 
 	const CHARGES_API      = 'charges';
 	const INTENTIONS_API   = 'intentions';
+	const REFUNDS_API      = 'refunds';
 	const TRANSACTIONS_API = 'transactions';
 
 	/**
@@ -125,6 +126,23 @@ class WC_Payments_API_Client {
 		);
 
 		return $this->deserialize_intention_object_from_array( $response_array );
+	}
+
+	/**
+	 * Refund a charge
+	 *
+	 * @param string $charge_id - The charge to refund.
+	 * @param int    $amount    - Amount to charge.
+	 *
+	 * @return array
+	 * @throws Exception - Exception thrown on refund creation failure.
+	 */
+	public function refund_charge( $charge_id, $amount = null ) {
+		$request           = array();
+		$request['charge'] = $charge_id;
+		$request['amount'] = $amount;
+
+		return $this->request( $request, self::REFUNDS_API, self::POST );
 	}
 
 	/**
@@ -300,11 +318,14 @@ class WC_Payments_API_Client {
 		$created = new DateTime();
 		$created->setTimestamp( $intention_array['created'] );
 
+		$charge_id = 0 < $intention_array['charges']['total_count'] ? end( $intention_array['charges']['data'] )['id'] : null;
+
 		$intent = new WC_Payments_API_Intention(
 			$intention_array['id'],
 			$intention_array['amount'],
 			$created,
-			$intention_array['status']
+			$intention_array['status'],
+			$charge_id
 		);
 
 		return $intent;

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -318,14 +318,14 @@ class WC_Payments_API_Client {
 		$created = new DateTime();
 		$created->setTimestamp( $intention_array['created'] );
 
-		$charge_id = 0 < $intention_array['charges']['total_count'] ? end( $intention_array['charges']['data'] )['id'] : null;
+		$charge = 0 < $intention_array['charges']['total_count'] ? end( $intention_array['charges']['data'] ) : null;
 
 		$intent = new WC_Payments_API_Intention(
 			$intention_array['id'],
 			$intention_array['amount'],
 			$created,
 			$intention_array['status'],
-			$charge_id
+			$charge ? $charge['id'] : null
 		);
 
 		return $intent;

--- a/includes/wc-payment-api/models/class-wc-payments-api-intention.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-intention.php
@@ -94,7 +94,7 @@ class WC_Payments_API_Intention {
 	}
 
 	/**
-	 * Gets intention status
+	 * Returns the charge ID associated with this intention
 	 *
 	 * @return string
 	 */

--- a/includes/wc-payment-api/models/class-wc-payments-api-intention.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-intention.php
@@ -43,16 +43,18 @@ class WC_Payments_API_Intention {
 	/**
 	 * WC_Payments_API_Intention constructor.
 	 *
-	 * @param string   $id      - ID of the charge.
-	 * @param integer  $amount  - Amount charged.
-	 * @param DateTime $created - Time charge created.
-	 * @param string   $status  - Intention status.
+	 * @param string   $id        - ID of the intention.
+	 * @param integer  $amount    - Amount charged.
+	 * @param DateTime $created   - Time charge created.
+	 * @param string   $status    - Intention status.
+	 * @param string   $charge_id - ID of charge associated with intention.
 	 */
-	public function __construct( $id, $amount, DateTime $created, $status ) {
-		$this->id      = $id;
-		$this->amount  = $amount;
-		$this->created = $created;
-		$this->status  = $status;
+	public function __construct( $id, $amount, DateTime $created, $status, $charge_id ) {
+		$this->id        = $id;
+		$this->amount    = $amount;
+		$this->created   = $created;
+		$this->status    = $status;
+		$this->charge_id = $charge_id;
 	}
 
 	/**
@@ -89,5 +91,14 @@ class WC_Payments_API_Intention {
 	 */
 	public function get_status() {
 		return $this->status;
+	}
+
+	/**
+	 * Gets intention status
+	 *
+	 * @return string
+	 */
+	public function get_charge_id() {
+		return $this->charge_id;
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,6 +38,7 @@ function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/woocommerce-payments.php';
 
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/models/class-wc-payments-api-charge.php';
+	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/models/class-wc-payments-api-intention.php';
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-api-client.php';
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-http.php';
 }

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -115,8 +115,48 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 				)
 			);
 
-		$result = $this->payments_api_client->create_and_confirm_intention( 123, 'usd', 'pm_123456789' );
-		$this->assertEquals( $expected_amount, $result->get_amount() );
-		$this->assertEquals( $expected_status, $result->get_status() );
+			$result = $this->payments_api_client->create_and_confirm_intention( 123, 'usd', 'pm_123456789' );
+			$this->assertEquals( $expected_amount, $result->get_amount() );
+			$this->assertEquals( $expected_status, $result->get_status() );
+		}
+
+
+	/**
+	 * Test a successful call to refund_charge.
+	 *
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_create_refund_success() {
+		$this->markTestSkipped( 'Revisit once Jetpack Client dependency has been abstracted out of API client' );
+
+		// Mock up a test response from WP_Http.
+		$this->mock_http_client
+			->expects( $this->any() )
+			->method( 'request' )
+			->will(
+				$this->returnValue(
+					array(
+						'headers'  => array(),
+						'body'     => wp_json_encode(
+							array(
+								'id'      => 'test_refund_id',
+								'amount'  => '123',
+								'status'  => 'succeeded',
+							)
+						),
+						'response' => array(
+							'code' => 200,
+						),
+						'cookies'  => array(),
+						'filename' => null,
+					)
+				)
+			);
+
+		// Attempt to create a refund.
+		$refund = $this->payments_api_client->refund_charge( 'test_intention_id', 123 );
+
+		// Assert amount returned is correct (ignoring other properties for now since this is a stub implementation).
+		$this->assertEquals( 123, $refund['amount'] );
 	}
 }

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -59,8 +59,8 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 						'headers'  => array(),
 						'body'     => wp_json_encode(
 							array(
-								'id'      => 'test_transaction_id',
-								'amount'  => '123',
+								'id'      => 'test_charge_id',
+								'amount'  => 123,
 								'created' => 1557224304,
 								'status'  => 'success',
 							)
@@ -99,10 +99,21 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 						'headers'  => array(),
 						'body'     => wp_json_encode(
 							array(
-								'id'      => 'test_transaction_id',
+								'id'      => 'test_intention_id',
 								'amount'  => $expected_amount,
 								'created' => 1557224304,
 								'status'  => $expected_status,
+								'charges' => [
+									'total_count' => 1,
+									'data'        => [
+										[
+											'id'      => 'test_charge_id',
+											'amount'  => $expected_amount,
+											'created' => 1557224304,
+											'status'  => $expected_status,
+										],
+									],
+								],
 							)
 						),
 						'response' => array(
@@ -115,11 +126,10 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 				)
 			);
 
-			$result = $this->payments_api_client->create_and_confirm_intention( 123, 'usd', 'pm_123456789' );
-			$this->assertEquals( $expected_amount, $result->get_amount() );
-			$this->assertEquals( $expected_status, $result->get_status() );
-		}
-
+		$result = $this->payments_api_client->create_and_confirm_intention( 123, 'usd', 'pm_123456789' );
+		$this->assertEquals( $expected_amount, $result->get_amount() );
+		$this->assertEquals( $expected_status, $result->get_status() );
+	}
 
 	/**
 	 * Test a successful call to refund_charge.
@@ -127,21 +137,19 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 	 * @throws Exception - In the event of test failure.
 	 */
 	public function test_create_refund_success() {
-		$this->markTestSkipped( 'Revisit once Jetpack Client dependency has been abstracted out of API client' );
-
 		// Mock up a test response from WP_Http.
 		$this->mock_http_client
 			->expects( $this->any() )
-			->method( 'request' )
+			->method( 'remote_request' )
 			->will(
 				$this->returnValue(
 					array(
 						'headers'  => array(),
 						'body'     => wp_json_encode(
 							array(
-								'id'      => 'test_refund_id',
-								'amount'  => '123',
-								'status'  => 'succeeded',
+								'id'     => 'test_refund_id',
+								'amount' => 123,
+								'status' => 'succeeded',
 							)
 						),
 						'response' => array(
@@ -154,7 +162,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 			);
 
 		// Attempt to create a refund.
-		$refund = $this->payments_api_client->refund_charge( 'test_intention_id', 123 );
+		$refund = $this->payments_api_client->refund_charge( 'test_charge_id', 123 );
 
 		// Assert amount returned is correct (ignoring other properties for now since this is a stub implementation).
 		$this->assertEquals( 123, $refund['amount'] );


### PR DESCRIPTION
Fixes #13

Depends on https://github.com/Automattic/woocommerce-payments-server/pull/21

Adds "automatic" refund support to the WooCommerce Payments gateway.

To test, create an order (so that the charge ID is stored), and click Refund on the Edit Order screen. Input an amount to refund:

<img width="881" alt="Screen Shot 2019-06-19 at 1 17 14 PM" src="https://user-images.githubusercontent.com/1867547/59786329-fda86f00-9294-11e9-98b4-37e372e2ddac.png">

Click "Refund […] via WooCommerce Payments".

<img width="294" alt="Screen Shot 2019-06-19 at 1 17 43 PM" src="https://user-images.githubusercontent.com/1867547/59786412-31839480-9295-11e9-9cd3-5e1d79be93bf.png">

The application fee should be returned:

<img width="507" alt="Screen Shot 2019-06-19 at 1 18 23 PM" src="https://user-images.githubusercontent.com/1867547/59786444-44966480-9295-11e9-8a6e-e9df7de97941.png">

Concerns:

- Should we check that the intent status is successful before allowing refund?
- What to do with `$reason` – just add to metadata as the Stripe extension does [[code](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/6e325714b8026b35f2747890bf1d573fc1371d56/includes/abstracts/abstract-wc-stripe-payment-gateway.php#L851-L855)]?