### PR TITLE
Initial payment form styling

### DIFF
--- a/assets/css/wc-payment-checkout.css
+++ b/assets/css/wc-payment-checkout.css
@@ -1,0 +1,5 @@
+.wc-payment-card-mounted {
+    border: 1px solid #ddd;
+    padding: 5px 7px;
+    background-color: #fff;
+}

--- a/assets/js/wc-payment-checkout.js
+++ b/assets/js/wc-payment-checkout.js
@@ -3,13 +3,14 @@ jQuery( function() {
 	'use strict';
 
 	var stripe   = new Stripe( wc_payment_config.publishableKey, {
-		stripeAccount: wc_payment_config.accountId
+		stripeAccount: wc_payment_config.accountId,
 	} );
 	var elements = stripe.elements();
 
 	// Create a card element.
 	var cardElement = elements.create( 'card', {
-		hidePostalCode: true
+		hidePostalCode: true,
+		classes: { base: 'wc-payment-card-mounted' },
 	} );
 
 	// Only attempt to mount the card element once that section of the page has loaded. We can use the updated_checkout
@@ -21,12 +22,13 @@ jQuery( function() {
 	} );
 
 	// Update the validation state based on the element's state.
-	cardElement.addEventListener( 'change', function(event) {
-		var displayError = document.getElementById( 'wc-payment-errors' );
-		if (event.error) {
-			displayError.textContent = event.error.message;
+	cardElement.addEventListener( 'change', function( event ) {
+		var displayError = jQuery( '#wc-payment-errors' );
+		if ( event.error ) {
+			displayError.html( '<ul class="woocommerce-error"><li /></ul>' )
+				.find( 'li' ).text( event.error.message );
 		} else {
-			displayError.textContent = '';
+			displayError.html( '' );
 		}
 	} );
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -174,13 +174,21 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		wp_localize_script( 'wc-payment-checkout', 'wc_payment_config', $js_config );
 		wp_enqueue_script( 'wc-payment-checkout' );
 
+		wp_enqueue_style(
+			'wc-payment-checkout',
+			plugins_url( 'assets/css/wc-payment-checkout.css', WCPAY_PLUGIN_FILE ),
+			array(),
+			filemtime( WCPAY_ABSPATH . 'assets/css/wc-payment-checkout.css' )
+		);
+
 		// Output the form HTML.
-		// TODO: Style this up. Formatting, escaping double line breaks etc.
 		?>
 		<p><?php echo wp_kses_post( $this->get_description() ); ?></p>
-		<div id="wc-payment-card-element"></div>
-		<div id="wc-payment-errors" role="alert"></div>
-		<input id="wc-payment-method" type="hidden" name="wc-payment-method" />
+		<fieldset>
+			<div id="wc-payment-card-element" class="form-row"></div>
+			<div id="wc-payment-errors" role="alert"></div>
+			<input id="wc-payment-method" type="hidden" name="wc-payment-method" />
+		</fieldset>
 		<?php
 	}
 


### PR DESCRIPTION
Addresses #57 (but will leave open for design review)

#### Changes proposed in this Pull Request

* Adds WC core form and error structure for default styling, and some light styling on the field.

&nbsp; | `master` | this branch
-- | -- | --
default | <img width="351" src="https://user-images.githubusercontent.com/1867547/61913977-df293980-af0c-11e9-8834-ab31228b7afa.png"> | <img width="355" src="https://user-images.githubusercontent.com/1867547/61913996-f23c0980-af0c-11e9-8b84-471941d5b17d.png">
error | <img width="345" src="https://user-images.githubusercontent.com/1867547/61913983-e51f1a80-af0c-11e9-979e-5544a49de9df.png"> | <img width="348" src="https://user-images.githubusercontent.com/1867547/61914004-fc5e0800-af0c-11e9-8f9d-435d9172d362.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Select the payment method in checkout and verify improved spacing
* Enter invalid input and verify proper error styling

-------------------

- [ ] Tested on mobile (or does not apply)
