### PR TITLE
Add payment intention API error handling

### DIFF
--- a/assets/js/wc-payment-checkout.js
+++ b/assets/js/wc-payment-checkout.js
@@ -39,6 +39,19 @@ jQuery( function() {
 			return;
 		}
 
+		// Block the checkout form while we process the payment
+		var $checkout_form = jQuery('form.checkout.woocommerce-checkout');
+		var checkout_form_data = $checkout_form.data();
+		if ( 1 !== checkout_form_data['blockUI.isBlocked'] ) {
+			$checkout_form.block( {
+				message: null,
+				overlayCSS: {
+					background: '#fff',
+					opacity: 0.6
+				}
+			} );
+		}
+
 		stripe.createPaymentMethod( 'card', cardElement )
 			.then( function( result ) {
 				var paymentMethod = result.paymentMethod;
@@ -115,6 +128,8 @@ jQuery( function() {
 				displayError.textContent = error.message;
 
 				console.log('Error processing payment:', error);
+
+				$checkout_form.unblock();
 			} );
 
 		// Prevent form submission so that we can fire it once a payment method has been generated.

--- a/assets/js/wc-payment-checkout.js
+++ b/assets/js/wc-payment-checkout.js
@@ -71,6 +71,7 @@ jQuery( function() {
 					{
 						action: 'create_payment_intention',
 						wc_payment_method_id: paymentMethodId,
+						_ajax_nonce: wc_payment_config.create_payment_intention_nonce,
 					}
 				);
 			} )

--- a/assets/js/wc-payment-checkout.js
+++ b/assets/js/wc-payment-checkout.js
@@ -51,18 +51,19 @@ jQuery( function() {
 				return paymentMethod;
 			} )
 			.then( function( paymentMethod ) {
-				var id = paymentMethod.id;
+				var paymentMethodId = paymentMethod.id;
 
 				// Flag that the payment method has been successfully generated so that we can allow the form
 				// submission next time.
 				paymentMethodGenerated = true;
 
-				// Populate form with the payment method.
-				var paymentMethodInput   = document.getElementById( 'wc-payment-method' );
-				paymentMethodInput.value = id;
-
-				// Re-submit the form.
-				jQuery( '.woocommerce-checkout' ).submit();
+				return jQuery.post(
+					wc_payment_config.ajaxurl,
+					{
+						action: 'create_payment_intention',
+						wc_payment_method_id: paymentMethodId,
+					}
+				);
 			} );
 
 		// Prevent form submission so that we can fire it once a payment method has been generated.

--- a/assets/js/wc-payment-checkout.js
+++ b/assets/js/wc-payment-checkout.js
@@ -30,12 +30,12 @@ jQuery( function() {
 		}
 	} );
 
-	// Create payment method on submission.
-	var paymentMethodGenerated;
+	// Create payment intention on submission.
+	var paymentIntentionGenerated;
 	jQuery( 'form.checkout' ).on( 'checkout_place_order_woocommerce_payments', function() {
 		// We'll resubmit the form after populating our payment method, so if this is the second time this event
 		// is firing we should let the form submission happen.
-		if ( paymentMethodGenerated ) {
+		if ( paymentIntentionGenerated ) {
 			return;
 		}
 
@@ -53,10 +53,6 @@ jQuery( function() {
 			.then( function( paymentMethod ) {
 				var paymentMethodId = paymentMethod.id;
 
-				// Flag that the payment method has been successfully generated so that we can allow the form
-				// submission next time.
-				paymentMethodGenerated = true;
-
 				return jQuery.post(
 					wc_payment_config.ajaxurl,
 					{
@@ -64,6 +60,61 @@ jQuery( function() {
 						wc_payment_method_id: paymentMethodId,
 					}
 				);
+			} )
+			.then( function( paymentIntentionResult ) {
+				if ( ! paymentIntentionResult.success ) {
+					var error = paymentIntentionResult.data;
+					throw error;
+				}
+
+				var paymentIntention = paymentIntentionResult.data;
+
+				if ( false === paymentIntention.requires_action ) {
+					// Populate form with the payment intention ID and
+					var paymentMethodInput   = document.getElementById( 'wc-payment-intention-id' );
+					paymentMethodInput.value = paymentIntention.payment_intention_id;
+
+					// Flag that the payment method has been successfully generated so that we can allow the form
+					// submission next time.
+					paymentIntentionGenerated = true;
+
+					// Re-submit the form.
+					jQuery( '.woocommerce-checkout' ).submit();
+				}
+
+				if ( true === paymentIntention.requires_action ) {
+					return stripe.handleCardAction(
+						paymentIntention.payment_intention_client_secret
+					)
+				}
+			} )
+			.then( function( handleCardActionResult ) {
+				if ( ! handleCardActionResult ) {
+					// No card action needs to be handled.
+					return;
+				}
+
+				var error = handleCardActionResult.error;
+				if ( error ) {
+					throw error;
+				}
+
+				// Populate form with the payment intention ID and
+				var paymentIntentionInput = document.getElementById( 'wc-payment-intention-id' );
+				paymentIntentionInput.value = handleCardActionResult.paymentIntent.id;
+
+				// Flag that the payment method has been successfully generated so that we can allow the form
+				// submission next time.
+				paymentIntentionGenerated = true;
+
+				// Re-submit the form.
+				jQuery( '.woocommerce-checkout' ).submit();
+			} )
+			.catch( function( error ) {
+				var displayError = document.getElementById( 'wc-payment-errors' );
+				displayError.textContent = error.message;
+
+				console.log('Error processing payment:', error);
 			} );
 
 		// Prevent form submission so that we can fire it once a payment method has been generated.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -218,6 +218,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				}
 			}
 			die();
+		} catch ( WC_Payments_API_Exception $e ) {
+			wp_send_json_error(
+				array(
+					'message' => $e->getMessage(),
+				)
+			);
 		} catch ( Exception $e ) {
 			wp_send_json_error(
 				array(

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -134,6 +134,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+		add_action( 'wc_ajax_create_payment_intention', array( $this, 'create_payment_intention' ) );
 	}
 
 	/**
@@ -146,6 +147,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$js_config = array(
 			'publishableKey' => $this->publishable_key,
 			'accountId'      => $this->get_option( 'stripe_account_id' ),
+			'ajaxurl'        => WC_AJAX::get_endpoint( 'create_payment_intention' ),
 		);
 
 		// Register Stripe's JavaScript using the same ID as the Stripe Gateway plugin. This prevents this JS being
@@ -176,8 +178,51 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		<p><?php echo wp_kses_post( $this->get_description() ); ?></p>
 		<div id="wc-payment-card-element"></div>
 		<div id="wc-payment-errors" role="alert"></div>
-		<input id="wc-payment-method" type="hidden" name="wc-payment-method" />
 		<?php
+	}
+
+	/**
+	 * Handle AJAX request to create payment intention.
+	 * Once the payment intention is created, respond with
+	 * whether or not it requires further user action (i.e. 3DS) and
+	 * the payment intention ID.
+	 */
+	public function create_payment_intention() {
+		$payment_method_id = $this->get_payment_method_id_from_request();
+		$amount            = WC()->cart->total;
+
+		try {
+			if ( $amount > 0 ) {
+				$intention = $this->payments_api_client->create_and_confirm_intention(
+					round( (float) $amount * 100 ),
+					'usd',
+					$payment_method_id
+				);
+
+				if ( 'requires_action' === $intention->get_status() ) {
+					wp_send_json_success(
+						array(
+							'requires_action' => true,
+							'payment_intention_client_secret' => $intention->get_client_secret(),
+						)
+					);
+				} else {
+					wp_send_json_success(
+						array(
+							'requires_action'      => false,
+							'payment_intention_id' => $intention->get_id(),
+						)
+					);
+				}
+			}
+			die();
+		} catch ( Exception $e ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'There was a problem with your payment.', 'woocommerce-payments' ),
+				)
+			);
+		}
 	}
 
 	/**
@@ -242,21 +287,21 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Extract the payment method from the request's POST variables
+	 * Extract the payment method ID from the request's POST variables
 	 *
 	 * @return string
-	 * @throws Exception - If no payment method is found.
+	 * @throws Exception - If no payment method ID is found.
 	 */
-	private function get_payment_method_from_request() {
+	private function get_payment_method_id_from_request() {
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
-		if ( ! isset( $_POST['wc-payment-method'] ) ) {
-			// If no payment method is set then stop here with an error.
-			throw new Exception( __( 'Payment method not found.', 'woocommerce-payments' ) );
+		if ( ! isset( $_POST['wc_payment_method_id'] ) ) {
+			// If no payment method ID is set then stop here with an error.
+			throw new Exception( __( 'Payment method ID not found.', 'woocommerce-payments' ) );
 		}
 
-		$payment_method = wc_clean( $_POST['wc-payment-method'] ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		$payment_method_id = wc_clean( $_POST['wc_payment_method_id'] ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
 
-		return $payment_method;
+		return $payment_method_id;
 	}
 }

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -178,6 +178,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		<p><?php echo wp_kses_post( $this->get_description() ); ?></p>
 		<div id="wc-payment-card-element"></div>
 		<div id="wc-payment-errors" role="alert"></div>
+		<input id="wc-payment-intention-id" type="hidden" name="wc-payment-intention-id" />
 		<?php
 	}
 
@@ -233,7 +234,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return array|null
 	 */
 	public function process_payment( $order_id ) {
-		$order = wc_get_order( $order_id );
+		$order                = wc_get_order( $order_id );
+		$payment_intention_id = $this->get_payment_intention_id_from_request();
 
 		try {
 			$amount = $order->get_total();
@@ -241,37 +243,36 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$transaction_id = '';
 
 			if ( $amount > 0 ) {
-				// Get the payment method from the request (generated when the user entered their card details).
-				$payment_method = $this->get_payment_method_from_request();
+				// Retrieve intention.
+				$intention = $this->payments_api_client->retrieve_intention( $payment_intention_id );
 
-				// Create intention, try to confirm it & capture the charge (if 3DS is not required).
-				$intent = $this->payments_api_client->create_and_confirm_intention(
-					round( (float) $amount * 100 ),
-					'usd',
-					$payment_method
-				);
+				if ( 'requires_confirmation' === $intention->get_status() ) {
+					$intention = $this->payments_api_client->confirm_intention( $intention );
+				}
 
-				// TODO: We're not handling *all* sorts of things here. For example, redirecting to a 3DS auth flow.
-				$transaction_id = $intent->get_id();
+				if ( 'succeeded' === $intention->get_status() ) {
+					$transaction_id = $intention->get_id();
 
-				$note = sprintf(
-					/* translators: %1: the successfully charged amount, %2: transaction ID of the payment */
-					__( 'A payment of %1$s was successfully charged using WooCommerce Payments (Transaction #%2$s)', 'woocommerce-payments' ),
-					wc_price( $amount ),
-					$transaction_id
-				);
-				$order->add_order_note( $note );
+					$note = sprintf(
+						/* translators: %1: the successfully charged amount, %2: transaction ID of the payment */
+						__( 'A payment of %1$s was successfully charged using WooCommerce Payments (Transaction #%2$s)', 'woocommerce-payments' ),
+						wc_price( $amount ),
+						$transaction_id
+					);
+						$order->add_order_note( $note );
+
+					$order->payment_complete( $transaction_id );
+
+					wc_reduce_stock_levels( $order_id );
+					WC()->cart->empty_cart();
+
+					return array(
+						'result'   => 'success',
+						'redirect' => $this->get_return_url( $order ),
+					);
+				}
+				return;
 			}
-
-			$order->payment_complete( $transaction_id );
-
-			wc_reduce_stock_levels( $order_id );
-			WC()->cart->empty_cart();
-
-			return array(
-				'result'   => 'success',
-				'redirect' => $this->get_return_url( $order ),
-			);
 		} catch ( Exception $e ) {
 			// TODO: Create or wire-up a logger for writing messages to the server filesystem.
 			// TODO: Create plugin specific exceptions so that we can be smarter about what we create notices for.
@@ -303,5 +304,24 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
 
 		return $payment_method_id;
+	}
+
+	/**
+	 * Extract the payment intention ID from the request's POST variables
+	 *
+	 * @return string
+	 * @throws Exception - If no payment intention ID is found.
+	 */
+	private function get_payment_intention_id_from_request() {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		if ( ! isset( $_POST['wc-payment-intention-id'] ) ) {
+			// If no payment intention ID is set then stop here with an error.
+			throw new Exception( __( 'Payment intention ID not found.', 'woocommerce-payments' ) );
+		}
+
+		$payment_intention_id = wc_clean( $_POST['wc-payment-intention-id'] ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
+
+		return $payment_intention_id;
 	}
 }

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -145,9 +145,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public function payment_fields() {
 		// Add JavaScript for the payment form.
 		$js_config = array(
-			'publishableKey' => $this->publishable_key,
-			'accountId'      => $this->get_option( 'stripe_account_id' ),
-			'ajaxurl'        => WC_AJAX::get_endpoint( 'create_payment_intention' ),
+			'publishableKey'                 => $this->publishable_key,
+			'accountId'                      => $this->get_option( 'stripe_account_id' ),
+			'ajaxurl'                        => WC_AJAX::get_endpoint( 'create_payment_intention' ),
+			'create_payment_intention_nonce' => wp_create_nonce( 'woocommerce-payments-create-payment-intention' ),
 		);
 
 		// Register Stripe's JavaScript using the same ID as the Stripe Gateway plugin. This prevents this JS being
@@ -294,14 +295,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @throws Exception - If no payment method ID is found.
 	 */
 	private function get_payment_method_id_from_request() {
-		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		check_ajax_referer( 'woocommerce-payments-create-payment-intention' );
+
 		if ( ! isset( $_POST['wc_payment_method_id'] ) ) {
 			// If no payment method ID is set then stop here with an error.
 			throw new Exception( __( 'Payment method ID not found.', 'woocommerce-payments' ) );
 		}
 
 		$payment_method_id = wc_clean( $_POST['wc_payment_method_id'] ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
 
 		return $payment_method_id;
 	}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -195,6 +195,7 @@ class WC_Payments {
 	public static function create_api_client() {
 		require_once dirname( __FILE__ ) . '/wc-payment-api/models/class-wc-payments-api-charge.php';
 		require_once dirname( __FILE__ ) . '/wc-payment-api/models/class-wc-payments-api-intention.php';
+		require_once dirname( __FILE__ ) . '/wc-payment-api/models/class-wc-payments-api-exception.php';
 		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-api-client.php';
 		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-http.php';
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -220,6 +220,7 @@ class WC_Payments_API_Client {
 	 *
 	 * @return array
 	 * @throws Exception - If the account ID hasn't been set.
+	 * @throws WC_Payments_API_Exception - If the response status is not 2xx.
 	 */
 	private function request( $request, $api, $method ) {
 		// Add account ID to the request.
@@ -271,8 +272,7 @@ class WC_Payments_API_Client {
 		// Check the response code and handle any errors.
 		$response_code = wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $response_code ) {
-			// TODO: Handle non-200 codes better.
-			throw new Exception( __( 'Server Error.', 'woocommerce-payments' ) );
+			throw WC_Payments_API_Exception::build_from_api_response( $response_body, $response_code );
 		}
 
 		return $response_body;

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -317,7 +317,7 @@ class WC_Payments_API_Client {
 		$created = new DateTime();
 		$created->setTimestamp( $intention_array['created'] );
 
-		$intent = new WC_Payments_API_Intention(
+		$intention = new WC_Payments_API_Intention(
 			$intention_array['id'],
 			$intention_array['amount'],
 			$created,
@@ -325,6 +325,6 @@ class WC_Payments_API_Client {
 			$intention_array['client_secret']
 		);
 
-		return $intent;
+		return $intention;
 	}
 }

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -109,22 +109,38 @@ class WC_Payments_API_Client {
 	/**
 	 * Confirm an intention
 	 *
-	 * @param WC_Payments_API_Intention $intent            - The intention to confirm.
-	 * @param string                    $payment_method_id - ID of payment method to process charge with.
+	 * @param WC_Payments_API_Intention $intention - The intention ID to confirm.
 	 *
 	 * @return WC_Payments_API_Intention
 	 * @throws Exception - Exception thrown on intention confirmation failure.
 	 */
-	public function confirm_intention( WC_Payments_API_Intention $intent, $payment_method_id ) {
-		$request                   = array();
-		$request['payment_method'] = $payment_method_id;
+	public function confirm_intention( WC_Payments_API_Intention $intention ) {
+		$request = array();
 
 		$response_array = $this->request(
 			$request,
-			self::INTENTIONS_API . '/' . $intent->get_id() . '/confirm',
+			self::INTENTIONS_API . '/' . $intention->get_id() . '/confirm',
 			self::POST
 		);
+		return $this->deserialize_intention_object_from_array( $response_array );
+	}
 
+	/**
+	 * Retrieve an intention
+	 *
+	 * @param string $payment_intention_id - The intention ID to retrieve.
+	 *
+	 * @return WC_Payments_API_Intention
+	 * @throws Exception - Exception thrown on intention confirmation failure.
+	 */
+	public function retrieve_intention( $payment_intention_id ) {
+		$request = array();
+
+		$response_array = $this->request(
+			$request,
+			self::INTENTIONS_API . '/' . $payment_intention_id,
+			self::GET
+		);
 		return $this->deserialize_intention_object_from_array( $response_array );
 	}
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -220,6 +220,8 @@ class WC_Payments_API_Client {
 	 *
 	 * @return array
 	 * @throws Exception - If the account ID hasn't been set.
+	 * @throws Exception - If unable to encode body for request.
+	 * @throws Exception - If unable to decode response.
 	 * @throws WC_Payments_API_Exception - If the response status is not 2xx.
 	 */
 	private function request( $request, $api, $method ) {

--- a/includes/wc-payment-api/models/class-wc-payments-api-exception.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-exception.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Generic exception class for WooCommerce Payments API errors.
+ *
+ * @package WooCommerce\Payments
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * An exception object used by the WooCommerce Payments API.
+ */
+class WC_Payments_API_Exception extends Exception {
+
+	/**
+	 * Type of API response error.
+	 *
+	 * One of these several types:
+	 * https://stripe.com/docs/api/errors#errors-type
+	 *
+	 * @var string
+	 */
+	protected $type;
+
+	/**
+	 * WC_Payments_API_Intention constructor.
+	 *
+	 * @param string $type - type of error.
+	 * @param string $message - error message.
+	 * @param int    $status - HTTP status code of API response.
+	 */
+	public function __construct( $type, $message, $status ) {
+		$this->type    = $type;
+		$this->message = $message;
+
+		if ( 'card_error' !== $this->type ) {
+			$this->message = __(
+				'There was a problem with your payment.',
+				'woocommerce-payments'
+			);
+		}
+	}
+
+	/**
+	 * Gets the error type.
+	 *
+	 * @return string
+	 */
+	public function getType() {
+		return $this->type;
+	}
+
+	/**
+	 * Creates a new WC_Payments_API_Exception object directly from the API response body and status.
+	 *
+	 * @param array $response_body - response body.
+	 * @param int   $response_status_code - HTTP status code of API response.
+	 * @return WC_Payments_API_Exception
+	 * @throws Exception - If no error is found in $response_body.
+	 */
+	public static function build_from_api_response( $response_body, $response_status_code ) {
+		if ( ! isset( $response_body['error'] ) ) {
+			throw new Exception( __( 'No error found in API response.', 'woocommerce-payments' ) );
+		}
+
+		$error   = $response_body['error'];
+		$type    = $error['type'];
+		$message = $error['message'];
+
+		return new WC_Payments_API_Exception( $type, $message, $response_status_code );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,6 +39,7 @@ function _manually_load_plugin() {
 
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/models/class-wc-payments-api-charge.php';
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/models/class-wc-payments-api-intention.php';
+	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/models/class-wc-payments-api-exception.php';
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-api-client.php';
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-http.php';
 }


### PR DESCRIPTION
This PR handles non-2xx responses from the server by throwing a custom exception, `WC_Payments_API_Exception`.

It's based on the discussions in PR #133.

The constructor determines whether the error message received from the server should be shown to user, and if not, it uses a default error message instead. Only errors of type `card_error` should have their messages shown to users.

When the server responds with a non-2xx code, an error object is sent in the response ([docs](https://stripe.com/docs/api/errors)).

The constructor takes a status code but does nothing with it for the time being. It may be useful for displaying different errors messages. If you'd prefer me not to ship it, lmk.

Once this is approved, similar changes will need to be made for refunds and in the request function ([#](https://github.com/Automattic/woocommerce-payments/blob/0e650426d400e032703f8b7419d4b982a07e3443/includes/wc-payment-api/class-wc-payments-api-client.php#L277)).

Before merging, this issue needs to be fixed on the server: Automattic/woocommerce-payments-server#29