### PR TITLE
Fix fatal by applying account methods refactor to new filters

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -390,8 +390,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'wc_payments_account_actions',
 			$description,
 			$this->is_stripe_connected(),
-			$this->get_login_url(),
-			$this->get_connect_url()
+			WC_Payments_Account::get_login_url(),
+			WC_Payments_Account::get_connect_url()
 		);
 
 		ob_start();


### PR DESCRIPTION
Avoids fatal error on Settings screen by applying refactor in https://github.com/Automattic/woocommerce-payments/pull/274 to the filters added in https://github.com/Automattic/woocommerce-payments/pull/273 (missed in the merge). To test, verify that the Settings screen loads without error.