### PR TITLE
Use the Jetpack Connection package, remove any reference to Jetpack-the-plugin from the docs

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -59,9 +59,6 @@ cli wp import wp-content/plugins/woocommerce/sample-data/sample_products.xml --a
 echo "Installing and activating the WooCommerce Admin plugin..."
 cli wp plugin install woocommerce-admin --activate
 
-echo "Installing and activating the Jetpack plugin..."
-cli wp plugin install jetpack --activate
-
 echo "Activating the WooCommerce Payments plugin..."
 cli wp plugin activate woocommerce-payments
 

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,15 @@
       }
     },
     "require": {
+      "automattic/jetpack-connection": "^1.11.0",
+      "automattic/jetpack-config": "^1.1.0",
+      "automattic/jetpack-autoloader": "^1.6.0"
     },
     "require-dev": {
-      "composer/installers": "1.7.0",
+      "woocommerce/woocommerce": "^4.1.0",
       "phpunit/phpunit": "6.5.14",
-      "woocommerce/woocommerce": "3.9.3",
+      "composer/installers": "^1.7.0",
+      "squizlabs/php_codesniffer": "^3.9.3",
       "woocommerce/woocommerce-sniffs": "0.0.6"
     },
     "scripts": {
@@ -38,4 +42,4 @@
       },
       "installer-disable": true
     }
-  }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a9b152a82443771741fa033f8adb1c88",
-    "packages": [],
-    "packages-dev": [
+    "content-hash": "d16dd66001d8c75e1ca17bc38f70eca8",
+    "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v1.3.2",
+            "version": "v1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "301c2fbcf070d4f0147753447616b6e982bda09e"
+                "reference": "7c6736eeee0f9fc49fa691fe3e958725efb27ca0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/301c2fbcf070d4f0147753447616b6e982bda09e",
-                "reference": "301c2fbcf070d4f0147753447616b6e982bda09e",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/7c6736eeee0f9fc49fa691fe3e958725efb27ca0",
+                "reference": "7c6736eeee0f9fc49fa691fe3e958725efb27ca0",
                 "shasum": ""
             },
             "require": {
@@ -41,8 +40,173 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "time": "2019-09-24T06:39:29+00:00"
+            "time": "2020-04-23T02:28:37+00:00"
         },
