### PR TITLE
Handle forwarded "account.updated" webhook

### DIFF
--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Class WC_REST_Payments_Webhook_Controller
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+use WCPay\Exceptions\WC_Payments_Rest_Exception;
+use WCPay\Logger;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST controller for webhooks.
+ */
+class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
+
+	/**
+	 * Result codes for returning to the WCPay server API. They don't have any special meaning, but can will be logged
+	 * and are therefore useful when debugging how we reacted to a webhook.
+	 */
+	const RESULT_SUCCESS     = 'success';
+	const RESULT_BAD_REQUEST = 'bad_request';
+	const RESULT_ERROR       = 'error';
+
+	/**
+	 * Endpoint path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'payments/webhook';
+
+	/**
+	 * DB wrapper.
+	 *
+	 * @var WC_Payments_DB
+	 */
+	private $wcpay_db;
+
+	/**
+	 * WC_REST_Payments_Webhook_Controller constructor.
+	 *
+	 * @param WC_Payments_API_Client $api_client WC_Payments_API_Client instance.
+	 * @param WC_Payments_DB         $wcpay_db   WC_Payments_DB instance.
+	 */
+	public function __construct( WC_Payments_API_Client $api_client, WC_Payments_DB $wcpay_db ) {
+		parent::__construct( $api_client );
+		$this->wcpay_db = $wcpay_db;
+	}
+
+	/**
+	 * Configure REST API routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_webhook' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
+	}
+
+	/**
+	 * Retrieve transactions to respond with via API.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function handle_webhook( $request ) {
+		$body = $request->get_json_params();
+
+		try {
+			// Extract information about the webhook event.
+			$event_type   = $this->read_property( $body, 'type' );
+			$event_data   = $this->read_property( $body, 'data' );
+			$event_object = $this->read_property( $event_data, 'object' );
+
+			switch ( $event_type ) {
+				case 'charge.refund.updated':
+					$this->process_webhook_refund_updated( $event_object );
+					break;
+			}
+		} catch ( WC_Payments_Rest_Exception $e ) {
+			Logger::error( $e );
+			return new WP_REST_Response( array( 'result' => self::RESULT_BAD_REQUEST ), 400 );
+		} catch ( Exception $e ) {
+			Logger::error( $e );
+			return new WP_REST_Response( array( 'result' => self::RESULT_ERROR ), 500 );
+		}
+
+		return new WP_REST_Response( array( 'result' => self::RESULT_SUCCESS ) );
+	}
+
+	/**
+	 * Process webhook refund updated.
+	 *
+	 * @param array $event_object The event that triggered the webhook.
+	 *
+	 * @throws WC_Payments_Rest_Exception Required parameters not found.
+	 * @throws Exception                  Unable to resolve charge ID to order.
+	 */
+	private function process_webhook_refund_updated( $event_object ) {
+		// First, check the reason for the update. We're only interesting in a status of failed.
+		$status = $this->read_property( $event_object, 'status' );
+		if ( 'failed' !== $status ) {
+			return;
+		}
+
+		// Fetch the details of the failed refund so that we can find the associated order and write a note.
+		$charge_id = $this->read_property( $event_object, 'charge' );
+		$refund_id = $this->read_property( $event_object, 'id' );
+		$amount    = $this->read_property( $event_object, 'amount' );
+
+		// Look up the order related to this charge.
+		$order = $this->wcpay_db->order_from_charge_id( $charge_id );
+		if ( ! $order ) {
+			throw new Exception( 'Could not find order via charge ID: ' . $charge_id );
+		}
+
+		$note = sprintf(
+			/* translators: %1: the refund amount, %2: ID of the refund */
+			__( 'A refund of %1$s was <strong>unsuccessful</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
+			wc_price( $amount / 100 ),
+			$refund_id
+		);
+		$order->add_order_note( $note );
+	}
+
+	/**
+	 * Get a property from a refund event.
+	 *
+	 * @param array  $event_object Event object to read from.
+	 * @param string $key          Name of property to get.
+	 *
+	 * @return string|array
+	 * @throws WC_Payments_Rest_Exception Thrown if property not found.
+	 */
+	private function read_property( $event_object, $key ) {
+		if ( ! isset( $event_object[ $key ] ) ) {
+			throw new WC_Payments_Rest_Exception( $key . ' property not found in refund event' );
+		}
+		return $event_object[ $key ];
+	}
+}

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -38,14 +38,23 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	private $wcpay_db;
 
 	/**
+	 * WC Payments Account.
+	 *
+	 * @var WC_Payments_Account
+	 */
+	private $account;
+
+	/**
 	 * WC_REST_Payments_Webhook_Controller constructor.
 	 *
 	 * @param WC_Payments_API_Client $api_client WC_Payments_API_Client instance.
 	 * @param WC_Payments_DB         $wcpay_db   WC_Payments_DB instance.
+	 * @param WC_Payments_Account    $account    WC_Payments_Account instance.
 	 */
