### PR TITLE
Add a note about handling a Stripe JavaScript upgrade

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -256,7 +256,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			// Register Stripe's JavaScript using the same ID as the Stripe Gateway plugin. This prevents this JS being
 			// loaded twice in the event a site has both plugins enabled. We still run the risk of different plugins
-			// loading different versions however.
+			// loading different versions however. If Stripe release a v4 of their JavaScript, we could consider
+			// changing the ID to stripe_v4. This would allow older plugins to keep using v3 while we used any new
+			// feature in v4. Stripe have allowed loading of 2 different versions of stripe.js in the past (
+			// https://stripe.com/docs/stripe-js/elements/migrating).
 			wp_register_script(
 				'stripe',
 				'https://js.stripe.com/v3/',


### PR DESCRIPTION
Fixes #53 

I think the issue can be closed without any actual code changes, I've just added a comment to the code so that we see it if we ever need to upgrade the Stripe JavaScript version.

What I've investigated:

* I've tested having the WCPay and Stripe plugins active on the same site, I can checkout with either method successfully and we don't get any JavaScript errors (because we're using the same script ID in both plugins).
* As noted in the issue, we can't really control if other plugins try to include stripe.js. What we can do is recommend that they also use the same script ID in the event we become aware of any compatibility issues.
* If Stripe release a v4 of their JavaScript in the future, we might have a situation where WCPay is using v4 and the Stripe plugin is using v3 (for example). In their [migration guide for v2 to v3](https://stripe.com/docs/stripe-js/elements/migrating), Stripe says: "If you need to use both versions of Stripe.js for some period of time, they can be loaded and used on the same page.". Hopefully the same would apply for a v3 to v4 migration. Given that, we could update the script ID to something like `stripe_v4`, which would cause both plugins to load their own versions until we got them both onto the same one. There's no suggestion that Stripe will release a v4 of their JavaScript any time soon, but given this might happen at an unknown point in the future it felt worth while having the note close to the code.

I'm also open to not merging this PR and simply closing the issue in case anyone thinks the additional comment makes things less clear.