### PR TITLE
Transaction Details: Remove payment and session cards

### DIFF
--- a/client/payment-details/index.js
+++ b/client/payment-details/index.js
@@ -19,10 +19,10 @@ const PaymentDetails = ( props ) => {
 		<div>
 			<PaymentDetailsSummary charge={ charge }></PaymentDetailsSummary>
 			<PaymentDetailsTimeline charge={ charge }></PaymentDetailsTimeline>
-			{ // Hidden for the private beta.
+			{ // Hidden for the beta.
 				false && <PaymentDetailsPayment charge={ charge }></PaymentDetailsPayment> }
 			<PaymentDetailsPaymentMethod charge={ charge }></PaymentDetailsPaymentMethod>
-			{ // Hidden for the private beta.
+			{ // Hidden for the beta.
 				false && <PaymentDetailsSession charge={ charge }></PaymentDetailsSession> }
 		</div>
 	);

--- a/client/payment-details/index.js
+++ b/client/payment-details/index.js
@@ -19,9 +19,11 @@ const PaymentDetails = ( props ) => {
 		<div>
 			<PaymentDetailsSummary charge={ charge }></PaymentDetailsSummary>
 			<PaymentDetailsTimeline charge={ charge }></PaymentDetailsTimeline>
-			<PaymentDetailsPayment charge={ charge }></PaymentDetailsPayment>
+			{ // Hidden for the private beta.
+				false && <PaymentDetailsPayment charge={ charge }></PaymentDetailsPayment> }
 			<PaymentDetailsPaymentMethod charge={ charge }></PaymentDetailsPaymentMethod>
-			<PaymentDetailsSession charge={ charge }></PaymentDetailsSession>
+			{ // Hidden for the private beta.
+				false && <PaymentDetailsSession charge={ charge }></PaymentDetailsSession> }
 		</div>
 	);
 };


### PR DESCRIPTION
Fixes #370

#### Changes proposed in this Pull Request

Remove payment and session cards from payment details ahead of private beta.

#### Testing instructions

1. `npm run build`
2. Navigate to a the details of the transaction.
3. Make sure the Payment & Session components are not displayed.