### PR TITLE
Evaluate Psalm for static type checking

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,95 @@
+<?php
+
+// Some of the packages register autoloaders, so let's load what we can from these.
+require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload_packages.php';
+
+// WordPress
+define( 'WP_DEBUG', true );
+
+define( 'WPINC', 'wp-includes' );
+define( 'ABSPATH', __DIR__ . '/vendor/wordpress/wordpress/');
+
+define( 'MINUTE_IN_SECONDS', 60 );
+define( 'HOUR_IN_SECONDS', 60 * MINUTE_IN_SECONDS );
+define( 'DAY_IN_SECONDS', 24 * HOUR_IN_SECONDS );
+
+$GLOBALS['wp_embed'] = false;
+
+require_once ABSPATH . 'wp-includes/functions.php';
+require_once ABSPATH . 'wp-includes/functions.wp-scripts.php';
+require_once ABSPATH . 'wp-includes/plugin.php';
+require_once ABSPATH . 'wp-includes/functions.wp-styles.php';
+require_once ABSPATH . 'wp-includes/formatting.php';
+require_once ABSPATH . 'wp-includes/load.php';
+require_once ABSPATH . 'wp-includes/cache.php';
+require_once ABSPATH . 'wp-includes/l10n.php';
+require_once ABSPATH . 'wp-includes/capabilities.php';
+require_once ABSPATH . 'wp-includes/link-template.php';
+require_once ABSPATH . 'wp-includes/kses.php';
+require_once ABSPATH . 'wp-includes/pluggable.php';
+require_once ABSPATH . 'wp-includes/general-template.php';
+require_once ABSPATH . 'wp-includes/http.php';
+
+require_once ABSPATH . 'wp-includes/class-wp-error.php';
+require_once ABSPATH . 'wp-includes/class-wp-widget.php';
+require_once ABSPATH . 'wp-includes/class-wp-user.php';
+
+require_once ABSPATH . 'wp-admin/includes/screen.php';
+
+// WordPress REST API
+require_once ABSPATH . 'wp-includes/class-wp-http-response.php';
+require_once ABSPATH . 'wp-includes/rest-api/endpoints/class-wp-rest-controller.php';
+require_once ABSPATH . 'wp-includes/rest-api/class-wp-rest-server.php';
+require_once ABSPATH . 'wp-includes/rest-api/class-wp-rest-request.php';
+require_once ABSPATH . 'wp-includes/rest-api/class-wp-rest-response.php';
+require_once ABSPATH . 'wp-includes/rest-api.php';
+
+// WP Admin
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
+
+// WooCommerce Admin
+require_once __DIR__ . '/vendor/woocommerce/woocommerce-admin/includes/page-controller-functions.php';
+
+// WooCommerce
+define( 'WC_PLUGIN_FILE', __DIR__ . '/vendor/woocommerce/woocommerce/woocommerce.php' );
+define( 'WC_ABSPATH', __DIR__ . '/vendor/woocommerce/woocommerce/' );
+
+require_once __DIR__ . '/vendor/woocommerce/woocommerce/includes/interfaces/class-wc-logger-interface.php';
+require_once __DIR__ . '/vendor/woocommerce/woocommerce/includes/class-wc-logger.php';
+
+require_once __DIR__ . '/vendor/woocommerce/woocommerce/includes/abstracts/abstract-wc-settings-api.php';
+require_once __DIR__ . '/vendor/woocommerce/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php';
+require_once __DIR__ . '/vendor/woocommerce/woocommerce/includes/gateways/class-wc-payment-gateway-cc.php';
+
+require_once __DIR__ . '/vendor/woocommerce/woocommerce/includes/traits/trait-wc-item-totals.php';
+require_once __DIR__ . '/vendor/woocommerce/woocommerce/includes/abstracts/abstract-wc-data.php';
+require_once __DIR__ . '/vendor/woocommerce/woocommerce/includes/legacy/abstract-wc-legacy-order.php';
+require_once __DIR__ . '/vendor/woocommerce/woocommerce/includes/abstracts/abstract-wc-order.php';
+require_once __DIR__ . '/vendor/woocommerce/woocommerce/includes/class-wc-order.php';
+require_once __DIR__ . '/vendor/woocommerce/woocommerce/includes/class-wc-order-refund.php';
+
+require_once __DIR__ . '/vendor/woocommerce/woocommerce/includes/wc-core-functions.php';
+require_once __DIR__ . '/vendor/woocommerce/woocommerce/includes/wc-notice-functions.php';
+
+function WC() {
+	return;
+}
+
+// Jetpack
+define( 'JETPACK_MASTER_USER', 1 );
+define( 'JETPACK__PLUGIN_DIR', __DIR__ . '/docker/wordpress/wp-content/plugins/jetpack/' );
+define( 'JETPACK__SANDBOX_DOMAIN', false );
+
+require_once __DIR__ . '/vendor/automattic/jetpack/class.jetpack-data.php';
+
+// WooCommerce Payments
+define( 'WCPAY_VERSION_NUMBER', '0.0' );
+
+require_once dirname( __FILE__ ) . '/woocommerce-payments.php';
+
+require_once dirname( __FILE__ ) . '/includes/wc-payment-api/models/class-wc-payments-api-charge.php';
+require_once dirname( __FILE__ ) . '/includes/wc-payment-api/models/class-wc-payments-api-intention.php';
+require_once dirname( __FILE__ ) . '/includes/wc-payment-api/class-wc-payments-api-client.php';
+require_once dirname( __FILE__ ) . '/includes/wc-payment-api/class-wc-payments-http.php';

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
       "composer/installers": "1.6.0",
       "phpunit/phpunit": "5.7.27",
       "woocommerce/woocommerce": "3.7.1",
