### PR TITLE
Add TOS message to WP.com setup notification

### DIFF
--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Card, Link } from '@woocommerce/components';
 import { Button } from '@wordpress/components';
 import Gridicon from 'gridicons';
@@ -13,30 +13,20 @@ import Gridicon from 'gridicons';
 import './style.scss';
 
 const ConnectAccountPage = () => {
-	const tosLabel = {
-		__html: sprintf(
-			/* translators: %s: WordPress.com TOS URL */
-			__(
-				'By using WooCommerce Payments, you agree to our %sTerms of Service%s.',
-				'woocommmerce-payments'
-			),
-			'<a href="https://wordpress.com/tos/">',
-			'</a>'
-		),
-	};
 	return (
 		<div className="connect-account">
 			<Card className="connect-account__card" >
 				<p><Gridicon icon="credit-card" size={ 72 } /></p>
 				<h2>
-					{ __(
-						'Accept credit cards online using WooCommerce Payments. Verify your business details to begin receiving payments.',
-						'woocommmerce-payments'
-					) }
+					{ wcpaySettings.strings.setupHeading }
 				</h2>
-				<p><Button isPrimary isLarge href={ wcpaySettings.connectUrl }>{ __( 'Get started', 'woocommerce-payments' ) }</Button></p>
 				<p>
-					<span dangerouslySetInnerHTML={ tosLabel } />
+					<Link href={ wcpaySettings.tosUrl }>
+						{ wcpaySettings.strings.setupTerms }
+					</Link>
+				</p>
+				<p>
+					<Button isPrimary isLarge href={ wcpaySettings.connectUrl }>{ wcpaySettings.strings.setupGetStarted }</Button>
 				</p>
 				<p>
 					<Link href="admin.php?page=wc-settings&tab=checkout" type="wp-admin">

--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -17,10 +17,11 @@ const ConnectAccountPage = () => {
 		__html: sprintf(
 			/* translators: %s: WordPress.com TOS URL */
 			__(
-				'By clicking \'Get started\' you agree to WooCommerce Payments <a href="%s">terms of service</a>.',
+				'By using WooCommerce Payments, you agree to our %sTerms of Service%s.',
 				'woocommmerce-payments'
 			),
-			'https://wordpress.com/tos/'
+			'<a href="https://wordpress.com/tos/">',
+			'</a>'
 		),
 	};
 	return (

--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -13,14 +13,16 @@ import Gridicon from 'gridicons';
 import './style.scss';
 
 const ConnectAccountPage = () => {
-	const tosLabel = sprintf(
-		/* translators: %s: WordPress.com TOS URL */
-		__(
-			'By clicking \'Get started\' you agree to WooCommerce Payments <a href="%s">terms of service</a>.',
-			'woocommmerce-payments'
-		),
-		"https://wordpress.com/tos/"
-	);
+	const tosLabel = {
+		__html: sprintf(
+			/* translators: %s: WordPress.com TOS URL */
+			__(
+				'By clicking \'Get started\' you agree to WooCommerce Payments <a href="%s">terms of service</a>.',
+				'woocommmerce-payments'
+			),
+			"https://wordpress.com/tos/"
+		)
+	};
 	return (
 		<div className="connect-account">
 			<Card className="connect-account__card" >
@@ -33,7 +35,7 @@ const ConnectAccountPage = () => {
 				</h2>
 				<p><Button isPrimary isLarge href={ wcpaySettings.connectUrl }>{ __( 'Get started', 'woocommerce-payments' ) }</Button></p>
 				<p>
-					{ tosLabel }
+					<span dangerouslySetInnerHTML={ tosLabel } />
 				</p>
 				<p>
 					<Link href="admin.php?page=wc-settings&tab=checkout" type="wp-admin">

--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Card, Link } from '@woocommerce/components';
 import { Button } from '@wordpress/components';
 import Gridicon from 'gridicons';
@@ -13,6 +13,14 @@ import Gridicon from 'gridicons';
 import './style.scss';
 
 const ConnectAccountPage = () => {
+	const tosLabel = sprintf(
+		/* translators: %s: WordPress.com TOS URL */
+		__(
+			'By clicking \'Get started\' you agree to WooCommerce Payments <a href="%s">terms of service</a>.',
+			'woocommmerce-payments'
+		),
+		"https://wordpress.com/tos/"
+	);
 	return (
 		<div className="connect-account">
 			<Card className="connect-account__card" >
@@ -25,10 +33,7 @@ const ConnectAccountPage = () => {
 				</h2>
 				<p><Button isPrimary isLarge href={ wcpaySettings.connectUrl }>{ __( 'Get started', 'woocommerce-payments' ) }</Button></p>
 				<p>
-					{ __( 'By clicking \'Get started\' you agree to WooCommerce Payments', 'woocommmerce-payments' ) }
-					&nbsp;
-					<a href="https://wordpress.com/tos/">{ __( 'terms of service', 'woocommerce-payments' ) }</a>
-					.
+					{ tosLabel }
 				</p>
 				<p>
 					<Link href="admin.php?page=wc-settings&tab=checkout" type="wp-admin">

--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -20,8 +20,8 @@ const ConnectAccountPage = () => {
 				'By clicking \'Get started\' you agree to WooCommerce Payments <a href="%s">terms of service</a>.',
 				'woocommmerce-payments'
 			),
-			'https://wordpress.com/tos/',
-		)
+			'https://wordpress.com/tos/'
+		),
 	};
 	return (
 		<div className="connect-account">

--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -27,9 +27,7 @@ const ConnectAccountPage = () => {
 				<p>
 					{ __( 'By clicking \'Get started\' you agree to WooCommerce Payments', 'woocommmerce-payments' ) }
 					&nbsp;
-					{ /* TODO: Update this once we have the TOS link */ }
-					{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-					<a href="#">{ __( 'terms of service', 'woocommerce-payments' ) }</a>
+					<a href="https://wordpress.com/tos/">{ __( 'terms of service', 'woocommerce-payments' ) }</a>
 					.
 				</p>
 				<p>

--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -20,7 +20,7 @@ const ConnectAccountPage = () => {
 				'By clicking \'Get started\' you agree to WooCommerce Payments <a href="%s">terms of service</a>.',
 				'woocommmerce-payments'
 			),
-			"https://wordpress.com/tos/"
+			'https://wordpress.com/tos/',
 		)
 	};
 	return (

--- a/client/connect-account-page/test/__snapshots__/index.js.snap
+++ b/client/connect-account-page/test/__snapshots__/index.js.snap
@@ -26,7 +26,13 @@ exports[`ConnectAccountPage should render correctly 1`] = `
       </ForwardRef(Button)>
     </p>
     <p>
-      By clicking 'Get started' you agree to WooCommerce Payments &lt;a href="https://wordpress.com/tos/"&gt;terms of service&lt;/a&gt;.
+      <span
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "By clicking 'Get started' you agree to WooCommerce Payments <a href=\\"https://wordpress.com/tos/\\">terms of service</a>.",
+          }
+        }
+      />
     </p>
     <p>
       <Link

--- a/client/connect-account-page/test/__snapshots__/index.js.snap
+++ b/client/connect-account-page/test/__snapshots__/index.js.snap
@@ -14,24 +14,19 @@ exports[`ConnectAccountPage should render correctly 1`] = `
       />
     </p>
     <h2>
-      Accept credit cards online using WooCommerce Payments. Verify your business details to begin receiving payments.
+      setup-heading
     </h2>
+    <p>
+      <Link
+        href="/tos-url"
+        type="wc-admin"
+      />
+    </p>
     <p>
       <ForwardRef(Button)
         href="/wcpay-connect-url"
         isLarge={true}
         isPrimary={true}
-      >
-        Get started
-      </ForwardRef(Button)>
-    </p>
-    <p>
-      <span
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "By clicking 'Get started' you agree to WooCommerce Payments <a href=\\"https://wordpress.com/tos/\\">terms of service</a>.",
-          }
-        }
       />
     </p>
     <p>

--- a/client/connect-account-page/test/__snapshots__/index.js.snap
+++ b/client/connect-account-page/test/__snapshots__/index.js.snap
@@ -26,14 +26,7 @@ exports[`ConnectAccountPage should render correctly 1`] = `
       </ForwardRef(Button)>
     </p>
     <p>
-      By clicking 'Get started' you agree to WooCommerce Payments
-       
-      <a
-        href="#"
-      >
-        terms of service
-      </a>
-      .
+      By clicking 'Get started' you agree to WooCommerce Payments &lt;a href="https://wordpress.com/tos/"&gt;terms of service&lt;/a&gt;.
     </p>
     <p>
       <Link

--- a/client/connect-account-page/test/index.js
+++ b/client/connect-account-page/test/index.js
@@ -10,9 +10,9 @@ import { shallow } from 'enzyme';
 import ConnectAccountPage from '..';
 
 describe( 'ConnectAccountPage', () => {
-	const setupHeading    = 'setup-heading';
+	const setupHeading = 'setup-heading';
 	const wcpayConnectUrl = '/wcpay-connect-url';
-	const tosUrl          = '/tos-url';
+	const tosUrl = '/tos-url';
 	beforeEach( () => {
 		window.location.assign = jest.fn();
 		global.wcpaySettings = {
@@ -20,7 +20,7 @@ describe( 'ConnectAccountPage', () => {
 			strings: {
 				setupHeading: setupHeading,
 			},
-			tosUrl:     tosUrl,
+			tosUrl: tosUrl,
 		};
 	} );
 

--- a/client/connect-account-page/test/index.js
+++ b/client/connect-account-page/test/index.js
@@ -10,11 +10,17 @@ import { shallow } from 'enzyme';
 import ConnectAccountPage from '..';
 
 describe( 'ConnectAccountPage', () => {
+	const setupHeading    = 'setup-heading';
 	const wcpayConnectUrl = '/wcpay-connect-url';
+	const tosUrl          = '/tos-url';
 	beforeEach( () => {
 		window.location.assign = jest.fn();
 		global.wcpaySettings = {
 			connectUrl: wcpayConnectUrl,
+			strings: {
+				setupHeading: setupHeading,
+			},
+			tosUrl:     tosUrl,
 		};
 	} );
 

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -180,12 +180,28 @@ class WC_Payments_Admin {
 			true
 		);
 
+		$strings                 = array();
+		$strings['setupHeading'] = __(
+			'Accept credit cards online using WooCommerce payments. Simply verify your business details to begin receiving payments.',
+			'woocommerce-payments'
+		);
+
+		/* translators: Link to WordPress.com TOS URL */
+		$strings['setupTerms'] = __(
+			'By clicking \'Get started\' you agree to WooCommerce Payments terms of service.',
+			'woocommerce-payments'
+		);
+
+		$strings['setupGetStarted'] = __( ' Get started', 'woocommerce-payments' );
+
 		wp_localize_script(
 			'WCPAY_DASH_APP',
 			'wcpaySettings',
 			array(
 				'connectUrl' => WC_Payments_Account::get_connect_url(),
 				'testMode'   => $this->wcpay_gateway->is_in_test_mode(),
+				'strings'    => $strings,
+				'tosUrl'     => 'https://wordpress.com/tos',
 			)
 		);
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -432,6 +432,39 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					WC_Payments_Account::get_login_url()
 				);
 			} else {
+				$description  = '<p>';
+				$description .= __(
+					'Accept credit cards online using WooCommerce payments. Simply verify your business details to begin receiving payments.',
+					'woocommerce-payments'
+				);
+				$description .= ' ';
+
+				/* translators: Link to WordPress.com TOS URL */
+				$terms_message = __(
+					'By clicking \'Get started\' you agree to WooCommerce Payments {A}terms of service{/A}.',
+					'woocommerce-payments'
+				);
+				$terms_message = str_replace( '{A}', '<a href="https://wordpress.com/tos">', $terms_message );
+				$terms_message = str_replace( '{/A}', '</a>', $terms_message );
+				$description  .= $terms_message;
+				$description  .= '</p>';
+
+				$description .= '<p>';
+				$description .= '<a href="' . WC_Payments_Account::get_connect_url() . '" class="button">';
+				$description .= __( ' Get started', 'woocommerce-payments' );
+				$description .= '</a>';
+				$description .= '</p>';
+
+				$description = wp_kses(
+					$description,
+					array(
+						'a' => array(
+							'class' => array(),
+							'href'  => array(),
+						),
+						'p' => array(),
+					)
+				);
 				$description = WC_Payments_Account::get_connect_message();
 			}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -235,8 +235,8 @@ class WC_Payments_Account {
 	 */
 	public static function get_connect_message() {
 		return sprintf(
-			/* translators: 1) oauth entry point URL */
-			__( 'Accept credit cards online. Simply verify your business details to activate WooCommerce Payments. <a href="%1$s">Get started</a>', 'woocommerce-payments' ),
+			/* translators: 1) oauth entry point URL - TODO: Update TOS with live link */
+			__( 'Accept credit cards online. Simply verify your business details to activate WooCommerce Payments. <a href="%1$s">Get started</a> <p>By clicking \'Get started\' you agree to WooCommerce Payments <a href="#">terms of service</a></p>', 'woocommerce-payments' ),
 			self::get_connect_url()
 		);
 	}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -135,7 +135,41 @@ class WC_Payments_Account {
 		}
 
 		if ( empty( $account ) ) {
-			$message = self::get_connect_message();
+			$message  = '<p>';
+			$message .= __(
+				'Accept credit cards online using WooCommerce payments. Simply verify your business details to begin receiving payments.',
+				'woocommerce-payments'
+			);
+			$message .= '</p>';
+			$message .= '<p>';
+
+			/* translators: Link to WordPress.com TOS URL */
+			$terms_message = __(
+				'By clicking \'Get started\' you agree to WooCommerce Payments {A}terms of service{/A}.',
+				'woocommerce-payments'
+			);
+			$terms_message = str_replace( '{A}', '<a href="https://wordpress.com/tos">', $terms_message );
+			$terms_message = str_replace( '{/A}', '</a>', $terms_message );
+			$message      .= $terms_message;
+			$message      .= '</p>';
+
+			$message .= '<p>';
+			$message .= '<a href="' . self::get_connect_url() . '" class="button">';
+			$message .= __( ' Get started', 'woocommerce-payments' );
+			$message .= '</a>';
+			$message .= '</p>';
+
+			$message = wp_kses(
+				$message,
+				array(
+					'a' => array(
+						'class' => array(),
+						'href'  => array(),
+					),
+					'p' => array(),
+				)
+			);
+
 			add_filter(
 				'admin_notices',
 				function () use ( $message ) {
@@ -157,7 +191,6 @@ class WC_Payments_Account {
 				}
 			);
 		}
-
 		return true;
 	}
 
@@ -228,24 +261,6 @@ class WC_Payments_Account {
 	 */
 	public static function get_connect_url() {
 		return wp_nonce_url( add_query_arg( [ 'wcpay-connect' => '1' ] ), 'wcpay-connect' );
-	}
-
-	/**
-	 * Get Stripe connect message with connect link
-	 */
-	public static function get_connect_message() {
-		return sprintf(
-			wp_kses(
-				/* translators: 1) oauth entry point URL, 2) WordPress.com TOS URL */
-				__( 'Accept credit cards online. Simply verify your business details to activate WooCommerce Payments. <a href="%1$s">Get started</a><br/><br/>By clicking \'Get started\' you agree to WooCommerce Payments <a href="%2$s">terms of service</a>.', 'woocommerce-payments' ),
-				array(
-					'a'  => array( 'href' => array() ),
-					'br' => array(),
-				)
-			),
-			self::get_connect_url(),
-			'https://wordpress.com/tos'
-		);
 	}
 
 	/**

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -235,8 +235,8 @@ class WC_Payments_Account {
 	 */
 	public static function get_connect_message() {
 		return sprintf(
-			/* translators: 1) oauth entry point URL - TODO: Update TOS with live link */
-			__( 'Accept credit cards online. Simply verify your business details to activate WooCommerce Payments. <a href="%1$s">Get started</a> <p>By clicking \'Get started\' you agree to WooCommerce Payments <a href="#">terms of service</a></p>', 'woocommerce-payments' ),
+			/* translators: 1) oauth entry point URL */
+			__( 'Accept credit cards online. Simply verify your business details to activate WooCommerce Payments. <a href="%1$s">Get started</a> <p>By clicking \'Get started\' you agree to WooCommerce Payments <a href="https://wordpress.com/tos/">terms of service</a></p>', 'woocommerce-payments' ),
 			self::get_connect_url()
 		);
 	}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -235,9 +235,10 @@ class WC_Payments_Account {
 	 */
 	public static function get_connect_message() {
 		return sprintf(
-			/* translators: 1) oauth entry point URL */
-			__( 'Accept credit cards online. Simply verify your business details to activate WooCommerce Payments. <a href="%1$s">Get started</a> <p>By clicking \'Get started\' you agree to WooCommerce Payments <a href="https://wordpress.com/tos/">terms of service</a></p>', 'woocommerce-payments' ),
-			self::get_connect_url()
+			/* translators: 1) oauth entry point URL, 2) WordPress.com TOS URL */
+			__( 'Accept credit cards online. Simply verify your business details to activate WooCommerce Payments. <a href="%1$s">Get started</a> <p>By clicking \'Get started\' you agree to WooCommerce Payments <a href="%2$s">terms of service</a>.</p>', 'woocommerce-payments' ),
+			self::get_connect_url(),
+			'https://wordpress.com/tos'
 		);
 	}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -235,8 +235,14 @@ class WC_Payments_Account {
 	 */
 	public static function get_connect_message() {
 		return sprintf(
-			/* translators: 1) oauth entry point URL, 2) WordPress.com TOS URL */
-			__( 'Accept credit cards online. Simply verify your business details to activate WooCommerce Payments. <a href="%1$s">Get started</a> <p>By clicking \'Get started\' you agree to WooCommerce Payments <a href="%2$s">terms of service</a>.</p>', 'woocommerce-payments' ),
+			wp_kses(
+				/* translators: 1) oauth entry point URL, 2) WordPress.com TOS URL */
+				__( 'Accept credit cards online. Simply verify your business details to activate WooCommerce Payments. <a href="%1$s">Get started</a><br/><br/>By clicking \'Get started\' you agree to WooCommerce Payments <a href="%2$s">terms of service</a>.', 'woocommerce-payments' ),
+				array(
+					'a'  => array( 'href' => array() ),
+					'br' => array(),
+				)
+			),
 			self::get_connect_url(),
 			'https://wordpress.com/tos'
 		);


### PR DESCRIPTION
Fixes #400 

#### Changes proposed in this Pull Request

*Adds the TOS acceptance message and link to TOS to the WooCommerce Payments WordPress get started notification

Must be updated once we have the link to the live TOS

Before:

<img width="1525" alt="Screen Shot 2020-02-04 at 3 51 33 PM" src="https://user-images.githubusercontent.com/4500952/73797979-4a7a8080-4766-11ea-9f5c-186aa62c2e4f.png">

After:
<img width="1481" alt="Screen Shot 2020-02-04 at 3 51 49 PM" src="https://user-images.githubusercontent.com/4500952/73798003-5f571400-4766-11ea-9cba-f110dc78506e.png">

