### PR TITLE
Add manual capture support

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -222,11 +222,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				// Get the payment method from the request (generated when the user entered their card details).
 				$payment_method = $this->get_payment_method_from_request();
 
+				$capture_method = 'yes' === $this->get_option( 'manual_capture' ) ? 'manual' : 'automatic';
+
 				// Create intention, try to confirm it & capture the charge (if 3DS is not required).
 				$intent = $this->payments_api_client->create_and_confirm_intention(
 					round( (float) $amount * 100 ),
 					'usd',
-					$payment_method
+					$payment_method,
+					$capture_method
 				);
 
 				// TODO: We're not handling *all* sorts of things here. For example, redirecting to a 3DS auth flow.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -126,7 +126,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			),
 			'manual_capture'       => array(
 				'title'       => __( 'Manual Capture', 'woocommerce-payments' ),
-				'label'       => __( 'Separate authorization and capture', 'woocommerce-payments' ),
+				'label'       => __( 'Issue authorization and capture later', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
 				'description' => __( 'Manually capture funds within 7 days after the customer authorizes payment on checkout.', 'woocommerce-payments' ),
 				'default'     => 'no',

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -103,8 +103,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'desc_tip'    => true,
 			),
 			'testmode'             => array(
-				'title'       => __( 'Test mode', 'woocommerce-payments' ),
-				'label'       => __( 'Enable Test Mode', 'woocommerce-payments' ),
+				'title'       => __( 'Test Mode', 'woocommerce-payments' ),
+				'label'       => __( 'Enable test mode', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
 				'description' => __( 'Place the payment gateway in test mode using test API keys.', 'woocommerce-payments' ),
 				'default'     => 'yes',
@@ -122,6 +122,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'type'        => 'password',
 				'description' => __( 'Get your API keys from your Stripe account.', 'woocommerce-payments' ),
 				'default'     => '',
+				'desc_tip'    => true,
+			),
+			'manual_capture'       => array(
+				'title'       => __( 'Manual Capture', 'woocommerce-payments' ),
+				'label'       => __( 'Separate authorization and capture', 'woocommerce-payments' ),
+				'type'        => 'checkbox',
+				'description' => __( 'Manually capture funds within 7 days after the customer authorizes payment on checkout.', 'woocommerce-payments' ),
+				'default'     => 'no',
 				'desc_tip'    => true,
 			),
 		);
@@ -384,7 +392,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		?>
 		<tr valign="top">
 			<th scope="row">
-				<?php echo esc_html( __( 'Payment details', 'woocommerce-payments' ) ); ?>
+				<?php echo esc_html( __( 'Payment Details', 'woocommerce-payments' ) ); ?>
 			</th>
 			<td>
 				<?php echo wp_kses_post( $description ); ?>

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -234,7 +234,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				// Get the payment method from the request (generated when the user entered their card details).
 				$payment_method = $this->get_payment_method_from_request();
 
-				$capture_method = 'yes' === $this->get_option( 'manual_capture' ) ? 'manual' : 'automatic';
+				$manual_capture = 'yes' === $this->get_option( 'manual_capture' );
 
 				// Create intention, try to confirm it & capture the charge (if 3DS is not required).
 				$intent = $this->payments_api_client->create_and_confirm_intention(

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -491,7 +491,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 	}
 
-	/*
+	/**
 	 * Add capture and cancel actions for orders with an authorized charge.
 	 *
 	 * @param array $actions - Actions to make available in order actions metabox.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -497,15 +497,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @param array $actions - Actions to make available in order actions metabox.
 	 */
 	public function add_order_actions( $actions ) {
-		global $post;
+		global $theorder;
 
-		$order = wc_get_order( $post->ID );
-
-		if ( $this->id !== $order->get_payment_method() ) {
+		if ( $this->id !== $theorder->get_payment_method() ) {
 			return $actions;
 		}
 
-		if ( 'requires_capture' !== $order->get_meta( '_intention_status', true ) ) {
+		if ( 'requires_capture' !== $theorder->get_meta( '_intention_status', true ) ) {
 			return $actions;
 		}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -241,7 +241,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					round( (float) $amount * 100 ),
 					'usd',
 					$payment_method,
-					$capture_method
+					$manual_capture
 				);
 
 				// TODO: We're not handling *all* sorts of things here. For example, redirecting to a 3DS auth flow.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -251,7 +251,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				if ( 'requires_capture' === $status ) {
 					$note = sprintf(
 						/* translators: %1: the authorized amount, %2: transaction ID of the payment */
-						__( 'A payment of %1$s was authorized using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
+						__( 'A payment of %1$s was <strong>authorized</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
 						wc_price( $amount ),
 						$transaction_id
 					);
@@ -260,7 +260,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				} else {
 					$note = sprintf(
 						/* translators: %1: the successfully charged amount, %2: transaction ID of the payment */
-						__( 'A payment of %1$s was successfully charged using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
+						__( 'A payment of %1$s was <strong>successfully charged</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
 						wc_price( $amount ),
 						$transaction_id
 					);
@@ -533,7 +533,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if ( 'succeeded' === $status ) {
 			$note = sprintf(
 				/* translators: %1: the successfully charged amount */
-				__( 'A payment of %1$s was successfully captured using WooCommerce Payments.', 'woocommerce-payments' ),
+				__( 'A payment of %1$s was <strong>successfully captured</strong> using WooCommerce Payments.', 'woocommerce-payments' ),
 				wc_price( $amount )
 			);
 			$order->add_order_note( $note );
@@ -541,7 +541,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		} else {
 			$note = sprintf(
 				/* translators: %1: the successfully charged amount */
-				__( 'A capture of %1$s failed to complete.', 'woocommerce-payments' ),
+				__( 'A capture of %1$s <strong>failed</strong> to complete.', 'woocommerce-payments' ),
 				wc_price( $amount )
 			);
 			$order->add_order_note( $note );
@@ -561,11 +561,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$order->save();
 
 		if ( 'canceled' === $status ) {
-			$order->update_status( 'cancelled', __( 'Payment authorization was successfully cancelled.', 'woocommerce-payments' ) );
+			$order->update_status( 'cancelled', __( 'Payment authorization was successfully <strong>cancelled</strong>.', 'woocommerce-payments' ) );
 		} else {
 			$note = sprintf(
 				/* translators: %1: the successfully charged amount */
-				__( 'Canceling authorization failed to complete.', 'woocommerce-payments' ),
+				__( 'Canceling authorization <strong>failed</strong> to complete.', 'woocommerce-payments' ),
 				wc_price( $amount )
 			);
 			$order->add_order_note( $note );

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -90,19 +90,19 @@ class WC_Payments_API_Client {
 	 * @param int    $amount            - Amount to charge.
 	 * @param string $currency_code     - Currency to charge in.
 	 * @param string $payment_method_id - ID of payment method to process charge with.
-	 * @param string $capture_method    - Whether to automatically capture funds.
+	 * @param string $manual_capture    - Whether to capture funds via manual action.
 	 *
 	 * @return WC_Payments_API_Intention
 	 * @throws Exception - Exception thrown on intention creation failure.
 	 */
-	public function create_and_confirm_intention( $amount, $currency_code, $payment_method_id, $capture_method = 'automatic' ) {
+	public function create_and_confirm_intention( $amount, $currency_code, $payment_method_id, $manual_capture = false ) {
 		// TODO: There's scope to have amount and currency bundled up into an object.
 		$request                   = array();
 		$request['amount']         = $amount;
 		$request['currency']       = $currency_code;
 		$request['confirm']        = 'true';
 		$request['payment_method'] = $payment_method_id;
-		$request['capture_method'] = $capture_method;
+		$request['capture_method'] = $manual_capture ? 'manual' : 'automatic';
 
 		$response_array = $this->request( $request, self::INTENTIONS_API, self::POST );
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -90,17 +90,19 @@ class WC_Payments_API_Client {
 	 * @param int    $amount            - Amount to charge.
 	 * @param string $currency_code     - Currency to charge in.
 	 * @param string $payment_method_id - ID of payment method to process charge with.
+	 * @param string $capture_method    - Whether to automatically capture funds.
 	 *
 	 * @return WC_Payments_API_Intention
 	 * @throws Exception - Exception thrown on intention creation failure.
 	 */
-	public function create_and_confirm_intention( $amount, $currency_code, $payment_method_id ) {
+	public function create_and_confirm_intention( $amount, $currency_code, $payment_method_id, $capture_method = 'automatic' ) {
 		// TODO: There's scope to have amount and currency bundled up into an object.
 		$request                   = array();
 		$request['amount']         = $amount;
 		$request['currency']       = $currency_code;
 		$request['confirm']        = 'true';
 		$request['payment_method'] = $payment_method_id;
+		$request['capture_method'] = $capture_method;
 
 		$response_array = $this->request( $request, self::INTENTIONS_API, self::POST );
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -90,7 +90,7 @@ class WC_Payments_API_Client {
 	 * @param int    $amount            - Amount to charge.
 	 * @param string $currency_code     - Currency to charge in.
 	 * @param string $payment_method_id - ID of payment method to process charge with.
-	 * @param string $manual_capture    - Whether to capture funds via manual action.
+	 * @param bool   $manual_capture    - Whether to capture funds via manual action.
 	 *
 	 * @return WC_Payments_API_Intention
 	 * @throws Exception - Exception thrown on intention creation failure.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -149,6 +149,46 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Capture an intention
+	 *
+	 * @param string $intention_id - The ID of the intention to capture.
+	 * @param int    $amount       - Amount to capture.
+	 *
+	 * @return WC_Payments_API_Intention
+	 * @throws Exception - Exception thrown on intention capture failure.
+	 */
+	public function capture_intention( $intention_id, $amount ) {
+		$request                      = array();
+		$request['amount_to_capture'] = $amount;
+
+		$response_array = $this->request(
+			$request,
+			self::INTENTIONS_API . '/' . $intention_id . '/capture',
+			self::POST
+		);
+
+		return $this->deserialize_intention_object_from_array( $response_array );
+	}
+
+	/**
+	 * Cancel an intention
+	 *
+	 * @param string $intention_id - The ID of the intention to cancel.
+	 *
+	 * @return WC_Payments_API_Intention
+	 * @throws Exception - Exception thrown on intention cancellation failure.
+	 */
+	public function cancel_intention( $intention_id ) {
+		$response_array = $this->request(
+			array(),
+			self::INTENTIONS_API . '/' . $intention_id . '/cancel',
+			self::POST
+		);
+
+		return $this->deserialize_intention_object_from_array( $response_array );
+	}
+
+	/**
 	 * Retrive an order ID from the DB using a corresponding Stripe charge ID.
 	 *
 	 * @param string $charge_id Charge ID corresponding to an order ID.

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -126,7 +126,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 				)
 			);
 
-		$result = $this->payments_api_client->create_and_confirm_intention( 123, 'usd', 'pm_123456789' );
+		$result = $this->payments_api_client->create_and_confirm_intention( $expected_amount, 'usd', 'pm_123456789' );
 		$this->assertEquals( $expected_amount, $result->get_amount() );
 		$this->assertEquals( $expected_status, $result->get_status() );
 	}
@@ -137,6 +137,8 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 	 * @throws Exception - In the event of test failure.
 	 */
 	public function test_create_refund_success() {
+		$expected_amount = 123;
+
 		// Mock up a test response from WP_Http.
 		$this->mock_http_client
 			->expects( $this->any() )
@@ -148,7 +150,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 						'body'     => wp_json_encode(
 							array(
 								'id'     => 'test_refund_id',
-								'amount' => 123,
+								'amount' => $expected_amount,
 								'status' => 'succeeded',
 							)
 						),
@@ -162,10 +164,10 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 			);
 
 		// Attempt to create a refund.
-		$refund = $this->payments_api_client->refund_charge( 'test_charge_id', 123 );
+		$refund = $this->payments_api_client->refund_charge( 'test_charge_id', $expected_amount );
 
 		// Assert amount returned is correct (ignoring other properties for now since this is a stub implementation).
-		$this->assertEquals( 123, $refund['amount'] );
+		$this->assertEquals( $expected_amount, $refund['amount'] );
 	}
 
 	/**
@@ -187,7 +189,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 						'headers'  => array(),
 						'body'     => wp_json_encode(
 							array(
-								'id'      => 'test_transaction_id',
+								'id'      => 'test_intention_id',
 								'amount'  => $expected_amount,
 								'created' => 1557224304,
 								'status'  => $expected_status,
@@ -213,8 +215,8 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 					)
 				)
 			);
- 
-		$result = $this->payments_api_client->create_and_confirm_intention( 123, 'usd', 'pm_123456789', true );
+
+		$result = $this->payments_api_client->create_and_confirm_intention( $expected_amount, 'usd', 'pm_123456789', true );
 		$this->assertEquals( $expected_amount, $result->get_amount() );
 		$this->assertEquals( $expected_status, $result->get_status() );
 	}

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -167,4 +167,44 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 		// Assert amount returned is correct (ignoring other properties for now since this is a stub implementation).
 		$this->assertEquals( 123, $refund['amount'] );
 	}
+
+	/**
+	 * Test a successful call to create_intention with manual capture.
+	 *
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_create_intention_authorization_success() {
+		$expected_amount = 123;
+		$expected_status = 'requires_capture';
+
+		$this->mock_http_client
+			->expects( $this->any() )
+			->method( 'remote_request' )
+			->with( $this->anything(), $this->stringContains( '"manual"' ) )
+			->will(
+				$this->returnValue(
+					array(
+						'headers'  => array(),
+						'body'     => wp_json_encode(
+							array(
+								'id'      => 'test_transaction_id',
+								'amount'  => $expected_amount,
+								'created' => 1557224304,
+								'status'  => $expected_status,
+							)
+						),
+						'response' => array(
+							'code'    => 200,
+							'message' => 'OK',
+						),
+						'cookies'  => array(),
+						'filename' => null,
+					)
+				)
+			);
+ 
+		$result = $this->payments_api_client->create_and_confirm_intention( 123, 'usd', 'pm_123456789', true );
+		$this->assertEquals( $expected_amount, $result->get_amount() );
+		$this->assertEquals( $expected_status, $result->get_status() );
+	}
 }

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -220,4 +220,102 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected_amount, $result->get_amount() );
 		$this->assertEquals( $expected_status, $result->get_status() );
 	}
+
+	/**
+	 * Test a successful call to capture intention.
+	 *
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_capture_intention_success() {
+		$expected_amount = 103;
+		$expected_status = 'succeeded';
+
+		$this->mock_http_client
+			->expects( $this->any() )
+			->method( 'remote_request' )
+			->will(
+				$this->returnValue(
+					array(
+						'headers'  => array(),
+						'body'     => wp_json_encode(
+							array(
+								'id'              => 'test_intention_id',
+								'amount'          => 123,
+								'amount_captured' => $expected_amount,
+								'created'         => 1557224304,
+								'status'          => $expected_status,
+								'charges'         => [
+									'total_count' => 1,
+									'data'        => [
+										[
+											'id'      => 'test_charge_id',
+											'amount'  => $expected_amount,
+											'created' => 1557224305,
+											'status'  => 'succeeded',
+										],
+									],
+								],
+							)
+						),
+						'response' => array(
+							'code'    => 200,
+							'message' => 'OK',
+						),
+						'cookies'  => array(),
+						'filename' => null,
+					)
+				)
+			);
+
+		$result = $this->payments_api_client->capture_intention( 'test_intention_id', $expected_amount );
+		$this->assertEquals( $expected_status, $result->get_status() );
+	}
+
+	/**
+	 * Test a successful call to cancel intention.
+	 *
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_cancel_intention_success() {
+		$expected_status = 'canceled';
+
+		$this->mock_http_client
+			->expects( $this->any() )
+			->method( 'remote_request' )
+			->will(
+				$this->returnValue(
+					array(
+						'headers'  => array(),
+						'body'     => wp_json_encode(
+							array(
+								'id'      => 'test_intention_id',
+								'amount'  => 123,
+								'created' => 1557224304,
+								'status'  => $expected_status,
+								'charges' => [
+									'total_count' => 1,
+									'data'        => [
+										[
+											'id'      => 'test_charge_id',
+											'amount'  => 123,
+											'created' => 1557224305,
+											'status'  => 'succeeded',
+										],
+									],
+								],
+							)
+						),
+						'response' => array(
+							'code'    => 200,
+							'message' => 'OK',
+						),
+						'cookies'  => array(),
+						'filename' => null,
+					)
+				)
+			);
+
+		$result = $this->payments_api_client->cancel_intention( 'test_intention_id' );
+		$this->assertEquals( $expected_status, $result->get_status() );
+	}
 }

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -109,8 +109,8 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 										[
 											'id'      => 'test_charge_id',
 											'amount'  => $expected_amount,
-											'created' => 1557224304,
-											'status'  => $expected_status,
+											'created' => 1557224305,
+											'status'  => 'succeeded',
 										],
 									],
 								],
@@ -191,6 +191,17 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 								'amount'  => $expected_amount,
 								'created' => 1557224304,
 								'status'  => $expected_status,
+								'charges' => [
+									'total_count' => 1,
+									'data'        => [
+										[
+											'id'      => 'test_charge_id',
+											'amount'  => $expected_amount,
+											'created' => 1557224305,
+											'status'  => 'succeeded',
+										],
+									],
+								],
 							)
 						),
 						'response' => array(


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-payments/issues/12

Adds a setting for merely authorizing payment on checkout rather than capturing immediately:

<img width="538" src="https://user-images.githubusercontent.com/1867547/61419067-a369f080-a8ca-11e9-97f3-dcbf39225f6e.png">

…and adds order actions for capturing and cancelling authorized payment:

&nbsp; | Before | After
-- | -- | --
Capture | <img width="295" alt="Screen Shot 2019-06-21 at 5 04 20 PM" src="https://user-images.githubusercontent.com/1867547/59951438-ead59c00-9446-11e9-8e13-cd6e1956a8fe.png"> | <img width="297" alt="Screen Shot 2019-06-21 at 5 05 23 PM" src="https://user-images.githubusercontent.com/1867547/59951435-ea3d0580-9446-11e9-97a4-047722f0ce99.png">
Cancel | <img width="295" alt="Screen Shot 2019-06-21 at 5 04 40 PM" src="https://user-images.githubusercontent.com/1867547/59951437-ead59c00-9446-11e9-8cb5-bb2df3b49564.png"> | <img width="296" alt="Screen Shot 2019-06-21 at 5 05 14 PM" src="https://user-images.githubusercontent.com/1867547/59951436-ead59c00-9446-11e9-94f3-37a9f81cc858.png">

Things to consider beyond code review:
- The `WC_Payments_API_Intention` model isn't being passed to the API client functions because we aren't currently saving/loading them locally, and only the ID is needed anyway. However, the status _is_ needed (or, whether the status is "requires_capture"), so I'm manually saving/loading it in meta.
  - Since a similar thing is being done for charge ID in https://github.com/Automattic/woocommerce-payments/pull/102, we may want a more general solution, depending on the vision/opportunity for how the model class(es) would be used.
  - After rebasing on https://github.com/Automattic/woocommerce-payments/pull/102, we'll probably want to add a status condition for when Refund is available (e.g. `( 'succeeded' === $order->get_meta( '_intention_status', true ) )`)
- Chose to make the actions trigger a status change rather than vice versa – this is a break from precedent (e.g. PayPal Standard, Stripe) and so we might want to add status change hooks too.
- Added markup to the order notes – is there reason not to do this? [[Automatic capture screenshot](https://cloudup.com/cF7ZpiHK6Rb).]
- I settled on "Manual Capture" as the name of the feature, but open to suggestions on these labels and description still.
- What automated tests do we want for the new behaviors?