### PR TITLE
Update packages to fix high severity vulnerabilites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-payments",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -53,6 +53,12 @@
             "minimist": "^1.2.0"
           }
         },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -72,6 +78,14 @@
         "lodash": "^4.17.11",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -123,6 +137,14 @@
         "@babel/helper-function-name": "^7.1.0",
         "@babel/types": "^7.4.4",
         "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -194,6 +216,14 @@
         "@babel/template": "^7.4.4",
         "@babel/types": "^7.4.4",
         "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -218,6 +248,14 @@
       "dev": true,
       "requires": {
         "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -457,6 +495,14 @@
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-transform-classes": {
@@ -831,9 +877,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.5.tgz",
-      "integrity": "sha512-5yLuwzvIDecKwYMzJtiarky4Fb5643H3Ao5jwX0HrMR5oM5mn2iHH9wSZonxwNK0oAjAFUQAiOd4jT7/9Y2jMQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz",
+      "integrity": "sha512-FYATQVR00NSNi7mUfpPDp7E8RYMXDuO8gaix7u/w3GekfUinKgX1AcTxs7SoiEmoEW9mbpjrwqWSW6zCmw5h8A==",
       "dev": true,
       "requires": {
         "core-js": "^2.6.5",
@@ -885,6 +931,12 @@
             "ms": "^2.1.1"
           }
         },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -902,6 +954,14 @@
         "esutils": "^2.0.2",
         "lodash": "^4.17.11",
         "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@cnakazawa/watch": {
@@ -1665,12 +1725,12 @@
       }
     },
     "@woocommerce/components": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@woocommerce/components/-/components-3.1.0.tgz",
-      "integrity": "sha512-0qDxCY5VPaiNjDsEgiAFvq8zks9wX97+L0G6rf4+ESbd0bh6/qOSZCN0TPfjFIa88igNa2+r0sbyRFYt46tF2A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/components/-/components-3.2.0.tgz",
+      "integrity": "sha512-Z4G7+ix7qCFT4xDfR6yUH6chPEIGYSUCkflDe4mpbg+ot9VM9dq3ZB8K0H3TvUzNezAgNnECfEh221XUs4lMrw==",
       "dev": true,
       "requires": {
-        "@babel/runtime-corejs2": "7.4.5",
+        "@babel/runtime-corejs2": "7.5.5",
         "@woocommerce/csv-export": "1.1.0",
         "@woocommerce/currency": "1.1.1",
         "@woocommerce/date": "1.0.7",
@@ -1695,8 +1755,8 @@
         "emoji-flags": "^1.2.0",
         "gridicons": "3.3.1",
         "interpolate-components": "1.1.1",
-        "lodash": "4.17.11",
-        "memoize-one": "5.0.4",
+        "lodash": "4.17.15",
+        "memoize-one": "5.0.5",
         "moment": "2.22.1",
         "prop-types": "15.7.2",
         "qs": "6.7.0",
@@ -1725,6 +1785,12 @@
                 "core-js": "^2.6.5",
                 "regenerator-runtime": "^0.13.2"
               }
+            },
+            "lodash": {
+              "version": "4.17.11",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+              "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+              "dev": true
             }
           }
         },
@@ -1776,6 +1842,12 @@
                 "tannin": "^1.0.1"
               }
             },
+            "lodash": {
+              "version": "4.17.11",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+              "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+              "dev": true
+            },
             "moment": {
               "version": "2.22.2",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
@@ -1818,9 +1890,9 @@
           "dev": true
         },
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "moment": {
@@ -1879,34 +1951,34 @@
       }
     },
     "@woocommerce/currency": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@woocommerce/currency/-/currency-1.1.2.tgz",
-      "integrity": "sha512-7gyZ25w1T9mRvvmsKrh8mYed4kxc9SgvWKCyzTMJDjnSKKQIeB5o3f1OR/J+c1MUyHkjRD3RsTVdeFm3EfgQTQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@woocommerce/currency/-/currency-1.1.3.tgz",
+      "integrity": "sha512-gOzMRlDa0Q9yxVjfOt+qtoWiBNPumRXldKimHN5l5nFJ9oDQCiDuyZ+3DAa5Ue+VS8tlkCUljU8STqjbpxvVWw==",
       "dev": true,
       "requires": {
-        "@babel/runtime-corejs2": "7.4.5",
+        "@babel/runtime-corejs2": "7.5.5",
         "@woocommerce/number": "1.0.2",
-        "lodash": "4.17.11"
+        "lodash": "4.17.15"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         }
       }
     },
     "@woocommerce/date": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@woocommerce/date/-/date-1.2.0.tgz",
