### PR TITLE
Redirect to onboarding flow after creating new account

### DIFF
--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -39,7 +39,7 @@ const ConnectAccountPage = () => {
 				</p>
 				<hr className="full-width" />
 				<p className="connect-account__action">
-					<Button isPrimary isLarge href={ wcpaySettings.connectUrl }>{ __( 'Set up', 'woocommerce-payments' ) }</Button>
+					<Button isPrimary isLarge href={ wcpaySettings.onboardingUrl }>{ __( 'Set up', 'woocommerce-payments' ) }</Button>
 				</p>
 				</>
 				) : (

--- a/client/connect-account-page/test/__snapshots__/index.js.snap
+++ b/client/connect-account-page/test/__snapshots__/index.js.snap
@@ -198,7 +198,7 @@ exports[`ConnectAccountPage should render correctly 1`] = `
         >
           <a
             class="components-button is-button is-primary is-large"
-            href="/wcpay-connect-url"
+            href="/wcpay-onboarding-url"
           >
             Set up
           </a>

--- a/client/connect-account-page/test/index.js
+++ b/client/connect-account-page/test/index.js
@@ -14,6 +14,7 @@ describe( 'ConnectAccountPage', () => {
 		window.location.assign = jest.fn();
 		global.wcpaySettings = {
 			connectUrl: '/wcpay-connect-url',
+			onboardingUrl: '/wcpay-onboarding-url',
 		};
 	} );
 

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -180,6 +180,7 @@ class WC_Payments_Admin {
 			'wcpaySettings',
 			[
 				'connectUrl'         => WC_Payments_Account::get_connect_url(),
+				'onboardingUrl'      => WC_Payments_Account::get_onboarding_url(),
 				'testMode'           => $this->wcpay_gateway->is_in_test_mode(),
 				'onBoardingDisabled' => $on_boarding_disabled,
 			]

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -313,6 +313,55 @@ class WC_Payments_Account {
 	}
 
 	/**
+	 * Create an account and redirect to onboarding flow.
+	 */
+	private function onboard_account() {
+		// Clear account transient when generating new Stripe account.
+		delete_transient( self::ACCOUNT_TRANSIENT );
+
+		$current_user = wp_get_current_user();
+		$settings_url = WC_Payment_Gateway_WCPay::get_settings_url();
+
+		$prefilled_data = [
+			'business_profile' => [
+				'name' => get_bloginfo( 'name' ),
+				'url'  => get_home_url(),
+			],
+			'business_type'    => 'individual',
+			'individual'       => [
+				'email'   => $current_user->user_email,
+				'address' => [
+					'line1'       => WC()->countries->get_base_address(),
+					'line2'       => WC()->countries->get_base_address_2(),
+					'city'        => WC()->countries->get_base_city(),
+					'state'       => WC()->countries->get_base_state(),
+					'postal_code' => WC()->countries->get_base_postcode(),
+					'country'     => WC()->countries->get_base_country(),
+				],
+
+				/**
+				 * 'first_name' => 'Mockfirstname',
+				 * 'last_name' => 'Mocklastname',
+				 * 'phone' => '+14152342345',
+				 * 'dob' => [ 'year' => 1966, 'month' => 1, 'day' => 11 ],
+				 * 'ssn_last_4' => 3535,
+				 */
+			],
+		];
+
+		$account_data = $this->payments_api_client->onboard_account( $settings_url, $prefilled_data );
+
+		$url = $account_data['url'];
+		if ( false === $url ) {
+			WC_Payments::get_gateway()->update_option( 'enabled', 'yes' );
+			$url = add_query_arg( array( 'wcpay-connection-success' => '1' ), $settings_url );
+		}
+
+		wp_safe_redirect( $url );
+		exit;
+	}
+
+	/**
 	 * Initializes the OAuth flow by fetching the URL from the API and redirecting to it
 	 *
 	 * @param string $wcpay_connect_from - where the user should be returned to after connecting.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -293,6 +293,15 @@ class WC_Payments_Account {
 	}
 
 	/**
+	 * Get Stripe onboarding url
+	 *
+	 * @return string Stripe account onboarding url.
+	 */
+	public static function get_onboarding_url() {
+		return wp_nonce_url( add_query_arg( [ 'wcpay-onboarding' => '1' ] ), 'wcpay-onboarding' );
+	}
+
+	/**
 	 * Get Stripe connect url
 	 *
 	 * @return string Stripe account login url.
@@ -366,7 +375,7 @@ class WC_Payments_Account {
 		$url = $account_data['url'];
 		if ( false === $url ) {
 			WC_Payments::get_gateway()->update_option( 'enabled', 'yes' );
-			$url = add_query_arg( array( 'wcpay-connection-success' => '1' ), $settings_url );
+			$url = add_query_arg( [ 'wcpay-connection-success' => '1' ], $settings_url );
 		}
 
 		set_transient( 'wcpay_oauth_state', $account_data['state'], DAY_IN_SECONDS );

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -219,6 +219,18 @@ class WC_Payments_Account {
 			return;
 		}
 
+		if ( isset( $_GET['wcpay-onboarding'] ) && check_admin_referer( 'wcpay-onboarding' ) ) {
+			try {
+				$this->onboard_account();
+			} catch ( Exception $e ) {
+				$this->add_notice_to_settings_page(
+					__( 'There was a problem redirecting you to the new account verification step. Please try again.', 'woocommerce-payments' ),
+					'notice-error'
+				);
+			}
+			return;
+		}
+
 		if ( isset( $_GET['wcpay-login'] ) && check_admin_referer( 'wcpay-login' ) ) {
 			try {
 				$this->redirect_to_login();

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -369,6 +369,8 @@ class WC_Payments_Account {
 			$url = add_query_arg( array( 'wcpay-connection-success' => '1' ), $settings_url );
 		}
 
+		set_transient( 'wcpay_oauth_state', $account_data['state'], DAY_IN_SECONDS );
+
 		wp_safe_redirect( $url );
 		exit;
 	}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -500,7 +500,7 @@ class WC_Payments_API_Client {
 	 */
 	public function onboard_account( $return_url, $account_data = [] ) {
 		$request_args = apply_filters(
-			'wc_payments_onboard_account_args',
+			'wc_payments_get_oauth_data_args',
 			[
 				'return_url'          => $return_url,
 				'account_data'        => $account_data,

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -502,9 +502,9 @@ class WC_Payments_API_Client {
 		$request_args = apply_filters(
 			'wc_payments_get_oauth_data_args',
 			[
-				'return_url'          => $return_url,
-				'account_data'        => $account_data,
-				'create_live_account' => ! WC_Payments::get_gateway()->is_in_dev_mode(),
+				'return_url'   => $return_url,
+				'account_data' => $account_data,
+				'test_account' => WC_Payments::get_gateway()->is_in_dev_mode(),
 			]
 		);
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -491,6 +491,27 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Create an account and return onboarding URL.
+	 *
+	 * @param string $return_url   - URL to redirect to at the end of the flow.
+	 * @param array  $account_data - data to prefill the form.
+	 *
+	 * @return array An array containing the onboarding URL and other account data.
+	 */
+	public function onboard_account( $return_url, $account_data = [] ) {
+		$request_args = apply_filters(
+			'wc_payments_onboard_account_args',
+			[
+				'return_url'          => $return_url,
+				'account_data'        => $account_data,
+				'create_live_account' => ! WC_Payments::get_gateway()->is_in_dev_mode(),
+			]
+		);
+
+		return $this->request( $request_args, self::ACCOUNTS_API, self::POST );
+	}
+
+	/**
 	 * Get data needed to initialize the OAuth flow
 	 *
 	 * @param string $return_url    - URL to redirect to at the end of the flow.


### PR DESCRIPTION
Depends on server 217

#### Changes proposed in this Pull Request

Use new account creation endpoint for onboarding instead of the OAuth flow, and pass business information for pre-filling the KYC flow at stripe.com.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In disconnected state, click "Verify details" on the "Payments" screen, settings form, or admin notice. Verify redirect to stripe.com flow, presence of known address and other information in form, and redirect back to settings upon completion of onboarding.

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
