### PR TITLE
Handle site being already connected to Stripe

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -504,6 +504,17 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				return;
 			}
 
+			if ( false === $oauth_data['url'] ) {
+				$account_id           = sanitize_text_field( wp_unslash( $oauth_data['account_id'] ) );
+				$live_publishable_key = sanitize_text_field( wp_unslash( $oauth_data['live_publishable_key'] ) );
+				$test_publishable_key = sanitize_text_field( wp_unslash( $oauth_data['test_publishable_key'] ) );
+				$this->update_option( 'stripe_account_id', $account_id );
+				$this->update_option( 'publishable_key', $live_publishable_key );
+				$this->update_option( 'test_publishable_key', $test_publishable_key );
+				wp_safe_redirect( $this->get_settings_url() );
+				exit;
+			}
+
 			set_transient( 'wcpay_oauth_state', $oauth_data['state'], DAY_IN_SECONDS );
 
 			wp_safe_redirect( $oauth_data['url'] );


### PR DESCRIPTION
With server PR 69 about to be shipped, we will be storing the connected account info on the server. 

There can be scenarios where a site loses some of the wcpay settings, but retains its wpcom blog id. In this case, rather than making the user go through the OAuth flow again, we just connect them to the old account.

Test steps:
* Checkout server pr 69 
* Connect to a new account to make sure it has been stored in the server (toggle test mode to retrigger connection flow)
* Toggle to live mode again and attempt to connect the account again
* Rather than going through the oauth flow, you should be redirected to the settings page already with the old account connected