### PR TITLE
Remove create_charge and its tests

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -68,26 +68,6 @@ class WC_Payments_API_Client {
 	}
 
 	/**
-	 * Create a charge
-	 *
-	 * @param int    $amount    - Amount to charge.
-	 * @param string $source_id - ID of the source to associate with charge.
-	 *
-	 * @return WC_Payments_API_Charge
-	 * @throws WC_Payments_API_Exception - Exception thrown on payment failure.
-	 */
-	public function create_charge( $amount, $source_id ) {
-
-		$request           = array();
-		$request['amount'] = $amount;
-		$request['source'] = $source_id;
-
-		$response_array = $this->request( $request, self::CHARGES_API, self::POST );
-
-		return $this->deserialize_charge_object_from_array( $response_array );
-	}
-
-	/**
 	 * Create an intention, and automatically confirm it.
 	 *
 	 * @param int    $amount            - Amount to charge.

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -54,30 +54,6 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test a successful call to create_charge.
-	 *
-	 * @throws Exception - In the event of test failure.
-	 */
-	public function test_create_charge_success() {
-		// Mock up a test response from WP_Http.
-		$this->set_http_mock_response(
-			200,
-			array(
-				'id'      => 'test_charge_id',
-				'amount'  => 123,
-				'created' => 1557224304,
-				'status'  => 'success',
-			)
-		);
-
-		// Attempt to create a charge.
-		$result = $this->payments_api_client->create_charge( 123, 'test_source' );
-
-		// Assert amount returned is correct (ignoring other properties for now since this is a stub implementation).
-		$this->assertEquals( 123, $result->get_amount() );
-	}
-
-	/**
 	 * Test a successful call to create_intention.
 	 *
 	 * @throws Exception - In the event of test failure.


### PR DESCRIPTION
Fixes server's issue 250

#### Changes proposed in this Pull Request

* Removes `create_charge` and the tests.

#### Testing instructions

* Perform a global search and confirm the function has not been used anywhere
* Unit tests should pass
