### PR TITLE
Fix typos in disputes strings

### DIFF
--- a/client/disputes/details/test/__snapshots__/index.js.snap
+++ b/client/disputes/details/test/__snapshots__/index.js.snap
@@ -483,7 +483,7 @@ exports[`Dispute details screen renders correctly for credit_not_processed dispu
           </div>
         </div>
         <p>
-          If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next the next screen.
+          If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next screen.
         </p>
         <p>
           If your customer was not refunded appropriately, you will need to accept the dispute, or resolve the issue with your customer. The credit card networks place liability for accepting disputed payments with you, the business.
@@ -1052,7 +1052,7 @@ exports[`Dispute details screen renders correctly for duplicate dispute 1`] = `
           </div>
         </div>
         <p>
-          If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next the next screen.
+          If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next screen.
         </p>
         <p>
           If there were duplicate payments, you should accept the dispute. You cannot issue a refund while a payment is being disputed. The credit card networks place liability for accepting disputed payments with you, the business.
@@ -1265,7 +1265,7 @@ exports[`Dispute details screen renders correctly for fraudulent dispute 1`] = `
           </div>
         </div>
         <p>
-          If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next the next screen.
+          If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next screen.
         </p>
         <p>
           If you believe the payment was actually made using a stolen credit card, you will need to accept the dispute. The credit card networks place liability for accepting fraudulent payments with you, the business.
@@ -1475,7 +1475,7 @@ exports[`Dispute details screen renders correctly for general dispute 1`] = `
           </div>
         </div>
         <p>
-          If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next the next screen.
+          If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next screen.
         </p>
         <div
           class="woocommerce-card__footer"
@@ -2024,7 +2024,7 @@ exports[`Dispute details screen renders correctly for product_not_received dispu
           </div>
         </div>
         <p>
-          If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next the next screen.
+          If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next screen.
         </p>
         <p>
           If you can not prove the customer received their product or service, you should accept the dispute. You cannot issue a refund while a payment is being disputed. The credit card networks place liability for accepting disputed payments with you, the business.
@@ -2231,7 +2231,7 @@ exports[`Dispute details screen renders correctly for product_unacceptable dispu
           </div>
         </div>
         <p>
-          If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next the next screen.
+          If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next screen.
         </p>
         <p>
           If you can not prove the customer received their product or service as described, you should accept the dispute. You cannot issue a refund while a payment is being disputed. The credit card networks place liability for accepting disputed payments with you, the business.
@@ -2447,7 +2447,7 @@ exports[`Dispute details screen renders correctly for subscription_canceled disp
           </div>
         </div>
         <p>
-          If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next the next screen.
+          If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next screen.
         </p>
         <p>
           If you can not prove the customer’s subscription was canceled, and or they did not follow your cancelation policy, you should accept the dispute. You cannot issue a refund while a payment is being disputed. The credit card networks place liability for accepting disputed payments with you, the business.
@@ -2657,7 +2657,7 @@ exports[`Dispute details screen renders correctly for unrecognized dispute 1`] =
           </div>
         </div>
         <p>
-          If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next the next screen.
+          If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next screen.
         </p>
         <p>
           If you can not prove the customer’s subscription was canceled, and or they did not follow your cancelation policy, you should accept the dispute. You cannot issue a refund while a payment is being disputed. The credit card networks place liability for accepting disputed payments with you, the business.

--- a/client/disputes/strings.js
+++ b/client/disputes/strings.js
@@ -18,7 +18,7 @@ export const reasons = {
 	credit_not_processed: {
 		display: __( 'Credit not processed', 'woocommerce-payments' ),
 		overview: [
-			__( 'If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next the next screen.', 'woocommerce-payments' ),
+			__( 'If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next screen.', 'woocommerce-payments' ),
 			__( 'If your customer was not refunded appropriately, you will need to accept the dispute, or resolve the issue with your customer. The credit card networks place liability for accepting disputed payments with you, the business.', 'woocommerce-payments' ),
 		],
 		summary: [
@@ -41,7 +41,7 @@ export const reasons = {
 	duplicate: {
 		display: __( 'Duplicate', 'woocommerce-payments' ),
 		overview: [
-			__( 'If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next the next screen.', 'woocommerce-payments' ),
+			__( 'If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next screen.', 'woocommerce-payments' ),
 			__( 'If there were duplicate payments, you should accept the dispute. You cannot issue a refund while a payment is being disputed. The credit card networks place liability for accepting disputed payments with you, the business.', 'woocommerce-payments' ),
 		],
 		summary: [
@@ -60,7 +60,7 @@ export const reasons = {
 	fraudulent: {
 		display: __( 'Fraudulent', 'woocommerce-payments' ),
 		overview: [
-			__( 'If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next the next screen.', 'woocommerce-payments' ),
+			__( 'If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next screen.', 'woocommerce-payments' ),
 			__( 'If you believe the payment was actually made using a stolen credit card, you will need to accept the dispute. The credit card networks place liability for accepting fraudulent payments with you, the business.', 'woocommerce-payments' ),
 		],
 		summary: [
@@ -78,7 +78,7 @@ export const reasons = {
 	general: {
 		display: __( 'General', 'woocommerce-payments' ),
 		overview: [
-			__( 'If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next the next screen.', 'woocommerce-payments' ),
+			__( 'If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next screen.', 'woocommerce-payments' ),
 		],
 		summary: [
 			__( 'This is an uncategorized dispute, so you should contact the customer for additional details to find out why the payment was disputed.', 'woocommerce-payments' ),
@@ -93,7 +93,7 @@ export const reasons = {
 	product_not_received: {
 		display: __( 'Product not received', 'woocommerce-payments' ),
 		overview: [
-			__( 'If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next the next screen.', 'woocommerce-payments' ),
+			__( 'If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next screen.', 'woocommerce-payments' ),
 			__( 'If you can not prove the customer received their product or service, you should accept the dispute. You cannot issue a refund while a payment is being disputed. The credit card networks place liability for accepting disputed payments with you, the business.', 'woocommerce-payments' ),
 		],
 		summary: [
@@ -110,7 +110,7 @@ export const reasons = {
 	product_unacceptable: {
 		display: __( 'Product unacceptable', 'woocommerce-payments' ),
 		overview: [
-			__( 'If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next the next screen.', 'woocommerce-payments' ),
+			__( 'If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next screen.', 'woocommerce-payments' ),
 			__( 'If you can not prove the customer received their product or service as described, you should accept the dispute. You cannot issue a refund while a payment is being disputed. The credit card networks place liability for accepting disputed payments with you, the business.', 'woocommerce-payments' ),
 		],
 		summary: [
@@ -130,7 +130,7 @@ export const reasons = {
 	subscription_canceled: {
 		display: __( 'Subscription canceled', 'woocommerce-payments' ),
 		overview: [
-			__( 'If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next the next screen.', 'woocommerce-payments' ),
+			__( 'If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next screen.', 'woocommerce-payments' ),
 			__( 'If you can not prove the customer’s subscription was canceled, and or they did not follow your cancelation policy, you should accept the dispute. You cannot issue a refund while a payment is being disputed. The credit card networks place liability for accepting disputed payments with you, the business.', 'woocommerce-payments' ),
 		],
 		summary: [
@@ -148,7 +148,7 @@ export const reasons = {
 	unrecognized: {
 		display: __( 'Unrecognized', 'woocommerce-payments' ),
 		overview: [
-			__( 'If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next the next screen.', 'woocommerce-payments' ),
+			__( 'If you believe the dispute is invalid, you can challenge it by submitting the appropriate evidence using the response forms on the next screen.', 'woocommerce-payments' ),
 			__( 'If you can not prove the customer’s subscription was canceled, and or they did not follow your cancelation policy, you should accept the dispute. You cannot issue a refund while a payment is being disputed. The credit card networks place liability for accepting disputed payments with you, the business.', 'woocommerce-payments' ),
 		],
 		summary: [


### PR DESCRIPTION
Fixes #661 

#### Changes proposed in this Pull Request

* Update dispute strings.

#### Testing instructions

* Check there is no duplicate `the next the next` substrings in dispute messages. 

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
