### PR TITLE
Update functional prototype settings

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -64,6 +64,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$this->has_fields         = true;
 		$this->method_title       = __( 'WooCommerce Payments', 'woocommerce-payments' );
 		$this->method_description = __( 'Accept payments via credit card.', 'woocommerce-payments' );
+		$this->title              = __( 'Credit Card', 'woocommerce-payments' );
+		$this->description        = __( 'Enter your card details', 'woocommerce-payments' );
 		$this->supports           = array(
 			'products',
 			'refunds',
@@ -77,20 +79,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'type'        => 'checkbox',
 				'description' => '',
 				'default'     => 'no',
-			),
-			'title'           => array(
-				'title'       => __( 'Title', 'woocommerce-payments' ),
-				'type'        => 'text',
-				'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce-payments' ),
-				'default'     => __( 'Credit Card', 'woocommerce-payments' ),
-				'desc_tip'    => true,
-			),
-			'description'     => array(
-				'title'       => __( 'Description', 'woocommerce-payments' ),
-				'type'        => 'text',
-				'description' => __( 'This controls the description which the user sees during checkout.', 'woocommerce-payments' ),
-				'default'     => __( 'Enter your card details', 'woocommerce-payments' ),
-				'desc_tip'    => true,
 			),
 			'account_details' => array(
 				'type' => 'account_actions',
@@ -137,9 +125,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * Extracts values to be used in this class from the settings
 	 */
 	public function extract_settings_values() {
-		$this->title       = $this->get_option( 'title' );
-		$this->description = $this->get_option( 'description' );
-
 		$this->testmode        = 'yes' === $this->get_option( 'testmode' );
 		$this->publishable_key = $this->testmode ? $this->get_option( 'test_publishable_key' ) : $this->get_option( 'publishable_key' );
 	}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -73,13 +73,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// Define setting fields.
 		$this->form_fields = array(
-			'enabled'         => array(
-				'title'       => __( 'Enable/Disable', 'woocommerce-payments' ),
-				'label'       => __( 'Enable WooCommerce Payments', 'woocommerce-payments' ),
-				'type'        => 'checkbox',
-				'description' => '',
-				'default'     => 'no',
-			),
 			'account_details' => array(
 				'type' => 'account_actions',
 			),
@@ -98,6 +91,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'description' => __( 'Place the payment gateway in test mode using test API keys.', 'woocommerce-payments' ),
 				'default'     => 'yes',
 				'desc_tip'    => true,
+			),
+			'enabled'         => array(
+				'title'       => __( 'Enable/Disable', 'woocommerce-payments' ),
+				'label'       => __( 'Enable WooCommerce Payments', 'woocommerce-payments' ),
+				'type'        => 'checkbox',
+				'description' => '',
+				'default'     => 'no',
 			),
 		);
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -95,20 +95,20 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'payment_details' => array(
 				'type' => 'account_actions',
 			),