-      "integrity": "sha512-V9IJVGnMneyJvEPc0IsYDfFypEjFJToG4al2AFx15zdaf5UNkOskb/bwuqkfhKtZtjVaXtdbDByN49agQvLxXw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@woocommerce/date/-/date-1.2.1.tgz",
+      "integrity": "sha512-FrvyYy1AetdBLgV6/rPWTKuzOvOyxJU2s6Wfm1yAhFAeG24nbANC0e6a4e5gNb+JSCvNSr61YvaWNROUI9dFQQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime-corejs2": "7.4.5",
+        "@babel/runtime-corejs2": "7.5.5",
         "@wordpress/date": "3.3.0",
         "@wordpress/i18n": "3.4.0",
-        "lodash": "4.17.11",
+        "lodash": "4.17.15",
         "moment": "2.22.2"
       },
       "dependencies": {
@@ -1925,9 +1997,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "moment": {
@@ -2022,13 +2094,13 @@
       }
     },
     "@wordpress/a11y": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.4.0.tgz",
-      "integrity": "sha512-pFnfTPB+c4UdfNGSgOMop03mgHzF/0UhkNhsh3l5MjGrMTw06/vxYpYtyVY19p+7wnah6gvVTpOuepWdGRT/Rg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.5.0.tgz",
+      "integrity": "sha512-KY+Z0NFQUH6cNbFnP9P58fTCLS93zBz+SIEDA633yG46u1NHOBfWDS4lIrx52fihFdaakSTS0f2OH6yeRb41HQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@wordpress/dom-ready": "^2.4.0"
+        "@wordpress/dom-ready": "^2.5.0"
       }
     },
     "@wordpress/api-fetch": {
@@ -2103,6 +2175,14 @@
         "rememo": "^3.0.0",
         "tinycolor2": "^1.4.1",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@wordpress/compose": {
@@ -2115,39 +2195,75 @@
         "@wordpress/element": "^2.4.0",
         "@wordpress/is-shallow-equal": "^1.3.0",
         "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@wordpress/data": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.6.0.tgz",
-      "integrity": "sha512-42BNtWtN0ppnzbnxz0tA72KNtuEKjrIRr4PbVCw3JVrHN2Nfhbo9SiCUutReKAXGQaT4LPnO7gAGmIsdC/mBUw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.7.0.tgz",
+      "integrity": "sha512-6ytvrcvg6otalvFNA26gnHv0GQkQT0h9/a780IKl0wyUqAYdKbn1J52CcJWopyfZ53HDq816NCZng1a4tWxHjQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@wordpress/compose": "^3.4.0",
-        "@wordpress/deprecated": "^2.4.0",
-        "@wordpress/element": "^2.5.0",
-        "@wordpress/is-shallow-equal": "^1.4.0",
-        "@wordpress/priority-queue": "^1.2.0",
-        "@wordpress/redux-routine": "^3.4.0",
+        "@wordpress/compose": "^3.5.0",
+        "@wordpress/deprecated": "^2.5.0",
+        "@wordpress/element": "^2.6.0",
+        "@wordpress/is-shallow-equal": "^1.5.0",
+        "@wordpress/priority-queue": "^1.3.0",
+        "@wordpress/redux-routine": "^3.5.0",
         "equivalent-key-map": "^0.2.2",
         "is-promise": "^2.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.14",
         "redux": "^4.0.0",
         "turbo-combine-reducers": "^1.0.2"
       },
       "dependencies": {
         "@wordpress/compose": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.4.0.tgz",
-          "integrity": "sha512-mrOS0iob7fyptp8C+bMlorv4B4CAX6byfKhM6IrdV1rXFmTvTTCz7tCGwi++QXGCCifDGnQY8SpwfJ5oGMb4rg==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
+          "integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
           "dev": true,
           "requires": {
             "@babel/runtime": "^7.4.4",
-            "@wordpress/element": "^2.5.0",
-            "@wordpress/is-shallow-equal": "^1.4.0",
-            "lodash": "^4.17.11"
+            "@wordpress/element": "^2.6.0",
+            "@wordpress/is-shallow-equal": "^1.5.0",
+            "lodash": "^4.17.14"
           }
+        },
+        "@wordpress/element": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
+          "integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@wordpress/escape-html": "^1.5.0",
+            "lodash": "^4.17.14",
+            "react": "^16.8.4",
+            "react-dom": "^16.8.4"
+          }
+        },
+        "@wordpress/escape-html": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.5.0.tgz",
+          "integrity": "sha512-9jGwPbpdJ309EP4Acf6/zwHWeuYi0Bi5RAZx9q+BIYC7bjxLs3oFDS5QkEAi2mzrVAhIz+BbEWBGRg70U1RLlA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         }
       }
     },
