### PR TITLE
Enable source maps for production builds

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const WordPressExternalDependenciesPlugin = require( '@wordpress/dependency-extr
 
 const webpackConfig = {
 	mode: NODE_ENV,
+	devtool: 'source-map',
 	entry: {
 		index: './client/index.js',
 	},


### PR DESCRIPTION
Improve debugging of the extension for our end users by including source maps in production builds. Source maps are only downloaded if you have the developer tools open, so there should be no impact on page load, besides a minor increase in build time.

Webpack also recommends having source maps for production here: https://webpack.js.org/guides/production/#source-mapping

Fixes #49 

#### Changes proposed in this Pull Request

* Include source maps generation when building for production

#### Testing instructions

* Run `npm run build` and check dist folder for index.js.map and index.css.map
* Navigate to a WC Payments page and open up the developer tools
* You should see the source code under **webpack://** --> **.** --> **client**

-------------------

- [x] Tested on mobile (or does not apply)
