### PR TITLE
Remove table card style overrides

### DIFF
--- a/client/deposits/details/index.js
+++ b/client/deposits/details/index.js
@@ -7,7 +7,7 @@ import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
 import Currency from '@woocommerce/currency';
-import { OrderStatus } from '@woocommerce/components';
+import { Card, OrderStatus } from '@woocommerce/components';
 
 /**
  * Internal dependencies.
@@ -35,7 +35,7 @@ export const DepositOverview = ( { depositId } ) => {
 	}
 
 	return (
-		<div className="wcpay-deposit-overview">
+		<Card className="wcpay-deposit-overview">
 			<div className="wcpay-deposit-detail">
 				<div className="wcpay-deposit-date">
 					{ `${ __( 'Deposit date', 'woocommerce-payments' ) }: ` }
@@ -54,7 +54,7 @@ export const DepositOverview = ( { depositId } ) => {
 					{ currency.formatCurrency( deposit.amount / 100 ) }
 				</div>
 			</div>
-		</div>
+		</Card>
 	);
 };
 

--- a/client/deposits/details/style.scss
+++ b/client/deposits/details/style.scss
@@ -1,13 +1,11 @@
 .wcpay-deposit-overview {
-	background: $white;
-	border: 1px solid $light-gray-700;
-	margin-bottom: 24px;
-	display: flex;
-	flex-direction: row;
+	.woocommerce-card__body {
+		display: flex;
+		flex-direction: row;
+	}
 
 	.wcpay-deposit-detail {
 		flex-grow: 1;
-		padding: 18px 16px;
 	}
 	.wcpay-deposit-date {
 		font-size: 11px;
@@ -50,8 +48,9 @@
 
 	.wcpay-deposit-hero {
 		flex-grow: 5;
-		padding: 18px 16px;
 		border-left: 1px solid $light-gray-500;
+		margin: -16px 0;
+		padding: 16px 0;
 	}
 	.wcpay-deposit-amount {
 		text-align: right;

--- a/client/deposits/details/test/__snapshots__/index.js.snap
+++ b/client/deposits/details/test/__snapshots__/index.js.snap
@@ -12,7 +12,7 @@ exports[`Deposit details page renders correctly 1`] = `
 `;
 
 exports[`Deposit overview renders correctly 1`] = `
-<div
+<Card
   className="wcpay-deposit-overview"
 >
   <div
@@ -46,5 +46,5 @@ exports[`Deposit overview renders correctly 1`] = `
       $20.00
     </div>
   </div>
-</div>
+</Card>
 `;

--- a/client/style.scss
+++ b/client/style.scss
@@ -53,8 +53,8 @@
 	}
 
 	.woocommerce-table__summary {
-		border-radius: 0px 0px 3px 3px;
-	}	
+		border-radius: 0 0 3px 3px;
+	}
 
 	.woocommerce-card__menu {
 		margin: -6px 0;

--- a/client/style.scss
+++ b/client/style.scss
@@ -43,9 +43,6 @@
 }
 
 .woocommerce-table {
-	border-radius: 0;
-	border: 1px solid $light-gray-700;
-	box-shadow: none;
 
 	font-weight: 300;
 	letter-spacing: 0.012rem;
@@ -55,12 +52,10 @@
 		border-bottom: 1px solid $light-gray-700;
 	}
 
-	.woocommerce-card__title {
-		padding: 3px;
-		font-size: 16px;
-		font-size: 1rem;
-		font-weight: 500;
-	}
+	.woocommerce-table__summary {
+		border-radius: 0px 0px 3px 3px;
+	}	
+
 	.woocommerce-card__menu {
 		margin: -6px 0;
 	}


### PR DESCRIPTION
Removing the style override on the table cards, so that the tables match the cards in the transaction details / dispute details etc. 

**Before**

<img width="1079" alt="Screen Shot 2020-02-24 at 1 44 23 PM" src="https://user-images.githubusercontent.com/4500952/75194090-507fd380-570c-11ea-9bf9-af3f95b237b2.png">

**After**

<img width="1082" alt="Screen Shot 2020-02-24 at 1 45 14 PM" src="https://user-images.githubusercontent.com/4500952/75194123-61304980-570c-11ea-8b62-71839abb90cc.png">

Note the soothing rounded corners and larger table header type. Matches with the transaction details screen etc...

<img width="967" alt="Screen Shot 2020-02-24 at 1 38 51 PM" src="https://user-images.githubusercontent.com/4500952/75194218-8de46100-570c-11ea-853b-0e2f604a5a99.png">
 
