### PR TITLE
Add repository information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "webpack.config.js",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",
-  "repository": "",
+  "repository": "github:Automattic/woocommerce-payments",
   "engines": {
     "node": ">=8.0.0",
     "npm": ">=6.0.0"


### PR DESCRIPTION
Fixes #126.

#### Changes proposed in this Pull Request

* Add the repository information to [package.json](https://github.com/Automattic/woocommerce-payments/blob/master/package.json).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `npm docs` from the repo's root directory, and make sure it opens the GitHub repository page.
