### PR TITLE
Remove horizontal list items top border

### DIFF
--- a/client/components/horizontal-list/style.scss
+++ b/client/components/horizontal-list/style.scss
@@ -21,6 +21,7 @@
 		padding: 0.75rem 1rem;
 		border-left: 0;
 		border-bottom: 1px solid $studio-gray-5;
+		border-top: 0;
 		@include breakpoint( '>800px' ) {
 			padding: 0 1rem;
 			border-left: 1px solid $studio-gray-5;


### PR DESCRIPTION
Fixes #771 

#### Changes proposed in this Pull Request

* Remove horizontal list items top border

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the latest version of WC Admin or WC 4.3, navigate to a transactions details page
* Make sure the summary items do not display a border on top

![image](https://user-images.githubusercontent.com/7714042/86964691-dbea8600-c13c-11ea-9bef-ff21e947bc74.png)


-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
