### PR TITLE
Add support for DEV mode to the API class

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -361,7 +361,7 @@ class WC_Payments_API_Client {
 	}
 
 	/**
-	 * Check if test mode is enabled or not. This function uses is_in_dev_mode, which overides
+	 * Check if test mode is enabled or not. This function uses is_in_dev_mode, which overrides
 	 * the function result.
 	 *
 	 * TODO: We should probably refactor this somewhat, since this is basically doing the


### PR DESCRIPTION
Relates to  #301 

#### Changes proposed in this Pull Request

- Add a new method to check for dev mode
- Add an extra parameter to the API call for the oauth endpoint data to clearly communicate the intention of the request
- Update the is_test_mode function to be overridden by the is_dev_mode.

#### Testing instructions

Check out this PR on the server side: 127-gh-woocommerce-payments-server

**1.**
- Enable dev mode by defining this constant as `true`: `WCPAY_DEV_MODE` OR installing and activating the dev mode plugin: https://github.com/dwainm/woocommerce-payments-dev-mode
- Try creating an account and you should be taken to the test account KYC signup.

**2.** 
- Disable the dev mode plugin.
- Try creating an account and you should be taken to the live KYC signup.

**3.** 
Enable dev mode plugin again but disable the test mode checkbox. Now create a transaction. You should see the transaction in the test db table.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
