### PR TITLE
Add basic transaction info to transaction summary

### DIFF
--- a/client/transaction-details/summary/index.js
+++ b/client/transaction-details/summary/index.js
@@ -26,11 +26,11 @@ const TransactionSummaryDetails = ( props ) => {
 		<Card>
 			<div className="transaction-summary">
 				<div className="transaction-summary__section">
-					<h1 className="transaction-summary__amount">
+					<p className="transaction-summary__amount">
 						{ formatCurrency( ( transaction.amount || 0 ) / 100 ) }
 						<span className="transaction-summary__amount-currency">{ ( transaction.currency || 'cur' ) }</span>
 						<PaymentStatusChip transaction={ transaction } />
-					</h1>
+					</p>
 					<div className="transaction-summary__breakdown">
 						{ isTransactionRefunded( transaction )
 							? <p>

--- a/client/transaction-details/summary/index.js
+++ b/client/transaction-details/summary/index.js
@@ -6,10 +6,12 @@
 import { __ } from '@wordpress/i18n';
 import { Card } from '@woocommerce/components';
 import { formatCurrency } from '@woocommerce/currency';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies.
  */
+import { isTransactionRefunded } from '../../utils/transaction';
 import PaymentStatusChip from '../../components/payment-status-chip';
 import './style.scss';
 
@@ -25,6 +27,12 @@ const TransactionSummaryDetails = ( props ) => {
 						<PaymentStatusChip transaction={ transaction } />
 					</h1>
 					<div className="transaction-summary__breakdown">
+						{ isTransactionRefunded( transaction )
+							? <p>
+								{ `${ __( 'Refunded', 'woocommerce-payments' ) }: ` }
+								{ formatCurrency( ( -get( transaction, 'source.amount_refunded' ) || 0 ) / 100 ) }
+							</p>
+							: '' }
 						<p>
 							{ `${ __( 'Fee', 'woocommerce-payments' ) }: ` }
 							{ formatCurrency( ( -transaction.fee || 0 ) / 100 ) }

--- a/client/transaction-details/summary/index.js
+++ b/client/transaction-details/summary/index.js
@@ -3,18 +3,43 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Card } from '@woocommerce/components';
+import { formatCurrency } from '@woocommerce/currency';
 
 /**
  * Internal dependencies.
  */
 import PaymentStatusChip from '../../components/payment-status-chip';
+import './style.scss';
 
 const TransactionSummaryDetails = ( props ) => {
 	const { transaction } = props;
 	return (
 		<Card>
-			<PaymentStatusChip transaction={ transaction } />
+			<div className="transaction-summary">
+				<div className="transaction-summary__section">
+					<h1 className="transaction-summary__amount">
+						{ formatCurrency( ( transaction.amount || 0 ) / 100 ) }
+						<span className="transaction-summary__amount-currency">{ ( transaction.currency || 'cur' ) }</span>
+						<PaymentStatusChip transaction={ transaction } />
+					</h1>
+					<div className="transaction-summary__breakdown">
+						<p>
+							{ `${ __( 'Fee', 'woocommerce-payments' ) }: ` }
+							{ formatCurrency( ( -transaction.fee || 0 ) / 100 ) }
+						</p>
+						<p>
+							{ `${ __( 'Net', 'woocommerce-payments' ) }: ` }
+							{ formatCurrency( ( transaction.net || 0 ) / 100 ) }
+						</p>
+					</div>
+				</div>
+				<div className="transaction-summary__section">
+					{ /* TODO: implement control buttons depending on the transaction status */ }
+					{ /* E.g. if transaction is under dispute display Accept Dispute and Respond to Dispute buttons */ }
+				</div>
+			</div>
 		</Card>
 	);
 };

--- a/client/transaction-details/summary/index.js
+++ b/client/transaction-details/summary/index.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 import { Card } from '@woocommerce/components';
 import { formatCurrency } from '@woocommerce/currency';
 import { get } from 'lodash';
@@ -11,7 +12,11 @@ import { get } from 'lodash';
 /**
  * Internal dependencies.
  */
-import { isTransactionRefunded } from '../../utils/transaction';
+import {
+	isTransactionRefunded,
+	isTransactionPartiallyRefunded,
+	isTransactionFullyRefunded,
+} from '../../utils/transaction';
 import PaymentStatusChip from '../../components/payment-status-chip';
 import './style.scss';
 
@@ -46,6 +51,17 @@ const TransactionSummaryDetails = ( props ) => {
 				<div className="transaction-summary__section">
 					{ /* TODO: implement control buttons depending on the transaction status */ }
 					{ /* E.g. if transaction is under dispute display Accept Dispute and Respond to Dispute buttons */ }
+					<div className="transaction-summary__actions">
+						<Button className="transaction-summary__actions-item"
+							isDefault
+							isLarge
+							disabled={ ! get( transaction, 'order.url' ) ||	isTransactionFullyRefunded( transaction ) }
+							href={ `${ get( transaction, 'order.url' ) }#woocommerce-order-items` }>
+							{ ( isTransactionPartiallyRefunded( transaction ) )
+								? __( 'Refund more', 'woocommerce-payments' )
+								: __( 'Refund', 'woocommerce-payments' ) }
+						</Button>
+					</div>
 				</div>
 			</div>
 		</Card>

--- a/client/transaction-details/summary/style.scss
+++ b/client/transaction-details/summary/style.scss
@@ -1,10 +1,10 @@
 /** @format */
-$break-width: 30rem;
+$break-width: 32rem;
 
 .transaction-summary {
 	display: flex;
 	flex-direction: column;
-	@media screen and ( min-width: $break-width + 1 ) {
+	@media screen and ( min-width: $break-width ) {
 		flex-direction: initial;
 	}
 
@@ -16,6 +16,7 @@ $break-width: 30rem;
 		font-size: 2rem;
 		font-weight: 300;
 		padding: 0;
+		margin: 0;
 		display: flex;
 		align-items: center;
 
@@ -32,10 +33,10 @@ $break-width: 30rem;
 			font-size: 0.875rem;
 			color: #555D66;
 			display: inline-block;
-			margin: 0.5rem 0 0 0.75rem;
+			margin: 0.5rem 0.75rem 0 0;
 		}
-		p:first-child {
-			margin-left: 0;
+		p:last-child {
+			margin-right: 0;
 		}
 	}
 
@@ -44,12 +45,12 @@ $break-width: 30rem;
 		display: flex;
 		align-items: center;
 		justify-content: initial;
-		@media screen and ( min-width: $break-width + 1 ) {
+		@media screen and ( min-width: $break-width ) {
 			justify-content: flex-end;
 		}
 		.transaction-summary__actions-item {
 			margin-top: 1rem;
-			@media screen and ( min-width: $break-width + 1 ) {
+			@media screen and ( min-width: $break-width ) {
 				margin-top: 0;
 			}
 		}

--- a/client/transaction-details/summary/style.scss
+++ b/client/transaction-details/summary/style.scss
@@ -38,4 +38,20 @@ $break-width: 30rem;
 			margin-left: 0;
 		}
 	}
+
+	.transaction-summary__actions {
+		height: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: initial;
+		@media screen and ( min-width: $break-width + 1 ) {
+			justify-content: flex-end;
+		}
+		.transaction-summary__actions-item {
+			margin-top: 1rem;
+			@media screen and ( min-width: $break-width + 1 ) {
+				margin-top: 0;
+			}
+		}
+	}
 }

--- a/client/transaction-details/summary/style.scss
+++ b/client/transaction-details/summary/style.scss
@@ -1,0 +1,41 @@
+/** @format */
+$break-width: 30rem;
+
+.transaction-summary {
+	display: flex;
+	flex-direction: column;
+	@media screen and ( min-width: $break-width + 1 ) {
+		flex-direction: initial;
+	}
+
+	.transaction-summary__section {
+		flex-grow: 1;
+	}
+
+	.transaction-summary__amount {
+		font-size: 2rem;
+		font-weight: 300;
+		padding: 0;
+		display: flex;
+		align-items: center;
+
+		.transaction-summary__amount-currency {
+			text-transform: uppercase;
+			font-size: 1rem;
+			margin: 0 1rem 0 0.25rem;
+			color: #50575E;
+		}
+	}
+
+	.transaction-summary__breakdown {
+		p {
+			font-size: 0.875rem;
+			color: #555D66;
+			display: inline-block;
+			margin: 0.5rem 0 0 0.75rem;
+		}
+		p:first-child {
+			margin-left: 0;
+		}
+	}
+}

--- a/client/transaction-details/summary/test/__snapshots__/index.js.snap
+++ b/client/transaction-details/summary/test/__snapshots__/index.js.snap
@@ -25,6 +25,7 @@ exports[`TransactionSummaryDetails correctly renders a transaction 1`] = `
               "fee": 74,
               "id": "txn_38jdHA39KKA",
               "net": 1426,
+              "type": "charge",
             }
           }
         />
@@ -80,6 +81,64 @@ exports[`TransactionSummaryDetails renders defaults if transaction object is emp
         <p>
           Net: 
           $0.00
+        </p>
+      </div>
+    </div>
+    <div
+      className="transaction-summary__section"
+    />
+  </div>
+</Card>
+`;
+
+exports[`TransactionSummaryDetails renders refund information for a transaction 1`] = `
+<Card>
+  <div
+    className="transaction-summary"
+  >
+    <div
+      className="transaction-summary__section"
+    >
+      <h1
+        className="transaction-summary__amount"
+      >
+        $15.00
+        <span
+          className="transaction-summary__amount-currency"
+        >
+          usd
+        </span>
+        <PaymentStatusChip
+          transaction={
+            Object {
+              "amount": 1500,
+              "currency": "usd",
+              "fee": 74,
+              "id": "txn_38jdHA39KKA",
+              "net": 1426,
+              "source": Object {
+                "amount_refunded": 1200,
+                "refunded": false,
+              },
+              "type": "charge",
+            }
+          }
+        />
+      </h1>
+      <div
+        className="transaction-summary__breakdown"
+      >
+        <p>
+          Refunded: 
+          $-12.00
+        </p>
+        <p>
+          Fee: 
+          $-0.74
+        </p>
+        <p>
+          Net: 
+          $14.26
         </p>
       </div>
     </div>

--- a/client/transaction-details/summary/test/__snapshots__/index.js.snap
+++ b/client/transaction-details/summary/test/__snapshots__/index.js.snap
@@ -25,6 +25,10 @@ exports[`TransactionSummaryDetails correctly renders a transaction 1`] = `
               "fee": 74,
               "id": "txn_38jdHA39KKA",
               "net": 1426,
+              "order": Object {
+                "number": 45981,
+                "url": "https://somerandomorderurl.com/?edit_order=45981",
+              },
               "type": "charge",
             }
           }
@@ -45,7 +49,21 @@ exports[`TransactionSummaryDetails correctly renders a transaction 1`] = `
     </div>
     <div
       className="transaction-summary__section"
-    />
+    >
+      <div
+        className="transaction-summary__actions"
+      >
+        <ForwardRef(Button)
+          className="transaction-summary__actions-item"
+          disabled={false}
+          href="https://somerandomorderurl.com/?edit_order=45981#woocommerce-order-items"
+          isDefault={true}
+          isLarge={true}
+        >
+          Refund
+        </ForwardRef(Button)>
+      </div>
+    </div>
   </div>
 </Card>
 `;
@@ -86,12 +104,26 @@ exports[`TransactionSummaryDetails renders defaults if transaction object is emp
     </div>
     <div
       className="transaction-summary__section"
-    />
+    >
+      <div
+        className="transaction-summary__actions"
+      >
+        <ForwardRef(Button)
+          className="transaction-summary__actions-item"
+          disabled={true}
+          href="undefined#woocommerce-order-items"
+          isDefault={true}
+          isLarge={true}
+        >
+          Refund
+        </ForwardRef(Button)>
+      </div>
+    </div>
   </div>
 </Card>
 `;
 
-exports[`TransactionSummaryDetails renders refund information for a transaction 1`] = `
+exports[`TransactionSummaryDetails renders fully refunded information for a transaction 1`] = `
 <Card>
   <div
     className="transaction-summary"
@@ -116,6 +148,86 @@ exports[`TransactionSummaryDetails renders refund information for a transaction 
               "fee": 74,
               "id": "txn_38jdHA39KKA",
               "net": 1426,
+              "order": Object {
+                "number": 45981,
+                "url": "https://somerandomorderurl.com/?edit_order=45981",
+              },
+              "source": Object {
+                "amount_refunded": 1500,
+                "refunded": true,
+              },
+              "type": "charge",
+            }
+          }
+        />
+      </h1>
+      <div
+        className="transaction-summary__breakdown"
+      >
+        <p>
+          Refunded: 
+          $-15.00
+        </p>
+        <p>
+          Fee: 
+          $-0.74
+        </p>
+        <p>
+          Net: 
+          $14.26
+        </p>
+      </div>
+    </div>
+    <div
+      className="transaction-summary__section"
+    >
+      <div
+        className="transaction-summary__actions"
+      >
+        <ForwardRef(Button)
+          className="transaction-summary__actions-item"
+          disabled={true}
+          href="https://somerandomorderurl.com/?edit_order=45981#woocommerce-order-items"
+          isDefault={true}
+          isLarge={true}
+        >
+          Refund
+        </ForwardRef(Button)>
+      </div>
+    </div>
+  </div>
+</Card>
+`;
+
+exports[`TransactionSummaryDetails renders partially refunded information for a transaction 1`] = `
+<Card>
+  <div
+    className="transaction-summary"
+  >
+    <div
+      className="transaction-summary__section"
+    >
+      <h1
+        className="transaction-summary__amount"
+      >
+        $15.00
+        <span
+          className="transaction-summary__amount-currency"
+        >
+          usd
+        </span>
+        <PaymentStatusChip
+          transaction={
+            Object {
+              "amount": 1500,
+              "currency": "usd",
+              "fee": 74,
+              "id": "txn_38jdHA39KKA",
+              "net": 1426,
+              "order": Object {
+                "number": 45981,
+                "url": "https://somerandomorderurl.com/?edit_order=45981",
+              },
               "source": Object {
                 "amount_refunded": 1200,
                 "refunded": false,
@@ -144,7 +256,21 @@ exports[`TransactionSummaryDetails renders refund information for a transaction 
     </div>
     <div
       className="transaction-summary__section"
-    />
+    >
+      <div
+        className="transaction-summary__actions"
+      >
+        <ForwardRef(Button)
+          className="transaction-summary__actions-item"
+          disabled={false}
+          href="https://somerandomorderurl.com/?edit_order=45981#woocommerce-order-items"
+          isDefault={true}
+          isLarge={true}
+        >
+          Refund more
+        </ForwardRef(Button)>
+      </div>
+    </div>
   </div>
 </Card>
 `;

--- a/client/transaction-details/summary/test/__snapshots__/index.js.snap
+++ b/client/transaction-details/summary/test/__snapshots__/index.js.snap
@@ -2,8 +2,90 @@
 
 exports[`TransactionSummaryDetails correctly renders a transaction 1`] = `
 <Card>
-  <PaymentStatusChip
-    transaction={Object {}}
-  />
+  <div
+    className="transaction-summary"
+  >
+    <div
+      className="transaction-summary__section"
+    >
+      <h1
+        className="transaction-summary__amount"
+      >
+        $15.00
+        <span
+          className="transaction-summary__amount-currency"
+        >
+          usd
+        </span>
+        <PaymentStatusChip
+          transaction={
+            Object {
+              "amount": 1500,
+              "currency": "usd",
+              "fee": 74,
+              "id": "txn_38jdHA39KKA",
+              "net": 1426,
+            }
+          }
+        />
+      </h1>
+      <div
+        className="transaction-summary__breakdown"
+      >
+        <p>
+          Fee: 
+          $-0.74
+        </p>
+        <p>
+          Net: 
+          $14.26
+        </p>
+      </div>
+    </div>
+    <div
+      className="transaction-summary__section"
+    />
+  </div>
+</Card>
+`;
+
+exports[`TransactionSummaryDetails renders defaults if transaction object is empty 1`] = `
+<Card>
+  <div
+    className="transaction-summary"
+  >
+    <div
+      className="transaction-summary__section"
+    >
+      <h1
+        className="transaction-summary__amount"
+      >
+        $0.00
+        <span
+          className="transaction-summary__amount-currency"
+        >
+          cur
+        </span>
+        <PaymentStatusChip
+          transaction={Object {}}
+        />
+      </h1>
+      <div
+        className="transaction-summary__breakdown"
+      >
+        <p>
+          Fee: 
+          $0.00
+        </p>
+        <p>
+          Net: 
+          $0.00
+        </p>
+      </div>
+    </div>
+    <div
+      className="transaction-summary__section"
+    />
+  </div>
 </Card>
 `;

--- a/client/transaction-details/summary/test/__snapshots__/index.js.snap
+++ b/client/transaction-details/summary/test/__snapshots__/index.js.snap
@@ -8,7 +8,7 @@ exports[`TransactionSummaryDetails correctly renders a transaction 1`] = `
     <div
       className="transaction-summary__section"
     >
-      <h1
+      <p
         className="transaction-summary__amount"
       >
         $15.00
@@ -33,7 +33,7 @@ exports[`TransactionSummaryDetails correctly renders a transaction 1`] = `
             }
           }
         />
-      </h1>
+      </p>
       <div
         className="transaction-summary__breakdown"
       >
@@ -76,7 +76,7 @@ exports[`TransactionSummaryDetails renders defaults if transaction object is emp
     <div
       className="transaction-summary__section"
     >
-      <h1
+      <p
         className="transaction-summary__amount"
       >
         $0.00
@@ -88,7 +88,7 @@ exports[`TransactionSummaryDetails renders defaults if transaction object is emp
         <PaymentStatusChip
           transaction={Object {}}
         />
-      </h1>
+      </p>
       <div
         className="transaction-summary__breakdown"
       >
@@ -131,7 +131,7 @@ exports[`TransactionSummaryDetails renders fully refunded information for a tran
     <div
       className="transaction-summary__section"
     >
-      <h1
+      <p
         className="transaction-summary__amount"
       >
         $15.00
@@ -160,7 +160,7 @@ exports[`TransactionSummaryDetails renders fully refunded information for a tran
             }
           }
         />
-      </h1>
+      </p>
       <div
         className="transaction-summary__breakdown"
       >
@@ -207,7 +207,7 @@ exports[`TransactionSummaryDetails renders partially refunded information for a 
     <div
       className="transaction-summary__section"
     >
-      <h1
+      <p
         className="transaction-summary__amount"
       >
         $15.00
@@ -236,7 +236,7 @@ exports[`TransactionSummaryDetails renders partially refunded information for a 
             }
           }
         />
-      </h1>
+      </p>
       <div
         className="transaction-summary__breakdown"
       >

--- a/client/transaction-details/summary/test/index.js
+++ b/client/transaction-details/summary/test/index.js
@@ -10,12 +10,24 @@ import { shallow } from 'enzyme';
 import TransactionSummaryDetails from '../';
 
 const getBaseTransaction = ( transaction = {} ) => ( {
+	...{
+		id: 'txn_38jdHA39KKA',
+		amount: 1500,
+		fee: 74,
+		net: 1426,
+		currency: 'usd',
+	},
 	...transaction,
 } );
 
 describe( 'TransactionSummaryDetails', () => {
 	test( 'correctly renders a transaction', () => {
 		const transactionSummaryDetails = renderTransaction( getBaseTransaction() );
+		expect( transactionSummaryDetails ).toMatchSnapshot();
+	} );
+
+	test( 'renders defaults if transaction object is empty', () => {
+		const transactionSummaryDetails = renderTransaction( {} );
 		expect( transactionSummaryDetails ).toMatchSnapshot();
 	} );
 

--- a/client/transaction-details/summary/test/index.js
+++ b/client/transaction-details/summary/test/index.js
@@ -16,6 +16,7 @@ const getBaseTransaction = ( transaction = {} ) => ( {
 		fee: 74,
 		net: 1426,
 		currency: 'usd',
+		type: 'charge',
 	},
 	...transaction,
 } );
@@ -23,6 +24,12 @@ const getBaseTransaction = ( transaction = {} ) => ( {
 describe( 'TransactionSummaryDetails', () => {
 	test( 'correctly renders a transaction', () => {
 		const transactionSummaryDetails = renderTransaction( getBaseTransaction() );
+		expect( transactionSummaryDetails ).toMatchSnapshot();
+	} );
+
+	test( 'renders refund information for a transaction', () => {
+		// eslint-disable-next-line camelcase
+		const transactionSummaryDetails = renderTransaction( getBaseTransaction( { source: { refunded: false, amount_refunded: 1200 } } ) );
 		expect( transactionSummaryDetails ).toMatchSnapshot();
 	} );
 

--- a/client/transaction-details/summary/test/index.js
+++ b/client/transaction-details/summary/test/index.js
@@ -17,6 +17,10 @@ const getBaseTransaction = ( transaction = {} ) => ( {
 		net: 1426,
 		currency: 'usd',
 		type: 'charge',
+		order: {
+			number: 45981,
+			url: 'https://somerandomorderurl.com/?edit_order=45981',
+		},
 	},
 	...transaction,
 } );
@@ -27,9 +31,15 @@ describe( 'TransactionSummaryDetails', () => {
 		expect( transactionSummaryDetails ).toMatchSnapshot();
 	} );
 
-	test( 'renders refund information for a transaction', () => {
+	test( 'renders partially refunded information for a transaction', () => {
 		// eslint-disable-next-line camelcase
 		const transactionSummaryDetails = renderTransaction( getBaseTransaction( { source: { refunded: false, amount_refunded: 1200 } } ) );
+		expect( transactionSummaryDetails ).toMatchSnapshot();
+	} );
+
+	test( 'renders fully refunded information for a transaction', () => {
+		// eslint-disable-next-line camelcase
+		const transactionSummaryDetails = renderTransaction( getBaseTransaction( { source: { refunded: true, amount_refunded: 1500 } } ) );
 		expect( transactionSummaryDetails ).toMatchSnapshot();
 	} );
 

--- a/client/utils/transaction/index.js
+++ b/client/utils/transaction/index.js
@@ -9,22 +9,22 @@ import { get } from 'lodash';
  * Internal dependencies.
  */
 
-export const getCharge = ( transaction ) => get( transaction, 'type' ) === 'refund'
+export const getTransactionSourceCharge = ( transaction ) => get( transaction, 'type' ) === 'refund'
 	? get( transaction, 'source.charge' ) || {}
 	: get( transaction, 'source' ) || {};
 
 export const isTransactionSuccessful = ( transaction ) =>
-	getCharge( transaction ).status === 'succeeded' && getCharge( transaction ).paid === true;
+	getTransactionSourceCharge( transaction ).status === 'succeeded' && getTransactionSourceCharge( transaction ).paid === true;
 
-export const isTransactionFailed = ( transaction ) => getCharge( transaction ).status === 'failed';
+export const isTransactionFailed = ( transaction ) => getTransactionSourceCharge( transaction ).status === 'failed';
 
-export const isTransactionCaptured = ( transaction ) => getCharge( transaction ).captured === true;
+export const isTransactionCaptured = ( transaction ) => getTransactionSourceCharge( transaction ).captured === true;
 
-export const isTransactionDisputed = ( transaction ) => getCharge( transaction ).disputed === true;
+export const isTransactionDisputed = ( transaction ) => getTransactionSourceCharge( transaction ).disputed === true;
 
-export const isTransactionRefunded = ( transaction ) => getCharge( transaction ).amount_refunded > 0;
+export const isTransactionRefunded = ( transaction ) => getTransactionSourceCharge( transaction ).amount_refunded > 0;
 
-export const isTransactionFullyRefunded = ( transaction ) => getCharge( transaction ).refunded === true;
+export const isTransactionFullyRefunded = ( transaction ) => getTransactionSourceCharge( transaction ).refunded === true;
 
 export const isTransactionPartiallyRefunded = ( transaction ) =>
 	isTransactionRefunded( transaction ) && ! isTransactionFullyRefunded( transaction );

--- a/client/utils/transaction/test/index.js
+++ b/client/utils/transaction/test/index.js
@@ -21,13 +21,13 @@ describe( 'Transaction utilities', () => {
 	test( 'should get the charge object for charge transactions', () => {
 		const charge = { id: 'ch_281' };
 		const transaction = { type: 'charge', source: charge };
-		expect( utils.getCharge( transaction ) ).toStrictEqual( charge );
+		expect( utils.getTransactionSourceCharge( transaction ) ).toStrictEqual( charge );
 	} );
 
 	test( 'should get the charge object for refund transactions', () => {
 		const charge = { id: 'ch_281' };
 		const transaction = { type: 'refund', source: { charge } };
-		expect( utils.getCharge( transaction ) ).toStrictEqual( charge );
+		expect( utils.getTransactionSourceCharge( transaction ) ).toStrictEqual( charge );
 	} );
 
 	test( 'should identify a captured successful transaction as successful', () => {


### PR DESCRIPTION
Fixes #202 

Please refer to Merchant Dashboard - Transaction Details (in figma file).

#### Changes proposed in this Pull Request

* Add amount, fee, net and refunded information to transaction summary
* Add refund action button to transaction summary

#### Testing instructions

1. Run tests and make sure they pass
2. Navigate to a transaction details view, either from the transaction list or direct URL
3. You should see the basic transaction information and the refund button
    - The refunded information should only appear when the charge was refunded
    - The button should say *"Refund more"* when the transaction wasn't fully refunded
    - The button should say *"Refund"* when the transaction wasn't refunded or was fully refunded
    - The button should be disabled when the transaction was fully refunded

![image](https://user-images.githubusercontent.com/7714042/69726849-1c424a00-1100-11ea-8c1d-2042ea0032f4.png)
![image](https://user-images.githubusercontent.com/7714042/69726860-22d0c180-1100-11ea-9e48-c4cb1d9e5686.png)
![image](https://user-images.githubusercontent.com/7714042/69726867-25cbb200-1100-11ea-9355-69a3369797f2.png)


*This screen should only be used for charge transactions. #285 will fix this behavior for refund ones.*


-------------------

- [x] Tested on mobile (or does not apply)
- Some CSS changes are going to be applied by https://github.com/Automattic/woocommerce-payments/pull/288/commits/c67c9e1cf17c62ce08ced1bab533e0e2e2513d2d