### PR TITLE
Fix Jetpack Client deprecation warning

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -26,6 +26,10 @@ class WC_Payments_Http {
 		$args['blog_id'] = Jetpack_Options::get_option( 'id' );
 		$args['user_id'] = JETPACK_MASTER_USER;
 		// TODO: Either revamp this auth before releasing WCPay, or properly check that Jetpack is installed & connected.
-		return Jetpack_Client::remote_request( $args, $body );
+		if ( class_exists( 'Automattic\Jetpack\Connection\Client' ) ) {
+			return Automattic\Jetpack\Connection\Client::remote_request( $args, $body );
+		} else {
+			return Jetpack_Client::remote_request( $args, $body );
+		}
 	}
 }


### PR DESCRIPTION
Fixes a warning appearing if Jetpack is newer than 7.5:

<img width="887" alt="Screenshot 2019-10-04 at 11 49 43" src="https://user-images.githubusercontent.com/800604/66202254-2fefa800-e69d-11e9-926c-627e18ee22f8.png">


#### Changes proposed in this Pull Request

* Check if the new Jetpack class is available and use it if it is. Otherwise, fall back to the old way of making the request

#### Testing instructions
* Enable `WP_DEBUG` in you site's config
* Make sure you're using Jetpack >=7.5
* In the WcPay settings page, attempt to connect to Stripe or to use the login link
  * Everything should work
* Should also still work for older versions of Jetpack
* Without this branch, using one of the Stripe links on the settings page would just result in a page with the warning
