### PR TITLE
Bump the timeline feature flag to 1.4.0

### DIFF
--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -264,7 +264,7 @@ class WC_Payments_Admin {
 	 */
 	private function get_frontend_feature_flags() {
 		return [
-			'paymentTimeline' => self::version_compare( WC_ADMIN_VERSION_NUMBER, '1.3.0', '>=' ),
+			'paymentTimeline' => self::version_compare( WC_ADMIN_VERSION_NUMBER, '1.4.0', '>=' ),
 		];
 	}
 


### PR DESCRIPTION
Fixes #774

#### Changes proposed in this Pull Request

* Bumps the version of WC-Admin that the timeline depends on to 1.4.0
* 1.4.0 will be released next month
* Right now there's no way of testing the timeline without modifying the flags and running a dev version of wc-admin 

#### Testing instructions

* Update to Woo core 4.3, make sure wc-admin plugin is deactivated if it's installed separately
* Navigate to any transaction view
* The view should render without errors, no timeline should be visible