### PR TITLE
Fix array offset on bool notice in PHP7

### DIFF
--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -164,11 +164,13 @@ class WC_Payments_Admin {
 			WC_Payments::get_file_version( 'dist/index.css' )
 		);
 
-		$settings_script_src_url = plugins_url( 'dist/settings.js', WCPAY_PLUGIN_FILE );
+		$settings_script_src_url    = plugins_url( 'dist/settings.js', WCPAY_PLUGIN_FILE );
+		$settings_script_asset_path = WCPAY_ABSPATH . 'dist/settings.asset.php';
+		$settings_script_asset      = file_exists( $settings_script_asset_path ) ? require_once $settings_script_asset_path : null;
 		wp_register_script(
 			'WCPAY_ADMIN_SETTINGS',
 			$settings_script_src_url,
-			$script_asset['dependencies'],
+			$settings_script_asset['dependencies'],
 			WC_Payments::get_file_version( 'dist/settings.js' ),
 			true
 		);


### PR DESCRIPTION
Fixes #396

`dist/index.asset.php` is already required and its value is stored as `$script_asset`. No need to `require_once` it again, the variable can be reused.

#### Testing instructions

* Make sure `WP_DEBUG` and `WP_DEBUG_DISPLAY` are both set to `true`
* Visit wp-admin
* No PHP notice should appear