-	public function __construct( WC_Payments_API_Client $api_client, WC_Payments_DB $wcpay_db ) {
+	public function __construct( WC_Payments_API_Client $api_client, WC_Payments_DB $wcpay_db, WC_Payments_Account $account ) {
 		parent::__construct( $api_client );
 		$this->wcpay_db = $wcpay_db;
+		$this->account  = $account;
 	}
 
 	/**
@@ -82,6 +91,9 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 			switch ( $event_type ) {
 				case 'charge.refund.updated':
 					$this->process_webhook_refund_updated( $event_object );
+					break;
+				case 'account.updated':
+					$this->account->update_cached_account_data( $event_object );
 					break;
 			}
 		} catch ( WC_Payments_Rest_Exception $e ) {

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -88,6 +88,9 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 			$event_data   = $this->read_property( $body, 'data' );
 			$event_object = $this->read_property( $event_data, 'object' );
 
+			Logger::debug( 'Webhook recieved: ' . $event_type );
+			Logger::debug( 'Webhook body: ' . var_export( $body, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+
 			switch ( $event_type ) {
 				case 'charge.refund.updated':
 					$this->process_webhook_refund_updated( $event_object );

--- a/includes/class-wc-payments-db.php
+++ b/includes/class-wc-payments-db.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * WC_Payments_DB class
+ *
+ * @package WooCommerce\Payments
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Wrapper class for accessing the database.
+ */
+class WC_Payments_DB {
+	/**
+	 * Retrieve an order from the DB using a corresponding Stripe charge ID.
+	 *
+	 * @param string $charge_id Charge ID corresponding to an order ID.
+	 *
+	 * @return boolean|WC_Order|WC_Order_Refund
+	 */
+	public function order_from_charge_id( $charge_id ) {
+		$order_id = $this->order_id_from_charge_id( $charge_id );
+
+		if ( $order_id ) {
+			return wc_get_order( $order_id );
+		}
+		return false;
+	}
+
+	/**
+	 * Retrieve an order ID from the DB using a corresponding Stripe charge ID.
+	 *
+	 * @param string $charge_id Charge ID corresponding to an order ID.
+	 *
+	 * @return null|string
+	 */
+	private function order_id_from_charge_id( $charge_id ) {
+		global $wpdb;
+
+		// The order ID is saved to DB in `WC_Payment_Gateway_WCPay::process_payment()`.
+		$order_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = '_charge_id'",
+				$charge_id
+			)
+		);
+		return $order_id;
+	}
+}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -475,7 +475,7 @@ class WC_Payments {
 		$timeline_controller->register_routes();
 
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-webhook-controller.php';
-		$webhook_controller = new WC_REST_Payments_Webhook_Controller( self::$api_client, self::$db_helper );
+		$webhook_controller = new WC_REST_Payments_Webhook_Controller( self::$api_client, self::$db_helper, self::$account );
 		$webhook_controller->register_routes();
 	}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -31,6 +31,13 @@ class WC_Payments {
 	private static $api_client;
 
 	/**
+	 * Instance of WC_Payments_DB.
+	 *
+	 * @var WC_Payments_DB
+	 */
+	private static $db_helper;
+
+	/**
 	 * Instance of WC_Payments_Account, created in init function.
 	 *
 	 * @var WC_Payments_Account
@@ -60,6 +67,9 @@ class WC_Payments {
 		};
 
 		add_filter( 'plugin_action_links_' . plugin_basename( WCPAY_PLUGIN_FILE ), array( __CLASS__, 'add_plugin_links' ) );
+
+		include_once dirname( __FILE__ ) . '/class-wc-payments-db.php';
+		self::$db_helper = new WC_Payments_DB();
 
 		self::$api_client = self::create_api_client();
 
@@ -430,7 +440,8 @@ class WC_Payments {
 
 		$payments_api_client = new WC_Payments_API_Client(
 			'WooCommerce Payments/' . WCPAY_VERSION_NUMBER,
-			new WC_Payments_Http()
+			new WC_Payments_Http(),
+			self::$db_helper
 		);
 
 		return $payments_api_client;

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -451,6 +451,7 @@ class WC_Payments {
 	 * Initialize the REST API controllers.
 	 */
 	public static function init_rest_api() {
+		include_once WCPAY_ABSPATH . 'includes/exceptions/class-wc-payments-rest-exception.php';
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-rest-controller.php';
 
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-deposits-controller.php';
@@ -472,6 +473,10 @@ class WC_Payments {
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-timeline-controller.php';
 		$timeline_controller = new WC_REST_Payments_Timeline_Controller( self::$api_client );
 		$timeline_controller->register_routes();
+
+		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-webhook-controller.php';
+		$webhook_controller = new WC_REST_Payments_Webhook_Controller( self::$api_client, self::$db_helper );
+		$webhook_controller->register_routes();
 	}
 
 	/**

--- a/includes/exceptions/class-wc-payments-rest-exception.php
+++ b/includes/exceptions/class-wc-payments-rest-exception.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Class WC_Payments_Rest_Exception
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Exceptions;
+
+use Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Exception for throwing errors in REST API controllers (e.g. issues with missing parameters in requests).
+ */
+class WC_Payments_Rest_Exception extends Exception {}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -47,14 +47,23 @@ class WC_Payments_API_Client {
 	private $http_client;
 
 	/**
+	 * DB access wrapper.
+	 *
+	 * @var WC_Payments_DB
+	 */
+	private $wcpay_db;
+
+	/**
 	 * WC_Payments_API_Client constructor.
 	 *
 	 * @param string           $user_agent  - User agent string to report in requests.
 	 * @param WC_Payments_Http $http_client - Used to send HTTP requests.
+	 * @param WC_Payments_DB   $wcpay_db    - DB access wrapper.
 	 */
-	public function __construct( $user_agent, $http_client ) {
+	public function __construct( $user_agent, $http_client, $wcpay_db ) {
 		$this->user_agent  = $user_agent;
 		$this->http_client = $http_client;
+		$this->wcpay_db    = $wcpay_db;
 	}
 
 	/**
@@ -184,42 +193,6 @@ class WC_Payments_API_Client {
 		);
 
 		return $this->deserialize_intention_object_from_array( $response_array );
-	}
-
-	/**
-	 * Retrive an order ID from the DB using a corresponding Stripe charge ID.
-	 *
-	 * @param string $charge_id Charge ID corresponding to an order ID.
-	 *
-	 * @return null|string
-	 */
-	private function order_id_from_charge_id( $charge_id ) {
-		global $wpdb;
-
-		// The order ID is saved to DB in `WC_Payment_Gateway_WCPay::process_payment()`.
-		$order_id = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = '_charge_id'",
-				$charge_id
-			)
-		);
-		return $order_id;
-	}
-
-	/**
-	 * Retrieve an order from the DB using a corresponding Stripe charge ID.
-	 *
-	 * @param string $charge_id Charge ID corresponding to an order ID.
-	 *
-	 * @return boolean|WC_Order|WC_Order_Refund
-	 */
-	private function order_from_charge_id( $charge_id ) {
-		$order_id = $this->order_id_from_charge_id( $charge_id );
-
-		if ( $order_id ) {
-			return wc_get_order( $order_id );
-		}
-		return false;
 	}
 
 	/**
@@ -660,7 +633,7 @@ class WC_Payments_API_Client {
 	 * @return array  new object with order information.
 	 */
 	private function add_order_info_to_object( $charge_id, $object ) {
-		$order = $this->order_from_charge_id( $charge_id );
+		$order = $this->wcpay_db->order_from_charge_id( $charge_id );
 
 		// Add order information to the `$transaction`.
 		// If the order couldn't be retrieved, return an empty order.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,6 +16,9 @@
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" >
 		<exclude name="Generic.Commenting.Todo.TaskFound"/>
+
+		<!-- This rule is currently generating some false positives, it would be worth retrying after PHPCS upgrades -->
+        <exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber"/>
 	</rule>
 
 	<rule ref="WordPress.WP.I18n">

--- a/tests/admin/test-class-wc-rest-payments-webhook.php
+++ b/tests/admin/test-class-wc-rest-payments-webhook.php
@@ -54,12 +54,14 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$account = new WC_Payments_Account( $mock_api_client );
+
 		$this->mock_db_wrapper = $this->getMockBuilder( WC_Payments_DB::class )
 			->disableOriginalConstructor()
 			->setMethods( array( 'order_from_charge_id' ) )
 			->getMock();
 
-		$this->controller = new WC_REST_Payments_Webhook_Controller( $mock_api_client, $this->mock_db_wrapper );
+		$this->controller = new WC_REST_Payments_Webhook_Controller( $mock_api_client, $this->mock_db_wrapper, $account );
 
 		// Setup a test request.
 		$this->request = new WP_REST_Request(

--- a/tests/admin/test-class-wc-rest-payments-webhook.php
+++ b/tests/admin/test-class-wc-rest-payments-webhook.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * Class WC_REST_Payments_Webhook_Controller_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * WC_REST_Payments_Webhook_Controller unit tests.
+ */
+class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
+
+	/**
+	 * The system under test.
+	 *
+	 * @var WC_REST_Payments_Webhook_Controller
+	 */
+	private $controller;
+
+	/**
+	 * @var WC_Payments_DB|MockObject
+	 */
+	private $mock_db_wrapper;
+
+	/**
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * @var WP_REST_Request
+	 */
+	private $request;
+
+	/**
+	 * @var array
+	 */
+	private $request_body;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Set the user so that we can pass the authentication.
+		wp_set_current_user( 1 );
+
+		// TODO: Remove this as a requirement?
+		/** @var WC_Payments_API_Client|MockObject $mock_api_client */
+		$mock_api_client = $this->getMockBuilder( WC_Payments_API_Client::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mock_db_wrapper = $this->getMockBuilder( WC_Payments_DB::class )
+			->disableOriginalConstructor()
+			->setMethods( array( 'order_from_charge_id' ) )
+			->getMock();
+
+		$this->controller = new WC_REST_Payments_Webhook_Controller( $mock_api_client, $this->mock_db_wrapper );
+
+		// Setup a test request.
+		$this->request = new WP_REST_Request(
+			'POST',
+			'/wc/v3/payments/webhook'
+		);
+
+		$this->request->set_header( 'Content-Type', 'application/json' );
+
+		// Build the test request data.
+		$event_object = array();
+
+		$event_data           = array();
+		$event_data['object'] = $event_object;
+
+		$this->request_body         = array();
+		$this->request_body['data'] = $event_data;
+	}
+
+	/**
+	 * Test processing a webhook that requires no action.
+	 */
+	public function test_noop_webhook() {
+		// TODO: Test unauthenticated user - could put on base class?
+		// Setup test request data.
+		$this->request_body['type'] = 'unknown.webhook.event';
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
+
+		// Run the test.
+		$response = $this->controller->handle_webhook( $this->request );
+
+		// Check the response.
+		$response_data = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( array( 'result' => 'success' ), $response_data );
+	}
+
+	/**
+	 * Test a webhook with no type property.
+	 */
+	public function test_webhook_with_no_type_property() {
+		// Setup test request data.
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
+
+		// Run the test.
+		$response = $this->controller->handle_webhook( $this->request );
+
+		// Check the response.
+		$response_data = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( array( 'result' => 'bad_request' ), $response_data );
+	}
+
+	/**
+	 * Test a webhook with no object property.
+	 */
+	public function test_webhook_with_no_object_property() {
+		// Setup test request data.
+		$this->request_body['type'] = 'unknown.webhook.event';
+		unset( $this->request_body['data']['object'] );
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
+
+		// Run the test.
+		$response = $this->controller->handle_webhook( $this->request );
+
+		// Check the response.
+		$response_data = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( array( 'result' => 'bad_request' ), $response_data );
+	}
+
+	/**
+	 * Test a webhook with no object property.
+	 */
+	public function test_webhook_with_no_data_property() {
+		// Setup test request data.
+		$this->request_body['type'] = 'unknown.webhook.event';
+		unset( $this->request_body['data'] );
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
+
+		// Run the test.
+		$response = $this->controller->handle_webhook( $this->request );
+
+		// Check the response.
+		$response_data = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( array( 'result' => 'bad_request' ), $response_data );
+	}
+
+	/**
+	 * Test a valid failed refund update webhook.
+	 */
+	public function test_valid_failed_refund_update_webhook() {
+		// Setup test request data.
+		$this->request_body['type']           = 'charge.refund.updated';
+		$this->request_body['data']['object'] = array(
+			'status' => 'failed',
+			'charge' => 'test_charge_id',
+			'id'     => 'test_refund_id',
+			'amount' => 999,
+		);
+
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
+
+		$mock_order = $this->getMockBuilder( WC_Order::class )
+			->disableOriginalConstructor()
+			->setMethods( array( 'add_order_note' ) )
+			->getMock();
+
+		$mock_order
+			->expects( $this->once() )
+			->method( 'add_order_note' )
+			->with(
+				'A refund of <span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol">&pound;</span>9.99</span> was <strong>unsuccessful</strong> using WooCommerce Payments (<code>test_refund_id</code>).'
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'test_charge_id' )
+			->willReturn( $mock_order );
+
+		// Run the test.
+		$response = $this->controller->handle_webhook( $this->request );
+
+		// Check the response.
+		$response_data = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( array( 'result' => 'success' ), $response_data );
+	}
+
+	/**
+	 * Test a valid failed refund update webhook with an unknown charge ID.
+	 */
+	public function test_valid_failed_refund_update_webhook_with_unknown_charge_id() {
+		// Setup test request data.
+		$this->request_body['type']           = 'charge.refund.updated';
+		$this->request_body['data']['object'] = array(
+			'status' => 'failed',
+			'charge' => 'unknown_charge_id',
+			'id'     => 'test_refund_id',
+			'amount' => 999,
+		);
+
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'unknown_charge_id' )
+			->willReturn( false );
+
+		// Run the test.
+		$response = $this->controller->handle_webhook( $this->request );
+
+		// Check the response.
+		$response_data = $response->get_data();
+
+		$this->assertEquals( 500, $response->get_status() );
+		$this->assertEquals( array( 'result' => 'error' ), $response_data );
+	}
+
+	/**
+	 * Test a valid non-failed refund update webhook
+	 */
+	public function test_non_failed_refund_update_webhook() {
+		// Setup test request data.
+		$this->request_body['type']           = 'charge.refund.updated';
+		$this->request_body['data']['object'] = array(
+			'status' => 'updated',
+			'charge' => 'test_charge_id',
+			'id'     => 'test_refund_id',
+			'amount' => 999,
+		);
+
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
+
+		$this->mock_db_wrapper
+			->expects( $this->never() )
+			->method( 'order_from_charge_id' );
+
+		// Run the test.
+		$response = $this->controller->handle_webhook( $this->request );
+
+		// Check the response.
+		$response_data = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( array( 'result' => 'success' ), $response_data );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,6 +38,10 @@ function _manually_load_plugin() {
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/models/class-wc-payments-api-intention.php';
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-api-client.php';
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-http.php';
+
+	require_once dirname( __FILE__ ) . '/../includes/exceptions/class-wc-payments-rest-exception.php';
+	require_once dirname( __FILE__ ) . '/../includes/admin/class-wc-payments-rest-controller.php';
+	require_once dirname( __FILE__ ) . '/../includes/admin/class-wc-rest-payments-webhook-controller.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,6 +33,7 @@ function _manually_load_plugin() {
 
 	require dirname( dirname( __FILE__ ) ) . '/woocommerce-payments.php';
 
+	require_once dirname( __FILE__ ) . '/../includes/class-wc-payments-db.php';
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/models/class-wc-payments-api-charge.php';
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/models/class-wc-payments-api-intention.php';
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-api-client.php';

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -25,6 +25,13 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 	private $mock_http_client;
 
 	/**
+	 * Mock DB wrapper.
+	 *
+	 * @var WC_Payments_DB|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_db_wrapper;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function setUp() {
@@ -35,9 +42,14 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 			->setMethods( array( 'remote_request' ) )
 			->getMock();
 
+		$this->mock_db_wrapper = $this->getMockBuilder( 'WC_Payments_DB' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->payments_api_client = new WC_Payments_API_Client(
 			'Unit Test Agent/0.1.0',
-			$this->mock_http_client
+			$this->mock_http_client,
+			$this->mock_db_wrapper
 		);
 	}
 


### PR DESCRIPTION
Fixes #512 
Based on webhooks forwarding introduced in #411 

#### Changes proposed in this Pull Request

* Handle the hook by updating transient account cache when necessary.
* Log webhooks when debugging enabled.

Questions:
1. Should we set cache if it's empty or expired?
2. Are there any other cases when we should not update cached account except account id mismatch? E.g. live/test mode mismatch?

#### Testing instructions

1. Run unit tests with `./vendor/bin/phpunit`. 
2. Setup testing environment:

    * Apply server#225
    * If running server locally in docker Apply dev tools#4 to your local site. This allows the simple HTTP request to work without proper Jetpack authentication.
    * Forward Stripe webhooks to the server with CLI. 
    * If running the server in a sandbox launch HTTP tunnel to the URL used during Jetpack activation (associated with blog id).
 
3. Testing steps:
    * In WP Admin go to Payments > Settings. Check account settings.
    * Go to Stripe Dashboard > Connect > Connected Account and update account settings. E.g. payout schedule.
    * Reload account settings. Payout schedule should be updated.
    * Go to WC Admin > Status > Logs. Check `account.updated` webhook is logged.

![account-updated-webhook](https://user-images.githubusercontent.com/3139099/79708818-2d673f80-82c9-11ea-806e-e6e3ccb0bed7.gif)


-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
