### PR TITLE
Update disputes evidence form footer

### DIFF
--- a/client/components/card-footer/index.js
+++ b/client/components/card-footer/index.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies.
+ */
+
+import './style.scss';
+
+const CardFooter = ( { children } ) => {
+	return (
+		<div className="woocommerce-card__footer">
+			{ children }
+		</div>
+	);
+};
+
+export default CardFooter;

--- a/client/components/card-footer/index.js
+++ b/client/components/card-footer/index.js
@@ -1,11 +1,6 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-
-/**
- * Internal dependencies.
- */
-
 import './style.scss';
 
 const CardFooter = ( { children } ) => {

--- a/client/components/card-footer/style.scss
+++ b/client/components/card-footer/style.scss
@@ -1,0 +1,10 @@
+.woocommerce-card__body .woocommerce-card__footer {
+	/* Add margin and padding to align with .woocommerce-card__body padding */
+	margin: 16px -16px 0;
+	padding: 16px;
+	border-top: 1px solid #ddd;
+
+	&:last-child {
+		padding-bottom: 0;
+	}
+}

--- a/client/components/card-footer/style.scss
+++ b/client/components/card-footer/style.scss
@@ -2,7 +2,7 @@
 	/* Add margin and padding to align with .woocommerce-card__body padding */
 	margin: 16px -16px 0;
 	padding: 16px;
-	border-top: 1px solid #ddd;
+	border-top: 1px solid $gray-5;
 
 	&:last-child {
 		padding-bottom: 0;

--- a/client/components/page/index.js
+++ b/client/components/page/index.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies.
+ */
+
+import './style.scss';
+
+const Page = ( { children, maxWidth, isNarrow } ) => {
+	const customStyle = maxWidth ? { maxWidth } : null;
+	const classNames = [ 'woocommerce-payments-page' ];
+	if ( isNarrow ) {
+		classNames.push( 'is-narrow' );
+	}
+
+	return <div className={ classNames.join( ' ' ) } style={ customStyle }>{children}</div>;
+};
+
+export default Page;

--- a/client/components/page/index.js
+++ b/client/components/page/index.js
@@ -1,11 +1,6 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-
-/**
- * Internal dependencies.
- */
-
 import './style.scss';
 
 const Page = ( { children, maxWidth, isNarrow } ) => {
@@ -15,7 +10,7 @@ const Page = ( { children, maxWidth, isNarrow } ) => {
 		classNames.push( 'is-narrow' );
 	}
 
-	return <div className={ classNames.join( ' ' ) } style={ customStyle }>{children}</div>;
+	return <div className={ classNames.join( ' ' ) } style={ customStyle }>{ children }</div>;
 };
 
 export default Page;

--- a/client/components/page/style.scss
+++ b/client/components/page/style.scss
@@ -1,0 +1,8 @@
+.woocommerce-payments-page {
+	margin: 0 auto;
+	max-width: 1200px;
+
+	&.is-narrow {
+		max-width: 680px;
+	}
+}

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -48,6 +48,24 @@ export const DisputeEvidenceForm = props => {
 			{ evidenceSections }
 			{ readOnly ? null : (
 				<Card>
+					<p>
+						{ __(
+							'When you submit your evidence, we\'ll compile and send it to the cardholder\'s bank, ' +
+							'and then email you once the dispute has been decided.',
+							'woocommerce-payments'
+						) }
+						&nbsp;
+						<strong>{ __( 'Evidence submission is final.', 'woocommerce-payments' ) }</strong>
+					</p>
+					<p>
+						{ __(
+							'You can also save this evidence for later editing instead of submitting it immediately.',
+							'woocommerce-payments'
+						) }
+						&nbsp;
+						<strong>{__( 'We will automatically submit any saved evidence at the due date.', 'woocommerce-payments' )}</strong>
+					</p>
+
 					<Button isPrimary isLarge onClick={ () => onSave( true ) }>{ __( 'Submit Evidence' ) }</Button>
 					<Button isDefault isLarge onClick={ () => onSave( false ) }>{ __( 'Save For Later' ) }</Button>
 				</Card>

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -59,12 +59,12 @@ export const DisputeEvidenceForm = props => {
 					</p>
 					<p>
 						<strong>{ __( 'Evidence submission is final.', 'woocommerce-payments' ) }</strong>
-						&nbsp;
+						{ ' ' }
 						{ __(
 							'You can also save this evidence for later instead of submitting it immediately.',
 							'woocommerce-payments'
 						) }
-						&nbsp;
+						{ ' ' }
 						<strong>{__( 'We will automatically submit any saved evidence at the due date.', 'woocommerce-payments' )}</strong>
 					</p>
 

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -70,10 +70,10 @@ export const DisputeEvidenceForm = props => {
 
 					<CardFooter>
 						<Button isPrimary isLarge onClick={ () => onSave( true ) }>
-							{__( 'Submit Evidence' )}
+							{__( 'Submit Evidence', 'woocommerce-payments' )}
 						</Button>
 						<Button isDefault isLarge onClick={ () => onSave( false ) }>
-							{__( 'Save For Later' )}
+							{__( 'Save For Later', 'woocommerce-payments' )}
 						</Button>
 					</CardFooter>
 				</Card>

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -44,7 +44,7 @@ export const DisputeEvidenceForm = props => {
 	} );
 
 	return (
-		<Section>
+		<Section className="dispute-evidence-form-container">
 			{ evidenceSections }
 			{ readOnly ? null : (
 				<Card>

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -7,13 +7,14 @@ import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { Button, TextControl, TextareaControl } from '@wordpress/components';
-import { Section, Card } from '@woocommerce/components';
+import { Card } from '@woocommerce/components';
 
 /**
  * Internal dependencies.
  */
 import './style.scss';
 import evidenceFields from './fields';
+import Page from '../../components/page';
 import CardFooter from '../../components/card-footer';
 
 export const DisputeEvidenceForm = props => {
@@ -45,7 +46,7 @@ export const DisputeEvidenceForm = props => {
 	} );
 
 	return (
-		<Section className="dispute-evidence-form-container">
+		<Page isNarrow>
 			{ evidenceSections }
 			{ readOnly ? null : (
 				<Card>
@@ -77,7 +78,7 @@ export const DisputeEvidenceForm = props => {
 					</CardFooter>
 				</Card>
 			) }
-		</Section>
+		</Page>
 	);
 };
 

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -14,6 +14,7 @@ import { Section, Card } from '@woocommerce/components';
  */
 import './style.scss';
 import evidenceFields from './fields';
+import CardFooter from '../../components/card-footer';
 
 export const DisputeEvidenceForm = props => {
 	const { evidence, showPlaceholder, onChange, onSave, readOnly } = props;
@@ -66,8 +67,14 @@ export const DisputeEvidenceForm = props => {
 						<strong>{__( 'We will automatically submit any saved evidence at the due date.', 'woocommerce-payments' )}</strong>
 					</p>
 
-					<Button isPrimary isLarge onClick={ () => onSave( true ) }>{ __( 'Submit Evidence' ) }</Button>
-					<Button isDefault isLarge onClick={ () => onSave( false ) }>{ __( 'Save For Later' ) }</Button>
+					<CardFooter>
+						<Button isPrimary isLarge onClick={ () => onSave( true ) }>
+							{__( 'Submit Evidence' )}
+						</Button>
+						<Button isDefault isLarge onClick={ () => onSave( false ) }>
+							{__( 'Save For Later' )}
+						</Button>
+					</CardFooter>
 				</Card>
 			) }
 		</Section>

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -52,16 +52,16 @@ export const DisputeEvidenceForm = props => {
 				<Card>
 					<p>
 						{ __(
-							'When you submit your evidence, we\'ll compile and send it to the cardholder\'s bank, ' +
-							'and then email you once the dispute has been decided.',
+							// eslint-disable-next-line max-len
+							"When you submit your evidence, we'll format it and send it to the cardholder's bank, then email you once the dispute has been decided.",
 							'woocommerce-payments'
 						) }
-						&nbsp;
-						<strong>{ __( 'Evidence submission is final.', 'woocommerce-payments' ) }</strong>
 					</p>
 					<p>
+						<strong>{ __( 'Evidence submission is final.', 'woocommerce-payments' ) }</strong>
+						&nbsp;
 						{ __(
-							'You can also save this evidence for later editing instead of submitting it immediately.',
+							'You can also save this evidence for later instead of submitting it immediately.',
 							'woocommerce-payments'
 						) }
 						&nbsp;

--- a/client/disputes/evidence/style.scss
+++ b/client/disputes/evidence/style.scss
@@ -2,6 +2,11 @@
 	margin-left: 10px;
 }
 
+.dispute-evidence-form-container {
+	max-width: 680px;
+	margin: 0 auto;
+}
+
 .woocommerce-card > .woocommerce-card__header > .woocommerce-card__title-wrapper > .woocommerce-card__title {
 	padding: 3px 0;
 	font-size: 15px;

--- a/client/disputes/evidence/style.scss
+++ b/client/disputes/evidence/style.scss
@@ -2,11 +2,6 @@
 	margin-left: 10px;
 }
 
-.dispute-evidence-form-container {
-	max-width: 680px;
-	margin: 0 auto;
-}
-
 .woocommerce-card > .woocommerce-card__header > .woocommerce-card__title-wrapper > .woocommerce-card__title {
 	padding: 3px 0;
 	font-size: 15px;

--- a/client/disputes/evidence/test/__snapshots__/index.js.snap
+++ b/client/disputes/evidence/test/__snapshots__/index.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Dispute evidence form needing response, renders correctly 1`] = `
-<Section>
+<Section
+  className="dispute-evidence-form-container"
+>
   <Card
     key="general"
     title="General evidence"
@@ -81,7 +83,9 @@ exports[`Dispute evidence form needing response, renders correctly 1`] = `
 `;
 
 exports[`Dispute evidence form not needing response, renders correctly 1`] = `
-<Section>
+<Section
+  className="dispute-evidence-form-container"
+>
   <Card
     key="general"
     title="General evidence"

--- a/client/disputes/evidence/test/__snapshots__/index.js.snap
+++ b/client/disputes/evidence/test/__snapshots__/index.js.snap
@@ -57,9 +57,9 @@ exports[`Dispute evidence form needing response, renders correctly 1`] = `
       <strong>
         Evidence submission is final.
       </strong>
-       
+       
       You can also save this evidence for later instead of submitting it immediately.
-       
+       
       <strong>
         We will automatically submit any saved evidence at the due date.
       </strong>
@@ -141,9 +141,9 @@ exports[`Dispute evidence form not needing response, renders correctly 1`] = `
       <strong>
         Evidence submission is final.
       </strong>
-       
+       
       You can also save this evidence for later instead of submitting it immediately.
-       
+       
       <strong>
         We will automatically submit any saved evidence at the due date.
       </strong>

--- a/client/disputes/evidence/test/__snapshots__/index.js.snap
+++ b/client/disputes/evidence/test/__snapshots__/index.js.snap
@@ -64,20 +64,22 @@ exports[`Dispute evidence form needing response, renders correctly 1`] = `
         We will automatically submit any saved evidence at the due date.
       </strong>
     </p>
-    <ForwardRef(Button)
-      isLarge={true}
-      isPrimary={true}
-      onClick={[Function]}
-    >
-      Submit Evidence
-    </ForwardRef(Button)>
-    <ForwardRef(Button)
-      isDefault={true}
-      isLarge={true}
-      onClick={[Function]}
-    >
-      Save For Later
-    </ForwardRef(Button)>
+    <CardFooter>
+      <ForwardRef(Button)
+        isLarge={true}
+        isPrimary={true}
+        onClick={[Function]}
+      >
+        Submit Evidence
+      </ForwardRef(Button)>
+      <ForwardRef(Button)
+        isDefault={true}
+        isLarge={true}
+        onClick={[Function]}
+      >
+        Save For Later
+      </ForwardRef(Button)>
+    </CardFooter>
   </Card>
 </Section>
 `;
@@ -146,20 +148,22 @@ exports[`Dispute evidence form not needing response, renders correctly 1`] = `
         We will automatically submit any saved evidence at the due date.
       </strong>
     </p>
-    <ForwardRef(Button)
-      isLarge={true}
-      isPrimary={true}
-      onClick={[Function]}
-    >
-      Submit Evidence
-    </ForwardRef(Button)>
-    <ForwardRef(Button)
-      isDefault={true}
-      isLarge={true}
-      onClick={[Function]}
-    >
-      Save For Later
-    </ForwardRef(Button)>
+    <CardFooter>
+      <ForwardRef(Button)
+        isLarge={true}
+        isPrimary={true}
+        onClick={[Function]}
+      >
+        Submit Evidence
+      </ForwardRef(Button)>
+      <ForwardRef(Button)
+        isDefault={true}
+        isLarge={true}
+        onClick={[Function]}
+      >
+        Save For Later
+      </ForwardRef(Button)>
+    </CardFooter>
   </Card>
 </Section>
 `;

--- a/client/disputes/evidence/test/__snapshots__/index.js.snap
+++ b/client/disputes/evidence/test/__snapshots__/index.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Dispute evidence form needing response, renders correctly 1`] = `
-<Section
-  className="dispute-evidence-form-container"
+<Page
+  isNarrow={true}
 >
   <Card
     key="general"
@@ -81,12 +81,12 @@ exports[`Dispute evidence form needing response, renders correctly 1`] = `
       </ForwardRef(Button)>
     </CardFooter>
   </Card>
-</Section>
+</Page>
 `;
 
 exports[`Dispute evidence form not needing response, renders correctly 1`] = `
-<Section
-  className="dispute-evidence-form-container"
+<Page
+  isNarrow={true}
 >
   <Card
     key="general"
@@ -165,5 +165,5 @@ exports[`Dispute evidence form not needing response, renders correctly 1`] = `
       </ForwardRef(Button)>
     </CardFooter>
   </Card>
-</Section>
+</Page>
 `;

--- a/client/disputes/evidence/test/__snapshots__/index.js.snap
+++ b/client/disputes/evidence/test/__snapshots__/index.js.snap
@@ -51,14 +51,14 @@ exports[`Dispute evidence form needing response, renders correctly 1`] = `
   </Card>
   <Card>
     <p>
-      When you submit your evidence, we'll compile and send it to the cardholder's bank, and then email you once the dispute has been decided.
-       
+      When you submit your evidence, we'll format it and send it to the cardholder's bank, then email you once the dispute has been decided.
+    </p>
+    <p>
       <strong>
         Evidence submission is final.
       </strong>
-    </p>
-    <p>
-      You can also save this evidence for later editing instead of submitting it immediately.
+       
+      You can also save this evidence for later instead of submitting it immediately.
        
       <strong>
         We will automatically submit any saved evidence at the due date.
@@ -135,14 +135,14 @@ exports[`Dispute evidence form not needing response, renders correctly 1`] = `
   </Card>
   <Card>
     <p>
-      When you submit your evidence, we'll compile and send it to the cardholder's bank, and then email you once the dispute has been decided.
-       
+      When you submit your evidence, we'll format it and send it to the cardholder's bank, then email you once the dispute has been decided.
+    </p>
+    <p>
       <strong>
         Evidence submission is final.
       </strong>
-    </p>
-    <p>
-      You can also save this evidence for later editing instead of submitting it immediately.
+       
+      You can also save this evidence for later instead of submitting it immediately.
        
       <strong>
         We will automatically submit any saved evidence at the due date.

--- a/client/disputes/evidence/test/__snapshots__/index.js.snap
+++ b/client/disputes/evidence/test/__snapshots__/index.js.snap
@@ -48,6 +48,20 @@ exports[`Dispute evidence form needing response, renders correctly 1`] = `
     />
   </Card>
   <Card>
+    <p>
+      When you submit your evidence, we'll compile and send it to the cardholder's bank, and then email you once the dispute has been decided.
+       
+      <strong>
+        Evidence submission is final.
+      </strong>
+    </p>
+    <p>
+      You can also save this evidence for later editing instead of submitting it immediately.
+       
+      <strong>
+        We will automatically submit any saved evidence at the due date.
+      </strong>
+    </p>
     <ForwardRef(Button)
       isLarge={true}
       isPrimary={true}
@@ -114,6 +128,20 @@ exports[`Dispute evidence form not needing response, renders correctly 1`] = `
     />
   </Card>
   <Card>
+    <p>
+      When you submit your evidence, we'll compile and send it to the cardholder's bank, and then email you once the dispute has been decided.
+       
+      <strong>
+        Evidence submission is final.
+      </strong>
+    </p>
+    <p>
+      You can also save this evidence for later editing instead of submitting it immediately.
+       
+      <strong>
+        We will automatically submit any saved evidence at the due date.
+      </strong>
+    </p>
     <ForwardRef(Button)
       isLarge={true}
       isPrimary={true}

--- a/client/style.scss
+++ b/client/style.scss
@@ -11,6 +11,14 @@
 }
 
 .woocommerce-card__body {
+	> :first-child {
+		margin-top: 0;
+	}
+
+	> :last-child {
+		margin-bottom: 0;
+	}
+
 	hr.full-width {
 		/* Accounting for woocommerce-card__body padding */
 		margin: 0 -16px;


### PR DESCRIPTION
Fixes #380 

#### Changes proposed in this Pull Request

* Add text to the disputes evidence form footer.
* Limit form cards width as per designs.

#### Testing instructions

* Create a dispute which requires evidence form submission.
* Go to Payments > Disputes and click on arrow link near the `Needs response` in the status column.
* Check message and design. Designs at paJDYF-rW-p2

**Before:**
<img width="1020" alt="Screenshot 2020-02-07 at 15 07 00" src="https://user-images.githubusercontent.com/3139099/74028545-a853d600-49bb-11ea-9464-154696b4f547.png">

**After:** 
<img width="1018" alt="Screenshot 2020-02-07 at 15 06 30" src="https://user-images.githubusercontent.com/3139099/74028551-abe75d00-49bb-11ea-8f98-4fdd15517463.png">




-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
