### PR TITLE
Ignore the docker folder when running PHP code linting

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,6 +4,7 @@
 
     <!-- Exclude paths -->
 	<exclude-pattern>./dist/*</exclude-pattern>
+	<exclude-pattern>./docker/*</exclude-pattern>
 	<exclude-pattern>./node_modules/*</exclude-pattern>
 	<exclude-pattern>./vendor/*</exclude-pattern>
 	<exclude-pattern>*\.(?!php$)</exclude-pattern>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
If you're using Docker to run the local environment then the linter will run out of memory trying to parse all the files in the docker folder. We can just ignore it.

#### Testing instructions
1. Setup a Docker environment ([instructions](https://github.com/Automattic/woocommerce-payments/blob/master/CONTRIBUTING.md#docker-local-setup)).
2. Run `./vendor/bin/phpcs .`
3. The linter should run to completion