### PR TITLE
Enable WooCommerce Payments by default on plugin activation

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -103,7 +103,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'label'       => __( 'Enable WooCommerce Payments', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
 				'description' => '',
-				'default'     => 'yes',
+				'default'     => 'no',
 			),
 		);
 
@@ -511,6 +511,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$this->update_option( 'stripe_account_id', $account_id );
 				$this->update_option( 'publishable_key', $live_publishable_key );
 				$this->update_option( 'test_publishable_key', $test_publishable_key );
+				$this->update_option( 'enabled', 'yes' );
 				wp_safe_redirect( $this->get_settings_url() );
 				exit;
 			}


### PR DESCRIPTION
Fixes #257

To test:
- Start with a fresh install. Instead, you can deactivate the WCPay plugin, go to PHPMyAdmin and remove the `woocommerce_woocommerce_payments_settings` option from the `wp_options` table.
- After you install&activate the WooCommerce Payments plugin again, you'll see the payment gateway is already marked as "enabled", without any user input.

@allendav @LevinMedia This fixes the issue as described on #257, but I don't agree with this from the product's perspective. This is yet another payment gateway extension, what's the reasoning to enable it by default on installation, even when no other extension does that? What will happen when it gets integrated in WooCommerce Core? Will it be enabled by default if you're just doing a fresh install of WooCommerce?