-      "woocommerce/woocommerce-sniffs": "0.0.6"
+      "woocommerce/woocommerce-sniffs": "0.0.6",
+      "psalm/phar": "^3.4"
     },
     "scripts": {
       "test": [

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,30 @@
         "php": "7.0"
       }
     },
+    "repositories": [
+      {
+        "type": "package",
+        "package": {
+          "name": "wordpress/wordpress",
+          "version": "5.3.2",
+          "source": {
+            "url": "https://github.com/WordPress/WordPress",
+            "type": "git",
+            "reference": "master"
+          }
+        }
+      }
+    ],
     "require": {
     },
     "require-dev": {
-      "composer/installers": "1.6.0",
       "phpunit/phpunit": "5.7.27",
-      "woocommerce/woocommerce": "3.7.1",
+      "woocommerce/woocommerce": "^3.9",
       "woocommerce/woocommerce-sniffs": "0.0.6",
-      "psalm/phar": "^3.4"
+      "psalm/phar": "^3.4",
+      "wordpress/wordpress": "^5.3",
+      "woocommerce/woocommerce-admin": "^0.26.1",
+      "automattic/jetpack": "^8.2"
     },
     "scripts": {
       "test": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,149 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "edeaf85fe6e4a60d95373d99397159ab",
+    "content-hash": "36847416e3fe4878adc7fe8cda5c22ca",
     "packages": [],
     "packages-dev": [
         {
-            "name": "automattic/jetpack-autoloader",
-            "version": "v1.2.0",
+            "name": "automattic/jetpack",
+            "version": "8.2-alpha",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "4ad9631e68e9da8b8a764615766287becfb27f81"
+                "url": "https://github.com/Automattic/jetpack.git",
+                "reference": "0bc58167b95027d80381a0b1a75be170150670b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/4ad9631e68e9da8b8a764615766287becfb27f81",
-                "reference": "4ad9631e68e9da8b8a764615766287becfb27f81",
+                "url": "https://api.github.com/repos/Automattic/jetpack/zipball/0bc58167b95027d80381a0b1a75be170150670b6",
+                "reference": "0bc58167b95027d80381a0b1a75be170150670b6",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-abtest": "^1.0",
+                "automattic/jetpack-assets": "^1.1",
+                "automattic/jetpack-autoloader": "@dev",
+                "automattic/jetpack-backup": "^1.0",
+                "automattic/jetpack-compat": "^1.0",
+                "automattic/jetpack-config": "^1.1",
+                "automattic/jetpack-connection": "^1.8",
+                "automattic/jetpack-constants": "^1.1",
+                "automattic/jetpack-error": "^1.0",
+                "automattic/jetpack-jitm": "^1.1",
+                "automattic/jetpack-logo": "^1.1",
+                "automattic/jetpack-options": "^1.1",
+                "automattic/jetpack-partner": "^1.0",
+                "automattic/jetpack-roles": "^1.0",
+                "automattic/jetpack-status": "^1.1",
+                "automattic/jetpack-sync": "^1.7",
+                "automattic/jetpack-terms-of-service": "^1.0",
+                "automattic/jetpack-tracking": "^1.2",
+                "ext-fileinfo": "*",
+                "ext-json": "*",
+                "ext-openssl": "*"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "0.5.0",
+                "phpcompatibility/phpcompatibility-wp": "2.1.0",
+                "sirbrillig/phpcs-changed": "2.2.7",
+                "sirbrillig/phpcs-variable-analysis": "2.7.0",
+                "wp-coding-standards/wpcs": "2.2.0"
+            },
+            "type": "wordpress-plugin",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack supercharges your self‑hosted WordPress site with the awesome cloud power of WordPress.com",
+            "homepage": "https://jetpack.com/",
+            "time": "2020-01-27T15:58:53+00:00"
+        },
+        {
+            "name": "automattic/jetpack-abtest",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-abtest.git",
+                "reference": "faed5181e0dbe596b7e083e40affceed686928ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-abtest/zipball/faed5181e0dbe596b7e083e40affceed686928ba",
+                "reference": "faed5181e0dbe596b7e083e40affceed686928ba",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-error": "@dev"
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Provides an interface to the WP.com A/B tests.",
+            "time": "2019-11-08T21:16:05+00:00"
+        },
+        {
+            "name": "automattic/jetpack-assets",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-assets.git",
+                "reference": "157b2d4adfddc7cc395929b6a0de8ab43bc52155"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-assets/zipball/157b2d4adfddc7cc395929b6a0de8ab43bc52155",
+                "reference": "157b2d4adfddc7cc395929b6a0de8ab43bc52155",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-constants": "@dev"
+            },
+            "require-dev": {
+                "brain/monkey": "2.4.0",
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Asset management utilities for Jetpack ecosystem packages",
+            "time": "2020-01-27T11:04:11+00:00"
+        },
+        {
+            "name": "automattic/jetpack-autoloader",
+            "version": "v1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-autoloader.git",
+                "reference": "301c2fbcf070d4f0147753447616b6e982bda09e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/301c2fbcf070d4f0147753447616b6e982bda09e",
+                "reference": "301c2fbcf070d4f0147753447616b6e982bda09e",
                 "shasum": ""
             },
             "require": {
@@ -41,20 +169,518 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "time": "2019-06-24T15:13:23+00:00"
+            "time": "2019-09-24T06:39:29+00:00"
         },
         {
-            "name": "composer/installers",
-            "version": "v1.6.0",
+            "name": "automattic/jetpack-backup",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/composer/installers.git",
-                "reference": "cfcca6b1b60bc4974324efb5783c13dca6932b5b"
+                "url": "https://github.com/Automattic/jetpack-backup.git",
+                "reference": "ea2aaa9be3697d8b885a74a11411c7818fba5a75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/cfcca6b1b60bc4974324efb5783c13dca6932b5b",
-                "reference": "cfcca6b1b60bc4974324efb5783c13dca6932b5b",
+                "url": "https://api.github.com/repos/Automattic/jetpack-backup/zipball/ea2aaa9be3697d8b885a74a11411c7818fba5a75",
+                "reference": "ea2aaa9be3697d8b885a74a11411c7818fba5a75",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "actions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Tools to assist with backing up Jetpack sites.",
+            "time": "2019-11-08T21:16:05+00:00"
+        },
+        {
+            "name": "automattic/jetpack-compat",
+            "version": "v1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-compat.git",
+                "reference": "2a4a2fd64bbcaab0a6af6dfe3a5ea8342eca9cbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-compat/zipball/2a4a2fd64bbcaab0a6af6dfe3a5ea8342eca9cbf",
+                "reference": "2a4a2fd64bbcaab0a6af6dfe3a5ea8342eca9cbf",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "classmap": [
+                    "legacy"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Compatibility layer with previous versions of Jetpack",
+            "time": "2019-11-08T21:16:05+00:00"
+        },
+        {
+            "name": "automattic/jetpack-config",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-config.git",
+                "reference": "df7cfce4231fb50e8cd433a6ccf52e99a269c16c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/df7cfce4231fb50e8cd433a6ccf52e99a269c16c",
+                "reference": "df7cfce4231fb50e8cd433a6ccf52e99a269c16c",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
+            "time": "2020-01-21T22:42:22+00:00"
+        },
+        {
+            "name": "automattic/jetpack-connection",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-connection.git",
+                "reference": "e90e8192a1c47337301620bf597acd98db21a8ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/e90e8192a1c47337301620bf597acd98db21a8ea",
+                "reference": "e90e8192a1c47337301620bf597acd98db21a8ea",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-options": "@dev",
+                "automattic/jetpack-roles": "@dev"
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "legacy/load-ixr.php"
+                ],
+                "classmap": [
+                    "legacy",
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything needed to connect to the Jetpack infrastructure",
+            "time": "2020-02-12T05:23:16+00:00"
+        },
+        {
+            "name": "automattic/jetpack-constants",
+            "version": "v1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-constants.git",
+                "reference": "5fdd94dec1151e7defd684a97e0b64fe6ff1bd3a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/5fdd94dec1151e7defd684a97e0b64fe6ff1bd3a",
+                "reference": "5fdd94dec1151e7defd684a97e0b64fe6ff1bd3a",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A wrapper for defining constants in a more testable way.",
+            "time": "2019-11-08T21:16:05+00:00"
+        },
+        {
+            "name": "automattic/jetpack-error",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-error.git",
+                "reference": "2128dd5a666154506727010350518529cc87b23d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-error/zipball/2128dd5a666154506727010350518529cc87b23d",
+                "reference": "2128dd5a666154506727010350518529cc87b23d",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack Error - a wrapper around WP_Error.",
+            "time": "2019-11-08T21:16:05+00:00"
+        },
+        {
+            "name": "automattic/jetpack-jitm",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-jitm.git",
+                "reference": "8900a8f44ed2bb6a8c7777916311e2b664480a88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-jitm/zipball/8900a8f44ed2bb6a8c7777916311e2b664480a88",
+                "reference": "8900a8f44ed2bb6a8c7777916311e2b664480a88",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-logo": "@dev",
+                "automattic/jetpack-options": "@dev",
+                "automattic/jetpack-tracking": "@dev"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.2",
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Just in time messages for Jetpack",
+            "time": "2020-02-17T09:27:14+00:00"
+        },
+        {
+            "name": "automattic/jetpack-logo",
+            "version": "v1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-logo.git",
+                "reference": "7da178a529f772cddfd0bbf1775eb30a852739c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-logo/zipball/7da178a529f772cddfd0bbf1775eb30a852739c2",
+                "reference": "7da178a529f772cddfd0bbf1775eb30a852739c2",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A logo for Jetpack",
+            "time": "2019-11-08T21:16:05+00:00"
+        },
+        {
+            "name": "automattic/jetpack-options",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-options.git",
+                "reference": "5a8dfd4e987f73accf1915ce9da261943af06e74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/5a8dfd4e987f73accf1915ce9da261943af06e74",
+                "reference": "5a8dfd4e987f73accf1915ce9da261943af06e74",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-constants": "@dev"
+            },
+            "require-dev": {
+                "10up/wp_mock": "0.4.2",
+                "phpunit/phpunit": "7.*.*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "legacy"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A wrapper for wp-options to manage specific Jetpack options.",
+            "time": "2020-02-18T15:31:20+00:00"
+        },
+        {
+            "name": "automattic/jetpack-partner",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-partner.git",
+                "reference": "866dfe161654acd18115b94aa117186f53a6ee6d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-partner/zipball/866dfe161654acd18115b94aa117186f53a6ee6d",
+                "reference": "866dfe161654acd18115b94aa117186f53a6ee6d",
+                "shasum": ""
+            },
+            "require-dev": {
+                "brain/monkey": "2.4.0",
+                "mockery/mockery": "^1.2",
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Support functions for Jetpack hosting partners.",
+            "time": "2020-01-27T11:04:11+00:00"
+        },
+        {
+            "name": "automattic/jetpack-roles",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-roles.git",
+                "reference": "0cdcff4fdc489c79f20a361c084ec48e326ce483"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/0cdcff4fdc489c79f20a361c084ec48e326ce483",
+                "reference": "0cdcff4fdc489c79f20a361c084ec48e326ce483",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities, related with user roles and capabilities.",
+            "time": "2019-11-08T21:16:05+00:00"
+        },
+        {
+            "name": "automattic/jetpack-status",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-status.git",
+                "reference": "c688b03859381e66164c821971e851408a5e232a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/c688b03859381e66164c821971e851408a5e232a",
+                "reference": "c688b03859381e66164c821971e851408a5e232a",
+                "shasum": ""
+            },
+            "require-dev": {
+                "brain/monkey": "2.4.0",
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
+            "time": "2020-01-27T11:04:11+00:00"
+        },
+        {
+            "name": "automattic/jetpack-sync",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-sync.git",
+                "reference": "c9b7fa99b2bbef06f6c3f64ac057f51b1b7ff9b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-sync/zipball/c9b7fa99b2bbef06f6c3f64ac057f51b1b7ff9b7",
+                "reference": "c9b7fa99b2bbef06f6c3f64ac057f51b1b7ff9b7",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-options": "@dev",
+                "automattic/jetpack-roles": "@dev",
+                "automattic/jetpack-status": "@dev"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything needed to allow syncing to the WP.com infrastructure.",
+            "time": "2020-02-25T06:25:56+00:00"
+        },
+        {
+            "name": "automattic/jetpack-terms-of-service",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-terms-of-service.git",
+                "reference": "fcee8e9de7f37d36bd68ac1ebabdb15cf6e10952"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-terms-of-service/zipball/fcee8e9de7f37d36bd68ac1ebabdb15cf6e10952",
+                "reference": "fcee8e9de7f37d36bd68ac1ebabdb15cf6e10952",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-options": "@dev",
+                "automattic/jetpack-status": "@dev"
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything need to manage the terms of service state",
+            "time": "2019-11-15T16:03:27+00:00"
+        },
+        {
+            "name": "automattic/jetpack-tracking",
+            "version": "v1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-tracking.git",
+                "reference": "d337a8f4234c684e80a43ff9ad3051a46a1f35d6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-tracking/zipball/d337a8f4234c684e80a43ff9ad3051a46a1f35d6",
+                "reference": "d337a8f4234c684e80a43ff9ad3051a46a1f35d6",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-options": "@dev",
+                "automattic/jetpack-terms-of-service": "@dev"
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "legacy",
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Tracking for Jetpack",
+            "time": "2019-11-08T21:16:05+00:00"
+        },
+        {
+            "name": "composer/installers",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/installers.git",
+                "reference": "141b272484481432cda342727a427dc1e206bfa0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/installers/zipball/141b272484481432cda342727a427dc1e206bfa0",
+                "reference": "141b272484481432cda342727a427dc1e206bfa0",
                 "shasum": ""
             },
             "require": {
@@ -110,6 +736,7 @@
                 "RadPHP",
                 "SMF",
                 "Thelia",
+                "Whmcs",
                 "WolfCMS",
                 "agl",
                 "aimeos",
@@ -132,6 +759,7 @@
                 "installer",
                 "itop",
                 "joomla",
+                "known",
                 "kohana",
                 "laravel",
                 "lavalite",
@@ -161,7 +789,7 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2018-08-27T06:10:37+00:00"
+            "time": "2019-08-12T15:00:31+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -282,6 +910,66 @@
                 "instantiate"
             ],
             "time": "2015-06-14T21:17:01+00:00"
+        },
+        {
+            "name": "maxmind-db/reader",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maxmind/MaxMind-DB-Reader-php.git",
+                "reference": "febd4920bf17c1da84cef58e56a8227dfb37fbe4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maxmind/MaxMind-DB-Reader-php/zipball/febd4920bf17c1da84cef58e56a8227dfb37fbe4",
+                "reference": "febd4920bf17c1da84cef58e56a8227dfb37fbe4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "conflict": {
+                "ext-maxminddb": "<1.6.0,>=2.0.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "2.*",
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpcov": "^3.0",
+                "phpunit/phpunit": "5.*",
+                "squizlabs/php_codesniffer": "3.*"
+            },
+            "suggest": {
+                "ext-bcmath": "bcmath or gmp is required for decoding larger integers with the pure PHP decoder",
+                "ext-gmp": "bcmath or gmp is required for decoding larger integers with the pure PHP decoder",
+                "ext-maxminddb": "A C-based database decoder that provides significantly faster lookups"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MaxMind\\Db\\": "src/MaxMind/Db"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Gregory J. Oschwald",
+                    "email": "goschwald@maxmind.com",
+                    "homepage": "https://www.maxmind.com/"
+                }
+            ],
+            "description": "MaxMind DB Reader API",
+            "homepage": "https://github.com/maxmind/MaxMind-DB-Reader-php",
+            "keywords": [
+                "database",
+                "geoip",
+                "geoip2",
+                "geolocation",
+                "maxmind"
+            ],
+            "time": "2019-12-19T22:59:03+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1848,29 +2536,29 @@
         },
         {
             "name": "woocommerce/woocommerce",
-            "version": "3.7.1",
+            "version": "3.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce.git",
-                "reference": "2365525dcbe66cdc5137c6447631a538895bfe67"
+                "reference": "f3ceba5a95e700ef9429615b0ba82752ee328bb2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce/zipball/2365525dcbe66cdc5137c6447631a538895bfe67",
-                "reference": "2365525dcbe66cdc5137c6447631a538895bfe67",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce/zipball/f3ceba5a95e700ef9429615b0ba82752ee328bb2",
+                "reference": "f3ceba5a95e700ef9429615b0ba82752ee328bb2",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-autoloader": "1.2.0",
-                "composer/installers": "1.6.0",
+                "automattic/jetpack-autoloader": "^1.2.0",
+                "composer/installers": "1.7.0",
+                "maxmind-db/reader": "1.6.0",
                 "php": ">=5.6|>=7.0",
-                "woocommerce/woocommerce-blocks": "2.3.0",
-                "woocommerce/woocommerce-rest-api": "1.0.3"
+                "woocommerce/woocommerce-blocks": "2.5.11",
+                "woocommerce/woocommerce-rest-api": "1.0.7"
             },
             "require-dev": {
-                "myclabs/deep-copy": "1.7.0",
-                "phpunit/phpunit": "7.5.14",
-                "woocommerce/woocommerce-sniffs": "0.0.6"
+                "phpunit/phpunit": "7.5.18",
+                "woocommerce/woocommerce-sniffs": "0.0.9"
             },
             "type": "wordpress-plugin",
             "extra": {
@@ -1903,29 +2591,76 @@
             ],
             "description": "An eCommerce toolkit that helps you sell anything. Beautifully.",
             "homepage": "https://woocommerce.com/",
