### PR TITLE
Put Woocommerce Payments on top of the gateways list by default

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -350,21 +350,11 @@ class WC_Payments {
 	 * @return array Modified ordering.
 	 */
 	public static function set_gateway_top_of_list( $ordering ) {
-		$ordering        = (array) $ordering;
-		$id              = self::$gateway->id;
-		$target_position = 0;
+		$ordering = (array) $ordering;
+		$id       = self::$gateway->id;
 		// Only tweak the ordering if the list hasn't been reordered with WooCommerce Payments in it already.
 		if ( ! isset( $ordering[ $id ] ) || ! is_numeric( $ordering[ $id ] ) ) {
-			while ( 1 ) {
-				$key             = array_search( $target_position, $ordering, true );
-				$ordering[ $id ] = $target_position;
-				// Keep moving the rest of the gateways 1 position down until there are no clashes.
-				if ( ! $key ) {
-					break;
-				}
-				$id = $key;
-				$target_position++;
-			}
+			$ordering[ $id ] = empty( $ordering ) ? 0 : ( min( $ordering ) - 1 );
 		}
 		return $ordering;
 	}


### PR DESCRIPTION
Fixes #263

To test:
- Start with a fresh install. Alternatively, uninstall or deactivate the WCPay plugin, and then go to `WooCommerce -> Settings -> Payments` and click the "Save Changes" button.
- Install&activate WCPay.
- Go to `WooCommerce -> Settings -> Payments` again, see that WCPay is the first gateway on the list.
- Move some of the gateways around so WCPay is not the first on the list anymore, click `Save Changes`.
- Refresh the page, see that the list order you set is respected.

@LevinMedia My thoughts here are similar to the ones on https://github.com/Automattic/woocommerce-payments/pull/270. What makes WCPay so special that needs to be at the top? I get that WCPay is important to us, but these kind of UI patterns seem a bit shady.