### PR TITLE
Pass a query parameter to payments server indicating whether test mode is enabled

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -95,7 +95,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'label'       => __( 'Enable test mode', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
 				'description' => __( 'Place the payment gateway in test mode using test API keys.', 'woocommerce-payments' ),
-				'default'     => 'no', // TODO: temporary fix to force fresh installs to go through live mode, we should use 'yes' while we develop.
+				'default'     => 'no',
 				'desc_tip'    => true,
 			),
 			'enabled'         => array(

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -323,8 +323,10 @@ class WC_Payments_API_Client {
 	 */
 	private function is_in_test_mode() {
 		$options = get_option( 'woocommerce_woocommerce_payments_settings', array() );
+
+		// Default to live mode if option not available.
 		if ( ! isset( $options['test_mode'] ) ) {
-			return false; // TODO: temporary fix to force fresh installs to go through live mode, we should use true while we develop.
+			return false;
 		}
 
 		if ( ! is_bool( $options['test_mode'] ) ) {


### PR DESCRIPTION
Fixes #3.

Depends on server#70.

#### Changes proposed in this Pull Request

* Adds the `test_mode` query parameter to all relevant calls to the WooCommerce Payments Server to indicate whether test mode is enabled or not.

#### Testing instructions

* Make a payment and make sure request to the payments server has the `test_mode` parameter.
* Issue a refund and make sure request to the payments server has the `test_mode` parameter.
* Open transactions list and make sure request to the payments server has the `test_mode` parameter.
