### PR TITLE
Disable gateway when payments are disabled on the account

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -158,7 +158,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return false;
 		}
 
-		return parent::is_available() && $this->account->is_stripe_connected( false );
+		if ( ! parent::is_available() || ! $this->account->is_stripe_connected( false ) ) {
+			return false;
+		}
+
+		$account_status = $this->account->get_account_status_data();
+		return empty( $account_status['error'] ) && $account_status['paymentsEnabled'];
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/248 and https://github.com/Automattic/woocommerce-payments/issues/469

#### Changes proposed in this Pull Request

Adds a condition to the gateway's `is_available` method, for omitting it from the Checkout screen when the account is unable to accept payments.

If we need to account for an asynchronous verification process, then **this probably should not be merged until after https://github.com/Automattic/woocommerce-payments/issues/512 is closed.**

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create or link an account that isn't fully verified, and make sure WCPay doesn't appear as an available payment method on the Checkout screen.
- After verifying, make sure WCPay now appears on the front-end.

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
