### PR TITLE
Add filter to check for wcpay configuration

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -129,13 +129,21 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Check if the payment gateway is connected. This method is also used by
+	 * external plugins to check if a connection has been established.
+	 */
+	public function is_connected() {
+		return $this->account->is_stripe_connected( false );
+	}
+
+	/**
 	 * Returns true if the gateway needs additional configuration, false if it's ready to use.
 	 *
 	 * @see WC_Payment_Gateway::needs_setup
 	 * @return bool
 	 */
 	public function needs_setup() {
-		if ( ! $this->account->is_stripe_connected( false ) ) {
+		if ( ! $this->is_connected() ) {
 			return true;
 		}
 
@@ -506,7 +514,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return string Checkbox markup or empty string.
 	 */
 	public function generate_checkbox_html( $key, $data ) {
-		if ( 'enabled' === $key && ! $this->account->is_stripe_connected( false ) ) {
+		if ( 'enabled' === $key && ! $this->is_connected() ) {
 			return '';
 		}
 		return parent::generate_checkbox_html( $key, $data );
@@ -518,7 +526,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return string Container markup or empty if the account is not connected.
 	 */
 	public function generate_account_status_html() {
-		if ( ! $this->account->is_stripe_connected( false ) ) {
+		if ( ! $this->is_connected() ) {
 			return '';
 		}
 


### PR DESCRIPTION
Fixes #538 

#### Changes proposed in this Pull Request

* Adds a public method to check for configuration (connection) to allow others plugins to detect configuration.

#### Testing instructions

1. Make sure this payment gateway continues to work on the frontend and is still available.
1. ~~Check that the value of `apply_filters( 'woocommerce_payments_is_configured', false )` returns true when Stripe is connected from this plugin.~~
1. Optionally checkout this branch ( https://github.com/woocommerce/woocommerce-admin/pull/4145 ) and make sure that connecting wc pay shows the payments task as configured.