@@ -2173,29 +2289,37 @@
       }
     },
     "@wordpress/deprecated": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.4.0.tgz",
-      "integrity": "sha512-gsK1ist0Oook6iod+v5P1D48TWX/47jO7tOLoSwnhO1F4Qtm73bBtUofx2MntajRsxilB1j+wHXDmDUTV477XA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.5.0.tgz",
+      "integrity": "sha512-bryhXZZ9dZ8DlMQ2liDAV3CQV7wEiftJ9UAOB7X32X4MPZoPqvk3IGiKgHFs3/pEr4Ums0CCckgUlnY7AI+hxQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@wordpress/hooks": "^2.4.0"
+        "@wordpress/hooks": "^2.5.0"
       }
     },
     "@wordpress/dom": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.3.0.tgz",
-      "integrity": "sha512-cy/AD7gcbQmYJd8hSsuOVhdvkdFARsP1UBirZ1nwQZtQyjwAqWQzMdLUml5PzeczhEZQlo9vzJGo8fGwQvpxEw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.4.0.tgz",
+      "integrity": "sha512-8hcHi5iHgi1Z/1G6ti04bgsiYBDNlR05X7MiosjwP8U/iTmcRwKrmtA1X6qzsMlOgvJ3MetoLqGZb3lCjLtXmw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.14"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@wordpress/dom-ready": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.4.0.tgz",
-      "integrity": "sha512-0v4cPfghB8QAKaquQP7p3zrA1KxcYvZkGKw3X6mnWvnRUM2D6e5QQPzQ/QmmHtcFKkEw9bWcP7ItoC90xjIoFg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.5.0.tgz",
+      "integrity": "sha512-1CXRTZcQ0yn9Aj5x3e0xwYJeRv81NyuwoQUD2ZvDXRXCvaNq33fm79MDvpW5E2uYoo0t9jPHTCwadVXt7bzhwQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4"
@@ -2212,6 +2336,14 @@
         "lodash": "^4.17.11",
         "react": "^16.8.4",
         "react-dom": "^16.8.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@wordpress/escape-html": {
@@ -2237,9 +2369,9 @@
       }
     },
     "@wordpress/hooks": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.4.0.tgz",
-      "integrity": "sha512-z3+8Yq4IQ3DOvUF4VsXOfntdyk1fJ8RZBYlZTW8WfmHV7VKTDbX3LfHXmC2VCjXhVkeWQVKozi2weoEYopfGKA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.5.0.tgz",
+      "integrity": "sha512-+nsYv5AdX7Oj9gVHvtDIQSE9gntrJwA5FpXSEVlZ2u2E5lhjGQS+a+IrRhxZL/7f2eKby5zvQV6vYCrqMtKxYg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4"
@@ -2268,6 +2400,12 @@
         "tannin": "^1.0.1"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
         "sprintf-js": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
@@ -2277,9 +2415,9 @@
       }
     },
     "@wordpress/is-shallow-equal": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.4.0.tgz",
-      "integrity": "sha512-cghwkh4Ui4o52zdiMCD10dyR0y1K5rf7Cb92J8rF1+DhyoNgYRYWo2OtYLN8RPpsHdo4KPW8noL4SIuKse+Zkw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.5.0.tgz",
+      "integrity": "sha512-6GjIDZlwcgLmnt1uexUgnIj3zbzCPCtqe5vTqmsQeexC4zCIzgFJgzilOuuW/4kdwF/XB3jex91L9EImc5HTcw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4"
@@ -2294,6 +2432,14 @@
         "@babel/runtime": "^7.4.4",
         "jest-matcher-utils": "^24.7.0",
         "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@wordpress/jest-preset-default": {
@@ -2318,6 +2464,14 @@
         "@babel/runtime": "^7.4.4",
         "@wordpress/i18n": "^3.4.0",
         "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@wordpress/npm-package-json-lint-config": {
@@ -2327,18 +2481,18 @@
       "dev": true
     },
     "@wordpress/priority-queue": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.2.0.tgz",
-      "integrity": "sha512-po70nJhWK3oBhc9D/rBv2RFsX9do7fIABdUSVNAFQ+vRnatxlZTxJ6z8A2rtY71tiV244qgy3In6H7n1i6QO7A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.3.0.tgz",
+      "integrity": "sha512-HlhHZUCnKW56b2KFg2cZcn6fnGdi6mrmfOn2lE3cBOibjQLYfOY3pe3TCd+AxS4GdfkgXFA7BHfAinaWCBpAyg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4"
       }
     },
     "@wordpress/redux-routine": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.4.0.tgz",
