### PR TITLE
Add test for payment complete

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -333,17 +333,18 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	public function process_payment( $order_id ) {
 		$order = wc_get_order( $order_id );
-		return $this->process_payment_for_order( $order );
+		return $this->process_payment_for_order( $order, WC()->cart );
 	}
 
 	/**
 	 * Process the payment for a given order.
 	 *
 	 * @param WC_Order $order Order to process the payment for.
+	 * @param WC_Cart  $cart The WC_Cart object.
 	 *
 	 * @return array|null An array with result of payment and redirect URL, or nothing.
 	 */
-	public function process_payment_for_order( $order ) {
+	public function process_payment_for_order( $order, $cart ) {
 		try {
 			$order_id = $order->get_id();
 			$amount   = $order->get_total();
@@ -467,7 +468,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			}
 
 			wc_reduce_stock_levels( $order_id );
-			WC()->cart->empty_cart();
+			$cart->empty_cart();
 
 			return [
 				'result'   => 'success',

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -329,13 +329,24 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 *
 	 * @param int $order_id Order ID to process the payment for.
 	 *
-	 * @return array|null
+	 * @return array|null An array with result of payment and redirect URL, or nothing.
 	 */
 	public function process_payment( $order_id ) {
 		$order = wc_get_order( $order_id );
+		return $this->process_payment_for_order( $order );
+	}
 
+	/**
+	 * Process the payment for a given order.
+	 *
+	 * @param WC_Order $order Order to process the payment for.
+	 *
+	 * @return array|null An array with result of payment and redirect URL, or nothing.
+	 */
+	public function process_payment_for_order( $order ) {
 		try {
-			$amount = $order->get_total();
+			$order_id = $order->get_id();
+			$amount   = $order->get_total();
 
 			if ( $amount > 0 ) {
 				// Get the payment method from the request (generated when the user entered their card details).

--- a/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -201,9 +201,21 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$charge_id = 'ch_123';
 		$status    = 'requires_capture';
 		$secret    = 'client_secret_123';
+		$order_id  = 123;
+		$total     = 12.23;
 
 		// Arrange: Create an order to test with.
-		$order = WC_Helper_Order::create_order();
+		$mock_order = $this->createMock( 'WC_Order' );
+
+		// Arrange: Set a good return value for order ID.
+		$mock_order
+			->method( 'get_id' )
+			->willReturn( $order_id );
+
+		// Arrange: Set a good return value for order total.
+		$mock_order
+			->method( 'get_total' )
+			->willReturn( $total );
 
 		// Arrange: Return a 'requires_capture' response from create_and_confirm_intention().
 		$intent = new WC_Payments_API_Intention(
@@ -221,50 +233,57 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 				$this->returnValue( $intent )
 			);
 
-		// Act: process payment.
-		$result = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
-
-		// Assert: Returning correct array.
-		$this->assertEquals( 'success', $result['result'] );
-		$this->assertEquals( $this->return_url, $result['redirect'] );
+		// Assert: Order has correct charge id meta data.
+		// Assert: Order has correct intention status meta data.
+		// Assert: Order has correct intent ID.
+		// This test is a little brittle because we don't really care about the order
+		// in which the different calls are made, but it's not possible to write it
+		// otherwise for now.
+		// There's an issue open for that here:
+		// https://github.com/sebastianbergmann/phpunit/issues/4026.
+		$mock_order
+			->expects( $this->exactly( 3 ) )
+			->method( 'update_meta_data' )
+			->withConsecutive(
+				[ '_intent_id', $intent_id ],
+				[ '_charge_id', $charge_id ],
+				[ '_intention_status', $status ]
+			);
 
 		// Assert: The order note contains all the information we want:
 		// - status
 		// - intention id
 		// - amount charged.
-		$notes             = wc_get_order_notes(
-			[
-				'order_id' => $order->get_id(),
-			]
-		);
-		$latest_wcpay_note = current(
-			array_filter(
-				$notes,
-				function( $note ) {
-					return false !== strpos( $note->content, 'WooCommerce Payments' );
-				}
-			)
-		);
-		$this->assertContains( 'authorized', $latest_wcpay_note->content );
-		$this->assertContains( $intent_id, $latest_wcpay_note->content );
-		$this->assertContains( $order->get_total(), $latest_wcpay_note->content );
-
-		// Assert: Order has correct  status.
-		// Need to get the order again to see the correct order status.
-		$updated_order = wc_get_order( $order->get_id() );
-		$this->assertEquals( $updated_order->get_status(), 'on-hold' );
+		// Note that the note and the order status are updated at the same
+		// time using `update_status()`.
+		$mock_order
+			->expects( $this->exactly( 1 ) )
+			->method( 'update_status' )
+			->with(
+				'on-hold',
+				$this->callback(
+					function( $note ) use ( $intent_id, $total ) {
+						return (
+						strpos( $note, 'authorized' )
+						&& strpos( $note, $intent_id )
+						&& strpos( $note, strval( $total ) )
+						);
+					}
+				)
+			);
 
 		// Assert: Order has correct transaction ID set.
-		$this->assertEquals( $updated_order->get_transaction_id(), $intent_id );
+		$mock_order
+			->expects( $this->exactly( 1 ) )
+			->method( 'set_transaction_id' )
+			->with( $intent_id );
 
-		// Assert: Order has correct charge id meta data.
-		$this->assertEquals( $order->get_meta( '_charge_id' ), $charge_id );
+		// Act: process payment.
+		$result = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order );
 
-		// Assert: Order has correct intention status meta data.
-		$this->assertEquals( $order->get_meta( '_intention_status' ), $status );
-
-		// Assert: Order has correct intent ID.
-		$this->assertEquals( $order->get_meta( '_intent_id' ), $intent_id );
+		// Assert: Returning correct array.
+		$this->assertEquals( 'success', $result['result'] );
+		$this->assertEquals( $this->return_url, $result['redirect'] );
 	}
 
 	public function test_exception_thrown() {

--- a/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -127,6 +127,9 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->method( 'get_total' )
 			->willReturn( $total );
 
+		// Arrange: Create a mock cart.
+		$mock_cart = $this->createMock( 'WC_Cart' );
+
 		// Arrange: Return a successful response from create_and_confirm_intention().
 		$intent = new WC_Payments_API_Intention(
 			$intent_id,
@@ -184,8 +187,13 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'payment_complete' );
 
+		// Assert: empty_cart() was called.
+		$mock_cart
+			->expects( $this->once() )
+			->method( 'empty_cart' );
+
 		// Act: process a successful payment.
-		$result = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order );
+		$result = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order, $mock_cart );
 
 		// Assert: Returning correct array.
 		$this->assertEquals( 'success', $result['result'] );
@@ -216,6 +224,9 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$mock_order
 			->method( 'get_total' )
 			->willReturn( $total );
+
+		// Arrange: Create a mock cart.
+		$mock_cart = $this->createMock( 'WC_Cart' );
 
 		// Arrange: Return a 'requires_capture' response from create_and_confirm_intention().
 		$intent = new WC_Payments_API_Intention(
@@ -278,8 +289,13 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->method( 'set_transaction_id' )
 			->with( $intent_id );
 
+		// Assert: empty_cart() was called.
+		$mock_cart
+			->expects( $this->once() )
+			->method( 'empty_cart' );
+
 		// Act: process payment.
-		$result = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order );
+		$result = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order, $mock_cart );
 
 		// Assert: Returning correct array.
 		$this->assertEquals( 'success', $result['result'] );
@@ -304,6 +320,9 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$mock_order
 			->method( 'get_total' )
 			->willReturn( $total );
+
+		// Arrange: Create a mock cart.
+		$mock_cart = $this->createMock( 'WC_Cart' );
 
 		// Arrange: Throw an exception in create_and_confirm_intention.
 		$this->mock_api_client
@@ -343,8 +362,13 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->expects( $this->exactly( 0 ) )
 			->method( 'add_order_note' );
 
+		// Assert: empty_cart() was not called.
+		$mock_cart
+			->expects( $this->exactly( 0 ) )
+			->method( 'empty_cart' );
+
 		// Act: process payment.
-		$result = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order );
+		$result = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order, $mock_cart );
 
 		// Assert: A WooCommerce notice was added.
 		$this->assertTrue( wc_has_notice( $error_message, 'error' ) );
