### PR TITLE
Set charge id metadata before payment_complete()

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -391,6 +391,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 							wc_price( $amount ),
 							$intent_id
 						);
+
+						$order->update_meta_data( '_intent_id', $intent_id );
+						$order->update_meta_data( '_charge_id', $intent->get_charge_id() );
+						$order->update_meta_data( '_intention_status', $status );
+						$order->save();
+
 						$order->add_order_note( $note );
 						$order->payment_complete( $intent_id );
 						break;
@@ -407,8 +413,15 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 							wc_price( $amount ),
 							$intent_id
 						);
+
 						$order->update_status( 'on-hold', $note );
 						$order->set_transaction_id( $intent_id );
+
+						$order->update_meta_data( '_intent_id', $intent_id );
+						$order->update_meta_data( '_charge_id', $intent->get_charge_id() );
+						$order->update_meta_data( '_intention_status', $status );
+						$order->save();
+
 						break;
 					case 'requires_action':
 						// Add a note in case the customer does not complete the payment (exits the page),
@@ -436,11 +449,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 							'redirect' => sprintf( '#wcpay-confirm-pi:%s:%s', $order_id, $intent->get_client_secret() ),
 						];
 				}
-
-				$order->update_meta_data( '_intent_id', $intent_id );
-				$order->update_meta_data( '_charge_id', $intent->get_charge_id() );
-				$order->update_meta_data( '_intention_status', $status );
-				$order->save();
 			} else {
 				$order->payment_complete();
 			}


### PR DESCRIPTION
Fixes #681 

The changes here are moving the `$order->update_meta_data()` calls to happen before calling `$order->payment_complete()`.

This is so that the _charge_id metadata is saved in case something goes wrong while marking the payment complete. If something goes wrong, the store owner will still be able to see the related charge ID in the order edit screen, and will be able to use it for example to process a refund, etc.

# The problem

A store owner contacted us and told us about a customer who checked out multiple times. There was an error message shown during each payment. So the customer tried several times to complete the payment. However, each payment was in fact successful. Each payment created its own order, which had the status `processing`. The store owner wanted to refund the customer, but found out that there was no available refund button. This is because the `_charge_id` metadata was not recorded for each order. Once the `_charge_id` metadata was added manually to the DB, the refund button appeared.

## This is what we know about each payment:
- The charge went through successfully in the payment system
- There is a charge id (ch_...) available for the successful payment
- `_charge_id` was not added to the wp_postmeta table
- There was a problem checking out - an error was shown to the customer after payment
- There was an order associated per charge (so a new session for each payment?)
- The order status was `processing`
- No email received about the bad orders

## This is what we can gather about the code execution in `process_payment()`:
- There was likely a problem while calling `$order->payment_complete()` and the rest of the code was not executed.
- There was no exception thrown, though, since the order status was not `failed`. If there was an exception caught, we'd mark the order failed.

<img width="895" alt="code_execution_in_processing_order" src="https://user-images.githubusercontent.com/11487924/83321700-5eee0600-a28c-11ea-85f1-d8ba1bca5b22.png">

_Note this code is what was available in WooCommerce Payments version 1.0.0. The current code has a similar issue._

Orders are marked `processing` when calling `payment_complete()`. Emails are sent using the hook `woocommerce_order_status_pending_to_processing`, which gets called here:

https://github.com/woocommerce/woocommerce/blob/fabebd9c6a3d75dbb25af463040c4329d8df2c05/includes/class-wc-order.php#L372

So, it's likely nothing past that line was executed, resulting in the state that was described above.

## What else?

I find it pretty strange that something would go wrong in `payment_complete()` without any indication in the logs.

# Testing
You can test this by stepping through the code during checkout, and noticing that the order metadata for `_charge_id` is added before executing `payment_complete()`.