### PR TITLE
Use Jetpack Connection to authenticate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,10 @@
     "prefer-stable": true,
     "minimum-stability": "dev",
     "require": {
-      "composer/installers": "1.6.0"
+      "composer/installers": "1.6.0",
+      "automattic/jetpack-connection": "@dev",
+      "automattic/jetpack-constants": "@dev",
+      "automattic/jetpack-options": "@dev"
     },
     "require-dev": {
       "phpunit/phpunit": "6.5.13",
@@ -30,5 +33,11 @@
         "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
         "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
       }
-    }
-  }
+    },
+    "repositories": [
+      {
+        "type": "path",
+        "url": "/Users/daniel/Projects/jetpack/packages/*"
+      }
+    ]
+}

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,10 @@
     "repositories": [
       {
         "type": "path",
-        "url": "/Users/daniel/Projects/jetpack/packages/*"
+        "url": "/Users/daniel/Projects/jetpack/packages/*",
+        "options": {
+            "symlink": false
+        }
       }
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     "require": {
       "composer/installers": "1.6.0",
       "automattic/jetpack-connection": "@dev",
-      "automattic/jetpack-constants": "@dev",
       "automattic/jetpack-options": "@dev"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6934398511205543d8dbddf66101fac9",
+    "content-hash": "f27b21b3abdf3d0be3c72506b3574579",
     "packages": [
         {
             "name": "automattic/jetpack-connection",
@@ -2101,7 +2101,6 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "automattic/jetpack-connection": 20,
-        "automattic/jetpack-constants": 20,
         "automattic/jetpack-options": 20
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,98 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b0025eb557d1cde6be826cf8f1aa2cc1",
+    "content-hash": "6934398511205543d8dbddf66101fac9",
     "packages": [
+        {
+            "name": "automattic/jetpack-connection",
+            "version": "dev-master",
+            "dist": {
+                "type": "path",
+                "url": "/Users/daniel/Projects/jetpack/packages/connection",
+                "reference": "0a0e293d73c17d59376590d56e5667b169d26877"
+            },
+            "require": {
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-options": "@dev"
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Connection\\": "src"
+                },
+                "classmap": [
+                    "legacy"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything needed to connect to the Jetpack infrastructure"
+        },
+        {
+            "name": "automattic/jetpack-constants",
+            "version": "dev-master",
+            "dist": {
+                "type": "path",
+                "url": "/Users/daniel/Projects/jetpack/packages/constants",
+                "reference": "a6ab6360f4b48962ec7d62b06b39d1470b1dbe95"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A wrapper for defining constants in a more testable way."
+        },
+        {
+            "name": "automattic/jetpack-options",
+            "version": "dev-master",
+            "dist": {
+                "type": "path",
+                "url": "/Users/daniel/Projects/jetpack/packages/options",
+                "reference": "78220bf7d3c1a3a5ed4edb77462e84982b3c408f"
+            },
+            "require": {
+                "automattic/jetpack-constants": "@dev"
+            },
+            "require-dev": {
+                "10up/wp_mock": "0.4.2",
+                "phpunit/phpunit": "7.*.*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "legacy"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A wrapper for wp-options to manage specific Jetpack options."
+        },
         {
             "name": "composer/installers",
             "version": "v1.6.0",
@@ -1968,12 +2058,12 @@
             "version": "1.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
                 "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
                 "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
                 "shasum": ""
             },
@@ -2009,7 +2099,11 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "automattic/jetpack-connection": 20,
+        "automattic/jetpack-constants": 20,
+        "automattic/jetpack-options": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,16 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f27b21b3abdf3d0be3c72506b3574579",
+    "content-hash": "177654fe6d6140b61e7941a1fc4c90d9",
     "packages": [
         {
             "name": "automattic/jetpack-connection",
-            "version": "dev-master",
+            "version": "dev-try/connection-package-fix",
             "dist": {
                 "type": "path",
-                "url": "/Users/daniel/Projects/jetpack/packages/connection",
-                "reference": "0a0e293d73c17d59376590d56e5667b169d26877"
+                "url": "/Users/rado/Desktop/jetpack/packages/connection",
+                "reference": "38e6f5458ed6df52514aafcb3760e4716beea5db",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -40,15 +41,19 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Everything needed to connect to the Jetpack infrastructure"
+            "description": "Everything needed to connect to the Jetpack infrastructure",
+            "transport-options": {
+                "symlink": false
+            }
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-master",
+            "version": "dev-try/connection-package-fix",
             "dist": {
                 "type": "path",
-                "url": "/Users/daniel/Projects/jetpack/packages/constants",
-                "reference": "a6ab6360f4b48962ec7d62b06b39d1470b1dbe95"
+                "url": "/Users/rado/Desktop/jetpack/packages/constants",
+                "reference": "5a262dd5c59892dca9701efeeabc27a599130179",
+                "shasum": null
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
@@ -68,15 +73,19 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "A wrapper for defining constants in a more testable way."
+            "description": "A wrapper for defining constants in a more testable way.",
+            "transport-options": {
+                "symlink": false
+            }
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "dev-master",
+            "version": "dev-try/connection-package-fix",
             "dist": {
                 "type": "path",
-                "url": "/Users/daniel/Projects/jetpack/packages/options",
-                "reference": "78220bf7d3c1a3a5ed4edb77462e84982b3c408f"
+                "url": "/Users/rado/Desktop/jetpack/packages/options",
+                "reference": "26627ba39e991f22e003e40c2589b137bd5e4540",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -94,7 +103,10 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "A wrapper for wp-options to manage specific Jetpack options."
+            "description": "A wrapper for wp-options to manage specific Jetpack options.",
+            "transport-options": {
+                "symlink": false
+            }
         },
         {
             "name": "composer/installers",
@@ -286,27 +298,29 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "^6.2.3",
-                "squizlabs/php_codesniffer": "^3.0.2"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -331,25 +345,25 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2017-07-22T11:58:36+00:00"
+            "time": "2019-03-17T17:37:11+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.8.1",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8"
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
-                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
                 "shasum": ""
             },
             "require": {
@@ -384,7 +398,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2018-06-11T23:09:50+00:00"
+            "time": "2019-04-07T13:18:21+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -490,16 +504,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.1.1",
+            "version": "9.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "2b63c5d284ab8857f7b1d5c240ddb507a6b2293c"
+                "reference": "3db1bf1e28123fd574a4ae2e9a84072826d51b5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/2b63c5d284ab8857f7b1d5c240ddb507a6b2293c",
-                "reference": "2b63c5d284ab8857f7b1d5c240ddb507a6b2293c",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/3db1bf1e28123fd574a4ae2e9a84072826d51b5e",
+                "reference": "3db1bf1e28123fd574a4ae2e9a84072826d51b5e",
                 "shasum": ""
             },
             "require": {
@@ -513,7 +527,7 @@
                 "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -544,7 +558,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-12-30T23:16:27+00:00"
+            "time": "2019-06-27T19:58:56+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
@@ -702,16 +716,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.0",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
                 "shasum": ""
             },
             "require": {
@@ -749,7 +763,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30T07:14:17+00:00"
+            "time": "2019-04-30T17:48:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -800,16 +814,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
                 "shasum": ""
             },
             "require": {
@@ -830,8 +844,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -859,7 +873,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-08-05T17:53:17+00:00"
+            "time": "2019-06-13T12:50:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1815,16 +1829,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.4.0",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "379deb987e26c7cd103a7b387aea178baec96e48"
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/379deb987e26c7cd103a7b387aea178baec96e48",
-                "reference": "379deb987e26c7cd103a7b387aea178baec96e48",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
                 "shasum": ""
             },
             "require": {
@@ -1857,25 +1871,25 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-12-19T23:57:18+00:00"
+            "time": "2019-04-10T23:49:02+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+                "reference": "82ebae02209c21113908c229e9883c419720738a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
+                "reference": "82ebae02209c21113908c229e9883c419720738a",
                 "shasum": ""
             },
             "require": {
@@ -1887,7 +1901,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -1909,7 +1923,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -1920,20 +1934,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.1.0",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
                 "shasum": ""
             },
             "require": {
@@ -1960,7 +1974,7 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07T12:08:54+00:00"
+            "time": "2019-06-13T22:48:21+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -56,6 +56,9 @@ class WC_Payments {
 		}
 
 		add_action( 'rest_api_init', array( __CLASS__, 'init_rest_api' ) );
+
+		$jetpack_connection = new Automattic\Jetpack\Connection\Manager();
+		$jetpack_connection->init();
 	}
 
 	/**

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -170,7 +170,7 @@ class WC_Payments_API_Client {
 				'method'  => $method,
 				'headers' => $headers,
 				'blog_id' => Jetpack_Options::get_option( 'id' ),
-				'user_id' => true, // Automattic\Jetpack\Constants::get_constant( 'JETPACK_MASTER_USER' ),
+				'user_id' => Automattic\Jetpack\Connection\Manager::JETPACK_MASTER_USER,
 			),
 			$body
 		);

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -164,13 +164,13 @@ class WC_Payments_API_Client {
 		$headers['User-Agent']   = $this->user_agent;
 
 		// TODO: Either revamp this auth before releasing WCPay, or properly check that Jetpack is installed & connected.
-		$response = Jetpack_Client::remote_request(
+		$response = Automattic\Jetpack\Connection\Client::remote_request(
 			array(
 				'url'     => $url,
 				'method'  => $method,
 				'headers' => $headers,
 				'blog_id' => Jetpack_Options::get_option( 'id' ),
-				'user_id' => JETPACK_MASTER_USER,
+				'user_id' => true, // Automattic\Jetpack\Constants::get_constant( 'JETPACK_MASTER_USER' ),
 			),
 			$body
 		);

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,8 +9,8 @@
 	<exclude-pattern>*\.(?!php$)</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="4.7" />
-	<config name="testVersion" value="5.2-" />
+	<config name="minimum_supported_wp_version" value="5.0" />
+	<config name="testVersion" value="5.3-" />
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" >

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -19,6 +19,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+require_once dirname( __FILE__ ) . '/vendor/autoload.php';
+
 define( 'WCPAY_PLUGIN_FILE', __FILE__ );
 define( 'WCPAY_ABSPATH', dirname( WCPAY_PLUGIN_FILE ) . '/' );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/111

Quick & dirty `try` branch, let's not merge it by accident :)

Setup:
- Deactivate Jetpack in your site (don't uninstall it, I think that clears the tokens).
- Go to your `wp-content/plugins` folder and delete the `jetpack` folder. You can also just move it to someplace else.
- Clone the Jetpack repo on a completely different path in your machine (or move the `jetpack` folder there), update it to the `try/connection-package-fix` branch.
- Update WCPay to this branch.
- Edit line 39 on `composer.json` so it points to the path where you cloned `jetpack`.
- Run `composer install`, it will say that it created a bunch of symlinks to the `jetpack/packages/[...]` folders.
- Run `npm run watch`.
- Go to the `Payments` section on WP-Admin, you should see a list of transactions correctly fetched all the way from WPCOM :)

See https://github.com/Automattic/jetpack/commit/ca4cdd56658a0028374d180c2fb8d3eb695e5a28 for the changes I had to make in `jetpack` just to make it work. I based that commit off the https://github.com/Automattic/jetpack/pull/12699 PR.

This just works if there's already a Jetpack token in the database, so it will only work if you had the full fat Jetpack plugin correctly connected and you deactivated it as said in the instructions.

Sometimes, the Connection package would just work if `jetpack` the plugin was deactivated but still in `wp-content/plugins`, because the code would still be there. That's why I recommend you completely remove it, to eliminate false positives.

Communication from WPCOM to the site doesn't work, so forget about managing your WCPay site from Calypso.

Edit: ~I based this branch off `add/link-to-order-in-transaction` because right now there's no place in `master` to test that a connection works as easily as this: just go to the transactions list, see if it loads a bunch of data, you're done.~ Now the list transactions code is in `master`, so I rebased this branch.

cc/ @zinigor @marcinbot @v18 @allendav @RadoslavGeorgiev