### PR TITLE
Use always the get_settings_url function, also refactor it to make it cleaner

### DIFF
--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -109,16 +109,7 @@ class WC_Payments_Admin {
 			$submenu[ $last_submenu_key ][] = array( // PHPCS:Ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 				__( 'Settings', 'woocommerce' ), // PHPCS:Ignore WordPress.WP.I18n.TextDomainMismatch
 				'manage_woocommerce',
-				admin_url(
-					add_query_arg(
-						array(
-							'page'    => 'wc-settings',
-							'tab'     => 'checkout',
-							'section' => WC_Payment_Gateway_WCPay::GATEWAY_ID,
-						),
-						'admin.php'
-					)
-				),
+				WC_Payment_Gateway_WCPay::get_settings_url(),
 			);
 
 			// Temporary fix to settings menu disappearance is to register the page after settings menu has been manually added.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -134,7 +134,16 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return string URL of the configuration screen for this gateway
 	 */
 	public static function get_settings_url() {
-		return admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . self::GATEWAY_ID );
+		return admin_url(
+			add_query_arg(
+				array(
+					'page'    => 'wc-settings',
+					'tab'     => 'checkout',
+					'section' => self::GATEWAY_ID,
+				),
+				'admin.php'
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Minor refactor, use the `WC_Payment_Gateway_WCPay::get_settings_url()` helper in all the cases that the URL is needed. I also made building the URL a bit cleaner, with `add_query_arg()` instead of writing the raw URL.

This PR is just a refactor, it shouldn't change any behaviour.