### PR TITLE
Add the 7-day capture notice to manual capture label

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -100,11 +100,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			],
 			'manual_capture'  => [
 				'title'       => __( 'Manual capture', 'woocommerce-payments' ),
-				'label'       => __( 'Issue an authorization on checkout, and capture later', 'woocommerce-payments' ),
+				'label'       => __( 'Issue an authorization on checkout, and capture later.', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
-				'description' => __( 'Manually capture funds within 7 days after the customer authorizes payment on checkout.', 'woocommerce-payments' ),
+				'description' => __( 'Charge must be captured within 7 days of authorization, otherwise the authorization and order will be canceled.', 'woocommerce-payments' ),
 				'default'     => 'no',
-				'desc_tip'    => true,
 			],
 			'test_mode'       => [
 				'title'       => __( 'Test mode', 'woocommerce-payments' ),


### PR DESCRIPTION
This commit removes the tooltip regarding the 7-day capture window and adds an improved description to the checkbox label to make it clearer.

Fixes #742 

#### Changes proposed in this Pull Request

* Remove manual capture tooltip
* Add ["Charge must be captured within 7 days of authorization, otherwise the authorization and order will be canceled."](https://github.com/Automattic/woocommerce-payments/pull/747#issuecomment-647723013) to the manual capture label

<!-- ![image](https://user-images.githubusercontent.com/7714042/85325008-4646c980-b4a1-11ea-9c50-ea770514a617.png) -->

![image](https://user-images.githubusercontent.com/7714042/85413699-82ca0200-b541-11ea-8415-f3fb5f773f50.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the WooCommerce Payments settings page
* Make sure that the 7-day explanation is shown in the manual capture description

-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
