### PR TITLE
Remove brand identification in checkout and tweak styles

### DIFF
--- a/assets/css/wc-payment-checkout.css
+++ b/assets/css/wc-payment-checkout.css
@@ -1,5 +1,21 @@
-.wc-payment-card-mounted {
+#payment .payment_methods li .payment_box.payment_method_woocommerce_payments fieldset {
+    padding: 0;
+}
+
+.payment_method_woocommerce_payments > fieldset > legend {
+    padding-top: 0;
+}
+
+.payment_method_woocommerce_payments .woocommerce-error {
+    margin: 1em 0 0;
+}
+
+#wc-payment-card-element {
     border: 1px solid #ddd;
     padding: 5px 7px;
+    min-height: 29px;
+}
+
+.wc-payment-card-mounted {
     background-color: #fff;
 }

--- a/assets/js/wc-payment-checkout.js
+++ b/assets/js/wc-payment-checkout.js
@@ -33,7 +33,7 @@ jQuery( function( $ ) {
 			displayError.html( '<ul class="woocommerce-error"><li /></ul>' )
 				.find( 'li' ).text( event.error.message );
 		} else {
-			displayError.html( '' );
+			displayError.empty();
 		}
 	} );
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -182,14 +182,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		);
 
 		// Output the form HTML.
-		$description = $this->get_description();
 		?>
 		<fieldset>
-			<?php if ( ! empty( $description ) ) : ?>
-				<legend><?php echo wp_kses_post( $description ); ?></legend>
+			<?php if ( ! empty( $this->get_description() ) ) : ?>
+				<legend><?php echo wp_kses_post( $this->get_description() ); ?></legend>
 			<?php endif; ?>
 
-			<div id="wc-payment-card-element" class="form-row"></div>
+			<div id="wc-payment-card-element"></div>
 			<div id="wc-payment-errors" role="alert"></div>
 			<input id="wc-payment-method" type="hidden" name="wc-payment-method" />
 		</fieldset>

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -63,7 +63,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$this->icon               = ''; // TODO: icon.
 		$this->has_fields         = true;
 		$this->method_title       = __( 'WooCommerce Payments', 'woocommerce-payments' );
-		$this->method_description = __( 'Accept payments via a WooCommerce-branded payment gateway', 'woocommerce-payments' );
+		$this->method_description = __( 'Accept payments via credit card.', 'woocommerce-payments' );
 		$this->supports           = array(
 			'products',
 			'refunds',
@@ -82,14 +82,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'title'       => __( 'Title', 'woocommerce-payments' ),
 				'type'        => 'text',
 				'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce-payments' ),
-				'default'     => __( 'Credit Card (WooCommerce Payments)', 'woocommerce-payments' ),
+				'default'     => __( 'Credit Card', 'woocommerce-payments' ),
 				'desc_tip'    => true,
 			),
 			'description'          => array(
 				'title'       => __( 'Description', 'woocommerce-payments' ),
 				'type'        => 'text',
 				'description' => __( 'This controls the description which the user sees during checkout.', 'woocommerce-payments' ),
-				'default'     => __( 'Pay with your credit card via WooCommerce Payments.', 'woocommerce-payments' ),
+				'default'     => '',
 				'desc_tip'    => true,
 			),
 			'stripe_account_id'    => array(
@@ -182,9 +182,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		);
 
 		// Output the form HTML.
+		$description = $this->get_description();
 		?>
-		<p><?php echo wp_kses_post( $this->get_description() ); ?></p>
 		<fieldset>
+			<?php if ( ! empty( $description ) ) : ?>
+				<legend><?php echo wp_kses_post( $description ); ?></legend>
+			<?php endif; ?>
+
 			<div id="wc-payment-card-element" class="form-row"></div>
 			<div id="wc-payment-errors" role="alert"></div>
 			<input id="wc-payment-method" type="hidden" name="wc-payment-method" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,7 +10,7 @@
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="4.7" />
-	<config name="testVersion" value="5.2-" />
+	<config name="testVersion" value="5.6-" />
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" >


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/22

#### Changes proposed in this Pull Request

- Since WooCommerce (Payments) is not a customer-facing brand, this change removes mention from the default gateway title and description.
- Also, the default description is now empty, as there is currently nothing that is in need of verbal instruction [[#](https://github.com/Automattic/woocommerce-payments/issues/57#issuecomment-515568106)].
- Finally, the styles are touched up a bit, primarily to avoid wasting space.

Default:
<img width="343" src="https://user-images.githubusercontent.com/1867547/62157505-4f540880-b2db-11e9-8f99-cb104c83ac90.png">

Error state:
<img width="344" src="https://user-images.githubusercontent.com/1867547/62157519-609d1500-b2db-11e9-8ffa-7fdeb953b1a2.png">

With description added:
<img width="343" src="https://user-images.githubusercontent.com/1867547/62157513-58dd7080-b2db-11e9-992c-9821edaecd82.png">

(This uses a `<legend>` element within the `<fieldset>`, but can revert to `<p>` if that's best, in which case we should just wrap the description in `wpautop`.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Checkout screen with WooCommerce Payments enabled
* Verify brand, copy, and appearance changes

-------------------

- [ ] Tested on mobile (or does not apply)
