### PR TITLE
Add Transaction details view

### DIFF
--- a/client/components/order-link/index.js
+++ b/client/components/order-link/index.js
@@ -1,0 +1,19 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { Link } from '@woocommerce/components';
+
+/**
+ * Internal dependencies.
+ */
+
+const OrderLink = ( props ) => {
+	const { order } = props;
+    return order
+        ? <Link href={ order.url } type="external">{ order.number }</Link>
+        : <span>&ndash;</span>;
+};
+
+export default OrderLink;

--- a/client/components/order-link/test/__snapshots__/index.js.snap
+++ b/client/components/order-link/test/__snapshots__/index.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OrderLink renders a dash if no order was provided 1`] = `
+<span>
+  –
+</span>
+`;
+
+exports[`OrderLink renders a link to a valid order 1`] = `
+<Link
+  href="https://automattic.com/"
+  type="external"
+>
+  45891
+</Link>
+`;

--- a/client/components/order-link/test/index.js
+++ b/client/components/order-link/test/index.js
@@ -1,0 +1,27 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import OrderLink from '../';
+
+describe( 'OrderLink', () => {
+    test( 'renders a link to a valid order', () => {
+        const orderLink = renderOrder( { url: 'https://automattic.com/', number: '45891' } );
+        expect( orderLink ).toMatchSnapshot();
+    } );
+
+    test( 'renders a dash if no order was provided', () => {
+        const orderLink = renderOrder( null );
+        expect( orderLink ).toMatchSnapshot();
+    } );
+
+    function renderOrder( order ) {
+        return shallow( <OrderLink order={ order } /> );
+    }
+} );
+

--- a/client/index.js
+++ b/client/index.js
@@ -12,6 +12,7 @@ import { addFilter } from '@wordpress/hooks';
 import './style.scss';
 import { HelloWorld } from 'hello-world';
 import TransactionsPage from 'transactions';
+import TransactionDetailsPage from 'transaction-details';
 import 'payments-api/payments-data-store';
 
 const DepositsPage = () => <HelloWorld>Hello from the deposits page</HelloWorld>;
@@ -36,6 +37,16 @@ addFilter( 'woocommerce_admin_pages_list', 'woocommerce-payments', pages => {
         breadcrumbs: [
             rootLink,
             __( 'Transactions', 'woocommerce-payments' ),
+        ],
+    } );
+    pages.push( {
+        container: TransactionDetailsPage,
+        path: '/payments/transactions/details',
+        wpOpenMenu: menuID,
+        breadcrumbs: [
+            rootLink,
+            [ '/payments/transactions', __( 'Transactions', 'woocommerce-payments' ) ],
+            __( 'Payment Details', 'woocommerce-payments' ),
         ],
     } );
     pages.push( {

--- a/client/transaction-details/index.js
+++ b/client/transaction-details/index.js
@@ -6,12 +6,23 @@
 /**
  * Internal dependencies.
  */
+import TransactionSummaryDetails from './summary';
+import TransactionTimelineDetails from './timeline';
+import TransactionPaymentDetails from './payment';
+import TransactionPaymentMethodDetails from './payment-method';
+import TransactionSessionDetails from './session';
 
-const TransactionDetails = ( props ) => {
-	const transactionId = props.query.id;
+ const TransactionDetails = ( props ) => {
+	const transaction = { id: props.query.id };
 	return (
-		<p>You are vieweing details for transaction { transactionId }</p>
+		<div>
+			<TransactionSummaryDetails transaction={ transaction }></TransactionSummaryDetails>
+			<TransactionTimelineDetails transaction={ transaction }></TransactionTimelineDetails>
+			<TransactionPaymentDetails transaction={ transaction }></TransactionPaymentDetails>
+			<TransactionPaymentMethodDetails transaction={ transaction }></TransactionPaymentMethodDetails>
+			<TransactionSessionDetails transaction={ transaction }></TransactionSessionDetails>
+		</div>
 	);
-};
+ };
 
 export default TransactionDetails;

--- a/client/transaction-details/index.js
+++ b/client/transaction-details/index.js
@@ -27,11 +27,9 @@ const TransactionDetails = ( props ) => {
 };
 
 export default withSelect( ( select, ownProps ) => {
-	const { getTransactions } = select( 'wc-payments-api' );
 	// TODO: Create selector for fetching a single transaction and use it here, instead of
-	// using getTransactions() and then filtering the result
-	const transactions = getTransactions().data || [];
-	const transaction = transactions.filter( txn => txn.id === ownProps.query.id )[ 0 ] || {};
+	// creating an empty transaction object
+	const transaction = { id: ownProps.query.id };
 
 	return { transaction };
 } )( TransactionDetails );

--- a/client/transaction-details/index.js
+++ b/client/transaction-details/index.js
@@ -6,6 +6,7 @@
 /**
  * Internal dependencies.
  */
+import withSelect from 'payments-api/with-select';
 import TransactionSummaryDetails from './summary';
 import TransactionTimelineDetails from './timeline';
 import TransactionPaymentDetails from './payment';
@@ -13,7 +14,7 @@ import TransactionPaymentMethodDetails from './payment-method';
 import TransactionSessionDetails from './session';
 
  const TransactionDetails = ( props ) => {
-	const transaction = { id: props.query.id };
+	const { transaction } = props;
 	return (
 		<div>
 			<TransactionSummaryDetails transaction={ transaction }></TransactionSummaryDetails>
@@ -25,4 +26,12 @@ import TransactionSessionDetails from './session';
 	);
  };
 
-export default TransactionDetails;
+ export default withSelect( ( select, ownProps ) => {
+	const { getTransactions } = select( 'wc-payments-api' );
+	// TODO: Create selector for fetching a single transaction and use it here, instead of
+	// using getTransactions() and then filtering the result
+	const transactions = getTransactions().data || [];
+	const transaction = transactions.filter( txn => txn.id === ownProps.query.id )[ 0 ] || {};
+
+	return { transaction };
+} )( TransactionDetails );

--- a/client/transaction-details/index.js
+++ b/client/transaction-details/index.js
@@ -13,7 +13,7 @@ import TransactionPaymentDetails from './payment';
 import TransactionPaymentMethodDetails from './payment-method';
 import TransactionSessionDetails from './session';
 
- const TransactionDetails = ( props ) => {
+const TransactionDetails = ( props ) => {
 	const { transaction } = props;
 	return (
 		<div>
@@ -24,9 +24,9 @@ import TransactionSessionDetails from './session';
 			<TransactionSessionDetails transaction={ transaction }></TransactionSessionDetails>
 		</div>
 	);
- };
+};
 
- export default withSelect( ( select, ownProps ) => {
+export default withSelect( ( select, ownProps ) => {
 	const { getTransactions } = select( 'wc-payments-api' );
 	// TODO: Create selector for fetching a single transaction and use it here, instead of
 	// using getTransactions() and then filtering the result

--- a/client/transaction-details/index.js
+++ b/client/transaction-details/index.js
@@ -1,0 +1,17 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+/**
+ * Internal dependencies.
+ */
+
+const TransactionDetails = ( props ) => {
+	const transactionId = props.query.id;
+	return (
+		<p>You are vieweing details for transaction { transactionId }</p>
+	);
+};
+
+export default TransactionDetails;

--- a/client/transaction-details/payment-method/index.js
+++ b/client/transaction-details/payment-method/index.js
@@ -1,0 +1,21 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { Card } from '@woocommerce/components';
+
+/**
+ * Internal dependencies.
+ */
+
+const TransactionPaymentMethodDetails = ( props ) => {
+	const { transaction } = props;
+	return (
+		<Card title="Payment method">
+			Payment method details for transaction { transaction.id }.
+		</Card>
+	);
+};
+
+export default TransactionPaymentMethodDetails;

--- a/client/transaction-details/payment-method/index.js
+++ b/client/transaction-details/payment-method/index.js
@@ -11,6 +11,7 @@ import { Card } from '@woocommerce/components';
 
 const TransactionPaymentMethodDetails = ( props ) => {
 	const { transaction } = props;
+	// TODO: this is a placeholder card and does not require translation
 	return (
 		<Card title="Payment method">
 			Payment method details for transaction { transaction.id }.

--- a/client/transaction-details/payment/index.js
+++ b/client/transaction-details/payment/index.js
@@ -1,0 +1,21 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { Card } from '@woocommerce/components';
+
+/**
+ * Internal dependencies.
+ */
+
+const TransactionPaymentDetails = ( props ) => {
+	const { transaction } = props;
+	return (
+		<Card title="Payment">
+			Payment details for transaction { transaction.id }.
+		</Card>
+	);
+};
+
+export default TransactionPaymentDetails;

--- a/client/transaction-details/payment/index.js
+++ b/client/transaction-details/payment/index.js
@@ -11,6 +11,7 @@ import { Card } from '@woocommerce/components';
 
 const TransactionPaymentDetails = ( props ) => {
 	const { transaction } = props;
+	// TODO: this is a placeholder card and does not require translation
 	return (
 		<Card title="Payment">
 			Payment details for transaction { transaction.id }.

--- a/client/transaction-details/session/index.js
+++ b/client/transaction-details/session/index.js
@@ -1,0 +1,21 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { Card } from '@woocommerce/components';
+
+/**
+ * Internal dependencies.
+ */
+
+const TransactionSessionDetails = ( props ) => {
+	const { transaction } = props;
+	return (
+		<Card title="Session">
+			Session details for transaction { transaction.id }.
+		</Card>
+	);
+};
+
+export default TransactionSessionDetails;

--- a/client/transaction-details/session/index.js
+++ b/client/transaction-details/session/index.js
@@ -11,6 +11,7 @@ import { Card } from '@woocommerce/components';
 
 const TransactionSessionDetails = ( props ) => {
 	const { transaction } = props;
+	// TODO: this is a placeholder card and does not require translation
 	return (
 		<Card title="Session">
 			Session details for transaction { transaction.id }.

--- a/client/transaction-details/summary/index.js
+++ b/client/transaction-details/summary/index.js
@@ -11,6 +11,7 @@ import { Card } from '@woocommerce/components';
 
 const TransactionSummaryDetails = ( props ) => {
 	const { transaction } = props;
+	// TODO: this is a placeholder card and does not require translation
 	return (
 		<Card title="Summary" action={ transaction.id }>
 			Summary details for transaction { transaction.id }.

--- a/client/transaction-details/summary/index.js
+++ b/client/transaction-details/summary/index.js
@@ -1,0 +1,21 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { Card } from '@woocommerce/components';
+
+/**
+ * Internal dependencies.
+ */
+
+const TransactionSummaryDetails = ( props ) => {
+	const { transaction } = props;
+	return (
+		<Card title="Summary" action={ transaction.id }>
+			Summary details for transaction { transaction.id }.
+		</Card>
+	);
+};
+
+export default TransactionSummaryDetails;

--- a/client/transaction-details/timeline/index.js
+++ b/client/transaction-details/timeline/index.js
@@ -1,0 +1,21 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { Card } from '@woocommerce/components';
+
+/**
+ * Internal dependencies.
+ */
+
+const TransactionTimelineDetails = ( props ) => {
+	const { transaction } = props;
+	return (
+		<Card title="Timeline">
+			Timeline details for transaction { transaction.id }.
+		</Card>
+	);
+};
+
+export default TransactionTimelineDetails;

--- a/client/transaction-details/timeline/index.js
+++ b/client/transaction-details/timeline/index.js
@@ -11,6 +11,7 @@ import { Card } from '@woocommerce/components';
 
 const TransactionTimelineDetails = ( props ) => {
 	const { transaction } = props;
+	// TODO: this is a placeholder card and does not require translation
 	return (
 		<Card title="Timeline">
 			Timeline details for transaction { transaction.id }.

--- a/client/transactions/index.js
+++ b/client/transactions/index.js
@@ -6,8 +6,9 @@
 import { dateI18n } from '@wordpress/date';
 import moment from 'moment';
 import { formatCurrency } from '@woocommerce/currency';
-import { TableCard } from '@woocommerce/components';
+import { TableCard, Link } from '@woocommerce/components';
 import { capitalize } from 'lodash';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies.
@@ -27,6 +28,7 @@ const headers = [
 	{ key: 'net', label: 'Net', isNumeric: true, required: true },
 	// TODO { key: 'deposit', label: 'Deposit', required: true },
 	{ key: 'risk_level', label: 'Risk Level', hiddenByDefault: true },
+	{ key: 'details', label: '', required: true },
 ];
 
 export const TransactionsList = ( props ) => {
@@ -37,6 +39,12 @@ export const TransactionsList = ( props ) => {
 	const rows = transactionsData.map( ( txn ) => {
 		const charge = txn.source.object === 'charge' ? txn.source : null;
 		const order_url = txn.order ? <a href={ txn.order.url }>#{ txn.order.number }</a> : <span>&ndash;</span>;
+		const details_link = (
+			<Link 	href={ `admin.php?page=wc-admin&path=/payments/transactions/details&id=${ txn.id }` }
+					style={ { height: '18px' } }>
+				<Gridicon icon="info-outline" size={ 18 } style={ { fill: '#969CA1' } } />
+			</Link>
+		);
 
 		// Extract nested properties from the charge.
 		const billing_details = charge ? charge.billing_details : null;
@@ -59,6 +67,7 @@ export const TransactionsList = ( props ) => {
 			net: { value: ( txn.amount - txn.fee ) / 100, display: formatCurrency( ( txn.amount - txn.fee ) / 100 ) },
 			// TODO deposit: { value: available_on * 1000, display: dateI18n( 'Y-m-d H:i', moment( available_on * 1000 ) ) },
 			risk_level: outcome && { value: outcome.risk_level, display: capitalize( outcome.risk_level ) },
+			details: { value: txn.id, display: details_link },
 		};
 
 		return headers.map( ( { key } ) => data[ key ] || { display: null } );

--- a/client/transactions/index.js
+++ b/client/transactions/index.js
@@ -40,9 +40,9 @@ export const TransactionsList = ( props ) => {
 
 	const rows = transactionsData.map( ( txn ) => {
 		const charge = txn.source.object === 'charge' ? txn.source : null;
-		const order_url = <OrderLink order={ txn.order } />;
+		const orderUrl = <OrderLink order={ txn.order } />;
 		// TODO: come up with a link generator utility (woocommerce-payments#229)
-		const details_link = (
+		const detailsLink = (
 			<Link
 				className="transaction-details-button"
 				href={ `admin.php?page=wc-admin&path=/payments/transactions/details&id=${ txn.id }` } >
@@ -62,7 +62,7 @@ export const TransactionsList = ( props ) => {
 			created: { value: txn.created * 1000, display: dateI18n( 'M j, Y / g:iA', moment( txn.created * 1000 ) ) },
 			type: { value: txn.type, display: capitalize( txn.type ) },
 			source: card && { value: card.brand, display: <code>{ card.brand }</code> },
-			order: { value: txn.order, display: order_url },
+			order: { value: txn.order, display: orderUrl },
 			customer: billing_details && { value: billing_details.name, display: billing_details.name },
 			email: billing_details && { value: billing_details.email, display: billing_details.email },
 			country: address && { value: address.country, display: address.country },
@@ -71,7 +71,7 @@ export const TransactionsList = ( props ) => {
 			net: { value: ( txn.amount - txn.fee ) / 100, display: formatCurrency( ( txn.amount - txn.fee ) / 100 ) },
 			// TODO deposit: { value: available_on * 1000, display: dateI18n( 'Y-m-d H:i', moment( available_on * 1000 ) ) },
 			risk_level: outcome && { value: outcome.risk_level, display: capitalize( outcome.risk_level ) },
-			details: { value: txn.id, display: details_link },
+			details: { value: txn.id, display: detailsLink },
 		};
 
 		return headers.map( ( { key } ) => data[ key ] || { display: null } );

--- a/client/transactions/index.js
+++ b/client/transactions/index.js
@@ -14,6 +14,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies.
  */
 import withSelect from 'payments-api/with-select';
+import OrderLink from '../components/order-link';
 
 const headers = [
 	{ key: 'created', label: 'Date / Time', required: true, isLeftAligned: true, defaultSort: true, defaultOrder: 'desc' },
@@ -38,7 +39,7 @@ export const TransactionsList = ( props ) => {
 
 	const rows = transactionsData.map( ( txn ) => {
 		const charge = txn.source.object === 'charge' ? txn.source : null;
-		const order_url = txn.order ? <a href={ txn.order.url }>#{ txn.order.number }</a> : <span>&ndash;</span>;
+		const order_url = <OrderLink order={ txn.order } />;
 		const details_link = (
 			<Link 	href={ `admin.php?page=wc-admin&path=/payments/transactions/details&id=${ txn.id }` }
 					style={ { height: '18px' } }>

--- a/client/transactions/index.js
+++ b/client/transactions/index.js
@@ -40,6 +40,7 @@ export const TransactionsList = ( props ) => {
 	const rows = transactionsData.map( ( txn ) => {
 		const charge = txn.source.object === 'charge' ? txn.source : null;
 		const order_url = <OrderLink order={ txn.order } />;
+		// TODO: come up with a link generator utility (woocommerce-payments#229)
 		const details_link = (
 			<Link 	href={ `admin.php?page=wc-admin&path=/payments/transactions/details&id=${ txn.id }` }
 					style={ { height: '18px' } }>

--- a/client/transactions/index.js
+++ b/client/transactions/index.js
@@ -9,6 +9,7 @@ import { formatCurrency } from '@woocommerce/currency';
 import { TableCard, Link } from '@woocommerce/components';
 import { capitalize } from 'lodash';
 import Gridicon from 'gridicons';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies.
@@ -42,10 +43,16 @@ export const TransactionsList = ( props ) => {
 		const charge = txn.source.object === 'charge' ? txn.source : null;
 		const orderUrl = <OrderLink order={ txn.order } />;
 		// TODO: come up with a link generator utility (woocommerce-payments#229)
+		const detailsUrl = addQueryArgs(
+			'admin.php',
+			{
+				page: 'wc-admin',
+				path: '/payments/transactions/details',
+				id: txn.id,
+			}
+		);
 		const detailsLink = (
-			<Link
-				className="transaction-details-button"
-				href={ `admin.php?page=wc-admin&path=/payments/transactions/details&id=${ txn.id }` } >
+			<Link className="transaction-details-button" href={ detailsUrl } >
 				<Gridicon icon="info-outline" size={ 18 } />
 			</Link>
 		);

--- a/client/transactions/index.js
+++ b/client/transactions/index.js
@@ -15,6 +15,7 @@ import Gridicon from 'gridicons';
  */
 import withSelect from 'payments-api/with-select';
 import OrderLink from '../components/order-link';
+import './style.scss';
 
 const headers = [
 	{ key: 'created', label: 'Date / Time', required: true, isLeftAligned: true, defaultSort: true, defaultOrder: 'desc' },
@@ -42,9 +43,10 @@ export const TransactionsList = ( props ) => {
 		const order_url = <OrderLink order={ txn.order } />;
 		// TODO: come up with a link generator utility (woocommerce-payments#229)
 		const details_link = (
-			<Link 	href={ `admin.php?page=wc-admin&path=/payments/transactions/details&id=${ txn.id }` }
-					style={ { height: '18px' } }>
-				<Gridicon icon="info-outline" size={ 18 } style={ { fill: '#969CA1' } } />
+			<Link
+				className="transaction-details-button"
+				href={ `admin.php?page=wc-admin&path=/payments/transactions/details&id=${ txn.id }` } >
+				<Gridicon icon="info-outline" size={ 18 } />
 			</Link>
 		);
 

--- a/client/transactions/style.scss
+++ b/client/transactions/style.scss
@@ -1,0 +1,4 @@
+.transaction-details-button {
+	height: 18px;
+	fill: #969CA1
+}

--- a/client/transactions/test/__snapshots__/index.js.snap
+++ b/client/transactions/test/__snapshots__/index.js.snap
@@ -92,9 +92,7 @@ exports[`Transactions list renders correctly 1`] = `
           "display": null,
         },
         Object {
-          "display": <span>
-            –
-          </span>,
+          "display": <OrderLink />,
           "value": undefined,
         },
         Object {
@@ -160,9 +158,7 @@ exports[`Transactions list renders correctly 1`] = `
           "value": "visa",
         },
         Object {
-          "display": <span>
-            –
-          </span>,
+          "display": <OrderLink />,
           "value": undefined,
         },
         Object {

--- a/client/transactions/test/__snapshots__/index.js.snap
+++ b/client/transactions/test/__snapshots__/index.js.snap
@@ -121,22 +121,13 @@ exports[`Transactions list renders correctly 1`] = `
         },
         Object {
           "display": <Link
+            className="transaction-details-button"
             href="admin.php?page=wc-admin&path=/payments/transactions/details&id=txn_j23jda9JJa"
-            style={
-              Object {
-                "height": "18px",
-              }
-            }
             type="wc-admin"
           >
             <t
               icon="info-outline"
               size={18}
-              style={
-                Object {
-                  "fill": "#969CA1",
-                }
-              }
             />
           </Link>,
           "value": "txn_j23jda9JJa",
@@ -191,22 +182,13 @@ exports[`Transactions list renders correctly 1`] = `
         },
         Object {
           "display": <Link
+            className="transaction-details-button"
             href="admin.php?page=wc-admin&path=/payments/transactions/details&id=txn_oa9kaKaa8"
-            style={
-              Object {
-                "height": "18px",
-              }
-            }
             type="wc-admin"
           >
             <t
               icon="info-outline"
               size={18}
-              style={
-                Object {
-                  "fill": "#969CA1",
-                }
-              }
             />
           </Link>,
           "value": "txn_oa9kaKaa8",

--- a/client/transactions/test/__snapshots__/index.js.snap
+++ b/client/transactions/test/__snapshots__/index.js.snap
@@ -122,7 +122,7 @@ exports[`Transactions list renders correctly 1`] = `
         Object {
           "display": <Link
             className="transaction-details-button"
-            href="admin.php?page=wc-admin&path=/payments/transactions/details&id=txn_j23jda9JJa"
+            href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=txn_j23jda9JJa"
             type="wc-admin"
           >
             <t
@@ -183,7 +183,7 @@ exports[`Transactions list renders correctly 1`] = `
         Object {
           "display": <Link
             className="transaction-details-button"
-            href="admin.php?page=wc-admin&path=/payments/transactions/details&id=txn_oa9kaKaa8"
+            href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=txn_oa9kaKaa8"
             type="wc-admin"
           >
             <t

--- a/client/transactions/test/__snapshots__/index.js.snap
+++ b/client/transactions/test/__snapshots__/index.js.snap
@@ -64,6 +64,11 @@ exports[`Transactions list renders correctly 1`] = `
         "key": "risk_level",
         "label": "Risk Level",
       },
+      Object {
+        "key": "details",
+        "label": "",
+        "required": true,
+      },
     ]
   }
   isLoading={false}
