### PR TITLE
Format currency amounts using proper currency code

### DIFF
--- a/client/deposits/details/index.js
+++ b/client/deposits/details/index.js
@@ -19,7 +19,7 @@ import Page from 'components/page';
 import Loadable from 'components/loadable';
 import './style.scss';
 
-const currency = new Currency();
+const { formatCurrency } = Currency();
 
 const Status = ( { status } ) => (
 	// Re-purpose order status indicator for deposit status.
@@ -53,7 +53,7 @@ export const DepositOverview = ( { depositId } ) => {
 			<div className="wcpay-deposit-hero">
 				<div className="wcpay-deposit-amount">
 					<Loadable isLoading={ isLoading } placeholder="Amount" display="inline">
-						{ currency.formatCurrency( deposit.amount / 100 ) }
+						{ formatCurrency( deposit.amount / 100 ) }
 					</Loadable>
 				</div>
 			</div>

--- a/client/deposits/details/index.js
+++ b/client/deposits/details/index.js
@@ -6,7 +6,6 @@
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
-import Currency from '@woocommerce/currency';
 import { Card, OrderStatus } from '@woocommerce/components';
 
 /**
@@ -17,9 +16,8 @@ import { displayStatus } from '../strings';
 import TransactionsList from 'transactions/list';
 import Page from 'components/page';
 import Loadable from 'components/loadable';
+import getCurrency from 'utils/format-currency';
 import './style.scss';
-
-const { formatCurrency } = Currency();
 
 const Status = ( { status } ) => (
 	// Re-purpose order status indicator for deposit status.
@@ -28,6 +26,8 @@ const Status = ( { status } ) => (
 
 export const DepositOverview = ( { depositId } ) => {
 	const { deposit = {}, isLoading } = useDeposit( depositId );
+
+	const { formatCurrency } = getCurrency( deposit.currency );
 
 	return (
 		<Card className="wcpay-deposit-overview">

--- a/client/deposits/list/index.js
+++ b/client/deposits/list/index.js
@@ -6,7 +6,6 @@
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
-import Currency from '@woocommerce/currency';
 import { TableCard, Link } from '@woocommerce/components';
 import { onQueryChange, getQuery } from '@woocommerce/navigation';
 
@@ -18,8 +17,7 @@ import { displayType, displayStatus } from '../strings';
 import { formatStringValue } from 'util';
 import DetailsLink, { getDetailsURL } from 'components/details-link';
 import ClickableCell from 'components/clickable-cell';
-
-const { formatCurrency } = Currency();
+import getCurrency from 'utils/format-currency';
 
 // TODO make date, amount sortable - when date is sortable, the background of the info buttons should match
 const columns = [
@@ -43,6 +41,8 @@ export const DepositsList = () => {
 	const { deposits, isLoading } = useDeposits( getQuery() );
 
 	const rows = deposits.map( ( deposit ) => {
+		const { formatCurrency } = getCurrency( deposit.currency );
+
 		const clickable = ( children ) => <ClickableCell href={ getDetailsURL( deposit.id, 'deposits' ) }>{ children }</ClickableCell>;
 		const detailsLink = <DetailsLink id={ deposit.id } parentSegment="deposits" />;
 

--- a/client/deposits/list/index.js
+++ b/client/deposits/list/index.js
@@ -19,7 +19,7 @@ import { formatStringValue } from 'util';
 import DetailsLink, { getDetailsURL } from 'components/details-link';
 import ClickableCell from 'components/clickable-cell';
 
-const currency = new Currency();
+const { formatCurrency } = Currency();
 
 // TODO make date, amount sortable - when date is sortable, the background of the info buttons should match
 const columns = [
@@ -57,7 +57,7 @@ export const DepositsList = () => {
 			details: { value: deposit.id, display: detailsLink },
 			date: { value: deposit.date, display: dateDisplay },
 			type: { value: deposit.type, display: clickable( displayType[ deposit.type ] ) },
-			amount: { value: deposit.amount / 100, display: clickable( currency.formatCurrency( deposit.amount / 100 ) ) },
+			amount: { value: deposit.amount / 100, display: clickable( formatCurrency( deposit.amount / 100 ) ) },
 			status: { value: deposit.status, display: clickable( displayStatus[ deposit.status ] || formatStringValue( deposit.status ) ) },
 			bankAccount: { value: deposit.bankAccount, display: clickable( deposit.bankAccount ) },
 		};

--- a/client/deposits/overview/index.js
+++ b/client/deposits/overview/index.js
@@ -17,9 +17,9 @@ import { useDepositsOverview } from 'data';
 import Loadable from 'components/loadable';
 import { getDetailsURL } from 'components/details-link';
 
-const currency = new Currency();
+const { formatCurrency } = Currency();
 const formatDate = ( format, date ) => dateI18n( format, moment.utc( date ) );
-const getAmount = ( obj ) => currency.formatCurrency( ( obj ? obj.amount : 0 ) / 100 );
+const getAmount = ( obj ) => formatCurrency( ( obj ? obj.amount : 0 ) / 100 );
 const getDepositDate = ( deposit ) => deposit ? formatDate( 'F j, Y', deposit.date ) : '—';
 const getBalanceDepositCount = ( balance ) =>
 	sprintf( _n( '%d deposit', '%d deposits', balance.deposits_count, 'woocommerce-payments' ), balance.deposits_count );

--- a/client/deposits/overview/index.js
+++ b/client/deposits/overview/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { SummaryListPlaceholder, SummaryList, SummaryNumber } from '@woocommerce/components';
-import Currency from '@woocommerce/currency';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 import Gridicon from 'gridicons';
@@ -16,13 +15,16 @@ import './style.scss';
 import { useDepositsOverview } from 'data';
 import Loadable from 'components/loadable';
 import { getDetailsURL } from 'components/details-link';
+import getCurrency from 'utils/format-currency';
 
-const { formatCurrency } = Currency();
+// TODO Retrieve currency from server response, and pass to getCurrency.
+const { formatCurrency } = getCurrency();
 const formatDate = ( format, date ) => dateI18n( format, moment.utc( date ) );
 const getAmount = ( obj ) => formatCurrency( ( obj ? obj.amount : 0 ) / 100 );
 const getDepositDate = ( deposit ) => deposit ? formatDate( 'F j, Y', deposit.date ) : '—';
 const getBalanceDepositCount = ( balance ) =>
 	sprintf( _n( '%d deposit', '%d deposits', balance.deposits_count, 'woocommerce-payments' ), balance.deposits_count );
+
 const getNextDepositLabelFormatted = ( deposit ) => {
 	const baseLabel = ( deposit ) ? `${ __( 'Est.', 'woocommerce-payments' ) } ${ formatDate( 'M j, Y', deposit.date ) }` : '—';
 	if ( deposit && 'in_transit' === deposit.status ) {
@@ -86,6 +88,7 @@ const getDepositScheduleDescriptor = ( { account: { deposits_schedule: schedule,
 
 const DepositsOverview = () => {
 	const { overview, isLoading } = useDepositsOverview();
+
 	return (
 		<div className="wcpay-deposits-overview">
 			<p className="wcpay-deposits-overview__schedule">

--- a/client/disputes/index.js
+++ b/client/disputes/index.js
@@ -22,7 +22,7 @@ import Page from 'components/page';
 import { reasons } from './strings';
 import { formatStringValue } from '../util';
 
-const currency = new Currency();
+const { formatCurrency } = Currency();
 
 const headers = [
 	{ key: 'details', label: '', required: true, cellClassName: 'info-button' },
@@ -60,7 +60,7 @@ export const DisputesList = ( props ) => {
 		const customer = charge.billing_details || {};
 
 		const data = {
-			amount: { value: dispute.amount / 100, display: clickable( currency.formatCurrency( dispute.amount / 100 ) ) },
+			amount: { value: dispute.amount / 100, display: clickable( formatCurrency( dispute.amount / 100 ) ) },
 			status: { value: dispute.status, display: clickable( <DisputeStatusChip status={ dispute.status } /> ) },
 			reason: { value: dispute.reason, display: clickable( reasonDisplay ) },
 			source: {

--- a/client/disputes/index.js
+++ b/client/disputes/index.js
@@ -8,7 +8,6 @@ import apiFetch from '@wordpress/api-fetch';
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
-import Currency from '@woocommerce/currency';
 import { TableCard } from '@woocommerce/components';
 
 /**
@@ -21,8 +20,7 @@ import DetailsLink, { getDetailsURL } from 'components/details-link';
 import Page from 'components/page';
 import { reasons } from './strings';
 import { formatStringValue } from '../util';
-
-const { formatCurrency } = Currency();
+import getCurrency from 'utils/format-currency';
 
 const headers = [
 	{ key: 'details', label: '', required: true, cellClassName: 'info-button' },
@@ -43,6 +41,8 @@ export const DisputesList = ( props ) => {
 	const disputesData = disputes.data || [];
 
 	const rows = disputesData.map( ( dispute ) => {
+		const { formatCurrency } = getCurrency( dispute.currency );
+
 		const order = dispute.order ? {
 			value: dispute.order.number,
 			display: <OrderLink order={ dispute.order } />,

--- a/client/disputes/info/index.js
+++ b/client/disputes/info/index.js
@@ -19,7 +19,7 @@ import { formatStringValue } from '../../util';
 import './style.scss';
 import Loadable from 'components/loadable';
 
-const currency = new Currency();
+const { formatCurrency } = Currency();
 
 const fields = [
 	{ key: 'created', label: __( 'Dispute date', 'woocommerce-payments' ) },
@@ -52,7 +52,7 @@ const Info = ( { dispute, isLoading } ) => {
 			transactionId: 'Transaction link',
 		} : {
 			created: dateI18n( 'M j, Y', moment( dispute.created * 1000 ) ),
-			amount: `${ currency.formatCurrency( dispute.amount / 100 ) } ${ dispute.currency.toUpperCase() }`,
+			amount: `${ formatCurrency( dispute.amount / 100 ) } ${ dispute.currency.toUpperCase() }`,
 			dueBy: dateI18n( 'M j, Y - g:iA', moment( dispute.evidence_details.due_by * 1000 ) ),
 			reason: composeDisputeReason( dispute ),
 			order: dispute.order ? ( <OrderLink order={ dispute.order } /> ) : null,

--- a/client/disputes/info/index.js
+++ b/client/disputes/info/index.js
@@ -6,7 +6,6 @@
 import { __ } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 import moment from 'moment';
-import Currency from '@woocommerce/currency';
 import { Link } from '@woocommerce/components';
 
 /**
@@ -16,10 +15,9 @@ import OrderLink from 'components/order-link';
 import { getDetailsURL } from 'components/details-link';
 import { reasons } from '../strings';
 import { formatStringValue } from '../../util';
+import getCurrency from 'utils/format-currency';
 import './style.scss';
 import Loadable from 'components/loadable';
-
-const { formatCurrency } = Currency();
 
 const fields = [
 	{ key: 'created', label: __( 'Dispute date', 'woocommerce-payments' ) },
@@ -42,6 +40,8 @@ const composeDisputeReason = dispute => {
 };
 
 const Info = ( { dispute, isLoading } ) => {
+	const { formatCurrency } = getCurrency( dispute.currency );
+
 	const data = isLoading ? {
 			created: 'Created date',
 			amount: 'Amount',

--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -22,7 +22,7 @@ import Loadable, { LoadableBlock } from 'components/loadable';
 import riskMappings from 'components/risk-level/strings';
 import './style.scss';
 
-const currency = new Currency();
+const { formatCurrency } = Currency();
 
 const placeholderValues = {
 	net: 0,
@@ -67,7 +67,7 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 				<div className="payment-details-summary__section">
 					<p className="payment-details-summary__amount">
 						<Loadable isLoading={ isLoading } placeholder="Amount placeholder" >
-							{ currency.formatCurrency( ( charge.amount || 0 ) / 100 ) }
+							{ formatCurrency( ( charge.amount || 0 ) / 100 ) }
 							<span className="payment-details-summary__amount-currency">
 								{ charge.currency || 'cur' }
 							</span>
@@ -78,7 +78,7 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 						{ refunded ? (
 							<p>
 								{ `${ __( 'Refunded', 'woocommerce-payments' ) }: ` }
-								{ currency.formatCurrency( -refunded / 100 ) }
+								{ formatCurrency( -refunded / 100 ) }
 							</p>
 						) : (
 							''
@@ -86,13 +86,13 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 						<p>
 							<Loadable isLoading={ isLoading } placeholder="Fee amount" >
 								{ `${ __( 'Fee', 'woocommerce-payments' ) }: ` }
-								{ currency.formatCurrency( -fee / 100 ) }
+								{ formatCurrency( -fee / 100 ) }
 							</Loadable>
 						</p>
 						<p>
 							<Loadable isLoading={ isLoading } placeholder="Net amount" >
 								{ `${ __( 'Net', 'woocommerce-payments' ) }: ` }
-								{ currency.formatCurrency( net / 100 ) }
+								{ formatCurrency( net / 100 ) }
 							</Loadable>
 						</p>
 					</div>

--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -7,7 +7,6 @@ import { __ } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 import { Button } from '@wordpress/components';
 import { Card } from '@woocommerce/components';
-import Currency from '@woocommerce/currency';
 import moment from 'moment';
 import { get } from 'lodash';
 
@@ -15,14 +14,13 @@ import { get } from 'lodash';
  * Internal dependencies.
  */
 import { getChargeAmounts } from 'utils/charge';
+import getCurrency from 'utils/format-currency';
 import PaymentStatusChip from 'components/payment-status-chip';
 import PaymentMethodDetails from 'components/payment-method-details';
 import HorizontalList from 'components/horizontal-list';
 import Loadable, { LoadableBlock } from 'components/loadable';
 import riskMappings from 'components/risk-level/strings';
 import './style.scss';
-
-const { formatCurrency } = Currency();
 
 const placeholderValues = {
 	net: 0,
@@ -60,6 +58,8 @@ const composePaymentSummaryItems = ( { charge } ) =>
 
 const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 	const { net, fee, refunded } = charge.amount ? getChargeAmounts( charge ) : placeholderValues;
+
+	const { formatCurrency } = getCurrency( charge.currency );
 
 	return (
 		<Card className="payment-details-summary-details">

--- a/client/transaction-details/summary/index.js
+++ b/client/transaction-details/summary/index.js
@@ -25,7 +25,7 @@ import PaymentMethodDetails from '../../components/payment-method-details';
 import HorizontalList from '../../components/horizontal-list';
 import './style.scss';
 
-const currency = new Currency();
+const { formatCurrency } = Currency();
 
 const TransactionSummaryDetails = ( props ) => {
 	const { transaction } = props;
@@ -34,7 +34,7 @@ const TransactionSummaryDetails = ( props ) => {
 			<div className="transaction-summary">
 				<div className="transaction-summary__section">
 					<p className="transaction-summary__amount">
-						{ currency.formatCurrency( ( transaction.amount || 0 ) / 100 ) }
+						{ formatCurrency( ( transaction.amount || 0 ) / 100 ) }
 						<span className="transaction-summary__amount-currency">{ ( transaction.currency || 'cur' ) }</span>
 						<PaymentStatusChip transaction={ transaction } />
 					</p>
@@ -42,16 +42,16 @@ const TransactionSummaryDetails = ( props ) => {
 						{ isTransactionRefunded( transaction )
 							? <p>
 								{ `${ __( 'Refunded', 'woocommerce-payments' ) }: ` }
-								{ currency.formatCurrency( ( -get( transaction, 'source.amount_refunded' ) || 0 ) / 100 ) }
+								{ formatCurrency( ( -get( transaction, 'source.amount_refunded' ) || 0 ) / 100 ) }
 							</p>
 							: '' }
 						<p>
 							{ `${ __( 'Fee', 'woocommerce-payments' ) }: ` }
-							{ currency.formatCurrency( ( -transaction.fee || 0 ) / 100 ) }
+							{ formatCurrency( ( -transaction.fee || 0 ) / 100 ) }
 						</p>
 						<p>
 							{ `${ __( 'Net', 'woocommerce-payments' ) }: ` }
-							{ currency.formatCurrency( ( transaction.net || 0 ) / 100 ) }
+							{ formatCurrency( ( transaction.net || 0 ) / 100 ) }
 						</p>
 					</div>
 				</div>

--- a/client/transaction-details/summary/index.js
+++ b/client/transaction-details/summary/index.js
@@ -7,7 +7,6 @@ import { __ } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 import { Button } from '@wordpress/components';
 import { Card } from '@woocommerce/components';
-import Currency from '@woocommerce/currency';
 import moment from 'moment';
 import { get } from 'lodash';
 
@@ -18,17 +17,19 @@ import {
 	isTransactionRefunded,
 	isTransactionPartiallyRefunded,
 	isTransactionFullyRefunded,
-} from '../../utils/transaction';
-import PaymentStatusChip from '../../components/payment-status-chip';
-import OrderLink from '../../components/order-link';
-import PaymentMethodDetails from '../../components/payment-method-details';
-import HorizontalList from '../../components/horizontal-list';
+} from 'utils/transaction';
+import getCurrency from 'utils/format-currency';
+import PaymentStatusChip from 'components/payment-status-chip';
+import OrderLink from 'components/order-link';
+import PaymentMethodDetails from 'components/payment-method-details';
+import HorizontalList from 'components/horizontal-list';
 import './style.scss';
-
-const { formatCurrency } = Currency();
 
 const TransactionSummaryDetails = ( props ) => {
 	const { transaction } = props;
+
+	const { formatCurrency } = getCurrency( transaction.currency );
+
 	return (
 		<Card className="transaction-summary-details">
 			<div className="transaction-summary">

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -6,7 +6,6 @@
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
-import Currency from '@woocommerce/currency';
 import { TableCard } from '@woocommerce/components';
 import { onQueryChange, getQuery } from '@woocommerce/navigation';
 
@@ -18,12 +17,11 @@ import OrderLink from 'components/order-link';
 import RiskLevel from 'components/risk-level';
 import ClickableCell from 'components/clickable-cell';
 import DetailsLink, { getDetailsURL } from 'components/details-link';
+import getCurrency from 'utils/format-currency';
 import { displayType } from './strings';
 import { formatStringValue } from '../../util';
 import Deposit from './deposit';
 import './style.scss';
-
-const { formatCurrency } = Currency();
 
 const columns = [
 	{ key: 'details', label: '', required: true },
@@ -123,6 +121,8 @@ export const TransactionsList = ( props ) => {
 	}
 
 	const rows = transactions.map( ( txn ) => {
+		const { formatCurrency } = getCurrency( txn.currency );
+
 		const detailsURL = getDetailsURL( txn.charge_id, 'transactions' );
 		const clickable = ( children ) => <ClickableCell href={ detailsURL }>{ children }</ClickableCell>;
 		const detailsLink = <DetailsLink id={ txn.charge_id } parentSegment="transactions" />;
@@ -158,6 +158,7 @@ export const TransactionsList = ( props ) => {
 		return columnsToDisplay.map( ( { key } ) => data[ key ] || { display: null } );
 	} );
 
+	const { formatCurrency } = getCurrency();
 	const summary = [
 		{ label: 'transactions', value: `${ transactionsSummary.count }` },
 		{ label: 'total', value: `${ formatCurrency( transactionsSummary.total / 100 ) }` },

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -23,7 +23,7 @@ import { formatStringValue } from '../../util';
 import Deposit from './deposit';
 import './style.scss';
 
-const currency = new Currency();
+const { formatCurrency } = Currency();
 
 const columns = [
 	{ key: 'details', label: '', required: true },
@@ -146,10 +146,10 @@ export const TransactionsList = ( props ) => {
 			customer_email: { value: txn.customer_email, display: clickable( txn.customer_email ) },
 			// eslint-disable-next-line camelcase
 			customer_country: { value: txn.customer_country, display: clickable( txn.customer_country ) },
-			amount: { value: txn.amount / 100, display: clickable( currency.formatCurrency( txn.amount / 100 ) ) },
+			amount: { value: txn.amount / 100, display: clickable( formatCurrency( txn.amount / 100 ) ) },
 			// fees should display as negative. The format $-9.99 is determined by WC-Admin
-			fees: { value: txn.fees / 100, display: clickable( currency.formatCurrency( ( txn.fees / 100 ) * -1 ) ) },
-			net: { value: txn.net / 100, display: clickable( currency.formatCurrency( txn.net / 100 ) ) },
+			fees: { value: txn.fees / 100, display: clickable( formatCurrency( ( txn.fees / 100 ) * -1 ) ) },
+			net: { value: txn.net / 100, display: clickable( formatCurrency( txn.net / 100 ) ) },
 			// eslint-disable-next-line camelcase
 			risk_level: { value: txn.risk_level, display: clickable( riskLevel ) },
 			deposit: { value: txn.deposit_id, display: deposit },
@@ -160,9 +160,9 @@ export const TransactionsList = ( props ) => {
 
 	const summary = [
 		{ label: 'transactions', value: `${ transactionsSummary.count }` },
-		{ label: 'total', value: `${ currency.formatCurrency( transactionsSummary.total / 100 ) }` },
-		{ label: 'fees', value: `${ currency.formatCurrency( transactionsSummary.fees / 100 ) }` },
-		{ label: 'net', value: `${ currency.formatCurrency( transactionsSummary.net / 100 ) }` },
+		{ label: 'total', value: `${ formatCurrency( transactionsSummary.total / 100 ) }` },
+		{ label: 'fees', value: `${ formatCurrency( transactionsSummary.fees / 100 ) }` },
+		{ label: 'net', value: `${ formatCurrency( transactionsSummary.net / 100 ) }` },
 	];
 
 	return (

--- a/client/utils/format-currency.js
+++ b/client/utils/format-currency.js
@@ -1,0 +1,16 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import Currency, { getCurrencyData } from '@woocommerce/currency';
+import { keyBy } from 'lodash';
+
+const currencyByCode = keyBy(
+	getCurrencyData(),
+	currency => currency.code.toLowerCase()
+);
+
+const getCurrency = ( code ) => Currency( currencyByCode[ code ] );
+
+export default getCurrency;


### PR DESCRIPTION
Addresses one aspect of https://github.com/Automattic/woocommerce-payments/issues/507

#### Changes proposed in this Pull Request

Initialize the Currency object (through which the `formatCurrency` function is exposed) with the correct currency provided with the amount being formatted.

See https://github.com/Automattic/woocommerce-payments/issues/579#issuecomment-611830927 for a change to the `@woocommerce/currency` package that this change is adapting to. Note that (as of this writing) the change are not yet released as a packaged version, which is why the tests are currently erroring out – this should be addressed by bumping the dependency package version **before merging this PR** (after the next release – cc @psealock).

I've left `TODO`s in two places – transaction summary and deposit overview – where the default currency (USD) is being used due to a currency code not yet being available in context. 

A couple of other notes:
- If currency code is not recognized (i.e. not present in [this set](https://github.com/woocommerce/woocommerce-admin/blob/f9ff2d11c1a639833ef2282aa573ea993265c699/packages/currency/src/index.js#L151-L265)), we might consider falling back to showing some "raw" amount along with the country code, though the ambiguous precision could be an issue so it might be best to make sure that all foreseeable presentment currencies are available there.
- We may or may not want to override/wrap the `formatCurrency` function to accept an integer amount, and then divide by `10 ^ precision`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test with USD payments and verify no change in behavior across any views:
- Deposits overview and list
- Deposit details
- Transactions list
- Payment details
- Disputes list
- Dispute Details and/or Challenge Dispute

Test with a different currency by changing `'usd'` to `'gbp'` (or any other supported currency).

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
