### PR TITLE
Prompt before navigating away from unsaved dispute evidence changes

### DIFF
--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -23,6 +23,7 @@ import Info from '../info';
 import Page from 'components/page';
 import CardFooter from 'components/card-footer';
 import Loadable, { LoadableBlock } from 'components/loadable';
+import useConfirmNavigation from 'utils/use-confirm-navigation';
 
 const PRODUCT_TYPE_META_KEY = '__product_type';
 
@@ -194,33 +195,6 @@ const getDisputeProductType = dispute => {
 	return productType;
 };
 
-/**
- * Hook for displaying an optional confirmation message.
- *
- * @param {Function} getMessage returns confirmation message string if one should appear
- * @param {Array} deps effect dependencies
- */
-const useConfirmUnsavedChanges = ( getMessage, deps ) => {
-	useEffect( () => {
-		const message = getMessage();
-		if ( ! message ) {
-			return;
-		}
-
-		const handler = event => {
-			event.preventDefault();
-			event.returnValue = '';
-		};
-		window.addEventListener( 'beforeunload', handler );
-		const unblock = getHistory().block( message );
-
-		return () => {
-			window.removeEventListener( 'beforeunload', handler );
-			unblock();
-		};
-	}, deps );
-};
-
 // Temporary MVP data wrapper
 export default ( { query } ) => {
 	const path = `/wc/v3/payments/disputes/${ query.id }`;
@@ -237,7 +211,7 @@ export default ( { query } ) => {
 		}
 	} );
 
-	useConfirmUnsavedChanges( () => {
+	useConfirmNavigation( () => {
 		if ( pristine ) {
 			return;
 		}

--- a/client/utils/use-confirm-navigation.js
+++ b/client/utils/use-confirm-navigation.js
@@ -1,0 +1,40 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { getHistory } from '@woocommerce/navigation';
+
+/**
+ * Hook for displaying an optional confirmation message.
+ *
+ * Usage:
+ * - useConfirmNavigation( () => 'Are you sure you want to leave?' );
+ * - useConfirmNavigation( saved => { if ( ! saved ) return 'Discard unsaved changes?' }, [ saved ] );
+ *
+ * @param {Function} getMessage returns confirmation message string if one should appear
+ * @param {Array} deps effect dependencies
+ */
+const useConfirmNavigation = ( getMessage, deps ) => {
+	useEffect( () => {
+		const message = getMessage();
+		if ( ! message ) {
+			return;
+		}
+
+		const handler = event => {
+			event.preventDefault();
+			event.returnValue = '';
+		};
+		window.addEventListener( 'beforeunload', handler );
+		const unblock = getHistory().block( message );
+
+		return () => {
+			window.removeEventListener( 'beforeunload', handler );
+			unblock();
+		};
+	}, deps );
+};
+
+export default useConfirmNavigation;


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/562

#### Changes proposed in this Pull Request

Show a confirmation when leaving the dispute evidence form with unsaved values.

Page-load navigation yields browser native `onbeforeunload` behavior:

<img width="603" src="https://user-images.githubusercontent.com/1867547/78708198-bfda0d00-78df-11ea-91e5-3005055ef860.png">

Client-side routing yields custom confirmation message via `getHistory().block` API:

<img width="659" src="https://user-images.githubusercontent.com/1867547/78708197-bf417680-78df-11ea-86c6-8cd5d5c0cad7.png">

Currently the form is considered "pristine" (i.e. possible to navigate away from without loss of transient state) before any value is modified, and until the values are saved on the dispute object.

**Only exceptional events should lead to closing the screen without confirming**, to my knowledge – i.e. forced shutdown of software or hardware.

Q: Is there another way to register `onbeforeunload` behavior that might avoid potentially conflicting with simultaneous independent uses of this event?

Q: Given how the history API works, there isn't any way to have done the unblocking without an imperative hook (`useRef`) – is there?

Note: the client-side case may need to be adapted if we wish to keep unsaved changes in wp.data state (see https://github.com/Automattic/woocommerce-payments/issues/331), but I'd expect that we would rather not want to persist hidden unsaved changes.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Make a change to a dispute evidence form value and verify that either closing the tab or any navigation away from the screen (e.g. via browser UI, "Products" in nav sidebar, or "Payments » Deposits" in nav sidebar) proceeds if and only if the merchant approves it via browser prompt.

Also verify that it proceeds without a prompt before making a change, and after submission/save.

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
