### PR TITLE
Add transactions search bar

### DIFF
--- a/client/data/transactions/hooks.js
+++ b/client/data/transactions/hooks.js
@@ -34,27 +34,48 @@ export const useTransactions = (
 				isResolving,
 			} = select( STORE_NAME );
 
-	const query = {
-		paged: Number.isNaN( parseInt( paged, 10 ) ) ? '1' : paged,
-		perPage: Number.isNaN( parseInt( perPage, 10 ) ) ? '25' : perPage,
-		orderby: orderby || 'date',
-		order: order || 'desc',
-		match,
-		dateBefore,
-		dateAfter,
-		dateBetween: dateBetween && dateBetween.sort( ( a, b ) => moment( a ).diff( moment( b ) ) ),
-		typeIs,
-		typeIsNot,
-		depositId,
-		search,
-	};
+			const query = {
+				paged: Number.isNaN( parseInt( paged, 10 ) ) ? '1' : paged,
+				perPage: Number.isNaN( parseInt( perPage, 10 ) )
+					? '25'
+					: perPage,
+				orderby: orderby || 'date',
+				order: order || 'desc',
+				match,
+				dateBefore,
+				dateAfter,
+				dateBetween:
+					dateBetween &&
+					dateBetween.sort( ( a, b ) =>
+						moment( a ).diff( moment( b ) )
+					),
+				typeIs,
+				typeIsNot,
+				depositId,
+				search,
+			};
 
-	return {
-		transactions: getTransactions( query ),
-		transactionsError: getTransactionsError( query ),
-		isLoading: isResolving( 'getTransactions', [ query ] ),
-	};
-}, [ paged, perPage, orderby, order, match, dateBefore, dateAfter, dateBetween, typeIs, typeIsNot, depositId, search ] );
+			return {
+				transactions: getTransactions( query ),
+				transactionsError: getTransactionsError( query ),
+				isLoading: isResolving( 'getTransactions', [ query ] ),
+			};
+		},
+		[
+			paged,
+			perPage,
+			orderby,
+			order,
+			match,
+			dateBefore,
+			dateAfter,
+			dateBetween,
+			typeIs,
+			typeIsNot,
+			depositId,
+			search,
+		]
+	);
 
 export const useTransactionsSummary = (
 	{
@@ -74,19 +95,30 @@ export const useTransactionsSummary = (
 				STORE_NAME
 			);
 
-	const query = {
-		match,
-		dateBefore,
-		dateAfter,
-		dateBetween,
-		typeIs,
-		typeIsNot,
-		depositId,
-		search,
-	};
+			const query = {
+				match,
+				dateBefore,
+				dateAfter,
+				dateBetween,
+				typeIs,
+				typeIsNot,
+				depositId,
+				search,
+			};
 
-	return {
-		transactionsSummary: getTransactionsSummary( query ),
-		isLoading: isResolving( 'getTransactionsSummary', [ query ] ),
-	};
-}, [ match, dateBefore, dateAfter, dateBetween, typeIs, typeIsNot, depositId, search ] );
+			return {
+				transactionsSummary: getTransactionsSummary( query ),
+				isLoading: isResolving( 'getTransactionsSummary', [ query ] ),
+			};
+		},
+		[
+			match,
+			dateBefore,
+			dateAfter,
+			dateBetween,
+			typeIs,
+			typeIsNot,
+			depositId,
+			search,
+		]
+	);

--- a/client/data/transactions/hooks.js
+++ b/client/data/transactions/hooks.js
@@ -22,6 +22,7 @@ export const useTransactions = (
 		date_between: dateBetween,
 		type_is: typeIs,
 		type_is_not: typeIsNot,
+		search,
 	},
 	depositId
 ) =>
@@ -33,46 +34,27 @@ export const useTransactions = (
 				isResolving,
 			} = select( STORE_NAME );
 
-			const query = {
-				paged: Number.isNaN( parseInt( paged, 10 ) ) ? '1' : paged,
-				perPage: Number.isNaN( parseInt( perPage, 10 ) )
-					? '25'
-					: perPage,
-				orderby: orderby || 'date',
-				order: order || 'desc',
-				match,
-				dateBefore,
-				dateAfter,
-				dateBetween:
-					dateBetween &&
-					dateBetween.sort( ( a, b ) =>
-						moment( a ).diff( moment( b ) )
-					),
-				typeIs,
-				typeIsNot,
-				depositId,
-			};
+	const query = {
+		paged: Number.isNaN( parseInt( paged, 10 ) ) ? '1' : paged,
+		perPage: Number.isNaN( parseInt( perPage, 10 ) ) ? '25' : perPage,
+		orderby: orderby || 'date',
+		order: order || 'desc',
+		match,
+		dateBefore,
+		dateAfter,
+		dateBetween: dateBetween && dateBetween.sort( ( a, b ) => moment( a ).diff( moment( b ) ) ),
+		typeIs,
+		typeIsNot,
+		depositId,
+		search,
+	};
 
