### PR TITLE
Auth capture and void buttons and modals

### DIFF
--- a/client/edit-order.js
+++ b/client/edit-order.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
-import { render, useState } from '@wordpress/element';
+import { Button, Modal } from '@wordpress/components';
+import { render, useState, Fragment } from '@wordpress/element';
 import $ from 'jquery';
 
 const doOrderAction = ( actionId ) => {
@@ -10,6 +10,7 @@ const doOrderAction = ( actionId ) => {
 };
 
 const CaptureAction = () => {
+	const [ isOpen, setOpen ] = useState( false );
 	const [ isBusy, setBusy ] = useState( false );
 
 	const doAction = () => {
@@ -18,11 +19,20 @@ const CaptureAction = () => {
 	}
 
 	return (
-		<Button isDefault onClick={ doAction } isBusy={ isBusy }>Capture Charge</Button>
+		<Fragment>
+			<Button isDefault onClick={ () => setOpen( true ) }>Capture Charge</Button>
+			{ isOpen && (
+				<Modal title="Capture Charge" onRequestClose={ () => setOpen( false ) }>
+					<Button isDefault onClick={ () => setOpen( false ) }>Close</Button>
+					<Button isPrimary onClick={ doAction } isBusy={ isBusy }>Capture Charge</Button>
+				</Modal>
+			) }
+		</Fragment>
 	);
 };
 
 const VoidAction = () => {
+	const [ isOpen, setOpen ] = useState( false );
 	const [ isBusy, setBusy ] = useState( false );
 
 	const doAction = () => {
@@ -31,7 +41,15 @@ const VoidAction = () => {
 	}
 
 	return (
-		<Button isDefault onClick={ doAction } isBusy={ isBusy }>Void Authorization</Button>
+		<Fragment>
+			<Button isDefault onClick={ () => setOpen( true ) }>Void Authorization</Button>
+			{ isOpen && (
+				<Modal title="Void Authorization" onRequestClose={ () => setOpen( false ) }>
+					<Button isDefault onClick={ () => setOpen( false ) }>Close</Button>
+					<Button isPrimary onClick={ doAction } isBusy={ isBusy }>Void Authorization</Button>
+				</Modal>
+			) }
+		</Fragment>
 	);
 };
 

--- a/client/edit-order.js
+++ b/client/edit-order.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { render, useState } from '@wordpress/element';
+import $ from 'jquery';
+
+const doOrderAction = ( actionId ) => {
+	$( '#actions select' ).val( actionId ).closest( 'form' ).submit();
+};
+
+const CaptureAction = () => {
+	const [ isBusy, setBusy ] = useState( false );
+
+	const doAction = () => {
+		setBusy( true );
+		doOrderAction( 'capture_charge' );
+	}
+
+	return (
+		<Button isDefault onClick={ doAction } isBusy={ isBusy }>Capture Charge</Button>
+	);
+};
+
+const VoidAction = () => {
+	const [ isBusy, setBusy ] = useState( false );
+
+	const doAction = () => {
+		setBusy( true );
+		doOrderAction( 'void_authorization' );
+	}
+
+	return (
+		<Button isDefault onClick={ doAction } isBusy={ isBusy }>Void Authorization</Button>
+	);
+};
+
+const AuthorizedChargeActions = () => (
+	<div style={ { float: 'right' } }>
+		<VoidAction />
+		<CaptureAction />
+	</div>
+);
+
+const container = $( '<div>' )
+	.attr( 'class', 'authorized-charge-action-container' )
+	.prependTo( '.woocommerce-order-data__meta.order_number' )
+	.get( 0 );
+
+render( <AuthorizedChargeActions />, container );

--- a/client/edit-order/index.js
+++ b/client/edit-order/index.js
@@ -15,48 +15,24 @@ const doOrderAction = ( actionId ) => {
 	$( '#actions select' ).val( actionId ).closest( 'form' ).submit();
 };
 
-const CaptureAction = () => {
+const ConfirmAction = ( { action, title, children } ) => {
 	const [ isOpen, setOpen ] = useState( false );
 	const [ isBusy, setBusy ] = useState( false );
 
 	const doAction = () => {
 		setBusy( true );
-		doOrderAction( 'capture_charge' );
-	}
+		doOrderAction( action );
+	};
 
 	return (
 		<Fragment>
-			<Button isDefault onClick={ () => setOpen( true ) }>Capture Charge</Button>
+			<Button isDefault onClick={ () => setOpen( true ) }>{ title }</Button>
 			{ isOpen && (
-				<Modal title="Capture Charge" onRequestClose={ () => setOpen( false ) } className="authorized-charge-modal">
+				<Modal title={ title } onRequestClose={ () => setOpen( false ) } className="authorized-charge-modal">
+					{ children }
 					<div className="authorized-charge-modal-buttons">
-						<Button isDefault onClick={ () => setOpen( false ) }>Close</Button>
-						<Button isPrimary onClick={ doAction } isBusy={ isBusy }>Capture Charge</Button>
-					</div>
-				</Modal>
-			) }
-		</Fragment>
-	);
-};
-
-const VoidAction = () => {
-	const [ isOpen, setOpen ] = useState( false );
-	const [ isBusy, setBusy ] = useState( false );
-
-	const doAction = () => {
-		setBusy( true );
-		doOrderAction( 'void_authorization' );
-	}
-
-	return (
-		<Fragment>
-			<Button isDefault onClick={ () => setOpen( true ) }>Void Authorization</Button>
-			{ isOpen && (
-				<Modal title="Void Authorization" onRequestClose={ () => setOpen( false ) } className="authorized-charge-modal">
-					<div className="authorized-charge-modal-buttons">
-						<p>{ __( 'Voiding this authorization will cancel the order, and restock all items.' ) }</p>
-						<Button isDefault onClick={ () => setOpen( false ) }>Close</Button>
-						<Button isPrimary onClick={ doAction } isBusy={ isBusy }>Void Authorization</Button>
+						<Button isDefault onClick={ () => setOpen( false ) }>{ __( 'Close' ) }</Button>
+						<Button isPrimary onClick={ doAction } isBusy={ isBusy }>{ title }</Button>
 					</div>
 				</Modal>
 			) }
@@ -66,8 +42,10 @@ const VoidAction = () => {
 
 const AuthorizedChargeActions = () => (
 	<Fragment>
-		<VoidAction />
-		<CaptureAction />
+		<ConfirmAction action="void_authorization" title={ __( 'Void Authorization' ) }>
+			<p>{ __( 'Voiding this authorization will cancel the order.' ) }</p>
+		</ConfirmAction>
+		<ConfirmAction action="capture_charge" title={ __( 'Capture Charge' ) } />
 	</Fragment>
 );
 

--- a/client/edit-order/index.js
+++ b/client/edit-order/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Button, Modal } from '@wordpress/components';
 import { render, useState, Fragment } from '@wordpress/element';
 import $ from 'jquery';
@@ -53,6 +54,7 @@ const VoidAction = () => {
 			{ isOpen && (
 				<Modal title="Void Authorization" onRequestClose={ () => setOpen( false ) } className="authorized-charge-modal">
 					<div className="authorized-charge-modal-buttons">
+						<p>{ __( 'Voiding this authorization will cancel the order, and restock all items.' ) }</p>
 						<Button isDefault onClick={ () => setOpen( false ) }>Close</Button>
 						<Button isPrimary onClick={ doAction } isBusy={ isBusy }>Void Authorization</Button>
 					</div>

--- a/client/edit-order/index.js
+++ b/client/edit-order/index.js
@@ -5,6 +5,11 @@ import { Button, Modal } from '@wordpress/components';
 import { render, useState, Fragment } from '@wordpress/element';
 import $ from 'jquery';
 
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
 const doOrderAction = ( actionId ) => {
 	$( '#actions select' ).val( actionId ).closest( 'form' ).submit();
 };
@@ -22,9 +27,11 @@ const CaptureAction = () => {
 		<Fragment>
 			<Button isDefault onClick={ () => setOpen( true ) }>Capture Charge</Button>
 			{ isOpen && (
-				<Modal title="Capture Charge" onRequestClose={ () => setOpen( false ) }>
-					<Button isDefault onClick={ () => setOpen( false ) }>Close</Button>
-					<Button isPrimary onClick={ doAction } isBusy={ isBusy }>Capture Charge</Button>
+				<Modal title="Capture Charge" onRequestClose={ () => setOpen( false ) } className="authorized-charge-modal">
+					<div className="authorized-charge-modal-buttons">
+						<Button isDefault onClick={ () => setOpen( false ) }>Close</Button>
+						<Button isPrimary onClick={ doAction } isBusy={ isBusy }>Capture Charge</Button>
+					</div>
 				</Modal>
 			) }
 		</Fragment>
@@ -44,9 +51,11 @@ const VoidAction = () => {
 		<Fragment>
 			<Button isDefault onClick={ () => setOpen( true ) }>Void Authorization</Button>
 			{ isOpen && (
-				<Modal title="Void Authorization" onRequestClose={ () => setOpen( false ) }>
-					<Button isDefault onClick={ () => setOpen( false ) }>Close</Button>
-					<Button isPrimary onClick={ doAction } isBusy={ isBusy }>Void Authorization</Button>
+				<Modal title="Void Authorization" onRequestClose={ () => setOpen( false ) } className="authorized-charge-modal">
+					<div className="authorized-charge-modal-buttons">
+						<Button isDefault onClick={ () => setOpen( false ) }>Close</Button>
+						<Button isPrimary onClick={ doAction } isBusy={ isBusy }>Void Authorization</Button>
+					</div>
 				</Modal>
 			) }
 		</Fragment>
@@ -54,10 +63,10 @@ const VoidAction = () => {
 };
 
 const AuthorizedChargeActions = () => (
-	<div style={ { float: 'right' } }>
+	<Fragment>
 		<VoidAction />
 		<CaptureAction />
-	</div>
+	</Fragment>
 );
 
 const container = $( '<div>' )

--- a/client/edit-order/index.js
+++ b/client/edit-order/index.js
@@ -11,6 +11,10 @@ import $ from 'jquery';
  */
 import './style.scss';
 
+const hasOrderAction = ( actionId ) => {
+	return 0 < $( '#actions select' ).has( `[value=${ actionId }]` ).length;
+}
+
 const doOrderAction = ( actionId ) => {
 	$( '#actions select' ).val( actionId ).closest( 'form' ).submit();
 };
@@ -18,6 +22,10 @@ const doOrderAction = ( actionId ) => {
 const ConfirmAction = ( { action, title, children } ) => {
 	const [ isOpen, setOpen ] = useState( false );
 	const [ isBusy, setBusy ] = useState( false );
+
+	if ( ! hasOrderAction( action ) ) {
+		return;
+	}
 
 	const doAction = () => {
 		setBusy( true );

--- a/client/edit-order/style.scss
+++ b/client/edit-order/style.scss
@@ -1,0 +1,13 @@
+.authorized-charge-action-container, .authorized-charge-modal {
+	button {
+		margin-left: 10px;
+	}
+}
+
+.authorized-charge-action-container {
+	float: right;
+}
+
+.authorized-charge-modal-buttons {
+	text-align: right;
+}

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -13,12 +13,17 @@ defined( 'ABSPATH' ) || exit;
 class WC_Payments_Admin {
 	/**
 	 * Hook in admin menu items.
+	 *
+	 * @param WC_Payments_API_Client $payments_api_client - WooCommerce Payments API client.
 	 */
-	public function __construct() {
+	public function __construct( WC_Payments_API_Client $payments_api_client ) {
 		// Add menu items.
 		add_action( 'admin_menu', array( $this, 'add_payments_menu' ), 9 );
 		add_action( 'init', array( $this, 'register_payments_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_payments_scripts' ) );
+
+		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-edit-order.php';
+		new WC_Payments_Edit_Order( $payments_api_client );
 	}
 
 	/**

--- a/includes/admin/class-wc-payments-edit-order.php
+++ b/includes/admin/class-wc-payments-edit-order.php
@@ -130,6 +130,13 @@ class WC_Payments_Edit_Order {
 			filemtime( WCPAY_ABSPATH . 'dist/edit-order.js' ),
 			true
 		);
+
+		wp_register_style(
+			'WCPAY_EDIT_ORDER',
+			plugins_url( 'dist/edit-order.css', WCPAY_PLUGIN_FILE ),
+			array( 'wc-components' ),
+			filemtime( WCPAY_ABSPATH . 'dist/edit-order.css' )
+		);
 	}
 
 	/**
@@ -141,6 +148,6 @@ class WC_Payments_Edit_Order {
 		}
 
 		wp_enqueue_script( 'WCPAY_EDIT_ORDER' );
-		wp_enqueue_style( 'wc-components' );
+		wp_enqueue_style( 'WCPAY_EDIT_ORDER' );
 	}
 }

--- a/includes/admin/class-wc-payments-edit-order.php
+++ b/includes/admin/class-wc-payments-edit-order.php
@@ -30,6 +30,9 @@ class WC_Payments_Edit_Order {
 		add_action( 'woocommerce_order_actions', array( $this, 'add_order_actions' ) );
 		add_action( 'woocommerce_order_action_capture_charge', array( $this, 'capture_charge' ) );
 		add_action( 'woocommerce_order_action_void_authorization', array( $this, 'void_authorization' ) );
+
+		add_action( 'init', array( $this, 'register_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 	}
 
 	/**
@@ -109,5 +112,35 @@ class WC_Payments_Edit_Order {
 			);
 			$order->add_order_note( $note );
 		}
+	}
+
+	/**
+	 * Register the CSS and JS scripts
+	 */
+	public function register_scripts() {
+		$script_src_url      = plugins_url( 'dist/edit-order.js', WCPAY_PLUGIN_FILE );
+		$script_deps_path    = WCPAY_ABSPATH . 'dist/edit-order.deps.json';
+		$script_dependencies = file_exists( $script_deps_path )
+			? json_decode( file_get_contents( $script_deps_path ) ) // PHPCS:Ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			: array();
+		wp_register_script(
+			'WCPAY_EDIT_ORDER',
+			$script_src_url,
+			$script_dependencies,
+			filemtime( WCPAY_ABSPATH . 'dist/edit-order.js' ),
+			true
+		);
+	}
+
+	/**
+	 * Load the assets
+	 */
+	public function enqueue_scripts() {
+		if ( 'shop_order' !== get_current_screen()->id ) {
+			return;
+		}
+
+		wp_enqueue_script( 'WCPAY_EDIT_ORDER' );
+		wp_enqueue_style( 'wc-components' );
 	}
 }

--- a/includes/admin/class-wc-payments-edit-order.php
+++ b/includes/admin/class-wc-payments-edit-order.php
@@ -29,11 +29,11 @@ class WC_Payments_Edit_Order {
 
 		add_action( 'woocommerce_order_actions', array( $this, 'add_order_actions' ) );
 		add_action( 'woocommerce_order_action_capture_charge', array( $this, 'capture_charge' ) );
-		add_action( 'woocommerce_order_action_cancel_authorization', array( $this, 'cancel_authorization' ) );
+		add_action( 'woocommerce_order_action_void_authorization', array( $this, 'void_authorization' ) );
 	}
 
 	/**
-	 * Add capture and cancel actions for orders with an authorized charge.
+	 * Add capture and void actions for orders with an authorized charge.
 	 *
 	 * @param array $actions - Actions to make available in order actions metabox.
 	 */
@@ -49,8 +49,8 @@ class WC_Payments_Edit_Order {
 		}
 
 		$new_actions = array(
-			'capture_charge'       => __( 'Capture charge', 'woocommerce-payments' ),
-			'cancel_authorization' => __( 'Cancel authorization', 'woocommerce-payments' ),
+			'capture_charge'     => __( 'Capture charge', 'woocommerce-payments' ),
+			'void_authorization' => __( 'Void authorization', 'woocommerce-payments' ),
 		);
 
 		return array_merge( $new_actions, $actions );
@@ -88,11 +88,11 @@ class WC_Payments_Edit_Order {
 	}
 
 	/**
-	 * Cancel previously authorized charge.
+	 * Void previously authorized charge.
 	 *
-	 * @param WC_Order $order - Order to cancel authorization on.
+	 * @param WC_Order $order - Order to void authorization on.
 	 */
-	public function cancel_authorization( $order ) {
+	public function void_authorization( $order ) {
 		$intent = $this->payments_api_client->cancel_intention( $order->get_transaction_id() );
 		$status = $intent->get_status();
 
@@ -100,11 +100,11 @@ class WC_Payments_Edit_Order {
 		$order->save();
 
 		if ( 'canceled' === $status ) {
-			$order->update_status( 'cancelled', __( 'Payment authorization was successfully <strong>cancelled</strong>.', 'woocommerce-payments' ) );
+			$order->update_status( 'cancelled', __( 'Payment authorization was successfully <strong>voided</strong>.', 'woocommerce-payments' ) );
 		} else {
 			$note = sprintf(
 				/* translators: %1: the successfully charged amount */
-				__( 'Canceling authorization <strong>failed</strong> to complete.', 'woocommerce-payments' ),
+				__( 'Voiding authorization <strong>failed</strong> to complete.', 'woocommerce-payments' ),
 				wc_price( $amount )
 			);
 			$order->add_order_note( $note );

--- a/includes/admin/class-wc-payments-edit-order.php
+++ b/includes/admin/class-wc-payments-edit-order.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Class WC_Payments_Edit_Order
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Controller for edit order screen actions.
+ */
+class WC_Payments_Edit_Order {
+
+	/**
+	 * Client for making requests to the WooCommerce Payments API
+	 *
+	 * @var WC_Payments_API_Client
+	 */
+	private $payments_api_client;
+
+	/**
+	 * WC_Payments_Edit_Order constructor.
+	 *
+	 * @param WC_Payments_API_Client $payments_api_client - WooCommerce Payments API client.
+	 */
+	public function __construct( WC_Payments_API_Client $payments_api_client ) {
+		$this->payments_api_client = $payments_api_client;
+
+		add_action( 'woocommerce_order_actions', array( $this, 'add_order_actions' ) );
+		add_action( 'woocommerce_order_action_capture_charge', array( $this, 'capture_charge' ) );
+		add_action( 'woocommerce_order_action_cancel_authorization', array( $this, 'cancel_authorization' ) );
+	}
+
+	/**
+	 * Add capture and cancel actions for orders with an authorized charge.
+	 *
+	 * @param array $actions - Actions to make available in order actions metabox.
+	 */
+	public function add_order_actions( $actions ) {
+		global $theorder;
+
+		if ( WC_Payment_Gateway_WCPay::GATEWAY_ID !== $theorder->get_payment_method() ) {
+			return $actions;
+		}
+
+		if ( 'requires_capture' !== $theorder->get_meta( '_intention_status', true ) ) {
+			return $actions;
+		}
+
+		$new_actions = array(
+			'capture_charge'       => __( 'Capture charge', 'woocommerce-payments' ),
+			'cancel_authorization' => __( 'Cancel authorization', 'woocommerce-payments' ),
+		);
+
+		return array_merge( $new_actions, $actions );
+	}
+
+	/**
+	 * Capture previously authorized charge.
+	 *
+	 * @param WC_Order $order - Order to capture charge on.
+	 */
+	public function capture_charge( $order ) {
+		$amount = $order->get_total();
+		$intent = $this->payments_api_client->capture_intention( $order->get_transaction_id(), round( (float) $amount * 100 ) );
+		$status = $intent->get_status();
+
+		$order->update_meta_data( '_intention_status', $status );
+		$order->save();
+
+		if ( 'succeeded' === $status ) {
+			$note = sprintf(
+				/* translators: %1: the successfully charged amount */
+				__( 'A payment of %1$s was <strong>successfully captured</strong> using WooCommerce Payments.', 'woocommerce-payments' ),
+				wc_price( $amount )
+			);
+			$order->add_order_note( $note );
+			$order->payment_complete();
+		} else {
+			$note = sprintf(
+				/* translators: %1: the successfully charged amount */
+				__( 'A capture of %1$s <strong>failed</strong> to complete.', 'woocommerce-payments' ),
+				wc_price( $amount )
+			);
+			$order->add_order_note( $note );
+		}
+	}
+
+	/**
+	 * Cancel previously authorized charge.
+	 *
+	 * @param WC_Order $order - Order to cancel authorization on.
+	 */
+	public function cancel_authorization( $order ) {
+		$intent = $this->payments_api_client->cancel_intention( $order->get_transaction_id() );
+		$status = $intent->get_status();
+
+		$order->update_meta_data( '_intention_status', $status );
+		$order->save();
+
+		if ( 'canceled' === $status ) {
+			$order->update_status( 'cancelled', __( 'Payment authorization was successfully <strong>cancelled</strong>.', 'woocommerce-payments' ) );
+		} else {
+			$note = sprintf(
+				/* translators: %1: the successfully charged amount */
+				__( 'Canceling authorization <strong>failed</strong> to complete.', 'woocommerce-payments' ),
+				wc_price( $amount )
+			);
+			$order->add_order_note( $note );
+		}
+	}
+}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -154,10 +154,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		add_action( 'admin_notices', array( $this, 'display_errors' ) );
 		add_action( 'woocommerce_init', array( $this, 'maybe_handle_oauth' ) );
 		add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
-
-		add_action( 'woocommerce_order_actions', array( $this, 'add_order_actions' ) );
-		add_action( 'woocommerce_order_action_capture_charge', array( $this, 'capture_charge' ) );
-		add_action( 'woocommerce_order_action_cancel_authorization', array( $this, 'cancel_authorization' ) );
 	}
 
 	/**
@@ -488,85 +484,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			wp_safe_redirect( remove_query_arg( [ 'wcpay-state', 'wcpay-account-id', 'wcpay-publishable-key', 'wcpay-mode' ] ) );
 			exit;
-		}
-	}
-
-	/**
-	 * Add capture and cancel actions for orders with an authorized charge.
-	 *
-	 * @param array $actions - Actions to make available in order actions metabox.
-	 */
-	public function add_order_actions( $actions ) {
-		global $theorder;
-
-		if ( $this->id !== $theorder->get_payment_method() ) {
-			return $actions;
-		}
-
-		if ( 'requires_capture' !== $theorder->get_meta( '_intention_status', true ) ) {
-			return $actions;
-		}
-
-		$new_actions = array(
-			'capture_charge'       => __( 'Capture charge', 'woocommerce-payments' ),
-			'cancel_authorization' => __( 'Cancel authorization', 'woocommerce-payments' ),
-		);
-
-		return array_merge( $new_actions, $actions );
-	}
-
-	/**
-	 * Capture previously authorized charge.
-	 *
-	 * @param WC_Order $order - Order to capture charge on.
-	 */
-	public function capture_charge( $order ) {
-		$amount = $order->get_total();
-		$intent = $this->payments_api_client->capture_intention( $order->get_transaction_id(), round( (float) $amount * 100 ) );
-		$status = $intent->get_status();
-
-		$order->update_meta_data( '_intention_status', $status );
-		$order->save();
-
-		if ( 'succeeded' === $status ) {
-			$note = sprintf(
-				/* translators: %1: the successfully charged amount */
-				__( 'A payment of %1$s was <strong>successfully captured</strong> using WooCommerce Payments.', 'woocommerce-payments' ),
-				wc_price( $amount )
-			);
-			$order->add_order_note( $note );
-			$order->payment_complete();
-		} else {
-			$note = sprintf(
-				/* translators: %1: the successfully charged amount */
-				__( 'A capture of %1$s <strong>failed</strong> to complete.', 'woocommerce-payments' ),
-				wc_price( $amount )
-			);
-			$order->add_order_note( $note );
-		}
-	}
-
-	/**
-	 * Cancel previously authorized charge.
-	 *
-	 * @param WC_Order $order - Order to cancel authorization on.
-	 */
-	public function cancel_authorization( $order ) {
-		$intent = $this->payments_api_client->cancel_intention( $order->get_transaction_id() );
-		$status = $intent->get_status();
-
-		$order->update_meta_data( '_intention_status', $status );
-		$order->save();
-
-		if ( 'canceled' === $status ) {
-			$order->update_status( 'cancelled', __( 'Payment authorization was successfully <strong>cancelled</strong>.', 'woocommerce-payments' ) );
-		} else {
-			$note = sprintf(
-				/* translators: %1: the successfully charged amount */
-				__( 'Canceling authorization <strong>failed</strong> to complete.', 'woocommerce-payments' ),
-				wc_price( $amount )
-			);
-			$order->add_order_note( $note );
 		}
 	}
 }

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -52,7 +52,7 @@ class WC_Payments {
 		// Add admin screens.
 		if ( is_admin() ) {
 			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin.php';
-			new WC_Payments_Admin();
+			new WC_Payments_Admin( self::$api_client );
 		}
 
 		add_action( 'rest_api_init', array( __CLASS__, 'init_rest_api' ) );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ const webpackConfig = {
 	mode: NODE_ENV,
 	entry: {
 		index: './client/index.js',
-		'edit-order': './client/edit-order.js',
+		'edit-order': './client/edit-order/index.js',
 	},
 	output: {
 		filename: '[name].js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ const webpackConfig = {
 	mode: NODE_ENV,
 	entry: {
 		index: './client/index.js',
+		'edit-order': './client/edit-order.js',
 	},
 	output: {
 		filename: '[name].js',


### PR DESCRIPTION
Addresses #173 in part

#### Changes proposed in this Pull Request

Based on current designs in paJDYF-dz-p2

Quickly decided against thickbox [[#](https://core.trac.wordpress.org/ticket/46985)] in favor of the new JS `<Modal>` in `@wordpress/components`.

Add buttons that trigger capture and void actions, via confirmation modals.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Tested on mobile (or does not apply)
