### PR TITLE
Update required and available transactions table columns

### DIFF
--- a/client/transactions-list.js
+++ b/client/transactions-list.js
@@ -10,7 +10,7 @@ import { TableCard } from '@woocommerce/components';
 import { capitalize } from 'lodash';
 
 const headers = [
-	{ key: 'created', label: 'Date / Time', required: true, isLeftAligned: true },
+	{ key: 'created', label: 'Date / Time', required: true, isLeftAligned: true, defaultSort: true, defaultOrder: 'desc' },
 	{ key: 'type', label: 'Type', required: true },
 	{ key: 'source', label: 'Source' },
 	// { key: 'order', label: 'Order #', required: true },
@@ -46,7 +46,7 @@ export default () => {
 		const charge = txn.source.object === 'charge' ? txn.source : null;
 
 		const data = {
-			created: { value: txn.created * 1000, display: dateI18n( 'Y-m-d H:i', moment( txn.created * 1000 ) ) },
+			created: { value: txn.created * 1000, display: dateI18n( 'M j, Y / g:iA', moment( txn.created * 1000 ) ) },
 			type: { value: txn.type, display: capitalize( txn.type ) },
 			source: charge && { value: charge.payment_method_details.card.brand, display: <code>{ charge.payment_method_details.card.brand }</code> },
 			// TODO order: {},

--- a/client/transactions-list.js
+++ b/client/transactions-list.js
@@ -17,9 +17,9 @@ const headers = [
 	{ key: 'customer', label: 'Customer' },
 	{ key: 'email', label: 'Email', hiddenByDefault: true },
 	{ key: 'country', label: 'Country', hiddenByDefault: true },
-	{ key: 'amount', label: 'Amount' },
-	{ key: 'fee', label: 'Fees' },
-	{ key: 'net', label: 'Net', required: true },
+	{ key: 'amount', label: 'Amount', isNumeric: true },
+	{ key: 'fee', label: 'Fees', isNumeric: true },
+	{ key: 'net', label: 'Net', isNumeric: true, required: true },
 	// TODO { key: 'deposit', label: 'Deposit', required: true },
 	{ key: 'risk_level', label: 'Risk Level', hiddenByDefault: true },
 ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adjusts required and available columns to current mockup (thanks @LevinMedia):

Default | Available
-- | --
<img width="1109" alt="Screen Shot 2019-07-01 at 6 49 04 PM" src="https://user-images.githubusercontent.com/1867547/60471078-0d2e9d00-9c31-11e9-9d87-f9b54f8cb1a0.png"> | <img width="1110" alt="Screen Shot 2019-07-01 at 6 49 15 PM" src="https://user-images.githubusercontent.com/1867547/60471081-10298d80-9c31-11e9-9816-6823d47e26b6.png">

Includes small refactor to map cells from headers to prevent accidental mismatch of header to column.

None of the fields derived from `billing_details` (customer, email, country) are filled. I believe this is because we aren't providing this data with the original payment, but it may be worth testing further.

Also, these columns are left unaddressed:
- Source needs logo image corresponding to value
- Order ID omitted (see https://github.com/Automattic/woocommerce-payments/issues/94)
- Deposit omitted (see https://github.com/Automattic/woocommerce-payments/issues/123)

-------------------

- [x] Tested on mobile [dev tools emulator]
