### PR TITLE
Support redirect to wc-admin task payments page after completing connection

### DIFF
--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -337,7 +337,6 @@ class WC_Payments_Account {
 	 * Initializes the OAuth flow by fetching the URL from the API and redirecting to it
 	 *
 	 * @param string $wcpay_connect_from - where the user should be returned to after connecting.
-	 *
 	 */
 	private function init_oauth( $wcpay_connect_from ) {
 		// Clear account transient when generating Stripe's oauth data.


### PR DESCRIPTION
Fixes #516

Work in progress

#### Changes proposed in this Pull Request

* Listen for `WCADMIN_PAYMENT_TASK` in `$_GET['wcpay-connect']` during OAuth flow and, if present, redirect to the wc-admin payments page instead of WCPay settings page

#### Testing instructions

* Important: Since you'll need to complete the OAuth flow on a site that has 1) never had a WCPay account and 2) has had a WCPay account, you should start 1) with a completely new site that has never had Jetpack or 2) by deleting any WCPay account for the site under test before doing anything else using server 207
* You should probably test this flow with dev mode active (`WCPAY_DEV_MODE`). A live account KYC is not required/recommended.
* Install this plugin (from this branch), **but do not activate it**
* Install and activate WC-ADMIN 1.1.0 (e.g. from https://github.com/woocommerce/woocommerce-admin/releases)
* Make sure your store is set with a US based location and USD. (WCPay only supports US right now.)
* Make sure Jetpack is connected
* Navigate to wp-admin > WooCommerce > Status, look for the Help drop down in the top right and click on it. Click on the Setup Wizard tab in help. Enable the New Onboarding experience. Repeat the steps and then Enable the Task List too in the same way.
* Navigate to `/wp-admin/admin.php?page=wc-admin&task=payments`
* You should see a big purple "WooCommerce Payments" box at the top of the page. Click on the "Set up" button to begin the plugin activation process.
* When that completes, click on the "Verify" button to begin the OAuth process.
* Complete setting up the test account with Stripe (you can use test data for almost everything except the email address) and verify you are returned to the payments task list and that WooCommerce Payments now shows the (enable/disable) toggle instead of the "Set up" button
* Deactivate the WooCommerce Payments plugin
* Navigate to `/wp-admin/admin.php?page=wc-admin&task=payments`
* You should see a big purple "WooCommerce Payments" box at the top of the page. Click on the "Set up" button to begin the plugin activation process process.
* When that completes, click on the "Verify" button. You should NOT need to do KYC (since you have an account now) and should instead be immediately returned to the payments tasks.

-------------------

- [ ] Tested on mobile (or does not apply)