### PR TITLE
Install Woo core dependencies before running tests

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -172,6 +172,7 @@ install_woocommerce() {
 	fi
 
 	git checkout $WC_VERSION
+	composer install
 	cd -
 }
 


### PR DESCRIPTION
Fixes the failing unit tests in Travis

#### Changes proposed in this Pull Request

* Woo core was displaying a warning about the local installation process not being complete without Composer dependencies. I think that led to some intermittent race conditions which resulted in the `WooCommerce` class not being loaded, which in turn prevented this plugin's files from loading.

#### Testing instructions

* The phpunit tests should pass in Travis.

