### PR TITLE
Display confirmation dialog when enabling manual capture

### DIFF
--- a/client/settings.js
+++ b/client/settings.js
@@ -24,8 +24,8 @@ if ( isWCPaySettingsPage() ) {
 			if ( manualCaptureCheckbox.checked ) {
 				const hasUserConfirmed = confirm(
 					__(
-						'When manual capture is enabled, you need to capture funds manually within 7 days of the order being placed, \
-otherwise the authorization will be canceled alongside the order. Are you sure you want to enable it?',
+						'When manual capture is enabled, charges must be captured within 7 days of authorization, otherwise the \
+authorization and order will be canceled. Are you sure you want to enable it?',
 						'woocommerce-payments'
 					)
 				);


### PR DESCRIPTION
Fixes #743 

#### Changes proposed in this Pull Request

* Add a confirmation dialog before saving the settings when manual capture is enabled

![image](https://user-images.githubusercontent.com/7714042/85334458-ab0a2000-b4b1-11ea-8ace-8f9bd26a6ea7.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the WCPay settings page
* Disabled Manual capture in case it's enabled and save changes
* Check the Manual capture checkbox and click on save
* You should get a confirmation dialog, informing of the 7-day capture window
    * Click on cancel, the settings should not be saved
    * Click on confirm, the settings should be changed
* Save button clicks should not prompt for confirmation in case the checkbox was already selected

-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
