### PR TITLE
Update disputes list and details to use wp.data

### DIFF
--- a/client/data/deposits/test/resolvers.js
+++ b/client/data/deposits/test/resolvers.js
@@ -18,7 +18,7 @@ import {
 } from '../actions';
 import { getDepositsOverview, getDeposit, getDeposits } from '../resolvers';
 
-const stripePayouts = [	{
+const stripePayouts = [ {
 	id: 'test_po_1',
 	object: 'payout',
 	amount: 3930,

--- a/client/data/disputes/action-types.js
+++ b/client/data/disputes/action-types.js
@@ -1,5 +1,6 @@
 /** @format */
 
 export default {
+	SET_DISPUTE: 'SET_DISPUTE',
 	SET_DISPUTES: 'SET_DISPUTES',
 };

--- a/client/data/disputes/action-types.js
+++ b/client/data/disputes/action-types.js
@@ -1,0 +1,5 @@
+/** @format */
+
+export default {
+	SET_DISPUTES: 'SET_DISPUTES',
+};

--- a/client/data/disputes/actions.js
+++ b/client/data/disputes/actions.js
@@ -5,6 +5,13 @@
  */
 import TYPES from './action-types';
 
+export function updateDispute( data ) {
+	return {
+		type: TYPES.SET_DISPUTE,
+		data,
+	};
+}
+
 export function updateDisputes( query, data ) {
 	return {
 		type: TYPES.SET_DISPUTES,

--- a/client/data/disputes/actions.js
+++ b/client/data/disputes/actions.js
@@ -1,8 +1,17 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { apiFetch, dispatch } from '@wordpress/data-controls';
+import { addQueryArgs } from '@wordpress/url';
+import { getHistory } from '@woocommerce/navigation';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
+import { NAMESPACE, STORE_NAME } from '../constants';
 import TYPES from './action-types';
 
 export function updateDispute( data ) {
@@ -18,4 +27,32 @@ export function updateDisputes( query, data ) {
 		query,
 		data,
 	};
+}
+
+export function* acceptDispute( id ) {
+	try {
+		yield dispatch( STORE_NAME, 'startResolution', 'getDispute', [ id ] );
+
+		const dispute = yield apiFetch( {
+			path: `${ NAMESPACE }/disputes/${ id }/close`,
+			method: 'post',
+		} );
+
+		yield updateDispute( dispute );
+		yield dispatch( STORE_NAME, 'finishResolution', 'getDispute', [ id ] );
+
+		// Redirect to Disputes list.
+		getHistory().push( addQueryArgs( 'admin.php', {
+			page: 'wc-admin',
+			path: '/payments/disputes',
+		} ) );
+
+		const message = dispute.order
+			? sprintf( __( 'You have accepted the dispute for order #%s.', 'woocommerce-payments' ), dispute.order.number )
+			: __( 'You have accepted the dispute.', 'woocommerce-payments' );
+		yield dispatch( 'core/notices', 'createSuccessNotice', message );
+	} catch ( e ) {
+		const message = __( 'There has been an error accepting the dispute. Please try again later.', 'woocommerce-payments' );
+		yield dispatch( 'core/notices', 'createErrorNotice', message );
+	}
 }

--- a/client/data/disputes/actions.js
+++ b/client/data/disputes/actions.js
@@ -1,0 +1,14 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import TYPES from './action-types';
+
+export function updateDisputes( query, data ) {
+	return {
+		type: TYPES.SET_DISPUTES,
+		query,
+		data,
+	};
+}

--- a/client/data/disputes/hooks.js
+++ b/client/data/disputes/hooks.js
@@ -22,6 +22,11 @@ export const useDispute = ( id ) => {
 	return { dispute, isLoading, doAccept };
 };
 
+export const useDisputeEvidence = () => {
+	const { updateDispute } = useDispatch( STORE_NAME );
+	return { updateDispute };
+};
+
 // eslint-disable-next-line camelcase
 export const useDisputes = ( { paged, per_page: perPage } ) => useSelect( select => {
 	const { getDisputes, isResolving } = select( STORE_NAME );

--- a/client/data/disputes/hooks.js
+++ b/client/data/disputes/hooks.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { STORE_NAME } from '../constants';
 
 export const useDispute = ( id ) => {
@@ -16,7 +16,10 @@ export const useDispute = ( id ) => {
 		};
 	}, [ id ] );
 
-	return { dispute, isLoading };
+	const { acceptDispute } = useDispatch( STORE_NAME );
+	const doAccept = () => acceptDispute( id );
+
+	return { dispute, isLoading, doAccept };
 };
 
 // eslint-disable-next-line camelcase

--- a/client/data/disputes/hooks.js
+++ b/client/data/disputes/hooks.js
@@ -6,6 +6,19 @@
 import { useSelect } from '@wordpress/data';
 import { STORE_NAME } from '../constants';
 
+export const useDispute = ( id ) => {
+	const { dispute, isLoading } = useSelect( select => {
+		const { getDispute, isResolving } = select( STORE_NAME );
+
+		return {
+			dispute: getDispute( id ),
+			isLoading: isResolving( 'getDispute', [ id ] ),
+		};
+	}, [ id ] );
+
+	return { dispute, isLoading };
+};
+
 // eslint-disable-next-line camelcase
 export const useDisputes = ( { paged, per_page: perPage } ) => useSelect( select => {
 	const { getDisputes, isResolving } = select( STORE_NAME );

--- a/client/data/disputes/hooks.js
+++ b/client/data/disputes/hooks.js
@@ -1,0 +1,22 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { STORE_NAME } from '../constants';
+
+// eslint-disable-next-line camelcase
+export const useDisputes = ( { paged, per_page: perPage } ) => useSelect( select => {
+	const { getDisputes, isResolving } = select( STORE_NAME );
+
+	const query = {
+		paged: Number.isNaN( parseInt( paged, 10 ) ) ? '1' : paged,
+		perPage: Number.isNaN( parseInt( perPage, 10 ) ) ? '25' : perPage,
+	};
+
+	const disputes = getDisputes( query );
+	const isLoading = isResolving( 'getDisputes', [ query ] );
+
+	return { disputes, isLoading };
+}, [ paged, perPage ] );

--- a/client/data/disputes/index.js
+++ b/client/data/disputes/index.js
@@ -1,0 +1,12 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as selectors from './selectors';
+import * as actions from './actions';
+import * as resolvers from './resolvers';
+
+export { reducer, selectors, actions, resolvers };
+export * from './hooks';

--- a/client/data/disputes/reducer.js
+++ b/client/data/disputes/reducer.js
@@ -1,0 +1,36 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { map, keyBy } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import TYPES from './action-types';
+import { getResourceId } from '../util';
+
+const defaultState = { byId: {}, queries: {} };
+
+const receiveDisputes = ( state = defaultState, { type, query = {}, data = [] } ) => {
+	const index = getResourceId( query );
+
+	switch ( type ) {
+		case TYPES.SET_DISPUTES:
+			return {
+				...state,
+				byId: { ...state.byId, ...( keyBy( data, 'id' ) ) },
+				queries: {
+					...state.queries,
+					[ index ]: {
+						data: map( data, 'id' ),
+					},
+				},
+			};
+	}
+
+	return state;
+};
+
+export default receiveDisputes;

--- a/client/data/disputes/reducer.js
+++ b/client/data/disputes/reducer.js
@@ -17,6 +17,11 @@ const receiveDisputes = ( state = defaultState, { type, query = {}, data = [] } 
 	const index = getResourceId( query );
 
 	switch ( type ) {
+		case TYPES.SET_DISPUTE:
+			return {
+				...state,
+				byId: { ...state.byId, [ data.id ]: data },
+			};
 		case TYPES.SET_DISPUTES:
 			return {
 				...state,

--- a/client/data/disputes/resolvers.js
+++ b/client/data/disputes/resolvers.js
@@ -10,8 +10,24 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { NAMESPACE } from '../constants';
-import { updateDisputes } from './actions';
+import { NAMESPACE, STORE_NAME } from '../constants';
+import { updateDispute, updateDisputes } from './actions';
+
+/**
+ * Retrieve a single dispute from the disputes API.
+ *
+ * @param {string} id Identifier for specified dispute to retrieve.
+ */
+export function* getDispute( id ) {
+	const path = addQueryArgs( `${ NAMESPACE }/disputes/${ id }` );
+
+	try {
+		const result = yield apiFetch( { path } );
+		yield updateDispute( result );
+	} catch ( e ) {
+		yield dispatch( 'core/notices', 'createErrorNotice', __( 'Error retrieving dispute.', 'woocommerce-payments' ) );
+	}
+}
 
 /**
  * Retrieves a series of disputes from the disputes list API.
@@ -30,6 +46,11 @@ export function* getDisputes( query ) {
 	try {
 		const results = yield apiFetch( { path } ) || {};
 		yield updateDisputes( query, results.data );
+
+		// Update resolution state on getDispute selector for each result.
+		for ( const i in results.data ) {
+			yield dispatch( STORE_NAME, 'finishResolution', 'getDispute', [ results.data[ i ].id ] );
+		}
 	} catch ( e ) {
 		yield dispatch( 'core/notices', 'createErrorNotice', __( 'Error retrieving disputes.', 'woocommerce-payments' ) );
 	}

--- a/client/data/disputes/resolvers.js
+++ b/client/data/disputes/resolvers.js
@@ -1,0 +1,36 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { apiFetch, dispatch } from '@wordpress/data-controls';
+import { addQueryArgs } from '@wordpress/url';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { NAMESPACE } from '../constants';
+import { updateDisputes } from './actions';
+
+/**
+ * Retrieves a series of disputes from the disputes list API.
+ *
+ * @param {string} query Data on which to parameterize the selection.
+ */
+export function* getDisputes( query ) {
+	const path = addQueryArgs(
+		`${ NAMESPACE }/disputes`,
+		{
+			page: query.paged,
+			pagesize: query.perPage,
+		}
+	);
+
+	try {
+		const results = yield apiFetch( { path } ) || {};
+		yield updateDisputes( query, results.data );
+	} catch ( e ) {
+		yield dispatch( 'core/notices', 'createErrorNotice', __( 'Error retrieving disputes.', 'woocommerce-payments' ) );
+	}
+}

--- a/client/data/disputes/selectors.js
+++ b/client/data/disputes/selectors.js
@@ -1,0 +1,47 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getResourceId } from '../util';
+
+/**
+ * Retrieves the disputes state from the wp.data store if the state
+ * has been initialized, otherwise returns an empty state.
+ *
+ * @param {object} state Current wp.data state.
+ *
+ * @returns {object} The disputes state.
+ */
+const getDisputesState = ( state ) => {
+	if ( ! state ) {
+		return {};
+	}
+
+	return state.disputes || {};
+};
+
+const getDispute = ( state, id ) => {
+	const disputeById = getDisputesState( state ).byId || {};
+	return disputeById[ id ];
+};
+
+/**
+ * Retrieves the disputes corresponding to the provided query or a sane
+ * default if they don't exist.
+ *
+ * @param {object} state Current wp.data state.
+ * @param {object} query The disputes query.
+ *
+ * @returns {object} The list of disputes for the given query.
+ */
+const getDisputesForQuery = ( state, query ) => {
+	const index = getResourceId( query );
+	const queries = getDisputesState( state ).queries || {};
+	return queries[ index ] || {};
+};
+
+export const getDisputes = ( state, query ) => {
+	const ids = getDisputesForQuery( state, query ).data || [];
+	return ids.map( getDispute.bind( this, state ) );
+};

--- a/client/data/disputes/selectors.js
+++ b/client/data/disputes/selectors.js
@@ -21,7 +21,7 @@ const getDisputesState = ( state ) => {
 	return state.disputes || {};
 };
 
-const getDispute = ( state, id ) => {
+export const getDispute = ( state, id ) => {
 	const disputeById = getDisputesState( state ).byId || {};
 	return disputeById[ id ];
 };

--- a/client/data/disputes/test/actions.js
+++ b/client/data/disputes/test/actions.js
@@ -1,0 +1,56 @@
+/** @format */
+/* eslint-disable camelcase */
+
+/**
+ * External dependencies
+ */
+import { apiFetch, dispatch } from '@wordpress/data-controls';
+import { getHistory } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { acceptDispute, updateDispute } from '../actions';
+
+jest.mock( '@woocommerce/navigation', () => ( {
+	getHistory: jest.fn( () => ( { push: () => {} } ) ),
+} ) );
+
+describe( 'acceptDispute action', () => {
+	const mockDispute = {
+		id: 'dp_mock1',
+		reason: 'product_unacceptable',
+		status: 'lost',
+	};
+
+	test( 'should close dispute and update state with dispute data', () => {
+		const generator = acceptDispute( 'dp_mock1' );
+
+		expect( generator.next().value ).toEqual(
+			dispatch( 'wc/payments', 'startResolution', 'getDispute', [ 'dp_mock1' ] )
+		);
+		expect( generator.next().value ).toEqual(
+			apiFetch( { path: '/wc/v3/payments/disputes/dp_mock1/close', method: 'post' } )
+		);
+		expect( generator.next( mockDispute ).value ).toEqual( updateDispute( mockDispute ) );
+		expect( generator.next().value ).toEqual(
+			dispatch( 'wc/payments', 'finishResolution', 'getDispute', [ 'dp_mock1' ] )
+		);
+
+		const noticeAction = generator.next().value;
+		expect( getHistory.mock.calls.length ).toEqual( 1 );
+		expect( noticeAction ).toEqual(
+			dispatch( 'core/notices', 'createSuccessNotice', expect.any( String ) )
+		);
+		expect( generator.next().done ).toStrictEqual( true );
+	} );
+
+	test( 'should show notice on error', () => {
+		const generator = acceptDispute( 'dp_mock1' );
+
+		generator.next();
+		expect( generator.throw( { code: 'error' } ).value ).toEqual(
+			dispatch( 'core/notices', 'createErrorNotice', expect.any( String ) )
+		);
+	} );
+} );

--- a/client/data/disputes/test/reducer.js
+++ b/client/data/disputes/test/reducer.js
@@ -1,0 +1,87 @@
+/** @format */
+/* eslint-disable camelcase */
+
+/**
+ * Internal dependencies
+ */
+import reducer from '../reducer';
+import types from '../action-types';
+import { getResourceId } from '../../util';
+
+describe( 'Disputes reducer tests', () => {
+	const mockQuery = { paged: '2', perPage: '50' };
+	const mockDisputes = [
+		{
+			id: 'dp_mock1',
+			reason: 'product_unacceptable',
+		},
+		{
+			id: 'dp_mock2',
+			reason: 'fraudulent',
+		},
+	];
+
+	test( 'New disputes reduced correctly', () => {
+		const reduced = reducer(
+			undefined, // Default state.
+			{
+				type: types.SET_DISPUTES,
+				data: mockDisputes,
+				query: mockQuery,
+			}
+		);
+
+		const after = {
+			byId: {
+				dp_mock1: mockDisputes[ 0 ],
+				dp_mock2: mockDisputes[ 1 ],
+			},
+			queries: {
+				[ getResourceId( mockQuery ) ]: {
+					data: [ 'dp_mock1', 'dp_mock2' ],
+				},
+			},
+		};
+
+		expect( reduced ).toStrictEqual( after );
+	} );
+
+	test( 'Disputes updated correctly on updated info', () => {
+		const before = {
+			byId: {
+				dp_mock1: mockDisputes[ 0 ],
+			},
+			queries: {
+				earlierQuery: {
+					data: [ 'dp_mock1' ],
+				},
+			},
+		};
+
+		const reduced = reducer(
+			before,
+			{
+				type: types.SET_DISPUTES,
+				data: mockDisputes.slice( 1 ),
+				query: mockQuery,
+			}
+		);
+
+		const after = {
+			byId: {
+				dp_mock1: mockDisputes[ 0 ],
+				dp_mock2: mockDisputes[ 1 ],
+			},
+			queries: {
+				earlierQuery: {
+					data: [ 'dp_mock1' ],
+				},
+				[ getResourceId( mockQuery ) ]: {
+					data: [ 'dp_mock2' ],
+				},
+			},
+		};
+
+		expect( reduced ).toStrictEqual( after );
+	} );
+} );

--- a/client/data/disputes/test/reducer.js
+++ b/client/data/disputes/test/reducer.js
@@ -21,6 +21,39 @@ describe( 'Disputes reducer tests', () => {
 		},
 	];
 
+	test( 'New individual disputes reduced correctly', () => {
+		const stateAfterOne = reducer(
+			undefined, // Default state.
+			{
+				type: types.SET_DISPUTE,
+				data: mockDisputes[ 0 ],
+			}
+		);
+
+		expect( stateAfterOne ).toStrictEqual( {
+			byId: {
+				dp_mock1: mockDisputes[ 0 ],
+			},
+			queries: {},
+		} );
+
+		const stateAfterTwo = reducer(
+			stateAfterOne,
+			{
+				type: types.SET_DISPUTE,
+				data: mockDisputes[ 1 ],
+			}
+		);
+
+		expect( stateAfterTwo ).toStrictEqual( {
+			byId: {
+				dp_mock1: mockDisputes[ 0 ],
+				dp_mock2: mockDisputes[ 1 ],
+			},
+			queries: {},
+		} );
+	} );
+
 	test( 'New disputes reduced correctly', () => {
 		const reduced = reducer(
 			undefined, // Default state.

--- a/client/data/disputes/test/resolvers.js
+++ b/client/data/disputes/test/resolvers.js
@@ -9,8 +9,8 @@ import { apiFetch, dispatch } from '@wordpress/data-controls';
 /**
  * Internal dependencies
  */
-import { updateDisputes } from '../actions';
-import { getDisputes } from '../resolvers';
+import { updateDispute, updateDisputes } from '../actions';
+import { getDispute, getDisputes } from '../resolvers';
 
 const mockDisputes = [
 	{
@@ -23,6 +23,35 @@ const mockDisputes = [
 	},
 ];
 const errorResponse = { code: 'error' };
+
+describe( 'getDispute resolver', () => {
+	let generator = null;
+
+	beforeEach( () => {
+		generator = getDispute( 'dp_mock1' );
+		expect( generator.next().value ).toEqual(
+			apiFetch( { path: '/wc/v3/payments/disputes/dp_mock1' } )
+		);
+	} );
+
+	afterEach( () => {
+		expect( generator.next().done ).toStrictEqual( true );
+	} );
+
+	describe( 'on success', () => {
+		test( 'should update state with dispute data', () => {
+			expect( generator.next( mockDisputes[ 0 ] ).value ).toEqual( updateDispute( mockDisputes[ 0 ] ) );
+		} );
+	} );
+
+	describe( 'on error', () => {
+		test( 'should update state with error on error', () => {
+			expect( generator.throw( errorResponse ).value ).toEqual(
+				dispatch( 'core/notices', 'createErrorNotice', expect.any( String ) )
+			);
+		} );
+	} );
+} );
 
 describe( 'getDisputes resolver', () => {
 	let generator = null;
@@ -43,6 +72,11 @@ describe( 'getDisputes resolver', () => {
 		test( 'should update state with disputes data', () => {
 			expect( generator.next( { data: mockDisputes } ).value )
 				.toEqual( updateDisputes( query, mockDisputes ) );
+			mockDisputes.forEach( dispute => {
+				expect( generator.next().value ).toEqual(
+					dispatch( 'wc/payments', 'finishResolution', 'getDispute', [ dispute.id ] )
+				);
+			} );
 		} );
 	} );
 

--- a/client/data/disputes/test/resolvers.js
+++ b/client/data/disputes/test/resolvers.js
@@ -1,0 +1,56 @@
+/** @format */
+/* eslint-disable camelcase */
+
+/**
+ * External dependencies
+ */
+import { apiFetch, dispatch } from '@wordpress/data-controls';
+
+/**
+ * Internal dependencies
+ */
+import { updateDisputes } from '../actions';
+import { getDisputes } from '../resolvers';
+
+const mockDisputes = [
+	{
+		id: 'dp_mock1',
+		reason: 'product_unacceptable',
+	},
+	{
+		id: 'dp_mock2',
+		reason: 'fraudulent',
+	},
+];
+const errorResponse = { code: 'error' };
+
+describe( 'getDisputes resolver', () => {
+	let generator = null;
+	const query = { paged: 1, perPage: 25 };
+
+	beforeEach( () => {
+		generator = getDisputes( query );
+		expect( generator.next().value ).toEqual(
+			apiFetch( { path: '/wc/v3/payments/disputes?page=1&pagesize=25' } )
+		);
+	} );
+
+	afterEach( () => {
+		expect( generator.next().done ).toStrictEqual( true );
+	} );
+
+	describe( 'on success', () => {
+		test( 'should update state with disputes data', () => {
+			expect( generator.next( { data: mockDisputes } ).value )
+				.toEqual( updateDisputes( query, mockDisputes ) );
+		} );
+	} );
+
+	describe( 'on error', () => {
+		test( 'should update state with error on error', () => {
+			expect( generator.throw( errorResponse ).value ).toEqual(
+				dispatch( 'core/notices', 'createErrorNotice', expect.any( String ) )
+			);
+		} );
+	} );
+} );

--- a/client/data/disputes/test/selectors.js
+++ b/client/data/disputes/test/selectors.js
@@ -5,12 +5,35 @@
  * Internal dependencies
  */
 import { getResourceId } from '../../util';
-import { getDisputes } from '../selectors';
+import { getDispute, getDisputes } from '../selectors';
 
 // Sections in initial state are empty.
 const emptyState = {
 	disputes: {},
 };
+
+describe( 'Dispute selector', () => {
+	const mockDispute = {
+		id: 'dp_mock1',
+		reason: 'product_unacceptable',
+	};
+
+	const filledState = {
+		disputes: {
+			byId: {
+				dp_mock1: mockDispute,
+			},
+		},
+	};
+
+	test( 'Returns undefined when dispute is not present', () => {
+		expect( getDispute( emptyState, 'dp_mock1' ) ).toStrictEqual( undefined );
+	} );
+
+	test( 'Returns dispute when it is present', () => {
+		expect( getDispute( filledState, 'dp_mock1' ) ).toStrictEqual( mockDispute );
+	} );
+} );
 
 describe( 'Disputes selectors', () => {
 	// Mock objects.

--- a/client/data/disputes/test/selectors.js
+++ b/client/data/disputes/test/selectors.js
@@ -1,0 +1,52 @@
+/** @format */
+/* eslint-disable camelcase */
+
+/**
+ * Internal dependencies
+ */
+import { getResourceId } from '../../util';
+import { getDisputes } from '../selectors';
+
+// Sections in initial state are empty.
+const emptyState = {
+	disputes: {},
+};
+
+describe( 'Disputes selectors', () => {
+	// Mock objects.
+	const mockQuery = { paged: '2', perPage: '50' };
+	const mockDisputes = [
+		{
+			id: 'dp_mock1',
+			reason: 'product_unacceptable',
+		},
+		{
+			id: 'dp_mock2',
+			reason: 'fraudulent',
+		},
+	];
+
+	// State is populated.
+	const filledSuccessState = {
+		disputes: {
+			byId: {
+				dp_mock1: mockDisputes[ 0 ],
+				dp_mock2: mockDisputes[ 1 ],
+			},
+			queries: {
+				[ getResourceId( mockQuery ) ]: {
+					data: [ 'dp_mock1', 'dp_mock2' ],
+				},
+			},
+		},
+	};
+
+	test( 'Returns empty disputes list when disputes list is empty', () => {
+		expect( getDisputes( emptyState, mockQuery ) ).toStrictEqual( [] );
+	} );
+
+	test( 'Returns disputes list from state', () => {
+		const expected = mockDisputes;
+		expect( getDisputes( filledSuccessState, mockQuery ) ).toStrictEqual( expected );
+	} );
+} );

--- a/client/data/index.js
+++ b/client/data/index.js
@@ -14,3 +14,4 @@ export * from './deposits';
 export * from './transactions';
 export * from './charges';
 export * from './timeline';
+export * from './disputes';

--- a/client/data/store.js
+++ b/client/data/store.js
@@ -12,6 +12,7 @@ import * as deposits from './deposits';
 import * as transactions from './transactions';
 import * as charges from './charges';
 import * as timeline from './timeline';
+import * as disputes from './disputes';
 
 // Extracted into wrapper function to facilitate testing.
 export const initStore = () => registerStore( STORE_NAME, {
@@ -20,12 +21,14 @@ export const initStore = () => registerStore( STORE_NAME, {
 		transactions: transactions.reducer,
 		charges: charges.reducer,
 		timeline: timeline.reducer,
+		disputes: disputes.reducer,
 	} ),
 	actions: {
 		...deposits.actions,
 		...transactions.actions,
 		...charges.actions,
 		...timeline.actions,
+		...disputes.actions,
 	},
 	controls,
 	selectors: {
@@ -33,12 +36,14 @@ export const initStore = () => registerStore( STORE_NAME, {
 		...transactions.selectors,
 		...charges.selectors,
 		...timeline.selectors,
+		...disputes.selectors,
 	},
 	resolvers: {
 		...deposits.resolvers,
 		...transactions.resolvers,
 		...charges.resolvers,
 		...timeline.resolvers,
+		...disputes.resolvers,
 	},
 } );
 

--- a/client/disputes/details/index.js
+++ b/client/disputes/details/index.js
@@ -4,16 +4,12 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
-import { addQueryArgs } from '@wordpress/url';
-import { getHistory } from '@woocommerce/navigation';
-import apiFetch from '@wordpress/api-fetch';
 import { Card } from '@woocommerce/components';
 
 /**
  * Internal dependencies.
  */
+import { useDispute } from 'data';
 import { reasons } from '../strings';
 import Actions from './actions';
 import Info from '../info';
@@ -22,14 +18,16 @@ import Page from 'components/page';
 import Loadable, { LoadableBlock } from 'components/loadable';
 import '../style.scss';
 
-export const DisputeDetails = ( { isLoading, dispute = {}, onAccept } ) => {
+const DisputeDetails = ( { query: { id: disputeId } } ) => {
+	const { dispute = {}, isLoading, doAccept } = useDispute( disputeId );
+
 	const disputeIsAvailable = ! isLoading && dispute.id;
 
 	const actions = disputeIsAvailable && <Actions
 			id={ dispute.id }
 			needsResponse={ 'needs_response' === dispute.status || 'warning_needs_response' === dispute.status }
 			isSubmitted={ dispute.evidence_details && dispute.evidence_details.submission_count > 0 }
-			onAccept={ onAccept }
+			onAccept={ doAccept }
 		/>;
 
 	const mapping = reasons[ dispute.reason ] || {};
@@ -84,54 +82,4 @@ export const DisputeDetails = ( { isLoading, dispute = {}, onAccept } ) => {
 	);
 };
 
-// Temporary MVP data wrapper
-export default ( { query } ) => {
-	const path = `/wc/v3/payments/disputes/${ query.id }`;
-
-	const [ dispute, setDispute ] = useState();
-	const [ loading, setLoading ] = useState( true );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( 'core/notices' );
-
-	const fetchDispute = async () => {
-		setLoading( true );
-		try {
-			setDispute( await apiFetch( { path } ) );
-		} finally {
-			setLoading( false );
-		}
-	};
-	useEffect( () => {
-		fetchDispute();
-	}, [] );
-
-	const handleAcceptSuccess = () => {
-		const message = dispute.order
-			? sprintf( __( 'You have accepted the dispute for order #%s.', 'woocommerce-payments' ), dispute.order.number )
-			: __( 'You have accepted the dispute.', 'woocommerce-payments' );
-		createSuccessNotice( message );
-		getHistory().push( addQueryArgs( 'admin.php', {
-			page: 'wc-admin',
-			path: '/payments/disputes',
-		} ) );
-	};
-
-	const doAccept = async () => {
-		setLoading( true );
-		try {
-			setDispute( await apiFetch( { path: `${ path }/close`, method: 'post' } ) );
-			handleAcceptSuccess();
-		} catch ( err ) {
-			createErrorNotice( __( 'There has been an error accepting the dispute. Please try again later.', 'woocommerce-payments' ) );
-		} finally {
-			setLoading( false );
-		}
-	};
-
-	return (
-		<DisputeDetails
-			isLoading={ loading }
-			dispute={ dispute }
-			onAccept={ doAccept }
-		/>
-	);
-};
+export default DisputeDetails;

--- a/client/disputes/details/test/index.js
+++ b/client/disputes/details/test/index.js
@@ -7,7 +7,12 @@ import { render } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import { DisputeDetails } from '../';
+import DisputeDetails from '../';
+import { useDispute } from 'data';
+
+jest.mock( 'data', () => ( {
+	useDispute: jest.fn(),
+} ) );
 
 describe( 'Dispute details screen', () => {
 	const reasons = [
@@ -46,11 +51,10 @@ describe( 'Dispute details screen', () => {
 			},
 		};
 
+		useDispute.mockReturnValue( { dispute, isLoading: false } );
+
 		const { container } = render(
-			<DisputeDetails
-				dispute={ dispute }
-				showPlaceholder={ false }
-			/>
+			<DisputeDetails query={ { id: 'dp_asdfghjkl' } } />
 		);
 		expect( container ).toMatchSnapshot();
 	} );

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -17,6 +17,7 @@ import { merge, some, flatten, isMatchWith } from 'lodash';
  * Internal dependencies.
  */
 import '../style.scss';
+import { useDisputeEvidence } from 'data';
 import evidenceFields from './fields';
 import { FileUploadControl } from './file-upload';
 import Info from '../info';
@@ -308,6 +309,8 @@ export default ( { query } ) => {
 		createErrorNotice( message );
 	};
 
+	const { updateDispute: updateDisputeInStore } = useDisputeEvidence();
+
 	const doSave = async submit => {
 		// Prevent submit if upload is in progress.
 		if ( isUploadingEvidence() ) {
@@ -332,6 +335,7 @@ export default ( { query } ) => {
 			setDispute( updatedDispute );
 			handleSaveSuccess( submit );
 			setEvidence( {} );
+			updateDisputeInStore( updatedDispute );
 		} catch ( err ) {
 			handleSaveError( submit );
 		} finally {

--- a/client/disputes/evidence/test/index.js
+++ b/client/disputes/evidence/test/index.js
@@ -10,6 +10,10 @@ import { render, fireEvent } from '@testing-library/react';
  */
 import { DisputeEvidenceForm, DisputeEvidencePage } from '../';
 
+jest.mock( 'data', () => ( {
+	useDisputeEvidence: jest.fn(),
+} ) );
+
 /* eslint-disable camelcase */
 const disputeNeedsResponse = {
 	id: 'dp_asdfghjkl',

--- a/client/disputes/index.js
+++ b/client/disputes/index.js
@@ -3,17 +3,17 @@
 /**
  * External dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
-import apiFetch from '@wordpress/api-fetch';
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
 import Currency from '@woocommerce/currency';
 import { TableCard } from '@woocommerce/components';
+import { onQueryChange, getQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies.
  */
+import { useDisputes } from 'data';
 import OrderLink from 'components/order-link';
 import DisputeStatusChip from 'components/dispute-status-chip';
 import ClickableCell from 'components/clickable-cell';
@@ -38,11 +38,10 @@ const headers = [
 	{ key: 'dueBy', label: __( 'Respond by', 'woocommerce-payments' ), required: true },
 ];
 
-export const DisputesList = ( props ) => {
-	const { disputes, showPlaceholder } = props;
-	const disputesData = disputes.data || [];
+export const DisputesList = () => {
+	const { disputes, isLoading } = useDisputes( getQuery() );
 
-	const rows = disputesData.map( ( dispute ) => {
+	const rows = disputes.map( ( dispute ) => {
 		const order = dispute.order ? {
 			value: dispute.order.number,
 			display: <OrderLink order={ dispute.order } />,
@@ -86,37 +85,16 @@ export const DisputesList = ( props ) => {
 		<Page>
 			<TableCard
 				title={ __( 'Disputes', 'woocommerce-payments' ) }
-				isLoading={ showPlaceholder }
+				isLoading={ isLoading }
 				rowsPerPage={ 10 }
 				totalRows={ 10 }
 				headers={ headers }
 				rows={ rows }
+				query={ getQuery() }
+				onQueryChange={ onQueryChange }
 			/>
 		</Page>
 	);
 };
 
-// Temporary MVP data wrapper
-export default () => {
-	const [ disputes, setDisputes ] = useState( [] );
-	const [ loading, setLoading ] = useState( false );
-
-	const fetchDisputes = async () => {
-		setLoading( true );
-		try {
-			setDisputes( await apiFetch( { path: '/wc/v3/payments/disputes' } ) );
-		} finally {
-			setLoading( false );
-		}
-	};
-	useEffect( () => {
-		fetchDisputes();
-	}, [] );
-
-	return (
-		<DisputesList
-			disputes={ disputes }
-			showPlaceholder={ loading }
-		/>
-	);
-};
+export default DisputesList;

--- a/client/disputes/test/index.js
+++ b/client/disputes/test/index.js
@@ -8,11 +8,17 @@ import { shallow } from 'enzyme';
  * Internal dependencies
  */
 import { DisputesList } from '../';
+import { useDisputes } from 'data';
+
+jest.mock( 'data', () => ( {
+	useDisputes: jest.fn(),
+} ) );
 
 describe( 'Disputes list', () => {
 	test( 'renders correctly', () => {
-		const disputes = {
-			data: [
+		useDisputes.mockReturnValue( {
+			isLoading: false,
+			disputes: [
 				{
 					id: 'dp_asdfghjkl',
 					amount: 1000,
@@ -62,13 +68,10 @@ describe( 'Disputes list', () => {
 					// dispute without order or charge information
 				},
 			],
-		};
+		} );
 
 		const list = shallow(
-			<DisputesList
-				disputes={ disputes }
-				showPlaceholder={ false }
-			/>
+			<DisputesList />
 		);
 		expect( list ).toMatchSnapshot();
 	} );

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -408,7 +408,14 @@ class WC_Payments_API_Client {
 	 * @return array dispute object.
 	 */
 	public function close_dispute( $dispute_id ) {
-		return $this->request( [], self::DISPUTES_API . '/' . $dispute_id . '/close', self::POST );
+		$dispute = $this->request( [], self::DISPUTES_API . '/' . $dispute_id . '/close', self::POST );
+
+		if ( is_wp_error( $dispute ) ) {
+			return $dispute;
+		}
+
+		$charge_id = is_array( $dispute['charge'] ) ? $dispute['charge']['id'] : $dispute['charge'];
+		return $this->add_order_info_to_object( $charge_id, $dispute );
 	}
 
 	/**


### PR DESCRIPTION
Partially addresses https://github.com/Automattic/woocommerce-payments/issues/331

#### Changes proposed in this Pull Request

Adds new reducer to the data store for retrieving/manipulating _disputes_ data, along with actions and selectors (and accompanying resolvers). Also adds hooks for interfacing with them, and updates **Disputes list** and **Dispute Details** views to use those in place of custom provider components.

Mostly the changes are directly adapted from existing code (specifically `client/data/deposits`), with the exception of `acceptDispute` which will be the first [action creator generator](https://unfoldingneurons.com/2020/wordpress-data-store-properties-action-creator-generators) in the store.

The only intentional user-facing changes are to do with data persistence: if a dispute has loaded, it doesn't need to be fetched again when…
- going _back_ to the list screen (after being there before)
- going _back_ to the details screen for the same dispute (after being there before)
- going from the list into any of the rows' details screens
- accepting a dispute or submitting evidence and being redirected _back_ to the list – in this case, the dispute status should already be updated without a refetch of the whole list

The "Challenge dispute" screen is unchanged in this PR except to update the wp.data cache upon evidence submission.

(There was an idea I'd considered for redirecting to the list screen immediately on "accept" action, and showing loading placeholders for the affected row only – see https://github.com/Automattic/woocommerce-payments/commit/d85d0b6eda4442283d1cc951c895d3cf6d21d58b – but the optimistic update _might_ require more care around edge cases.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify that dispute views work just as before, except that data is re-loaded only when updated:

- Check out with a [dispute test card](https://stripe.com/docs/testing#disputes) a couple of times
- Navigate to the Disputes list
- Go into a Dispute Details screen and verify that it shows up without loading
- (Optionally go back to the list and back again into a dispute's details – verify instant rendering)
- "Accept dispute" and verify that it redirects back to the list without reloading the whole list, and shows updated ("Lost") status on that dispute
- "Challenge dispute" for another dispute, "Submit evidence", and verify redirection back to the list without reloading the whole list, and updated status ("Under review") on that dispute

-------------------

- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
