### PR TITLE
Prevent plugin initialization if Jetpack 8.1 or earlier is installed

### DIFF
--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -55,6 +55,7 @@ function wcpay_init() {
 }
 
 // Make sure this is run *after* WooCommerce has a chance to initialize its packages (wc-admin, etc). That is run with priority 10.
+// If you change the priority of this action, you'll need to change it in the wcpay_check_old_jetpack_version function too.
 add_action( 'plugins_loaded', 'wcpay_init', 11 );
 
 /**
@@ -81,7 +82,7 @@ function wcpay_show_old_jetpack_notice() {
 	?>
 	<div class="notice wcpay-notice notice-error">
 		<p><b><?php echo esc_html( __( 'WooCommerce Payments', 'woocommerce-payments' ) ); ?></b></p>
-		<p><?php echo esc_html( __( 'The version of Jetpack installed is too old to be used with WooCommerce Payments. Please deactivate or update Jetpack.', 'woocommerce-payments' ) ); ?></p>
+		<p><?php echo esc_html( __( 'The version of Jetpack installed is too old to be used with WooCommerce Payments. WooCommerce Payments has been disabled. Please deactivate or update Jetpack.', 'woocommerce-payments' ) ); ?></p>
 	</div>
 	<?php
 }


### PR DESCRIPTION
Due to changes in the autoloader, if Jetpack 8.1 or earlier is installed alongside WCPay, the whole site would crash. The crash would happen in the `\Jetpack\Config` initialization code.

I added a quick & dirty check to show an admin notice if Jetpack 8.1 or earlier is installed, and prevent the rest of the plugin from initializing. I didn't want to spend a lot of effort in this so it's not as smart as the main dependency checker (which shows a link to update the dependency, tells you which version of the dependency you have, etc). I just wanted something temporary that's better than the site crashing.

Jetpack 8.2 (which is already compatible with WCPay) was released in February 2020. I think we can remove this piece of code in a few months, maybe when that version is 1 year old? Anyway, I left a TODO comment, if someone stumbles upon it in the distant future it can be removed.

To test:
- Install Jetpack 8.1 without using this WCPay branch. Note that the site crashes.
- Install Jetpack 8.2. Everything works fine.
- Install Jetpack 8.1 again, now using this WCPay branch. You'll see a notice telling you to upgrade, and you won't see the `[$] Payments` menu at all.
- Install Jetpack 8.2, still using this WCPay branch. Everything should work fine.
- Disable Jetpack. Everything should still work fine.

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->

Fixes #577.