### PR TITLE
Avoid localizing deposit date or displaying time-of-day precision

### DIFF
--- a/client/deposits/details/index.js
+++ b/client/deposits/details/index.js
@@ -35,7 +35,7 @@ export const DepositOverview = ( { depositId } ) => {
 				<div className="wcpay-deposit-date">
 					<Loadable isLoading={ isLoading } placeholder="Date placeholder">
 						{ `${ __( 'Deposit date', 'woocommerce-payments' ) }: ` }
-						{ dateI18n( 'M j, Y', moment.utc( deposit.date ).local() ) }
+						{ dateI18n( 'M j, Y', moment.utc( deposit.date ) ) }
 					</Loadable>
 				</div>
 				<div className="wcpay-deposit-status">

--- a/client/deposits/list/index.js
+++ b/client/deposits/list/index.js
@@ -48,7 +48,7 @@ export const DepositsList = () => {
 
 		const dateDisplay = (
 			<Link href={ getDetailsURL( deposit.id, 'deposits' ) }>
-				{ dateI18n( 'M j, Y / g:iA', moment.utc( deposit.date ).local() ) }
+				{ dateI18n( 'M j, Y', moment.utc( deposit.date ) ) }
 			</Link>
 		);
 

--- a/client/deposits/list/test/__snapshots__/index.js.snap
+++ b/client/deposits/list/test/__snapshots__/index.js.snap
@@ -166,7 +166,7 @@ exports[`Deposits list renders correctly 1`] = `
                   data-link-type="wc-admin"
                   href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=po_mock1"
                 >
-                  Jan 2, 2020 / 12:46PM
+                  Jan 2, 2020
                 </a>
               </td>
               <td
@@ -249,7 +249,7 @@ exports[`Deposits list renders correctly 1`] = `
                   data-link-type="wc-admin"
                   href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=po_mock2"
                 >
-                  Jan 3, 2020 / 12:46PM
+                  Jan 3, 2020
                 </a>
               </td>
               <td

--- a/client/deposits/overview/index.js
+++ b/client/deposits/overview/index.js
@@ -18,7 +18,7 @@ import Loadable from 'components/loadable';
 import { getDetailsURL } from 'components/details-link';
 
 const currency = new Currency();
-const formatDate = ( format, date ) => dateI18n( format, moment.utc( date ).local() );
+const formatDate = ( format, date ) => dateI18n( format, moment.utc( date ) );
 const getAmount = ( obj ) => currency.formatCurrency( ( obj ? obj.amount : 0 ) / 100 );
 const getDepositDate = ( deposit ) => deposit ? formatDate( 'F j, Y', deposit.date ) : '—';
 const getBalanceDepositCount = ( balance ) =>

--- a/client/deposits/overview/test/__snapshots__/index.js.snap
+++ b/client/deposits/overview/test/__snapshots__/index.js.snap
@@ -71,7 +71,7 @@ exports[`Deposits overview renders correctly 1`] = `
                 $65.74
               </span>
               <div
-                aria-label="No change from April 17, 2019"
+                aria-label="No change from April 18, 2019"
                 class="woocommerce-summary__item-delta"
                 role="presentation"
               >
@@ -98,7 +98,7 @@ exports[`Deposits overview renders correctly 1`] = `
             <span
               class="woocommerce-summary__item-prev-label"
             >
-              April 17, 2019
+              April 18, 2019
             </span>
              
             <span
@@ -131,7 +131,7 @@ exports[`Deposits overview renders correctly 1`] = `
                 $15.22
               </span>
               <div
-                aria-label="No change from Est. Apr 21, 2019"
+                aria-label="No change from Est. Apr 22, 2019"
                 class="woocommerce-summary__item-delta"
                 role="presentation"
               >
@@ -158,7 +158,7 @@ exports[`Deposits overview renders correctly 1`] = `
             <span
               class="woocommerce-summary__item-prev-label"
             >
-              Est. Apr 21, 2019
+              Est. Apr 22, 2019
             </span>
              
             <span

--- a/client/deposits/overview/test/index.js
+++ b/client/deposits/overview/test/index.js
@@ -109,7 +109,7 @@ describe( 'Deposits overview', () => {
 		mockUseDepositsOverview( overview );
 		const { getByText } = render( <DepositsOverview /> );
 		// tests run on America/New_York timezone, so date should be Apr 21
-		const nextDepositDate = getByText( 'Est. Apr 21, 2019 - In transit' );
+		const nextDepositDate = getByText( 'Est. Apr 22, 2019 - In transit' );
 		expect( nextDepositDate.parentElement.textContent ).toContain( 'Next deposit' );
 	} );
 

--- a/client/deposits/overview/test/index.js
+++ b/client/deposits/overview/test/index.js
@@ -108,7 +108,6 @@ describe( 'Deposits overview', () => {
 		const overview = getMockedOverview( { next_deposit: { status: 'in_transit' } } );
 		mockUseDepositsOverview( overview );
 		const { getByText } = render( <DepositsOverview /> );
-		// tests run on America/New_York timezone, so date should be Apr 21
 		const nextDepositDate = getByText( 'Est. Apr 22, 2019 - In transit' );
 		expect( nextDepositDate.parentElement.textContent ).toContain( 'Next deposit' );
 	} );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/609

#### Changes proposed in this Pull Request

Since the deposit date is just a date with no time-of-day precision, this change omits the time of day in the Deposits list, and changes all cases of deposit date from local to UTC.

&nbsp; | `master` | this branch
-- | -- | --
Deposits list | <img width="1254" src="https://user-images.githubusercontent.com/1867547/82073315-11c43e80-96a7-11ea-8103-ba7d2dd396cd.png"> | <img width="1260" src="https://user-images.githubusercontent.com/1867547/82073320-14bf2f00-96a7-11ea-9b40-507c08c56ed4.png">
Deposit details | <img width="426" src="https://user-images.githubusercontent.com/1867547/82073360-23a5e180-96a7-11ea-95c0-719ba5f80444.png"> | <img width="430" src="https://user-images.githubusercontent.com/1867547/82073361-243e7800-96a7-11ea-8b03-2bd76011f2e7.png">

(My locale is currently UTC-4.)

The dates in this branch are consistent with those on the Stripe dashboard [screenshots: [estimated](https://user-images.githubusercontent.com/1867547/82073520-5d76e800-96a7-11ea-967b-259a3dfecf2a.png), [actual](https://user-images.githubusercontent.com/1867547/82073504-55b74380-96a7-11ea-813e-f6882023bc39.png)].

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

With an account linked that has existing and/or estimated deposits, verify that the deposit date is accurate and has the proper precision in the:
- Deposits overview
- Deposits list
- Deposit details

Not sure how to mock the timezone to reproduce the incorrect date if testing in UTC+n, other than changing the system time on the machine.

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
