### PR TITLE
Change style name for loadable placeholder

### DIFF
--- a/client/components/loadable/index.js
+++ b/client/components/loadable/index.js
@@ -17,7 +17,7 @@ import './style.scss';
  */
 const Loadable = ( { isLoading, display, placeholder, value, children } ) =>
 	isLoading ? (
-		<span className={ display ? `is-placeholder is-${ display }` : 'is-placeholder' } aria-busy="true">
+		<span className={ display ? `is-lodable-placeholder is-${ display }` : 'is-lodable-placeholder' } aria-busy="true">
 			{ undefined === placeholder ? children || value : placeholder }
 		</span>
 	) : ( children || value || null );

--- a/client/components/loadable/style.scss
+++ b/client/components/loadable/style.scss
@@ -1,4 +1,4 @@
-.is-placeholder {
+.is-lodable-placeholder {
 	animation: loading-fade 1.6s ease-in-out infinite;
 	background-color: $light-gray-500;
 	color: transparent;

--- a/client/components/loadable/test/__snapshots__/index.js.snap
+++ b/client/components/loadable/test/__snapshots__/index.js.snap
@@ -3,7 +3,7 @@
 exports[`Loadable when active uses children as placeholder if not passed 1`] = `
 <span
   aria-busy="true"
-  className="is-placeholder"
+  className="is-lodable-placeholder"
 >
   <ChildComponent />
 </span>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Renamed style to `is-loadable-placeholder` for `Loadable` component to avoid interference with WC Admin styling.

#### Testing instructions

* Run the app and check the loadable placeholders are still the same.

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
