### PR TITLE
Run all code on page load instead of after updated_checkout event

### DIFF
--- a/assets/js/wc-payment-checkout.js
+++ b/assets/js/wc-payment-checkout.js
@@ -1,5 +1,7 @@
-// Setup the Stripe elements when the checkout page is updated.
-jQuery( document.body ).on( 'updated_checkout', function() {
+/* global jQuery, Stripe, wc_payment_config */
+jQuery( function() {
+	'use strict';
+
 	var stripe   = new Stripe( wc_payment_config.publishableKey, {
 		stripeAccount: wc_payment_config.accountId
 	} );
@@ -9,7 +11,14 @@ jQuery( document.body ).on( 'updated_checkout', function() {
 	var cardElement = elements.create( 'card', {
 		hidePostalCode: true
 	} );
-	cardElement.mount( '#wc-payment-card-element' );
+
+	// Only attempt to mount the card element once that section of the page has loaded. We can use the updated_checkout
+	// event for this. This part of the page can also reload based on changes to checkout details, so we call unmount
+	// first to ensure the card element is re-mounted correctly.
+	jQuery( document.body ).on( 'updated_checkout', function() {
+		cardElement.unmount();
+		cardElement.mount( '#wc-payment-card-element' );
+	} );
 
 	// Update the validation state based on the element's state.
 	cardElement.addEventListener( 'change', function(event) {


### PR DESCRIPTION
Fixes #84

#### Changes proposed in this Pull Request

Setup everything before the `updated_checkout` event runs. The only thing we need to do inside that event is mount / unmount / re-mount the card element as appropriate.

I'd like to hold off on merging this until #133 is merged, since that makes a lot of changes here. It'll be easier to apply my changes to that than visa versa.

I might take the chance to re-factor the checkout JavaScript to be more inline with the existing Stripe extension as well. I think the code in #133 will push us over the point where that will become worthwhile.

#### Testing instructions

1. Add an item to your cart
2. Go to checkout
3. Select the "Credit Card (WooCommerce Payments)" payment method if not already selected
4. Change the country on the billing details
5. Complete checkout
6. The order is created and the transaction appears in Stripe
