### PR TITLE
Fix undefined variable: stripe_connected

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -419,19 +419,20 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			} else {
 				$description = WC_Payments_Account::get_connect_message();
 			}
+
+			// Allow the description text to be altered by filters.
+			$description = apply_filters(
+				'wc_payments_account_actions',
+				$description,
+				$stripe_connected,
+				WC_Payments_Account::get_login_url(),
+				WC_Payments_Account::get_connect_url()
+			);
+
 		} catch ( Exception $e ) {
 			// do not render the actions if the server is unreachable.
 			$description = __( 'Error determining the connection status.', 'woocommerce-payments' );
 		}
-
-		// Allow the description text to be altered by filters.
-		$description = apply_filters(
-			'wc_payments_account_actions',
-			$description,
-			$stripe_connected,
-			WC_Payments_Account::get_login_url(),
-			WC_Payments_Account::get_connect_url()
-		);
 
 		ob_start();
 		?>


### PR DESCRIPTION
Fixes #428

#### To reproduce the issue:

* Make sure WP_DEBUG is enabled in your client config
* `delete from wp_options where option_name='_transient_wcpay_account_data'` in your client DB
* Cause the '/accounts' endpoint on the server return an error
  * If using the docker env you can simply bring it down
  * Otherwise add code that returns an error early
* Visit the wcpay settings page
* A notice is displayed

#### Testing instructions

* Follow the repro instructions
* No notice should appear
