### PR TITLE
Generate class map and use class autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
       "woocommerce/woocommerce": "3.9.3",
       "woocommerce/woocommerce-sniffs": "0.0.6"
     },
+    "autoload": {
+      "classmap": ["includes/"]
+    },
     "scripts": {
       "test": [
         "phpunit"

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -50,8 +50,6 @@ class WC_Payments {
 	public static function init() {
 		define( 'WCPAY_VERSION_NUMBER', self::get_plugin_headers()['Version'] );
 
-		include_once dirname( __FILE__ ) . '/class-wc-payments-utils.php';
-
 		if ( ! self::check_plugin_dependencies( true ) ) {
 			add_filter( 'admin_notices', array( __CLASS__, 'check_plugin_dependencies' ) );
 			return;
@@ -65,9 +63,6 @@ class WC_Payments {
 
 		self::$api_client = self::create_api_client();
 
-		include_once dirname( __FILE__ ) . '/class-wc-payments-account.php';
-		include_once dirname( __FILE__ ) . '/class-logger.php';
-		include_once dirname( __FILE__ ) . '/class-wc-payment-gateway-wcpay.php';
 		self::$account = new WC_Payments_Account( self::$api_client );
 		self::$gateway = new WC_Payment_Gateway_WCPay( self::$api_client, self::$account );
 
@@ -77,7 +72,6 @@ class WC_Payments {
 
 		// Add admin screens.
 		if ( is_admin() ) {
-			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin.php';
 			new WC_Payments_Admin( self::$gateway, self::$account );
 		}
 
@@ -342,7 +336,6 @@ class WC_Payments {
 	 * @return bool true if Jetpack connection is available and authenticated.
 	 */
 	public static function is_jetpack_connected() {
-		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-http.php';
 		return WC_Payments_Http::is_connected();
 	}
 
@@ -423,12 +416,6 @@ class WC_Payments {
 	 * @return WC_Payments_API_Client
 	 */
 	public static function create_api_client() {
-		require_once dirname( __FILE__ ) . '/wc-payment-api/models/class-wc-payments-api-charge.php';
-		require_once dirname( __FILE__ ) . '/wc-payment-api/models/class-wc-payments-api-intention.php';
-		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-api-client.php';
-		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-api-exception.php';
-		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-http.php';
-
 		$payments_api_client = new WC_Payments_API_Client(
 			'WooCommerce Payments/' . WCPAY_VERSION_NUMBER,
 			new WC_Payments_Http()
@@ -441,25 +428,18 @@ class WC_Payments {
 	 * Initialize the REST API controllers.
 	 */
 	public static function init_rest_api() {
-		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-rest-controller.php';
-
-		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-deposits-controller.php';
 		$deposits_controller = new WC_REST_Payments_Deposits_Controller( self::$api_client );
 		$deposits_controller->register_routes();
 
-		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-transactions-controller.php';
 		$transactions_controller = new WC_REST_Payments_Transactions_Controller( self::$api_client );
 		$transactions_controller->register_routes();
 
-		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-disputes-controller.php';
 		$disputes_controller = new WC_REST_Payments_Disputes_Controller( self::$api_client );
 		$disputes_controller->register_routes();
 
-		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-charges-controller.php';
 		$charges_controller = new WC_REST_Payments_Charges_Controller( self::$api_client );
 		$charges_controller->register_routes();
 
-		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-timeline-controller.php';
 		$timeline_controller = new WC_REST_Payments_Timeline_Controller( self::$api_client );
 		$timeline_controller->register_routes();
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,12 +31,10 @@ function _manually_load_plugin() {
 	// Load the WooCommerce plugin so we can use its classes in our WooCommerce Payments plugin.
 	require_once dirname( __FILE__ ) . '/../vendor/woocommerce/woocommerce/woocommerce.php';
 
-	require dirname( dirname( __FILE__ ) ) . '/woocommerce-payments.php';
+	// Include the Composer autoloader so that we can load classes from this project.
+	require_once dirname( __FILE__ ) . '/../vendor/autoload.php';
 
-	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/models/class-wc-payments-api-charge.php';
-	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/models/class-wc-payments-api-intention.php';
-	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-api-client.php';
-	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-http.php';
+	require dirname( dirname( __FILE__ ) ) . '/woocommerce-payments.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -30,7 +30,7 @@ define( 'WCPAY_MIN_WC_ADMIN_VERSION', '0.23.2' );
  * so WooCommerce classes are guaranteed to exist at this point (if WooCommerce is enabled).
  */
 function wcpay_init() {
-	include_once dirname( __FILE__ ) . '/includes/class-wc-payments.php';
+	include_once dirname( __FILE__ ) . '/vendor/autoload.php';
 	WC_Payments::init();
 }
 


### PR DESCRIPTION
Fixes #566 - just a proposal for discussion.

#### Changes proposed in this Pull Request

Instead of adding a new require statement (and one to our unit test bootstrap) when creating a new class, we just need to run `composer dumpautoload`. For developers freshly cloning the project, creating the autoloader is handled by `composer install`.

If we ever adopt an autoloader compliant class naming convention we can do away with the dump autoload step.

#### Testing instructions

* Unit tests should pass
* Plugin should load up normally in the browser
* Building a release includes the autoloader in the vendor folder
