### PR TITLE
Update test card doc to link to WCCOM

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -229,7 +229,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					<p class="testmode-info">
 					<?php
 						/* translators: link to Stripe testing page */
-						echo wp_kses_post( sprintf( __( '<strong>Test mode:</strong> use test card numbers listed <a href="%s" target="_blank">here</a>.', 'woocommerce-payments' ), 'https://stripe.com/docs/testing' ) );
+						echo wp_kses_post( sprintf( __( '<strong>Test mode:</strong> use test card numbers listed <a href="%s" target="_blank">here</a>.', 'woocommerce-payments' ), 'https://docs.woocommerce.com/document/payments/testing/#test-cards' ) );
 					?>
 					</p>
 				<?php endif; ?>


### PR DESCRIPTION
Fixes #261

#### Changes proposed in this Pull Request

* Update test card doc to link to WooCommerce.com instead of Stripe.com

#### Testing instructions

1. Enable Test Mode
2. Go to Checkout
3. Confirm the **Test mode** notice links to https://docs.woocommerce.com/document/payments/testing/#test-cards https://d.pr/i/fUv22v

-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
