### PR TITLE
Escape translated strings before replacing placeholders with real HTML

### DIFF
--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -190,7 +190,7 @@ class WC_Payments_Admin {
 		$on_boarding_disabled = WC_Payments_Account::is_on_boarding_disabled();
 
 		/* translators: Link to WordPress.com TOS URL */
-		$terms_message = __(
+		$terms_message = esc_html__(
 			'By clicking “Verify details,” you agree to the {A}Terms of Service{/A}.',
 			'woocommerce-payments'
 		);

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -439,7 +439,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$description .= ' ';
 
 				/* translators: Link to WordPress.com TOS URL */
-				$terms_message = __(
+				$terms_message = esc_html__(
 					'By clicking “Verify details,” you agree to the {A}Terms of Service{/A}.',
 					'woocommerce-payments'
 				);

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -147,7 +147,7 @@ class WC_Payments_Account {
 				$message .= '<p>';
 
 				/* translators: Link to WordPress.com TOS URL */
-				$terms_message = __(
+				$terms_message = esc_html__(
 					'By clicking “Verify details,” you agree to the {A}Terms of Service{/A}.',
 					'woocommerce-payments'
 				);


### PR DESCRIPTION
As discussed in paJDYF-zR-p2 , we should escape the HTML out of translatable strings. Specially on sensitive strings like the one that points to the ToS. We are using this pattern:
```php
$msg = __( 'By clicking “Verify details,” you agree to the {A}Terms of Service{/A}.', 'woocommerce-payments' );
$msg = str_replace( '{A}', '<a href="https://sensitive-url-that-should-not-be-tampered-with">', $msg );	
$msg = str_replace( '{/A}', '</a>', $msg );
// echo $msg, or whatever
```

If we are going to those lengths to make sure that translators can't mess with the link, we should also make sure that the translated string doesn't actually contain any arbitrary HTML. This PR does exactly that.