### PR TITLE
Trigger the Jetpack connection flow from the plugin UI

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -59,9 +59,6 @@ cli wp import wp-content/plugins/woocommerce/sample-data/sample_products.xml --a
 echo "Installing and activating the WooCommerce Admin plugin..."
 cli wp plugin install woocommerce-admin --activate
 
-echo "Installing and activating the Jetpack plugin..."
-cli wp plugin install jetpack --activate
-
 echo "Activating the WooCommerce Payments plugin..."
 cli wp plugin activate woocommerce-payments
 

--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -5,6 +5,7 @@
 import { __ } from '@wordpress/i18n';
 import { Card } from '@woocommerce/components';
 import { Button, Notice } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { __experimentalCreateInterpolateElement as createInterpolateElement } from 'wordpress-element';
 
 /**
@@ -15,6 +16,8 @@ import Page from 'components/page';
 import HeroImage from './hero-image';
 
 const ConnectAccountPage = () => {
+	const [ isSubmitted, setSubmitted ] = useState( false );
+
 	return (
 		<Page isNarrow className="connect-account">
 			{ wcpaySettings.errorMessage &&
@@ -44,7 +47,15 @@ const ConnectAccountPage = () => {
 				</p>
 				<hr className="full-width" />
 				<p className="connect-account__action">
-					<Button isPrimary isLarge href={ wcpaySettings.connectUrl }>{ __( 'Set up', 'woocommerce-payments' ) }</Button>
+					<Button
+						isPrimary
+						isLarge
+						isBusy={ isSubmitted }
+						disabled={ isSubmitted }
+						onClick={ () => setSubmitted( true ) }
+						href={ wcpaySettings.connectUrl }>
+						{ __( 'Set up', 'woocommerce-payments' ) }
+					</Button>
 				</p>
 				</>
 				) : (

--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -4,7 +4,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Card } from '@woocommerce/components';
-import { Button } from '@wordpress/components';
+import { Button, Notice } from '@wordpress/components';
 import { __experimentalCreateInterpolateElement as createInterpolateElement } from 'wordpress-element';
 
 /**
@@ -17,6 +17,11 @@ import HeroImage from './hero-image';
 const ConnectAccountPage = () => {
 	return (
 		<Page isNarrow className="connect-account">
+			{ wcpaySettings.errorMessage &&
+				<Notice className="wcpay-connect-error-notice" status="error" isDismissible={ false }>
+					{ wcpaySettings.errorMessage }
+				</Notice>
+			}
 			<Card className="connect-account__card">
 				<HeroImage />
 				<h2> { __( 'WooCommerce Payments', 'woocommerce-payments' ) } </h2>

--- a/client/settings.js
+++ b/client/settings.js
@@ -6,16 +6,7 @@ import ReactDOM from 'react-dom';
 /**
  * External dependencies
  */
-import { addFilter } from '@wordpress/hooks';
 import AccountStatus from 'account-status';
-
-addFilter( 'woocommerce_admin_notices_to_show', 'plugin-domain', notices => {
-	return [
-		...notices,
-		[ 'wcpay-test-mode-notice', null, null ],
-		[ null, [ 'wcpay-settings-notice' ], null ],
-	];
-} );
 
 ReactDOM.render(
 	<AccountStatus { ...wcpayAdminSettings } />,

--- a/client/style.scss
+++ b/client/style.scss
@@ -100,6 +100,11 @@
 	background-color: $studio-yellow-5;
 }
 
+.wcpay-connect-error-notice.components-notice {
+	margin: 24px 0;
+	padding: 12px;
+}
+
 .wcpay-payment-details {
 	.woocommerce-card__header {
 		border-bottom: 1px solid $studio-gray-5;

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,14 @@
       }
     },
     "require": {
+      "automattic/jetpack-connection": "^1.11.0",
+      "automattic/jetpack-config": "^1.1.0",
+      "automattic/jetpack-autoloader": "^1.6.0"
     },
     "require-dev": {
-      "composer/installers": "1.7.0",
+      "woocommerce/woocommerce": "^4.1.0",
+      "composer/installers": "^1.7.0",
       "phpunit/phpunit": "6.5.14",
-      "woocommerce/woocommerce": "3.9.3",
       "woocommerce/woocommerce-sniffs": "0.0.10"
     },
     "scripts": {
@@ -38,4 +41,4 @@
       },
       "installer-disable": true
     }
-  }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cab2457e97cb655f34e3c45f52de75d5",
-    "packages": [],
-    "packages-dev": [
+    "content-hash": "7e9d4e8a8fe700c23d3cebf0ebeda536",
+    "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v1.3.2",
+            "version": "v1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "301c2fbcf070d4f0147753447616b6e982bda09e"
+                "reference": "7c6736eeee0f9fc49fa691fe3e958725efb27ca0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/301c2fbcf070d4f0147753447616b6e982bda09e",
-                "reference": "301c2fbcf070d4f0147753447616b6e982bda09e",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/7c6736eeee0f9fc49fa691fe3e958725efb27ca0",
+                "reference": "7c6736eeee0f9fc49fa691fe3e958725efb27ca0",
                 "shasum": ""
             },
             "require": {
@@ -41,8 +40,173 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "time": "2019-09-24T06:39:29+00:00"
+            "time": "2020-04-23T02:28:37+00:00"
         },