-            "time": "2019-10-09T11:55:36+00:00"
+            "time": "2020-02-13T16:18:48+00:00"
         },
         {
-            "name": "woocommerce/woocommerce-blocks",
-            "version": "v2.3.0",
+            "name": "woocommerce/woocommerce-admin",
+            "version": "v0.26.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "79911c596a29ad675c7998bfc7939e92b7530bdc"
+                "url": "https://github.com/woocommerce/woocommerce-admin.git",
+                "reference": "dd5b6f79c8894a7a514c0d5dd1f6666f9cc1da6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/79911c596a29ad675c7998bfc7939e92b7530bdc",
-                "reference": "79911c596a29ad675c7998bfc7939e92b7530bdc",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/dd5b6f79c8894a7a514c0d5dd1f6666f9cc1da6c",
+                "reference": "dd5b6f79c8894a7a514c0d5dd1f6666f9cc1da6c",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-autoloader": "1.2.0",
-                "composer/installers": "1.6.0"
+                "automattic/jetpack-autoloader": "^1.2.0",
+                "composer/installers": "1.7.0",
+                "php": ">=5.6|>=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "7.5.20",
+                "woocommerce/woocommerce-sniffs": "0.0.9"
+            },
+            "type": "wordpress-plugin",
+            "extra": {
+                "scripts-description": {
+                    "test": "Run unit tests",
+                    "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
+                    "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "includes/"
+                ],
+                "psr-4": {
+                    "Automattic\\WooCommerce\\Admin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "description": "A modern, javascript-driven WooCommerce Admin experience.",
+            "homepage": "https://github.com/woocommerce/woocommerce-admin",
+            "time": "2020-02-25T20:50:27+00:00"
+        },
+        {
+            "name": "woocommerce/woocommerce-blocks",
+            "version": "v2.5.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
+                "reference": "3d3c7bf1b425bbf39a222a4715b1c8efe9e72f60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/3d3c7bf1b425bbf39a222a4715b1c8efe9e72f60",
+                "reference": "3d3c7bf1b425bbf39a222a4715b1c8efe9e72f60",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-autoloader": "1.3.2",
+                "composer/installers": "1.7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "6.5.14",
-                "woocommerce/woocommerce-sniffs": "0.0.6"
+                "woocommerce/woocommerce-sniffs": "0.0.7"
             },
             "type": "wordpress-plugin",
             "extra": {
@@ -1950,28 +2685,28 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "time": "2019-08-12T11:08:10+00:00"
+            "time": "2020-01-20T20:26:05+00:00"
         },
         {
             "name": "woocommerce/woocommerce-rest-api",
-            "version": "1.0.3",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-rest-api.git",
-                "reference": "7d9babf1c25890c32df3edb28b8351732640f5ce"
+                "reference": "49162ec26a25bd0c6efc0f3452b113cdfff0a823"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-rest-api/zipball/7d9babf1c25890c32df3edb28b8351732640f5ce",
-                "reference": "7d9babf1c25890c32df3edb28b8351732640f5ce",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-rest-api/zipball/49162ec26a25bd0c6efc0f3452b113cdfff0a823",
+                "reference": "49162ec26a25bd0c6efc0f3452b113cdfff0a823",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-autoloader": "1.2.0"
+                "automattic/jetpack-autoloader": "^1.2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "6.5.14",
-                "woocommerce/woocommerce-sniffs": "0.0.6"
+                "woocommerce/woocommerce-sniffs": "0.0.9"
             },
             "type": "wordpress-plugin",
             "autoload": {
@@ -1990,7 +2725,7 @@
             ],
             "description": "The WooCommerce core REST API.",
             "homepage": "https://github.com/woocommerce/woocommerce-rest-api",
-            "time": "2019-07-16T14:27:40+00:00"
+            "time": "2020-01-28T21:04:51+00:00"
         },
         {
             "name": "woocommerce/woocommerce-sniffs",
@@ -2031,6 +2766,16 @@
                 "wordpress"
             ],
             "time": "2019-03-11T15:30:23+00:00"
