### PR TITLE
Use a span instead of a paragraph tag in RiskLevel component

### DIFF
--- a/client/components/risk-level/index.js
+++ b/client/components/risk-level/index.js
@@ -21,7 +21,7 @@ const RiskLevel = ( props ) => {
 	const { risk } = props;
 
 	return (
-		<p style={ { color: colorMappings[ risk ] } }>{ riskMappings[ risk ] }</p>
+		<span style={ { color: colorMappings[ risk ] } }>{ riskMappings[ risk ] }</span>
 	);
 };
 

--- a/client/components/risk-level/test/__snapshots__/index.js.snap
+++ b/client/components/risk-level/test/__snapshots__/index.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RiskLevel Renders elevated risk correctly. 1`] = `
-<p
+<span
   style={
     Object {
       "color": "orange",
@@ -9,11 +9,11 @@ exports[`RiskLevel Renders elevated risk correctly. 1`] = `
   }
 >
   Elevated
-</p>
+</span>
 `;
 
 exports[`RiskLevel Renders highest risk correctly. 1`] = `
-<p
+<span
   style={
     Object {
       "color": "red",
@@ -21,11 +21,11 @@ exports[`RiskLevel Renders highest risk correctly. 1`] = `
   }
 >
   Highest
-</p>
+</span>
 `;
 
 exports[`RiskLevel Renders normal risk correctly. 1`] = `
-<p
+<span
   style={
     Object {
       "color": "green",
@@ -33,5 +33,5 @@ exports[`RiskLevel Renders normal risk correctly. 1`] = `
   }
 >
   Normal
-</p>
+</span>
 `;


### PR DESCRIPTION
Fixes #388 

Creating this for consideration. I noticed that the rows in the transaction table are quite padded out.

![image](https://user-images.githubusercontent.com/686419/73351013-0b3fc180-4286-11ea-95b4-25aa2ba2bbf3.png)

Some of my data doesn't have a risk level set, and those rows were less padded. I think every transaction should have a risk level associated with it, but my bad data aside, I changed the risk level component to use a span instead of a paragraph tag.

![image](https://user-images.githubusercontent.com/686419/73350650-586f6380-4285-11ea-980d-76f7d79911fc.png)

Which brings the padding down to something that looks "normal" to me. Any thoughts?

cc @LevinMedia 