-      "integrity": "sha512-v4aQWBQjjsZ3qEbA1vnI/do7lEx8xBI1rVJKEOzN98+xfweAVtTQLW+2+bpQQDPTs+SUrp5LAqLgWLqFP6V1RQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.5.0.tgz",
+      "integrity": "sha512-fssGjVcXlNFbAIjv6VhCWZYgsv51sugxxCgxAqgSIexsDVnOphDODo5V5bhcgwiZeL3/n5rzqvFQ7Dv4agvc/A==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
@@ -2347,31 +2501,97 @@
       }
     },
     "@wordpress/rich-text": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.4.0.tgz",
-      "integrity": "sha512-fw6wFtbsVouKuoLhHoPV+go4caqBpmTlD0Up3FY8ofLVUtJJKS0r76vzKTPjGHp5HcvngYWId2pQgbFDkFE/Ow==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.5.0.tgz",
+      "integrity": "sha512-2Pi56SGcao0M0OjZtpwdIyYIXganIDg054InPpdE7zeJRUxf8gKvTGSXA2bYLdDJC0RgCLTtWp+45ItV6byZDg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@wordpress/compose": "^3.4.0",
-        "@wordpress/data": "^4.6.0",
-        "@wordpress/escape-html": "^1.4.0",
-        "@wordpress/hooks": "^2.4.0",
-        "lodash": "^4.17.11",
+        "@wordpress/compose": "^3.5.0",
+        "@wordpress/data": "^4.7.0",
+        "@wordpress/deprecated": "^2.5.0",
+        "@wordpress/dom": "^2.4.0",
+        "@wordpress/element": "^2.6.0",
+        "@wordpress/escape-html": "^1.5.0",
+        "@wordpress/hooks": "^2.5.0",
+        "@wordpress/is-shallow-equal": "^1.5.0",
+        "@wordpress/keycodes": "^2.5.0",
+        "classnames": "^2.2.5",
+        "lodash": "^4.17.14",
+        "memize": "^1.0.5",
         "rememo": "^3.0.0"
       },
       "dependencies": {
         "@wordpress/compose": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.4.0.tgz",
-          "integrity": "sha512-mrOS0iob7fyptp8C+bMlorv4B4CAX6byfKhM6IrdV1rXFmTvTTCz7tCGwi++QXGCCifDGnQY8SpwfJ5oGMb4rg==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
+          "integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
           "dev": true,
           "requires": {
             "@babel/runtime": "^7.4.4",
-            "@wordpress/element": "^2.5.0",
-            "@wordpress/is-shallow-equal": "^1.4.0",
-            "lodash": "^4.17.11"
+            "@wordpress/element": "^2.6.0",
+            "@wordpress/is-shallow-equal": "^1.5.0",
+            "lodash": "^4.17.14"
           }
+        },
+        "@wordpress/element": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
+          "integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@wordpress/escape-html": "^1.5.0",
+            "lodash": "^4.17.14",
+            "react": "^16.8.4",
+            "react-dom": "^16.8.4"
+          }
+        },
+        "@wordpress/escape-html": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.5.0.tgz",
+          "integrity": "sha512-9jGwPbpdJ309EP4Acf6/zwHWeuYi0Bi5RAZx9q+BIYC7bjxLs3oFDS5QkEAi2mzrVAhIz+BbEWBGRg70U1RLlA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4"
+          }
+        },
+        "@wordpress/i18n": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.0.tgz",
+          "integrity": "sha512-/fkc5OoUCrIyHAaBEKIsXKl+UWj2kKjquhMSSHu3eVqLv/WKrKAzypPPAZC9UXfdSVBY8MrORYLh7vUy9Ic3Vw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "gettext-parser": "^1.3.1",
+            "lodash": "^4.17.14",
+            "memize": "^1.0.5",
+            "sprintf-js": "^1.1.1",
+            "tannin": "^1.1.0"
+          }
+        },
+        "@wordpress/keycodes": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.5.0.tgz",
+          "integrity": "sha512-4SMN3pmJnNBexpd3/6JB6gJw+wcahBaVZaeMcHyF+Uw7bKcG6hDkzEAN6dWFJuifpdxmvilDE4H5JS/Ex9C6sA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@wordpress/i18n": "^3.6.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+          "dev": true
         }
       }
     },
