### PR TITLE
Distinguish pending requirements states to avoid misleading messaging

### DIFF
--- a/client/account-status/index.js
+++ b/client/account-status/index.js
@@ -94,7 +94,7 @@ const renderDepositsStatus = ( depositsStatus ) => {
 };
 
 const renderAccountStatusDescription = ( accountStatus ) => {
-	const { status, currentDeadline, accountLink } = accountStatus;
+	const { status, currentDeadline, pastDue, accountLink } = accountStatus;
 	if ( 'complete' === status ) {
 		return '';
 	}
@@ -113,7 +113,7 @@ const renderAccountStatusDescription = ( accountStatus ) => {
 			// eslint-disable-next-line jsx-a11y/anchor-has-content
 			{ a: <a href={ accountLink } /> }
 		);
-	} else if ( 'restricted' === status ) {
+	} else if ( 'restricted' === status && pastDue ) {
 		description = createInterpolateElement(
 			/* translators: <a> - dashboard login URL */
 			__(
@@ -123,7 +123,12 @@ const renderAccountStatusDescription = ( accountStatus ) => {
 			// eslint-disable-next-line jsx-a11y/anchor-has-content
 			{ a: <a href={ accountLink } /> }
 		);
-	} if ( 'rejected.fraud' === status ) {
+	} else if ( 'restricted' === status ) {
+		description = __(
+			'Payments and deposits are disabled for this account until business information is verified by the payment processor.',
+			'woocommerce-payments'
+		);
+	} else if ( 'rejected.fraud' === status ) {
 		description = __( 'This account has been rejected because of suspected fraudulent activity.', 'woocommerce-payments' );
 	} else if ( 'rejected.terms_of_service' === status ) {
 		description = __( 'This account has been rejected due to a Terms of Service violation.', 'woocommerce-payments' );
@@ -132,7 +137,7 @@ const renderAccountStatusDescription = ( accountStatus ) => {
 	}
 
 	if ( ! description ) {
-		return '';
+		return null;
 	}
 
 	return ( <div className="account-status__desc">{ description }</div> );

--- a/client/account-status/test/__snapshots__/index.js.snap
+++ b/client/account-status/test/__snapshots__/index.js.snap
@@ -205,6 +205,49 @@ exports[`AccountStatus renders restricted account 1`] = `
   <div
     className="account-status__desc"
   >
+    Payments and deposits are disabled for this account until business information is verified by the payment processor.
+  </div>
+</div>
+`;
+
+exports[`AccountStatus renders restricted account with overdue requirements 1`] = `
+<div>
+  <div>
+    <Chip
+      isCompact={true}
+      message="Restricted"
+      type="alert"
+    />
+    <span
+      className="account-status__info"
+    >
+      Payments:
+      <span
+        className="account-status__info__red"
+      >
+        <Component
+          size={18}
+        />
+        Disabled
+      </span>
+    </span>
+    <span
+      className="account-status__info"
+    >
+      Deposits:
+      <span
+        className="account-status__info__red"
+      >
+        <Component
+          size={18}
+        />
+        Disabled
+      </span>
+    </span>
+  </div>
+  <div
+    className="account-status__desc"
+  >
     Payments and deposits are disabled for this account until missing business information is updated. 
     <a
       href="/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments&wcpay-login=1"

--- a/client/account-status/test/index.js
+++ b/client/account-status/test/index.js
@@ -35,13 +35,26 @@ describe( 'AccountStatus', () => {
 		expect( accountStatus ).toMatchSnapshot();
 	} );
 
+	test( 'renders restricted account with overdue requirements', () => {
+		const accountStatus = renderAccountStatus( {
+			status: 'restricted',
+			paymentsEnabled: false,
+			depositsStatus: 'disabled',
+			currentDeadline: 1583844589,
+			pastDue: true,
+			accountLink: '/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments&wcpay-login=1',
+		} );
+		expect( accountStatus ).toMatchSnapshot();
+	} );
+
 	test( 'renders restricted account', () => {
 		const accountStatus = renderAccountStatus( {
 			status: 'restricted',
 			paymentsEnabled: false,
 			depositsStatus: 'disabled',
 			currentDeadline: 1583844589,
-			accountLink: '/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments&wcpay-login=1',
+			pastDue: false,
+			accountLink: '',
 		} );
 		expect( accountStatus ).toMatchSnapshot();
 	} );

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -224,10 +224,13 @@ class WC_Payments_Account {
 		}
 
 		if ( isset( $_GET['wcpay-connection-success'] ) ) {
-			$this->add_notice_to_settings_page(
-				__( 'Thanks for verifying your business details. You\'re ready to start taking payments!', 'woocommerce-payments' ),
-				'notice-success'
-			);
+			$account_status = $this->get_account_status_data();
+			if ( empty( $account_status['error'] ) && $account_status['paymentsEnabled'] ) {
+				$message = __( 'Thanks for verifying your business details. You\'re ready to start taking payments!', 'woocommerce-payments' );
+			} else {
+				$message = __( 'Thanks for verifying your business details!', 'woocommerce-payments' );
+			}
+			$this->add_notice_to_settings_page( $message, 'notice-success' );
 		}
 
 		if ( isset( $_GET['wcpay-connect'] ) && check_admin_referer( 'wcpay-connect' ) ) {

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -147,7 +147,7 @@ class WC_Payments_Account {
 			'paymentsEnabled' => $account['payments_enabled'],
 			'depositsStatus'  => $account['deposits_status'],
 			'currentDeadline' => isset( $account['current_deadline'] ) ? $account['current_deadline'] : false,
-			'pastDue'         => isset( $account['has_overdue_requirements'] ) ? $account['has_overdue_requirements'] : true,
+			'pastDue'         => isset( $account['has_overdue_requirements'] ) ? $account['has_overdue_requirements'] : false,
 			'accountLink'     => $this->get_login_url(),
 		);
 	}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -147,7 +147,7 @@ class WC_Payments_Account {
 			'paymentsEnabled' => $account['payments_enabled'],
 			'depositsStatus'  => $account['deposits_status'],
 			'currentDeadline' => isset( $account['current_deadline'] ) ? $account['current_deadline'] : false,
-			'pastDue'         => $account['has_overdue_requirements'],
+			'pastDue'         => isset( $account['has_overdue_requirements'] ) ? $account['has_overdue_requirements'] : true,
 			'accountLink'     => $this->get_login_url(),
 		);
 	}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -147,6 +147,7 @@ class WC_Payments_Account {
 			'paymentsEnabled' => $account['payments_enabled'],
 			'depositsStatus'  => $account['deposits_status'],
 			'currentDeadline' => isset( $account['current_deadline'] ) ? $account['current_deadline'] : false,
+			'pastDue'         => $account['has_overdue_requirements'],
 			'accountLink'     => $this->get_login_url(),
 		);
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/626

#### Changes proposed in this Pull Request

When the Stripe account is disabled, not due to requirements for the merchant but due to pending verification on Stripe's end, we should make clear that there is nothing for them to do. (Depends on server pull 260.)

<img width="510" src="https://user-images.githubusercontent.com/1867547/82289264-65b67800-9972-11ea-83b4-1b05a0e8ef78.png">

Before: <img width="992" src="https://user-images.githubusercontent.com/1867547/82289595-22a8d480-9973-11ea-8d02-115536411b6b.png">
After: <img width="1013" src="https://user-images.githubusercontent.com/1867547/82290549-32c1b380-9975-11ea-9bb0-9a404245e54f.png">

Also, we should avoid mentioning in the success message on redirect that they're ready to take payments if that isn't yet true.

Before: <img width="1377" src="https://user-images.githubusercontent.com/1867547/82289573-158be580-9973-11ea-982e-301ce6153e59.png">
After: <img width="1380" src="https://user-images.githubusercontent.com/1867547/82290565-3ce3b200-9975-11ea-8ca9-db4409c2434b.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

With the branch in server pull 260 checked out, onboard from the extension (not Task List) with new details – not copied from an already verified account.

Upon redirect back to the Settings page, verify the proper success message and status description.

No automated test changes, but open to adapting them for this parameter. (`status` is also currently missing from the account tests.)

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