@@ -380,6 +404,9 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$mock_order
 			->method( 'get_total' )
 			->willReturn( $total );
+
+		// Arrange: Create a mock cart.
+		$mock_cart = $this->createMock( 'WC_Cart' );
 
 		// Arrange: Return a 'requires_action' response from create_and_confirm_intention().
 		$intent = new WC_Payments_API_Intention(
@@ -442,8 +469,13 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->expects( $this->exactly( 0 ) )
 			->method( 'set_transaction_id' );
 
+		// Assert: empty_cart() was not called.
+		$mock_cart
+			->expects( $this->exactly( 0 ) )
+			->method( 'empty_cart' );
+
 		// Act: process payment.
-		$result = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order );
+		$result = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order, $mock_cart );
 
 		// Assert: Returning correct array.
 		$this->assertEquals( 'success', $result['result'] );


### PR DESCRIPTION
This PR updates the tests written for `process_payment` to include a test for the `payment_complete` call for a successful intent. To do that, the WC_Order object is mocked instead of being created using the helper class. This makes it easy to check whether `$order->payment_complete()` was called.

To facilitate this, the logic of the function `process_payment` is moved to another function called `payment_complete_for_order`, which takes an order object instead of an order ID. This is needed because it wasn't possible to mock the global function `wc_get_order` which gets the order using the order ID. I tried mocking it using WP_Mock and ran into some trouble getting it set up. I think it's still worthwhile to try again later, but I wanted to get these tests out the door for now.

Big thanks to @jrodger for helping me think through the architecture and how we can ship this sooner rather than later.

I also added an assertion for each test to check whether or not the cart was emptied. This is done by passing in `WC()->cart` to `payment_complete_for_order`.

There are only two things left untested after the intent object is fetched:
1. reducing stock
2. a zero-amount order

Testing reducing the stock will need to come with setting up something like WP_Mock since it's another global function. I intend to add tests for the zero-amount order soon, as well as tests for `update_order_status()` which will be similar to what we already have for `process_payment`.

Related PRs: #606, #686 

### Testing instructions

Run `./vendor/bin/phpunit`.