### PR TITLE
Fix 2 Travis tests: mysql connection, WC_Payments_API_Intention missing class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ php:
   - 7.2
   - 7.3
 
+services:
+  - mysql
 
 # Different stages in order to only deploy when everything succeeds
 stages:

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,6 +38,7 @@ function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/woocommerce-payments.php';
 
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/models/class-wc-payments-api-charge.php';
+	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/models/class-wc-payments-api-intention.php';
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-api-client.php';
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-http.php';
 }


### PR DESCRIPTION
## This PR fixes 2 different issues currently affecting Travis test builds

1. MySQL connection issue:

```
+mysqladmin create woocommerce_test --user=root --password= --host=localhost --protocol=tcp
mysqladmin: [Warning] Using a password on the command line interface can be insecure.
mysqladmin: connect to server at 'localhost' failed
error: 'Can't connect to MySQL server on 'localhost' (111)'
```

Closes #144

2. The sometimes-intermittent missing `WC_Payments_API_Intention` class:

```
WC_Payments_API_Client_Test::test_create_intention_success
Error: Class 'WC_Payments_API_Intention' not found
```

## This PR does not fix the 7.0 failures

The error is this for tests with PHP 7.0:

```
$ bash bin/phpunit.sh
PHPUnit 7.5.0 by Sebastian Bergmann and contributors.
This version of PHPUnit is supported on PHP 7.1 and PHP 7.2.
You are using PHP 7.0.33 (/home/travis/.phpenv/versions/7.0.33/bin/php).
```

I have a solution in mind, but it's not working yet. For the curious, it's in branch `branch-testing/fix/tests-intention-class-not-found`, the commits can be seen here:

https://github.com/Automattic/woocommerce-payments/commit/5fd05f8b6890cf968d1096a0952e543b973e4cea