### PR TITLE
Fix inconsistent payment method input ID and name

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -198,7 +198,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			<div id="wcpay-card-element"></div>
 			<div id="wcpay-errors" role="alert"></div>
-			<input id="wcpay-method" type="hidden" name="wcpay-method" />
+			<input id="wcpay-payment-method" type="hidden" name="wcpay-payment-method" />
 		</fieldset>
 		<?php
 	}
@@ -275,12 +275,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	private function get_payment_method_from_request() {
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
-		if ( ! isset( $_POST['wcpay-method'] ) ) {
+		if ( ! isset( $_POST['wcpay-payment-method'] ) ) {
 			// If no payment method is set then stop here with an error.
 			throw new Exception( __( 'Payment method not found.', 'woocommerce-payments' ) );
 		}
 
-		$payment_method = wc_clean( $_POST['wcpay-method'] ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		$payment_method = wc_clean( $_POST['wcpay-payment-method'] ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
 
 		return $payment_method;


### PR DESCRIPTION
Fixes broken checkout due to a mistake in https://github.com/Automattic/woocommerce-payments/pull/182.

#### Changes proposed in this Pull Request

Give hidden input tracking payment method ID a proper and consistent name and ID:

`wcpay-payment-method`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Payment on checkout should work again, instead of throwing a JS error.

-------------------

- [ ] Tested on mobile (or does not apply)
