### PR TITLE
Add basic support for the Pay for Order page

### DIFF
--- a/assets/js/wcpay-checkout.js
+++ b/assets/js/wcpay-checkout.js
@@ -111,7 +111,7 @@ jQuery( function( $ ) {
 	 * @param {object} $form The jQuery object for the form.
 	 * @return {boolean} A flag for the event handler.
 	 */
-	var onPaymentFormSubmit = function( $form ) {
+	var handleOnPaymentFormSubmit = function( $form ) {
 		// We'll resubmit the form after populating our payment method, so if this is the second time this event
 		// is firing we should let the form submission happen.
 		if ( paymentMethodGenerated ) {
@@ -158,13 +158,13 @@ jQuery( function( $ ) {
 
 	// Handle the checkout form when WooCommerce Payments is chosen.
 	$( 'form.checkout' ).on( 'checkout_place_order_woocommerce_payments', function() {
-		return onPaymentFormSubmit( $( this ) );
+		return handleOnPaymentFormSubmit( $( this ) );
 	} );
 
 	// Handle the Pay for Order form if WooCommerce Payments is chosen.
 	$( '#order_review' ).on( 'submit', function() {
 		if ( $( '#payment_method_woocommerce_payments' ).is( ':checked' ) ) {
-			return onPaymentFormSubmit( $( '#order_review' ) );
+			return handleOnPaymentFormSubmit( $( '#order_review' ) );
 		}
 	} );
 } );


### PR DESCRIPTION
Fixes #487

#### Changes proposed in this Pull Request

Use the submission handler of the checkout form on the _Pay for Order_ (form `#order_review`) page. Unlike the checkout page, there are no specific handlers for different gateways, so we have to manually check whether WCPay is the chosen gateway.

#### Testing instructions

1. Attempt checkout with a card, which will be declined (ex. `4000000000009987`).
2. Navigate to My Account > Orders.
3. Click on the "Pay" button/link.
4. Use the same card in order to make sure that the form will get submitted, and you will see an error message.
5. Use a working card.
6. The order should be marked as paid.