### PR TITLE
Indicate test mode in checkout

### DIFF
--- a/assets/css/wcpay-checkout.css
+++ b/assets/css/wcpay-checkout.css
@@ -2,11 +2,15 @@
     padding: 0;
 }
 
-.payment_method_woocommerce_payments > fieldset > legend {
+#payment .payment_method_woocommerce_payments > fieldset > legend {
     padding-top: 0;
 }
 
-.payment_method_woocommerce_payments .woocommerce-error {
+#payment .payment_method_woocommerce_payments .testmode-info {
+    margin-bottom: 0.5em;
+}
+
+#payment .payment_method_woocommerce_payments .woocommerce-error {
     margin: 1em 0 0;
 }
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -141,12 +141,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$this->title       = $this->get_option( 'title' );
 		$this->description = $this->get_option( 'description' );
 
-		$this->testmode        = ( ! empty( $this->settings['testmode'] ) && 'yes' === $this->settings['testmode'] ) ? true : false;
-		$this->publishable_key = ! empty( $this->settings['publishable_key'] ) ? $this->settings['publishable_key'] : '';
-
-		if ( $this->testmode ) {
-			$this->publishable_key = ! empty( $this->settings['test_publishable_key'] ) ? $this->settings['test_publishable_key'] : '';
-		}
+		$this->testmode        = 'yes' === $this->get_option( 'testmode' );
+		$this->publishable_key = $this->testmode ? $this->get_option( 'test_publishable_key' ) : $this->get_option( 'publishable_key' );
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -204,6 +204,15 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				<legend><?php echo wp_kses_post( $this->get_description() ); ?></legend>
 			<?php endif; ?>
 
+			<?php if ( $this->testmode ) : ?>
+				<p class="testmode-info">
+				<?php
+					/* translators: link to Stripe testing page */
+					echo wp_kses_post( sprintf( __( '<strong>Test mode:</strong> use test card numbers listed <a href="%s" target="_blank">here</a>.', 'woocommerce-payments' ), 'https://stripe.com/docs/testing' ) );
+				?>
+				</p>
+			<?php endif; ?>
+
 			<div id="wcpay-card-element"></div>
 			<div id="wcpay-errors" role="alert"></div>
 			<input id="wcpay-payment-method" type="hidden" name="wcpay-payment-method" />


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/189

#### Changes proposed in this Pull Request

Adds a message to the payment method input on Checkout, with link to the Stripe testing doc, when in test mode. No effect on live mode.

<img width="338" alt="Screen Shot 2019-08-27 at 5 48 35 PM" src="https://user-images.githubusercontent.com/1867547/63815361-541fd280-c902-11e9-9d5d-2b893bd8dac0.png">

If a description is also present:

<img width="337" alt="Screen Shot 2019-08-27 at 7 41 19 PM" src="https://user-images.githubusercontent.com/1867547/63815471-abbe3e00-c902-11e9-96dd-3c56207b4de5.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify that the message appears in test mode but not in live mode.

-------------------

- [ ] Tested on mobile (or does not apply)