@@ -116,6 +121,28 @@ exports[`Transactions list renders correctly 1`] = `
         Object {
           "display": null,
         },
+        Object {
+          "display": <Link
+            href="admin.php?page=wc-admin&path=/payments/transactions/details&id=txn_j23jda9JJa"
+            style={
+              Object {
+                "height": "18px",
+              }
+            }
+            type="wc-admin"
+          >
+            <t
+              icon="info-outline"
+              size={18}
+              style={
+                Object {
+                  "fill": "#969CA1",
+                }
+              }
+            />
+          </Link>,
+          "value": "txn_j23jda9JJa",
+        },
       ],
       Array [
         Object {
@@ -165,6 +192,28 @@ exports[`Transactions list renders correctly 1`] = `
         Object {
           "display": "Normal",
           "value": "normal",
+        },
+        Object {
+          "display": <Link
+            href="admin.php?page=wc-admin&path=/payments/transactions/details&id=txn_oa9kaKaa8"
+            style={
+              Object {
+                "height": "18px",
+              }
+            }
+            type="wc-admin"
+          >
+            <t
+              icon="info-outline"
+              size={18}
+              style={
+                Object {
+                  "fill": "#969CA1",
+                }
+              }
+            />
+          </Link>,
+          "value": "txn_oa9kaKaa8",
         },
       ],
     ]

