### PR TITLE
For 3DS flows, set charge id metadata before payment_complete()

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -847,6 +847,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 						$intent_id
 					);
 					$order->add_order_note( $note );
+
+					// The order is successful, so update it to reflect that.
+					$order->update_meta_data( '_charge_id', $intent->get_charge_id() );
+					$order->update_meta_data( '_intention_status', $status );
+					$order->save();
+
 					$order->payment_complete( $intent_id );
 					break;
 				case 'requires_capture':
@@ -865,6 +871,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					// Save the note separately because if there is no change in status
 					// then the note is not saved using WC_Order::update_status.
 					$order->add_order_note( $note );
+
+					// The order is successful, so update it to reflect that.
+					$order->update_meta_data( '_charge_id', $intent->get_charge_id() );
+					$order->update_meta_data( '_intention_status', $status );
+					$order->save();
+
 					$order->update_status( 'on-hold' );
 					$order->set_transaction_id( $intent_id );
 					break;
@@ -889,11 +901,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			}
 
 			if ( 'succeeded' === $status || 'requires_capture' === $status ) {
-				// The order is successful, so update it to reflect that.
-				$order->update_meta_data( '_charge_id', $intent->get_charge_id() );
-				$order->update_meta_data( '_intention_status', $status );
-				$order->save();
-
 				wc_reduce_stock_levels( $order_id );
 				WC()->cart->empty_cart();
 


### PR DESCRIPTION
This PR has an identical fix to PR #695, but it's for the 3DS flow.

The charge ID is saved to the order meta before the payment is marked as complete. This is so that the charge will still appear on various screens, and so that the payment can be refunded if needed, etc.

For more info, take a look at the description for PR #695 

### Testing instructions
1. Check out using a 3DS test card like `4000 0027 6000 3184`
2. See that the meta data is saved before the payment is marked as complete in the successful case.