### PR TITLE
Add changelog.txt to the ZIP file created by npm run release

### DIFF
--- a/tasks/release.js
+++ b/tasks/release.js
@@ -33,8 +33,9 @@ confirm( colors.cyan( 'Howdy! This script is going to create a release folder wi
 	mkdir( releaseFolder );
 	mkdir( targetFolder );
 
-	// copy the main php file and readme.txt
+	// copy the main php file, changelog.txt, and readme.txt
 	cp( 'woocommerce-payments.php', targetFolder );
+	cp( 'changelog.txt', targetFolder );
 	cp( 'readme.txt', targetFolder );
 
 	// copy the directories to the release folder


### PR DESCRIPTION
Fixes #405 

#### Changes proposed in this Pull Request

* Adds changelog.txt to the ZIP like we do for other plugin ZIPs served by WooCommerce.com

#### Testing instructions

* `npm run release`
* Make sure the ZIP includes changelog.txt at the root of the zip
