### PR TITLE
Expose Apache logs to the Docker host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ contributors.md
 # Volumes mounted by Docker containers
 docker/data
 docker/wordpress
+docker/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - default.env
     volumes:
       - ./docker/wordpress:/var/www/html/
+      - ./docker/logs/apache2/:/var/log/apache2
       - .:/var/www/html/wp-content/plugins/woocommerce-payments
   db:
     container_name: woocommerce_payments_mysql


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Map the Apache logs folder to the host so that developers can easily access them

#### Testing instructions

* `docker-compose down` (if already running)
* `docker-compose up -d`
* Web server log files should be created in `docker/logs/apache2/`