-			return {
-				transactions: getTransactions( query ),
-				transactionsError: getTransactionsError( query ),
-				isLoading: isResolving( 'getTransactions', [ query ] ),
-			};
-		},
-		[
-			paged,
-			perPage,
-			orderby,
-			order,
-			match,
-			dateBefore,
-			dateAfter,
-			dateBetween,
-			typeIs,
-			typeIsNot,
-			depositId,
-		]
-	);
+	return {
+		transactions: getTransactions( query ),
+		transactionsError: getTransactionsError( query ),
+		isLoading: isResolving( 'getTransactions', [ query ] ),
+	};
+}, [ paged, perPage, orderby, order, match, dateBefore, dateAfter, dateBetween, typeIs, typeIsNot, depositId, search ] );
 
 export const useTransactionsSummary = (
 	{
@@ -82,6 +64,7 @@ export const useTransactionsSummary = (
 		date_between: dateBetween,
 		type_is: typeIs,
 		type_is_not: typeIsNot,
+		search,
 	},
 	depositId
 ) =>
@@ -91,28 +74,19 @@ export const useTransactionsSummary = (
 				STORE_NAME
 			);
 
-			const query = {
-				match,
-				dateBefore,
-				dateAfter,
-				dateBetween,
-				typeIs,
-				typeIsNot,
-				depositId,
-			};
+	const query = {
+		match,
+		dateBefore,
+		dateAfter,
+		dateBetween,
+		typeIs,
+		typeIsNot,
+		depositId,
+		search,
+	};
 
-			return {
-				transactionsSummary: getTransactionsSummary( query ),
-				isLoading: isResolving( 'getTransactionsSummary', [ query ] ),
-			};
-		},
-		[
-			match,
-			dateBefore,
-			dateAfter,
-			dateBetween,
-			typeIs,
-			typeIsNot,
-			depositId,
-		]
-	);
+	return {
+		transactionsSummary: getTransactionsSummary( query ),
+		isLoading: isResolving( 'getTransactionsSummary', [ query ] ),
+	};
+}, [ match, dateBefore, dateAfter, dateBetween, typeIs, typeIsNot, depositId, search ] );

--- a/client/data/transactions/resolvers.js
+++ b/client/data/transactions/resolvers.js
@@ -30,6 +30,7 @@ const formatQueryFilters = ( query ) => ( {
 	type_is: query.typeIs,
 	type_is_not: query.typeIsNot,
 	deposit_id: query.depositId,
+	search: query.search,
 } );
 /*eslint-enable camelcase*/
 

