### PR TITLE
Add basic logging to API calls and in places where we previously left…

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use WCPay\Utils;
+use WCPay\Logger;
 
 /**
  * Gateway class for WooCommerce Payments
@@ -281,8 +282,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'redirect' => $this->get_return_url( $order ),
 			);
 		} catch ( Exception $e ) {
-			// TODO: Create or wire-up a logger for writing messages to the server filesystem.
 			// TODO: Create plugin specific exceptions so that we can be smarter about what we create notices for.
+			Logger::log( $e->getMessage(), 'error' );
 			wc_add_notice( $e->getMessage(), 'error' );
 
 			$order->update_status( 'failed' );
@@ -349,7 +350,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			}
 		} catch ( Exception $e ) {
 
-			// TODO log error.
 			$note = sprintf(
 				/* translators: %1: the successfully charged amount, %2: error message */
 				__( 'A refund of %1$s failed to complete: %2$s', 'woocommerce-payments' ),
@@ -357,6 +357,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$e->getMessage()
 			);
 
+			Logger::log( $note );
 			$order->add_order_note( $note );
 
 			return new WP_Error( $e->getMessage() );

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -8,6 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use WCPay\Utils;
+use WCPay\Logger;
 
 /**
  * Communicates with WooCommerce Payments API.
@@ -423,6 +424,7 @@ class WC_Payments_API_Client {
 		$headers['Content-Type'] = 'application/json; charset=utf-8';
 		$headers['User-Agent']   = $this->user_agent;
 
+		Logger::log( "REQUEST $method $url" );
 		$response = $this->http_client->remote_request(
 			array(
 				'url'     => $url,
@@ -433,7 +435,10 @@ class WC_Payments_API_Client {
 			$is_site_specific
 		);
 
-		return $this->extract_response_body( $response );
+		$response_body = $this->extract_response_body( $response );
+		Logger::log( 'RESPONSE ' . var_export( $response_body, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+
+		return $response_body;
 	}
 
 	/**


### PR DESCRIPTION
Closes #301 

#### Changes proposed in this Pull Request

* Add some basic logging to places where we added a TODO as well in the API requests.

#### Testing instructions

* Visit the settings page and click on "View payouts and account details". Close the window again.
* Go to Amin > WooCommerce > Status > Logs and look for woocommerce-payments in the dropdown. You should see something like this in the logs:

```
INFO REQUEST POST https://public-api.wordpress.com/wpcom/v2/sites/%s/wcpay/accounts/login_links

INFO RESPONSE array (
  'object' => 'login_link',
  'created' => 1579080016,
  'url' => 'https://connect.stripe.com/express/xxxxxxxxxx',
)
```

-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
