### PR TITLE
Add logging for failing redirects to KYC flow

### DIFF
--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+use WCPay\Logger;
+
 /**
  * Class handling any account connection functionality
  */
@@ -231,6 +233,7 @@ class WC_Payments_Account {
 			try {
 				$this->init_oauth();
 			} catch ( Exception $e ) {
+				Logger::error( 'Init oauth flow failed. ' . $e );
 				$this->add_notice_to_settings_page(
 					__( 'There was a problem redirecting you to the account connection page. Please try again.', 'woocommerce-payments' ),
 					'notice-error'


### PR DESCRIPTION
Relates to #476. It doesn't fix the issue but allows us to move forward.

Sometimes redirect to KYC flow fails with unknown reason and cannot be
easily reproduced. According to [observed behaviour](https://github.com/Automattic/woocommerce-payments/issues/476#issuecomment-595151633) the issue is caused by the exception thrown in `init_oauth` [method](https://github.com/Automattic/woocommerce-payments/blob/b4a31db65eb8dfa4d4c3d8b0eb624991cdad336e/includes/class-wc-payments-account.php#L315). 

#### Changes proposed in this Pull Request

Add logging to get more info when it happens next time.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Force onboarding with WCPay dev tools by enabling `Force the plugin to act as disconnected from WcPay` option.
* Throw fake exception from `init_oauth` by adding the following code somewhere at the top of the [method](https://github.com/Automattic/woocommerce-payments/blob/b4a31db65eb8dfa4d4c3d8b0eb624991cdad336e/includes/class-wc-payments-account.php#L315): `throw new Exception( 'Fake oauth exception' );`
* Click `Verify details` button in the payments settings section of WC Admin.
* Go to logs ( WooCommerce > Status > Logs > wooCommerce-payments ) and check the error message at the end of the log.

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->

-------------------

#### TODO 

- [-] Fix an issue with displaying alert on Payments connect (see more info [here](https://github.com/Automattic/woocommerce-payments/issues/476#issuecomment-609007397)).