### PR TITLE
Display an admin notice if neither Jetpack transport is available for WCPay

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -144,7 +144,7 @@ class WC_Payments {
 			if ( ! $silent ) {
 				$message = sprintf(
 					/* translators: %1: WooCommerce Payments version */
-					__( 'WooCommerce Payments %1$s requires Jetpack. Please install, activate and connect Jetpack. This dependency will change in an upcoming release.', 'woocommerce-payments' ),
+					__( 'WooCommerce Payments %1$s requires Jetpack. Please install, activate, and connect Jetpack. This dependency will change in an upcoming release.', 'woocommerce-payments' ),
 					WCPAY_VERSION_NUMBER
 				);
 


### PR DESCRIPTION
Fixes #332 
Related to #339 cc @vbelolapotkov 

#### Changes proposed in this Pull Request

* Test for either Jetpack transport before allowing the plugin to activate (and fatal)

#### Testing instructions

* Deactivate Jetpack while WCPay is active.
* Ensure no Fatal Error results.
* Ensure you are prompted to install, activate and connect Jetpack "at this time."