+        },
+        {
+            "name": "wordpress/wordpress",
+            "version": "5.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress",
+                "reference": "master"
+            },
+            "type": "library"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2855ea1322538253d0d9ecd812d3cc7a",
+    "content-hash": "edeaf85fe6e4a60d95373d99397159ab",
     "packages": [],
     "packages-dev": [
         {
@@ -1092,6 +1092,34 @@
             ],
             "abandoned": true,
             "time": "2017-06-30T09:13:00+00:00"
+        },
+        {
+            "name": "psalm/phar",
+            "version": "3.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/phar.git",
+                "reference": "985918b7cd825b6fb4aa69cf3ec7946721245bb7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/phar/zipball/985918b7cd825b6fb4aa69cf3ec7946721245bb7",
+                "reference": "985918b7cd825b6fb4aa69cf3ec7946721245bb7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "bin": [
+                "psalm.phar"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer-based Psalm Phar",
+            "time": "2019-06-05T13:12:37+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/includes/admin/class-wc-payments-rest-controller.php
+++ b/includes/admin/class-wc-payments-rest-controller.php
@@ -60,6 +60,8 @@ class WC_Payments_REST_Controller extends WP_REST_Controller {
 	 * Verify access.
 	 *
 	 * Override this method if custom perimissions required.
+	 *
+	 * @return bool
 	 */
 	public function check_permission() {
 		return current_user_can( 'manage_woocommerce' );

--- a/includes/admin/class-wc-payments-rest-controller.php
+++ b/includes/admin/class-wc-payments-rest-controller.php
@@ -45,7 +45,6 @@ class WC_Payments_REST_Controller extends WP_REST_Controller {
 	 * @return WP_Error|mixed - Method result of WP_Error in case of WC_Payments_API_Exception.
 	 */
 	public function forward_request( $api_method, $args, $err_code = '' ) {
-		$response;
 		try {
 			$response = call_user_func_array( [ $this->api_client, $api_method ], $args );
 		} catch ( WC_Payments_API_Exception $e ) {

--- a/includes/admin/class-wc-payments-rest-controller.php
+++ b/includes/admin/class-wc-payments-rest-controller.php
@@ -38,9 +38,9 @@ class WC_Payments_REST_Controller extends WP_REST_Controller {
 	/**
 	 * Forwards request to API client with taking care of WC_Payments_API_Exception.
 	 *
-	 * @param string $api_method - API method name.
-	 * @param array  $args - API method args.
-	 * @param string $err_code - Optional error code to use for WP_Error.
+	 * @param string             $api_method - API method name.
+	 * @param array<int, mixed>  $args - API method args.
+	 * @param string             $err_code - Optional error code to use for WP_Error.
 	 *
 	 * @return WP_Error|mixed - Method result of WP_Error in case of WC_Payments_API_Exception.
 	 */

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -522,6 +522,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * Capture previously authorized charge.
 	 *
 	 * @param WC_Order $order - Order to capture charge on.
+	 *
+	 * @throws WC_Payments_API_Exception
 	 */
 	public function capture_charge( $order ) {
 		$amount = $order->get_total();
@@ -556,6 +558,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * Cancel previously authorized charge.
 	 *
 	 * @param WC_Order $order - Order to cancel authorization on.
+	 *
+	 * @throws WC_Payments_API_Exception
 	 */
 	public function cancel_authorization( $order ) {
 		$intent = $this->payments_api_client->cancel_intention( $order->get_transaction_id() );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -571,6 +571,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if ( 'canceled' === $status ) {
 			$order->update_status( 'cancelled', __( 'Payment authorization was successfully <strong>cancelled</strong>.', 'woocommerce-payments' ) );
 		} else {
+			$amount = $order->get_total();
 			$note = sprintf(
 				/* translators: %1: the successfully charged amount */
 				__( 'Canceling authorization <strong>failed</strong> to complete.', 'woocommerce-payments' ),

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -457,6 +457,8 @@ class WC_Payments_Account {
 	 * Once we have our custom dashboard running, Payouts should be renamed to Deposits.
 	 *
 	 * @param int|null $current_deadline Timestamp for when the requirements are due.
+	 *
+	 * @return string
 	 */
 	private function get_verify_requirements_message( $current_deadline = null ) {
 		if ( ! empty( $current_deadline ) ) {

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -299,6 +299,8 @@ class WC_Payments_Account {
 
 	/**
 	 * For the connected account, fetches the login url from the API and redirects to it
+	 *
+	 * @throws WC_Payments_API_Exception
 	 */
 	private function redirect_to_login() {
 		// Clear account transient when generating Stripe dashboard's login link.
@@ -311,6 +313,8 @@ class WC_Payments_Account {
 
 	/**
 	 * Initializes the OAuth flow by fetching the URL from the API and redirecting to it
+	 *
+	 * @throws WC_Payments_API_Exception
 	 */
 	private function init_oauth() {
 		// Clear account transient when generating Stripe's oauth data.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -243,6 +243,8 @@ class WC_Payments_API_Client {
 	 *
 	 * @param string $deposit_id id of requested deposit.
 	 * @return array deposit object.
+	 *
+	 * @throws WC_Payments_API_Exception
 	 */
 	public function get_deposit( $deposit_id ) {
 		return $this->request( array(), self::DEPOSITS_API . '/' . $deposit_id, self::GET );
@@ -299,6 +301,8 @@ class WC_Payments_API_Client {
 	 *
 	 * @param string $transaction_id id of requested transaction.
 	 * @return array transaction object.
+	 *
+	 * @throws WC_Payments_API_Exception
 	 */
 	public function get_transaction( $transaction_id ) {
 		$transaction = $this->request( array(), self::TRANSACTIONS_API . '/' . $transaction_id, self::GET );
@@ -315,6 +319,8 @@ class WC_Payments_API_Client {
 	 *
 	 * @param string $charge_id id of requested charge.
 	 * @return array charge object.
+	 *
+	 * @throws WC_Payments_API_Exception
 	 */
 	public function get_charge( $charge_id ) {
 		$charge = $this->request( array(), self::CHARGES_API . '/' . $charge_id, self::GET );
@@ -360,6 +366,8 @@ class WC_Payments_API_Client {
 	 *
 	 * @param string $dispute_id id of requested dispute.
 	 * @return array dispute object.
+	 *
+	 * @throws WC_Payments_API_Exception
 	 */
 	public function get_dispute( $dispute_id ) {
 		$dispute = $this->request( array(), self::DISPUTES_API . '/' . $dispute_id, self::GET );
@@ -379,6 +387,8 @@ class WC_Payments_API_Client {
 	 * @param array  $evidence   evidence to upload.
 	 * @param bool   $submit     whether to submit (rather than stage) evidence.
 	 * @return array dispute object.
+	 *
+	 * @throws WC_Payments_API_Exception
 	 */
 	public function update_dispute( $dispute_id, $evidence, $submit ) {
 		$request = array(
@@ -401,6 +411,8 @@ class WC_Payments_API_Client {
 	 *
 	 * @param string $dispute_id id of dispute to close.
 	 * @return array dispute object.
+	 *
+	 * @throws WC_Payments_API_Exception
 	 */
 	public function close_dispute( $dispute_id ) {
 		return $this->request( array(), self::DISPUTES_API . '/' . $dispute_id . '/close', self::POST );
@@ -410,6 +422,8 @@ class WC_Payments_API_Client {
 	 * Get current account data
 	 *
 	 * @return array An array describing an account object.
+	 *
+	 * @throws WC_Payments_API_Exception
 	 */
 	public function get_account_data() {
 		return $this->request(
@@ -428,6 +442,8 @@ class WC_Payments_API_Client {
 	 * @param array  $business_data - data to prefill the form.
 	 *
 	 * @return array An array containing the url and state fields.
+	 *
+	 * @throws WC_Payments_API_Exception
 	 */
 	public function get_oauth_data( $return_url, $business_data = array() ) {
 		$request_args = apply_filters(
@@ -448,6 +464,8 @@ class WC_Payments_API_Client {
 	 * @param string $redirect_url - URL to navigate back to from the dashboard.
 	 *
 	 * @return array An array containing the url field
+	 *
+	 * @throws WC_Payments_API_Exception
 	 */
 	public function get_login_data( $redirect_url ) {
 		return $this->request(

--- a/includes/wc-payment-api/models/class-wc-payments-api-intention.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-intention.php
@@ -41,6 +41,13 @@ class WC_Payments_API_Intention {
 	private $status;
 
 	/**
+	 * Associated charge ID
+	 *
+	 * @var string
+	 */
+	private $charge_id;
+
+	/**
 	 * WC_Payments_API_Intention constructor.
 	 *
 	 * @param string   $id        - ID of the intention.

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+
+	autoloader="bootstrap.php"
+	requireVoidReturnType="false"
+	checkForThrowsDocblock="true"
+>
+    <projectFiles>
+		<file name="woocommerce-payments.php" />
+        <directory name="includes" />
+        <ignoreFiles>
+			<directory name="docker" />
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <LessSpecificReturnType errorLevel="info" />
+    </issueHandlers>
+</psalm>


### PR DESCRIPTION
[Psalm](https://psalm.dev/) is a static type checker for PHP. It is one of a couple that were mentioned at several talks at the PHP UK conference. I wanted to look into it for a few reasons:

* I'm a fan of strong typing, but there are some blockers to going all out with it.
   * There's a potential runtime penalty of type checking everything (in some cases, and not sure how much)
   * We target a relatively low version of PHP so don't have access to all the features we might want
* We have been looking into how we can ensure Exceptions are properly caught. PHPCS doesn't quite cut it.

So by running static type checking before shipping our code we can work around some of these limitations.

This PR implements Psalm and has a go at fixing a few issues that it raises. At what I think is the strictest ruleset we only raise about 300 errors, which is pretty good since we haven't been developing with this in mind. Psalm is able to figure out the types for around 80% of our code base, which again, is pretty good.

There are more details in the commit messages.

**Testing Instructions**

1. `composer install` - we pull in all the dependencies with composer so there is no need to setup a WordPress testing environment (maybe we can do the same for some of our unit tests later?). The bootstrap file that loads everything is horrible, I hacked it together for the purposes of this experiment.
2. `./vendor/bin/psalm.phar` - gives a relatively verbose output.
3. `./vendor/bin/psalm.phar --output-format=compact` - is a nice PHPCS style output.
4. `./vendor/bin/psalm.phar --report=psalm.txt` - dumps results to file. There are plenty of options here for integrating with CI servers.
5. `./vendor/bin/psalm.phar --stats` - gives details on the typing coverage for each file. It's interesting that where we've made a dedicated class for things, that tends to have 100% coverage.
6. Revert some of the commits making fixes (or make your own new fixes). Re-run the tool and see the results update. Often fixing one thing allows Psalm to understand some typing better, which leads to further errors.

**Next Steps**
* Is this something that people would be interested in getting setup in our repositories?
* Can we do the bootstrap better?
* Can we apply the same bootstrapping to our unit tests?
* There might be additional rules we can apply if we're interested in particular things
* There are some actual bugs this process has turned up, I'll open separate issues for those and get the fixes merged in.