### PR TITLE
Fix test site deployment timing out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,3 +95,4 @@ deploy:
 branches:
   only:
     - master
+    - fix/test-site-deployment-timing-out

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ script:
 
 deploy:
   provider: script
-  script: travis_wait bash bin/deploy-to-test-site.sh
+  script: bash bin/deploy-to-test-site.sh
   skip_cleanup: true
   on:
     branch: fix/test-site-deployment-timing-out

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ script:
 
 deploy:
   provider: script
-  script: bash bin/deploy-to-test-site.sh
+  script: travis_wait bash bin/deploy-to-test-site.sh
   skip_cleanup: true
   on:
     branch: fix/test-site-deployment-timing-out

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ services:
 stages:
   - test
   - name: deploy
-    if: branch = master
+    if: branch = fix/test-site-deployment-timing-out
 
 env:
   - WP_VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ deploy:
   script: bash bin/deploy-to-test-site.sh
   skip_cleanup: true
   on:
-    branch: master
+    branch: fix/test-site-deployment-timing-out
     condition: $SHOULD_DEPLOY = 1
 
 branches:

--- a/bin/deploy-to-test-site.sh
+++ b/bin/deploy-to-test-site.sh
@@ -21,7 +21,7 @@ done
 
 # Send the temporary dir to the web server
 echo "Uploading"
-lftp sftp://$PRESSABLE_USERNAME:$PRESSABLE_PASSWORD@sftp.pressable.com -e "mirror --verbose=1 -R ./$TMP_DIR $PRESSABLE_SITE_NAME/wp-content/plugins/woocommerce-payments; quit"
+travis_wait lftp sftp://$PRESSABLE_USERNAME:$PRESSABLE_PASSWORD@sftp.pressable.com -e "mirror --verbose=1 -R ./$TMP_DIR $PRESSABLE_SITE_NAME/wp-content/plugins/woocommerce-payments; quit"
 
 # Cleanup
 echo "Cleaning up"

--- a/bin/deploy-to-test-site.sh
+++ b/bin/deploy-to-test-site.sh
@@ -21,7 +21,7 @@ done
 
 # Send the temporary dir to the web server
 echo "Uploading"
-lftp sftp://$PRESSABLE_USERNAME:$PRESSABLE_PASSWORD@sftp.pressable.com -e "mirror --verbose=0 -R ./$TMP_DIR $PRESSABLE_SITE_NAME/wp-content/plugins/woocommerce-payments; quit"
+lftp sftp://$PRESSABLE_USERNAME:$PRESSABLE_PASSWORD@sftp.pressable.com -e "mirror --verbose=1 -R ./$TMP_DIR $PRESSABLE_SITE_NAME/wp-content/plugins/woocommerce-payments; quit"
 
 # Cleanup
 echo "Cleaning up"

--- a/bin/deploy-to-test-site.sh
+++ b/bin/deploy-to-test-site.sh
@@ -1,7 +1,7 @@
 echo "Starting the deployment script"
 
 TMP_DIR="tmp-plugin"
-NEEDED_FILES=( assets client dist includes woocommerce-payments.php )
+NEEDED_FILES=( assets dist includes woocommerce-payments.php )
 
 # Build all necessary scripts
 echo "Compiling"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove unused folder from what we deploy (client)
* Increase logging on FTP mirror command so that it keeps the Travis build alive

#### Testing instructions

* Merging it and monitoring the build is one option, which isn't ideal. Any ideas?