### PR TITLE
Remove unused call to deleted function get_connect_message

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -464,7 +464,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 						'p' => array(),
 					)
 				);
-				$description = WC_Payments_Account::get_connect_message();
 			}
 
 			// Allow the description text to be altered by filters.


### PR DESCRIPTION
The merge for #401 seems to have gone slightly wrong. This PR just tidies up by removing a line that should have been removed.

**Testing Instructions**

1. Without this PR, visit the WCPay settings page with an unconnected store (/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments). There will be an error due to the call to an undefined function.
2. Apply the PR and repeat step 1.