### PR TITLE
Remove redundant code now that WCPay requires WC 4.0+

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -249,17 +249,11 @@ class WC_Payments {
 					[ 'strong' => '<strong>' ]
 				);
 
-				if ( defined( 'WC_ADMIN_PACKAGE_EXISTS' ) ) { // Let's assume for now that any WC-Admin version bundled with WooCommerce will meet our minimum requirements.
-					$message .= ' ' . __( 'There is a newer version of WooCommerce Admin bundled with WooCommerce.', 'woocommerce-payments' );
-					if ( current_user_can( 'deactivate_plugins' ) ) {
-						$deactivate_url = wp_nonce_url( admin_url( 'plugins.php?action=deactivate&plugin=woocommerce-admin/woocommerce-admin.php' ), 'deactivate-plugin_woocommerce-admin/woocommerce-admin.php' );
-						$message       .= ' <a href="' . $deactivate_url . '">' . __( 'Use the bundled version of WooCommerce Admin', 'woocommerce-payments' ) . '</a>';
-					}
-				} else {
-					if ( current_user_can( 'update_plugins' ) ) {
-						$update_url = wp_nonce_url( admin_url( 'update.php?action=upgrade-plugin&plugin=woocommerce-admin/woocommerce-admin.php' ), 'upgrade-plugin_woocommerce-admin/woocommerce-admin.php' );
-						$message   .= ' <a href="' . $update_url . '">' . __( 'Update WooCommerce Admin', 'woocommerce-payments' ) . '</a>';
-					}
+				// Let's assume for now that any WC-Admin version bundled with WooCommerce will meet our minimum requirements.
+				$message .= ' ' . __( 'There is a newer version of WooCommerce Admin bundled with WooCommerce.', 'woocommerce-payments' );
+				if ( current_user_can( 'deactivate_plugins' ) ) {
+					$deactivate_url = wp_nonce_url( admin_url( 'plugins.php?action=deactivate&plugin=woocommerce-admin/woocommerce-admin.php' ), 'deactivate-plugin_woocommerce-admin/woocommerce-admin.php' );
+					$message       .= ' <a href="' . $deactivate_url . '">' . __( 'Use the bundled version of WooCommerce Admin', 'woocommerce-payments' ) . '</a>';
 				}
 				self::display_admin_error( $message );
 			}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -217,6 +217,28 @@ class WC_Payments {
 			}
 		}
 
+		// Check if the version of WooCommerce is compatible with WooCommerce Payments.
+		if ( version_compare( WC_VERSION, $wc_version, '<' ) ) {
+			if ( ! $silent ) {
+				$message = WC_Payments_Utils::esc_interpolated_html(
+					sprintf(
+					/* translators: %1: required WC version number, %2: currently installed WC version number */
+						__( 'WooCommerce Payments requires <strong>WooCommerce %1$s</strong> or greater to be installed (you are using %2$s).', 'woocommerce-payments' ),
+						$wc_version,
+						WC_VERSION
+					),
+					[ 'strong' => '<strong>' ]
+				);
+				if ( current_user_can( 'update_plugins' ) ) {
+					// Take the user to the "plugins" screen instead of trying to update WooCommerce inline. WooCommerce adds important information
+					// on its plugin row regarding the currently installed extensions and their compatibility with the latest WC version.
+					$message .= ' <a href="' . admin_url( 'plugins.php' ) . '">' . __( 'Update WooCommerce', 'woocommerce-payments' ) . '</a>';
+				}
+				self::display_admin_error( $message );
+			}
+			return false;
+		}
+
 		// Check if the current WooCommerce version has WooCommerce Admin bundled (WC 4.0+) but it's disabled using a filter.
 		if ( ! defined( 'WC_ADMIN_VERSION_NUMBER' ) ) {
 			if ( ! $silent ) {
@@ -248,28 +270,6 @@ class WC_Payments {
 				if ( current_user_can( 'deactivate_plugins' ) ) {
 					$deactivate_url = wp_nonce_url( admin_url( 'plugins.php?action=deactivate&plugin=woocommerce-admin/woocommerce-admin.php' ), 'deactivate-plugin_woocommerce-admin/woocommerce-admin.php' );
 					$message       .= ' <a href="' . $deactivate_url . '">' . __( 'Use the bundled version of WooCommerce Admin', 'woocommerce-payments' ) . '</a>';
-				}
-				self::display_admin_error( $message );
-			}
-			return false;
-		}
-
-		// Check if the version of WooCommerce is compatible with WooCommerce Payments.
-		if ( version_compare( WC_VERSION, $wc_version, '<' ) ) {
-			if ( ! $silent ) {
-				$message = WC_Payments_Utils::esc_interpolated_html(
-					sprintf(
-						/* translators: %1: required WC version number, %2: currently installed WC version number */
-						__( 'WooCommerce Payments requires <strong>WooCommerce %1$s</strong> or greater to be installed (you are using %2$s).', 'woocommerce-payments' ),
-						$wc_version,
-						WC_VERSION
-					),
-					[ 'strong' => '<strong>' ]
-				);
-				if ( current_user_can( 'update_plugins' ) ) {
-					// Take the user to the "plugins" screen instead of trying to update WooCommerce inline. WooCommerce adds important information
-					// on its plugin row regarding the currently installed extensions and their compatibility with the latest WC version.
-					$message .= ' <a href="' . admin_url( 'plugins.php' ) . '">' . __( 'Update WooCommerce', 'woocommerce-payments' ) . '</a>';
 				}
 				self::display_admin_error( $message );
 			}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -181,12 +181,6 @@ class WC_Payments {
 				'slug'  => 'woocommerce',
 				'file'  => 'woocommerce/woocommerce.php',
 			],
-			[
-				'name'  => 'WooCommerce Admin',
-				'class' => '\Automattic\WooCommerce\Admin\FeaturePlugin',
-				'slug'  => 'woocommerce-admin',
-				'file'  => 'woocommerce-admin/woocommerce-admin.php',
-			],
 		];
 
 		// Check if WooCommerce and other dependencies are  installed and active.


### PR DESCRIPTION
Fixes #667

This PR simplifies the plugin dependencies checker. We are requiring WooCommerce 4.0+ now, so we can make a few assumptions:
- If the WooCommerce dependency is satisfied, then WC-Admin will be bundled.
- If the WooCommerce dependency is satisfied, then the bundled WC-Admin version will be compatible with WCPay.
- If the WooCommerce dependency is satisfied, the only scenario where WC-Admin is not present is if it's been disabled with a filter.

With those assumptions in mind, the dependency checker code can be greatly simplified. It's still taking into account the following situations:
- WooCommerce not installed.
- WooCommerce not activated.
- WooCommerce version too old.
- WC-Admin disabled with a filter.
- Old version of WC-Admin plugin installed (overrides the bundled WC-Admin version).
- WordPress version too old.

No need to test all those scenarios, since the dependency checker is already working in `master` just fine. Possible scenarios to test:
- Install an old WC-Admin version (0.23.0 or earlier). See that the `[$] Payments` menu doesn't appear, and a notice is shown that tells you to use the bundled WC-Admin version instead. Clicking the link in that notice should disable WC-Admin.
- Add `add_filter('woocommerce_admin_disabled', '__return_true');` to your site. You should see a notice telling you to remove that filter.