### PR TITLE
Fix PHP 7.0 tests by using PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,12 @@ before_script:
     if [[ $SHOULD_DEPLOY != 1 ]]; then
       bash ./bin/install-wp-tests.sh woocommerce_test root '' localhost $WP_VERSION false $WC_VERSION
     fi
+  - |
+    if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
+      echo "downloading phpunit"
+      wget https://phar.phpunit.de/phpunit-6.5.14.phar
+    fi
+
 
 script:
   - bash bin/phpunit.sh

--- a/bin/phpunit.sh
+++ b/bin/phpunit.sh
@@ -6,9 +6,15 @@ fi
 
 if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.2" ]] ||
 	[[ ${TRAVIS_PHP_VERSION:0:3} == "5.3" ]] ||
-	[[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]] ||
-	[[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
+	[[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]]; then
 	phpunit -c phpunit.xml.dist
+elif [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
+	# We can't run phpunit with PHP 7.0, nor composer
+	# So, run the latest supported version of PHPUnit with PHP 7.0
+	# h/t for the idea:
+	# https://github.com/travis-ci/travis-ci/issues/406#issuecomment-292213119
+	# https://github.com/OpenACalendar/OpenACalendar-Web-Core/commit/84abf236c14c4abbd36a95790449d5dee59db12c
+	php phpunit-6.5.14.phar -c phpunit.xml.dist
 else
   ./vendor/bin/phpunit
 fi


### PR DESCRIPTION
PHP 7.0 can't run composer, and it can't run the version of phpunit available by default on Travis. So, use PHPUnit 6.5.

Supported PHPUnit versions are listed here
https://phpunit.de/supported-versions.html

Idea h/t:
https://github.com/travis-ci/travis-ci/issues/406#issuecomment-292213119
https://github.com/OpenACalendar/OpenACalendar-Web-Core/commit/84abf236c14c4abbd36a95790449d5dee59db12c

Fixes #146 