### PR TITLE
Limit availability to USD

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -125,9 +125,15 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	/**
 	 * Checks if the gateway is enabled, and also if it's configured enough to accept payments from customers.
 	 *
+	 * Use parent method value alongside other business rules to make the decision.
+	 *
 	 * @return bool Whether the gateway is enabled and ready to accept payments.
 	 */
 	public function is_available() {
+		if ( 'USD' !== get_woocommerce_currency() ) {
+			return false;
+		}
+
 		return parent::is_available() && $this->is_stripe_connected();
 	}
 
@@ -193,20 +199,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			<input id="wcpay-payment-method" type="hidden" name="wcpay-payment-method" />
 		</fieldset>
 		<?php
-	}
-
-	/**
-	 * Use parent method value alongside other business rules to determine
-	 * if this gateway is available to store customers.
-	 *
-	 * @return bool
-	 */
-	public function is_available() {
-		if ( 'USD' !== get_woocommerce_currency() ) {
-			return false;
-		}
-
-		return parent::is_available();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #232 

#### Changes proposed in this Pull Request

* Only show the CC form when the Store currency is USD.  This utilizes the `is_available` function.


#### Testing instructions

* Check out this branch.
* Set your shop currency to Australia.
* Do a standard checkout and see that the cc form is no longer available.
* Switch your shop back to `USD`.
* Reload the checkout page and see the cc form show up again.
