### PR TITLE
Fix Jetpack connection check

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -86,8 +86,15 @@ class WC_Payments_Http {
 	 * @return bool true if Jetpack connection has access token.
 	 */
 	public static function is_connected() {
-		// TODO - Remove/update when Jetpack Connection package is all we need.
-		return ( class_exists( 'Automattic\Jetpack\Connection\Client' ) && ( new Automattic\Jetpack\Connection\Manager() )->get_access_token() )
-			|| ( class_exists( 'Jetpack_Client' ) && Jetpack_Data::get_access_token() );
+		if ( class_exists( 'Automattic\Jetpack\Connection\Manager' ) ) {
+			return ( new Automattic\Jetpack\Connection\Manager() )->is_active();
+		}
+
+		if ( class_exists( 'Jetpack_Data' ) ) {
+			// Pass true as an argument to check user token rather than blog token.
+			return (bool) Jetpack_Data::get_access_token( true );
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
Fixes #412 

#### Changes proposed in this Pull Request

Check that user token exists rather than blog token. This allows to
detect cases when a user started Jetpack setup but not approved
the connection.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Disconnect Jetpack in the Admin: Jetpack Dashboard > Manage connections > Disconnect.
2. Click the Setup button.
3. Once redirected login with WordPress.com account but DO NOT click `Approve` button.
4. Go back to the WP Admin Dashboard. WCPayments should NOT be initialized and alert should be displayed:
<img width="563" alt="Screenshot 2020-03-04 at 14 48 21" src="https://user-images.githubusercontent.com/3139099/75876717-43a76200-5e27-11ea-8df3-36fe99774815.png">

5. Make proper Jetpack setup.
6. Go back to the WP Admin. No alert should be displayed and WCPayments should be initialized.
-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
