### PR TITLE
Update minimum versions of PHP and WordPress for compatibility sniffs

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,8 +11,8 @@
 	<exclude-pattern>*\.(?!php$)</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="4.7" />
-	<config name="testVersion" value="5.6-" />
+	<config name="minimum_supported_wp_version" value="5.3" />
+	<config name="testVersion" value="7.0-" />
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" >


### PR DESCRIPTION
Now that we have PHP 7.0 and WordPress 5.3 as minimum versions, we can update the sniff config passed to `PHPCompatibility/PHPCompatibility` and `WordPress/WordPress-Coding-Standards`.

#### Testing instructions

* Run sniffs and ensure everything still passes (or check Travis results).