### PR TITLE
Store a dev mode value and handle the state accordingly.

### DIFF
--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -273,7 +273,6 @@ class WC_Payments_Account {
 		if ( false === $oauth_data['url'] ) {
 			$account_id = sanitize_text_field( wp_unslash( $oauth_data['account_id'] ) );
 			WC_Payments::get_gateway()->update_option( 'enabled', 'yes' );
-
 			wp_safe_redirect( WC_Payment_Gateway_WCPay::get_settings_url() );
 			exit;
 		}


### PR DESCRIPTION
Related to #301

#### Changes proposed in this Pull Request
- Disable the test_mode setting when in dev mode as dev mode enforces test transactions.
- Store a value to indicate that the current connected account is a dev mode account or delete it if it is not.

#### Testing instructions

**Firstly**
- Make sure you have dev mode enabled( define constant  `WCPAY_DEV_MODE`).
- You must already have an account to test this. 
- In your wp-options, delete the row with key: woocommerce_woocommerce_payments_settings
- Check what type of account you have on the server. If it is a dev account ( is_live fales) then make sure you enable dev mode on the client if not, leave is is.
- Make sure force account creation filters are disabled as we don't want to go through the KYC flow for this.
- Go to the WC-Pay settings and click on get started. This should bring you back to the settings without taking you through the KYC Flow.
- Check the wp-options tables or `woocommerce_woocommerce_payments_settings`, inspect the value an see that test_mode is yes/no depending on your account type.


**Secondly**
- Make sure you have dev mode enabled( define constant  `WCPAY_DEV_MODE`).
- Check the settings to see if the test_mode setting is disabled and that you see a valid warning.

** Thirdly **
Disable the dev mode constant and see that your are now being asked to get started and taken to the live KYC signup flow.



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
