### PR TITLE
Prevent non-A12S from enabling test mode

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -426,7 +426,7 @@ class WC_Payments_API_Client {
 		if ( 500 <= $response_code ) {
 			throw new Exception( __( 'Server error. Please try again.', 'woocommerce-payments' ) );
 		} elseif ( 400 <= $response_code ) {
-			if ( $response_body['error'] ) {
+			if ( ! empty( $response_body['error'] ) ) {
 				return new WP_Error( $response_body['error']['code'], $response_body['error']['message'], array( 'status' => $response_code ) );
 			};
 			return new WP_Error( $response_body['code'], $response_body['message'], array( 'status' => $response_code ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR relies on the `woocommerce_payments_allow_test_mode` option. It will automatically be initialized as `no`, but setting it to `yes` will allow a12s to enable test mode. The process of doing so is described in paJDYF-qU-p2

The `test_mode` setting of the gateway will only appear when `woocommerce_payments_allow_test_mode` is set to `yes`. This way merchants will not be able to enable test mode by default.

In case a clever user found the option and changed it manually, the server would reject the on-boarding flow by returning a `wcpay_test_mode_unavailable` code. If this happens:
1. The `woocommerce_payments_allow_test_mode` option will be set back to `no`.
2. Test mode will be disabled.
3. A notice with the following text will appear:

> Test mode is not available for your account. paJDYF-qU-p2

Q: Should we keep the link?

#### Testing instructions

1. Checkout the server PR and this PR 106-gh-woocommerce-payments-server
2. Follow the testing instructions in 106-gh-woocommerce-payments-server