### PR TITLE
Check all the plugin dependencies before doing anything else

### DIFF
--- a/includes/class-wc-payments-dependencies-validator.php
+++ b/includes/class-wc-payments-dependencies-validator.php
@@ -1,0 +1,341 @@
+<?php
+/**
+ * Class WC_Payments_Dependencies_Validator
+ *
+ * @package WooCommerce\Payments
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * This class validates that the WordPress site satisfies all of the plugin's requirements. PHP version, WooCommerce installed, etc.
+ */
+class WC_Payments_Dependencies_Validator {
+
+	const WC_PLUGIN_SLUG = 'woocommerce';
+	const WC_PLUGIN_NAME = 'woocommerce/woocommerce.php';
+	const WC_PLUGIN_URL  = 'https://wordpress.org/plugins/woocommerce/';
+
+	const WC_ADMIN_PLUGIN_SLUG = 'woocommerce-admin';
+	const WC_ADMIN_PLUGIN_NAME = 'woocommerce-admin/woocommerce-admin.php';
+	const WC_ADMIN_PLUGIN_URL  = 'https://wordpress.org/plugins/woocommerce-admin/';
+
+	/**
+	 * Checks if all the dependencies needed to run this plugin are present
+	 *
+	 * @param bool $silent True if the function should just return true/false, False if this function should display notice messages for failed dependencies.
+	 * @return bool True if all dependencies are met, false otherwise.
+	 */
+	public function check_plugin_dependencies( $silent ) {
+		foreach ( $this->match_plugin_requirements( $this->get_plugin_requirements() ) as $condition ) {
+			if ( ! $condition['satisfied'] ) {
+				if ( ! $silent ) {
+					$this->display_admin_error( call_user_func_array( array( $this, $condition['get_message'] ), $condition['get_message_args'] ) );
+				}
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Parses the readme.txt file, the plugin header, and some plugin-defined global constants to build a list of
+	 * all the requirements this plugin has.
+	 *
+	 * @return array Associative array with the versions of all the requirements.
+	 */
+	public function get_plugin_requirements() {
+		$plugin_headers = get_file_data(
+			WCPAY_PLUGIN_FILE,
+			array(
+				// Mirrors the functionality on WooCommerce core: https://github.com/woocommerce/woocommerce/blob/ff2eadeccec64aa76abd02c931bf607dd819bbf0/includes/wc-core-functions.php#L1916 .
+				'WCRequires' => 'WC requires at least',
+			)
+		);
+		$readme_headers = get_file_data(
+			WCPAY_ABSPATH . '/readme.txt',
+			array(
+				'requires'     => 'Requires at least',
+				'requires_php' => 'Requires PHP',
+			),
+			'plugin'
+		);
+
+		return array(
+			'wc_version'                   => $plugin_headers['WCRequires'],
+			'wp_version'                   => $readme_headers['requires'],
+			'php_version'                  => $readme_headers['requires_php'],
+			'wc_admin_version'             => WCPAY_WC_ADMIN_VERSION_REQUIRED,
+			'wc_min_version_with_wc_admin' => WCPAY_WC_MIN_VERSION_WITH_WC_ADMIN,
+		);
+	}
+
+	/**
+	 * Prints the given message in an "admin notice" wrapper with "error" class.
+	 *
+	 * @param string $message Message to print. Can contain HTML.
+	 */
+	private function display_admin_error( $message ) {
+		?>
+		<div class="notice notice-error">
+			<p><?php echo $message; // PHPCS:Ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * From a given list of version requirements, this function checks every one of them against the current environment.
+	 *
+	 * @param array $requirements List of required versions, see the get_plugin_requirements method for context.
+	 * @return array List of all the requirements. It should be ordered by priority, because only the first failed requirement will be displayed to the merchant.
+	 * Each requirement will have the following properties:
+	 * - satisfied: true/false Whether the site fulfills this particular requirement or not.
+	 * - get_message: Which method of this class should be called to get the error message that should be displayed to the merchant about this failed requirement.
+	 * - get_message_args: Array of arguments that will be passed to the get_message function.
+	 */
+	public function match_plugin_requirements( $requirements ) {
+		$has_wc_with_bundled_wc_admin = $requirements['wc_min_version_with_wc_admin'] && defined( 'WC_VERSION' ) && version_compare( WC_VERSION, $requirements['wc_min_version_with_wc_admin'], '>=' );
+		return array(
+			// Minimum PHP version.
+			array(
+				'satisfied'        => version_compare( phpversion(), $requirements['php_version'], '>=' ),
+				'get_message'      => 'get_update_php_error_message',
+				'get_message_args' => array(
+					phpversion(),
+					$requirements['php_version'],
+				),
+			),
+			// WooCommerce installed & active.
+			array(
+				'satisfied'        => class_exists( 'WooCommerce' ),
+				'get_message'      => 'get_install_woocommerce_error_message',
+				'get_message_args' => array(
+					current_user_can( 'install_plugins' ),
+					function_exists( 'validate_plugin' ) && 0 === validate_plugin( self::WC_PLUGIN_NAME ),
+				),
+			),
+			// Minimum WooCommerce version.
+			array(
+				'satisfied'        => defined( 'WC_VERSION' ) && version_compare( WC_VERSION, $requirements['wc_version'], '>=' ),
+				'get_message'      => 'get_update_woocommerce_error_message',
+				'get_message_args' => array(
+					defined( 'WC_VERSION' ) ? WC_VERSION : null,
+					$requirements['wc_version'],
+					$requirements['wc_min_version_with_wc_admin'],
+					current_user_can( 'update_plugins' ),
+				),
+			),
+			// Minimum WordPress version.
+			array(
+				'satisfied'        => version_compare( get_bloginfo( 'version' ), $requirements['wp_version'], '>=' ),
+				'get_message'      => 'get_update_wordpress_error_message',
+				'get_message_args' => array(
+					get_bloginfo( 'version' ),
+					$requirements['wp_version'],
+					current_user_can( 'update_core' ),
+				),
+			),
+			// WooCommerce Admin installed & active.
+			array(
+				// This requirement and the next one can be satisfied by installing/updating WC-Admin *or* updating WooCommerce to a version that has WC-Admin bundled in.
+				'satisfied'        => $has_wc_with_bundled_wc_admin || defined( 'WC_ADMIN_VERSION_NUMBER' ),
+				'get_message'      => 'get_install_wc_admin_error_message',
+				'get_message_args' => array(
+					defined( 'WC_VERSION' ) ? WC_VERSION : null,
+					$requirements['wc_min_version_with_wc_admin'],
+					current_user_can( 'install_plugins' ),
+					function_exists( 'validate_plugin' ) && 0 === validate_plugin( self::WC_ADMIN_PLUGIN_NAME ),
+				),
+			),
+			// Minimum WooCommerce Admin version.
+			array(
+				'satisfied'        => $has_wc_with_bundled_wc_admin || ( defined( 'WC_ADMIN_VERSION_NUMBER' ) && version_compare( WC_ADMIN_VERSION_NUMBER, $requirements['wc_admin_version'], '>=' ) ),
+				'get_message'      => 'get_update_wc_admin_error_message',
+				'get_message_args' => array(
+					defined( 'WC_ADMIN_VERSION_NUMBER' ) ? WC_ADMIN_VERSION_NUMBER : null,
+					$requirements['wc_admin_version'],
+					defined( 'WC_VERSION' ) ? WC_VERSION : null,
+					$requirements['wc_min_version_with_wc_admin'],
+					current_user_can( 'update_plugins' ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Build the error message that will be displayed to the merchant if the site is running a version of PHP that's too old.
+	 *
+	 * @param string $current_php_version PHP version the site is using.
+	 * @param string $required_php_version Required PHP version for the plugin to run.
+	 * @return string Error message. Can contain HTML.
+	 */
+	public function get_update_php_error_message( $current_php_version, $required_php_version ) {
+		return sprintf(
+			/* translators: %1: required PHP version number, %2: currently installed PHP version number */
+			__( 'WooCommerce Payments requires <strong>PHP %1$s</strong> or greater (you are using %2$s).', 'woocommerce-payments' ),
+			$required_php_version,
+			$current_php_version
+		);
+	}
+
+	/**
+	 * Build the error message that will be displayed to the merchant if the site doesn't have WooCommerce installed.
+	 *
+	 * @param boolean $can_install_plugin Whether the current user can install plugins or not.
+	 * @param boolean $is_installed Whether WooCommerce is installed (but deactivated), or not installed at all.
+	 * @return string Error message. Can contain HTML.
+	 */
+	public function get_install_woocommerce_error_message( $can_install_plugin, $is_installed ) {
+		$message = sprintf(
+			/* translators: %1: WooCommerce plugin URL */
+			__( 'WooCommerce Payments requires <a href="%1$s">WooCommerce</a> to be installed and active.', 'woocommerce-payments' ),
+			self::WC_PLUGIN_URL
+		);
+
+		if ( $can_install_plugin ) {
+			if ( $is_installed ) {
+				// The plugin is installed, so it just needs to be enabled.
+				$activate_url = wp_nonce_url( admin_url( 'plugins.php?action=activate&plugin=' . self::WC_PLUGIN_NAME ), 'activate-plugin_' . self::WC_PLUGIN_NAME );
+				$message     .= ' <a href="' . $activate_url . '">' . __( 'Activate WooCommerce', 'woocommerce-payments' ) . '</a>';
+			} else {
+				// The plugin is not installed.
+				$activate_url = wp_nonce_url( admin_url( 'update.php?action=install-plugin&plugin=' . self::WC_PLUGIN_SLUG ), 'install-plugin_' . self::WC_PLUGIN_SLUG );
+				$message     .= ' <a href="' . $activate_url . '">' . __( 'Install WooCommerce', 'woocommerce-payments' ) . '</a>';
+			}
+		}
+
+		return $message;
+	}
+
+	/**
+	 * Build the error message that will be displayed to the merchant if the site has a version of WooCommerce that's too old.
+	 *
+	 * @param string       $current_wc_version WooCommerce version the site is using.
+	 * @param string       $required_wc_version Required WooCommerce version for the plugin to run.
+	 * @param string|false $recommended_wc_version Recommenced WooCommerce version. It will be the version that has WC-Admin built-in, or False if there's no WooCommerce version that includes WC-Admin yet.
+	 * @param boolean      $can_update_plugin Whether the current user can update plugins or not.
+	 * @return string Error message. Can contain HTML.
+	 */
+	public function get_update_woocommerce_error_message( $current_wc_version, $required_wc_version, $recommended_wc_version, $can_update_plugin ) {
+		$message = sprintf(
+			/* translators: %1: required WC version number, %2: currently installed WC version number */
+			__( 'WooCommerce Payments requires <strong>WooCommerce %1$s</strong> or greater to be installed (you are using %2$s).', 'woocommerce-payments' ),
+			$required_wc_version,
+			$current_wc_version
+		);
+
+		if ( $recommended_wc_version && $recommended_wc_version !== $required_wc_version ) {
+			$message .= ' ' . sprintf(
+				/* translators: %1: recommended WC version number */
+				__( '<strong>WooCommerce %1$s</strong> or greater is recommended, since it includes all the functionality from the WooCommerce Admin plugin.', 'woocommerce-payments' ),
+				$recommended_wc_version
+			);
+		}
+
+		if ( $can_update_plugin ) {
+			// Take the user to the "plugins" screen instead of trying to update WooCommerce inline. WooCommerce adds important information
+			// on its plugin row regarding the currently installed extensions and their compatibility with the latest WC version.
+			$message .= ' <a href="' . admin_url( 'plugins.php' ) . '">' . __( 'Update WooCommerce', 'woocommerce-payments' ) . '</a>';
+		}
+
+		return $message;
+	}
+
+	/**
+	 * Build the error message that will be displayed to the merchant if the site has a version of WordPress that's too old.
+	 *
+	 * @param string  $current_wp_version WordPress version the site is using.
+	 * @param string  $required_wp_version Required WordPress version for the plugin to run.
+	 * @param boolean $can_update_wp Whether the current user can update WordPress or not.
+	 * @return string Error message. Can contain HTML.
+	 */
+	public function get_update_wordpress_error_message( $current_wp_version, $required_wp_version, $can_update_wp ) {
+		$message = sprintf(
+			/* translators: %1: required WP version number, %2: currently installed WP version number */
+			__( 'WooCommerce Payments requires <strong>WordPress %1$s</strong> or greater (you are using %2$s).', 'woocommerce-payments' ),
+			$required_wp_version,
+			$current_wp_version
+		);
+
+		if ( $can_update_wp ) {
+			$message .= ' <a href="' . admin_url( 'update-core.php' ) . '">' . __( 'Update WordPress', 'woocommerce-payments' ) . '</a>';
+		}
+
+		return $message;
+	}
+
+	/**
+	 * Build the error message that will be displayed to the merchant if the site doesn't have WC-Admin installed.
+	 * If there's a version of WooCommerce that already has WC-Admin built-in, we will recommend the merchant to update WooCommerce instead of installing WC-Admin.
+	 *
+	 * @param string       $current_wc_version WooCommerce version the site is using.
+	 * @param string|false $wc_min_version_with_wc_admin Minimum WooCommerce version that already includes WC-Admin. False if there's no WooCommerce version that includes WC-Admin yet.
+	 * @param boolean      $can_install_plugin Whether the current user can install plugins or not.
+	 * @param boolean      $is_installed Whether WC-Admin is installed (but deactivated), or not installed at all.
+	 * @return string Error message. Can contain HTML.
+	 */
+	public function get_install_wc_admin_error_message( $current_wc_version, $wc_min_version_with_wc_admin, $can_install_plugin, $is_installed ) {
+		if ( $wc_min_version_with_wc_admin ) {
+			$message_wc       = $this->get_update_woocommerce_error_message( $current_wc_version, $wc_min_version_with_wc_admin, null, $can_install_plugin );
+			$message_wc_admin = sprintf(
+				/* translators: %1: WooCommerce Admin plugin URL */
+				__( 'If updating WooCommerce at this moment is inconvenient, you can also use <a href="%1$s">WooCommerce Admin</a> to start using WooCommerce Payments.', 'woocommerce-payments' ),
+				self::WC_ADMIN_PLUGIN_URL
+			);
+		} else {
+			$message_wc_admin = sprintf(
+				/* translators: %1: WooCommerce Admin plugin URL */
+				__( 'WooCommerce Payments requires <a href="%1$s">WooCommerce Admin</a> to be installed and active.', 'woocommerce-payments' ),
+				self::WC_ADMIN_PLUGIN_URL
+			);
+		}
+
+		if ( $can_install_plugin ) {
+			if ( $is_installed ) {
+				// The plugin is installed, so it just needs to be enabled.
+				$activate_url      = wp_nonce_url( admin_url( 'plugins.php?action=activate&plugin=' . self::WC_ADMIN_PLUGIN_NAME ), 'activate-plugin_' . self::WC_ADMIN_PLUGIN_NAME );
+				$message_wc_admin .= ' <a href="' . $activate_url . '">' . __( 'Activate WooCommerce Admin', 'woocommerce-payments' ) . '</a>';
+			} else {
+				// The plugin is not installed.
+				$activate_url      = wp_nonce_url( admin_url( 'update.php?action=install-plugin&plugin=' . self::WC_ADMIN_PLUGIN_SLUG ), 'install-plugin_' . self::WC_ADMIN_PLUGIN_SLUG );
+				$message_wc_admin .= ' <a href="' . $activate_url . '">' . __( 'Install WooCommerce Admin', 'woocommerce-payments' ) . '</a>';
+			}
+		}
+
+		return $wc_min_version_with_wc_admin ? ( $message_wc . '<br/>' . $message_wc_admin ) : $message_wc_admin;
+	}
+
+	/**
+	 * Build the error message that will be displayed to the merchant if the site has an WC-Admin version that's too old.
+	 * If there's a version of WooCommerce that already has WC-Admin built-in, we will recommend the merchant to update WooCommerce instead of updating WC-Admin.
+	 *
+	 * @param string       $current_wc_admin_version WC-Admin version the site is using.
+	 * @param string       $required_wc_admin_version Required WC-Admin version for the plugin to run.
+	 * @param string       $current_wc_version WooCommerce version the site is using.
+	 * @param string|false $wc_min_version_with_wc_admin Minimum WooCommerce version that already includes WC-Admin. False if there's no WooCommerce version that includes WC-Admin yet.
+	 * @param boolean      $can_update_plugin Whether the current user can update plugins or not.
+	 * @return string Error message. Can contain HTML.
+	 */
+	public function get_update_wc_admin_error_message( $current_wc_admin_version, $required_wc_admin_version, $current_wc_version, $wc_min_version_with_wc_admin, $can_update_plugin ) {
+		if ( $wc_min_version_with_wc_admin ) {
+			$message_wc       = $this->get_update_woocommerce_error_message( $current_wc_version, $wc_min_version_with_wc_admin, null, $can_update_plugin );
+			$message_wc_admin = __( 'If updating WooCommerce at this moment is inconvenient, you can also update <strong>WooCommerce Admin</strong> to start using WooCommerce Payments.', 'woocommerce-payments' );
+		} else {
+			$message_wc_admin = sprintf(
+				/* translators: %1: required WC-Admin version number, %2: currently installed WC-Admin version number */
+				__( 'WooCommerce Payments requires <strong>WooCommerce Admin %1$s</strong> or greater to be installed (you are using %2$s).', 'woocommerce-payments' ),
+				$required_wc_admin_version,
+				$current_wc_admin_version
+			);
+		}
+
+		if ( $can_update_plugin ) {
+			$update_url        = wp_nonce_url( admin_url( 'update.php?action=upgrade-plugin&plugin=' . self::WC_ADMIN_PLUGIN_NAME ), 'upgrade-plugin_' . self::WC_ADMIN_PLUGIN_NAME );
+			$message_wc_admin .= ' <a href="' . $update_url . '">' . __( 'Update WooCommerce Admin', 'woocommerce-payments' ) . '</a>';
+		}
+
+		return $wc_min_version_with_wc_admin ? ( $message_wc . '<br/>' . $message_wc_admin ) : $message_wc_admin;
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,6 +41,7 @@ function _manually_load_plugin() {
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/models/class-wc-payments-api-intention.php';
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-api-client.php';
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-http.php';
+	require_once dirname( __FILE__ ) . '/../includes/class-wc-payments-dependencies-validator.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/test-class-wc-payments-dependencies-validator.php
+++ b/tests/test-class-wc-payments-dependencies-validator.php
@@ -1,0 +1,535 @@
+<?php
+/**
+ * Class WC_Payments_Dependencies_Validator_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * WC_Payments_API_Client unit tests.
+ */
+class WC_Payments_Dependencies_Validator_Test extends WP_UnitTestCase {
+
+	/**
+	 * System under test
+	 *
+	 * @var WC_Payments_Dependencies_Validator
+	 */
+	private $dependencies_validator;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->dependencies_validator = new WC_Payments_Dependencies_Validator();
+	}
+
+	/**
+	 * @param string $message Full message.
+	 * @param array  $expected_strings List of strings that should be in the message.
+	 * @throws Exception On failure.
+	 */
+	private function assertMessageContains( $message, $expected_strings ) {
+		foreach ( $expected_strings as $str ) {
+			$this->assertRegExp( '/' . preg_quote( $str, '/' ) . '/', $message );
+		}
+	}
+
+	/**
+	 * @param string $message Full message.
+	 * @param array  $expected_strings List of strings that should *not* be in the message.
+	 * @throws Exception On failure.
+	 */
+	private function assertMessageDoesntContain( $message, $expected_strings ) {
+		foreach ( $expected_strings as $str ) {
+			$this->assertNotRegExp( '/' . preg_quote( $str, '/' ) . '/', $message );
+		}
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_update_php_error_message() {
+		$message = $this->dependencies_validator->get_update_php_error_message( '5.3.3', '5.6' );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'PHP 5.6',
+				'you are using 5.3.3',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_install_woocommerce_error_message_wc_disabled_can_enable() {
+		$message = $this->dependencies_validator->get_install_woocommerce_error_message( true, true );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'WooCommerce</a> to be installed',
+				'>Activate WooCommerce<',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'>Install WooCommerce<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_install_woocommerce_error_message_wc_disabled_cant_enable() {
+		$message = $this->dependencies_validator->get_install_woocommerce_error_message( false, true );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'WooCommerce</a> to be installed',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'>Activate WooCommerce<',
+				'>Install WooCommerce<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_install_woocommerce_error_message_can_install() {
+		$message = $this->dependencies_validator->get_install_woocommerce_error_message( true, false );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'WooCommerce</a> to be installed',
+				'>Install WooCommerce<',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'>Activate WooCommerce<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_install_woocommerce_error_message_cant_install() {
+		$message = $this->dependencies_validator->get_install_woocommerce_error_message( false, false );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'WooCommerce</a> to be installed',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'>Activate WooCommerce<',
+				'>Install WooCommerce<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_update_woocommerce_error_message_can_update() {
+		$message = $this->dependencies_validator->get_update_woocommerce_error_message( '2.6.0', '3.6', false, true );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'requires <strong>WooCommerce 3.6</strong> or greater',
+				'>Update WooCommerce<',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'is recommended',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_update_woocommerce_error_message_cant_update() {
+		$message = $this->dependencies_validator->get_update_woocommerce_error_message( '2.6.0', '3.6', false, false );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'requires <strong>WooCommerce 3.6</strong> or greater',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'>Update WooCommerce<',
+				'is recommended',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_update_woocommerce_error_message_recommended_version_can_update() {
+		$message = $this->dependencies_validator->get_update_woocommerce_error_message( '2.6.0', '3.6', '4.0', true );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'requires <strong>WooCommerce 3.6</strong> or greater',
+				'<strong>WooCommerce 4.0</strong> or greater is recommended',
+				'>Update WooCommerce<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_update_woocommerce_error_message_recommended_version_cant_update() {
+		$message = $this->dependencies_validator->get_update_woocommerce_error_message( '2.6.0', '3.6', '4.0', false );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'requires <strong>WooCommerce 3.6</strong> or greater',
+				'<strong>WooCommerce 4.0</strong> or greater is recommended',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'>Update WooCommerce<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_update_wordpress_error_message_can_update() {
+		$message = $this->dependencies_validator->get_update_wordpress_error_message( '4.5', '5.2', true );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'WordPress 5.2',
+				'you are using 4.5',
+				'>Update WordPress<',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'>Update WooCommerce<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_update_wordpress_error_message_cant_update() {
+		$message = $this->dependencies_validator->get_update_wordpress_error_message( '4.5', '5.2', false );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'WordPress 5.2',
+				'you are using 4.5',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'>Update WordPress<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_install_wc_admin_error_message_can_install() {
+		$message = $this->dependencies_validator->get_install_wc_admin_error_message( '3.6', false, true, false );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'WooCommerce Admin</a> to be installed',
+				'>Install WooCommerce Admin<',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'requires <strong>WooCommerce 3.6</strong> or greater',
+				'>Update WooCommerce<',
+				'you can also use',
+				'>Activate WooCommerce Admin<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_install_wc_admin_error_message_cant_install() {
+		$message = $this->dependencies_validator->get_install_wc_admin_error_message( '3.6', false, false, false );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'WooCommerce Admin</a> to be installed',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'requires <strong>WooCommerce 3.6</strong> or greater',
+				'>Update WooCommerce<',
+				'you can also use',
+				'>Install WooCommerce Admin<',
+				'>Activate WooCommerce Admin<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_install_wc_admin_error_message_wc_admin_disabled_can_enable() {
+		$message = $this->dependencies_validator->get_install_wc_admin_error_message( '3.6', false, true, true );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'WooCommerce Admin</a> to be installed',
+				'>Activate WooCommerce Admin<',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'requires <strong>WooCommerce 3.6</strong> or greater',
+				'>Update WooCommerce<',
+				'you can also use',
+				'>Install WooCommerce Admin<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_install_wc_admin_error_message_wc_admin_disabled_cant_enable() {
+		$message = $this->dependencies_validator->get_install_wc_admin_error_message( '3.6', false, false, true );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'WooCommerce Admin</a> to be installed',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'requires <strong>WooCommerce 3.6</strong> or greater',
+				'>Update WooCommerce<',
+				'you can also use',
+				'>Install WooCommerce Admin<',
+				'>Activate WooCommerce Admin<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_install_wc_admin_error_message_recommended_wc_version_can_install() {
+		$message = $this->dependencies_validator->get_install_wc_admin_error_message( '3.6', '4.0', true, false );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'requires <strong>WooCommerce 4.0</strong> or greater',
+				'>Update WooCommerce<',
+				'you can also use',
+				'>Install WooCommerce Admin<',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'WooCommerce Admin</a> to be installed',
+				'>Activate WooCommerce Admin<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_install_wc_admin_error_message_recommended_wc_version_cant_install() {
+		$message = $this->dependencies_validator->get_install_wc_admin_error_message( '3.6', '4.0', false, false );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'requires <strong>WooCommerce 4.0</strong> or greater',
+				'you can also use',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'WooCommerce Admin</a> to be installed',
+				'>Update WooCommerce<',
+				'>Install WooCommerce Admin<',
+				'>Activate WooCommerce Admin<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_install_wc_admin_error_message_recommended_wc_version_wc_admin_disabled_can_enable() {
+		$message = $this->dependencies_validator->get_install_wc_admin_error_message( '3.6', '4.0', true, true );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'requires <strong>WooCommerce 4.0</strong> or greater',
+				'>Update WooCommerce<',
+				'you can also use',
+				'>Activate WooCommerce Admin<',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'WooCommerce Admin</a> to be installed',
+				'>Install WooCommerce Admin<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_install_wc_admin_error_message_recommended_wc_version_wc_admin_disabled_cant_enable() {
+		$message = $this->dependencies_validator->get_install_wc_admin_error_message( '3.6', '4.0', false, true );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'requires <strong>WooCommerce 4.0</strong> or greater',
+				'you can also use',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'WooCommerce Admin</a> to be installed',
+				'>Update WooCommerce<',
+				'>Install WooCommerce Admin<',
+				'>Activate WooCommerce Admin<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_update_wc_admin_error_message_can_update() {
+		$message = $this->dependencies_validator->get_update_wc_admin_error_message( '0.14.0', '0.15', '3.6', false, true );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'WooCommerce Admin 0.15',
+				'>Update WooCommerce Admin<',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'requires <strong>WooCommerce 3.6</strong> or greater',
+				'>Update WooCommerce<',
+				'>Activate WooCommerce Admin<',
+				'you can also update',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_update_wc_admin_error_message_cant_update() {
+		$message = $this->dependencies_validator->get_update_wc_admin_error_message( '0.14.0', '0.15', '3.6', false, false );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'WooCommerce Admin 0.15',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'>Update WooCommerce Admin<',
+				'requires <strong>WooCommerce 3.6</strong> or greater',
+				'>Update WooCommerce<',
+				'>Activate WooCommerce Admin<',
+				'you can also update',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_update_wc_admin_error_message_recommended_wc_version_can_update() {
+		$message = $this->dependencies_validator->get_update_wc_admin_error_message( '0.14.0', '0.15', '3.6', '4.0', true );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'requires <strong>WooCommerce 4.0</strong> or greater',
+				'>Update WooCommerce<',
+				'you can also update',
+				'>Update WooCommerce Admin<',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'WooCommerce Admin 0.15',
+				'>Activate WooCommerce Admin<',
+			)
+		);
+	}
+
+	/**
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_get_update_wc_admin_error_message_recommended_wc_version_cant_update() {
+		$message = $this->dependencies_validator->get_update_wc_admin_error_message( '0.14.0', '0.15', '3.6', '4.0', false );
+		$this->assertMessageContains(
+			$message,
+			array(
+				'requires <strong>WooCommerce 4.0</strong> or greater',
+				'you can also update',
+			)
+		);
+		$this->assertMessageDoesntContain(
+			$message,
+			array(
+				'>Update WooCommerce<',
+				'>Update WooCommerce Admin<',
+				'>Activate WooCommerce Admin<',
+				'WooCommerce Admin 0.15',
+			)
+		);
+	}
+}

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -7,13 +7,16 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
- * WC requires at least: 3.5
+ * WC requires at least: 3.6
  * WC tested up to: 3.6.4
- * Requires WP: 5.0
  * Version: 0.2.0
  *
  * @package WooCommerce\Payments
  */
+
+define( 'WCPAY_WC_ADMIN_VERSION_REQUIRED', '0.15' );
+// When a WooCommerce version that bundles WC-Admin is released, set it here if it satisfies our requirements.
+define( 'WCPAY_WC_MIN_VERSION_WITH_WC_ADMIN', false );
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/110

This PR introduces a more elaborate and comprehensive way to test for all the dependencies this plugin requires to work. It checks for:
- WordPress minimum version (as specified in the `readme.txt` header)
- WooCommerce being installed and enabled
- WooCommerce minimum version (as specified in the plugin file header)
- WooCommerce Admin being installed and active
- WooCommerce Admin minimum version (as speficied in a constant in the main plugin file)

Alternatively, we can define in a constant the minimum version of WooCommerce that has WC-Admin integrated. So, for example, if WC-Admin is merged into Core on WooCommerce 4.0, then we'll set that constant to `'4.0'`, and a WooCommerce 4.0+ version will automatically satisfy the WC-Admin requirement too. In that situation, the user will be recommended to update WooCommerce instead of updating/installing WC-Admin, altough he will be presented with both options (see the screenshots).

I implemented the `get_plugin_requirements` and `match_plugin_requirements` to be as testable as possible, but there's simply no way to test them because they have to read constants (WC version, WC-Admin version, `phpversion()`, etc). Instead, I made sure that the `get_message_*` functions are pure so they can be unit tested. That means that those functions receive a lot of parameters, up to 5. Would it be cleaner if they received a single `$args` associative array?

To get all the error messages, replace the contents of the `check_plugin_dependencies` function with this:

```php

		if ( ! $silent ) {
			$this->display_admin_error( '<i><b>Error messages when you have permission to install/update plugins:</b></i>' );
			$this->display_admin_error( $this->get_update_php_error_message( '5.3.3', '5.6' ) );
			$this->display_admin_error( $this->get_install_woocommerce_error_message( true, false ) );
			$this->display_admin_error( $this->get_install_woocommerce_error_message( true, true ) );
			$this->display_admin_error( $this->get_update_woocommerce_error_message( '2.6.0', '3.6', false, true ) );
			$this->display_admin_error( $this->get_update_wordpress_error_message( '4.5', '5.2', true ) );
			$this->display_admin_error( $this->get_install_wc_admin_error_message( '3.6', false, true, false ) );
			$this->display_admin_error( $this->get_install_wc_admin_error_message( '3.6', false, true, true ) );
			$this->display_admin_error( $this->get_update_wc_admin_error_message( '0.14.0', '0.15', '3.6', false, true ) );
			$this->display_admin_error( '<i><b>Error messages when you have permission to install/update plugins and WooCommerce 4.0 includes WC-Admin:</b></i>' );
			$this->display_admin_error( $this->get_update_woocommerce_error_message( '2.6.0', '3.6', '4.0', true ) );
			$this->display_admin_error( $this->get_install_wc_admin_error_message( '3.6', '4.0', true, false ) );
			$this->display_admin_error( $this->get_install_wc_admin_error_message( '3.6', '4.0', true, true ) );
			$this->display_admin_error( $this->get_update_wc_admin_error_message( '0.14.0', '0.15', '3.6', '4.0', true ) );
			$this->display_admin_error( '<i><b>Error messages when you don\'t have permission to install/update plugins:</b></i>' );
			$this->display_admin_error( $this->get_install_woocommerce_error_message( false, false ) );
			$this->display_admin_error( $this->get_install_woocommerce_error_message( false, true ) );
			$this->display_admin_error( $this->get_update_woocommerce_error_message( '2.6.0', '3.6', false, false ) );
			$this->display_admin_error( $this->get_update_wordpress_error_message( '4.5', '5.2', false ) );
			$this->display_admin_error( $this->get_install_wc_admin_error_message( '3.6', false, false, false ) );
			$this->display_admin_error( $this->get_install_wc_admin_error_message( '3.6', false, false, true ) );
			$this->display_admin_error( $this->get_update_wc_admin_error_message( '0.14.0', '0.15', '3.6', false, false ) );
			$this->display_admin_error( '<i><b>Error messages when you don\'t have permission to install/update plugins and WooCommerce 4.0 includes WC-Admin:</b></i>' );
			$this->display_admin_error( $this->get_update_woocommerce_error_message( '2.6.0', '3.6', '4.0', false ) );
			$this->display_admin_error( $this->get_install_wc_admin_error_message( '3.6', '4.0', false, false ) );
			$this->display_admin_error( $this->get_install_wc_admin_error_message( '3.6', '4.0', false, true ) );
			$this->display_admin_error( $this->get_update_wc_admin_error_message( '0.14.0', '0.15', '3.6', '4.0', false ) );
		}
		return false;
```

You'll get something like these screenshoots:
![Screenshot 2019-07-22 at 10 49 06](https://user-images.githubusercontent.com/1715800/61623505-abc97f00-ac6e-11e9-9533-5bb094d050a4.png)
![Screenshot 2019-07-22 at 10 51 26](https://user-images.githubusercontent.com/1715800/61623524-b1bf6000-ac6e-11e9-97d2-bd3c39116870.png)

I just guessed the messages, I'm open to input around the messaging and links.

Some things to note:
- If the user is not allowed to update/install the plugin or wordpress, the `Install/Update [plugin]` links won't be displayed. The rest of the message stays the same.
- For installing, updating, and activating plugins, the link performs the action directly. The only exception is updating WooCommerce. That link points to the "plugins list" page, because the WooCommerce plugin row gives some useful warnings regarding potential extensions incompatibilities.
- Only the first failed requirement will display an error message. So, if both your WooCommerce version and WordPress versions are too old, only the `WooCommerce` error will show. The order of requirements is in `match_plugin_requirements` and it's kind-of arbitrary. I set it roughly as "which requirement failure is harder to fix", so I settled on this order:
  - PHP version, you'll need to contact your hosting provider and maybe sacrifice a goat
  - WooCommerce version, they may be some extension compatibilities issues
  - WordPress version, updating WordPress is generally painless
  - WC-Admin version, should be a one-click solution

Maybe I've overdone this a bit, but hopefully we won't ever have to worry about checking for plugin dependencies.