### PR TITLE
Fix missing payment status for disputes

### DIFF
--- a/client/components/payment-status-chip/index.js
+++ b/client/components/payment-status-chip/index.js
@@ -59,6 +59,11 @@ const statuses = {
 		type: 'light',
 		message: __( 'Disputed: Lost', 'woocommerce-payments' ),
 	},
+	// eslint-disable-next-line camelcase
+	disputed_closed: {
+		type: 'light',
+		message: __( 'Disputed: Inquiry closed', 'woocommerce-payments' ),
+	},
 	default: {
 		type: 'light',
 		message: '',

--- a/client/components/payment-status-chip/index.js
+++ b/client/components/payment-status-chip/index.js
@@ -3,77 +3,21 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies.
  */
-import { getChargeStatus } from '../../utils/charge';
+import displayStatus from './mappings';
 import Chip from '../chip';
+import { formatStringValue } from '../../util';
 
-/* TODO: implement other payment statuses */
-const statuses = {
-	// eslint-disable-next-line camelcase
-	refunded_partial: {
-		type: 'light',
-		message: __( 'Partial refund', 'woocommerce-payments' ),
-	},
-	// eslint-disable-next-line camelcase
-	refunded_full: {
-		type: 'light',
-		message: __( 'Refunded', 'woocommerce-payments' ),
-	},
-	paid: {
-		type: 'light',
-		message: __( 'Paid', 'woocommerce-payments' ),
-	},
-	authorized: {
-		type: 'primary',
-		message: __( 'Payment authorized', 'woocommerce-payments' ),
-	},
-	failed: {
-		type: 'alert',
-		message: __( 'Payment failed', 'woocommerce-payments' ),
-	},
-	blocked: {
-		type: 'alert',
-		message: __( 'Payment blocked', 'woocommerce-payments' ),
-	},
-	// eslint-disable-next-line camelcase
-	disputed_needs_response: {
-		type: 'primary',
-		message: __( 'Disputed: Needs response', 'woocommerce-payments' ),
-	},
-	// eslint-disable-next-line camelcase
-	disputed_under_review: {
-		type: 'light',
-		message: __( 'Disputed: In review', 'woocommerce-payments' ),
-	},
-	// eslint-disable-next-line camelcase
-	disputed_won: {
-		type: 'light',
-		message: __( 'Disputed: Won', 'woocommerce-payments' ),
-	},
-	// eslint-disable-next-line camelcase
-	disputed_lost: {
-		type: 'light',
-		message: __( 'Disputed: Lost', 'woocommerce-payments' ),
-	},
-	// eslint-disable-next-line camelcase
-	disputed_closed: {
-		type: 'light',
-		message: __( 'Disputed: Inquiry closed', 'woocommerce-payments' ),
-	},
-	default: {
-		type: 'light',
-		message: '',
-	},
-};
-
-const PaymentStatusChip = ( props ) => {
-	const { charge } = props;
-	const status = statuses[ getChargeStatus( charge ) ] || statuses.default;
-	return <Chip message={ status.message } type={ status.type } />;
+const PaymentStatusChip = ( { status } ) => {
+	const mapping = displayStatus[ status ] || {};
+	const message = mapping.message || formatStringValue( status );
+	const type = mapping.type || 'light';
+	return (
+		<Chip message={ message } type={ type } />
+	);
 };
 
 export default PaymentStatusChip;

--- a/client/components/payment-status-chip/mappings.js
+++ b/client/components/payment-status-chip/mappings.js
@@ -1,0 +1,55 @@
+/** @format **/
+/* eslint-disable camelcase */
+
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/* TODO: implement other payment statuses (SCA and authorizations) */
+export default {
+	refunded_partial: {
+		type: 'light',
+		message: __( 'Partial refund', 'woocommerce-payments' ),
+	},
+	refunded_full: {
+		type: 'light',
+		message: __( 'Refunded', 'woocommerce-payments' ),
+	},
+	paid: {
+		type: 'light',
+		message: __( 'Paid', 'woocommerce-payments' ),
+	},
+	authorized: {
+		type: 'primary',
+		message: __( 'Payment authorized', 'woocommerce-payments' ),
+	},
+	failed: {
+		type: 'alert',
+		message: __( 'Payment failed', 'woocommerce-payments' ),
+	},
+	blocked: {
+		type: 'alert',
+		message: __( 'Payment blocked', 'woocommerce-payments' ),
+	},
+	disputed_needs_response: {
+		type: 'primary',
+		message: __( 'Disputed: Needs response', 'woocommerce-payments' ),
+	},
+	disputed_under_review: {
+		type: 'light',
+		message: __( 'Disputed: In review', 'woocommerce-payments' ),
+	},
+	disputed_won: {
+		type: 'light',
+		message: __( 'Disputed: Won', 'woocommerce-payments' ),
+	},
+	disputed_lost: {
+		type: 'light',
+		message: __( 'Disputed: Lost', 'woocommerce-payments' ),
+	},
+	disputed_closed: {
+		type: 'light',
+		message: __( 'Disputed: Inquiry closed', 'woocommerce-payments' ),
+	},
+};

--- a/client/components/payment-status-chip/mappings.js
+++ b/client/components/payment-status-chip/mappings.js
@@ -4,7 +4,26 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import disputeStatuses from 'components/dispute-status-chip/mappings';
+
+const formattedDisputeStatuses = Object.entries( disputeStatuses ).reduce(
+	( statuses, [ status, mapping ] ) => {
+		statuses[ 'disputed_' + status ] = {
+			type: mapping.type,
+			message: status.startsWith( 'warning_' )
+				? mapping.message
+				/** translators: %s dispute status, e.g. Won, Lost, Under review, etc. */
+				: sprintf( __( 'Disputed: %s', 'woocommerce-payments' ), mapping.message ),
+		};
+		return statuses;
+	},
+	{}
+);
 
 /* TODO: implement other payment statuses (SCA and authorizations) */
 export default {
@@ -32,24 +51,5 @@ export default {
 		type: 'alert',
 		message: __( 'Payment blocked', 'woocommerce-payments' ),
 	},
-	disputed_needs_response: {
-		type: 'primary',
-		message: __( 'Disputed: Needs response', 'woocommerce-payments' ),
-	},
-	disputed_under_review: {
-		type: 'light',
-		message: __( 'Disputed: In review', 'woocommerce-payments' ),
-	},
-	disputed_won: {
-		type: 'light',
-		message: __( 'Disputed: Won', 'woocommerce-payments' ),
-	},
-	disputed_lost: {
-		type: 'light',
-		message: __( 'Disputed: Lost', 'woocommerce-payments' ),
-	},
-	disputed_closed: {
-		type: 'light',
-		message: __( 'Disputed: Inquiry closed', 'woocommerce-payments' ),
-	},
+	...formattedDisputeStatuses,
 };

--- a/client/components/payment-status-chip/test/__snapshots__/index.js.snap
+++ b/client/components/payment-status-chip/test/__snapshots__/index.js.snap
@@ -30,16 +30,6 @@ exports[`PaymentStatusChip renders default appearance if status is unrecognized 
 </div>
 `;
 
-exports[`PaymentStatusChip renders disputed_closed status 1`] = `
-<div>
-  <span
-    class="chip chip-light"
-  >
-    Disputed: Inquiry closed
-  </span>
-</div>
-`;
-
 exports[`PaymentStatusChip renders disputed_lost status 1`] = `
 <div>
   <span
@@ -65,7 +55,37 @@ exports[`PaymentStatusChip renders disputed_under_review status 1`] = `
   <span
     class="chip chip-light"
   >
-    Disputed: In review
+    Disputed: Under review
+  </span>
+</div>
+`;
+
+exports[`PaymentStatusChip renders disputed_warning_closed status 1`] = `
+<div>
+  <span
+    class="chip chip-light"
+  >
+    Inquiry: Closed
+  </span>
+</div>
+`;
+
+exports[`PaymentStatusChip renders disputed_warning_needs_response status 1`] = `
+<div>
+  <span
+    class="chip chip-primary"
+  >
+    Inquiry: Needs response
+  </span>
+</div>
+`;
+
+exports[`PaymentStatusChip renders disputed_warning_under_review status 1`] = `
+<div>
+  <span
+    class="chip chip-light"
+  >
+    Inquiry: Under review
   </span>
 </div>
 `;

--- a/client/components/payment-status-chip/test/__snapshots__/index.js.snap
+++ b/client/components/payment-status-chip/test/__snapshots__/index.js.snap
@@ -1,84 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PaymentStatusChip renders a default light chip with no message if status does not match 1`] = `
-<div>
-  <span
-    class="chip chip-light"
-  />
-</div>
-`;
-
-exports[`PaymentStatusChip renders a light chip with dispute message if there's a closed dispute 1`] = `
-<div>
-  <span
-    class="chip chip-light"
-  >
-    Disputed: Inquiry closed
-  </span>
-</div>
-`;
-
-exports[`PaymentStatusChip renders a light chip with dispute message if there's a dispute in review 1`] = `
-<div>
-  <span
-    class="chip chip-light"
-  >
-    Disputed: In review
-  </span>
-</div>
-`;
-
-exports[`PaymentStatusChip renders a light chip with dispute message if there's a lost dispute 1`] = `
-<div>
-  <span
-    class="chip chip-light"
-  >
-    Disputed: Lost
-  </span>
-</div>
-`;
-
-exports[`PaymentStatusChip renders a light chip with dispute message if there's a won dispute 1`] = `
-<div>
-  <span
-    class="chip chip-light"
-  >
-    Disputed: Won
-  </span>
-</div>
-`;
-
-exports[`PaymentStatusChip renders a light chip with fully refunded message if there's a full refund 1`] = `
-<div>
-  <span
-    class="chip chip-light"
-  >
-    Refunded
-  </span>
-</div>
-`;
-
-exports[`PaymentStatusChip renders a light chip with paid message if it is paid 1`] = `
-<div>
-  <span
-    class="chip chip-light"
-  >
-    Paid
-  </span>
-</div>
-`;
-
-exports[`PaymentStatusChip renders a light chip with partially refunded message if there's a partial refund 1`] = `
-<div>
-  <span
-    class="chip chip-light"
-  >
-    Partial refund
-  </span>
-</div>
-`;
-
-exports[`PaymentStatusChip renders a primary chip with authorized message if payment was not captured 1`] = `
+exports[`PaymentStatusChip renders authorized status 1`] = `
 <div>
   <span
     class="chip chip-primary"
@@ -88,17 +10,7 @@ exports[`PaymentStatusChip renders a primary chip with authorized message if pay
 </div>
 `;
 
-exports[`PaymentStatusChip renders a primary chip with dispute message if there's a dispute needing response 1`] = `
-<div>
-  <span
-    class="chip chip-primary"
-  >
-    Disputed: Needs response
-  </span>
-</div>
-`;
-
-exports[`PaymentStatusChip renders an alert chip with failed message if payment status is blocked 1`] = `
+exports[`PaymentStatusChip renders blocked status 1`] = `
 <div>
   <span
     class="chip chip-alert"
@@ -108,12 +20,102 @@ exports[`PaymentStatusChip renders an alert chip with failed message if payment 
 </div>
 `;
 
-exports[`PaymentStatusChip renders an alert chip with failed message if payment status is failed 1`] = `
+exports[`PaymentStatusChip renders default appearance if status is unrecognized 1`] = `
+<div>
+  <span
+    class="chip chip-light"
+  >
+    Mock status
+  </span>
+</div>
+`;
+
+exports[`PaymentStatusChip renders disputed_closed status 1`] = `
+<div>
+  <span
+    class="chip chip-light"
+  >
+    Disputed: Inquiry closed
+  </span>
+</div>
+`;
+
+exports[`PaymentStatusChip renders disputed_lost status 1`] = `
+<div>
+  <span
+    class="chip chip-light"
+  >
+    Disputed: Lost
+  </span>
+</div>
+`;
+
+exports[`PaymentStatusChip renders disputed_needs_response status 1`] = `
+<div>
+  <span
+    class="chip chip-primary"
+  >
+    Disputed: Needs response
+  </span>
+</div>
+`;
+
+exports[`PaymentStatusChip renders disputed_under_review status 1`] = `
+<div>
+  <span
+    class="chip chip-light"
+  >
+    Disputed: In review
+  </span>
+</div>
+`;
+
+exports[`PaymentStatusChip renders disputed_won status 1`] = `
+<div>
+  <span
+    class="chip chip-light"
+  >
+    Disputed: Won
+  </span>
+</div>
+`;
+
+exports[`PaymentStatusChip renders failed status 1`] = `
 <div>
   <span
     class="chip chip-alert"
   >
     Payment failed
+  </span>
+</div>
+`;
+
+exports[`PaymentStatusChip renders paid status 1`] = `
+<div>
+  <span
+    class="chip chip-light"
+  >
+    Paid
+  </span>
+</div>
+`;
+
+exports[`PaymentStatusChip renders refunded_full status 1`] = `
+<div>
+  <span
+    class="chip chip-light"
+  >
+    Refunded
+  </span>
+</div>
+`;
+
+exports[`PaymentStatusChip renders refunded_partial status 1`] = `
+<div>
+  <span
+    class="chip chip-light"
+  >
+    Partial refund
   </span>
 </div>
 `;

--- a/client/components/payment-status-chip/test/__snapshots__/index.js.snap
+++ b/client/components/payment-status-chip/test/__snapshots__/index.js.snap
@@ -8,6 +8,16 @@ exports[`PaymentStatusChip renders a default light chip with no message if statu
 </div>
 `;
 
+exports[`PaymentStatusChip renders a light chip with dispute message if there's a closed dispute 1`] = `
+<div>
+  <span
+    class="chip chip-light"
+  >
+    Disputed: Inquiry closed
+  </span>
+</div>
+`;
+
 exports[`PaymentStatusChip renders a light chip with dispute message if there's a dispute in review 1`] = `
 <div>
   <span

--- a/client/components/payment-status-chip/test/index.js
+++ b/client/components/payment-status-chip/test/index.js
@@ -7,74 +7,30 @@ import { render } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import { getChargeStatus } from '../../../utils/charge';
 import PaymentStatusChip from '../';
 
-jest.mock( '../../../utils/charge', () => ( { getChargeStatus: jest.fn() } ) );
-
 describe( 'PaymentStatusChip', () => {
-	test( 'renders a default light chip with no message if status does not match', () => {
-		getChargeStatus.mockReturnValue( 'teststatus' );
-		expect( renderPaymentStatus() ).toMatchSnapshot();
+	test( 'renders default appearance if status is unrecognized', () => {
+		const { container } = render( <PaymentStatusChip status="mock_status" /> );
+		expect( container ).toMatchSnapshot();
 	} );
 
-	test( "renders a light chip with partially refunded message if there's a partial refund", () => {
-		getChargeStatus.mockReturnValue( 'refunded_partial' );
-		expect( renderPaymentStatus() ).toMatchSnapshot();
-	} );
+	const statuses = [
+		'refunded_partial',
+		'refunded_full',
+		'paid',
+		'authorized',
+		'failed',
+		'blocked',
+		'disputed_needs_response',
+		'disputed_under_review',
+		'disputed_won',
+		'disputed_lost',
+		'disputed_closed',
+	];
 
-	test( "renders a light chip with fully refunded message if there's a full refund", () => {
-		getChargeStatus.mockReturnValue( 'refunded_full' );
-		expect( renderPaymentStatus() ).toMatchSnapshot();
+	test.each( statuses )( 'renders %s status', ( status ) => {
+		const { container } = render( <PaymentStatusChip status={ status } /> );
+		expect( container ).toMatchSnapshot();
 	} );
-
-	test( 'renders a light chip with paid message if it is paid', () => {
-		getChargeStatus.mockReturnValue( 'paid' );
-		expect( renderPaymentStatus() ).toMatchSnapshot();
-	} );
-
-	test( 'renders a primary chip with authorized message if payment was not captured', () => {
-		getChargeStatus.mockReturnValue( 'authorized' );
-		const paymentStatusChip = renderPaymentStatus();
-		expect( paymentStatusChip ).toMatchSnapshot();
-	} );
-
-	test( 'renders an alert chip with failed message if payment status is failed', () => {
-		getChargeStatus.mockReturnValue( 'failed' );
-		expect( renderPaymentStatus() ).toMatchSnapshot();
-	} );
-
-	test( 'renders an alert chip with failed message if payment status is blocked', () => {
-		getChargeStatus.mockReturnValue( 'blocked' );
-		expect( renderPaymentStatus() ).toMatchSnapshot();
-	} );
-
-	test( "renders a primary chip with dispute message if there's a dispute needing response", () => {
-		getChargeStatus.mockReturnValue( 'disputed_needs_response' );
-		expect( renderPaymentStatus() ).toMatchSnapshot();
-	} );
-
-	test( "renders a light chip with dispute message if there's a dispute in review", () => {
-		getChargeStatus.mockReturnValue( 'disputed_under_review' );
-		expect( renderPaymentStatus() ).toMatchSnapshot();
-	} );
-
-	test( "renders a light chip with dispute message if there's a won dispute", () => {
-		getChargeStatus.mockReturnValue( 'disputed_won' );
-		expect( renderPaymentStatus() ).toMatchSnapshot();
-	} );
-
-	test( "renders a light chip with dispute message if there's a lost dispute", () => {
-		getChargeStatus.mockReturnValue( 'disputed_lost' );
-		expect( renderPaymentStatus() ).toMatchSnapshot();
-	} );
-
-	test( 'renders a light chip with dispute message if there\'s a closed dispute', () => {
-		getChargeStatus.mockReturnValue( 'disputed_closed' );
-		expect( renderPaymentStatus() ).toMatchSnapshot();
-	} );
-
-	function renderPaymentStatus() {
-		return render( <PaymentStatusChip charge={ {} } /> ).container;
-	}
 } );

--- a/client/components/payment-status-chip/test/index.js
+++ b/client/components/payment-status-chip/test/index.js
@@ -69,6 +69,11 @@ describe( 'PaymentStatusChip', () => {
 		expect( renderPaymentStatus() ).toMatchSnapshot();
 	} );
 
+	test( 'renders a light chip with dispute message if there\'s a closed dispute', () => {
+		getChargeStatus.mockReturnValue( 'disputed_closed' );
+		expect( renderPaymentStatus() ).toMatchSnapshot();
+	} );
+
 	function renderPaymentStatus() {
 		return render( <PaymentStatusChip charge={ {} } /> ).container;
 	}

--- a/client/components/payment-status-chip/test/index.js
+++ b/client/components/payment-status-chip/test/index.js
@@ -26,7 +26,9 @@ describe( 'PaymentStatusChip', () => {
 		'disputed_under_review',
 		'disputed_won',
 		'disputed_lost',
-		'disputed_closed',
+		'disputed_warning_needs_response',
+		'disputed_warning_under_review',
+		'disputed_warning_closed',
 	];
 
 	test.each( statuses )( 'renders %s status', ( status ) => {

--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -14,7 +14,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies.
  */
-import { getChargeAmounts } from 'utils/charge';
+import { getChargeAmounts, getChargeStatus } from 'utils/charge';
 import PaymentStatusChip from 'components/payment-status-chip';
 import PaymentMethodDetails from 'components/payment-method-details';
 import HorizontalList from 'components/horizontal-list';
@@ -77,7 +77,7 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 							<span className="payment-details-summary__amount-currency">
 								{ charge.currency || 'cur' }
 							</span>
-							<PaymentStatusChip charge={ charge } />
+							<PaymentStatusChip status={ getChargeStatus( charge ) } />
 						</Loadable>
 					</p>
 					<div className="payment-details-summary__breakdown">

--- a/client/payment-details/summary/test/__snapshots__/index.js.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.js.snap
@@ -25,7 +25,9 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
             </span>
             <span
               class="chip chip-light"
-            />
+            >
+              Paid
+            </span>
           </p>
           <div
             class="payment-details-summary__breakdown"
@@ -545,7 +547,9 @@ exports[`PaymentDetailsSummary renders the information of a disputed charge 1`] 
             </span>
             <span
               class="chip chip-light"
-            />
+            >
+              Disputed
+            </span>
           </p>
           <div
             class="payment-details-summary__breakdown"

--- a/client/payment-details/summary/test/__snapshots__/index.js.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.js.snap
@@ -548,7 +548,7 @@ exports[`PaymentDetailsSummary renders the information of a disputed charge 1`] 
             <span
               class="chip chip-light"
             >
-              Disputed
+              Disputed: Under review
             </span>
           </p>
           <div

--- a/client/payment-details/summary/test/index.js
+++ b/client/payment-details/summary/test/index.js
@@ -9,14 +9,13 @@ import { render } from '@testing-library/react';
  */
 import PaymentDetailsSummary from '../';
 
+/* eslint-disable camelcase */
 const getBaseCharge = () => ( {
 	id: 'ch_38jdHA39KKA',
 	/* Stripe data comes in seconds, instead of the default Date milliseconds */
 	created: Date.parse( 'Sep 19, 2019, 5:24 pm' ) / 1000,
 	amount: 1500,
-	// eslint-disable-next-line camelcase
 	amount_refunded: 0,
-	// eslint-disable-next-line camelcase
 	application_fee_amount: 70,
 	disputed: false,
 	dispute: null,
@@ -24,15 +23,16 @@ const getBaseCharge = () => ( {
 	net: 1426,
 	currency: 'usd',
 	type: 'charge',
+	status: 'succeeded',
+	paid: true,
+	captured: true,
 	order: {
 		number: 45981,
 		url: 'https://somerandomorderurl.com/?edit_order=45981',
 	},
-	// eslint-disable-next-line camelcase
 	billing_details: {
 		name: 'Customer name',
 	},
-	// eslint-disable-next-line camelcase
 	payment_method_details: {
 		card: {
 			brand: 'visa',
@@ -41,10 +41,10 @@ const getBaseCharge = () => ( {
 		type: 'card',
 	},
 	outcome: {
-		// eslint-disable-next-line camelcase
 		risk_level: 'normal',
 	},
 } );
+/* eslint-enable camelcase */
 
 describe( 'PaymentDetailsSummary', () => {
 	test( 'correctly renders a charge', () => {

--- a/client/payment-details/summary/test/index.js
+++ b/client/payment-details/summary/test/index.js
@@ -77,6 +77,7 @@ describe( 'PaymentDetailsSummary', () => {
 		charge.disputed = true;
 		charge.dispute = {
 			amount: 1500,
+			status: 'under_review',
 		};
 
 		const paymentDetailsSummary = renderCharge( charge );

--- a/client/utils/charge/index.js
+++ b/client/utils/charge/index.js
@@ -44,6 +44,10 @@ export const mapDisputeStatusToChargeStatus = ( status ) => {
 			return 'disputed_won';
 		case 'lost':
 			return 'disputed_lost';
+		case 'warning_closed':
+			return 'disputed_closed';
+		case 'charge_refunded':
+			return 'refunded_full';
 		default:
 			return 'disputed';
 	}

--- a/client/utils/charge/index.js
+++ b/client/utils/charge/index.js
@@ -32,27 +32,6 @@ export const isChargeFullyRefunded = ( charge = {} ) =>
 export const isChargePartiallyRefunded = ( charge = {} ) =>
 	isChargeRefunded( charge ) && ! isChargeFullyRefunded( charge );
 
-export const mapDisputeStatusToChargeStatus = ( status ) => {
-	switch ( status ) {
-		case 'warning_needs_response':
-		case 'needs_response':
-			return 'disputed_needs_response';
-		case 'warning_under_review':
-		case 'under_review':
-			return 'disputed_under_review';
-		case 'won':
-			return 'disputed_won';
-		case 'lost':
-			return 'disputed_lost';
-		case 'warning_closed':
-			return 'disputed_closed';
-		case 'charge_refunded':
-			return 'refunded_full';
-		default:
-			return 'disputed';
-	}
-};
-
 /* TODO: implement authorization and SCA charge statuses */
 export const getChargeStatus = ( charge = {} ) => {
 	if ( isChargeFailed( charge ) ) {
@@ -62,9 +41,7 @@ export const getChargeStatus = ( charge = {} ) => {
 		return 'blocked';
 	}
 	if ( isChargeDisputed( charge ) ) {
-		return mapDisputeStatusToChargeStatus(
-			getDisputeStatus( charge.dispute )
-		);
+		return 'disputed_' + getDisputeStatus( charge.dispute );
 	}
 	if ( isChargePartiallyRefunded( charge ) ) {
 		return 'refunded_partial';
@@ -75,7 +52,7 @@ export const getChargeStatus = ( charge = {} ) => {
 	if ( isChargeSuccessful( charge ) ) {
 		return isChargeCaptured( charge ) ? 'paid' : 'authorized';
 	}
-	return '';
+	return charge.status;
 };
 
 /**

--- a/client/utils/charge/test/index.js
+++ b/client/utils/charge/test/index.js
@@ -22,158 +22,105 @@ const blockedCharge = {
 	outcome: { type: 'blocked' },
 };
 const authorizedCharge = { status: 'succeeded', paid: true, captured: false };
-const disputedChargeNeedsResponse = {
-	disputed: true,
-	dispute: { status: 'needs_response' },
-};
-const disputedChargeUnderReview = {
-	disputed: true,
-	dispute: { status: 'under_review' },
-};
-const disputedChargeWon = { disputed: true, dispute: { status: 'won' } };
-const disputedChargeLost = { disputed: true, dispute: { status: 'lost' } };
-const disputedChargeClosed = { disputed: true, dispute: { status: 'warning_closed' } };
-const disputedChargeRefunded = { disputed: true, dispute: { status: 'charge_refunded' } };
+const getDisputedChargeWithStatus = status => ( { disputed: true, dispute: { status: status } } );
 // eslint-disable-next-line camelcase
 const fullyRefundedCharge = { amount: 1500, refunded: true, amount_refunded: 1500 };
 // eslint-disable-next-line camelcase
 const partiallyRefundedCharge = { amount: 1500, refunded: false, amount_refunded: 1200 };
 
 describe( 'Charge utilities', () => {
-	test( 'should identify a captured successful charge as successful', () => {
-		expect( utils.isChargeSuccessful( paidCharge ) ).toEqual( true );
+	describe( 'isCharge methods', () => {
+		test( 'should identify a captured successful charge as successful', () => {
+			expect( utils.isChargeSuccessful( paidCharge ) ).toEqual( true );
+		} );
+
+		test( 'should identify a not captured successful charge as successful', () => {
+			expect( utils.isChargeSuccessful( authorizedCharge ) ).toEqual( true );
+		} );
+
+		test( 'should identify a captured successful charge as captured', () => {
+			expect( utils.isChargeCaptured( paidCharge ) ).toEqual( true );
+		} );
+
+		test( 'should not identify a not captured successful charge as captured', () => {
+			expect( utils.isChargeCaptured( authorizedCharge ) ).toEqual( false );
+		} );
+
+		test( 'should not identify a failed charge as successful', () => {
+			expect( utils.isChargeSuccessful( failedCharge ) ).toEqual( false );
+		} );
+
+		test( 'should not identify a blocked charge as successful', () => {
+			expect( utils.isChargeSuccessful( blockedCharge ) ).toEqual( false );
+		} );
+
+		test( 'should identify a failed charge as failed', () => {
+			expect( utils.isChargeFailed( failedCharge ) ).toEqual( true );
+		} );
+
+		test( 'should identify a blocked charge as blocked', () => {
+			expect( utils.isChargeBlocked( blockedCharge ) ).toEqual( true );
+		} );
+
+		test( 'should not identify a successful charge as failed', () => {
+			expect( utils.isChargeFailed( paidCharge ) ).toEqual( false );
+		} );
+
+		test( 'should not identify a successful charge as failed', () => {
+			expect( utils.isChargeBlocked( paidCharge ) ).toEqual( false );
+		} );
+
+		test( 'should identify a fully refunded charge as fully refunded', () => {
+			expect( utils.isChargeFullyRefunded( fullyRefundedCharge ) ).toEqual( true );
+		} );
+
+		test( 'should not identify a partially refunded charge as fully refunded', () => {
+			expect( utils.isChargeFullyRefunded( partiallyRefundedCharge ) ).toEqual( false );
+		} );
+
+		test( 'should not identify a successful charge as fully refunded', () => {
+			expect( utils.isChargeFullyRefunded( paidCharge ) ).toEqual( false );
+		} );
+
+		test( 'should identify a partially refunded charge as partially refunded', () => {
+			expect( utils.isChargePartiallyRefunded( partiallyRefundedCharge ) ).toEqual( true );
+		} );
+
+		test( 'should not identify a fully refunded charge as partially refunded', () => {
+			expect( utils.isChargePartiallyRefunded( fullyRefundedCharge ) ).toEqual( false );
+		} );
+
+		test( 'should not identify a successful charge as partially refunded', () => {
+			expect( utils.isChargePartiallyRefunded( paidCharge ) ).toEqual( false );
+		} );
 	} );
 
-	test( 'should identify a not captured successful charge as successful', () => {
-		expect( utils.isChargeSuccessful( authorizedCharge ) ).toEqual( true );
-	} );
+	describe( 'getChargeStatus', () => {
+		const chargeStatuses = [
+			[ 'paid', paidCharge ],
+			[ 'authorized', authorizedCharge ],
+			[ 'failed', failedCharge ],
+			[ 'refunded_full', fullyRefundedCharge ],
+			[ 'refunded_partial', partiallyRefundedCharge ],
+		];
 
-	test( 'should identify a captured successful charge as captured', () => {
-		expect( utils.isChargeCaptured( paidCharge ) ).toEqual( true );
-	} );
+		test.each( chargeStatuses )( 'returns %s status for charge', ( status, charge ) => {
+			expect( utils.getChargeStatus( charge ) ).toEqual( status );
+		} );
 
-	test( 'should not identify a not captured successful charge as captured', () => {
-		expect( utils.isChargeCaptured( authorizedCharge ) ).toEqual( false );
-	} );
+		const disputedStatuses = [
+			'disputed_needs_response',
+			'disputed_under_review',
+			'disputed_won',
+			'disputed_lost',
+			'disputed_warning_needs_response',
+			'disputed_warning_under_review',
+			'disputed_warning_closed',
+		];
 
-	test( 'should not identify a failed charge as successful', () => {
-		expect( utils.isChargeSuccessful( failedCharge ) ).toEqual( false );
-	} );
-
-	test( 'should not identify a blocked charge as successful', () => {
-		expect( utils.isChargeSuccessful( blockedCharge ) ).toEqual( false );
-	} );
-
-	test( 'should identify a failed charge as failed', () => {
-		expect( utils.isChargeFailed( failedCharge ) ).toEqual( true );
-	} );
-
-	test( 'should identify a blocked charge as blocked', () => {
-		expect( utils.isChargeBlocked( blockedCharge ) ).toEqual( true );
-	} );
-
-	test( 'should not identify a successful charge as failed', () => {
-		expect( utils.isChargeFailed( paidCharge ) ).toEqual( false );
-	} );
-
-	test( 'should not identify a successful charge as failed', () => {
-		expect( utils.isChargeBlocked( paidCharge ) ).toEqual( false );
-	} );
-
-	test( 'should identify a disputed charge as disputed', () => {
-		expect( utils.isChargeDisputed( disputedChargeWon ) ).toEqual( true );
-	} );
-
-	test( 'should identify a fully refunded charge as fully refunded', () => {
-		expect( utils.isChargeFullyRefunded( fullyRefundedCharge ) ).toEqual(
-			true
-		);
-	} );
-
-	test( 'should not identify a partially refunded charge as fully refunded', () => {
-		expect(
-			utils.isChargeFullyRefunded( partiallyRefundedCharge )
-		).toEqual( false );
-	} );
-
-	test( 'should not identify a successful charge as fully refunded', () => {
-		expect( utils.isChargeFullyRefunded( paidCharge ) ).toEqual( false );
-	} );
-
-	test( 'should identify a partially refunded charge as partially refunded', () => {
-		expect(
-			utils.isChargePartiallyRefunded( partiallyRefundedCharge )
-		).toEqual( true );
-	} );
-
-	test( 'should not identify a fully refunded charge as partilly refunded', () => {
-		expect(
-			utils.isChargePartiallyRefunded( fullyRefundedCharge )
-		).toEqual( false );
-	} );
-
-	test( 'should not identify a successful charge as partilly refunded', () => {
-		expect( utils.isChargePartiallyRefunded( paidCharge ) ).toEqual(
-			false
-		);
-	} );
-
-	test( 'should return status paid for captured successful charges', () => {
-		expect( utils.getChargeStatus( paidCharge ) ).toEqual( 'paid' );
-	} );
-
-	test( 'should return status authorized for not captured successful charges', () => {
-		expect( utils.getChargeStatus( authorizedCharge ) ).toEqual(
-			'authorized'
-		);
-	} );
-
-	test( 'should return status failed for failed charges', () => {
-		expect( utils.getChargeStatus( failedCharge ) ).toEqual( 'failed' );
-	} );
-
-	test( 'should return status disputed_needs_response for disputed charges that needs response', () => {
-		expect( utils.getChargeStatus( disputedChargeNeedsResponse ) ).toEqual(
-			'disputed_needs_response'
-		);
-	} );
-
-	test( 'should return status disputed_under_review for disputed charges in review', () => {
-		expect( utils.getChargeStatus( disputedChargeUnderReview ) ).toEqual(
-			'disputed_under_review'
-		);
-	} );
-
-	test( 'should return status disputed_won for won disputed charges', () => {
-		expect( utils.getChargeStatus( disputedChargeWon ) ).toEqual(
-			'disputed_won'
-		);
-	} );
-
-	test( 'should return status disputed_lost for lost disputed charges', () => {
-		expect( utils.getChargeStatus( disputedChargeLost ) ).toEqual(
-			'disputed_lost'
-		);
-	} );
-
-	test( 'should return status disputed_closed for closed disputed charges', () => {
-		expect( utils.getChargeStatus( disputedChargeClosed ) ).toEqual( 'disputed_closed' );
-	} );
-
-	test( 'should return status refunded_full for charge refunded disputed charges', () => {
-		expect( utils.getChargeStatus( disputedChargeRefunded ) ).toEqual( 'refunded_full' );
-	} );
-
-	test( 'should return status refunded_full for fully refunded charges', () => {
-		expect( utils.getChargeStatus( fullyRefundedCharge ) ).toEqual(
-			'refunded_full'
-		);
-	} );
-
-	test( 'should return status refunded_partial for partially refunded charges', () => {
-		expect( utils.getChargeStatus( partiallyRefundedCharge ) ).toEqual(
-			'refunded_partial'
-		);
+		test.each( disputedStatuses )( 'returns disputed status for %s', ( status ) => {
+			expect( utils.getChargeStatus( getDisputedChargeWithStatus( status ) ) ).toEqual( 'disputed_' + status );
+		} );
 	} );
 } );
 

--- a/client/utils/charge/test/index.js
+++ b/client/utils/charge/test/index.js
@@ -108,18 +108,28 @@ describe( 'Charge utilities', () => {
 			expect( utils.getChargeStatus( charge ) ).toEqual( status );
 		} );
 
-		const disputedStatuses = [
-			'disputed_needs_response',
-			'disputed_under_review',
-			'disputed_won',
-			'disputed_lost',
-			'disputed_warning_needs_response',
-			'disputed_warning_under_review',
-			'disputed_warning_closed',
+		const disputeStatuses = [
+			'needs_response',
+			'under_review',
+			'won',
+			'lost',
+			'warning_needs_response',
+			'warning_under_review',
+			'warning_closed',
 		];
 
-		test.each( disputedStatuses )( 'returns disputed status for %s', ( status ) => {
+		test.each( disputeStatuses )( 'returns disputed status for %s', ( status ) => {
 			expect( utils.getChargeStatus( getDisputedChargeWithStatus( status ) ) ).toEqual( 'disputed_' + status );
+		} );
+
+		test.each( disputeStatuses )( 'disputed statuses take precedence over refunds', ( status ) => {
+			const charge = {
+				...getDisputedChargeWithStatus( status ),
+				...fullyRefundedCharge,
+			};
+			expect( utils.getChargeStatus( charge ) ).toEqual( 'disputed_' + status );
+			expect( charge.refunded ).toEqual( true );
+			expect( charge.amount_refunded ).toEqual( 1500 );
 		} );
 	} );
 } );

--- a/client/utils/charge/test/index.js
+++ b/client/utils/charge/test/index.js
@@ -32,18 +32,12 @@ const disputedChargeUnderReview = {
 };
 const disputedChargeWon = { disputed: true, dispute: { status: 'won' } };
 const disputedChargeLost = { disputed: true, dispute: { status: 'lost' } };
-const fullyRefundedCharge = {
-	amount: 1500,
-	refunded: true,
-	// eslint-disable-next-line camelcase
-	amount_refunded: 1500,
-};
-const partiallyRefundedCharge = {
-	amount: 1500,
-	refunded: false,
-	// eslint-disable-next-line camelcase
-	amount_refunded: 1200,
-};
+const disputedChargeClosed = { disputed: true, dispute: { status: 'warning_closed' } };
+const disputedChargeRefunded = { disputed: true, dispute: { status: 'charge_refunded' } };
+// eslint-disable-next-line camelcase
+const fullyRefundedCharge = { amount: 1500, refunded: true, amount_refunded: 1500 };
+// eslint-disable-next-line camelcase
+const partiallyRefundedCharge = { amount: 1500, refunded: false, amount_refunded: 1200 };
 
 describe( 'Charge utilities', () => {
 	test( 'should identify a captured successful charge as successful', () => {
@@ -160,6 +154,14 @@ describe( 'Charge utilities', () => {
 		expect( utils.getChargeStatus( disputedChargeLost ) ).toEqual(
 			'disputed_lost'
 		);
+	} );
+
+	test( 'should return status disputed_closed for closed disputed charges', () => {
+		expect( utils.getChargeStatus( disputedChargeClosed ) ).toEqual( 'disputed_closed' );
+	} );
+
+	test( 'should return status refunded_full for charge refunded disputed charges', () => {
+		expect( utils.getChargeStatus( disputedChargeRefunded ) ).toEqual( 'refunded_full' );
 	} );
 
 	test( 'should return status refunded_full for fully refunded charges', () => {


### PR DESCRIPTION
Fixes #737 

#### Changes proposed in this Pull Request

* Update payment statuses to match the ones used in the disputes list
* Adds a test to ensure dispute and inquiry statuses take precedence over refunds
* Refactor Payment Status Chip and extract mapping logic
* Tidy up some payment status and charge utils tests

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check if existing payment statuses are working
2. Make a payment using Stripe's `inquiry` type [dispute testing number](https://stripe.com/docs/testing#disputes) to make a payment: `4000 0000 0000 1976`
2.1. Challenge the dispute with either `winning_evidence` or `losing_evidence`, or fully refund the order. All of the options should result in `warning_closed`
2.2. Make sure that the transaction details page has a `Disputed: Inquiry closed` status

\* `charge_refunded` hasn't been reproduced yet, but we should cover our bases there anyway

-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