--- a/client/transactions/test/index.js
+++ b/client/transactions/test/index.js
@@ -14,6 +14,7 @@ describe( 'Transactions list', () => {
 		const transactions = {
 			data: [
 				{
+					id: 'txn_j23jda9JJa',
 					created: 1572590800,
 					type: 'refund',
 					source: {
@@ -24,6 +25,7 @@ describe( 'Transactions list', () => {
 					// available_on: 1573199200,
 				},
 				{
+					id: 'txn_oa9kaKaa8',
 					created: 1572580800,
 					type: 'charge',
 					source: {

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -57,6 +57,15 @@ class WC_Payments_Admin {
 
 		wc_admin_register_page(
 			array(
+				'id'     => 'wc-payments-transaction-details',
+				'title'  => __( 'Payment Details', 'woocommerce-payments' ),
+				'parent' => 'wc-payments-transactions',
+				'path'   => '/payments/transactions/details',
+			)
+		);
+
+		wc_admin_register_page(
+			array(
 				'id'     => 'wc-payments-disputes',
 				'title'  => __( 'Disputes', 'woocommerce-payments' ),
 				'parent' => 'wc-payments',


### PR DESCRIPTION
Fixes #98 

#### Changes proposed in this Pull Request

* Add link to Transaction details page in Transactions list view
* Create Transaction details page with card placeholders

#### Testing instructions

* Navigate to Payments > Transactions: to the right of each row you should see an info button
* Clicking on the button should lead you to a page with placeholder cards with transaction details

-------------------

- [x] Tested on mobile (or does not apply)
