### PR TITLE
Pass URL for pre-filling OAuth form

### DIFF
--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -346,6 +346,7 @@ class WC_Payments_Account {
 			array(
 				'email'         => $current_user->user_email,
 				'business_name' => get_bloginfo( 'name' ),
+				'url'           => get_home_url(),
 			)
 		);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

Stripe now appears to support prefilling the business URL in the OAuth form, and this change is to pass the site URL. According to [this Stripe OAuth doc](https://stripe.com/docs/connect/oauth-reference), this field is "recommended" to be passed.

![Screenshot of the relevant onboarding step](https://user-images.githubusercontent.com/1867547/79939656-a41d4d80-842d-11ea-9731-446601683e34.png)

(I believe I tested this a couple of months ago and it didn't work.)

The intended behavior also requires a server change to whitelist this key in `$allowed_business_data`, but that is not a blocker for this PR.

Pre-filling this field could help guide the merchant towards a good default for the statement descriptor, see https://github.com/Automattic/woocommerce-payments/issues/407#issuecomment-613772368, cc @thenbrent 

Note that switching away from the OAuth flow altogether is being explored – see https://github.com/Automattic/woocommerce-payments/pull/583 – but this change is simple enough that we should consider shipping it so that we have the option of pre-filling this field independently of the completion of that work.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With the necessary server change in place, open the OAuth flow and verify that the site URL is already filled.

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
