### PR TITLE
Fix styling for textarea control (#357)

### DIFF
--- a/client/style.scss
+++ b/client/style.scss
@@ -20,6 +20,17 @@
 		/* Mokes text area taking full width of the card */
 		width: 100%;
 		padding: 6px 8px;
+
+		/**
+		 * This styling makes focused textares look like other inputs.
+		 * Original styling is defined here https://github.com/woocommerce/woocommerce-admin/blob/c5811495987a05010513ce51e3dfcf538d52049a/client/stylesheets/shared/_global.scss.
+		 * TODO: remove if PR released (https://github.com/woocommerce/woocommerce-admin/pull/3655).
+		 */
+		&:focus {
+			color: $dark-gray-700;
+			border-color: $studio-woocommerce-purple-60;
+			box-shadow: 0 0 2px rgba($studio-woocommerce-purple-60, 0.8);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #357 

#### Changes proposed in this Pull Request

* Make Textarea control taking the full width of the parent container. The fix applies to all Textarea controls rendered inside `.woocommerce-card__body` container.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Payments > Disputes and click on an arrow link in a dispute status.
<img width="930" alt="Screenshot 2020-01-30 at 12 56 08" src="https://user-images.githubusercontent.com/3139099/73438990-fd5e6f00-435f-11ea-88e2-2aed931256ea.png">
* Check the styling of the evidence form:
<img width="931" alt="Screenshot 2020-01-30 at 13 00 14" src="https://user-images.githubusercontent.com/3139099/73439380-8fff0e00-4360-11ea-8c7d-a1662a873176.png">


**UPD 31.01.2020**
![textarea_styling_demo](https://user-images.githubusercontent.com/3139099/73534005-1edb5b80-4431-11ea-8f81-d47de3e30836.gif)

-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->

