### PR TITLE
Disable WCPay when WooCommerce Multi-Currency is active 

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -100,19 +100,6 @@ class WC_Payments {
 	}
 
 	/**
-	 * Prints a dismissible admin notice when Woo Multi-Currency is enabled.
-	 */
-	public static function multi_currency_enabled__error() {
-		$class   = 'notice notice-error is-dismissible';
-		$message = sprintf(
-			/* translators: %1: WooCommerce Payments version */
-			__( 'WooCommerce Payments %1$s does not support WooCommerce Multi-Currency and has not been loaded.', 'woocommerce-payments' ),
-			WCPAY_VERSION_NUMBER
-		);
-		return printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
-	}
-
-	/**
 	 * Get plugin headers and cache the result to avoid reopening the file.
 	 * First call should execute get_file_data and fetch headers from plugin details comment.
 	 * Subsequent calls return the value stored in the variable $plugin_headers.
@@ -284,7 +271,18 @@ class WC_Payments {
 	 */
 	public static function check_multi_currency_disabled() {
 		if ( class_exists( 'WOOMC\MultiCurrency\App' ) ) {
-			add_action( 'admin_notices', array( __CLASS__, 'multi_currency_enabled__error' ) );
+			$message = sprintf(
+				/* translators: %1: WooCommerce Payments version */
+				__( 'WooCommerce Payments %1$s does not support WooCommerce Multi-Currency and has not been loaded.', 'woocommerce-payments' ),
+				WCPAY_VERSION_NUMBER
+			);
+
+			add_filter(
+				'admin_notices',
+				function () use ( $message ) {
+					self::display_admin_error( $message );
+				}
+			);
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #193 

#### Changes proposed in this Pull Request

* Disable WCPay if Multi-Currency is enabled
* Add error notice when Multi-Currency is active

#### Testing instructions

* Install and enable https://woocommerce.com/products/multi-currency/
    * You should see an admin error warning that WCPay was not loaded due to Multi-Currency
    * You should not see the Payment Method under WooCommerce > Settings > Payments
    * You should not be able to complete an order using WCPay payment method
* Disable the multiple currency extension
    * The admin error should not be displayed
    * You should be able to see the Payment Method under WooCommerce > Settings > Payments
    * You should be able to complete an order using WCPay

-------------------

- [x] Tested on mobile (or does not apply)
