### PR TITLE
Put back timeline into data store initialization

### DIFF
--- a/client/data/store.js
+++ b/client/data/store.js
@@ -11,6 +11,7 @@ import { STORE_NAME } from './constants';
 import * as deposits from './deposits';
 import * as transactions from './transactions';
 import * as charges from './charges';
+import * as timeline from './timeline';
 
 // Extracted into wrapper function to facilitate testing.
 export const initStore = () => registerStore( STORE_NAME, {
@@ -18,22 +19,26 @@ export const initStore = () => registerStore( STORE_NAME, {
 		deposits: deposits.reducer,
 		transactions: transactions.reducer,
 		charges: charges.reducer,
+		timeline: timeline.reducer,
 	} ),
 	actions: {
 		...deposits.actions,
 		...transactions.actions,
 		...charges.actions,
+		...timeline.actions,
 	},
 	controls,
 	selectors: {
 		...deposits.selectors,
 		...transactions.selectors,
 		...charges.selectors,
+		...timeline.selectors,
 	},
 	resolvers: {
 		...deposits.resolvers,
 		...transactions.resolvers,
 		...charges.resolvers,
+		...timeline.resolvers,
 	},
 } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Timeline changes were missed during rebase in #580. This PR fixes it.
h/t @dechov for [catching](https://github.com/Automattic/woocommerce-payments/pull/580/files/6d237e0d9a9e76c37bcbd2b9f63c14cd8c704d43#r433290970) this.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch site.
* Open redux dev tools and check `root.timeline` state is present it `wc/payments` data store.

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
