### PR TITLE
Add wrapper around Jetpack_Client HTTP requests

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -196,9 +196,13 @@ class WC_Payments {
 		require_once dirname( __FILE__ ) . '/wc-payment-api/models/class-wc-payments-api-charge.php';
 		require_once dirname( __FILE__ ) . '/wc-payment-api/models/class-wc-payments-api-intention.php';
 		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-api-client.php';
+		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-http.php';
 
 		// TODO: Don't hard code user agent string.
-		$payments_api_client = new WC_Payments_API_Client( 'WooCommerce Payments/0.2.0' );
+		$payments_api_client = new WC_Payments_API_Client(
+			'WooCommerce Payments/0.1.0',
+			new WC_Payments_Http()
+		);
 
 		return $payments_api_client;
 	}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -36,7 +36,7 @@ class WC_Payments_API_Client {
 	private $account_id;
 
 	/**
-	 * The HTTP request wrapper.
+	 * An HTTP client implementation used to send HTTP requests.
 	 *
 	 * @var WC_Payments_Http
 	 */
@@ -46,7 +46,7 @@ class WC_Payments_API_Client {
 	 * WC_Payments_API_Client constructor.
 	 *
 	 * @param string           $user_agent  - User agent string to report in requests.
-	 * @param WC_Payments_Http $http_client - Function used to send HTTP requests.
+	 * @param WC_Payments_Http $http_client - Used to send HTTP requests.
 	 */
 	public function __construct( $user_agent, $http_client ) {
 		$this->user_agent  = $user_agent;
@@ -232,7 +232,6 @@ class WC_Payments_API_Client {
 		$headers['Content-Type'] = 'application/json; charset=utf-8';
 		$headers['User-Agent']   = $this->user_agent;
 
-		// TODO: Either revamp this auth before releasing WCPay, or properly check that Jetpack is installed & connected.
 		$response = $this->http_client->remote_request(
 			array(
 				'url'     => $url,

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -36,12 +36,21 @@ class WC_Payments_API_Client {
 	private $account_id;
 
 	/**
+	 * The HTTP request wrapper.
+	 *
+	 * @var WC_Payments_Http
+	 */
+	private $http_client;
+
+	/**
 	 * WC_Payments_API_Client constructor.
 	 *
-	 * @param string $user_agent     - User agent string to report in requests.
+	 * @param string           $user_agent  - User agent string to report in requests.
+	 * @param WC_Payments_Http $http_client - Function used to send HTTP requests.
 	 */
-	public function __construct( $user_agent ) {
-		$this->user_agent = $user_agent;
+	public function __construct( $user_agent, $http_client ) {
+		$this->user_agent  = $user_agent;
+		$this->http_client = $http_client;
 	}
 
 	/**
@@ -224,13 +233,11 @@ class WC_Payments_API_Client {
 		$headers['User-Agent']   = $this->user_agent;
 
 		// TODO: Either revamp this auth before releasing WCPay, or properly check that Jetpack is installed & connected.
-		$response = Jetpack_Client::remote_request(
+		$response = $this->http_client->remote_request(
 			array(
 				'url'     => $url,
 				'method'  => $method,
 				'headers' => $headers,
-				'blog_id' => Jetpack_Options::get_option( 'id' ),
-				'user_id' => JETPACK_MASTER_USER,
 			),
 			$body
 		);

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -25,6 +25,7 @@ class WC_Payments_Http {
 	public function remote_request( $args, $body = null ) {
 		$args['blog_id'] = Jetpack_Options::get_option( 'id' );
 		$args['user_id'] = JETPACK_MASTER_USER;
+		// TODO: Either revamp this auth before releasing WCPay, or properly check that Jetpack is installed & connected.
 		return Jetpack_Client::remote_request( $args, $body );
 	}
 }

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * WC_Payments_Http class.
+ *
+ * @package WooCommerce\Payments
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * A wrapper around Jetpack HTTP request library. Necessary to increase
+ * the testability of WC_Payments_API_Client, and allow dependency
+ * injection.
+ */
+class WC_Payments_Http {
+
+	/**
+	 * Sends a remote request through Jetpack (?).
+	 *
+	 * @param array  $args - The arguments to passed to Jetpack.
+	 * @param string $body - The body passed on to the HTTP request.
+	 *
+	 * @return WP_Error|array HTTP response on success.
+	 */
+	public function remote_request( $args, $body = null ) {
+		$args['blog_id'] = Jetpack_Options::get_option( 'id' );
+		$args['user_id'] = JETPACK_MASTER_USER;
+		return Jetpack_Client::remote_request( $args, $body );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,6 +39,7 @@ function _manually_load_plugin() {
 
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/models/class-wc-payments-api-charge.php';
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-api-client.php';
+	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-http.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -20,7 +20,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 	/**
 	 * Mock HTTP client
 	 *
-	 * @var WP_Http|PHPUnit_Framework_MockObject_MockObject
+	 * @var WC_Payments_Http|PHPUnit_Framework_MockObject_MockObject
 	 */
 	private $mock_http_client;
 
@@ -30,14 +30,14 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->mock_http_client = $this->getMockBuilder( 'WP_Http' )
+		$this->mock_http_client = $this->getMockBuilder( 'WC_Payments_Http' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'request' ) )
+			->setMethods( array( 'remote_request' ) )
 			->getMock();
 
 		$this->payments_api_client = new WC_Payments_API_Client(
-			$this->mock_http_client,
-			'Unit Test Agent/0.1.0'
+			'Unit Test Agent/0.1.0',
+			$this->mock_http_client
 		);
 
 		$this->payments_api_client->set_account_id( 'test_acc_id_12345' );
@@ -49,12 +49,10 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 	 * @throws Exception - In the event of test failure.
 	 */
 	public function test_create_charge_success() {
-		$this->markTestSkipped( 'Revisit once Jetpack Client dependency has been abstracted out of API client' );
-
 		// Mock up a test response from WP_Http.
 		$this->mock_http_client
 			->expects( $this->any() )
-			->method( 'request' )
+			->method( 'remote_request' )
 			->will(
 				$this->returnValue(
 					array(

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -18,7 +18,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 	private $payments_api_client;
 
 	/**
-	 * Mock HTTP client
+	 * Mock HTTP client.
 	 *
 	 * @var WC_Payments_Http|PHPUnit_Framework_MockObject_MockObject
 	 */

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -87,6 +87,9 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 	 * @throws Exception - In the event of test failure.
 	 */
 	public function test_create_intention_success() {
+		$expected_amount = 123;
+		$expected_status = 'succeeded';
+
 		$this->mock_http_client
 			->expects( $this->any() )
 			->method( 'remote_request' )
@@ -97,9 +100,9 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 						'body'     => wp_json_encode(
 							array(
 								'id'      => 'test_transaction_id',
-								'amount'  => 123,
+								'amount'  => $expected_amount,
 								'created' => 1557224304,
-								'status'  => 'succeeded',
+								'status'  => $expected_status,
 							)
 						),
 						'response' => array(
@@ -113,7 +116,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 			);
 
 		$result = $this->payments_api_client->create_and_confirm_intention( 123, 'usd', 'cash', 'pm_123456789' );
-		$this->assertEquals( 'succeeded', $result->get_status() );
-		$this->assertEquals( '123', $result->get_amount() );
+		$this->assertEquals( $expected_amount, $result->get_amount() );
+		$this->assertEquals( $expected_status, $result->get_status() );
 	}
 }

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -87,8 +87,6 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 	 * @throws Exception - In the event of test failure.
 	 */
 	public function test_create_intention_success() {
-		$this->markTestSkipped( 'Revisit once Jetpack Client dependency has been abstracted out of API client' );
-
 		$this->mock_http_client
 			->expects( $this->any() )
 			->method( 'remote_request' )
@@ -114,7 +112,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 				)
 			);
 
-		$result = $this->payments_api_client->create_intention( 123, 'usd', 'cash', 'pm_123456789' );
+		$result = $this->payments_api_client->create_and_confirm_intention( 123, 'usd', 'cash', 'pm_123456789' );
 		$this->assertEquals( 'succeeded', $result->get_status() );
 		$this->assertEquals( '123', $result->get_amount() );
 	}

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -115,7 +115,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 				)
 			);
 
-		$result = $this->payments_api_client->create_and_confirm_intention( 123, 'usd', 'cash', 'pm_123456789' );
+		$result = $this->payments_api_client->create_and_confirm_intention( 123, 'usd', 'pm_123456789' );
 		$this->assertEquals( $expected_amount, $result->get_amount() );
 		$this->assertEquals( $expected_status, $result->get_status() );
 	}


### PR DESCRIPTION
Fixes #73.

#### Changes proposed in this Pull Request

* Add a wrapper around `Jetpack_Client` calls in the Payments API Client and inject that dependency during API Client construction.

This will allow us to use a mocked HTTP client in unit tests, which will make it easier to test the API client.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run unit tests to make sure mocked client works as intended.
* Checkout an order, and make sure HTTP requests are handled correctly.