### PR TITLE
After onboarding, redirect to the WCPay task of the task list, instead of to the task list

### DIFF
--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -329,8 +329,9 @@ class WC_Payments_Account {
 		if ( strcmp( $wcpay_connect_from, 'WCADMIN_PAYMENT_TASK' ) === 0 ) {
 			$return_url = add_query_arg(
 				[
-					'page' => 'wc-admin',
-					'task' => 'payments',
+					'page'   => 'wc-admin',
+					'task'   => 'payments',
+					'method' => 'wcpay',
 				],
 				admin_url( 'admin.php' )
 			);


### PR DESCRIPTION
When the onboarding process is started on the WC-Admin task list, an special parameter is set to after the onboarding is completed the merchant is redirected back to the task list.

There's some logic in WC-Admin to show a success notice in that case ([here](https://github.com/woocommerce/woocommerce-admin/blob/4cf137ff2d1240478395abf787795740b5cd8939/client/task-list/tasks/payments/wcpay.js#L32-L41)).

Right now, the redirect is made to `page=wc-admin&task=payments`, so that notice is never shown.

This PR changes it so the redirect is made to `page=wc-admin&task=payments&method=wcpay`. That way, the logic I linked will trigger, a success "toast" notice will be displayed before rendering the Payments task list again.

An easy way to (indirectly) test this is:
- Make sure you have WCPay installed and activated.
- Go to `/wp-admin/admin.php?page=wc-admin&task=payments&wcpay-connection-success=1` manually (paste the URL in the URL bar). You won't see a notice. You'll see the payments task list.
- Go to `/wp-admin/admin.php?page=wc-admin&task=payments&method=wcpay&wcpay-connection-success=1`. You *will* see a notice. You'll see the payments task list.