### PR TITLE
Bundle @wordpress/components to avoid styling incompatibilities

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,6 +58,8 @@ const webpackConfig = {
 			injectPolyfill: true,
 			requestToExternal( request ) {
 				switch ( request ) {
+					case '@wordpress/components':
+						return null;
 					case '@woocommerce/components':
 						return [ 'wc', 'components' ];
 					case '@woocommerce/currency':
@@ -68,6 +70,8 @@ const webpackConfig = {
 			},
 			requestToHandle( request ) {
 				switch ( request ) {
+					case '@wordpress/components':
+						return null;
 					case '@woocommerce/components':
 						return 'wc-components';
 					case '@woocommerce/currency':


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follows WooCommerce Admin's lead in bundling the @wordpress/components package and pinning to major version 8, rather than depending on the externally loaded instance.

This change avoids missing styles due to changes in WP 5.4 – in particular a breaking change in https://github.com/WordPress/gutenberg/pull/19058 to remove the `is-button` class – in combination (I think) with style overrides in WooCommerce Admin.

Addresses https://github.com/Automattic/woocommerce-payments/issues/508#issuecomment-610047904 and other undesirable button styling such as on this entry point:

<img width="714" src="https://user-images.githubusercontent.com/1867547/78854328-04080300-79ef-11ea-9135-c5af484921be.png">

Compatibility with the external package can likely be addressed in a future PR, but I believe the most favorable outcome would be for WooCommerce Admin to solve compatibility with version 9 of the package, perhaps by generalizing the selectors or just removing overrides (see https://github.com/woocommerce/woocommerce-admin/issues/3897).

#### Testing instructions

With a dispute needing review, navigate to dispute evidence screen.

Force disconnected view and navigate to onboarding screen.

Verify proper colors, margins, and border radius for buttons on all screens.

(Requires re-running build/watch.)

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
