### PR TITLE
Add/js/tracking

### DIFF
--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -52,7 +52,10 @@ const ConnectAccountPage = () => {
 						isLarge
 						isBusy={ isSubmitted }
 						disabled={ isSubmitted }
-						onClick={ () => setSubmitted( true ) }
+						onClick={ () => {
+							setSubmitted( true );
+							window.wcTracks.recordEvent( 'wcpay_connect_account_clicked' );
+						} }
 						href={ wcpaySettings.connectUrl }>
 						{ __( 'Set up', 'woocommerce-payments' ) }
 					</Button>

--- a/client/disputes/details/actions.js
+++ b/client/disputes/details/actions.js
@@ -34,7 +34,9 @@ const Actions = ( { id, needsResponse, isSubmitted, onAccept } ) => {
 
 	return (
 		<CardFooter>
-			<Link href={ challengeUrl } className="components-button is-button is-primary is-large">
+			<Link
+				href={ challengeUrl } className="components-button is-button is-primary is-large"
+				onClick={ () => window.wcTracks.recordEvent( 'wcpay_dispute_challenge_clicked' ) }>
 				{ needsResponse
 					? __( 'Challenge dispute', 'woocommerce-payments' )
 					: __( 'View submitted evidence', 'woocommerce-payments' )

--- a/client/disputes/details/actions.js
+++ b/client/disputes/details/actions.js
@@ -36,7 +36,12 @@ const Actions = ( { id, needsResponse, isSubmitted, onAccept } ) => {
 		<CardFooter>
 			<Link
 				href={ challengeUrl } className="components-button is-button is-primary is-large"
-				onClick={ () => window.wcTracks.recordEvent( 'wcpay_dispute_challenge_clicked' ) }>
+				onClick={ () =>
+					needsResponse
+					? window.wcTracks.recordEvent( 'wcpay_dispute_challenge_clicked' )
+					: window.wcTracks.recordEvent( 'wcpay_view_submitted_evidence_clicked' )
+				}
+		>
 				{ needsResponse
 					? __( 'Challenge dispute', 'woocommerce-payments' )
 					: __( 'View submitted evidence', 'woocommerce-payments' )

--- a/client/disputes/details/index.js
+++ b/client/disputes/details/index.js
@@ -105,6 +105,7 @@ export default ( { query } ) => {
 	}, [] );
 
 	const handleAcceptSuccess = () => {
+		window.wcTracks.recordEvent( 'wcpay_dispute_accept_success' );
 		const message = dispute.order
 			? sprintf( __( 'You have accepted the dispute for order #%s.', 'woocommerce-payments' ), dispute.order.number )
 			: __( 'You have accepted the dispute.', 'woocommerce-payments' );
@@ -118,10 +119,13 @@ export default ( { query } ) => {
 	const doAccept = async () => {
 		setLoading( true );
 		try {
+			window.wcTracks.recordEvent( 'wcpay_dispute_accept_clicked' );
 			setDispute( await apiFetch( { path: `${ path }/close`, method: 'post' } ) );
 			handleAcceptSuccess();
 		} catch ( err ) {
-			createErrorNotice( __( 'There has been an error accepting the dispute. Please try again later.', 'woocommerce-payments' ) );
+			const notice = __( 'There has been an error accepting the dispute. Please try again later.', 'woocommerce-payments' );
+			window.wcTracks.recordEvent( 'wcpay_dispute_accept_failed', { message: notice } );
+			createErrorNotice( notice );
 		} finally {
 			setLoading( false );
 		}

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -274,6 +274,8 @@ export default ( { query } ) => {
 				isUploading: { [ key ]: false },
 			} );
 			updateEvidence( key, uploadedFile.id );
+
+			window.wcTracks.recordEvent( 'wcpay_dipute_file_upload_success', { type: key } );
 		} catch ( err ) {
 			window.wcTracks.recordEvent( 'wcpay_dispute_file_upload_failed', { message: err.message } );
 

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -326,7 +326,10 @@ export default ( { query } ) => {
 		setLoading( true );
 
 		try {
-			window.wcTracks.recordEvent( 'wcpay_dispute_submit_evidence_clicked' );
+			submit
+			? window.wcTracks.recordEvent( 'wcpay_dispute_submit_evidence_clicked' )
+			: window.wcTracks.recordEvent( 'wcpay_dispute_save_evidence_clicked' );
+
 			const { metadata } = dispute;
 			const updatedDispute = await apiFetch( {
 				path,

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -299,7 +299,9 @@ export default ( { query } ) => {
 			path: '/payments/disputes',
 		} );
 
-		window.wcTracks.recordEvent( 'wcpay_dispute_submit_evidence_success' );
+		submit
+			? window.wcTracks.recordEvent( 'wcpay_dispute_submit_evidence_success' )
+			: window.wcTracks.recordEvent( 'wcpay_dispute_save_evidence_success' );
 		/*
 			We rely on WC-Admin Transient notices to display success message.
 			https://github.com/woocommerce/woocommerce-admin/tree/master/client/layout/transient-notices.
@@ -313,7 +315,10 @@ export default ( { query } ) => {
 		const message = submit
 			? __( 'Failed to submit evidence!', 'woocommerce-payments' )
 			: __( 'Failed to save evidence!', 'woocommerce-payments' );
-		window.wcTracks.recordEvent( 'wcpay_dispute_submit_evidence_failed' );
+
+		submit
+			? window.wcTracks.recordEvent( 'wcpay_dispute_submit_evidence_failed' )
+			: window.wcTracks.recordEvent( 'wcpay_dispute_save_evidence_failed' );
 		createErrorNotice( message );
 	};
 


### PR DESCRIPTION
Fixes #74

#### Changes proposed in this Pull Request

* Add all JS event tracking to our Admin interface.

#### Testing instructions

##### Setup event
- While logged into admin
- Open the browse inspector and go to the Network tab. 
- Make sure to preserve the log 
- under filter enter `.gif`

1. In WCPay dev mode settings force WCPay as disconnected. 
1. Go to the WCPay settings page and click on setup.
1. Look at the network tab and notice the event pixe is sent to wp.com. 
1. It should contain `_en= wcpay_connect_account_clicked`

##### Dispute events
1. Make sure your server is running and accepting webhooks ( `npm start` in the server repo ).
1. keep the network tab open.
1. Clear it so you have a clean slate.
1. In a new tab open the shop and purchase something with this card `4000000000002685`.  It will ensure the purchase is disputed.
1. No in admin go to the disputes list page an click on the dispute just created. 
1. Start interacting with the dispute buttons and notice how the tracking pixels are fired off to wp.com.

The following actions will trigger tracking events:
- Challenging a dispute.
- Changing the product type.
- Uploading a file ( we track all the file upload fields )
- Accepting a dispute

-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
