### PR TITLE
Use specified return URL for redirect upon successful setup

### DIFF
--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -405,8 +405,14 @@ class WC_Payments_Account {
 
 		wp_safe_redirect(
 			add_query_arg(
-				array( 'wcpay-connection-success' => '1' ),
-				WC_Payment_Gateway_WCPay::get_settings_url()
+				[
+					'wcpay-state'                => false,
+					'wcpay-account-id'           => false,
+					'wcpay-live-publishable-key' => false,
+					'wcpay-test-publishable-key' => false,
+					'wcpay-mode'                 => false,
+					'wcpay-connection-success'   => '1',
+				]
 			)
 		);
 		exit;


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/642

#### Changes proposed in this Pull Request

Keeps current URL (already determined by `return_url` param passed earlier in the flow) when redirecting to success state, and removes existing `wcpay-` query params from it.

This doesn't address the display of a success notice at all – the closest thing currently in place is the toggled-on state – but I think that will need a WooCommerce Admin change anyway.

<img width="734" alt="Screen Shot 2020-05-06 at 12 42 32 PM" src="https://user-images.githubusercontent.com/1867547/81204416-2a41a400-8f97-11ea-9cdc-bab9a6b53273.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to the Payments task on a US store, with Jetpack connected and WCPay deactivated
- Go through OAuth flow and verify redirect to task list at the end

See more detailed test instructions in https://github.com/Automattic/woocommerce-payments/pull/594

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
