### PR TITLE
Display alert on WP Admin if Jetpack is not connected

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -141,6 +141,11 @@ class WC_Payments {
 
 		$plugin_headers = self::get_plugin_headers();
 
+		// Do not show alerts while installing plugins.
+		if ( ! $silent && self::is_at_plugin_install_page() ) {
+			return true;
+		}
+
 		$wc_version = $plugin_headers['WCRequires'];
 		$wp_version = $plugin_headers['RequiresWP'];
 
@@ -235,7 +240,8 @@ class WC_Payments {
 
 		// Check if Jetpack is connected.
 		if ( ! self::is_jetpack_connected() ) {
-			if ( ! $silent ) {
+			// Do not show an alert on Jetpack admin pages.
+			if ( ! $silent && ! self::is_at_jetpack_admin_page() ) {
 				$set_up_url = wp_nonce_url( 'admin.php?page=jetpack' );
 				$message    = sprintf(
 					/* translators: %1: WooCommerce Payments version, %2: Jetpack setup url */
@@ -250,6 +256,26 @@ class WC_Payments {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Checks if current page is plugin installation process page.
+	 *
+	 * @return bool True when installing plugin.
+	 */
+	private static function is_at_plugin_install_page() {
+		$cur_screen = get_current_screen();
+		return 'update' === $cur_screen->id && 'plugins' === $cur_screen->parent_base;
+	}
+
+	/**
+	 * Checks if current page is Jetpack admin page.
+	 *
+	 * @return bool True when current page is one of the Jetpack admin pages.
+	 */
+	private static function is_at_jetpack_admin_page() {
+		$cur_screen = get_current_screen();
+		return 'jetpack' === $cur_screen->parent_base;
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -240,8 +240,11 @@ class WC_Payments {
 			|| ( class_exists( 'Jetpack_Client' ) && ! Jetpack_Data::get_access_token() )
 		) {
 			if ( ! $silent ) {
-				// TODO: Create better alert message.
-				$message = 'Jetpack is not connected!';
+				$set_up_url = wp_nonce_url( 'admin.php?page=jetpack' );
+				$message    = sprintf(
+					'To use WooCommerce Payments you\'ll need to <a href="%1$s">set up</a> the Jetpack plugin. Don\'t worry this is temporary thing.',
+					$set_up_url
+				);
 				self::display_admin_error( $message );
 			}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -239,7 +239,7 @@ class WC_Payments {
 				$set_up_url = wp_nonce_url( 'admin.php?page=jetpack' );
 				$message    = sprintf(
 					/* translators: %1: WooCommerce Payments version, %2: Jetpack setup url */
-					__( 'To use WooCommerce Payments %1$s you\'ll need to <a href="%2$s">set up</a> the Jetpack plugin. Don\'t worry this is temporary thing.', 'woocommerce-payments' ),
+					__( 'To use WooCommerce Payments %1$s you\'ll need to <a href="%2$s">set up</a> the Jetpack plugin.', 'woocommerce-payments' ),
 					WCPAY_VERSION_NUMBER,
 					$set_up_url
 				);

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -144,7 +144,6 @@ class WC_Payments {
 		$wc_version = $plugin_headers['WCRequires'];
 		$wp_version = $plugin_headers['RequiresWP'];
 
-		// TODO: Check if Jetpack  is installed at all.
 		$plugin_dependencies = array(
 			array(
 				'name'  => 'WooCommerce',
@@ -157,6 +156,12 @@ class WC_Payments {
 				'class' => '\Automattic\WooCommerce\Admin\FeaturePlugin',
 				'slug'  => 'woocommerce-admin',
 				'file'  => 'woocommerce-admin/woocommerce-admin.php',
+			),
+			array(
+				'name'  => 'Jetpack',
+				'class' => 'Jetpack',
+				'slug'  => 'jetpack',
+				'file'  => 'jetpack/jetpack.php',
 			),
 		);
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -144,6 +144,7 @@ class WC_Payments {
 		$wc_version = $plugin_headers['WCRequires'];
 		$wp_version = $plugin_headers['RequiresWP'];
 
+		// TODO: Check if Jetpack  is installed at all.
 		$plugin_dependencies = array(
 			array(
 				'name'  => 'WooCommerce',
@@ -224,6 +225,21 @@ class WC_Payments {
 				}
 				self::display_admin_error( $message );
 			}
+			return false;
+		}
+
+		// TODO: Extract the check into static method of WC_Payments_Http.
+		// Check if Jetpack is connected.
+		if (
+			( class_exists( 'Automattic\Jetpack\Connection\Client' ) && ! ( new Automattic\Jetpack\Connection\Manager() )->get_access_token() )
+			|| ( class_exists( 'Jetpack_Client' ) && ! Jetpack_Data::get_access_token() )
+		) {
+			if ( ! $silent ) {
+				// TODO: Create better alert message.
+				$message = 'Jetpack is not connected!';
+				self::display_admin_error( $message );
+			}
+
 			return false;
 		}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -233,12 +233,8 @@ class WC_Payments {
 			return false;
 		}
 
-		// TODO: Extract the check into static method of WC_Payments_Http.
 		// Check if Jetpack is connected.
-		if (
-			( class_exists( 'Automattic\Jetpack\Connection\Client' ) && ! ( new Automattic\Jetpack\Connection\Manager() )->get_access_token() )
-			|| ( class_exists( 'Jetpack_Client' ) && ! Jetpack_Data::get_access_token() )
-		) {
+		if ( ! self::is_jetpack_connected() ) {
 			if ( ! $silent ) {
 				$set_up_url = wp_nonce_url( 'admin.php?page=jetpack' );
 				$message    = sprintf(
@@ -252,6 +248,16 @@ class WC_Payments {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Checks if Jetpack is connected.
+	 *
+	 * @return bool true if Jetpack connection is available and authenticated.
+	 */
+	public static function is_jetpack_connected() {
+		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-http.php';
+		return WC_Payments_Http::is_connected();
 	}
 
 	/**

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -38,4 +38,16 @@ class WC_Payments_Http {
 			return Jetpack_Client::remote_request( $args, $body );
 		}
 	}
+
+	/**
+	 * Checks if Jetpack is connected.
+	 *
+	 * Checks if connection is authenticated in the same way as Jetpack_Client or Jetpack Connection Client does.
+	 *
+	 * @return bool true if Jetpack connection has access token.
+	 */
+	public static function is_connected() {
+		return ( class_exists( 'Automattic\Jetpack\Connection\Client' ) && ( new Automattic\Jetpack\Connection\Manager() )->get_access_token() )
+			|| ( class_exists( 'Jetpack_Client' ) && Jetpack_Data::get_access_token() );
+	}
 }

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -47,6 +47,7 @@ class WC_Payments_Http {
 	 * @return bool true if Jetpack connection has access token.
 	 */
 	public static function is_connected() {
+		// TODO - Remove/update when Jetpack Connection package is all we need.
 		return ( class_exists( 'Automattic\Jetpack\Connection\Client' ) && ( new Automattic\Jetpack\Connection\Manager() )->get_access_token() )
 			|| ( class_exists( 'Jetpack_Client' ) && Jetpack_Data::get_access_token() );
 	}


### PR DESCRIPTION
Fixes #339 #249 #195
Relates to #196 
Resolved conflicts with #394 should not affect #332 🙂

#### Changes proposed in this Pull Request

* Display alert on WP Admin if Jetpack is not installed or not activated. 
* Display alert on WP Admin if Jetpack is not connected.
* Prevent WCPayments plugin initialization when Jetpack is either not activated or not connected.

#### Testing instructions

For fresh WooCommerce site without WCPayments configured start at step 3.
1.  Go to Admin > Plugins > Installed plugins and deactivate Jetpack. 

    - Alert should appear at the top:
<img width="569" alt="Screenshot 2020-02-04 at 13 27 12" src="https://user-images.githubusercontent.com/3139099/73736592-19905080-4752-11ea-80e7-54923ac0f74f.png">


    - No new fatal error message should appear in the logs.

2. (Optionally)Admin > Plugins > Installed plugins and delete Jetpack from the site.
Alert should appear at the top.
<img width="587" alt="Screenshot 2020-02-04 at 13 21 27" src="https://user-images.githubusercontent.com/3139099/73736129-57d94000-4751-11ea-834d-0765673dcfdf.png">

3. Install Jetpack if removed at step 2 or it does not exist after step 2.

    - Alert should appear at the top:
<img width="569" alt="Screenshot 2020-02-04 at 13 27 12" src="https://user-images.githubusercontent.com/3139099/73736592-19905080-4752-11ea-80e7-54923ac0f74f.png">

4. Activate Jetpack but **do not set up at the moment**. If Jetpack setup page is displayed, go to Dashboard.

    - Another alert should appear at the top
<img width="673" alt="Screenshot 2020-02-04 at 13 29 48" src="https://user-images.githubusercontent.com/3139099/73736791-7855ca00-4752-11ea-80df-39f3a5af70f8.png">

5. Go to Jetpack setup page, connect it and get back to the admin dashboard.
 _At this step tunnelled Http connection is required (details are [here](https://fieldguide.automattic.com/developing-woocommerce-payments/) in section 2.3.1.1.)._ 

 6. Go to Payments > Settings:

    - All settings should be in place for an existing site.
    - The setup page should be displayed for a fresh site.



-------------------

- [x] Tested on mobile (or does not apply)
