### PR TITLE
Update payment detail action button to point to order page

### DIFF
--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -54,12 +54,14 @@ const PaymentDetailsSummary = ( props ) => {
 				<div className="payment-details-summary__section">
 					{ /* TODO: implement control buttons depending on the transaction status */ }
 					<div className="payment-details-summary__actions">
-						<Button className="payment-details-summary__actions-item"
-							isDefault
-							isLarge
-							href={ get( charge, 'order.url' ) }>
-								{ `${ __( 'View order' ) } ${ get( charge, 'order.number' ) || '' }` }
-						</Button>
+						{ charge.order
+							? <Button className="payment-details-summary__actions-item"
+								isDefault
+								isLarge
+								href={ charge.order.url }>
+									{ `${ __( 'View order' ) } ${ charge.order.number }` }
+							</Button>
+							: '' }
 					</div>
 				</div>
 			</div>

--- a/client/payment-details/summary/test/__snapshots__/index.js.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.js.snap
@@ -162,15 +162,7 @@ exports[`PaymentDetailsSummary renders defaults if charge object is empty 1`] = 
     >
       <div
         className="payment-details-summary__actions"
-      >
-        <ForwardRef(Button)
-          className="payment-details-summary__actions-item"
-          isDefault={true}
-          isLarge={true}
-        >
-          View order 
-        </ForwardRef(Button)>
-      </div>
+      />
     </div>
   </div>
   <hr


### PR DESCRIPTION
The previous design could be confusing. For example, clicking the "refund" action button would have directed a user to the order detail screen and from there they would have had to click the refund button to issue the refund. The link to the order page was removed from the details row.

Fixes #309 

#### Changes proposed in this Pull Request

* Remove order link from payment details list
* Update payment details action button to redirect to order page

![image](https://user-images.githubusercontent.com/7714042/70918482-da6d3b00-1ffd-11ea-972a-74aeb34ca9a1.png)


#### Testing instructions

* Open the payment details view for a transaction
* You should see that the order link has been removed from the details row
* Clicking on the "View order #" button should navigate to the order details view

-------------------

- [X] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