-			'testmode'        => array(
-				'title'       => __( 'Test Mode', 'woocommerce-payments' ),
-				'label'       => __( 'Enable test mode', 'woocommerce-payments' ),
-				'type'        => 'checkbox',
-				'description' => __( 'Place the payment gateway in test mode using test API keys.', 'woocommerce-payments' ),
-				'default'     => 'yes',
-				'desc_tip'    => true,
-			),
 			'manual_capture'  => array(
 				'title'       => __( 'Manual Capture', 'woocommerce-payments' ),
 				'label'       => __( 'Issue authorization and capture later', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
 				'description' => __( 'Manually capture funds within 7 days after the customer authorizes payment on checkout.', 'woocommerce-payments' ),
 				'default'     => 'no',
+				'desc_tip'    => true,
+			),
+			'testmode'        => array(
+				'title'       => __( 'Test Mode', 'woocommerce-payments' ),
+				'label'       => __( 'Enable test mode', 'woocommerce-payments' ),
+				'type'        => 'checkbox',
+				'description' => __( 'Place the payment gateway in test mode using test API keys.', 'woocommerce-payments' ),
+				'default'     => 'yes',
 				'desc_tip'    => true,
 			),
 		);

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -71,38 +71,31 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// Define setting fields.
 		$this->form_fields = array(
-			'enabled'              => array(
+			'enabled'         => array(
 				'title'       => __( 'Enable/Disable', 'woocommerce-payments' ),
 				'label'       => __( 'Enable WooCommerce Payments', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
 				'description' => '',
 				'default'     => 'no',
 			),
-			'title'                => array(
+			'title'           => array(
 				'title'       => __( 'Title', 'woocommerce-payments' ),
 				'type'        => 'text',
 				'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce-payments' ),
 				'default'     => __( 'Credit Card', 'woocommerce-payments' ),
 				'desc_tip'    => true,
 			),
-			'description'          => array(
+			'description'     => array(
 				'title'       => __( 'Description', 'woocommerce-payments' ),
 				'type'        => 'text',
 				'description' => __( 'This controls the description which the user sees during checkout.', 'woocommerce-payments' ),
 				'default'     => '',
 				'desc_tip'    => true,
 			),
-			'payment_details'      => array(
+			'payment_details' => array(
 				'type' => 'account_actions',
 			),
-			'stripe_account_id'    => array(
-				'title'       => __( 'Stripe Account ID', 'woocommerce-payments' ),
-				'type'        => 'text',
-				'description' => __( 'Get your account ID from your Stripe account.', 'woocommerce-payments' ),
-				'default'     => '',
-				'desc_tip'    => true,
-			),
-			'testmode'             => array(
+			'testmode'        => array(
 				'title'       => __( 'Test Mode', 'woocommerce-payments' ),
 				'label'       => __( 'Enable test mode', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
@@ -110,21 +103,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'default'     => 'yes',
 				'desc_tip'    => true,
 			),
-			'test_publishable_key' => array(
-				'title'       => __( 'Test Publishable Key', 'woocommerce-payments' ),
-				'type'        => 'password',
-				'description' => __( 'Get your API keys from your Stripe account.', 'woocommerce-payments' ),
-				'default'     => '',
-				'desc_tip'    => true,
-			),
-			'publishable_key'      => array(
-				'title'       => __( 'Live Publishable Key', 'woocommerce-payments' ),
-				'type'        => 'password',
-				'description' => __( 'Get your API keys from your Stripe account.', 'woocommerce-payments' ),
-				'default'     => '',
-				'desc_tip'    => true,
-			),
-			'manual_capture'       => array(
+			'manual_capture'  => array(
 				'title'       => __( 'Manual Capture', 'woocommerce-payments' ),
 				'label'       => __( 'Issue authorization and capture later', 'woocommerce-payments' ),
 				'type'        => 'checkbox',

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -396,7 +396,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		} else {
 			$description = sprintf(
 				/* translators: 1) oauth entry point URL */
-				__( 'Connect to a new Stripe account <a href="%1$s">here</a>', 'woocommerce-payments' ),
+				__( 'Accept credit cards online. Simply verify your business details to activate WooCommerce Payments. <a href="%1$s">[get started]</a>', 'woocommerce-payments' ),
 				$connect_url
 			);
 		}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -92,7 +92,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'default'     => __( 'Enter your card details', 'woocommerce-payments' ),
 				'desc_tip'    => true,
 			),
-			'payment_details' => array(
+			'account_details' => array(
 				'type' => 'account_actions',
 			),
 			'manual_capture'  => array(
@@ -405,7 +405,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if ( $this->is_stripe_connected() ) {
 			$description = sprintf(
 				/* translators: 1) dashboard login URL */
-				__( 'View and update your bank deposit, company, or personal details <a href="%1$s">over at Stripe</a>', 'woocommerce-payments' ),
+				__( '<a href="%1$s">View payouts and account details</a>', 'woocommerce-payments' ),
 				$login_url
 			);
 		} else {
@@ -420,7 +420,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		?>
 		<tr valign="top">
 			<th scope="row">
-				<?php echo esc_html( __( 'Payment Details', 'woocommerce-payments' ) ); ?>
+				<?php echo esc_html( __( 'Account', 'woocommerce-payments' ) ); ?>
 			</th>
 			<td>
 				<?php echo wp_kses_post( $description ); ?>

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -378,17 +378,34 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Checks whether the user has a Stripe account already connected
+	 *
+	 * @return boolean if true stripe is connected
+	 */
+	public function is_stripe_connected() {
+		return $this->get_option( 'stripe_account_id' ) && $this->publishable_key;
+	}
+
+	/**
 	 * Generate markup for account actions
 	 */
 	public function generate_account_actions_html() {
 		$login_url   = wp_nonce_url( add_query_arg( [ 'wcpay-login' => '1' ] ), 'wcpay-login' );
 		$connect_url = wp_nonce_url( add_query_arg( [ 'wcpay-connect' => '1' ] ), 'wcpay-connect' );
-		$description = sprintf(
-			/* translators: 1) dashboard login URL 2) oauth entry point URL */
-			__( 'View and update your bank deposit, company, or personal details <a href="%1$s">over at Stripe</a>. (Or connect to a new Stripe account <a href="%2$s">here</a>.)', 'woocommerce-payments' ),
-			$login_url,
-			$connect_url
-		);
+
+		if ( $this->is_stripe_connected() ) {
+			$description = sprintf(
+				/* translators: 1) dashboard login URL */
+				__( 'View and update your bank deposit, company, or personal details <a href="%1$s">over at Stripe</a>', 'woocommerce-payments' ),
+				$login_url
+			);
+		} else {
+			$description = sprintf(
+				/* translators: 1) oauth entry point URL */
+				__( 'Connect to a new Stripe account <a href="%1$s">here</a>', 'woocommerce-payments' ),
+				$connect_url
+			);
+		}
 
 		ob_start();
 		?>

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -89,7 +89,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'title'       => __( 'Description', 'woocommerce-payments' ),
 				'type'        => 'text',
 				'description' => __( 'This controls the description which the user sees during checkout.', 'woocommerce-payments' ),
-				'default'     => '',
+				'default'     => __( 'Enter your card details', 'woocommerce-payments' ),
 				'desc_tip'    => true,
 			),
 			'payment_details' => array(

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -116,14 +116,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// Load the settings.
 		$this->init_settings();
 
-		// Extract values we want to use in this class from the settings.
-		$this->title       = $this->get_option( 'title' );
-		$this->description = $this->get_option( 'description' );
-
-		$this->testmode        = 'yes' === $this->get_option( 'testmode' );
-		$this->publishable_key = $this->testmode ? $this->get_option( 'test_publishable_key' ) : $this->get_option( 'publishable_key' );
-
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+
+		// Extract values we want to use in this class from the settings.
+		$this->extract_settings_values();
+		// Update values in case settings are updated.
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'extract_settings_values' ) );
 
 		// TODO: move somewhere else?
 		add_action( 'admin_notices', array( $this, 'display_errors' ) );
@@ -133,6 +131,17 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		add_action( 'woocommerce_order_actions', array( $this, 'add_order_actions' ) );
 		add_action( 'woocommerce_order_action_capture_charge', array( $this, 'capture_charge' ) );
 		add_action( 'woocommerce_order_action_cancel_authorization', array( $this, 'cancel_authorization' ) );
+	}
+
+	/**
+	 * Extracts values to be used in this class from the settings
+	 */
+	public function extract_settings_values() {
+		$this->title       = $this->get_option( 'title' );
+		$this->description = $this->get_option( 'description' );
+
+		$this->testmode        = 'yes' === $this->get_option( 'testmode' );
+		$this->publishable_key = $this->testmode ? $this->get_option( 'test_publishable_key' ) : $this->get_option( 'publishable_key' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #200 

#### Changes proposed in this Pull Request

* Remove stripe account and keys settings
* Move test mode and Enable/Disable controls to the end of the form
* Add "Enter your card details" as the default value for Description control
* Conditionally display Stripe connect or dashboard link
* Fix settings values extraction when save settings form is submitted
* Remove Title and Description controls from the settings page

**When merchant is already connected to Stripe:**

![image (1)](https://user-images.githubusercontent.com/7714042/65795167-06d09400-e140-11e9-990f-294948c5a65d.png)

**When merchant is not connected to Stripe:**

![image](https://user-images.githubusercontent.com/7714042/65795174-0b954800-e140-11e9-8fc0-fbdc5327d2a1.png)


#### Testing instructions

* Navigate to WCPay settings
    * You should not see any settings related to Stripe account information (id and keys)
    * You should not see Title and Description settings - however on checkout page they should be "Credit Card" and "Enter your card details", respectively.
    * Test mode should be the last option in the form
    * Toggle test mode - you should now see the option to connect to a new account instead of the dashboard link (since we don't support live mode yet, trying to connect to a live account would not work)

-------------------

- [x] Tested on mobile (or does not apply)
