### PR TITLE
Remove the transaction timeline card since it's not implemented, set the transaction details cards to 1032px width

### DIFF
--- a/client/payment-details/index.js
+++ b/client/payment-details/index.js
@@ -9,12 +9,13 @@ import PaymentDetailsTimeline from './timeline';
 import PaymentDetailsPayment from './payment';
 import PaymentDetailsPaymentMethod from './payment-method';
 import PaymentDetailsSession from './session';
+import Page from 'components/page';
 
 const PaymentDetails = ( props ) => {
 	const chargeId = props.query.id;
 	const { charge } = useCharge( chargeId );
 	return (
-		<div className="wcpay-payment-details">
+		<Page maxWidth={ 1032 } className="wcpay-payment-details">
 			<PaymentDetailsSummary charge={ charge }></PaymentDetailsSummary>
 			<PaymentDetailsTimeline charge={ charge }></PaymentDetailsTimeline>
 			{ // Hidden for the beta.
@@ -22,7 +23,7 @@ const PaymentDetails = ( props ) => {
 			<PaymentDetailsPaymentMethod charge={ charge }></PaymentDetailsPaymentMethod>
 			{ // Hidden for the beta.
 				false && <PaymentDetailsSession charge={ charge }></PaymentDetailsSession> }
-		</div>
+		</Page>
 	);
 };
 

--- a/client/payment-details/timeline/index.js
+++ b/client/payment-details/timeline/index.js
@@ -1,22 +1,11 @@
 /** @format **/
 
 /**
- * External dependencies
- */
-import { Card } from '@woocommerce/components';
-
-/**
  * Internal dependencies.
  */
 
 const PaymentDetailsTimeline = ( props ) => {
-	const { charge } = props;
-	// TODO: this is a placeholder card and does not require translation
-	return (
-		<Card title="Timeline">
-			Timeline details for charge { charge.id }.
-		</Card>
-	);
+	return null; // TODO: not implemented yet
 };
 
 export default PaymentDetailsTimeline;

--- a/client/payment-details/timeline/index.js
+++ b/client/payment-details/timeline/index.js
@@ -4,7 +4,7 @@
  * Internal dependencies.
  */
 
-const PaymentDetailsTimeline = ( props ) => {
+const PaymentDetailsTimeline = () => {
 	return null; // TODO: not implemented yet
 };
 


### PR DESCRIPTION
Fixes #463

This PR removes the timeline card from the transaction details screen, since it's not implemented yet.

It also sets the max width of the cards on the transaction details screen to `1032px`.