### PR TITLE
Update order status on dispute events

### DIFF
--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -101,7 +101,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 			// Extract information about the webhook event.
 			$event_type = $this->read_rest_property( $body, 'type' );
 
-			Logger::debug( 'Webhook recieved: ' . $event_type );
+			Logger::debug( 'Webhook received: ' . $event_type );
 			Logger::debug(
 				'Webhook body: '
 				. var_export( WC_Payments_Utils::redact_array( $body, WC_Payments_API_Client::API_KEYS_TO_REDACT ), true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -164,6 +164,78 @@ class WC_Payments {
 		}
 
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );
+
+		// Setup dispute order statuses.
+		add_filter( 'woocommerce_register_shop_order_post_statuses', [ __CLASS__, 'register_dispute_order_statuses' ] );
+		add_filter( 'wc_order_statuses', [ __CLASS__, 'add_dispute_order_statuses' ] );
+	}
+
+	/**
+	 * Register dispute order statuses
+	 *
+	 * @param array $order_statuses - Existing order statuses.
+	 *
+	 * @return array
+	 */
+	public static function register_dispute_order_statuses( $order_statuses ) {
+		$order_statuses['wc-disputed'] = [
+			'label'                     => _x( 'Disputed', 'Order status', 'woocommerce-payments' ),
+			'public'                    => false,
+			'exclude_from_search'       => false,
+			'show_in_admin_all_list'    => true,
+			'show_in_admin_status_list' => true,
+			/* translators: %s: number of orders */
+			'label_count'               => _n_noop(
+				'Disputed <span class="count">(%s)</span>',
+				'Disputed <span class="count">(%s)</span>',
+				'woocommerce-payments'
+			),
+		];
+
+		$order_statuses['wc-disputed-accepted'] = [
+			'label'                     => _x( 'Disputed - Accepted', 'Order status', 'woocommerce-payments' ),
+			'public'                    => false,
+			'exclude_from_search'       => false,
+			'show_in_admin_all_list'    => true,
+			'show_in_admin_status_list' => true,
+			/* translators: %s: number of orders */
+			'label_count'               => _n_noop(
+				'Disputed - Accepted <span class="count">(%s)</span>',
+				'Disputed - Accepted <span class="count">(%s)</span>',
+				'woocommerce-payments'
+			),
+		];
+
+		$order_statuses['wc-disputed-lost'] = [
+			'label'                     => _x( 'Disputed - Lost', 'Order status', 'woocommerce-payments' ),
+			'public'                    => false,
+			'exclude_from_search'       => false,
+			'show_in_admin_all_list'    => true,
+			'show_in_admin_status_list' => true,
+			/* translators: %s: number of orders */
+			'label_count'               => _n_noop(
+				'Disputed - Lost <span class="count">(%s)</span>',
+				'Disputed - Lost <span class="count">(%s)</span>',
+				'woocommerce-payments'
+			),
+		];
+
+		return $order_statuses;
+	}
+
+	/**
+	 * Add dispute statuses to the WooCommerce "all statuses" list.
+	 *
+	 * @param array $order_statuses - Existing order statuses.
+	 *
+	 * @return array
+	 */
+	public static function add_dispute_order_statuses( $order_statuses ) {
+		$order_statuses['wc-disputed']          = _x( 'Disputed', 'Order status', 'woocommerce-payments' );
+		$order_statuses['wc-disputed-accepted'] = _x( 'Disputed - Accepted', 'Order status', 'woocommerce-payments' );
+		$order_statuses['wc-disputed-lost']     = _x( 'Disputed - Lost', 'Order status', 'woocommerce-payments' );
+
+		return $order_statuses;
 	}
 
 	/**


### PR DESCRIPTION
Related to #526.

#### Changes proposed in this Pull Request
* Creates 3 new order statuses
* Updates order status on dispute events:
   * Dispute created - Order is moved to "Disputed" status
   * Dispute accepted - Order is moved to "Disputed - Accepted" status
   * Dispute lost - Order is moved to "Disputed - Lost" status
   * Dispute won - Order is moved back to it's pre-dispute status

#### Notes
* As discussed in p2-pc1FvE-1b, ideally we'd break some of this code out into a package so that we can apply the same order statuses in all our payment gateways (that handle disputes). The long term aim would be merging the behaviour into core.
* The link to the dispute details uses the URL that the WCPay server sent the webhook to. This should be fine in production, but for our dev environment ends up with a broken link because we can't access the internal address used by Docker containers. I don't think there is a better way to get the URL here?
* Wording of all the status changes and notes needs reviewing
* There's a lot of duplicate code related to extracting values from the incoming event. I've left this for now because it would be nice to land some refactoring of this webhook controller before we merge this PR. The changes in here definitely push it over the edge into "too big". Ditto for the lack of unit tests.

Dispute statuses on the order screen
<img src="https://user-images.githubusercontent.com/686419/84180955-3fbb5980-aa80-11ea-97fb-1328e5826e1d.png" width=500>

Disputed order note
<img src="https://user-images.githubusercontent.com/686419/84181068-6ed1cb00-aa80-11ea-9bd0-a595623ec749.png" width=200>

Accepted dispute order note
<img src="https://user-images.githubusercontent.com/686419/84181325-ab9dc200-aa80-11ea-9c6a-62810c56d537.png" width=200>

Lost dispute order note
<img src="https://user-images.githubusercontent.com/686419/84181375-bbb5a180-aa80-11ea-8e18-d10f5338b497.png" width=200>

Won dispute order note (and status moving back to pre-dispute status)
<img src="https://user-images.githubusercontent.com/686419/84181576-033c2d80-aa81-11ea-8ef4-901ac1460840.png" width=200>


#### Testing instructions
* TODO