### PR TITLE
Add husky pre commit checks with PHPCS

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -42,7 +42,7 @@ files.forEach( file => {
 	}
 
 	try {
-		execSync( `./vendor/bin/phpcs --standard=phpcs.xml.dist --colors ${ file }` );
+		execSync( `./vendor/bin/phpcs --standard=phpcs.xml.dist --basepath=. --colors ${ file }` );
 	} catch( err ) {
 		console.log( err.stdout.toString( 'utf8' ) );
 		foundErrors = true;

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -42,8 +42,7 @@ files.forEach( file => {
 	}
 
 	try {
-		console.log( 'Evaluating', file );
-		execSync( `./vendor/bin/phpcs --standard=phpcs.xml.dist ${ file }` );
+		execSync( `./vendor/bin/phpcs --standard=phpcs.xml.dist --colors ${ file }` );
 	} catch( err ) {
 		console.log( err.stdout.toString( 'utf8' ) );
 		foundErrors = true;

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -1,0 +1,56 @@
+'use-strict';
+
+/**
+ * External dependencies
+ */
+const execSync = require( 'child_process' ).execSync;
+
+/**
+ * Parses the output of a git diff command into javascript file paths.
+ *
+ * @param   {String} command Command to run. Expects output like `git diff --name-only […]`
+ * @returns {Array}          Paths output from git command
+ */
+function parseGitDiffToPathArray( command ) {
+	return execSync( command )
+		.toString()
+		.split( '\n' )
+		.map( name => name.trim() )
+		.filter(
+			name => name.endsWith( '.js' ) || name.endsWith( '.jsx' ) || name.endsWith( '.scss' ) || name.endsWith( '.php' )
+		);
+}
+
+const files = parseGitDiffToPathArray( 'git diff --cached --name-only --diff-filter=ACM' );
+
+try {
+	// Check if PHP_CodeSniffer is installed.
+	execSync( `./vendor/bin/phpcs -h` );
+} catch( e ) {
+	console.log(
+		'PHP_CodeSniffer is not installed. ' +
+		'Please, run `composer install` ' +
+		'and run the command again.' );
+	process.exit( 1 );
+}
+
+let foundErrors = false;
+
+files.forEach( file => {
+	if ( ! file.endsWith( '.php' ) ) {
+		return;
+	}
+
+	try {
+		console.log( 'Evaluating', file );
+		execSync( `./vendor/bin/phpcs --standard=phpcs.xml.dist ${ file }` );
+	} catch( err ) {
+		console.log( err.stdout.toString( 'utf8' ) );
+		foundErrors = true;
+	}
+} );
+
+if ( foundErrors ) {
+	process.exit( 1 );
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1178,6 +1178,12 @@
       "integrity": "sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==",
       "dev": true
     },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -6161,6 +6167,105 @@
         }
       }
     },
+    "husky": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-2.4.1.tgz",
+      "integrity": "sha512-ZRwMWHr7QruR22dQ5l3rEGXQ7rAQYsJYqaeCd+NyOsIFczAtqaApZQP3P4HwLZjCtFbm3SUNYoKuoBXX3AYYfw==",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^5.2.0",
+        "execa": "^1.0.0",
+        "find-up": "^3.0.0",
+        "get-stdin": "^7.0.0",
+        "is-ci": "^2.0.0",
+        "pkg-dir": "^4.1.0",
+        "please-upgrade-node": "^3.1.1",
+        "read-pkg": "^5.1.1",
+        "run-node": "^1.0.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+          "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+              }
+            }
+          }
+        },
+        "read-pkg": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.1.1.tgz",
+          "integrity": "sha512-dFcTLQi6BZ+aFUaICg7er+/usEoqFdQxiEBsEMNGoipenihtxxtdrQuBXvyANCEI8VuUIVYFgeHGx9sLLvim4w==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^4.0.0",
+            "type-fest": "^0.4.1"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -9397,6 +9502,15 @@
         "find-up": "^3.0.0"
       }
     },
+    "please-upgrade-node": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz",
+      "integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
+      }
+    },
     "plur": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/plur/-/plur-3.1.1.tgz",
@@ -10398,6 +10512,12 @@
         "is-promise": "^2.1.0"
       }
     },
+    "run-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
+      "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
+      "dev": true
+    },
     "run-parallel": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
@@ -10557,6 +10677,12 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
     "send": {
@@ -12115,6 +12241,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.4.1.tgz",
+      "integrity": "sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "test": "wp-scripts test-unit-js --config tests/js/jest.config.json",
     "watch": "webpack --watch"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "node ./bin/pre-commit-hook.js"
+    }
+  },
   "dependencies": {
     "css-loader": "^2.1.1"
   },
@@ -25,6 +30,7 @@
     "@wordpress/scripts": "3.1.0",
     "babel-loader": "^8.0.5",
     "core-js": "^3.1.3",
+    "husky": "^2.4.1",
     "mini-css-extract-plugin": "^0.6.0",
     "node-sass": "^4.11.0",
     "react-test-renderer": "^16.8.6",

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 3.5
- * WC tested up to: 3.5.6
+ * WC tested up to: 3.6.4
  * Requires WP: 5.0
  * Version: 0.1.0
  *


### PR DESCRIPTION
Fixes #69 

Runs PHPCS on all files in the commit as a pre-commit hook. Patterned after pre-commit hook in woocommerce-admin.

To test

- install this branch
- run `npm install`
- run `composer install`
- modify a file to make it fail WP PHP coding standards, e.g. remove a space from the last line of woocommerce-payments.php `add_action( 'plugins_loaded', 'wcpay_init' );`
- `git add .`
- `git commit`
- verify the commit is blocked
- revert the change you made
- `git add .`
- `git commit`
- verify the commit is NOT blocked (you can :quit on the commit to avoid actually committing)