--- a/client/data/transactions/test/resolvers.js
+++ b/client/data/transactions/test/resolvers.js
@@ -32,6 +32,7 @@ const filterQuery = {
 	typeIs: 'charge',
 	typeIsNot: 'dispute',
 	depositId: 'mock_po_id',
+	search: 'Test user',
 };
 
 describe( 'getTransactions resolver', () => {
@@ -41,7 +42,7 @@ describe( 'getTransactions resolver', () => {
 		'page=1&pagesize=25&sort=date&direction=desc' +
 		'&match=all&date_before=2020-04-29%2003%3A59%3A59&date_after=2020-04-29%2004%3A00%3A00' +
 		'&date_between%5B0%5D=2020-04-28%2004%3A00%3A00&date_between%5B1%5D=2020-04-30%2003%3A59%3A59&type_is=charge' +
-		'&type_is_not=dispute&deposit_id=mock_po_id';
+		'&type_is_not=dispute&deposit_id=mock_po_id&search=Test%20user';
 	let generator = null;
 
 	beforeEach( () => {
@@ -80,7 +81,7 @@ describe( 'getTransactionsSummary resolver', () => {
 	const expectedQueryString =
 		'match=all&date_before=2020-04-29%2003%3A59%3A59&date_after=2020-04-29%2004%3A00%3A00' +
 		'&date_between%5B0%5D=2020-04-28%2004%3A00%3A00&date_between%5B1%5D=2020-04-30%2003%3A59%3A59&type_is=charge' +
-		'&type_is_not=dispute&deposit_id=mock_po_id';
+		'&type_is_not=dispute&deposit_id=mock_po_id&search=Test%20user';
 	let generator = null;
 
 	beforeEach( () => {

--- a/client/transactions/autocompleter.js
+++ b/client/transactions/autocompleter.js
@@ -1,0 +1,125 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
+import interpolateComponents from 'interpolate-components';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies
+ */
+
+/**
+ * Parse a string suggestion, split apart by where the first matching query is.
+ * Used to display matched partial in bold.
+ *
+ * @param {string} suggestion The item's label as returned from the API.
+ * @param {string} query The search term to match in the string.
+ * @return {Object} A list in three parts: before, match, and after.
+ */
+export function computeSuggestionMatch( suggestion, query ) {
+	if ( ! query ) {
+		return null;
+	}
+	const indexOfMatch = suggestion
+		.toLocaleLowerCase()
+		.indexOf( query.toLocaleLowerCase() );
+
+	if ( -1 === indexOfMatch ) {
+		return null;
+	}
+
+	return {
+		suggestionBeforeMatch: decodeEntities( suggestion.substring( 0, indexOfMatch ) ),
+		suggestionMatch: decodeEntities( suggestion.substring(
+			indexOfMatch,
+			indexOfMatch + query.length
+		) ),
+		suggestionAfterMatch: decodeEntities( suggestion.substring(
+			indexOfMatch + query.length
+		) ),
+	};
+}
+
+/**
+ * @typedef {Object} Completer
+ */
+
+/**
+ * A transaction completer.
+ * See https://github.com/WordPress/gutenberg/tree/master/packages/components/src/autocomplete#the-completer-interface
+ *
+ * @type {Completer}
+ */
+export default {
+	name: 'transactions',
+	className: 'woocommerce-search__transactions-result',
+	options( name ) {
+		const query = name ? { query: name } : {};
+		return apiFetch( {
+			path: addQueryArgs( '/wc/v3/payments/transactions/search', query ),
+		} )
+		// Transform customer name and email to be of format 'Name (email)'.
+		.then( options => options.map( option => ( { customer: `${ option.customer_name } (${ option.customer_email })` } ) ) );
+	},
+	isDebounced: true,
+	getOptionIdentifier( option ) {
+		return option.customer;
+	},
+	getOptionKeywords( option ) {
+		return [ option.customer ];
+	},
+	getFreeTextOptions( query ) {
+		const label = (
+			<span key="name" className="woocommerce-search__result-name">
+				{ interpolateComponents( {
+					mixedString: __(
+						'All transactions with transaction names or emails that include {{query /}}',
+						'woocommerce-admin'
+					),
+					components: {
+						query: (
+							<strong className="components-form-token-field__suggestion-match">
+								{ query }
+							</strong>
+						),
+					},
+				} ) }
+			</span>
+		);
+		const nameOption = {
+			key: 'name',
+			label,
+			// eslint-disable-next-line camelcase
+			value: { customer: query },
+		};
+
+		return [ nameOption ];
+	},
+	getOptionLabel( option, query ) {
+		const match = computeSuggestionMatch( option.customer, query );
+		return (
+			<span
+				key="name"
+				className="woocommerce-search__result-name"
+				aria-label={ option.customer }
+			>
+				{ match.suggestionBeforeMatch }
+				<strong className="components-form-token-field__suggestion-match">
+					{ match.suggestionMatch }
+				</strong>
+				{ match.suggestionAfterMatch }
+			</span>
+		);
+	},
+	// This is slightly different than gutenberg/Autocomplete, we don't support different methods
+	// of replace/insertion, so we can just return the value.
+	getOptionCompletion( option ) {
+		return {
+			key: option.customer,
+			label: option.customer,
+		};
+	},
+};

--- a/client/transactions/autocompleter.js
+++ b/client/transactions/autocompleter.js
@@ -60,16 +60,14 @@ export default {
 		const query = name ? { query: name } : {};
 		return apiFetch( {
 			path: addQueryArgs( '/wc/v3/payments/transactions/search', query ),
-		} )
-		// Transform customer name and email to be of format 'Name (email)'.
-		.then( options => options.map( option => ( { customer: `${ option.customer_name } (${ option.customer_email })` } ) ) );
+		} );
 	},
 	isDebounced: true,
 	getOptionIdentifier( option ) {
-		return option.customer;
+		return option.label;
 	},
 	getOptionKeywords( option ) {
-		return [ option.customer ];
+		return [ option.label ];
 	},
 	getFreeTextOptions( query ) {
 		const label = (
@@ -93,18 +91,18 @@ export default {
 			key: 'name',
 			label,
 			// eslint-disable-next-line camelcase
-			value: { customer: query },
+			value: { label: query },
 		};
 
 		return [ nameOption ];
 	},
 	getOptionLabel( option, query ) {
-		const match = computeSuggestionMatch( option.customer, query );
+		const match = computeSuggestionMatch( option.label, query );
 		return (
 			<span
 				key="name"
 				className="woocommerce-search__result-name"
-				aria-label={ option.customer }
+				aria-label={ option.label }
 			>
 				{ match.suggestionBeforeMatch }
 				<strong className="components-form-token-field__suggestion-match">
@@ -118,8 +116,8 @@ export default {
 	// of replace/insertion, so we can just return the value.
 	getOptionCompletion( option ) {
 		return {
-			key: option.customer,
-			label: option.customer,
+			key: option.label,
+			label: option.label,
 		};
 	},
 };

--- a/client/transactions/autocompleter.js
+++ b/client/transactions/autocompleter.js
@@ -74,7 +74,7 @@ export default {
 			<span key="name" className="woocommerce-search__result-name">
 				{ interpolateComponents( {
 					mixedString: __(
-						'All transactions with transaction names or emails that include {{query /}}',
+						'All transactions with customer names or billing emails that include {{query /}}',
 						'woocommerce-admin'
 					),
 					components: {

--- a/client/transactions/autocompleter.js
+++ b/client/transactions/autocompleter.js
@@ -56,8 +56,9 @@ export function computeSuggestionMatch( suggestion, query ) {
 export default {
 	name: 'transactions',
 	className: 'woocommerce-search__transactions-result',
-	options( name ) {
-		const query = name ? { query: name } : {};
+	options( term ) {
+		// eslint-disable-next-line camelcase
+		const query = term ? { search_term: term } : {};
 		return apiFetch( {
 			path: addQueryArgs( '/wc/v3/payments/transactions/search', query ),
 		} );
@@ -88,10 +89,8 @@ export default {
 			</span>
 		);
 		const nameOption = {
-			key: 'name',
+			key: 'all',
 			label,
-			// eslint-disable-next-line camelcase
-			value: { label: query },
 		};
 
 		return [ nameOption ];

--- a/client/transactions/autocompleter.js
+++ b/client/transactions/autocompleter.js
@@ -59,6 +59,7 @@ export default {
 		const nameOption = {
 			key: 'all',
 			label,
+			value: { label: query },
 		};
 
 		return [ nameOption ];

--- a/client/transactions/autocompleter.js
+++ b/client/transactions/autocompleter.js
@@ -5,43 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import interpolateComponents from 'interpolate-components';
-import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
  */
-
-/**
- * Parse a string suggestion, split apart by where the first matching query is.
- * Used to display matched partial in bold.
- *
- * @param {string} suggestion The item's label as returned from the API.
- * @param {string} query The search term to match in the string.
- * @return {Object} A list in three parts: before, match, and after.
- */
-export function computeSuggestionMatch( suggestion, query ) {
-	if ( ! query ) {
-		return null;
-	}
-	const indexOfMatch = suggestion
-		.toLocaleLowerCase()
-		.indexOf( query.toLocaleLowerCase() );
-
-	if ( -1 === indexOfMatch ) {
-		return null;
-	}
-
-	return {
-		suggestionBeforeMatch: decodeEntities( suggestion.substring( 0, indexOfMatch ) ),
-		suggestionMatch: decodeEntities( suggestion.substring(
-			indexOfMatch,
-			indexOfMatch + query.length
-		) ),
-		suggestionAfterMatch: decodeEntities( suggestion.substring(
-			indexOfMatch + query.length
-		) ),
-	};
-}
+import computeSuggestionMatch from 'utils/compute-suggestion-match';
 
 /**
  * @typedef {Object} Completer

--- a/client/transactions/filters/config.js
+++ b/client/transactions/filters/config.js
@@ -18,7 +18,7 @@ export const filters = [
 	{
 		label: __( 'Show', 'woocommerce-payments' ),
 		param: 'filter',
-		staticParams: [ 'paged', 'per_page' ],
+		staticParams: [ 'paged', 'per_page', 'search' ],
 		showFilters: () => true,
 		filters: [
 			{

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import moment from 'moment';
 import Currency from '@woocommerce/currency';
 import { TableCard, Search } from '@woocommerce/components';
-import { onQueryChange, getQuery, getSearchWords, updateQueryString } from '@woocommerce/navigation';
+import { onQueryChange, getQuery, updateQueryString } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -241,17 +241,14 @@ export const TransactionsList = ( props ) => {
 		},
 	];
 
-	const searchWords = getSearchWords( getQuery() );
-	const searchedLabels = searchWords.map( ( v ) => ( {
+	const searchedLabels = getQuery().search && getQuery().search.map( ( v ) => ( {
 		key: v,
 		label: v,
 	} ) );
 
 	const onSearchChange = ( values ) => {
-		// A comma is used as a separator between search terms, so we want to escape any comma they contain.
-		const labels = values.map( ( v ) => v.label.replace( ',', '%2C' ) );
 		updateQueryString( {
-			search: labels.length ? uniq( labels ).join( ',' ) : undefined,
+			search: values.length ? uniq( values.map( v => v.label ) ) : undefined,
 		} );
 	};
 

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -22,6 +22,7 @@ import DetailsLink, { getDetailsURL } from 'components/details-link';
 import { displayType } from 'transactions/strings';
 import { formatStringValue } from '../../util';
 import Deposit from './deposit';
+import autocompleter from 'transactions/autocompleter';
 import './style.scss';
 
 const currency = new Currency();
@@ -280,7 +281,8 @@ export const TransactionsList = ( props ) => {
 					}
 					selected={ searchedLabels }
 					showClearButton={ true }
-					type="customers"
+					type="custom"
+					autocompleter={ autocompleter }
 				/>,
 			] }
 		/>

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -277,11 +277,15 @@ export const TransactionsList = ( props ) => {
 					key="search"
 					onChange={ onSearchChange }
 					placeholder={
-						__( 'Search by order number, customer name, or billing email', 'woocommerce-payments' )
+						wcpaySettings.featureFlags.customSearch
+							? __( 'Search by order number, customer name, or billing email', 'woocommerce-payments' )
+							: __( 'Search by customer name', 'woocommerce-payments' )
 					}
 					selected={ searchedLabels }
 					showClearButton={ true }
-					type="custom"
+					type={
+						wcpaySettings.featureFlags.customSearch ? 'custom' : 'customers'
+					}
 					autocompleter={ autocompleter }
 				/>,
 			] }

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -277,7 +277,7 @@ export const TransactionsList = ( props ) => {
 					key="search"
 					onChange={ onSearchChange }
 					placeholder={
-						__( 'Search by customer name or email', 'woocommerce-admin' )
+						__( 'Search by order number, customer name, or billing email', 'woocommerce-admin' )
 					}
 					selected={ searchedLabels }
 					showClearButton={ true }

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -9,7 +9,11 @@ import { __ } from '@wordpress/i18n';
 import moment from 'moment';
 import Currency from '@woocommerce/currency';
 import { TableCard, Search } from '@woocommerce/components';
-import { onQueryChange, getQuery, updateQueryString } from '@woocommerce/navigation';
+import {
+	onQueryChange,
+	getQuery,
+	updateQueryString,
+} from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -241,23 +245,28 @@ export const TransactionsList = ( props ) => {
 		},
 	];
 
-	const searchedLabels = getQuery().search && getQuery().search.map( ( v ) => ( {
-		key: v,
-		label: v,
-	} ) );
+	const searchedLabels =
+		getQuery().search &&
+		getQuery().search.map( ( v ) => ( {
+			key: v,
+			label: v,
+		} ) );
 
 	const onSearchChange = ( values ) => {
 		updateQueryString( {
-			search: values.length ? uniq( values.map( v => v.label ) ) : undefined,
+			search: values.length
+				? uniq( values.map( ( v ) => v.label ) )
+				: undefined,
 		} );
 	};
 
 	return (
 		<TableCard
 			className="transactions-list woocommerce-report-table has-search"
-			title={ props.depositId
-				? __( 'Deposit transactions', 'woocommerce-payments' )
-				: __( 'Transactions', 'woocommerce-payments' )
+			title={
+				props.depositId
+					? __( 'Deposit transactions', 'woocommerce-payments' )
+					: __( 'Transactions', 'woocommerce-payments' )
 			}
 			isLoading={ isLoading }
 			rowsPerPage={ getQuery().per_page || 25 }
@@ -275,13 +284,21 @@ export const TransactionsList = ( props ) => {
 					onChange={ onSearchChange }
 					placeholder={
 						wcpaySettings.featureFlags.customSearch
-							? __( 'Search by order number, customer name, or billing email', 'woocommerce-payments' )
-							: __( 'Search by customer name', 'woocommerce-payments' )
+							? __(
+									'Search by order number, customer name, or billing email',
+									'woocommerce-payments'
+							  )
+							: __(
+									'Search by customer name',
+									'woocommerce-payments'
+							  )
 					}
 					selected={ searchedLabels }
 					showClearButton={ true }
 					type={
-						wcpaySettings.featureFlags.customSearch ? 'custom' : 'customers'
+						wcpaySettings.featureFlags.customSearch
+							? 'custom'
+							: 'customers'
 					}
 					autocompleter={ autocompleter }
 				/>,

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -3,12 +3,13 @@
 /**
  * External dependencies
  */
+import { uniq } from 'lodash';
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
 import Currency from '@woocommerce/currency';
-import { TableCard } from '@woocommerce/components';
-import { onQueryChange, getQuery } from '@woocommerce/navigation';
+import { TableCard, Search } from '@woocommerce/components';
+import { onQueryChange, getQuery, getSearchWords, updateQueryString } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -239,13 +240,26 @@ export const TransactionsList = ( props ) => {
 		},
 	];
 
+	const searchWords = getSearchWords( getQuery() );
+	const searchedLabels = searchWords.map( ( v ) => ( {
+		key: v,
+		label: v,
+	} ) );
+
+	const onSearchChange = ( values ) => {
+		// A comma is used as a separator between search terms, so we want to escape any comma they contain.
+		const labels = values.map( ( v ) => v.label.replace( ',', '%2C' ) );
+		updateQueryString( {
+			search: labels.length ? uniq( labels ).join( ',' ) : undefined,
+		} );
+	};
+
 	return (
 		<TableCard
-			className="transactions-list"
-			title={
-				props.depositId
-					? __( 'Deposit transactions', 'woocommerce-payments' )
-					: __( 'Transactions', 'woocommerce-payments' )
+			className="transactions-list woocommerce-report-table has-search"
+			title={ props.depositId
+				? __( 'Deposit transactions', 'woocommerce-payments' )
+				: __( 'Transactions', 'woocommerce-payments' )
 			}
 			isLoading={ isLoading }
 			rowsPerPage={ getQuery().per_page || 25 }
@@ -255,6 +269,20 @@ export const TransactionsList = ( props ) => {
 			summary={ isSummaryLoading ? null : summary }
 			query={ getQuery() }
 			onQueryChange={ onQueryChange }
+			actions={ [
+				<Search
+					allowFreeTextSearch={ true }
+					inlineTags
+					key="search"
+					onChange={ onSearchChange }
+					placeholder={
+						__( 'Search by customer name or email', 'woocommerce-admin' )
+					}
+					selected={ searchedLabels }
+					showClearButton={ true }
+					type="customers"
+				/>,
+			] }
 		/>
 	);
 };

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -277,7 +277,7 @@ export const TransactionsList = ( props ) => {
 					key="search"
 					onChange={ onSearchChange }
 					placeholder={
-						__( 'Search by order number, customer name, or billing email', 'woocommerce-admin' )
+						__( 'Search by order number, customer name, or billing email', 'woocommerce-payments' )
 					}
 					selected={ searchedLabels }
 					showClearButton={ true }

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -6,8 +6,8 @@
 
 /**
  * Sourced from https://github.com/woocommerce/woocommerce-admin/blob/ec36a00b77b5c0e313985a5a64c88aaec9eb154e/client/analytics/components/report-table/style.scss.
- * This styles are not loaded if not using the analytics components, so they need to be included here.
- * Once we switch to the Report components, we can remove them from here, as they would be loaded by wc-admin.
+ * Depending on the wc-admin version, these styles are not loaded if not using the analytics report components, so they need to be included here.
+ * If we switch to the Report components, we can remove them from here, as they would be loaded by wc-admin.
 */
 $gap: 16px;
 $gap-small: 12px;

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -3,3 +3,82 @@
 		min-width: 195px;
 	}
 }
+
+/**
+ * Sourced from https://github.com/woocommerce/woocommerce-admin/blob/ec36a00b77b5c0e313985a5a64c88aaec9eb154e/client/analytics/components/report-table/style.scss.
+ * This styles are not loaded if not using the analytics components, so they need to be included here.
+ * Once we switch to the Report components, we can remove them from here, as they would be loaded by wc-admin.
+*/
+$gap: 16px;
+$gap-small: 12px;
+.woocommerce-report-table {
+	.woocommerce-search {
+		flex-grow: 1;
+	}
+
+	.woocommerce-card__header {
+		position: relative;
+	}
+
+	&.has-search {
+		.woocommerce-card__action {
+			align-items: center;
+			text-align: left;
+			display: grid;
+			width: 100%;
+			grid-template-columns: auto 1fr auto;
+		}
+
+		@include breakpoint( '<960px' ) {
+			.woocommerce-card__action {
+				grid-gap: $gap-small;
+				grid-template-columns: auto 1fr;
+				grid-row-start: 2;
+				grid-row-end: 2;
+				grid-column-start: 1;
+				grid-column-end: 4;
+				margin: 0;
+
+				.woocommerce-table__compare {
+					display: flex;
+				}
+
+				.woocommerce-search {
+					grid-area: 2 / 2 / 3 / 4;
+					margin-right: 0;
+				}
+			}
+		}
+
+		&.has-search:not(.has-compare) {
+			.woocommerce-card__action {
+				grid-template-columns: 1fr auto;
+
+				.woocommerce-search {
+					align-self: center;
+					grid-column-start: 1;
+					grid-column-end: 2;
+				}
+			}
+
+			@include breakpoint( '<960px' ) {
+				.woocommerce-card__action {
+					grid-template-columns: auto;
+
+					.woocommerce-search {
+						grid-area: 2 / 1 / 3 / 4;
+						margin-left: 0;
+					}
+				}
+			}
+		}
+
+		.woocommerce-search {
+			margin: 0 $gap;
+
+			.woocommerce-select-control__control {
+				height: 38px;
+			}
+		}
+	}
+}

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -50,7 +50,7 @@ $gap-small: 12px;
 			}
 		}
 
-		&.has-search:not(.has-compare) {
+		&.has-search:not( .has-compare ) {
 			.woocommerce-card__action {
 				grid-template-columns: 1fr auto;
 

--- a/client/transactions/list/test/index.js
+++ b/client/transactions/list/test/index.js
@@ -85,6 +85,11 @@ describe( 'Transactions list', () => {
 		if ( ! isEmpty( getQuery() ) ) {
 			updateQueryString( {}, '/', {} );
 		}
+		global.wcpaySettings = {
+			featureFlags: {
+				customSearch: true,
+			},
+		};
 	} );
 
 	test( 'renders correctly when filtered to deposit', () => {

--- a/client/utils/compute-suggestion-match.js
+++ b/client/utils/compute-suggestion-match.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies
+ */
+
+/**
+ * Parse a string suggestion, split apart by where the first matching query is.
+ * Used to display matched partial in bold.
+ *
+ * @param {string} suggestion The item's label as returned from the API.
+ * @param {string} query The search term to match in the string.
+ * @return {Object} A list in three parts: before, match, and after.
+ */
+export default function computeSuggestionMatch( suggestion, query ) {
+	if ( ! query ) {
+		return null;
+	}
+	const indexOfMatch = suggestion
+		.toLocaleLowerCase()
+		.indexOf( query.toLocaleLowerCase() );
+
+	if ( -1 === indexOfMatch ) {
+		return null;
+	}
+
+	return {
+		suggestionBeforeMatch: decodeEntities( suggestion.substring( 0, indexOfMatch ) ),
+		suggestionMatch: decodeEntities( suggestion.substring(
+			indexOfMatch,
+			indexOfMatch + query.length
+		) ),
+		suggestionAfterMatch: decodeEntities( suggestion.substring(
+			indexOfMatch + query.length
+		) ),
+	};
+}

--- a/client/utils/compute-suggestion-match.js
+++ b/client/utils/compute-suggestion-match.js
@@ -28,13 +28,14 @@ export default function computeSuggestionMatch( suggestion, query ) {
 	}
 
 	return {
-		suggestionBeforeMatch: decodeEntities( suggestion.substring( 0, indexOfMatch ) ),
-		suggestionMatch: decodeEntities( suggestion.substring(
-			indexOfMatch,
-			indexOfMatch + query.length
-		) ),
-		suggestionAfterMatch: decodeEntities( suggestion.substring(
-			indexOfMatch + query.length
-		) ),
+		suggestionBeforeMatch: decodeEntities(
+			suggestion.substring( 0, indexOfMatch )
+		),
+		suggestionMatch: decodeEntities(
+			suggestion.substring( indexOfMatch, indexOfMatch + query.length )
+		),
+		suggestionAfterMatch: decodeEntities(
+			suggestion.substring( indexOfMatch + query.length )
+		),
 	};
 }

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -265,6 +265,7 @@ class WC_Payments_Admin {
 	private function get_frontend_feature_flags() {
 		return [
 			'paymentTimeline' => self::version_compare( WC_ADMIN_VERSION_NUMBER, '1.4.0', '>=' ),
+			'customSearch'    => self::version_compare( WC_ADMIN_VERSION_NUMBER, '1.3.0', '>=' ),
 		];
 	}
 

--- a/includes/admin/class-wc-rest-payments-transactions-controller.php
+++ b/includes/admin/class-wc-rest-payments-transactions-controller.php
@@ -43,6 +43,15 @@ class WC_REST_Payments_Transactions_Controller extends WC_Payments_REST_Controll
 		);
 		register_rest_route(
 			$this->namespace,
+			'/' . $this->rest_base . '/search',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_transactions_search' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base . '/(?P<transaction_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
@@ -86,6 +95,16 @@ class WC_REST_Payments_Transactions_Controller extends WC_Payments_REST_Controll
 		$deposit_id = $request->get_param( 'deposit_id' );
 		$filters    = $this->get_transactions_filters( $request );
 		return $this->forward_request( 'get_transactions_summary', [ $filters, $deposit_id ] );
+	}
+
+	/**
+	 * Retrieve transactions search options to respond with via API.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public function get_transactions_search( $request ) {
+		$query = $request->get_param( 'query' );
+		return $this->forward_request( 'get_transactions_search', [ $query ] );
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-payments-transactions-controller.php
+++ b/includes/admin/class-wc-rest-payments-transactions-controller.php
@@ -46,7 +46,7 @@ class WC_REST_Payments_Transactions_Controller extends WC_Payments_REST_Controll
 			'/' . $this->rest_base . '/search',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ $this, 'get_transactions_search' ],
+				'callback'            => [ $this, 'get_transactions_search_autocomplete' ],
 				'permission_callback' => [ $this, 'check_permission' ],
 			]
 		);
@@ -102,9 +102,9 @@ class WC_REST_Payments_Transactions_Controller extends WC_Payments_REST_Controll
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
-	public function get_transactions_search( $request ) {
-		$query = $request->get_param( 'query' );
-		return $this->forward_request( 'get_transactions_search', [ $query ] );
+	public function get_transactions_search_autocomplete( $request ) {
+		$search_term = $request->get_param( 'search_term' );
+		return $this->forward_request( 'get_transactions_search_autocomplete', [ $search_term ] );
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-payments-transactions-controller.php
+++ b/includes/admin/class-wc-rest-payments-transactions-controller.php
@@ -102,6 +102,7 @@ class WC_REST_Payments_Transactions_Controller extends WC_Payments_REST_Controll
 				'date_between' => $request->get_param( 'date_between' ),
 				'type_is'      => $request->get_param( 'type_is' ),
 				'type_is_not'  => $request->get_param( 'type_is_not' ),
+				'search'       => $request->get_param( 'search' ),
 			],
 			function ( $filter ) {
 				return null !== $filter;

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -141,4 +141,54 @@ class WC_Payments_Utils {
 			)
 		);
 	}
+
+	/**
+	 * Returns a charge_id for an "Order #" search term.
+	 *
+	 * @param string $term Search term.
+	 *
+	 * @return string The charge_id for the order, or empty if no order is found.
+	 */
+	public static function get_charge_id_from_search_term( $term ) {
+		$order_term = 'Order #';
+		if ( substr( $term, 0, strlen( $order_term ) ) === $order_term ) {
+			$term_parts = explode( '#', $term, 2 );
+			$order_id   = isset( $term_parts[1] ) ? $term_parts[1] : '';
+		}
+		if ( ! isset( $order_id ) || empty( $order_id ) ) {
+			return '';
+		}
+
+		$order = wc_get_order( $order_id );
+
+		if ( ! $order ) {
+			return '';
+		}
+
+		return $order->get_meta( '_charge_id' );
+	}
+
+	/**
+	 * Swaps "Order #" search terms with available charge_ids.
+	 *
+	 * @param string $search Search query.
+	 *
+	 * @return string Processed search string.
+	 */
+	public static function map_search_orders_to_charge_ids( $search ) {
+		// Map Order # terms to the actual charge id to be used in the server.
+		$terms = explode( ',', $search );
+		$terms = array_map(
+			function ( $term ) {
+				$charge_id = self::get_charge_id_from_search_term( $term );
+				if ( ! empty( $charge_id ) ) {
+					return $charge_id;
+				} else {
+					return $term;
+				}
+			},
+			$terms
+		);
+		return implode( ',', $terms );
+	}
 }

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -177,7 +177,6 @@ class WC_Payments_Utils {
 	 */
 	public static function map_search_orders_to_charge_ids( $search ) {
 		// Map Order # terms to the actual charge id to be used in the server.
-		$terms = explode( ',', $search );
 		$terms = array_map(
 			function ( $term ) {
 				$charge_id = self::get_charge_id_from_search_term( $term );
@@ -187,8 +186,8 @@ class WC_Payments_Utils {
 					return $term;
 				}
 			},
-			$terms
+			$search
 		);
-		return implode( ',', $terms );
+		return $terms;
 	}
 }

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -289,6 +289,11 @@ class WC_Payments_API_Client {
 	 * @throws WC_Payments_API_Exception Exception thrown on request failure.
 	 */
 	public function get_transactions_summary( $filters = [], $deposit_id = null ) {
+		// Map Order # terms to the actual charge id to be used in the server.
+		if ( ! empty( $filters['search'] ) ) {
+			$filters['search'] = WC_Payments_Utils::map_search_orders_to_charge_ids( $filters['search'] );
+		}
+
 		$query = array_merge(
 			$filters,
 			[
@@ -313,6 +318,11 @@ class WC_Payments_API_Client {
 	 * @throws WC_Payments_API_Exception - Exception thrown on request failure.
 	 */
 	public function list_transactions( $page = 0, $page_size = 25, $sort = 'date', $direction = 'desc', $filters = [], $deposit_id = null ) {
+		// Map Order # terms to the actual charge id to be used in the server.
+		if ( ! empty( $filters['search'] ) ) {
+			$filters['search'] = WC_Payments_Utils::map_search_orders_to_charge_ids( $filters['search'] );
+		}
+
 		$query = array_merge(
 			$filters,
 			[

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -360,8 +360,10 @@ class WC_Payments_API_Client {
 	 * @return array|WP_Error Search results.
 	 */
 	public function get_transactions_search( $query ) {
+		$order = wc_get_order( $query );
+
 		$search_results = $this->request( [ 'query' => $query ], self::TRANSACTIONS_API . '/search', self::GET );
-		return array_map(
+		$results        = array_map(
 			function ( $result ) {
 				return [
 					'label' => $result['customer_name'] . ' (' . $result['customer_email'] . ')',
@@ -369,6 +371,12 @@ class WC_Payments_API_Client {
 			},
 			$search_results
 		);
+
+		if ( $order ) {
+			array_unshift( $results, [ 'label' => __( 'Order #', 'woocommerce-payments' ) . $query ] );
+		}
+
+		return $results;
 	}
 
 	/**

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -383,7 +383,7 @@ class WC_Payments_API_Client {
 		);
 
 		if ( $order ) {
-			array_unshift( $results, [ 'label' => __( 'Order #', 'woocommerce-payments' ) . $query ] );
+			array_unshift( $results, [ 'label' => __( 'Order #', 'woocommerce-payments' ) . $search_term ] );
 		}
 
 		return $results;

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -366,13 +366,13 @@ class WC_Payments_API_Client {
 	/**
 	 * Fetch transactions search options for provided query.
 	 *
-	 * @param string $query Query to be used to get search options - can be an order ID, or part of a name or email.
+	 * @param string $search_term Query to be used to get search options - can be an order ID, or part of a name or email.
 	 * @return array|WP_Error Search results.
 	 */
-	public function get_transactions_search( $query ) {
-		$order = wc_get_order( $query );
+	public function get_transactions_search_autocomplete( $search_term ) {
+		$order = wc_get_order( $search_term );
 
-		$search_results = $this->request( [ 'query' => $query ], self::TRANSACTIONS_API . '/search', self::GET );
+		$search_results = $this->request( [ 'search_term' => $search_term ], self::TRANSACTIONS_API . '/search', self::GET );
 		$results        = array_map(
 			function ( $result ) {
 				return [

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -366,7 +366,7 @@ class WC_Payments_API_Client {
 	/**
 	 * Fetch transactions search options for provided query.
 	 *
-	 * @param string $query Query.
+	 * @param string $query Query to be used to get search options - can be an order ID, or part of a name or email.
 	 * @return array|WP_Error Search results.
 	 */
 	public function get_transactions_search( $query ) {

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -354,6 +354,16 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Fetch transactions search options for provided query.
+	 *
+	 * @param string $query Query.
+	 * @return array|WP_Error Search results.
+	 */
+	public function get_transactions_search( $query ) {
+		return $this->request( [ 'query' => $query ], self::TRANSACTIONS_API . '/search', self::GET );
+	}
+
+	/**
 	 * Fetch a single charge with provided id.
 	 *
 	 * @param string $charge_id id of requested charge.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -360,7 +360,15 @@ class WC_Payments_API_Client {
 	 * @return array|WP_Error Search results.
 	 */
 	public function get_transactions_search( $query ) {
-		return $this->request( [ 'query' => $query ], self::TRANSACTIONS_API . '/search', self::GET );
+		$search_results = $this->request( [ 'query' => $query ], self::TRANSACTIONS_API . '/search', self::GET );
+		return array_map(
+			function ( $result ) {
+				return [
+					'label' => $result['customer_name'] . ' (' . $result['customer_email'] . ')',
+				];
+			},
+			$search_results
+		);
 	}
 
 	/**

--- a/tests/test-class-wc-payments-utils.php
+++ b/tests/test-class-wc-payments-utils.php
@@ -155,4 +155,37 @@ class WC_Payments_Utils_Test extends WP_UnitTestCase {
 		);
 		$this->assertEquals( 'Hello <strong>there, <em>John Doe</em> <img src="test"/></strong>', $result );
 	}
+
+	public function test_get_charge_id_from_search_term_returns_charge_id() {
+		$charge_id = 'ch_test_charge';
+
+		// Create an order with charge_id to test with.
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( '_charge_id', $charge_id );
+		$order->save();
+
+		$result = WC_Payments_Utils::get_charge_id_from_search_term( 'Order #' . $order->get_id() );
+		$this->assertEquals( $charge_id, $result );
+	}
+
+	public function test_get_charge_id_from_search_term_skips_invalid_terms() {
+		$result = WC_Payments_Utils::get_charge_id_from_search_term( 'invalid term' );
+		$this->assertEquals( '', $result );
+	}
+
+	public function test_get_charge_id_from_search_term_handles_invalid_order() {
+		$result = WC_Payments_Utils::get_charge_id_from_search_term( 'Order #897' );
+		$this->assertEquals( '', $result );
+	}
+
+	public function test_map_search_orders_to_charge_ids() {
+		$charge_id = 'ch_test_charge';
+		// Create an order with charge_id to test with.
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( '_charge_id', $charge_id );
+		$order->save();
+
+		$result = WC_Payments_Utils::map_search_orders_to_charge_ids( "First term,Order #{$order->get_id()},Another term" );
+		$this->assertEquals( "First term,$charge_id,Another term", $result );
+	}
 }

--- a/tests/test-class-wc-payments-utils.php
+++ b/tests/test-class-wc-payments-utils.php
@@ -185,7 +185,7 @@ class WC_Payments_Utils_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->save();
 
-		$result = WC_Payments_Utils::map_search_orders_to_charge_ids( "First term,Order #{$order->get_id()},Another term" );
-		$this->assertEquals( "First term,$charge_id,Another term", $result );
+		$result = WC_Payments_Utils::map_search_orders_to_charge_ids( [ 'First term', "Order #{$order->get_id()}", 'Another term' ] );
+		$this->assertEquals( [ 'First term', $charge_id, 'Another term' ], $result );
 	}
 }


### PR DESCRIPTION
Fixes #597 

#### Changes proposed in this Pull Request

* Add transactions search by customer name and email, and order number

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run the server version from server/pull/279
2. Build wc-admin from https://github.com/woocommerce/woocommerce-admin/pull/4518
3. Go to the transactions page
4. Click on the search bar and type a customer name or email
5. You should see a list with suggestions and a wildcard search option
![image](https://user-images.githubusercontent.com/7714042/84067718-36f25700-a99e-11ea-9d59-8f364c4d43a8.png)
6. Clicking on a user should return all transactions for that combination of name and email
![image](https://user-images.githubusercontent.com/7714042/84067761-4bceea80-a99e-11ea-9e38-86e60e62d857.png)
7. Clicking on the wildcard search should return all transactions that include the search term
![image](https://user-images.githubusercontent.com/7714042/84067852-7ae55c00-a99e-11ea-8b55-c91531029d1f.png)
8. Add another search term for an order number (exact match)
9. You should see an "Order #" option
![image](https://user-images.githubusercontent.com/7714042/84067925-994b5780-a99e-11ea-8dbb-60c92ac99a15.png)
10. Clicking on that option should add transactions that match that order to the list
![image](https://user-images.githubusercontent.com/7714042/84067957-a6684680-a99e-11ea-9b14-f26cb326eeaa.png)


-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
