### PR TITLE
Reset payment method creation state on submit

### DIFF
--- a/assets/js/wcpay-checkout.js
+++ b/assets/js/wcpay-checkout.js
@@ -108,6 +108,7 @@ jQuery( function( $ ) {
 		// We'll resubmit the form after populating our payment method, so if this is the second time this event
 		// is firing we should let the form submission happen.
 		if ( paymentMethodGenerated ) {
+			paymentMethodGenerated = null;
 			return;
 		}
 


### PR DESCRIPTION
Fixes #323 

#### Changes proposed in this Pull Request

Allow creation of new payment method after error, by resetting state of payment method generation upon checkout form submission.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Simulate payment failure using a test card such as 4100000000000019, and then simulate a successful payment. Instead of reusing the first payment method and showing an error that this isn't allowed (as on `master`), the payment should succeed.

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
