### PR TITLE
Include the selected date on transactions before or after filters

### DIFF
--- a/client/data/transactions/resolvers.js
+++ b/client/data/transactions/resolvers.js
@@ -21,8 +21,8 @@ import { formatDateValue } from '../../util';
 /*eslint-disable camelcase*/
 const formatQueryFilters = ( query ) => ( {
 	match: query.match,
-	date_before: formatDateValue( query.dateBefore ),
-	date_after: formatDateValue( query.dateAfter, true ),
+	date_before: formatDateValue( query.dateBefore, true ),
+	date_after: formatDateValue( query.dateAfter ),
 	date_between: query.dateBetween && [
 		formatDateValue( query.dateBetween[ 0 ] ),
 		formatDateValue( query.dateBetween[ 1 ], true ),

--- a/client/data/transactions/test/resolvers.js
+++ b/client/data/transactions/test/resolvers.js
@@ -38,7 +38,7 @@ describe( 'getTransactions resolver', () => {
 	const successfulResponse = { data: [] };
 	const query = { ...paginationQuery, ...filterQuery };
 	const expectedQueryString = 'page=1&pagesize=25&sort=date&direction=desc' +
-		'&match=all&date_before=2020-04-28%2004%3A00%3A00&date_after=2020-04-30%2003%3A59%3A59' +
+		'&match=all&date_before=2020-04-29%2003%3A59%3A59&date_after=2020-04-29%2004%3A00%3A00' +
 		'&date_between%5B0%5D=2020-04-28%2004%3A00%3A00&date_between%5B1%5D=2020-04-30%2003%3A59%3A59&type_is=charge' +
 		'&type_is_not=dispute&deposit_id=mock_po_id';
 	let generator = null;
@@ -68,7 +68,7 @@ describe( 'getTransactions resolver', () => {
 describe( 'getTransactionsSummary resolver', () => {
 	const successfulResponse = {};
 	const query = filterQuery;
-	const expectedQueryString = 'match=all&date_before=2020-04-28%2004%3A00%3A00&date_after=2020-04-30%2003%3A59%3A59' +
+	const expectedQueryString = 'match=all&date_before=2020-04-29%2003%3A59%3A59&date_after=2020-04-29%2004%3A00%3A00' +
 		'&date_between%5B0%5D=2020-04-28%2004%3A00%3A00&date_between%5B1%5D=2020-04-30%2003%3A59%3A59&type_is=charge' +
 		'&type_is_not=dispute&deposit_id=mock_po_id';
 	let generator = null;


### PR DESCRIPTION
Fixes #778 

#### Changes proposed in this Pull Request

* Include the selected date on transactions before or after filters

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the transactions list
* Add a `before` date filter to the exact day of a transaction and apply it
* The results should contain the transactions from the selected date
* Add an `after` date filter to the exact day of a transaction and apply it
* The results should contain the transactions from the selected date


![image](https://user-images.githubusercontent.com/7714042/87052948-c24a4c80-c1d7-11ea-9d63-9850f01f9cb4.png)

![image](https://user-images.githubusercontent.com/7714042/87052959-c5453d00-c1d7-11ea-81f3-8e14a9bd5fd0.png)

-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
