### PR TITLE
Create and pass Payment Method instead of Source object

### DIFF
--- a/assets/js/wc-payment-checkout.js
+++ b/assets/js/wc-payment-checkout.js
@@ -21,42 +21,42 @@ jQuery( document.body ).on( 'updated_checkout', function() {
 		}
 	} );
 
-	// Create payment source on submission.
-	var sourceGenerated;
+	// Create payment method on submission.
+	var paymentMethodGenerated;
 	jQuery( 'form.checkout' ).on( 'checkout_place_order_woocommerce_payments', function() {
-		// We'll resubmit the form after populating our source, so if this is the second time this event is firing we
-		// should let the form submission happen.
-		if ( sourceGenerated ) {
+		// We'll resubmit the form after populating our payment method, so if this is the second time this event
+		// is firing we should let the form submission happen.
+		if ( paymentMethodGenerated ) {
 			return;
 		}
 
-		stripe.createSource( cardElement )
+		stripe.createPaymentMethod( 'card', cardElement )
 			.then( function( result ) {
-				var source = result.source;
+				var paymentMethod = result.paymentMethod;
 				var error = result.error;
 
 				if ( error ) {
 					throw error;
 				}
 
-				return source;
+				return paymentMethod;
 			} )
-			.then( function( source ) {
-				var id = source.id;
+			.then( function( paymentMethod ) {
+				var id = paymentMethod.id;
 
-				// Flag that the source has been successfully generated so that we can allow the form submission next
-				// time.
-				sourceGenerated = true;
+				// Flag that the payment method has been successfully generated so that we can allow the form
+				// submission next time.
+				paymentMethodGenerated = true;
 
-				// Populate form with the source.
-				var paymentSourceInput   = document.getElementById( 'wc-payment-source' );
-				paymentSourceInput.value = id;
+				// Populate form with the payment method.
+				var paymentMethodInput   = document.getElementById( 'wc-payment-method' );
+				paymentMethodInput.value = id;
 
 				// Re-submit the form.
 				jQuery( '.woocommerce-checkout' ).submit();
 			} );
 
-		// Prevent form submission so that we can fire it once a source has been generated.
+		// Prevent form submission so that we can fire it once a payment method has been generated.
 		return false;
 	} );
 } );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -181,7 +181,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		<p><?php echo wp_kses_post( $this->get_description() ); ?></p>
 		<div id="wc-payment-card-element"></div>
 		<div id="wc-payment-errors" role="alert"></div>
-		<input id="wc-payment-source" type="hidden" name="wc-payment-source" />
+		<input id="wc-payment-method" type="hidden" name="wc-payment-method" />
 		<?php
 	}
 
@@ -201,15 +201,15 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$transaction_id = '';
 
 			if ( $amount > 0 ) {
-				// Get the payment source from the request (generated when the user entered their card details).
-				$source = $this->get_source_from_request();
+				// Get the payment method from the request (generated when the user entered their card details).
+				$payment_method = $this->get_payment_method_from_request();
 
 				// Create intention.
 				$intent = $this->payments_api_client->create_intention( round( (float) $amount * 100 ), 'usd' );
 
 				// TODO: We could attempt to confirm the intention when creating it instead?
 				// Try to confirm the intention & capture the charge (if 3DS is not required).
-				$intent = $this->payments_api_client->confirm_intention( $intent, $source );
+				$intent = $this->payments_api_client->confirm_intention( $intent, $payment_method );
 
 				// TODO: We're not handling *all* sorts of things here. For example, redirecting to a 3DS auth flow.
 				$transaction_id = $intent->get_id();
@@ -247,21 +247,21 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Extract the payment source from the request's POST variables
+	 * Extract the payment method from the request's POST variables
 	 *
 	 * @return string
-	 * @throws Exception - If no source is found.
+	 * @throws Exception - If no payment method is found.
 	 */
-	private function get_source_from_request() {
+	private function get_payment_method_from_request() {
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
-		if ( ! isset( $_POST['wc-payment-source'] ) ) {
-			// If no payment source is set then stop here with an error.
-			throw new Exception( __( 'Payment source not found.', 'woocommerce-payments' ) );
+		if ( ! isset( $_POST['wc-payment-method'] ) ) {
+			// If no payment method is set then stop here with an error.
+			throw new Exception( __( 'Payment method not found.', 'woocommerce-payments' ) );
 		}
 
-		$source = wc_clean( $_POST['wc-payment-source'] ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		$payment_method = wc_clean( $_POST['wc-payment-method'] ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
 
-		return $source;
+		return $payment_method;
 	}
 }

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -18,7 +18,6 @@ class WC_Payments_API_Client {
 	const GET  = 'GET';
 
 	const CHARGES_API    = 'charges';
-	const SOURCES_API    = 'sources';
 	const INTENTIONS_API = 'intentions';
 
 	/**
@@ -96,15 +95,15 @@ class WC_Payments_API_Client {
 	/**
 	 * Confirm an intention
 	 *
-	 * @param WC_Payments_API_Intention $intent    - The intention to confirm.
-	 * @param string                    $source_id - ID of source to process charge with.
+	 * @param WC_Payments_API_Intention $intent            - The intention to confirm.
+	 * @param string                    $payment_method_id - ID of payment method to process charge with.
 	 *
 	 * @return WC_Payments_API_Intention
 	 * @throws Exception - Exception thrown on intention confirmation failure.
 	 */
-	public function confirm_intention( WC_Payments_API_Intention $intent, $source_id ) {
-		$request           = array();
-		$request['source'] = $source_id;
+	public function confirm_intention( WC_Payments_API_Intention $intent, $payment_method_id ) {
+		$request                   = array();
+		$request['payment_method'] = $payment_method_id;
 
 		$response_array = $this->request(
 			$request,


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/80

Though Sources are technically compatible with Payment Intents, the newer Payment Methods are more conceptually compatible with them because the Payment Intent flow renders the "chargeable" Source flow obsolete.

#### Changes proposed in this Pull Request

* Replace `createSource` from stripe.js with `createPaymentMethod`
* Replace `source` API param with `payment_method`
* Refactor: basically find and replace _(payment) source_ with _payment method_ terminology

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm that charges on checkout work just as before, except that the resulting payment has a Payment Method object attached rather than a Source:

Before | After
-- | --
<img width="470" alt="src_" src="https://user-images.githubusercontent.com/1867547/60124681-31353e80-9758-11e9-8e05-508577414ac7.png"> | <img width="470" alt="pm_" src="https://user-images.githubusercontent.com/1867547/60124687-33979880-9758-11e9-89dc-0704a3eb301c.png">


-------------------

- [ ] Tested on mobile
