### PR TITLE
Add link to order in transactions

### DIFF
--- a/client/transactions-list.js
+++ b/client/transactions-list.js
@@ -13,7 +13,7 @@ const headers = [
 	{ key: 'created', label: 'Date / Time', required: true, isLeftAligned: true, defaultSort: true, defaultOrder: 'desc' },
 	{ key: 'type', label: 'Type', required: true },
 	{ key: 'source', label: 'Source' },
-	// { key: 'order', label: 'Order #', required: true },
+	{ key: 'order', label: 'Order #', required: true },
 	{ key: 'customer', label: 'Customer' },
 	{ key: 'email', label: 'Email', hiddenByDefault: true },
 	{ key: 'country', label: 'Country', hiddenByDefault: true },
@@ -44,12 +44,13 @@ export default () => {
 
 	const rows = transactions.map( ( txn ) => {
 		const charge = txn.source.object === 'charge' ? txn.source : null;
+		const order_url = txn.order ? <a href={ txn.order.url }>#{ txn.order.number }</a> : <span>&ndash;</span>;
 
 		const data = {
 			created: { value: txn.created * 1000, display: dateI18n( 'M j, Y / g:iA', moment( txn.created * 1000 ) ) },
 			type: { value: txn.type, display: capitalize( txn.type ) },
 			source: charge && { value: charge.payment_method_details.card.brand, display: <code>{ charge.payment_method_details.card.brand }</code> },
-			// TODO order: {},
+			order: { value: txn.order, display: order_url },
 			customer: charge && { value: charge.billing_details.name, display: charge.billing_details.name },
 			email: charge && { value: charge.billing_details.email, display: charge.billing_details.email },
 			country: charge && { value: charge.billing_details.address.country, display: charge.billing_details.address.country },

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -116,6 +116,42 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Retrive an order ID from the DB using a corresponding Stripe charge ID.
+	 *
+	 * @param string $charge_id Charge ID corresponding to an order ID.
+	 *
+	 * @return null|string
+	 */
+	private function order_id_from_charge_id( $charge_id ) {
+		global $wpdb;
+
+		// The order ID is saved to DB in `WC_Payment_Gateway_WCPay::process_payment()`.
+		$order_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = '_charge_id'",
+				$charge_id
+			)
+		);
+		return $order_id;
+	}
+
+	/**
+	 * Retrieve an order from the DB using a corresponding Stripe charge ID.
+	 *
+	 * @param string $charge_id Charge ID corresponding to an order ID.
+	 *
+	 * @return boolean|WC_Order|WC_Order_Refund
+	 */
+	private function order_from_charge_id( $charge_id ) {
+		$order_id = $this->order_id_from_charge_id( $charge_id );
+
+		if ( $order_id ) {
+			return wc_get_order( $order_id );
+		}
+		return false;
+	}
+
+	/**
 	 * List transactions
 	 *
 	 * @return array

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -164,32 +164,17 @@ class WC_Payments_API_Client {
 		// TODO: Throw exception when `$transactions` or `$transaction` don't have the fields expected?
 		if ( isset( $transactions['data'] ) ) {
 			foreach ( $transactions['data'] as &$transaction ) {
-				global $wpdb;
-
-				// The order ID is saved to DB in `WC_Payment_Gateway_WCPay::process_payment()`.
 				$charge_id = $transaction['source']['id'];
-				$order_id  = $wpdb->get_var(
-					$wpdb->prepare(
-						"SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s",
-						$charge_id,
-						'_charge_id'
-					)
-				);
+				$order     = $this->order_from_charge_id( $charge_id );
 
 				// Add order information to the `$transaction`.
 				// If the order couldn't be retrieved, return an empty order.
-				// TODO: Throw exception when order information can't be retrieved?
 				$transaction['order'] = null;
-				if ( $order_id ) {
-					$order = wc_get_order( $order_id );
-
-					// Note: if order couldn't be retrieved, `$transaction['order']` retains a value of `null`.
-					if ( $order ) {
-						$transaction['order'] = array(
-							'number' => $order->get_order_number(),
-							'url'    => $order->get_edit_order_url(),
-						);
-					}
+				if ( $order ) {
+					$transaction['order'] = array(
+						'number' => $order->get_order_number(),
+						'url'    => $order->get_edit_order_url(),
+					);
 				}
 			}
 		}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -122,7 +122,43 @@ class WC_Payments_API_Client {
 	 * @throws Exception - Exception thrown on request failure.
 	 */
 	public function list_transactions() {
-		return $this->request( array(), self::TRANSACTIONS_API, self::GET );
+		$transactions = $this->request( array(), self::TRANSACTIONS_API, self::GET );
+
+		// Add order information to each transaction available.
+		// TODO: Throw exception when `$transactions` or `$transaction` don't have the fields expected?
+		if ( isset( $transactions['data'] ) ) {
+			foreach ( $transactions['data'] as &$transaction ) {
+				global $wpdb;
+
+				// The order ID is saved to DB in `WC_Payment_Gateway_WCPay::process_payment()`.
+				$charge_id = $transaction['source']['id'];
+				$order_id  = $wpdb->get_var(
+					$wpdb->prepare(
+						"SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s",
+						$charge_id,
+						'_charge_id'
+					)
+				);
+
+				// Add order information to the `$transaction`.
+				// If the order couldn't be retrieved, return an empty order.
+				// TODO: Throw exception when order information can't be retrieved?
+				$transaction['order'] = null;
+				if ( $order_id ) {
+					$order = wc_get_order( $order_id );
+
+					// Note: if order couldn't be retrieved, `$transaction['order']` retains a value of `null`.
+					if ( $order ) {
+						$transaction['order'] = array(
+							'number' => $order->get_order_number(),
+							'url'    => $order->get_edit_order_url(),
+						);
+					}
+				}
+			}
+		}
+
+		return $transactions;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #94.

Depends on #102.

#### Changes proposed in this Pull Request

* Add order information to each transaction retrieved from client API.
* Display order number, as well as a clickable link to that order's detail view, in the transaction table.

<img width="1123" alt="image" src="https://user-images.githubusercontent.com/13835680/60546491-f78ea580-9d0c-11e9-87da-7269dacd2a0c.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before you can test the code in this PR you need to merge code from #102.

1. Complete the checkout process for an order.
2. Ensure the transaction list contains an `order` field that contains the order number and order url.
3. Check that the order number and link are displayed in transactions list table.

-------------------

- [ ] Tested on mobile (or does not apply)
