### PR TITLE
Fix clearing of pagination when selecting transactions advanced filters

### DIFF
--- a/client/transactions/filters/config.js
+++ b/client/transactions/filters/config.js
@@ -18,7 +18,7 @@ export const filters = 	[
 	{
 		label: __( 'Show', 'woocommerce-payments' ),
 		param: 'filter',
-		staticParams: [],
+		staticParams: [ 'paged', 'per_page' ],
 		showFilters: () => true,
 		filters: [
 			{ label: __( 'All transactions', 'woocommerce-payments' ), value: 'all' },


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-admin/issues/4422 has been fixed by supplying staticParams to the filters config in the applicable reports. This commit does the same for transactions filters to avoid pagination from being reset when toggling filter modes.

Fixes #705 

#### Changes proposed in this Pull Request

* Add `paged` and `per_page` static parameters to transactions filters 

#### Testing instructions

1. Navigate to the transactions list
2. Go to page 2 or select a non-default value for Rows per page
3. Select Advanced filters
4. The list should stay on the same page until new filters are applied

-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
