### PR TITLE
Include the "jetpack-jitm" package even though WCPay doesn't use it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require": {
       "automattic/jetpack-connection": "^1.13.1",
       "automattic/jetpack-config": "^1.2.0",
-      "automattic/jetpack-autoloader": "^1.7.0"
+      "automattic/jetpack-autoloader": "^1.7.0",
+      "automattic/jetpack-jitm": "^1.6"
     },
     "require-dev": {
       "woocommerce/woocommerce": "^4.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,43 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4539f448451acbd12abcd41f5c64ff86",
+    "content-hash": "1cfc937a31bc7bae3f38e3482f6d4dfe",
     "packages": [
+        {
+            "name": "automattic/jetpack-assets",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-assets.git",
+                "reference": "8e03ee3a05ae6501a771fff65f0aaf57f0520974"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-assets/zipball/8e03ee3a05ae6501a771fff65f0aaf57f0520974",
+                "reference": "8e03ee3a05ae6501a771fff65f0aaf57f0520974",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-constants": "1.2.0"
+            },
+            "require-dev": {
+                "brain/monkey": "2.4.0",
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Asset management utilities for Jetpack ecosystem packages",
+            "time": "2020-05-26T13:41:40+00:00"
+        },
         {
             "name": "automattic/jetpack-autoloader",
             "version": "v1.7.0",
@@ -141,6 +176,80 @@
             "time": "2020-04-15T18:58:53+00:00"
         },
         {
+            "name": "automattic/jetpack-jitm",
+            "version": "v1.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-jitm.git",
+                "reference": "40bcb4ac1da4cc231a6b72143e08fda78150a2cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-jitm/zipball/40bcb4ac1da4cc231a6b72143e08fda78150a2cb",
+                "reference": "40bcb4ac1da4cc231a6b72143e08fda78150a2cb",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-assets": "1.4.0",
+                "automattic/jetpack-connection": "1.13.1",
+                "automattic/jetpack-constants": "1.2.0",
+                "automattic/jetpack-logo": "1.2.0",
+                "automattic/jetpack-options": "1.5.0",
+                "automattic/jetpack-partner": "1.0.1",
+                "automattic/jetpack-redirect": "1.1.0",
+                "automattic/jetpack-status": "1.1.1",
+                "automattic/jetpack-tracking": "1.6.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.2",
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Just in time messages for Jetpack",
+            "time": "2020-06-01T11:23:25+00:00"
+        },
+        {
+            "name": "automattic/jetpack-logo",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-logo.git",
+                "reference": "d7840f25d7836ab69de979bcb67e8190220e53a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-logo/zipball/d7840f25d7836ab69de979bcb67e8190220e53a3",
+                "reference": "d7840f25d7836ab69de979bcb67e8190220e53a3",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A logo for Jetpack",
+            "time": "2020-03-27T21:57:58+00:00"
+        },
+        {
             "name": "automattic/jetpack-options",
             "version": "v1.5.0",
             "source": {
@@ -175,6 +284,69 @@
             "time": "2020-05-26T13:35:15+00:00"
         },
         {
+            "name": "automattic/jetpack-partner",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-partner.git",
+                "reference": "866dfe161654acd18115b94aa117186f53a6ee6d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-partner/zipball/866dfe161654acd18115b94aa117186f53a6ee6d",
+                "reference": "866dfe161654acd18115b94aa117186f53a6ee6d",
+                "shasum": ""
+            },
+            "require-dev": {
+                "brain/monkey": "2.4.0",
+                "mockery/mockery": "^1.2",
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Support functions for Jetpack hosting partners.",
+            "time": "2020-01-27T11:04:11+00:00"
+        },
+        {
+            "name": "automattic/jetpack-redirect",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-redirect.git",
+                "reference": "504d2c2390279ec10f576484e5370867795deca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-redirect/zipball/504d2c2390279ec10f576484e5370867795deca9",
+                "reference": "504d2c2390279ec10f576484e5370867795deca9",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities to build URLs to the jetpack.com/redirect service",
+            "time": "2020-05-22T14:41:43+00:00"
+        },
+        {
             "name": "automattic/jetpack-roles",
             "version": "v1.0.4",
             "source": {
@@ -204,6 +376,110 @@
             ],
             "description": "Utilities, related with user roles and capabilities.",
             "time": "2019-11-08T21:16:05+00:00"
+        },
+        {
+            "name": "automattic/jetpack-status",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-status.git",
+                "reference": "c688b03859381e66164c821971e851408a5e232a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/c688b03859381e66164c821971e851408a5e232a",
+                "reference": "c688b03859381e66164c821971e851408a5e232a",
+                "shasum": ""
+            },
+            "require-dev": {
+                "brain/monkey": "2.4.0",
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
+            "time": "2020-01-27T11:04:11+00:00"
+        },
+        {
+            "name": "automattic/jetpack-terms-of-service",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-terms-of-service.git",
+                "reference": "db3a99fbd7fbec5c4d235c36690cd61ef18933c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-terms-of-service/zipball/db3a99fbd7fbec5c4d235c36690cd61ef18933c1",
+                "reference": "db3a99fbd7fbec5c4d235c36690cd61ef18933c1",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-connection": "1.13.1",
+                "automattic/jetpack-options": "1.5.0",
+                "automattic/jetpack-status": "1.1.1"
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything need to manage the terms of service state",
+            "time": "2020-06-01T09:05:31+00:00"
+        },
+        {
+            "name": "automattic/jetpack-tracking",
+            "version": "v1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-tracking.git",
+                "reference": "7a388b87766e826e2e02bb7515424dd4ab798b72"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-tracking/zipball/7a388b87766e826e2e02bb7515424dd4ab798b72",
+                "reference": "7a388b87766e826e2e02bb7515424dd4ab798b72",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-options": "1.5.0",
+                "automattic/jetpack-terms-of-service": "1.3.1"
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "legacy",
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Tracking for Jetpack",
+            "time": "2020-06-01T09:06:30+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
See this conversation for much more context: p1591879021108300-slack-jetpack-wcpay-connection

When WCPay is installed alongside Jetpack 8.5 or earlier, a PHP `E_NOTICE` appears:
> Notice: Unable to load class Automattic\Jetpack\JITMS\JITM. Please add the package that contains it using composer and make sure you are requiring the Jetpack autoloader in /var/www/html/wp-content/plugins/woocommerce-payments/vendor/automattic/jetpack-config/src/class-config.php on line 119

Long story short, there are some namespace compatibility problems between newer versions of `jetpack-config` (which we include) and older versions of `jetpack-jitm` (which Jetpack 8.5 includes). The long-term solution is to make `jetpack-config` more resilient. But, for now, the simplest solution is to add a newer version of `jetpack-jitm` to our dependencies, even if we don't use it at all.

This does **not** mean that the JITM code will be executed needlessly. It will only be executed if Jetpack-the-plugin is installed. The only downside of this PR is that it makes our ZIP a bit bigger than it needs to be, but it's temporary.

### To reproduce
- Install and activate Jetpack 8.5 or lower.
- Deactivate the `Client-Example` plugin if you have it.
- Set `define( 'WP_DEBUG', true );`.
- On `master`, you'll see a `NOTICE` in every page of WP-Admin. On this branch, you won't (remember to run `composer install`).