### PR TITLE
Enable 3DS verification during checkout

### DIFF
--- a/assets/js/wc-payment-checkout.js
+++ b/assets/js/wc-payment-checkout.js
@@ -122,8 +122,10 @@ jQuery( function() {
 				jQuery( '.woocommerce-checkout' ).submit();
 			} )
 			.catch( function( error ) {
+				var errorMessage = error.userMessage || wc_payment_config.default_payment_error_message;
+
 				var displayError = document.getElementById( 'wc-payment-errors' );
-				displayError.textContent = error.message;
+				displayError.textContent = errorMessage;
 
 				console.log('Error processing payment:', error);
 

--- a/assets/js/wc-payment-checkout.js
+++ b/assets/js/wc-payment-checkout.js
@@ -39,6 +39,18 @@ jQuery( function() {
 			return;
 		}
 
+		// Block the checkout form while we process the payment
+		var $checkout_form = jQuery('form.checkout.woocommerce-checkout');
+		if ( 1 !== $checkout_form.data('blockUI.isBlocked') ) {
+			$checkout_form.block( {
+				message: null,
+				overlayCSS: {
+					background: '#fff',
+					opacity: 0.6
+				}
+			} );
+		}
+
 		stripe.createPaymentMethod( 'card', cardElement )
 			.then( function( result ) {
 				var paymentMethod = result.paymentMethod;
@@ -113,6 +125,8 @@ jQuery( function() {
 				displayError.textContent = error.message;
 
 				console.log('Error processing payment:', error);
+
+				$checkout_form.unblock();
 			} );
 
 		// Prevent form submission so that we can fire it once a payment method has been generated.

--- a/assets/js/wc-payment-checkout.js
+++ b/assets/js/wc-payment-checkout.js
@@ -70,6 +70,7 @@ jQuery( function() {
 					{
 						action: 'create_payment_intention',
 						wc_payment_method_id: paymentMethodId,
+						_ajax_nonce: wc_payment_config.create_payment_intention_nonce,
 					}
 				);
 			} )

--- a/assets/js/wc-payment-checkout.js
+++ b/assets/js/wc-payment-checkout.js
@@ -51,18 +51,19 @@ jQuery( function() {
 				return paymentMethod;
 			} )
 			.then( function( paymentMethod ) {
-				var id = paymentMethod.id;
+				var paymentMethodId = paymentMethod.id;
 
 				// Flag that the payment method has been successfully generated so that we can allow the form
 				// submission next time.
 				paymentMethodGenerated = true;
 
-				// Populate form with the payment method.
-				var paymentMethodInput   = document.getElementById( 'wc-payment-method' );
-				paymentMethodInput.value = id;
-
-				// Re-submit the form.
-				jQuery( '.woocommerce-checkout' ).submit();
+				return jQuery.post(
+					wc_payment_config.ajaxurl,
+					{
+						action: 'create_payment_intention',
+						wc_payment_method_id: paymentMethodId,
+					}
+				);
 			} );
 
 		// Prevent form submission so that we can fire it once a payment method has been generated.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -145,9 +145,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public function payment_fields() {
 		// Add JavaScript for the payment form.
 		$js_config = array(
-			'publishableKey' => $this->publishable_key,
-			'accountId'      => $this->get_option( 'stripe_account_id' ),
-			'ajaxurl'        => WC_AJAX::get_endpoint( 'create_payment_intention' ),
+			'publishableKey'                 => $this->publishable_key,
+			'accountId'                      => $this->get_option( 'stripe_account_id' ),
+			'ajaxurl'                        => WC_AJAX::get_endpoint( 'create_payment_intention' ),
+			'create_payment_intention_nonce' => wp_create_nonce( 'woocommerce-payments-create-payment-intention' ),
 		);
 
 		// Register Stripe's JavaScript using the same ID as the Stripe Gateway plugin. This prevents this JS being
@@ -294,14 +295,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @throws Exception - If no payment method ID is found.
 	 */
 	private function get_payment_method_id_from_request() {
-		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		check_ajax_referer( 'woocommerce-payments-create-payment-intention' );
+
 		if ( ! isset( $_POST['wc_payment_method_id'] ) ) {
 			// If no payment method ID is set then stop here with an error.
 			throw new Exception( __( 'Payment method ID not found.', 'woocommerce-payments' ) );
 		}
 
 		$payment_method_id = wc_clean( $_POST['wc_payment_method_id'] ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
 
 		return $payment_method_id;
 	}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -149,6 +149,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'accountId'                      => $this->get_option( 'stripe_account_id' ),
 			'ajaxurl'                        => WC_AJAX::get_endpoint( 'create_payment_intention' ),
 			'create_payment_intention_nonce' => wp_create_nonce( 'woocommerce-payments-create-payment-intention' ),
+			'default_payment_error_message'  => __( 'There was a problem with your payment.', 'woocommerce-services' ),
 		);
 
 		// Register Stripe's JavaScript using the same ID as the Stripe Gateway plugin. This prevents this JS being
@@ -221,7 +222,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		} catch ( Exception $e ) {
 			wp_send_json_error(
 				array(
-					'message' => __( 'There was a problem with your payment.', 'woocommerce-payments' ),
+					'userMessage' => __( 'There was a problem with your payment.', 'woocommerce-payments' ),
 				)
 			);
 		}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -94,11 +94,12 @@ class WC_Payments_API_Client {
 	 */
 	public function create_and_confirm_intention( $amount, $currency_code, $payment_method_id ) {
 		// TODO: There's scope to have amount and currency bundled up into an object.
-		$request                   = array();
-		$request['amount']         = $amount;
-		$request['currency']       = $currency_code;
-		$request['confirm']        = 'true';
-		$request['payment_method'] = $payment_method_id;
+		$request                        = array();
+		$request['amount']              = $amount;
+		$request['currency']            = $currency_code;
+		$request['confirm']             = 'true';
+		$request['payment_method']      = $payment_method_id;
+		$request['confirmation_method'] = 'manual';
 
 		$response_array = $this->request( $request, self::INTENTIONS_API, self::POST );
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -317,7 +317,7 @@ class WC_Payments_API_Client {
 		$created = new DateTime();
 		$created->setTimestamp( $intention_array['created'] );
 
-		$intent = new WC_Payments_API_Intention(
+		$intention = new WC_Payments_API_Intention(
 			$intention_array['id'],
 			$intention_array['amount'],
 			$created,
@@ -325,6 +325,6 @@ class WC_Payments_API_Client {
 			$intention_array['client_secret']
 		);
 
-		return $intent;
+		return $intention;
 	}
 }

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -109,22 +109,38 @@ class WC_Payments_API_Client {
 	/**
 	 * Confirm an intention
 	 *
-	 * @param WC_Payments_API_Intention $intent            - The intention to confirm.
-	 * @param string                    $payment_method_id - ID of payment method to process charge with.
+	 * @param WC_Payments_API_Intention $intention - The intention ID to confirm.
 	 *
 	 * @return WC_Payments_API_Intention
 	 * @throws Exception - Exception thrown on intention confirmation failure.
 	 */
-	public function confirm_intention( WC_Payments_API_Intention $intent, $payment_method_id ) {
-		$request                   = array();
-		$request['payment_method'] = $payment_method_id;
+	public function confirm_intention( WC_Payments_API_Intention $intention ) {
+		$request = array();
 
 		$response_array = $this->request(
 			$request,
-			self::INTENTIONS_API . '/' . $intent->get_id() . '/confirm',
+			self::INTENTIONS_API . '/' . $intention->get_id() . '/confirm',
 			self::POST
 		);
+		return $this->deserialize_intention_object_from_array( $response_array );
+	}
 
+	/**
+	 * Retrieve an intention
+	 *
+	 * @param string $payment_intention_id - The intention ID to retrieve.
+	 *
+	 * @return WC_Payments_API_Intention
+	 * @throws Exception - Exception thrown on intention confirmation failure.
+	 */
+	public function retrieve_intention( $payment_intention_id ) {
+		$request = array();
+
+		$response_array = $this->request(
+			$request,
+			self::INTENTIONS_API . '/' . $payment_intention_id,
+			self::GET
+		);
 		return $this->deserialize_intention_object_from_array( $response_array );
 	}
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -304,7 +304,8 @@ class WC_Payments_API_Client {
 			$intention_array['id'],
 			$intention_array['amount'],
 			$created,
-			$intention_array['status']
+			$intention_array['status'],
+			$intention_array['client_secret']
 		);
 
 		return $intent;

--- a/includes/wc-payment-api/models/class-wc-payments-api-intention.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-intention.php
@@ -41,18 +41,27 @@ class WC_Payments_API_Intention {
 	private $status;
 
 	/**
+	 * The status of the intention
+	 *
+	 * @var string
+	 */
+	private $client_secret;
+
+	/**
 	 * WC_Payments_API_Intention constructor.
 	 *
-	 * @param string   $id      - ID of the charge.
-	 * @param integer  $amount  - Amount charged.
-	 * @param DateTime $created - Time charge created.
-	 * @param string   $status  - Intention status.
+	 * @param string   $id             - ID of the charge.
+	 * @param integer  $amount         - Amount charged.
+	 * @param DateTime $created        - Time charge created.
+	 * @param string   $status         - Intention status.
+	 * @param string   $client_secret  - Client secret.
 	 */
-	public function __construct( $id, $amount, DateTime $created, $status ) {
-		$this->id      = $id;
-		$this->amount  = $amount;
-		$this->created = $created;
-		$this->status  = $status;
+	public function __construct( $id, $amount, DateTime $created, $status, $client_secret ) {
+		$this->id            = $id;
+		$this->amount        = $amount;
+		$this->created       = $created;
+		$this->status        = $status;
+		$this->client_secret = $client_secret;
 	}
 
 	/**
@@ -89,5 +98,14 @@ class WC_Payments_API_Intention {
 	 */
 	public function get_status() {
 		return $this->status;
+	}
+
+	/**
+	 * Gets client secret
+	 *
+	 * @return string
+	 */
+	public function get_client_secret() {
+		return $this->client_secret;
 	}
 }

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -87,8 +87,9 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 	 * @throws Exception - In the event of test failure.
 	 */
 	public function test_create_intention_success() {
-		$expected_amount = 123;
-		$expected_status = 'succeeded';
+		$expected_amount        = 123;
+		$expected_status        = 'succeeded';
+		$expected_client_secret = 'test_client_secret';
 
 		$this->mock_http_client
 			->expects( $this->any() )
@@ -99,10 +100,11 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 						'headers'  => array(),
 						'body'     => wp_json_encode(
 							array(
-								'id'      => 'test_transaction_id',
-								'amount'  => $expected_amount,
-								'created' => 1557224304,
-								'status'  => $expected_status,
+								'id'            => 'test_transaction_id',
+								'amount'        => $expected_amount,
+								'created'       => 1557224304,
+								'status'        => $expected_status,
+								'client_secret' => $expected_client_secret,
 							)
 						),
 						'response' => array(
@@ -118,5 +120,6 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 		$result = $this->payments_api_client->create_and_confirm_intention( 123, 'usd', 'pm_123456789' );
 		$this->assertEquals( $expected_amount, $result->get_amount() );
 		$this->assertEquals( $expected_status, $result->get_status() );
+		$this->assertEquals( $expected_client_secret, $result->get_client_secret() );
 	}
 }


### PR DESCRIPTION
Closes #90

### Summary of changes

3DS support was added using the manual confirmation flow:

https://stripe.com/docs/payments/payment-intents/quickstart#manual-confirmation-flow

The whole checkout process looks like this now:

1. Customer checks out ('Place Order') 
2. WooCommerce triggers the handler for the event `checkout_place_order_woocommerce_payments` ([ref](https://github.com/woocommerce/woocommerce/blob/307096178304d62b8f927f27c64b375986192744/assets/js/frontend/checkout.js#L443)). If the handler returns false, then the check out does not proceed. This is what happens while we wait for a response from Stripe about whether or not the form requires additional verification in our event handler.
3. After we get back a response from Stripe, it either needs extra verification or not. If it does, we ask the user for it using `handleCardAction` ([ref](https://github.com/Automattic/woocommerce-payments/compare/Automattic:f9ad486...Automattic:e839f73#diff-ca240674e46858808b4eecceae9d70ccR74))
4. After any extra verification is done, the form is re-submitted ([ref](https://github.com/Automattic/woocommerce-payments/compare/Automattic:f9ad486...Automattic:e839f73#diff-ca240674e46858808b4eecceae9d70ccR83))
5. This time our event handler does not return false so the checkout goes through, and `process_payment` is called.

#### Still to do, part of this PR:

- [x] make sure that cart is blocked when submitting payment, before processing payment
- [x] security: escape variables, etc

#### To do, not part of this PR:

- [x] handle response errors from Stripe in `start_payment_process`
- [x] handle failed verification
- [x] handle response errors from Stripe after `process_payment`
- add unit tests for js - #159 
- add unit tests for `deserialize_intention_object_from_array` et al
- handle the case where the payment fails and the user does not refresh the page before re-submitting the form - #160

### Testing instructions

1. Add some products to cart
2. Check out using WCS with a test credit card requiring verification, [a list is here](https://stripe.com/docs/payments/3d-secure#three-ds-cards)