### PR TITLE
Fix "Nothing was returned from render" error for estimated deposits

### DIFF
--- a/client/components/loadable/index.js
+++ b/client/components/loadable/index.js
@@ -20,7 +20,7 @@ const Loadable = ( { isLoading, display, placeholder, value, children } ) =>
 		<span className={ display ? `is-placeholder is-${ display }` : 'is-placeholder' } aria-busy="true">
 			{ undefined === placeholder ? children || value : placeholder }
 		</span>
-	) : ( children || value || '' );
+	) : ( children || value || null );
 
 /**
  * Helper component for rendering loadable block which takes several lines in the ui.


### PR DESCRIPTION
Fixes #548 

#### Changes proposed in this Pull Request

* Make `Loadable` return an empty string when both `children` and `value` are falsey

**Note:**
I tried updating the unit tests, but we actually seem to have one that passes null as children and enzyme still renders an empty string and doesn't error out. So I couldn't reproduce the scenario without the real React.

#### Testing instructions

* `npm run build` or `npm run watch`
* Make and capture a transaction
* In wp-admin navigate to `Payments > Deposits`, the first deposit should be estimated
* Click on the estimated deposit
* The deposit details should render, no bank account should be shown below the deposit status
<img width="255" alt="Screenshot 2020-04-03 at 16 31 30" src="https://user-images.githubusercontent.com/800604/78378235-9a3fc180-75c8-11ea-8001-60e4bfe75a55.png">


