### PR TITLE
Add payment status chip to transaction summary

### DIFF
--- a/client/components/chip/index.js
+++ b/client/components/chip/index.js
@@ -1,0 +1,21 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+/**
+ * Internal dependencies.
+ */
+import './style.scss';
+
+const Chip = ( props ) => {
+	const { message, type } = props;
+	const types = [ 'primary', 'light', 'alert' ];
+	return (
+		<span className={ `chip chip-${ types.find( t => t === type ) || 'primary' }` }>
+			{ message }
+		</span>
+	);
+};
+
+export default Chip;

--- a/client/components/chip/style.scss
+++ b/client/components/chip/style.scss
@@ -1,0 +1,22 @@
+/** @format */
+
+.chip {
+	font-size: 14px;
+	border-radius: 12px;
+	padding: 2px 12px;
+
+	&.chip-primary {
+		background: #E5F5FA;
+		color: #00669B;
+	}
+
+	&.chip-light {
+		background: #E2E4E7;
+		color: #32373C;
+	}
+
+	&.chip-alert {
+		background: #FAEAEA;
+		color: #D94F4F;
+	}
+}

--- a/client/components/chip/style.scss
+++ b/client/components/chip/style.scss
@@ -1,9 +1,10 @@
 /** @format */
 
 .chip {
-	font-size: 14px;
-	border-radius: 12px;
-	padding: 2px 12px;
+	display: inline-block;
+	font-size: 0.875rem;
+	padding: 0.25rem 0.75rem;
+	border-radius: 1rem;
 
 	&.chip-primary {
 		background: #E5F5FA;

--- a/client/components/chip/test/__snapshots__/index.js.snap
+++ b/client/components/chip/test/__snapshots__/index.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Chip renders a light chip 1`] = `
+<span
+  className="chip chip-light"
+>
+  Light message
+</span>
+`;
+
+exports[`Chip renders a primary chip 1`] = `
+<span
+  className="chip chip-primary"
+>
+  Primary message
+</span>
+`;
+
+exports[`Chip renders a primary chip by default 1`] = `
+<span
+  className="chip chip-primary"
+>
+  Message
+</span>
+`;
+
+exports[`Chip renders an alert chip 1`] = `
+<span
+  className="chip chip-alert"
+>
+  Alert message
+</span>
+`;
+
+exports[`Chip renders default if type is invalid 1`] = `
+<span
+  className="chip chip-primary"
+>
+  Message
+</span>
+`;

--- a/client/components/chip/test/index.js
+++ b/client/components/chip/test/index.js
@@ -1,0 +1,42 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import Chip from '../';
+
+describe( 'Chip', () => {
+	test( 'renders an alert chip', () => {
+		const chip = renderChip( 'alert', 'Alert message' );
+		expect( chip ).toMatchSnapshot();
+	} );
+
+	test( 'renders a primary chip', () => {
+		const chip = renderChip( 'primary', 'Primary message' );
+		expect( chip ).toMatchSnapshot();
+	} );
+
+	test( 'renders a light chip', () => {
+		const chip = renderChip( 'light', 'Light message' );
+		expect( chip ).toMatchSnapshot();
+	} );
+
+	test( 'renders a primary chip by default', () => {
+		const chip = renderChip( undefined, 'Message' );
+		expect( chip ).toMatchSnapshot();
+	} );
+
+	test( 'renders default if type is invalid', () => {
+		const chip = renderChip( 'invalidtype', 'Message' );
+		expect( chip ).toMatchSnapshot();
+	} );
+
+	function renderChip( type, message ) {
+		return shallow( <Chip type={ type } message={ message } /> );
+	}
+} );
+

--- a/client/components/payment-status-chip/index.js
+++ b/client/components/payment-status-chip/index.js
@@ -1,0 +1,55 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies.
+ */
+import { getTransactionStatus } from '../../utils/transaction';
+import Chip from '../chip';
+
+/* TODO: implement other payment statuses */
+/* TODO: implement support for different dispute messages - check https://stripe.com/docs/api/disputes/object */
+const statuses = {
+	'partially-refunded': {
+		type: 'light',
+		message: __( 'Partially Refunded', 'woocommerce-payments' ),
+	},
+	'fully-refunded': {
+		type: 'light',
+		message: __( 'Fully Refunded', 'woocommerce-payments' ),
+	},
+	paid: {
+		type: 'light',
+		message: __( 'Paid', 'woocommerce-payments' ),
+	},
+	authorized: {
+		type: 'primary',
+		message: __( 'Payment Authorized', 'woocommerce-payments' ),
+	},
+	failed: {
+		type: 'alert',
+		message: __( 'Blocked', 'woocommerce-payments' ),
+	},
+	disputed: {
+		type: 'primary',
+		message: __( 'Disputed', 'woocommerce-payments' ),
+	},
+	default: {
+		type: 'light',
+		message: '',
+	},
+};
+
+const PaymentStatusChip = ( props ) => {
+	const { transaction } = props;
+	const status = statuses[ getTransactionStatus( transaction ) ] || statuses.default;
+	return (
+		<Chip message={ status.message } type={ status.type } />
+	);
+};
+
+export default PaymentStatusChip;

--- a/client/components/payment-status-chip/test/__snapshots__/index.js.snap
+++ b/client/components/payment-status-chip/test/__snapshots__/index.js.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PaymentStatusChip renders a default light chip with no message if status does not match 1`] = `
+<Chip
+  message=""
+  type="light"
+/>
+`;
+
+exports[`PaymentStatusChip renders a light chip with fully refunded message if there's a full refund 1`] = `
+<Chip
+  message="Fully Refunded"
+  type="light"
+/>
+`;
+
+exports[`PaymentStatusChip renders a light chip with paid message if it is paid 1`] = `
+<Chip
+  message="Paid"
+  type="light"
+/>
+`;
+
+exports[`PaymentStatusChip renders a light chip with partially refunded message if there's a partial refund 1`] = `
+<Chip
+  message="Partially Refunded"
+  type="light"
+/>
+`;
+
+exports[`PaymentStatusChip renders a primary chip with authorized message if payment was not captured 1`] = `
+<Chip
+  message="Payment Authorized"
+  type="primary"
+/>
+`;
+
+exports[`PaymentStatusChip renders a primary chip with dispute message if there's a dispute 1`] = `
+<Chip
+  message="Disputed"
+  type="primary"
+/>
+`;
+
+exports[`PaymentStatusChip renders an alert chip with failed message if payment status is failed 1`] = `
+<Chip
+  message="Blocked"
+  type="alert"
+/>
+`;

--- a/client/components/payment-status-chip/test/index.js
+++ b/client/components/payment-status-chip/test/index.js
@@ -1,0 +1,62 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { getTransactionStatus } from '../../../utils/transaction';
+import PaymentStatusChip from '../';
+
+jest.mock( '../../../utils/transaction', () => ( { getTransactionStatus: jest.fn() } ) );
+
+describe( 'PaymentStatusChip', () => {
+	test( 'renders a default light chip with no message if status does not match', () => {
+		getTransactionStatus.mockReturnValue( 'teststatus' );
+		const paymentStatusChip = renderPaymentStatus();
+		expect( paymentStatusChip ).toMatchSnapshot();
+	} );
+
+	test( 'renders a light chip with partially refunded message if there\'s a partial refund', () => {
+		getTransactionStatus.mockReturnValue( 'partially-refunded' );
+		const paymentStatusChip = renderPaymentStatus();
+		expect( paymentStatusChip ).toMatchSnapshot();
+	} );
+
+	test( 'renders a light chip with fully refunded message if there\'s a full refund', () => {
+		getTransactionStatus.mockReturnValue( 'fully-refunded' );
+		const paymentStatusChip = renderPaymentStatus();
+		expect( paymentStatusChip ).toMatchSnapshot();
+	} );
+
+	test( 'renders a light chip with paid message if it is paid', () => {
+		getTransactionStatus.mockReturnValue( 'paid' );
+		const paymentStatusChip = renderPaymentStatus();
+		expect( paymentStatusChip ).toMatchSnapshot();
+	} );
+
+	test( 'renders a primary chip with authorized message if payment was not captured', () => {
+		getTransactionStatus.mockReturnValue( 'authorized' );
+		const paymentStatusChip = renderPaymentStatus();
+		expect( paymentStatusChip ).toMatchSnapshot();
+	} );
+
+	test( 'renders an alert chip with failed message if payment status is failed', () => {
+		getTransactionStatus.mockReturnValue( 'failed' );
+		const paymentStatusChip = renderPaymentStatus();
+		expect( paymentStatusChip ).toMatchSnapshot();
+	} );
+
+	test( 'renders a primary chip with dispute message if there\'s a dispute', () => {
+		getTransactionStatus.mockReturnValue( 'disputed' );
+		const paymentStatusChip = renderPaymentStatus();
+		expect( paymentStatusChip ).toMatchSnapshot();
+	} );
+
+	function renderPaymentStatus() {
+		return shallow( <PaymentStatusChip transaction={ {} } /> );
+	}
+} );
+

--- a/client/transaction-details/summary/index.js
+++ b/client/transaction-details/summary/index.js
@@ -8,13 +8,13 @@ import { Card } from '@woocommerce/components';
 /**
  * Internal dependencies.
  */
+import PaymentStatusChip from '../../components/payment-status-chip';
 
 const TransactionSummaryDetails = ( props ) => {
 	const { transaction } = props;
-	// TODO: this is a placeholder card and does not require translation
 	return (
-		<Card title="Summary" action={ transaction.id }>
-			Summary details for transaction { transaction.id }.
+		<Card>
+			<PaymentStatusChip transaction={ transaction } />
 		</Card>
 	);
 };

--- a/client/transaction-details/summary/test/__snapshots__/index.js.snap
+++ b/client/transaction-details/summary/test/__snapshots__/index.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TransactionSummaryDetails correctly renders a transaction 1`] = `
+<Card>
+  <PaymentStatusChip
+    transaction={Object {}}
+  />
+</Card>
+`;

--- a/client/transaction-details/summary/test/index.js
+++ b/client/transaction-details/summary/test/index.js
@@ -1,0 +1,26 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import TransactionSummaryDetails from '../';
+
+const getBaseTransaction = ( transaction = {} ) => ( {
+	...transaction,
+} );
+
+describe( 'TransactionSummaryDetails', () => {
+	test( 'correctly renders a transaction', () => {
+		const transactionSummaryDetails = renderTransaction( getBaseTransaction() );
+		expect( transactionSummaryDetails ).toMatchSnapshot();
+	} );
+
+	function renderTransaction( transaction ) {
+		return shallow( <TransactionSummaryDetails transaction={ transaction } /> );
+	}
+} );
+

--- a/client/utils/transaction/index.js
+++ b/client/utils/transaction/index.js
@@ -1,0 +1,53 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies.
+ */
+
+export const getCharge = ( transaction ) => get( transaction, 'type' ) === 'refund'
+	? get( transaction, 'source.charge' ) || {}
+	: get( transaction, 'source' ) || {};
+
+export const isTransactionSuccessful = ( transaction ) =>
+	getCharge( transaction ).status === 'succeeded' && getCharge( transaction ).paid === true;
+
+export const isTransactionFailed = ( transaction ) => getCharge( transaction ).status === 'failed';
+
+export const isTransactionCaptured = ( transaction ) => getCharge( transaction ).captured === true;
+
+export const isTransactionDisputed = ( transaction ) => getCharge( transaction ).disputed === true;
+
+export const isTransactionRefunded = ( transaction ) => getCharge( transaction ).amount_refunded > 0;
+
+export const isTransactionFullyRefunded = ( transaction ) => getCharge( transaction ).refunded === true;
+
+export const isTransactionPartiallyRefunded = ( transaction ) =>
+	isTransactionRefunded( transaction ) && ! isTransactionFullyRefunded( transaction );
+
+/* TODO: implement other transaction statuses */
+export const getTransactionStatus = ( transaction ) => {
+	if ( isTransactionFailed( transaction ) ) {
+		return 'failed';
+	}
+	if ( isTransactionDisputed( transaction ) ) {
+		return 'disputed';
+	}
+	if ( isTransactionPartiallyRefunded( transaction ) ) {
+		return 'partially-refunded';
+	}
+	if ( isTransactionFullyRefunded( transaction ) ) {
+		return 'fully-refunded';
+	}
+	if ( isTransactionSuccessful( transaction ) && isTransactionCaptured( transaction ) ) {
+		return 'paid';
+	}
+	if ( isTransactionSuccessful( transaction ) && ! isTransactionCaptured( transaction ) ) {
+		return 'authorized';
+	}
+	return '';
+};

--- a/client/utils/transaction/test/index.js
+++ b/client/utils/transaction/test/index.js
@@ -1,0 +1,112 @@
+/** @format */
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import * as utils from '../';
+
+const paidTransaction = { type: 'charge', source: { status: 'succeeded', paid: true, captured: true } };
+const failedTransaction = { type: 'charge', source: { status: 'failed', paid: false, captured: false } };
+const authorizedTransaction = { type: 'charge', source: { status: 'succeeded', paid: true, captured: false } };
+const disputedTransaction = { type: 'charge', source: { disputed: true } };
+// eslint-disable-next-line camelcase
+const fullyRefundedTransaction = { amount: 1500, source: { refunded: true, amount_refunded: 1500 } };
+// eslint-disable-next-line camelcase
+const partiallyRefundedTransaction = { amount: 1500, source: { refunded: false, amount_refunded: 1200 } };
+
+describe( 'Transaction utilities', () => {
+	test( 'should get the charge object for charge transactions', () => {
+		const charge = { id: 'ch_281' };
+		const transaction = { type: 'charge', source: charge };
+		expect( utils.getCharge( transaction ) ).toStrictEqual( charge );
+	} );
+
+	test( 'should get the charge object for refund transactions', () => {
+		const charge = { id: 'ch_281' };
+		const transaction = { type: 'refund', source: { charge } };
+		expect( utils.getCharge( transaction ) ).toStrictEqual( charge );
+	} );
+
+	test( 'should identify a captured successful transaction as successful', () => {
+		expect( utils.isTransactionSuccessful( paidTransaction ) ).toEqual( true );
+	} );
+
+	test( 'should identify a not captured successful transaction as successful', () => {
+		expect( utils.isTransactionSuccessful( authorizedTransaction ) ).toEqual( true );
+	} );
+
+	test( 'should identify a captured successful transaction as captured', () => {
+		expect( utils.isTransactionCaptured( paidTransaction ) ).toEqual( true );
+	} );
+
+	test( 'should not identify a not captured successful transaction as captured', () => {
+		expect( utils.isTransactionCaptured( authorizedTransaction ) ).toEqual( false );
+	} );
+
+	test( 'should not identify a failed transaction as successful', () => {
+		expect( utils.isTransactionSuccessful( failedTransaction ) ).toEqual( false );
+	} );
+
+	test( 'should identify a failed transaction as failed', () => {
+		expect( utils.isTransactionFailed( failedTransaction ) ).toEqual( true );
+	} );
+
+	test( 'should not identify a successful transaction as failed', () => {
+		expect( utils.isTransactionFailed( paidTransaction ) ).toEqual( false );
+	} );
+
+	test( 'should identify a disputed transaction as disputed', () => {
+		expect( utils.isTransactionDisputed( disputedTransaction ) ).toEqual( true );
+	} );
+
+	test( 'should identify a fully refunded transaction as fully refunded', () => {
+		expect( utils.isTransactionFullyRefunded( fullyRefundedTransaction ) ).toEqual( true );
+	} );
+
+	test( 'should not identify a partially refunded transaction as fully refunded', () => {
+		expect( utils.isTransactionFullyRefunded( partiallyRefundedTransaction ) ).toEqual( false );
+	} );
+
+	test( 'should not identify a successful transaction as fully refunded', () => {
+		expect( utils.isTransactionFullyRefunded( paidTransaction ) ).toEqual( false );
+	} );
+
+	test( 'should identify a partially refunded transaction as partially refunded', () => {
+		expect( utils.isTransactionPartiallyRefunded( partiallyRefundedTransaction ) ).toEqual( true );
+	} );
+
+	test( 'should not identify a fully refunded transaction as partilly refunded', () => {
+		expect( utils.isTransactionPartiallyRefunded( fullyRefundedTransaction ) ).toEqual( false );
+	} );
+
+	test( 'should not identify a successful transaction as partilly refunded', () => {
+		expect( utils.isTransactionPartiallyRefunded( paidTransaction ) ).toEqual( false );
+	} );
+
+	test( 'should return status paid for captured successful transactions', () => {
+		expect( utils.getTransactionStatus( paidTransaction ) ).toEqual( 'paid' );
+	} );
+
+	test( 'should return status authorized for not captured successful transactions', () => {
+		expect( utils.getTransactionStatus( authorizedTransaction ) ).toEqual( 'authorized' );
+	} );
+
+	test( 'should return status failed for failed transactions', () => {
+		expect( utils.getTransactionStatus( failedTransaction ) ).toEqual( 'failed' );
+	} );
+
+	test( 'should return status disputed for disputed transactions', () => {
+		expect( utils.getTransactionStatus( disputedTransaction ) ).toEqual( 'disputed' );
+	} );
+
+	test( 'should return status fully-refunded for fully refunded transactions', () => {
+		expect( utils.getTransactionStatus( fullyRefundedTransaction ) ).toEqual( 'fully-refunded' );
+	} );
+
+	test( 'should return status partially-refunded for partially refunded transactions', () => {
+		expect( utils.getTransactionStatus( partiallyRefundedTransaction ) ).toEqual( 'partially-refunded' );
+	} );
+} );


### PR DESCRIPTION
Fixes #202 

Please refer to Merchant Dashboard - Transaction Details (in figma file).

#### Changes proposed in this Pull Request

* Add transaction utils with helpful methods to classify a transaction
* Add base chip component
* Add payment status chip to transaction summary view

#### Testing instructions

1. Run tests and make sure they pass
2. Navigate to a transaction details view, either from the transaction list or direct URL
3. You should see a chip indicating the correct status for a transaction
    - `Gray` indicates that no action is necessary, `blue` that some action is required and `red` that the payment has failed

![image](https://user-images.githubusercontent.com/7714042/69720328-2446bd80-10f1-11ea-9f86-224dfd00f0bd.png)


-------------------

- [x] Tested on mobile (or does not apply)
- Some CSS changes are going to be applied by https://github.com/Automattic/woocommerce-payments/pull/288/commits/c67c9e1cf17c62ce08ced1bab533e0e2e2513d2d
