### PR TITLE
Specify method on task list redirect, to show notice and mark configured

### DIFF
--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -350,8 +350,9 @@ class WC_Payments_Account {
 		if ( strcmp( $wcpay_connect_from, 'WCADMIN_PAYMENT_TASK' ) === 0 ) {
 			$return_url = add_query_arg(
 				array(
-					'page' => 'wc-admin',
-					'task' => 'payments',
+					'page'   => 'wc-admin',
+					'task'   => 'payments',
+					'method' => 'wcpay',
 				),
 				admin_url( 'admin.php' )
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Upon completion of onboarding, redirect back to the WCPay task, rather than the Payments screen, so that the **success notice** can be shown (before automatically redirecting to the Payments task upon marking the task "configured") [[code](https://github.com/woocommerce/woocommerce-admin/blob/f9ff2d11c1a639833ef2282aa573ea993265c699/client/task-list/tasks/payments/wcpay.js#L31-L41)].

This should be **released _after_ the WooCommerce 4.2 release** due to the change in condition [here](https://github.com/woocommerce/woocommerce-admin/pull/4373/files#diff-d026254daa29e061b18a2312e374b637R32), which will mark the WCPay task "configured" and redirect back to the Payments task, rather than stranding them in the WCPay task.

Redirected view, tested with the query condition fix in WooCommerce Admin 1.2.3:

<img width="1152" alt="success-message" src="https://user-images.githubusercontent.com/1867547/82832033-04b60500-9e88-11ea-8011-07fab03ee99b.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

With no account connected, set `define( 'WCPAY_DEV_MODE', true );` for test account onboarding, and go to Task list ("WooCommerce" in the nav) » Set up payments » WooCommerce Payments "Set up" » "Verify details". After completion of onboarding, make sure that it takes you back to the Payments task (as before) but shows a success notice at bottom.

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
