### PR TITLE
Connect to local instance of the WCPay Server

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -224,10 +224,19 @@ class WC_Payments {
 		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-jetpack-http.php';
 		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-local-http.php';
 
+		$endpoint    = 'https://public-api.wordpress.com/wpcom/v2/wcpay';
+		$http_client = new WC_Payments_Jetpack_Http();
+
+		if ( defined( 'WCPAY_LOCAL_SERVER' ) ) {
+			$endpoint    = WCPAY_LOCAL_SERVER;
+			$http_client = new WC_Payments_Local_Http();
+		}
+
 		// TODO: Don't hard code user agent string.
 		$payments_api_client = new WC_Payments_API_Client(
+			$endpoint,
 			'WooCommerce Payments/0.1.0',
-			new WC_Payments_Http()
+			$http_client
 		);
 
 		return $payments_api_client;

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -220,7 +220,9 @@ class WC_Payments {
 		require_once dirname( __FILE__ ) . '/wc-payment-api/models/class-wc-payments-api-charge.php';
 		require_once dirname( __FILE__ ) . '/wc-payment-api/models/class-wc-payments-api-intention.php';
 		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-api-client.php';
-		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-http.php';
+		require_once dirname( __FILE__ ) . '/wc-payment-api/interface-wc-payments-http.php';
+		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-jetpack-http.php';
+		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-local-http.php';
 
 		// TODO: Don't hard code user agent string.
 		$payments_api_client = new WC_Payments_API_Client(

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -12,8 +12,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class WC_Payments_API_Client {
 
-	const ENDPOINT = 'https://public-api.wordpress.com/wpcom/v2/wcpay';
-
 	const POST = 'POST';
 	const GET  = 'GET';
 
@@ -22,6 +20,13 @@ class WC_Payments_API_Client {
 	const REFUNDS_API      = 'refunds';
 	const TRANSACTIONS_API = 'transactions';
 	const OAUTH_API        = 'oauth';
+
+	/**
+	 * URL for the WooCommerce Payments API.
+	 *
+	 * @var string
+	 */
+	private $endpoint;
 
 	/**
 	 * User agent string to report in requests.
@@ -47,10 +52,12 @@ class WC_Payments_API_Client {
 	/**
 	 * WC_Payments_API_Client constructor.
 	 *
+	 * @param string           $endpoint    - URL for the WooCommerce Payments API.
 	 * @param string           $user_agent  - User agent string to report in requests.
 	 * @param WC_Payments_Http $http_client - Used to send HTTP requests.
 	 */
-	public function __construct( $user_agent, $http_client ) {
+	public function __construct( $endpoint, $user_agent, $http_client ) {
+		$this->endpoint    = $endpoint;
 		$this->user_agent  = $user_agent;
 		$this->http_client = $http_client;
 	}
@@ -303,11 +310,11 @@ class WC_Payments_API_Client {
 		$request['account_id'] = $this->account_id;
 
 		// Build the URL we want to send the URL to.
-		$url  = self::ENDPOINT . '/' . $api;
+		$url  = $this->endpoint . '/' . $api;
 		$body = null;
 
 		if ( self::GET === $method ) {
-			$url .= '?' . http_build_query( $request );
+			$url = add_query_arg( $request, $url );
 		} else {
 			// Encode the request body as JSON.
 			$body = wp_json_encode( $request );

--- a/includes/wc-payment-api/class-wc-payments-jetpack-http.php
+++ b/includes/wc-payment-api/class-wc-payments-jetpack-http.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  * the testability of WC_Payments_API_Client, and allow dependency
  * injection.
  */
-class WC_Payments_Http {
+class WC_Payments_Jetpack_Http implements WC_Payments_Http {
 
 	/**
 	 * Sends a remote request through Jetpack (?).

--- a/includes/wc-payment-api/class-wc-payments-local-http.php
+++ b/includes/wc-payment-api/class-wc-payments-local-http.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * WC_Payments_Local_Http class.
+ *
+ * @package WooCommerce\Payments
+ */
+
+/**
+ * A wrapper around a standard wp_remote_request call which can be injected into an instance of WC_Payments_Api_Client.
+ */
+class WC_Payments_Local_Http implements WC_Payments_Http {
+	/**
+	 * Make a request to the Payments server
+	 *
+	 * @param array  $args - The arguments to passed to Jetpack.
+	 * @param string $body - The body passed on to the HTTP request.
+	 *
+	 * @return WP_Error|array HTTP response on success.
+	 */
+	public function remote_request( $args, $body = null ) {
+		return wp_remote_request( $args['url'], $args );
+	}
+}

--- a/includes/wc-payment-api/interface-wc-payments-http.php
+++ b/includes/wc-payment-api/interface-wc-payments-http.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * WC_Payments_Http interface.
+ *
+ * @package WooCommerce\Payments
+ */
+
+/**
+ * An interface used by WC_Payments_Api_Client for making HTTP requests to various types of WooCommerce Payments
+ * servers.
+ */
+interface WC_Payments_Http {
+	/**
+	 * Make a request to the Payments server
+	 *
+	 * @param array  $args - The arguments to passed to the remote server.
+	 * @param string $body - The body passed on to the HTTP request.
+	 *
+	 * @return WP_Error|array HTTP response on success.
+	 */
+	public function remote_request( $args, $body = null );
+}


### PR DESCRIPTION
By defining `WCPAY_LOCAL_SERVER` we can point at something other than the WordPress.com API. In the example below we're targeting a server running on port 8086 of the Docker host that this project is running on.

```
define( 'WCPAY_LOCAL_SERVER', 'http://host.docker.internal:8086/index.php?rest_route=/wpcom/v2/wcpay' );
```

If Docker isn't being used for this project then an URL like `http://localhost:8086/index.php?rest_route=/wpcom/v2/wcpay` would work.

For WCPay Servers running locally, a lot of the authentication is disabled. Because of this we use a simplified client to make the connection.