@@ -3238,6 +3458,14 @@
         "@wordpress/data": "^4.5.0",
         "@wordpress/element": "^2.4.0",
         "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@xtuc/ieee754": {
@@ -3418,6 +3646,14 @@
         "tar-stream": "^1.5.0",
         "walkdir": "^0.0.11",
         "zip-stream": "^1.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "archiver-utils": {
@@ -3434,6 +3670,12 @@
         "readable-stream": "^2.0.0"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
         "normalize-path": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -3658,6 +3900,14 @@
       "dev": true,
       "requires": {
         "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "async-each": {
@@ -4540,6 +4790,14 @@
         "htmlparser2": "^3.9.1",
         "lodash": "^4.15.0",
         "parse5": "^3.0.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "chokidar": {
@@ -5218,9 +5476,9 @@
       "dev": true
     },
     "d3-color": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.2.8.tgz",
-      "integrity": "sha512-yeANXzP37PHk0DbSTMNPhnJD+Nn4G//O5E825bR6fAfHH43hobSBpgB9G9oWVl9+XgUaQ4yCnsX1H+l8DoaL9A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.3.0.tgz",
+      "integrity": "sha512-NHODMBlj59xPAwl2BDiO2Mog6V+PrGRtBfWKqKRrs9MCqlSkIEb0Z/SfY7jW29ReHTDC/j+vwXhnZcXI3+3fbg==",
       "dev": true
     },
     "d3-format": {
@@ -5239,9 +5497,9 @@
       }
     },
     "d3-path": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.7.tgz",
-      "integrity": "sha512-q0cW1RpvA5c5ma2rch62mX8AYaiLX0+bdaSM2wxSU9tXjU4DNvkx9qiUvjkuWCj3p22UO/hlPivujqMiR9PDzA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.8.tgz",
+      "integrity": "sha512-J6EfUNwcMQ+aM5YPOB8ZbgAZu6wc82f/0WFxrxwV6Ll8wBwLaHLKCqQ5Imub02JriCVVdPjgI+6P3a4EWJCxAg==",
       "dev": true
     },
     "d3-scale": {
@@ -5259,9 +5517,9 @@
       }
     },
     "d3-scale-chromatic": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.3.3.tgz",
