### PR TITLE
Update help text font size and color  for dispute fields

### DIFF
--- a/client/disputes/style.scss
+++ b/client/disputes/style.scss
@@ -72,9 +72,9 @@
 	.components-base-control > .components-base-control__help {
 		font-style: normal;
 		font-weight: 300;
-		font-size: 14px;
-		line-height: 20px;
-		color: $studio-gray-60;
+		font-size: 12px;
+		line-height: 16px;
+		color: $studio-gray-40;
 		margin-top: 0;
 	}
 


### PR DESCRIPTION
Updates the helper font size / line height to match "Caption" as outlined in figma file

Updates the font color as well. 

**Before**

<img width="710" alt="Screen Shot 2020-03-20 at 11 10 40 AM" src="https://user-images.githubusercontent.com/4500952/77193422-75f9c600-6a9b-11ea-883b-116e5b7b6a1b.png">


**After**

<img width="712" alt="Screen Shot 2020-03-20 at 11 08 26 AM" src="https://user-images.githubusercontent.com/4500952/77193257-316e2a80-6a9b-11ea-8334-be705b5140e4.png">
