### PR TITLE
Docker setup: Install and activate WooCommerce Admin and Jetpack

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -51,6 +51,12 @@ cli wp plugin install wordpress-importer --activate
 echo "Importing some sample data..."
 cli wp import wp-content/plugins/woocommerce/sample-data/sample_products.xml --authors=skip
 
+echo "Installing and activating the WooCommerce Admin plugin..."
+cli wp plugin install woocommerce-admin --activate
+
+echo "Installing and activating the Jetpack plugin..."
+cli wp plugin install jetpack --activate
+
 echo "Activating the WooCommerce Payments plugin..."
 cli wp plugin activate woocommerce-payments
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Installs Jetpack and WooCommerce Admin as part of the Docker setup. This will need changing in future as we develop the authentication with WP.com further, but for now it's nice to have everything ready to go.

#### Testing instructions

* From a fresh install or after running `docker-compose down` and deleting the `docker/wordpress` and `docker/data` folders.
* Run setup as normal.
* Jetpack and WooCommerce Admin plugins should be present and active once complete.
