### PR TITLE
Fixes undefined variable PHP notice in `cancel_authorization`

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -567,12 +567,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if ( 'canceled' === $status ) {
 			$order->update_status( 'cancelled', __( 'Payment authorization was successfully <strong>cancelled</strong>.', 'woocommerce-payments' ) );
 		} else {
-			$note = sprintf(
-				/* translators: %1: the successfully charged amount */
-				__( 'Canceling authorization <strong>failed</strong> to complete.', 'woocommerce-payments' ),
-				wc_price( $amount )
-			);
-			$order->add_order_note( $note );
+			$order->add_order_note( __( 'Canceling authorization <strong>failed</strong> to complete.', 'woocommerce-payments' ) );
 		}
 	}
 }


### PR DESCRIPTION
Small PR to fix the PHP Notice for undefined variable `$amount`.

This code was copy-pasted from the above code and could be tidied up a little bit.

Changes include:
- remove the `wc_price( $amount )` as it wasn't needed
- remove `sprintf(` since it's no longer needed

props @james-allan 