### PR TITLE
Display dispute currency code in dispute info

### DIFF
--- a/client/disputes/details/test/index.js
+++ b/client/disputes/details/test/index.js
@@ -31,6 +31,7 @@ describe( 'Dispute details screen', () => {
 		const dispute = {
 			id: 'dp_asdfghjkl',
 			amount: 1000,
+			currency: 'usd',
 			created: 1572590800,
 			// eslint-disable-next-line camelcase
 			evidence_details: {

--- a/client/disputes/evidence/test/index.js
+++ b/client/disputes/evidence/test/index.js
@@ -14,6 +14,7 @@ import { DisputeEvidenceForm, DisputeEvidencePage } from '../';
 const disputeNeedsResponse = {
 	id: 'dp_asdfghjkl',
 	amount: 1000,
+	currency: 'usd',
 	created: 1572590800,
 	evidence: {
 		customer_purchase_ip: '127.0.0.1',
@@ -29,6 +30,7 @@ const disputeNeedsResponse = {
 const disputeNoNeedForResponse = {
 	id: 'dp_zxcvbnm',
 	amount: 1050,
+	currency: 'usd',
 	created: 1572480800,
 	evidence: {
 		customer_purchase_ip: '127.0.0.1',

--- a/client/disputes/info/index.js
+++ b/client/disputes/info/index.js
@@ -52,7 +52,7 @@ const Info = ( { dispute, isLoading } ) => {
 			transactionId: 'Transaction link',
 		} : {
 			created: dateI18n( 'M j, Y', moment( dispute.created * 1000 ) ),
-			amount: `${ currency.formatCurrency( dispute.amount / 100 ) } ${ currency.code }`,
+			amount: `${ currency.formatCurrency( dispute.amount / 100 ) } ${ dispute.currency.toUpperCase() }`,
 			dueBy: dateI18n( 'M j, Y - g:iA', moment( dispute.evidence_details.due_by * 1000 ) ),
 			reason: composeDisputeReason( dispute ),
 			order: dispute.order ? ( <OrderLink order={ dispute.order } /> ) : null,

--- a/client/disputes/info/test/index.js
+++ b/client/disputes/info/test/index.js
@@ -15,6 +15,7 @@ describe( 'Dispute info', () => {
 		/* eslint-disable camelcase */
 		const dispute = {
 			amount: 1000,
+			currency: 'usd',
 			created: 1572590800,
 			evidence_details: {
 				due_by: 1573199200,

--- a/client/disputes/test/index.js
+++ b/client/disputes/test/index.js
@@ -16,6 +16,7 @@ describe( 'Disputes list', () => {
 				{
 					id: 'dp_asdfghjkl',
 					amount: 1000,
+					currency: 'usd',
 					created: 1572590800,
 					// eslint-disable-next-line camelcase
 					evidence_details: {
@@ -49,6 +50,7 @@ describe( 'Disputes list', () => {
 				{
 					id: 'dp_zxcvbnm',
 					amount: 1050,
+					currency: 'usd',
 					created: 1572480800,
 					// eslint-disable-next-line camelcase
 					evidence_details: {


### PR DESCRIPTION
Fixes #579 (in the short term)
Fixes https://github.com/Automattic/woocommerce-payments/issues/665

#### Changes proposed in this Pull Request

Show dispute amount currency in the dispute info view rather than attempting to show the store currency (and failing due to changes in the bundled `@woocommerce/currency` that's in latest versions of WooCommerce Admin).

`master` | this branch
-- | --
<img width="333" src="https://user-images.githubusercontent.com/1867547/82715318-94796a80-9c60-11ea-96c7-c9a73ca3274d.png"> | <img width="322" src="https://user-images.githubusercontent.com/1867547/82715325-9c390f00-9c60-11ea-9537-1dc4f84bf8e7.png">

Note: the actual amount ($3.00) is still **always formatted as USD** (the currency package default) – I've opened https://github.com/Automattic/woocommerce-payments/pull/679 to address this.

(An alternative short-term solution would be to hard-code this to `'USD'`.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to the Dispute Details and/or Challenge Dispute screen, and verify that the "Disputed amount" (listed towards the top) includes the currency code, instead of "undefined".

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