+        {
+            "name": "automattic/jetpack-config",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-config.git",
+                "reference": "4c6ea210ba8fa60f43f0d9eb725f70450f0ba210"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/4c6ea210ba8fa60f43f0d9eb725f70450f0ba210",
+                "reference": "4c6ea210ba8fa60f43f0d9eb725f70450f0ba210",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
+            "time": "2020-05-20T20:52:06+00:00"
+        },
+        {
+            "name": "automattic/jetpack-connection",
+            "version": "v1.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-connection.git",
+                "reference": "ff39d64a7b4f6626431b11ccee331d321119a261"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/ff39d64a7b4f6626431b11ccee331d321119a261",
+                "reference": "ff39d64a7b4f6626431b11ccee331d321119a261",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-constants": "1.2.0",
+                "automattic/jetpack-options": "1.5.0",
+                "automattic/jetpack-roles": "1.0.4"
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "legacy/load-ixr.php"
+                ],
+                "classmap": [
+                    "legacy",
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything needed to connect to the Jetpack infrastructure",
+            "time": "2020-05-26T13:37:36+00:00"
+        },
+        {
+            "name": "automattic/jetpack-constants",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-constants.git",
+                "reference": "881618defb04134ddba120e7835af1a474a11edc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/881618defb04134ddba120e7835af1a474a11edc",
+                "reference": "881618defb04134ddba120e7835af1a474a11edc",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A wrapper for defining constants in a more testable way.",
+            "time": "2020-04-15T18:58:53+00:00"
+        },
+        {
+            "name": "automattic/jetpack-options",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-options.git",
+                "reference": "5c9d947ab62bc786adc36b7071b0e3a7dc7470d1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/5c9d947ab62bc786adc36b7071b0e3a7dc7470d1",
+                "reference": "5c9d947ab62bc786adc36b7071b0e3a7dc7470d1",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-constants": "1.2.0"
+            },
+            "require-dev": {
+                "10up/wp_mock": "0.4.2",
+                "phpunit/phpunit": "7.*.*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "legacy"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A wrapper for wp-options to manage specific Jetpack options.",
+            "time": "2020-05-26T13:35:15+00:00"
+        },
+        {
+            "name": "automattic/jetpack-roles",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-roles.git",
+                "reference": "0cdcff4fdc489c79f20a361c084ec48e326ce483"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/0cdcff4fdc489c79f20a361c084ec48e326ce483",
+                "reference": "0cdcff4fdc489c79f20a361c084ec48e326ce483",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities, related with user roles and capabilities.",
+            "time": "2019-11-08T21:16:05+00:00"
+        }
+    ],
+    "packages-dev": [
         {
             "name": "composer/installers",
             "version": "v1.7.0",
@@ -389,6 +553,80 @@
                 "object graph"
             ],
             "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "pelago/emogrifier",
+            "version": "v3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MyIntervals/emogrifier.git",
+                "reference": "f6a5c7d44612d86c3901c93f1592f5440e6b2cd8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MyIntervals/emogrifier/zipball/f6a5c7d44612d86c3901c93f1592f5440e6b2cd8",
+                "reference": "f6a5c7d44612d86c3901c93f1592f5440e6b2cd8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": "^5.6 || ~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4",
+                "symfony/css-selector": "^2.8 || ^3.0 || ^4.0 || ^5.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.15.3",
+                "phpmd/phpmd": "^2.7.0",
+                "phpunit/phpunit": "^5.7.27",
+                "squizlabs/php_codesniffer": "^3.5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pelago\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Zoli Szabó",
+                    "email": "zoli.szabo+github@gmail.com"
+                },
+                {
+                    "name": "John Reeve",
+                    "email": "jreeve@pelagodesign.com"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake@qzdesign.co.uk"
+                },
+                {
+                    "name": "Cameron Brooks"
+                },
+                {
+                    "name": "Jaime Prado"
+                }
+            ],
+            "description": "Converts CSS styles into inline style attributes in your HTML code",
+            "homepage": "https://www.myintervals.com/emogrifier.php",
+            "keywords": [
+                "css",
+                "email",
+                "pre-processing"
+            ],
+            "time": "2019-12-26T19:37:31+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1870,17 +2108,70 @@
             "time": "2020-04-17T01:09:41+00:00"
         },
         {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.15.0",
+            "name": "symfony/css-selector",
+            "version": "v3.3.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14"
+                "url": "https://github.com/symfony/css-selector.git",
+                "reference": "4d882dced7b995d5274293039370148e291808f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
-                "reference": "4719fa9c18b0464d399f1a63bf624b42b6fa8d14",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/4d882dced7b995d5274293039370148e291808f2",
+                "reference": "4d882dced7b995d5274293039370148e291808f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\CssSelector\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony CssSelector Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-05-01T15:01:29+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
+                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
                 "shasum": ""
             },
             "require": {
@@ -1892,7 +2183,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.15-dev"
+                    "dev-master": "1.17-dev"
                 }
             },
             "autoload": {
@@ -1939,7 +2230,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-02-27T09:26:54+00:00"
+            "time": "2020-05-12T16:14:59+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1983,16 +2274,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
+                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
-                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
+                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
                 "shasum": ""
             },
             "require": {
@@ -2000,7 +2291,7 @@
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "vimeo/psalm": "<3.6.0"
+                "vimeo/psalm": "<3.9.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.36 || ^7.5.13"
@@ -2027,48 +2318,96 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-02-14T12:15:55+00:00"
+            "time": "2020-04-18T12:12:48+00:00"
         },
         {
-            "name": "woocommerce/woocommerce",
-            "version": "3.9.3",
+            "name": "woocommerce/action-scheduler",
+            "version": "3.1.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/woocommerce/woocommerce.git",
-                "reference": "310a620134199758e071ad00690816a95ced2100"
+                "url": "https://github.com/woocommerce/action-scheduler.git",
+                "reference": "275d0ba54b1c263dfc62688de2fa9a25a373edf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce/zipball/310a620134199758e071ad00690816a95ced2100",
-                "reference": "310a620134199758e071ad00690816a95ced2100",
+                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/275d0ba54b1c263dfc62688de2fa9a25a373edf8",
+                "reference": "275d0ba54b1c263dfc62688de2fa9a25a373edf8",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.6",
+                "woocommerce/woocommerce-sniffs": "0.0.8",
+                "wp-cli/wp-cli": "~1.5.1"
+            },
+            "type": "wordpress-plugin",
+            "extra": {
+                "scripts-description": {
+                    "test": "Run unit tests",
+                    "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
+                    "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "description": "Action Scheduler for WordPress and WooCommerce",
+            "homepage": "https://actionscheduler.org/",
+            "time": "2020-05-12T16:22:33+00:00"
+        },
+        {
+            "name": "woocommerce/woocommerce",
+            "version": "4.2.0-RC.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/woocommerce/woocommerce.git",
+                "reference": "038bfc8f707c592a96cb827a13758eb283b36c21"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce/zipball/038bfc8f707c592a96cb827a13758eb283b36c21",
+                "reference": "038bfc8f707c592a96cb827a13758eb283b36c21",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-autoloader": "^1.2.0",
+                "automattic/jetpack-autoloader": "^1.7.0",
+                "automattic/jetpack-constants": "^1.1",
                 "composer/installers": "1.7.0",
                 "maxmind-db/reader": "1.6.0",
-                "php": ">=5.6|>=7.0",
-                "woocommerce/woocommerce-blocks": "2.5.14",
-                "woocommerce/woocommerce-rest-api": "1.0.7"
+                "pelago/emogrifier": "^3.1",
+                "php": ">=7.0",
+                "woocommerce/action-scheduler": "3.1.6",
+                "woocommerce/woocommerce-admin": "1.2.3",
+                "woocommerce/woocommerce-blocks": "2.5.16",
+                "woocommerce/woocommerce-rest-api": "1.0.8"
             },
             "require-dev": {
-                "phpunit/phpunit": "7.5.18",
-                "woocommerce/woocommerce-sniffs": "0.0.9"
+                "phpunit/phpunit": "7.5.20",
+                "woocommerce/woocommerce-sniffs": "0.0.10",
+                "wp-cli/i18n-command": "^2.2"
             },
             "type": "wordpress-plugin",
             "extra": {
                 "installer-paths": {
+                    "packages/action-scheduler": [
+                        "woocommerce/action-scheduler"
+                    ],
                     "packages/woocommerce-rest-api": [
                         "woocommerce/woocommerce-rest-api"
                     ],
                     "packages/woocommerce-blocks": [
                         "woocommerce/woocommerce-blocks"
+                    ],
+                    "packages/woocommerce-admin": [
+                        "woocommerce/woocommerce-admin"
                     ]
                 },
                 "scripts-description": {
                     "test": "Run unit tests",
                     "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
-                    "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
+                    "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier",
+                    "makepot-audit": "Generate i18n/langauges/woocommerce.pot file and run audit",
+                    "makepot": "Generate i18n/langauges/woocommerce.pot file"
                 }
             },
             "autoload": {
@@ -2086,24 +2425,71 @@
             ],
             "description": "An eCommerce toolkit that helps you sell anything. Beautifully.",
             "homepage": "https://woocommerce.com/",
-            "time": "2020-03-04T09:08:17+00:00"
+            "time": "2020-05-26T22:30:38+00:00"
         },
         {
-            "name": "woocommerce/woocommerce-blocks",
-            "version": "v2.5.14",
+            "name": "woocommerce/woocommerce-admin",
+            "version": "v1.2.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "0dd70617085d2e73f3adfb38df98a90df3514816"
+                "url": "https://github.com/woocommerce/woocommerce-admin.git",
+                "reference": "5560c9b6e31e1d794a55a0eb4ccf040fd2cee4c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/0dd70617085d2e73f3adfb38df98a90df3514816",
-                "reference": "0dd70617085d2e73f3adfb38df98a90df3514816",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/5560c9b6e31e1d794a55a0eb4ccf040fd2cee4c7",
+                "reference": "5560c9b6e31e1d794a55a0eb4ccf040fd2cee4c7",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-autoloader": "1.3.2",
+                "automattic/jetpack-autoloader": "^1.6.0",
+                "composer/installers": "1.7.0",
+                "php": ">=5.6|>=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "7.5.20",
+                "woocommerce/woocommerce-sniffs": "0.0.9"
+            },
+            "type": "wordpress-plugin",
+            "extra": {
+                "scripts-description": {
+                    "test": "Run unit tests",
+                    "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
+                    "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "includes/"
+                ],
+                "psr-4": {
+                    "Automattic\\WooCommerce\\Admin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "description": "A modern, javascript-driven WooCommerce Admin experience.",
+            "homepage": "https://github.com/woocommerce/woocommerce-admin",
+            "time": "2020-05-22T18:45:16+00:00"
+        },
+        {
+            "name": "woocommerce/woocommerce-blocks",
+            "version": "v2.5.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
+                "reference": "3bd91b669247000fd3f5277954701d0b148d3f1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/3bd91b669247000fd3f5277954701d0b148d3f1a",
+                "reference": "3bd91b669247000fd3f5277954701d0b148d3f1a",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-autoloader": "^1.6.0",
                 "composer/installers": "1.7.0"
             },
             "require-dev": {
@@ -2133,20 +2519,20 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "time": "2020-03-03T13:25:56+00:00"
+            "time": "2020-04-07T11:47:19+00:00"
         },
         {
             "name": "woocommerce/woocommerce-rest-api",
-            "version": "1.0.7",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-rest-api.git",
-                "reference": "49162ec26a25bd0c6efc0f3452b113cdfff0a823"
+                "reference": "0756027c669bb5749554ee58b9416cbdcceaa752"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-rest-api/zipball/49162ec26a25bd0c6efc0f3452b113cdfff0a823",
-                "reference": "49162ec26a25bd0c6efc0f3452b113cdfff0a823",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-rest-api/zipball/0756027c669bb5749554ee58b9416cbdcceaa752",
+                "reference": "0756027c669bb5749554ee58b9416cbdcceaa752",
                 "shasum": ""
             },
             "require": {
@@ -2173,7 +2559,7 @@
             ],
             "description": "The WooCommerce core REST API.",
             "homepage": "https://github.com/woocommerce/woocommerce-rest-api",
-            "time": "2020-01-28T21:04:51+00:00"
+            "time": "2020-05-11T14:54:30+00:00"
         },
         {
             "name": "woocommerce/woocommerce-sniffs",

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -38,7 +38,6 @@ class WC_Payments_Admin {
 
 		// Add menu items.
 		add_action( 'admin_menu', [ $this, 'add_payments_menu' ], 9 );
-		add_action( 'init', [ $this, 'register_payments_scripts' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_payments_scripts' ] );
 	}
 
@@ -175,6 +174,9 @@ class WC_Payments_Admin {
 		// as appropriate.
 		$on_boarding_disabled = WC_Payments_Account::is_on_boarding_disabled();
 
+		$error_message = get_transient( WC_Payments_Account::ERROR_MESSAGE_TRANSIENT );
+		delete_transient( WC_Payments_Account::ERROR_MESSAGE_TRANSIENT );
+
 		wp_localize_script(
 			'WCPAY_DASH_APP',
 			'wcpaySettings',
@@ -182,6 +184,7 @@ class WC_Payments_Admin {
 				'connectUrl'         => WC_Payments_Account::get_connect_url(),
 				'testMode'           => $this->wcpay_gateway->is_in_test_mode(),
 				'onBoardingDisabled' => $on_boarding_disabled,
+				'errorMessage'       => $error_message,
 			]
 		);
 
@@ -235,6 +238,8 @@ class WC_Payments_Admin {
 	 * Load the assets
 	 */
 	public function enqueue_payments_scripts() {
+		$this->register_payments_scripts();
+
 		global $current_tab, $current_section;
 		if ( $current_tab && $current_section
 			&& 'checkout' === $current_tab

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -347,11 +347,11 @@ class WC_Payments_Account {
 		}
 
 		$redirect = add_query_arg(
-			array(
+			[
 				'wcpay-connect'                 => $wcpay_connect_from,
 				'wcpay-connect-jetpack-success' => '1',
 				'_wpnonce'                      => wp_create_nonce( 'wcpay-connect' ),
-			),
+			],
 			$this->get_oauth_return_url( $wcpay_connect_from )
 		);
 		$this->payments_api_client->start_server_connection( $redirect );

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -264,6 +264,7 @@ class WC_Payments_Account {
 				$this->redirect_to_onboarding_page(
 					__( 'Connection to WordPress.com failed. Please connect to WordPress.com to start using WooCommerce Payments.', 'woocommerce-payments' )
 				);
+				return;
 			}
 
 			try {
@@ -273,6 +274,7 @@ class WC_Payments_Account {
 				/* translators: error message. */
 					sprintf( __( 'There was a problem connecting this site to WordPress.com: "%s"', 'woocommerce-payments' ), $e->getMessage() )
 				);
+				return;
 			}
 
 			try {

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -37,6 +37,14 @@ class WC_Payments_Account {
 		add_action( 'admin_init', [ $this, 'maybe_handle_oauth' ] );
 		add_action( 'admin_init', [ $this, 'check_stripe_account_status' ] );
 		add_filter( 'allowed_redirect_hosts', [ $this, 'allowed_redirect_hosts' ] );
+		add_action( 'jetpack_site_registered', [ $this, 'clear_cache' ] );
+	}
+
+	/**
+	 * Wipes the account transient, forcing to re-fetch the account status from WP.com.
+	 */
+	public function clear_cache() {
+		delete_transient( self::ACCOUNT_TRANSIENT );
 	}
 
 	/**
@@ -239,11 +247,33 @@ class WC_Payments_Account {
 				$message = __( 'Thanks for verifying your business details!', 'woocommerce-payments' );
 			}
 			$this->add_notice_to_settings_page( $message, 'notice-success' );
+			return;
 		}
 
 		if ( isset( $_GET['wcpay-connect'] ) && check_admin_referer( 'wcpay-connect' ) ) {
+			$wcpay_connect_param = sanitize_text_field( wp_unslash( $_GET['wcpay-connect'] ) );
+
+			if ( ! $this->payments_api_client->is_server_connected() && isset( $_GET['wcpay-connect-jetpack-success'] ) ) {
+				$this->add_notice_to_settings_page(
+					__( 'Connection to WordPress.com failed. Please connect to WordPress.com to start using WooCommerce Payments.', 'woocommerce-payments' ),
+					'notice-error'
+				);
+
+				return;
+			}
+
 			try {
-				$wcpay_connect_param = sanitize_text_field( wp_unslash( $_GET['wcpay-connect'] ) );
+				$this->maybe_init_jetpack_connection( $wcpay_connect_param );
+			} catch ( Exception $e ) {
+				$this->add_notice_to_settings_page(
+				/* translators: error message. */
+					sprintf( __( 'There was a problem connecting this site to WordPress.com: "%s"', 'woocommerce-payments' ), $e->getMessage() ),
+					'notice-error'
+				);
+				return;
+			}
+
+			try {
 				$this->init_oauth( $wcpay_connect_param );
 			} catch ( Exception $e ) {
 				Logger::error( 'Init oauth flow failed. ' . $e );
@@ -301,11 +331,34 @@ class WC_Payments_Account {
 	}
 
 	/**
+	 * Starts the Jetpack connection flow if it's not already fully connected.
+	 *
+	 * @param string $wcpay_connect_from - where the user should be returned to after connecting.
+	 * @throws WC_Payments_API_Exception If there was an error when registering the site on WP.com.
+	 */
+	private function maybe_init_jetpack_connection( $wcpay_connect_from ) {
+		$is_jetpack_fully_connected = $this->payments_api_client->is_server_connected();
+		if ( $is_jetpack_fully_connected ) {
+			return;
+		}
+
+		$redirect = add_query_arg(
+			array(
+				'wcpay-connect'                 => $wcpay_connect_from,
+				'wcpay-connect-jetpack-success' => '1',
+				'_wpnonce'                      => wp_create_nonce( 'wcpay-connect' ),
+			),
+			$this->get_oauth_return_url( $wcpay_connect_from )
+		);
+		$this->payments_api_client->start_server_connection( $redirect );
+	}
+
+	/**
 	 * For the connected account, fetches the login url from the API and redirects to it
 	 */
 	private function redirect_to_login() {
 		// Clear account transient when generating Stripe dashboard's login link.
-		delete_transient( self::ACCOUNT_TRANSIENT );
+		$this->clear_cache();
 
 		$login_data = $this->payments_api_client->get_login_data( WC_Payment_Gateway_WCPay::get_settings_url() );
 		wp_safe_redirect( $login_data['url'] );
@@ -313,29 +366,37 @@ class WC_Payments_Account {
 	}
 
 	/**
-	 * Initializes the OAuth flow by fetching the URL from the API and redirecting to it
+	 * Builds the URL to return the user to after the Jetpack/OAuth flow.
 	 *
-	 * @param string $wcpay_connect_from - where the user should be returned to after connecting.
+	 * @param string $wcpay_connect_from - Constant to decide where the user should be returned to after connecting.
+	 * @return string
 	 */
-	private function init_oauth( $wcpay_connect_from ) {
-		// Clear account transient when generating Stripe's oauth data.
-		delete_transient( self::ACCOUNT_TRANSIENT );
-
-		$current_user = wp_get_current_user();
-
+	private function get_oauth_return_url( $wcpay_connect_from ) {
 		// Usually the return URL is the WCPay plugin settings page.
 		// But if connection originated on the WCADMIN payment task page, return there.
-		$return_url = WC_Payment_Gateway_WCPay::get_settings_url();
-		if ( strcmp( $wcpay_connect_from, 'WCADMIN_PAYMENT_TASK' ) === 0 ) {
-			$return_url = add_query_arg(
+		return 'WCADMIN_PAYMENT_TASK' === $wcpay_connect_from
+			? add_query_arg(
 				[
 					'page'   => 'wc-admin',
 					'task'   => 'payments',
 					'method' => 'wcpay',
 				],
 				admin_url( 'admin.php' )
-			);
-		}
+			)
+			: WC_Payment_Gateway_WCPay::get_settings_url();
+	}
+
+	/**
+	 * Initializes the OAuth flow by fetching the URL from the API and redirecting to it.
+	 *
+	 * @param string $wcpay_connect_from - where the user should be returned to after connecting.
+	 */
+	private function init_oauth( $wcpay_connect_from ) {
+		// Clear account transient when generating Stripe's oauth data.
+		$this->clear_cache();
+
+		$current_user = wp_get_current_user();
+		$return_url   = $this->get_oauth_return_url( $wcpay_connect_from );
 
 		$oauth_data = $this->payments_api_client->get_oauth_data(
 			$return_url,
@@ -379,7 +440,7 @@ class WC_Payments_Account {
 			return;
 		}
 		delete_transient( 'wcpay_oauth_state' );
-		delete_transient( self::ACCOUNT_TRANSIENT );
+		$this->clear_cache();
 
 		WC_Payments::get_gateway()->update_option( 'enabled', 'yes' );
 		WC_Payments::get_gateway()->update_option( 'test_mode', 'test' === $mode ? 'yes' : 'no' );
@@ -407,6 +468,10 @@ class WC_Payments_Account {
 	 * @throws WC_Payments_API_Exception Bubbles up if get_account_data call fails.
 	 */
 	private function get_cached_account_data() {
+		if ( ! $this->payments_api_client->is_server_connected() ) {
+			return [];
+		}
+
 		$account = get_transient( self::ACCOUNT_TRANSIENT );
 
 		if ( $this->is_valid_cached_account( $account ) ) {

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -276,9 +276,9 @@ class WC_Payments_Account {
 			}
 
 			try {
-				$this->init_oauth( $wcpay_connect_param );
+				$this->init_stripe_oauth( $wcpay_connect_param );
 			} catch ( Exception $e ) {
-				Logger::error( 'Init oauth flow failed. ' . $e );
+				Logger::error( 'Init Stripe oauth flow failed. ' . $e );
 				$this->add_notice_to_settings_page(
 					__( 'There was a problem redirecting you to the account connection page. Please try again.', 'woocommerce-payments' ),
 					'notice-error'
@@ -393,7 +393,7 @@ class WC_Payments_Account {
 	 *
 	 * @param string $wcpay_connect_from - where the user should be returned to after connecting.
 	 */
-	private function init_oauth( $wcpay_connect_from ) {
+	private function init_stripe_oauth( $wcpay_connect_from ) {
 		// Clear account transient when generating Stripe's oauth data.
 		$this->clear_cache();
 
@@ -421,7 +421,7 @@ class WC_Payments_Account {
 			exit;
 		}
 
-		set_transient( 'wcpay_oauth_state', $oauth_data['state'], DAY_IN_SECONDS );
+		set_transient( 'wcpay_stripe_oauth_state', $oauth_data['state'], DAY_IN_SECONDS );
 
 		wp_safe_redirect( $oauth_data['url'] );
 		exit;
@@ -434,14 +434,14 @@ class WC_Payments_Account {
 	 * @param string $mode Mode in which this account has been connected. Either 'test' or 'live'.
 	 */
 	private function finalize_connection( $state, $mode ) {
-		if ( get_transient( 'wcpay_oauth_state' ) !== $state ) {
+		if ( get_transient( 'wcpay_stripe_oauth_state' ) !== $state ) {
 			$this->add_notice_to_settings_page(
 				__( 'There was a problem processing your account data. Please try again.', 'woocommerce-payments' ),
 				'notice-error'
 			);
 			return;
 		}
-		delete_transient( 'wcpay_oauth_state' );
+		delete_transient( 'wcpay_stripe_oauth_state' );
 		$this->clear_cache();
 
 		WC_Payments::get_gateway()->update_option( 'enabled', 'yes' );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -314,25 +314,6 @@ class WC_Payments {
 			return false;
 		}
 
-		// Check if Jetpack is connected.
-		if ( ! self::is_jetpack_connected() ) {
-			// Do not show an alert on Jetpack admin pages.
-			if ( ! $silent && ! self::is_at_jetpack_admin_page() ) {
-				$set_up_url = wp_nonce_url( 'admin.php?page=jetpack' );
-				$message    = WC_Payments_Utils::esc_interpolated_html(
-					sprintf(
-						/* translators: %1: WooCommerce Payments version */
-						__( 'To use WooCommerce Payments %1$s you\'ll need to <a>set up</a> the Jetpack plugin.', 'woocommerce-payments' ),
-						WCPAY_VERSION_NUMBER
-					),
-					[ 'a' => '<a href="' . $set_up_url . '">' ]
-				);
-				self::display_admin_error( $message );
-			}
-
-			return false;
-		}
-
 		return true;
 	}
 
@@ -344,26 +325,6 @@ class WC_Payments {
 	private static function is_at_plugin_install_page() {
 		$cur_screen = get_current_screen();
 		return 'update' === $cur_screen->id && 'plugins' === $cur_screen->parent_base;
-	}
-
-	/**
-	 * Checks if current page is Jetpack admin page.
-	 *
-	 * @return bool True when current page is one of the Jetpack admin pages.
-	 */
-	private static function is_at_jetpack_admin_page() {
-		$cur_screen = get_current_screen();
-		return 'jetpack' === $cur_screen->parent_base;
-	}
-
-	/**
-	 * Checks if Jetpack is connected.
-	 *
-	 * @return bool true if Jetpack connection is available and authenticated.
-	 */
-	public static function is_jetpack_connected() {
-		require_once dirname( __FILE__ ) . '/wc-payment-api/class-wc-payments-http.php';
-		return WC_Payments_Http::is_connected();
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -187,12 +187,6 @@ class WC_Payments {
 				'slug'  => 'woocommerce-admin',
 				'file'  => 'woocommerce-admin/woocommerce-admin.php',
 			],
-			[
-				'name'  => 'Jetpack',
-				'class' => 'Jetpack',
-				'slug'  => 'jetpack',
-				'file'  => 'jetpack/jetpack.php',
-			],
 		];
 
 		// Check if WooCommerce and other dependencies are  installed and active.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -451,7 +451,7 @@ class WC_Payments {
 
 		$payments_api_client = new WC_Payments_API_Client(
 			'WooCommerce Payments/' . WCPAY_VERSION_NUMBER,
-			new WC_Payments_Http(),
+			new WC_Payments_Http( new Automattic\Jetpack\Connection\Manager() ),
 			self::$db_helper
 		);
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -68,6 +68,47 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Whether the site can communicate with the WCPay server (i.e. Jetpack connection has been established).
+	 *
+	 * @return bool
+	 */
+	public function is_server_connected() {
+		return $this->http_client->is_connected();
+	}
+
+	/**
+	 * Starts the Jetpack connection process. Note that running this function will immediately redirect
+	 * to the Jetpack flow, so any PHP code after it will never be executed.
+	 *
+	 * @param string $redirect - URL to redirect to after the connection process is over.
+	 *
+	 * @throws WC_Payments_API_Exception - Exception thrown on failure.
+	 */
+	public function start_server_connection( $redirect ) {
+		$this->http_client->start_connection( $redirect );
+	}
+
+	/**
+	 * Create a charge
+	 *
+	 * @param int    $amount    - Amount to charge.
+	 * @param string $source_id - ID of the source to associate with charge.
+	 *
+	 * @return WC_Payments_API_Charge
+	 * @throws WC_Payments_API_Exception - Exception thrown on payment failure.
+	 */
+	public function create_charge( $amount, $source_id ) {
+
+		$request           = array();
+		$request['amount'] = $amount;
+		$request['source'] = $source_id;
+
+		$response_array = $this->request( $request, self::CHARGES_API, self::POST );
+
+		return $this->deserialize_charge_object_from_array( $response_array );
+	}
+
+	/**
 	 * Create an intention, and automatically confirm it.
 	 *
 	 * @param int    $amount            - Amount to charge.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -99,7 +99,7 @@ class WC_Payments_API_Client {
 	 */
 	public function create_charge( $amount, $source_id ) {
 
-		$request           = array();
+		$request           = [];
 		$request['amount'] = $amount;
 		$request['source'] = $source_id;
 

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -45,6 +45,16 @@ class WC_Payments_Http {
 	 * @throws WC_Payments_API_Exception - If not connected or request failed.
 	 */
 	public function remote_request( $args, $body = null, $is_site_specific = true ) {
+		// Make sure we're not sending requests if Jetpack is not connected.
+		if ( ! $this->is_connected() ) {
+			Logger::error( 'HTTP_REQUEST_ERROR Site is not connected to WordPress.com' );
+			throw new WC_Payments_API_Exception(
+				__( 'Site is not connected to WordPress.com', 'woocommerce-payments' ),
+				'wcpay_wpcom_not_connected',
+				409 // HTTP Conflict status code.
+			);
+		}
+
 		$args['blog_id'] = Jetpack_Options::get_option( 'id' );
 		$args['user_id'] = Automattic\Jetpack\Connection\Manager::JETPACK_MASTER_USER;
 
@@ -52,16 +62,6 @@ class WC_Payments_Http {
 			$url         = explode( '?', $args['url'], 2 );
 			$url[0]      = sprintf( $url[0], $args['blog_id'] );
 			$args['url'] = sprintf( '%s?%s', $url[0], $url[1] );
-		}
-
-		// Make sure we're not sending requests if Jetpack is not connected.
-		if ( ! $this->is_connected() ) {
-			Logger::error( 'HTTP_REQUEST_ERROR Jetpack is not connected' );
-			throw new WC_Payments_API_Exception(
-				__( 'Jetpack is not connected', 'woocommerce-payments' ),
-				'wcpay_jetpack_not_connected',
-				409 // HTTP Conflict status code.
-			);
 		}
 
 		return self::make_request( $args, $body );

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -31,7 +31,7 @@ class WC_Payments_Http {
 	public function __construct( $connection_manager ) {
 		$this->connection_manager = $connection_manager;
 
-		add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
+		add_filter( 'allowed_redirect_hosts', [ $this, 'allowed_redirect_hosts' ] );
 	}
 
 	/**
@@ -123,13 +123,13 @@ class WC_Payments_Http {
 		// Second, redirect the user to the Jetpack user connection flow.
 		add_filter( 'jetpack_use_iframe_authorization_flow', '__return_false' );
 		// Same logic as in WC-Admin.
-		$calypso_env = defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, array( 'development', 'wpcalypso', 'horizon', 'stage' ), true ) ? WOOCOMMERCE_CALYPSO_ENVIRONMENT : 'production';
+		$calypso_env = defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, [ 'development', 'wpcalypso', 'horizon', 'stage' ], true ) ? WOOCOMMERCE_CALYPSO_ENVIRONMENT : 'production';
 		wp_safe_redirect(
 			add_query_arg(
-				array(
+				[
 					'from'        => 'woocommerce-payments',
 					'calypso_env' => $calypso_env,
-				),
+				],
 				$this->connection_manager->get_authorization_url( null, $redirect )
 			)
 		);

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -17,7 +17,25 @@ use WCPay\Logger;
 class WC_Payments_Http {
 
 	/**
-	 * Sends a remote request through Jetpack (?).
+	 * Jetpack connection handler.
+	 *
+	 * @var Automattic\Jetpack\Connection\Manager
+	 */
+	private $connection_manager;
+
+	/**
+	 * WC_Payments_Http constructor.
+	 *
+	 * @param Automattic\Jetpack\Connection\Manager $connection_manager - Jetpack connection handler.
+	 */
+	public function __construct( $connection_manager ) {
+		$this->connection_manager = $connection_manager;
+
+		add_filter( 'allowed_redirect_hosts', array( $this, 'allowed_redirect_hosts' ) );
+	}
+
+	/**
+	 * Sends a remote request through Jetpack.
 	 *
 	 * @param array  $args             - The arguments to passed to Jetpack.
 	 * @param string $body             - The body passed on to the HTTP request.
@@ -28,7 +46,7 @@ class WC_Payments_Http {
 	 */
 	public function remote_request( $args, $body = null, $is_site_specific = true ) {
 		$args['blog_id'] = Jetpack_Options::get_option( 'id' );
-		$args['user_id'] = JETPACK_MASTER_USER;
+		$args['user_id'] = Automattic\Jetpack\Connection\Manager::JETPACK_MASTER_USER;
 
 		if ( $is_site_specific ) {
 			$url         = explode( '?', $args['url'], 2 );
@@ -36,8 +54,8 @@ class WC_Payments_Http {
 			$args['url'] = sprintf( '%s?%s', $url[0], $url[1] );
 		}
 
-		// Make sure we're not sendign requests if Jetpack is not connected.
-		if ( ! self::is_connected() ) {
+		// Make sure we're not sending requests if Jetpack is not connected.
+		if ( ! $this->is_connected() ) {
 			Logger::error( 'HTTP_REQUEST_ERROR Jetpack is not connected' );
 			throw new WC_Payments_API_Exception(
 				__( 'Jetpack is not connected', 'woocommerce-payments' ),
@@ -59,13 +77,7 @@ class WC_Payments_Http {
 	 * @throws WC_Payments_API_Exception - If request returns WP_Error.
 	 */
 	private static function make_request( $args, $body ) {
-		$response = null;
-		// TODO: Either revamp this auth before releasing WCPay, or properly check that Jetpack is installed & connected.
-		if ( class_exists( 'Automattic\Jetpack\Connection\Client' ) ) {
-			$response = Automattic\Jetpack\Connection\Client::remote_request( $args, $body );
-		} else {
-			$response = Jetpack_Client::remote_request( $args, $body );
-		}
+		$response = Automattic\Jetpack\Connection\Client::remote_request( $args, $body );
 
 		if ( is_wp_error( $response ) ) {
 			Logger::error( 'HTTP_REQUEST_ERROR ' . var_export( $response, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
@@ -87,16 +99,52 @@ class WC_Payments_Http {
 	 *
 	 * @return bool true if Jetpack connection has access token.
 	 */
-	public static function is_connected() {
-		if ( class_exists( 'Automattic\Jetpack\Connection\Manager' ) ) {
-			return ( new Automattic\Jetpack\Connection\Manager() )->is_active();
+	public function is_connected() {
+		return $this->connection_manager->is_registered();
+	}
+
+	/**
+	 * Starts the Jetpack connection process. Note that running this function will immediately redirect
+	 * to the Jetpack flow, so any PHP code after it will never be executed.
+	 *
+	 * @param string $redirect - URL to redirect to after the connection process is over.
+	 *
+	 * @throws WC_Payments_API_Exception - Exception thrown on failure.
+	 */
+	public function start_connection( $redirect ) {
+		// First, register the site to wp.com.
+		if ( ! $this->connection_manager->get_access_token() ) {
+			$result = $this->connection_manager->register();
+			if ( is_wp_error( $result ) ) {
+				throw new WC_Payments_API_Exception( $result->get_error_message(), 'wcpay_jetpack_register_site_failed', 500 );
+			}
 		}
 
-		if ( class_exists( 'Jetpack_Data' ) ) {
-			// Pass true as an argument to check user token rather than blog token.
-			return (bool) Jetpack_Data::get_access_token( true );
-		}
+		// Second, redirect the user to the Jetpack user connection flow.
+		add_filter( 'jetpack_use_iframe_authorization_flow', '__return_false' );
+		// Same logic as in WC-Admin.
+		$calypso_env = defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, array( 'development', 'wpcalypso', 'horizon', 'stage' ), true ) ? WOOCOMMERCE_CALYPSO_ENVIRONMENT : 'production';
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'from'        => 'woocommerce-payments',
+					'calypso_env' => $calypso_env,
+				),
+				$this->connection_manager->get_authorization_url( null, $redirect )
+			)
+		);
+		exit;
+	}
 
-		return false;
+	/**
+	 * Filter function to add WP.com to the list of allowed redirect hosts
+	 *
+	 * @param array $hosts - array of allowed hosts.
+	 *
+	 * @return array allowed hosts
+	 */
+	public function allowed_redirect_hosts( $hosts ) {
+		$hosts[] = 'jetpack.wordpress.com';
+		return $hosts;
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -41,7 +41,6 @@ Our global support team is available to answer questions you may have about WooC
 * United States-based business.
 * WordPress 5.3 or newer.
 * WooCommerce 4.0 or newer.
-* [Jetpack](http://wordpress.org/plugins/jetpack) 5.3 or newer.
 * PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
 
 = Try it now =
@@ -50,14 +49,7 @@ To try WooCommerce Payments on your store, simply [install it](https://wordpress
 
 == Installation ==
 
-Install and activate the WooCommerce and Jetpack plugins, if you haven't already done so, and connect your site to WordPress.com.
-
-1. Log in to your WordPress dashboard.
-1. Go to: Plugins > Add New.
-1. Enter "WooCommerce Payments" in the Search field.
-1. Click "Install Now".
-1. Go to: Payments.
-1. Create your WooCommerce Payments account.
+Install and activate the WooCommerce and WooCommerce Payments plugins, if you haven't already done so, then go to "Payments" in the WordPress admin menu and follow the instructions there.
 
 == Frequently Asked Questions ==
 

--- a/tests/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/test-class-wc-payment-gateway-wcpay.php
@@ -44,8 +44,9 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 		$this->mock_api_client = $this->getMockBuilder( 'WC_Payments_API_Client' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'get_account_data' ] )
+			->setMethods( [ 'get_account_data', 'is_server_connected' ] )
 			->getMock();
+		$this->mock_api_client->expects( $this->any() )->method( 'is_server_connected' )->willReturn( true );
 
 		$this->wcpay_account = new WC_Payments_Account( $this->mock_api_client );
 

--- a/tests/test-class-wc-payments-account.php
+++ b/tests/test-class-wc-payments-account.php
@@ -42,6 +42,7 @@ class WC_Payments_Account_Test extends WP_UnitTestCase {
 		$this->mock_api_client = $this->getMockBuilder( 'WC_Payments_API_Client' )
 			->disableOriginalConstructor()
 			->getMock();
+		$this->mock_api_client->expects( $this->any() )->method( 'is_server_connected' )->willReturn( true );
 
 		$this->wcpay_account = new WC_Payments_Account( $this->mock_api_client );
 	}

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -23,6 +23,19 @@ define( 'WCPAY_PLUGIN_FILE', __FILE__ );
 define( 'WCPAY_ABSPATH', dirname( WCPAY_PLUGIN_FILE ) . '/' );
 define( 'WCPAY_MIN_WC_ADMIN_VERSION', '0.23.2' );
 
+require_once WCPAY_ABSPATH . 'vendor/autoload_packages.php';
+
+/**
+ * Initialize the Jetpack connection functionality.
+ */
+function wcpay_jetpack_init() {
+	$jetpack_config = new Automattic\Jetpack\Config();
+	$jetpack_config->ensure( 'connection' );
+}
+
+// Jetpack-config will initialize the modules on "plugins_loaded" with priority 2, so this code needs to be run before that.
+add_action( 'plugins_loaded', 'wcpay_jetpack_init', 1 );
+
 /**
  * Initialize the extension. Note that this gets called on the "plugins_loaded" filter,
  * so WooCommerce classes are guaranteed to exist at this point (if WooCommerce is enabled).


### PR DESCRIPTION
Integrates the Jetpack connection flow with the existing WCPay onboarding flow. The complete flow would be like this:
- Click the "Setup" button on the Connect WCPay page.
- If there's no Jetpack connection, redirect to wp.com to the Jetpack Connect flow.
- When the Jetpack flow ends, if WCPay is not setup, automatically redirect to Stripe's KYC flow.
- Once that flow ends, the merchant is dropped into the WCPay settings screen.

Alternate flows:
- If the site is already connected to Jetpack, clicking `Setup` will start the Stripe KYC flow.
- If the site was *not* connected to Jetpack, but when the Jetpack connection flow is completed it turns out that the site already has a WCPay account configured, the user will be dropped into the WCPay Settings page instead of starting the Stripe KYC flow. You can test this by having WCPay fully configured and then disconnecting the site from Jetpack.
- If the flow was initiated from the WC-Admin setup task list, the user will be returned to there (instead of WCPay Settings). Note: I haven't tested this yet.

To test:
- Pick the main flow or one of the alternate flows and try to get to a fully functioning WCPay extension.

Note that you still need Jetpack-the-plugin installed and activated to test this.

Also note that the Jetpack Connect design still follows the Jetpack color scheme, there will be several PRs in WP-Calypso to change that.