### PR TITLE
Add changelog.txt

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,2 +1,4 @@
+*** WooCommerce Payments Changelog ***
+
 2020-02-05 - version 0.7.0
 * Alpha


### PR DESCRIPTION
Fixes #404 

Required by the `woorelease` script for WooCommerce.com deployments.