### PR TITLE
Docker: map DB to a port that's not 3306, and add phpMyAdmin dashboard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     container_name: woocommerce_payments_mysql
     image: mysql:5.7
     ports:
-      - "3306:3306"
+      - "5678:3306"
     env_file:
       - default.env
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,3 +26,10 @@ services:
       - default.env
     volumes:
       - ./docker/data:/var/lib/mysql
+  phpMyAdmin:
+    container_name: woocommerce_payments_phpmyadmin
+    image: phpmyadmin/phpmyadmin:latest
+    ports:
+      - "8083:80"
+    env_file:
+      - default.env


### PR DESCRIPTION
Fixes #77

#### Changes proposed in this Pull Request

* Don't map Docker DB to port `3306` on the host, since it's a commonly used port, especially for DB applications. Currently going with port `5678`.
* Add a phpMyAdmin dashboard to the container, so a DB manager is easily accessible by default. Currently the dashboard is exposed on port `8083` on the host (as opposed to `8082` for WP), and accessible on http://localhost:8083.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Connect to the database on port `5678` with any DB interface, using the credentials in [default.env](https://github.com/Automattic/woocommerce-payments/blob/master/default.env).
* Open http://localhost:8083 and log in to phpMyAdmin using the credentials in [default.env](https://github.com/Automattic/woocommerce-payments/blob/master/default.env).