### PR TITLE
Adding Pressable's SFTP to known hosts in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ matrix:
     stage: deploy
     env: SHOULD_DEPLOY=1
     addons:
+      ssh_known_hosts: sftp.pressable.com
       apt:
         packages:
         - lftp


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a single line to the configuration of the `Deployment to Pressable` job in order to avoid SSH errors.

#### Testing instructions

- Replace all instances of `master` with the name of this PR's branch within `.travis.yml`.
- Commit & push
- Open https://travis-ci.com/Automattic/woocommerce-payments/branches and click on the job number next to `fix/pressable-deployment`.
- Once completed, scroll down to "Deployment to Pressable" and click it.
- Click on the `Deploying application` line to expand it.
- Make sure there are no errors.
- Replace this PR's branch name with `master` in `.travis.yml`