### PR TITLE
Avoid re-mounting elements if already in DOM

### DIFF
--- a/assets/js/wc-payment-checkout.js
+++ b/assets/js/wc-payment-checkout.js
@@ -3,13 +3,13 @@ jQuery( function( $ ) {
 	'use strict';
 
 	var stripe   = new Stripe( wc_payment_config.publishableKey, {
-		stripeAccount: wc_payment_config.accountId
+		stripeAccount: wc_payment_config.accountId,
 	} );
 	var elements = stripe.elements();
 
 	// Create a card element.
 	var cardElement = elements.create( 'card', {
-		hidePostalCode: true
+		hidePostalCode: true,
 	} );
 
 	// Only attempt to mount the card element once that section of the page has loaded. We can use the updated_checkout

--- a/assets/js/wc-payment-checkout.js
+++ b/assets/js/wc-payment-checkout.js
@@ -1,5 +1,5 @@
 /* global jQuery, Stripe, wc_payment_config */
-jQuery( function() {
+jQuery( function( $ ) {
 	'use strict';
 
 	var stripe   = new Stripe( wc_payment_config.publishableKey, {
@@ -15,9 +15,9 @@ jQuery( function() {
 	// Only attempt to mount the card element once that section of the page has loaded. We can use the updated_checkout
 	// event for this. This part of the page can also reload based on changes to checkout details, so we call unmount
 	// first to ensure the card element is re-mounted correctly.
-	jQuery( document.body ).on( 'updated_checkout', function() {
+	$( document.body ).on( 'updated_checkout', function() {
 		// Don't re-mount if already mounted in DOM.
-		if ( jQuery( '#wc-payment-card-element' ).children().length ) {
+		if ( $( '#wc-payment-card-element' ).children().length ) {
 			return;
 		}
 
@@ -37,7 +37,7 @@ jQuery( function() {
 
 	// Create payment method on submission.
 	var paymentMethodGenerated;
-	jQuery( 'form.checkout' ).on( 'checkout_place_order_woocommerce_payments', function() {
+	$( 'form.checkout' ).on( 'checkout_place_order_woocommerce_payments', function() {
 		// We'll resubmit the form after populating our payment method, so if this is the second time this event
 		// is firing we should let the form submission happen.
 		if ( paymentMethodGenerated ) {
@@ -67,7 +67,7 @@ jQuery( function() {
 				paymentMethodInput.value = id;
 
 				// Re-submit the form.
-				jQuery( '.woocommerce-checkout' ).submit();
+				$( '.woocommerce-checkout' ).submit();
 			} );
 
 		// Prevent form submission so that we can fire it once a payment method has been generated.

--- a/assets/js/wc-payment-checkout.js
+++ b/assets/js/wc-payment-checkout.js
@@ -16,6 +16,11 @@ jQuery( function() {
 	// event for this. This part of the page can also reload based on changes to checkout details, so we call unmount
 	// first to ensure the card element is re-mounted correctly.
 	jQuery( document.body ).on( 'updated_checkout', function() {
+		// Don't re-mount if already mounted in DOM.
+		if ( jQuery( '#wc-payment-card-element' ).children().length ) {
+			return;
+		}
+
 		cardElement.unmount();
 		cardElement.mount( '#wc-payment-card-element' );
 	} );


### PR DESCRIPTION
Fixes #143 in combination with https://github.com/woocommerce/woocommerce/pull/24227

See equivalent fix in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/927

#### Changes proposed in this Pull Request

Upon checkout screen update, check if elements are still mounted in the DOM before re-mounting. This is to avoid unnecessarily clearing any payment information already entered.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- With branch in https://github.com/woocommerce/woocommerce/pull/24227 checked out…
- On the Checkout screen, enter payment information (e.g. card number, expiration)
- Make a change to a checkout field such as the address, which should trigger an AJAX request
- Verify that the entered payment information is unchanged

-------------------

- [x] Tested on mobile (or does not apply)
