### PR TITLE
Cache account details call

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -275,7 +275,10 @@ class WC_Payments_API_Client {
 
 		if ( false === $account ) {
 			$account = $this->request( array(), self::ACCOUNTS_API . '/' . $this->account_id, self::GET );
-			set_transient( self::STRIPE_ACCOUNT_TRANSIENT, $account, 2 * HOUR_IN_SECONDS );
+
+			if ( ! empty( $account ) && ! is_wp_error( $account ) ) {
+				set_transient( self::STRIPE_ACCOUNT_TRANSIENT, $account, 2 * HOUR_IN_SECONDS );
+			}
 		}
 
 		return $account;


### PR DESCRIPTION
Use transients to cache the account details call for 2 hours and clear the transient whenever a login or OAuth link is requested.

Fixes #235 

#### Changes proposed in this Pull Request

* Cache account details call

#### Testing instructions

* Use Query Monitor or any other debug plugin to see transients
* Load any `wp-admin` page for the first time after switching to this PR's branch
    * You should see the `stripe_account` being updated and an HTTP API call to get the account details
* Navigate to or reload any `wp-admin` page
    * The transient should not be updated and no HTTP API requests for account details must've been made
* From the settings page click on the *"View payouts and account details"* or *"Get started"* link
    * When navigating back to the store, you should see the transient being updated

-------------------

- [x] Tested on mobile (or does not apply)
