### PR TITLE
Fix settings sub-navigation disappearance

### DIFF
--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -72,15 +72,6 @@ class WC_Payments_Admin {
 
 			wc_admin_register_page(
 				array(
-					'id'     => 'wc-payments-transaction-details',
-					'title'  => __( 'Payment Details', 'woocommerce-payments' ),
-					'parent' => 'wc-payments-transactions',
-					'path'   => '/payments/transactions/details',
-				)
-			);
-
-			wc_admin_register_page(
-				array(
 					'id'     => 'wc-payments-disputes',
 					'title'  => __( 'Disputes', 'woocommerce-payments' ),
 					'parent' => 'wc-payments',
@@ -112,6 +103,17 @@ class WC_Payments_Admin {
 						'admin.php'
 					)
 				),
+			);
+
+			// Temporary fix to settings menu disappearance is to register the page after settings menu has been manually added.
+			// TODO: More robust solution is to be implemented by https://github.com/Automattic/woocommerce-payments/issues/231.
+			wc_admin_register_page(
+				array(
+					'id'     => 'wc-payments-transaction-details',
+					'title'  => __( 'Payment Details', 'woocommerce-payments' ),
+					'parent' => 'wc-payments-transactions',
+					'path'   => '/payments/transactions/details',
+				)
 			);
 		}
 


### PR DESCRIPTION
Add a temporary fix to the settings menu, which was conflicting with the /transactions/details page. Issue #231 will be kept open until we develop a more robust way to fix this problem.

In order for the details page to be loaded when navigating directly to its URL, it needs to be registered in wc-admin. However, registering a page also creates a menu entry for it.

In order to create the transaction details page, we registered a new /transaction/details page. We don't want to have a menu entry for this page, so it was nested in a way that it was not rendered. This broke the settings menu because it was added manually to the last menu entry (`$submenu[ $last_submenu_key ][] = array( ... );`).

This solution to fix the settings menu is to register the details page only after we manually place the settings entry, but that does not fix the issue that we actually do not want any kind of menu entry for that page and we're hiding it in a hacky way.

Partial fix to issue #231 

#### Changes proposed in this Pull Request

* Register /transactions/details page after manually adding settings sub-navigation

#### Testing instructions

* You should see the "Settings" sub-navigation under "Payments" menu
* Clicking on the transaction details button under transaction list should get you to the placeholder details screen
* Navigating directly to the link of transaction detail should also get you to the placeholder screen

-------------------

- [x] Tested on mobile (or does not apply)
