### PR TITLE
Fix undefined offset notice for site-specific URL with no query string

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -31,6 +31,7 @@ class WC_Payments_Http {
 		$args['user_id'] = JETPACK_MASTER_USER;
 
 		if ( $is_site_specific ) {
+			// We expect `url` to include a `%s` placeholder which will allow us inject the blog id.
 			$url         = explode( '?', $args['url'], 2 );
 			$url[0]      = sprintf( $url[0], $args['blog_id'] );
 			$args['url'] = implode( '?', $url );


### PR DESCRIPTION
Fixes #713 

#### Changes proposed in this Pull Request

* Fix undefined offset notice when building the site-specific URL in `remote_request`

#### Testing instructions

1. Navigate to the settings page
2. Click on the "View and edit account details" link
3. You should be redirected to Stripe
4. Check your logs, you should see an "Undefined offset: 1" notice
5. Apply this branch and click on the link
6. You should be redirected to Stripe and no notices should be logged

-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->

cc @dechov 