### PR TITLE
Overrides the base gateway "needs_setup" function

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -129,6 +129,21 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Returns true if the gateway needs additional configuration, false if it's ready to use.
+	 *
+	 * @see WC_Payment_Gateway::needs_setup
+	 * @return bool
+	 */
+	public function needs_setup() {
+		if ( ! $this->account->is_stripe_connected( false ) ) {
+			return true;
+		}
+
+		$account_status = $this->account->get_account_status_data();
+		return parent::needs_setup() || ! empty( $account_status['error'] ) || ! $account_status['paymentsEnabled'];
+	}
+
+	/**
 	 * Returns the URL of the configuration screen for this gateway, for use in internal links.
 	 *
 	 * @return string URL of the configuration screen for this gateway
@@ -180,12 +195,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return false;
 		}
 
-		if ( ! parent::is_available() || ! $this->account->is_stripe_connected( false ) ) {
-			return false;
-		}
-
-		$account_status = $this->account->get_account_status_data();
-		return empty( $account_status['error'] ) && $account_status['paymentsEnabled'];
+		return parent::is_available() && ! $this->needs_setup();
 	}
 
 	/**


### PR DESCRIPTION
Overrides the base gateway "needs_setup" function to redirect to the settings page when it gets enabled.

This is not directly related with the Jetpack Epic but I found it and wanted to do some cleaning up.

The method `WC_Payment_Gateway::needs_setup` is called when the user enables the payment gateway in the gateways list. If it returns `true`, then the user will be immediately redirected to the gateway's settings screen to finish setup.

To test:
- Distonnect your WCPay account, either running `wp wcpay disconnect BLOG_ID` in your sandbox, or using the DevTools plugin, or using a clean site.
- Go to the `WooCommerce -> Settings -> Payments` page (`wp-admin/admin.php?page=wc-settings&tab=checkout`)
- Enable WooCommerce Payments (disable it first if it was enabled already).
- You'll be immediatelty redirected to the WCPay settings screen.