### PR TITLE
Use isset on array index to avoid undefined index notice

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -404,7 +404,7 @@ class WC_Payments_API_Client {
 		if ( 500 <= $response_code ) {
 			throw new Exception( __( 'Server error. Please try again.', 'woocommerce-payments' ) );
 		} elseif ( 400 <= $response_code ) {
-			if ( $response_body['error'] ) {
+			if ( isset( $response_body['error'] ) ) {
 				return new WP_Error( $response_body['error']['code'], $response_body['error']['message'], array( 'status' => $response_code ) );
 			};
 			return new WP_Error( $response_body['code'], $response_body['message'], array( 'status' => $response_code ) );


### PR DESCRIPTION
Fixes #296 

#### Changes proposed in this Pull Request

* Test for the array index using isset instead of just accessing it for falsy-ness

#### Testing instructions

Visual inspection is probably sufficient. If you really want to run a test, modify `includes/wc-payment-api/class-wc-payments-api-client.php` to have a code in the 400 range without a error index in the $response_body

-------------------

- [x] Tested on mobile (or does not apply)
