### PR TITLE
Check if there is a bundled version of WooCommerce Admin, and if it's enabled

### DIFF
--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -23,6 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'WCPAY_PLUGIN_FILE', __FILE__ );
 define( 'WCPAY_ABSPATH', dirname( WCPAY_PLUGIN_FILE ) . '/' );
+define( 'WCPAY_MIN_WC_ADMIN_VERSION', '0.23.2' );
 
 /**
  * Initialize the extension. Note that this gets called on the "plugins_loaded" filter,
@@ -33,4 +34,5 @@ function wcpay_init() {
 	WC_Payments::init();
 }
 
-add_action( 'plugins_loaded', 'wcpay_init' );
+// Make sure this is run *after* WooCommerce has a chance to initialize its packages (wc-admin, etc). That is run with priority 10.
+add_action( 'plugins_loaded', 'wcpay_init', 11 );


### PR DESCRIPTION
Fixes #356

I've added some additional checks to make sure WCPay is compatible with the bundled version of WooCommerce Admin that will ship with WC 4.0. I've also checked that WCPay works just fine with said bundled version.

These are the notices that are displayed, I'm open to copy changes:
<img width="835" alt="Screenshot 2020-02-24 at 19 52 17" src="https://user-images.githubusercontent.com/1715800/75186693-64452d00-5740-11ea-86df-242d71d4500c.png">
<img width="688" alt="Screenshot 2020-02-24 at 19 33 01" src="https://user-images.githubusercontent.com/1715800/75186698-66a78700-5740-11ea-9d64-d799bde145aa.png">
<img width="835" alt="Screenshot 2020-02-24 at 19 50 30" src="https://user-images.githubusercontent.com/1715800/75186697-660ef080-5740-11ea-8089-fdb75d945e8d.png">

Regarding the last notice, @rrennick has pointed out that https://github.com/woocommerce/woocommerce-admin/pull/3687 will add similar functionality to `WooCommerce Admin 0.26` (which will be bundled in the final version of WC 4.0). Should I change the copy of our notice?

To test:
- Change the `WCPAY_MIN_WC_ADMIN_VERSION` constant to be `0.25.1`.
- Install and enable WC Admin 0.25.0 from here: https://es.wordpress.org/plugins/woocommerce-admin/advanced/
- You'll see the second notice (Update WooCommerce Admin).
- Upgrade WooCommerce to 4.0-beta1.
- You'll see the third notice (if you click the link, it will disable WC-Admin and use the bundled version instead).
- Add this filter: add_filter( 'woocommerce_admin_disabled', '__return_true' );
- You'll see the first notice.
- If you are seeing any of those error notices, you won't see the `Payments` menu item in the sidebar.