### PR TITLE
Make sure we load utils before attempting to use them

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -50,6 +50,8 @@ class WC_Payments {
 	public static function init() {
 		define( 'WCPAY_VERSION_NUMBER', self::get_plugin_headers()['Version'] );
 
+		include_once dirname( __FILE__ ) . '/class-wc-payments-utils.php';
+
 		if ( ! self::check_plugin_dependencies( true ) ) {
 			add_filter( 'admin_notices', array( __CLASS__, 'check_plugin_dependencies' ) );
 			return;
@@ -64,7 +66,6 @@ class WC_Payments {
 		self::$api_client = self::create_api_client();
 
 		include_once dirname( __FILE__ ) . '/class-wc-payments-account.php';
-		include_once dirname( __FILE__ ) . '/class-wc-payments-utils.php';
 		include_once dirname( __FILE__ ) . '/class-logger.php';
 		include_once dirname( __FILE__ ) . '/class-wc-payment-gateway-wcpay.php';
 		self::$account = new WC_Payments_Account( self::$api_client );
@@ -148,11 +149,6 @@ class WC_Payments {
 		// Do not show alerts while installing plugins.
 		if ( ! $silent && self::is_at_plugin_install_page() ) {
 			return true;
-		}
-
-		// If the silent dependency check failed, WC_Payments_Utils will not have yet loaded.
-		if ( ! class_exists( 'WC_Payments_Utils' ) ) {
-			include_once dirname( __FILE__ ) . '/class-wc-payments-utils.php';
 		}
 
 		$wc_version = $plugin_headers['WCRequires'];


### PR DESCRIPTION
Fixes #563

#### Changes proposed in this Pull Request

* Load utils if not yet loaded (i.e. if the silent dependency check fails)

#### Testing instructions

* Make sure WooCommerce Payments gracefully handles Jetpack not being connected and/or WooCommerce not being active