-      "integrity": "sha512-BWTipif1CimXcYfT02LKjAyItX5gKiwxuPRgr4xM58JwlLocWbjPLI7aMEjkcoOQXMkYsmNsvv3d2yl/OKuHHw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.4.0.tgz",
+      "integrity": "sha512-0vyEt8ZqhdgzC+IvdkJZL7fc3k7UZyJvMxR3zvU312z/HilJ0N+WSY3099jAxdfhe99ak9VhcK1ChDVVGc8Q0Q==",
       "dev": true,
       "requires": {
         "d3-color": "1",
@@ -5838,6 +6096,14 @@
       "dev": true,
       "requires": {
         "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "equivalent-key-map": {
@@ -6052,6 +6318,12 @@
           "requires": {
             "is-glob": "^4.0.1"
           }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         },
         "semver": {
           "version": "6.3.0",
@@ -7835,6 +8107,14 @@
         "glob": "~7.1.1",
         "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "gonzales-pe": {
@@ -8451,6 +8731,12 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "string-width": {
@@ -10323,9 +10609,9 @@
       "dev": true
     },
     "memoize-one": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz",
-      "integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.5.tgz",
+      "integrity": "sha512-ey6EpYv0tEaIbM/nTDOpHciXUvd+ackQrJgEzBwemhZZIWZjcyodqEcrmqDy2BKRTM3a65kKBV4WtLXJDt26SQ==",
       "dev": true
     },
     "memory-fs": {
@@ -10915,6 +11201,12 @@
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
@@ -11952,6 +12244,14 @@
         "lodash": "^4.17.11",
         "log-symbols": "^2.2.0",
         "postcss": "^7.0.7"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "postcss-resolve-nested-selector": {
@@ -12402,6 +12702,14 @@
         "react-portal": "^4.1.5",
         "react-with-styles": "^3.2.0",
         "react-with-styles-interface-css": "^4.0.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "react-dom": {
@@ -12428,23 +12736,23 @@
       "dev": true
     },
     "react-moment-proptypes": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.6.0.tgz",
-      "integrity": "sha512-4h7EuhDMTzQqZ+02KUUO+AVA7PqhbD88yXB740nFpNDyDS/bj9jiPyn2rwr9sa8oDyaE1ByFN9+t5XPyPTmN6g==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.7.0.tgz",
+      "integrity": "sha512-ZbOn/P4u469WEGAw5hgkS/E+g1YZqdves2BjYsLluJobzUZCtManhjHiZKjniBVT7MSHM6D/iKtRVzlXVv3ikA==",
       "dev": true,
       "requires": {
         "moment": ">=1.6.0"
       }
     },
     "react-outside-click-handler": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.2.3.tgz",
-      "integrity": "sha512-4orkx59ais0mM/j1Ekc5ewyRu5xNLX4a6pMs7RT8U7JkbPOlRsucE+190kXzYUUHsGfZvyAmsdQkL7lpqzMGBg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.2.4.tgz",
+      "integrity": "sha512-FwLnTllTa65O/HjIyDgIrlAKcgPeXQnRUE+iR1EV4NY5opzN37S87+AtO1FF0rAa8qBDKj2QuNp4VfkjmkiB7g==",
       "dev": true,
       "requires": {
-        "airbnb-prop-types": "^2.12.0",
+        "airbnb-prop-types": "^2.13.2",
         "consolidated-events": "^1.1.1 || ^2.0.0",
-        "document.contains": "^1.0.0",
+        "document.contains": "^1.0.1",
         "object.values": "^1.1.0",
         "prop-types": "^15.7.2"
       }
@@ -12489,15 +12797,6 @@
         "tiny-warning": "^1.0.0"
       },
       "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
-          "dev": true,
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -12588,17 +12887,6 @@
         "object.assign": "^4.1.0",
         "prop-types": "^15.6.2",
         "react-with-direction": "^1.3.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
-          "dev": true,
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        }
       }
     },
     "react-with-styles-interface-css": {
@@ -12940,6 +13228,14 @@
       "dev": true,
       "requires": {
         "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "request-promise-native": {
@@ -13195,6 +13491,14 @@
         "lodash": "^4.0.0",
         "scss-tokenizer": "^0.2.3",
         "yargs": "^7.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "sass-loader": {
@@ -14177,6 +14481,12 @@
             "path-exists": "^3.0.0"
           }
         },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
         "log-symbols": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -14421,6 +14731,12 @@
         "postcss-value-parser": "^4.0.0"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
         "postcss-value-parser": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.1.tgz",
@@ -14497,6 +14813,12 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "string-width": {
@@ -15898,6 +16220,12 @@
         "ws": "^6.0.0"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
         "ws": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
@@ -16332,6 +16660,14 @@
         "compress-commons": "^1.2.0",
         "lodash": "^4.8.0",
         "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
-    "@woocommerce/components": "^3.1.0",
-    "@woocommerce/currency": "^1.1.2",
-    "@woocommerce/date": "^1.2.0",
+    "@woocommerce/components": "^3.2.0",
+    "@woocommerce/currency": "^1.1.3",
+    "@woocommerce/date": "^1.2.1",
     "@wordpress/api-fetch": "^3.3.0",
     "@wordpress/babel-preset-default": "^4.1.0",
     "@wordpress/date": "^3.3.0",


### PR DESCRIPTION
Fixes the 16418 high severity vulnerabilities detected by `npm audit`.

`npm` detected _many_ high severity vulnerabilites:

<img width="657" alt="image" src="https://user-images.githubusercontent.com/13835680/61548059-43935700-aa3c-11e9-8227-1ff53f32cca2.png">

After running `npm audit fix` there is only one vulnerability remaining, and that one needs manual review:

<img width="657" alt="image" src="https://user-images.githubusercontent.com/13835680/61548205-ad136580-aa3c-11e9-8ced-12d210edef11.png">

#### Changes proposed in this Pull Request

* Update vulnerable packages to patch security issues via `npm audit fix`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `npm i` to update packages.
* `npm run watch` and make sure web app works as intended.