### PR TITLE
Unpin xdebug version

### DIFF
--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -1,4 +1,4 @@
 FROM wordpress
-RUN pecl install xdebug-2.6.1 \
+RUN pecl install xdebug \
 	&& docker-php-ext-enable xdebug
 COPY custom.ini $PHP_INI_DIR/conf.d/


### PR DESCRIPTION
We don't pin the version of the WordPress image. Since the config was written the most recent WordPress image has started using PHP 7.3, which requires a newer version of xdebug.

Not specifying the version of xdebug should allow pecl to successfully install it whatever version of PHP the image uses.

In the future we may want to pin the WordPress image version, but for now it makes sense to take the latest.

We also correct the line endings to LF and add a newline for the end of the file.