### PR TITLE
Fix issue where wcpay wasn't enabled after oauth flow

### DIFF
--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -255,6 +255,7 @@ class WC_Payments_Account {
 			delete_option( 'wcpay_test_only' );
 		}
 
+		$this->gateway->update_option( 'enabled', 'yes' );
 		$this->gateway->update_option( 'stripe_account_id', $account_id );
 		$this->gateway->update_option( 'test_mode', $test_mode ? 'yes' : 'no' );
 		$this->update_public_keys( $live_publishable_key, $test_publishable_key );


### PR DESCRIPTION
Fixes #336

#### Changes proposed in this Pull Request

* Enables WooCommerce Payments by default when you successfully complete the KYC flow.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Make sure WooCommerce Payments is not enabled on failure**

1. Start the KYC flow.
1. Stop in the middle of the flow and cancel.
1. Make sure WooCommerce Payments hasn't been enabled.

**Make sure WooCommerce Payments is enabled on success**

1. Start the KYC flow.
1. Finish the flow.
1. Make sure WooCommerce Payments has been enabled.