+        {
+            "name": "automattic/jetpack-config",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-config.git",
+                "reference": "df7cfce4231fb50e8cd433a6ccf52e99a269c16c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/df7cfce4231fb50e8cd433a6ccf52e99a269c16c",
+                "reference": "df7cfce4231fb50e8cd433a6ccf52e99a269c16c",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
+            "time": "2020-01-21T22:42:22+00:00"
+        },
+        {
+            "name": "automattic/jetpack-connection",
+            "version": "v1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-connection.git",
+                "reference": "82d6ff077a2a69d42a2e8fb3b49135b597098d96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/82d6ff077a2a69d42a2e8fb3b49135b597098d96",
+                "reference": "82d6ff077a2a69d42a2e8fb3b49135b597098d96",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-constants": "1.2.0",
+                "automattic/jetpack-options": "1.4.0",
+                "automattic/jetpack-roles": "1.0.4"
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "legacy/load-ixr.php"
+                ],
+                "classmap": [
+                    "legacy",
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything needed to connect to the Jetpack infrastructure",
+            "time": "2020-04-28T11:14:37+00:00"
+        },
+        {
+            "name": "automattic/jetpack-constants",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-constants.git",
+                "reference": "881618defb04134ddba120e7835af1a474a11edc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/881618defb04134ddba120e7835af1a474a11edc",
+                "reference": "881618defb04134ddba120e7835af1a474a11edc",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A wrapper for defining constants in a more testable way.",
+            "time": "2020-04-15T18:58:53+00:00"
+        },
+        {
+            "name": "automattic/jetpack-options",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-options.git",
+                "reference": "48373cc3ff4e1619483f13537bf4c76d2c7efc69"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/48373cc3ff4e1619483f13537bf4c76d2c7efc69",
+                "reference": "48373cc3ff4e1619483f13537bf4c76d2c7efc69",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-constants": "1.2.0"
+            },
+            "require-dev": {
+                "10up/wp_mock": "0.4.2",
+                "phpunit/phpunit": "7.*.*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "legacy"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A wrapper for wp-options to manage specific Jetpack options.",
+            "time": "2020-04-28T11:11:50+00:00"
+        },
+        {
+            "name": "automattic/jetpack-roles",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-roles.git",
+                "reference": "0cdcff4fdc489c79f20a361c084ec48e326ce483"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/0cdcff4fdc489c79f20a361c084ec48e326ce483",
+                "reference": "0cdcff4fdc489c79f20a361c084ec48e326ce483",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities, related with user roles and capabilities.",
+            "time": "2019-11-08T21:16:05+00:00"
+        }
+    ],
+    "packages-dev": [
         {
             "name": "composer/installers",
             "version": "v1.7.0",
@@ -389,6 +553,80 @@
                 "object graph"
             ],
             "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "pelago/emogrifier",
+            "version": "v3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MyIntervals/emogrifier.git",
+                "reference": "f6a5c7d44612d86c3901c93f1592f5440e6b2cd8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MyIntervals/emogrifier/zipball/f6a5c7d44612d86c3901c93f1592f5440e6b2cd8",
+                "reference": "f6a5c7d44612d86c3901c93f1592f5440e6b2cd8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": "^5.6 || ~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4",
+                "symfony/css-selector": "^2.8 || ^3.0 || ^4.0 || ^5.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.15.3",
+                "phpmd/phpmd": "^2.7.0",
+                "phpunit/phpunit": "^5.7.27",
+                "squizlabs/php_codesniffer": "^3.5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pelago\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Zoli Szabó",
+                    "email": "zoli.szabo+github@gmail.com"
+                },
+                {
+                    "name": "John Reeve",
+                    "email": "jreeve@pelagodesign.com"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake@qzdesign.co.uk"
+                },
+                {
+                    "name": "Cameron Brooks"
+                },
+                {
+                    "name": "Jaime Prado"
+                }
+            ],
+            "description": "Converts CSS styles into inline style attributes in your HTML code",
+            "homepage": "https://www.myintervals.com/emogrifier.php",
+            "keywords": [
+                "css",
+                "email",
+                "pre-processing"
+            ],
+            "time": "2019-12-26T19:37:31+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1820,16 +2058,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.4",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dceec07328401de6211037abbb18bda423677e26"
+                "reference": "ce62dee92da3b038a399a99353fc055b39d2853e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dceec07328401de6211037abbb18bda423677e26",
-                "reference": "dceec07328401de6211037abbb18bda423677e26",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ce62dee92da3b038a399a99353fc055b39d2853e",
+                "reference": "ce62dee92da3b038a399a99353fc055b39d2853e",
                 "shasum": ""
             },
             "require": {
@@ -1867,7 +2105,60 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-01-30T22:20:29+00:00"
+            "time": "2020-05-01T04:18:46+00:00"
+        },
+        {
+            "name": "symfony/css-selector",
+            "version": "v3.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/css-selector.git",
+                "reference": "4d882dced7b995d5274293039370148e291808f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/4d882dced7b995d5274293039370148e291808f2",
+                "reference": "4d882dced7b995d5274293039370148e291808f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\CssSelector\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony CssSelector Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-05-01T15:01:29+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1983,16 +2274,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
+                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
-                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
+                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
                 "shasum": ""
             },
             "require": {
@@ -2000,7 +2291,7 @@
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "vimeo/psalm": "<3.6.0"
+                "vimeo/psalm": "<3.9.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.36 || ^7.5.13"
@@ -2027,48 +2318,96 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-02-14T12:15:55+00:00"
+            "time": "2020-04-18T12:12:48+00:00"
         },
         {
-            "name": "woocommerce/woocommerce",
-            "version": "3.9.3",
+            "name": "woocommerce/action-scheduler",
+            "version": "3.1.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/woocommerce/woocommerce.git",
-                "reference": "310a620134199758e071ad00690816a95ced2100"
+                "url": "https://github.com/woocommerce/action-scheduler.git",
+                "reference": "5a01f0b549a283dc88c2feeef877650215907a76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce/zipball/310a620134199758e071ad00690816a95ced2100",
-                "reference": "310a620134199758e071ad00690816a95ced2100",
+                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/5a01f0b549a283dc88c2feeef877650215907a76",
+                "reference": "5a01f0b549a283dc88c2feeef877650215907a76",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.6",
+                "woocommerce/woocommerce-sniffs": "0.0.8",
+                "wp-cli/wp-cli": "~1.5.1"
+            },
+            "type": "wordpress-plugin",
+            "extra": {
+                "scripts-description": {
+                    "test": "Run unit tests",
+                    "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
+                    "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "description": "Action Scheduler for WordPress and WooCommerce",
+            "homepage": "https://actionscheduler.org/",
+            "time": "2020-03-18T15:05:10+00:00"
+        },
+        {
+            "name": "woocommerce/woocommerce",
+            "version": "4.1.0-rc.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/woocommerce/woocommerce.git",
+                "reference": "a03721fcf980a676f5597fa786bb60b1dba8d9e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce/zipball/a03721fcf980a676f5597fa786bb60b1dba8d9e7",
+                "reference": "a03721fcf980a676f5597fa786bb60b1dba8d9e7",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-autoloader": "^1.2.0",
+                "automattic/jetpack-autoloader": "^1.6.0",
+                "automattic/jetpack-constants": "^1.1",
                 "composer/installers": "1.7.0",
                 "maxmind-db/reader": "1.6.0",
+                "pelago/emogrifier": "^3.1",
                 "php": ">=5.6|>=7.0",
-                "woocommerce/woocommerce-blocks": "2.5.14",
+                "woocommerce/action-scheduler": "3.1.4",
+                "woocommerce/woocommerce-admin": "1.1.0",
+                "woocommerce/woocommerce-blocks": "2.5.16",
                 "woocommerce/woocommerce-rest-api": "1.0.7"
             },
             "require-dev": {
-                "phpunit/phpunit": "7.5.18",
-                "woocommerce/woocommerce-sniffs": "0.0.9"
+                "phpunit/phpunit": "7.5.20",
+                "woocommerce/woocommerce-sniffs": "0.0.9",
+                "wp-cli/i18n-command": "^2.2"
             },
             "type": "wordpress-plugin",
             "extra": {
                 "installer-paths": {
+                    "packages/action-scheduler": [
+                        "woocommerce/action-scheduler"
+                    ],
                     "packages/woocommerce-rest-api": [
                         "woocommerce/woocommerce-rest-api"
                     ],
                     "packages/woocommerce-blocks": [
                         "woocommerce/woocommerce-blocks"
+                    ],
+                    "packages/woocommerce-admin": [
+                        "woocommerce/woocommerce-admin"
                     ]
                 },
                 "scripts-description": {
                     "test": "Run unit tests",
                     "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
-                    "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
+                    "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier",
+                    "makepot-audit": "Generate i18n/langauges/woocommerce.pot file and run audit",
+                    "makepot": "Generate i18n/langauges/woocommerce.pot file"
                 }
             },
             "autoload": {
@@ -2086,24 +2425,71 @@
             ],
             "description": "An eCommerce toolkit that helps you sell anything. Beautifully.",
             "homepage": "https://woocommerce.com/",
-            "time": "2020-03-04T09:08:17+00:00"
+            "time": "2020-04-21T17:01:33+00:00"
         },
         {
-            "name": "woocommerce/woocommerce-blocks",
-            "version": "v2.5.14",
+            "name": "woocommerce/woocommerce-admin",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "0dd70617085d2e73f3adfb38df98a90df3514816"
+                "url": "https://github.com/woocommerce/woocommerce-admin.git",
+                "reference": "3ef2eedca2b19c54f05333df9d9168a00499901b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/0dd70617085d2e73f3adfb38df98a90df3514816",
-                "reference": "0dd70617085d2e73f3adfb38df98a90df3514816",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/3ef2eedca2b19c54f05333df9d9168a00499901b",
+                "reference": "3ef2eedca2b19c54f05333df9d9168a00499901b",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-autoloader": "1.3.2",
+                "automattic/jetpack-autoloader": "^1.6.0",
+                "composer/installers": "1.7.0",
+                "php": ">=5.6|>=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "7.5.20",
+                "woocommerce/woocommerce-sniffs": "0.0.9"
+            },
+            "type": "wordpress-plugin",
+            "extra": {
+                "scripts-description": {
+                    "test": "Run unit tests",
+                    "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
+                    "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "includes/"
+                ],
+                "psr-4": {
+                    "Automattic\\WooCommerce\\Admin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "description": "A modern, javascript-driven WooCommerce Admin experience.",
+            "homepage": "https://github.com/woocommerce/woocommerce-admin",
+            "time": "2020-04-21T00:28:43+00:00"
+        },
+        {
+            "name": "woocommerce/woocommerce-blocks",
+            "version": "v2.5.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
+                "reference": "3bd91b669247000fd3f5277954701d0b148d3f1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/3bd91b669247000fd3f5277954701d0b148d3f1a",
+                "reference": "3bd91b669247000fd3f5277954701d0b148d3f1a",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-autoloader": "^1.6.0",
                 "composer/installers": "1.7.0"
             },
             "require-dev": {
@@ -2133,7 +2519,7 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "time": "2020-03-03T13:25:56+00:00"
+            "time": "2020-04-07T11:47:19+00:00"
         },
         {
             "name": "woocommerce/woocommerce-rest-api",

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -187,12 +187,6 @@ class WC_Payments {
 				'slug'  => 'woocommerce-admin',
 				'file'  => 'woocommerce-admin/woocommerce-admin.php',
 			),
-			array(
-				'name'  => 'Jetpack',
-				'class' => 'Jetpack',
-				'slug'  => 'jetpack',
-				'file'  => 'jetpack/jetpack.php',
-			),
 		);
 
 		// Check if WooCommerce and other dependencies are  installed and active.

--- a/readme.txt
+++ b/readme.txt
@@ -41,7 +41,6 @@ Our global support team is available to answer questions you may have about WooC
 * United States-based business.
 * WordPress 5.3 or newer.
 * WooCommerce 4.0 or newer.
-* [Jetpack](http://wordpress.org/plugins/jetpack) 5.3 or newer.
 * PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
 
 = Try it now =
@@ -50,14 +49,7 @@ To try WooCommerce Payments on your store, simply [install it](https://wordpress
 
 == Installation ==
 
-Install and activate the WooCommerce and Jetpack plugins, if you haven't already done so, and connect your site to WordPress.com.
-
-1. Log in to your WordPress dashboard.
-1. Go to: Plugins > Add New.
-1. Enter "WooCommerce Payments" in the Search field.
-1. Click "Install Now".
-1. Go to: Payments.
-1. Create your WooCommerce Payments account.
+Install and activate the WooCommerce and WooCommerce Payments plugins, if you haven't already done so, then go to "Payments" in the WordPress admin menu and follow the instructions there.
 
 == Frequently Asked Questions ==
 

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -23,6 +23,19 @@ define( 'WCPAY_PLUGIN_FILE', __FILE__ );
 define( 'WCPAY_ABSPATH', dirname( WCPAY_PLUGIN_FILE ) . '/' );
 define( 'WCPAY_MIN_WC_ADMIN_VERSION', '0.23.2' );
 
+require_once WCPAY_ABSPATH . 'vendor/autoload_packages.php';
+
+/**
+ * Initialize the Jetpack connection functionality.
+ */
+function wcpay_jetpack_init() {
+	$jetpack_config = new Automattic\Jetpack\Config();
+	$jetpack_config->ensure( 'connection' );
+}
+
+// The Jetpack initialization needs to be run with higher priority.
+add_action( 'plugins_loaded', 'wcpay_jetpack_init', 1 );
+
 /**
  * Initialize the extension. Note that this gets called on the "plugins_loaded" filter,
  * so WooCommerce classes are guaranteed to exist at this point (if WooCommerce is enabled).

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -33,7 +33,7 @@ function wcpay_jetpack_init() {
 	$jetpack_config->ensure( 'connection' );
 }
 
-// The Jetpack initialization needs to be run with higher priority.
+// Jetpack-config will initialize the modules on "plugins_loaded" with priority 2, so this code needs to be run before that.
 add_action( 'plugins_loaded', 'wcpay_jetpack_init', 1 );
 
 /**


### PR DESCRIPTION
Fixes #196, fixes #195, fixes #111 

In this PR:
- Remove the Jetpack-the-plugin requirement from the plugin initialisation and docs.
- Use the Jetpack connection package instead.

To test:
- Disconnect your site from Jetpack, and delete Jetpack (I would even go as far as to delete the `jetpack` folder from `wp-content/plugins`). Or start with a clean site.
- Remember to run `composer install`. If it gives you any error, `rm -rf vendor && composer install`. To be extra-sure that this will work with just the packages that will be bundled in the plugin ZIP, `rm -rf vendor && composer install --no-dev`
- Repeat the testing steps on #637, only now you won't need Jetpack installed!