### PR TITLE
Add details for test cards

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -233,7 +233,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					<?php
 						echo WC_Payments_Utils::esc_interpolated_html(
 							/* translators: link to Stripe testing page */
-							__( '<strong>Test mode:</strong> use test card numbers listed <a>here</a>.', 'woocommerce-payments' ),
+							__( '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC, or any test card numbers listed <a>here</a>.', 'woocommerce-payments' ),
 							[
 								'strong' => '<strong>',
 								'a'      => '<a href="https://docs.woocommerce.com/document/payments/testing/#test-cards" target="_blank">',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add more details about test cards directly on checkout. This speeds up the process since most people just need any test card, not a specific one. It avoids having to visit a separate page just to get a card number by giving one by default in the description.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Just go to the checkout.

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
