### PR TITLE
Fix "undefined variable: account" warning

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -251,7 +251,7 @@ class WC_Payments {
 		if ( self::$gateway->account_has_pending_requirements( $account ) ) {
 			add_filter(
 				'admin_notices',
-				function () {
+				function () use ( $account ) {
 					self::display_admin_error(
 						self::$gateway->get_verify_requirements_message( $account['requirements']['current_deadline'] )
 					);


### PR DESCRIPTION
Fixes a notice when `WP_DEBUG` is enabled and there are any requirements on the account:
<img width="846" alt="Screenshot 2019-10-10 at 14 07 21" src="https://user-images.githubusercontent.com/800604/66575966-cecd4600-eb6e-11e9-9f84-bc2af45a098e.png">

#### Testing instructions

* Enable `WP_DEBUG`
* Open an admin page (for some reason this appears only on `/wp-admin/admin.php?page=wc-status&tab=logs` for me)
* No error notice should be displayeed

CC @luizreis 
