### PR TITLE
Add out-of-the-box support for ngrok when using Docker

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -26,6 +26,11 @@ cli wp core update --quiet
 echo "Updating the WordPress database..."
 cli wp core update-db --quiet
 
+echo "Configuring paths to work with ngrok...";
+cli config set DOCKER_REQUEST_URL "( ! empty( \$_SERVER['HTTPS'] ) ? 'https://' : 'http://' ) . ( ! empty( \$_SERVER['HTTP_HOST'] ) ? \$_SERVER['HTTP_HOST'] : 'localhost' )" --raw
+cli config set WP_SITEURL DOCKER_REQUEST_URL --raw
+cli config set WP_HOME DOCKER_REQUEST_URL --raw
+
 echo "Installing and activating WooCommerce..."
 cli wp plugin install woocommerce --activate
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As promised a while back, adding the snippet, which allows WP to work with dynamic URLs. This way, the Docker instance will work with both `http://localhost:8082` (for faster use) and `https://your-domain.ngrok.io` (for Jetpack setup, HTTPS tests).

@jrodger is there any reason not to put PHP code within a string within the shell script?

#### Testing instructions

0. `docker-compose down` all other instances of the client.
1. Check out this branch in a fresh directory.
2. Run `docker-compose up -d`
3. Run `./bin/docker-setup.sh`
4. Try the website with both `localhost` and an ngrok/proxied domain.

Optionally, connect to the container using `docker exec -it woocommerce_payments_wordpress /bin/bash`, install a text editor, and check `wp-config.php`. It should contain those lines:

```php
define( 'DOCKER_REQUEST_URL', ( ! empty( $_SERVER['HTTPS'] ) ? 'https://' : 'http://' ) . ( ! empty( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : 'localhost' ) );
define( 'WP_SITEURL', DOCKER_REQUEST_URL );
define( 'WP_HOME', DOCKER_REQUEST_URL );
```