### PR TITLE
Including customer details in payment method requests.

### DIFF
--- a/assets/js/wcpay-checkout.js
+++ b/assets/js/wcpay-checkout.js
@@ -52,7 +52,7 @@ jQuery( function( $ ) {
 	 *
 	 * @param {object} customerObj The object that the value should be loaded to.
 	 * @param {string} prop        The name of the prop in the object.
-	 * @param {string} inputId     The ID of the input on the page (or the data, preloaded by th server.)
+	 * @param {string} inputId     The ID of the input on the page (or the data, preloaded by the server.)
 	 */
 	var setCustomerValue = function( customerObj, prop, inputId ) {
 		var value;

--- a/assets/js/wcpay-checkout.js
+++ b/assets/js/wcpay-checkout.js
@@ -57,13 +57,16 @@ jQuery( function( $ ) {
 	var setCustomerValue = function( customerObj, prop, inputId ) {
 		var value;
 
+		// Try to load the value from the fields on the page.
 		if ( 'name' === inputId ) {
-			value = ( $( '#billing_first_name' ).val() + ' ' + $( '#billing_last_name' ).val() ).trim()
+			// If and whenever the first/last name fields do not exist on the page, this will be an empty string.
+			value = ( $( '#billing_first_name' ).val() + ' ' + $( '#billing_last_name' ).val() ).trim();
 		} else {
 			// No need to check whether the element exists, `$.fn.val()` would return `undefined`.
 			value = $( '#' + inputId ).val();
 		}
 
+		// Fall back to the value in `preparedCustomerData`.
 		if ( ( 'undefined' === typeof value ) || 0 === value.length ) {
 			value = preparedCustomerData[ inputId ]; // `undefined` if not set.
 		}
@@ -71,7 +74,7 @@ jQuery( function( $ ) {
 		if ( ( 'undefined' !== typeof value ) && 0 < value.length ) {
 			customerObj[ prop ] = value;
 		}
-	}
+	};
 
 	/**
 	 * Loads all necessary billing details for payment methods.
@@ -87,7 +90,6 @@ jQuery( function( $ ) {
 		setCustomerValue( billingDetails, 'email', 'billing_email' );
 		setCustomerValue( billingDetails, 'phone', 'billing_phone' );
 
-
 		// Populate the billing address.
 		setCustomerValue( billingAddress, 'city', 'billing_city' );
 		setCustomerValue( billingAddress, 'country', 'billing_country' );
@@ -98,7 +100,7 @@ jQuery( function( $ ) {
 
 		billingDetails.address = billingAddress;
 		return billingDetails;
-	}
+	};
 
 	// Create payment method on submission.
 	var paymentMethodGenerated;


### PR DESCRIPTION
Fixes #369, Fixes #373 

#### Changes proposed in this Pull Request

Gather customer details from checkout fields, and send them to Stripe during the creation of the PaymentMethod object.

The same are already included in the charge object, and [used by the server](https://github.com/Automattic/woocommerce-payments-server/blob/dbbefaf0febcfb0e3b3da3de5ac03e464fe01f61/wp-content/rest-api-plugins/endpoints/wcpay/cache/class-transaction.php#L121-L127) to populate the `customer_name`, `customer_email`, and `customer_country` columns in the caching table, as well as included in the the response of the `payments/transactions` endpoint.

I've already prepared a `preparedCustomerData` object in `wcpay-checkout.js`. When implementing additional payment screens (ex. the Pay for Order) that don't have fields for personal details, this object can be loaded through `wp_localize_script` in order to provide the needed values.

#### Testing instructions

1. Purchase something through the checkout page. Make sure all fields contain values.
2. Go to the Transactions page, and make sure that those details are included in the "Customer", Email", and "Country" columns.

If you see those values, everything works well. To be extra sure, you can navigate to the Stripe Dashboard of the Connect account and verify that other values (phone, address line 1 & 2, postal code, state, etc.) are also present.

-------------------

- [x] ~Tested on mobile~ (does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
