### PR TITLE
Add/407 merchant descriptor

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 1.3.1 - 2020-xx-xx =
+* Add - Allow merchant to edit statement descriptor
+
 = 1.3.0 - 2020-08-17 =
 * Add - Support for saved cards.
 * Add - Search bar for transactions.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -113,9 +113,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'type' => 'account_status',
 			],
 			'account_statement_descriptor' => [
-				'type'  => 'account_statement_descriptor',
-				'title' => __( 'Statement Descriptor', 'woocommerce-payments' ),
-				'label' => __( 'Statement descriptor to display in receipt', 'woocommerce-payments' ),
+				'type'        => 'account_statement_descriptor',
+				'title'       => __( 'Statement Descriptor', 'woocommerce-payments' ),
+				'description' => __( 'Statement descriptor to display in receipt.', 'woocommerce-payments' ),
 			],
 			'manual_capture'               => [
 				'title'       => __( 'Manual capture', 'woocommerce-payments' ),

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -769,7 +769,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public function sanitize_plugin_settings( $settings ) {
 		if ( isset( $settings['account_statement_descriptor'] ) ) {
 			$this->update_statement_descriptor( $settings['account_statement_descriptor'] );
-			$settings['account_statement_descriptor'] = '';
+			unset( $settings['account_statement_descriptor'] );
 		}
 
 		return $settings;

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -749,6 +749,35 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Validates statement descriptor value
+	 *
+	 * @param  string $key Field key.
+	 * @param  string $value Posted Value.
+	 *
+	 * @return string Sanitized statement descriptor.
+	 * @throws Exception When statement descriptor is invalid.
+	 */
+	public function validate_account_statement_descriptor_field( $key, $value ) {
+		$sanitized_value = $this->validate_text_field( $key, $value );
+
+		// Validation can be done with a single regex but splitting into multiple for better readability.
+		$valid_length   = '/^.{5,22}$/';
+		$has_one_letter = '/^.*[a-zA-Z]+/';
+		$no_specials    = '/^[^*"\']*$/';
+
+		if (
+			! preg_match( $valid_length, $sanitized_value ) ||
+			! preg_match( $has_one_letter, $sanitized_value ) ||
+			! preg_match( $no_specials, $sanitized_value )
+		) {
+			throw new Exception(
+				__( 'Invalid Statement descriptor. Statement descriptor should be between 5 and 22 characters long, contain at least single Latin character and does not contain special characters: \' " *', 'woocommerce-payments' )
+			);
+		}
+		return $value;
+	}
+
+	/**
 	 * Generate markup for account actions
 	 */
 	public function generate_account_actions_html() {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -151,7 +151,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// Load the settings.
 		$this->init_settings();
 
-		// TODO: override/hook into 'process_admin_options' to update option value in connected account.
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
 		add_action( 'woocommerce_order_actions', [ $this, 'add_order_actions' ] );
 		add_action( 'woocommerce_order_action_capture_charge', [ $this, 'capture_charge' ] );
@@ -784,6 +783,22 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		</tr>
 		<?php
 		return ob_get_clean();
+	}
+
+	/**
+	 * Handles plugin settings updates.
+	 *
+	 * @return bool was anything saved?
+	 */
+	public function process_admin_options() {
+		$saved = parent::process_admin_options();
+		if ( $saved ) {
+			$account_settings = [
+				'statement_descriptor' => $this->get_option( 'account_statement_descriptor' ),
+			];
+			$this->account->update_stripe_account( $account_settings );
+		}
+		return $saved;
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -828,23 +828,21 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @throws Exception When statement descriptor is invalid.
 	 */
 	public function validate_account_statement_descriptor_field( $key, $value ) {
-		$sanitized_value = $this->validate_text_field( $key, $value );
-
 		// Validation can be done with a single regex but splitting into multiple for better readability.
 		$valid_length   = '/^.{5,22}$/';
 		$has_one_letter = '/^.*[a-zA-Z]+/';
-		$no_specials    = '/^[^*"\']*$/';
+		$no_specials    = '/^[^*"\'<>]*$/';
 
 		if (
-			! preg_match( $valid_length, $sanitized_value ) ||
-			! preg_match( $has_one_letter, $sanitized_value ) ||
-			! preg_match( $no_specials, $sanitized_value )
+			! preg_match( $valid_length, $value ) ||
+			! preg_match( $has_one_letter, $value ) ||
+			! preg_match( $no_specials, $value )
 		) {
-			throw new Exception(
-				__( 'Invalid Statement descriptor. Statement descriptor should be between 5 and 22 characters long, contain at least single Latin character and does not contain special characters: \' " *', 'woocommerce-payments' )
-			);
+			throw new Exception( __( 'Invalid Statement descriptor. Statement descriptor should be between 5 and 22 characters long, contain at least single Latin character and does not contain special characters: \' " * &lt; &gt;', 'woocommerce-payments' ) );
 		}
-		return $value;
+
+		// Perform text validation after own checks to prevent special characters like < > escaped before own validation.
+		return $this->validate_text_field( $key, $value );
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -114,8 +114,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			],
 			'account_statement_descriptor' => [
 				'type'        => 'account_statement_descriptor',
-				'title'       => __( 'Statement Descriptor', 'woocommerce-payments' ),
-				'description' => __( 'Statement descriptor to display in receipt.', 'woocommerce-payments' ),
+				'title'       => __( 'Customer bank statement', 'woocommerce-payments' ),
+				'description' => __( 'Edit the way your store name appears on your customers’ bank statements.', 'woocommerce-payments' ),
 			],
 			'manual_capture'               => [
 				'title'       => __( 'Manual capture', 'woocommerce-payments' ),
@@ -838,7 +838,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			! preg_match( $has_one_letter, $value ) ||
 			! preg_match( $no_specials, $value )
 		) {
-			throw new Exception( __( 'Invalid Statement descriptor. Statement descriptor should be between 5 and 22 characters long, contain at least single Latin character and does not contain special characters: \' " * &lt; &gt;', 'woocommerce-payments' ) );
+			throw new Exception( __( 'Customer bank statement is invalid. Statement should be between 5 and 22 characters long, contain at least single Latin character and does not contain special characters: \' " * &lt; &gt;', 'woocommerce-payments' ) );
 		}
 
 		// Perform text validation after own checks to prevent special characters like < > escaped before own validation.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -152,6 +152,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$this->init_settings();
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
+		add_action( 'admin_notices', [ $this, 'display_errors' ], 9999 );
 		add_action( 'woocommerce_order_actions', [ $this, 'add_order_actions' ] );
 		add_action( 'woocommerce_order_action_capture_charge', [ $this, 'capture_charge' ] );
 		add_action( 'woocommerce_order_action_cancel_authorization', [ $this, 'cancel_authorization' ] );
@@ -796,7 +797,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$account_settings = [
 				'statement_descriptor' => $this->get_option( 'account_statement_descriptor' ),
 			];
-			$this->account->update_stripe_account( $account_settings );
+			$error_message    = $this->account->update_stripe_account( $account_settings );
+
+			if ( is_string( $error_message ) ) {
+				$msg = __( 'Failed to update statement descriptor. ', 'woocommerce-payments' ) . $error_message;
+				$this->add_error( $msg );
+			}
 		}
 		return $saved;
 	}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -829,7 +829,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$error_message    = $this->account->update_stripe_account( $account_settings );
 
 			if ( is_string( $error_message ) ) {
-				$msg = __( 'Failed to update statement descriptor. ', 'woocommerce-payments' ) . $error_message;
+				$msg = __( 'Failed to update Statement descriptor. ', 'woocommerce-payments' ) . $error_message;
 				$this->add_error( $msg );
 			}
 		}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -578,7 +578,7 @@ class WC_Payments_Account {
 			delete_transient( self::ACCOUNT_TRANSIENT );
 			$this->get_cached_account_data();
 		} catch ( Exception $e ) {
-			WCPay\Logger::error( "Failed to refresh account data. Error: $e" );
+			Logger::error( "Failed to refresh account data. Error: $e" );
 		}
 	}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -633,6 +633,8 @@ class WC_Payments_Account {
 	 * Updates Stripe account settings.
 	 *
 	 * @param array $stripe_account_settings Settings to update.
+	 *
+	 * @return null|string Error message if update failed.
 	 */
 	public function update_stripe_account( $stripe_account_settings ) {
 		try {
@@ -644,6 +646,7 @@ class WC_Payments_Account {
 			$this->cache_account( $updated_account );
 		} catch ( Exception $e ) {
 			Logger::error( 'Failed to update Stripe account ' . $e );
+			return $e->getMessage();
 		}
 	}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -163,6 +163,17 @@ class WC_Payments_Account {
 	}
 
 	/**
+	 * Gets the account statement descriptor for rendering on the settings page.
+	 *
+	 * @return string Account statement descriptor.
+	 * @throws WC_Payments_API_Exception Bubbles up from get_cached_account_data.
+	 */
+	public function get_statement_descriptor() {
+		$account = $this->get_cached_account_data();
+		return isset( $account['statement_descriptor'] ) ? $account['statement_descriptor'] : '';
+	}
+
+	/**
 	 * Utility function to immediately redirect to the main "Welcome to WooCommerce Payments" onboarding page.
 	 * Note that this function immediately ends the execution.
 	 *

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -613,6 +613,21 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Update Stripe account data
+	 *
+	 * @param array $stripe_account_settings Settings to update.
+	 *
+	 * @return array Updated account data.
+	 */
+	public function update_account( $stripe_account_settings ) {
+		return $this->request(
+			$stripe_account_settings,
+			self::ACCOUNTS_API,
+			self::POST
+		);
+	}
+
+	/**
 	 * Get data needed to initialize the OAuth flow
 	 *
 	 * @param string $return_url    - URL to redirect to at the end of the flow.

--- a/tests/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/test-class-wc-payment-gateway-wcpay.php
@@ -544,4 +544,36 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'error', $result['result'] );
 	}
+
+	/**
+	 * Tests account statement descriptor validator
+	 *
+	 * @dataProvider account_statement_descriptor_validation_provider
+	 */
+	public function test_validate_account_statement_descriptor_field( $is_valid, $value ) {
+		$key = 'account_statement_descriptor';
+		if ( $is_valid ) {
+			$validated_value = $this->wcpay_gateway->validate_account_statement_descriptor_field( $key, $value );
+			$this->assertNotEmpty( $validated_value );
+		} else {
+			$this->expectExceptionMessage( 'Invalid Statement descriptor.' );
+			$this->wcpay_gateway->validate_account_statement_descriptor_field( $key, $value );
+		}
+	}
+
+	public function account_statement_descriptor_validation_provider() {
+		return [
+			'valid'         => [ true, 'WCPAY dev' ],
+			'allow_digits'  => [ true, 'WCPay dev 2020' ],
+			'allow_special' => [ true, 'WCPay-Dev_2020' ],
+			'empty'         => [ false, '' ],
+			'short'         => [ false, 'WCP' ],
+			'long'          => [ false, 'WCPay_dev_WCPay_dev_WCPay_dev_WCPay_dev' ],
+			'no_*'          => [ false, 'WCPay * dev' ],
+			'no_sqt'        => [ false, 'WCPay \'dev\'' ],
+			'no_dqt'        => [ false, 'WCPay "dev"' ],
+			'req_latin'     => [ false, 'дескриптор' ],
+			'req_letter'    => [ false, '123456' ],
+		];
+	}
 }

--- a/tests/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/test-class-wc-payment-gateway-wcpay.php
@@ -556,7 +556,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			$validated_value = $this->wcpay_gateway->validate_account_statement_descriptor_field( $key, $value );
 			$this->assertNotEmpty( $validated_value );
 		} else {
-			$this->expectExceptionMessage( 'Invalid Statement descriptor.' );
+			$this->expectExceptionMessage( 'Customer bank statement is invalid.' );
 			$this->wcpay_gateway->validate_account_statement_descriptor_field( $key, $value );
 		}
 	}

--- a/tests/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/test-class-wc-payment-gateway-wcpay.php
@@ -572,6 +572,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			'no_*'          => [ false, 'WCPay * dev' ],
 			'no_sqt'        => [ false, 'WCPay \'dev\'' ],
 			'no_dqt'        => [ false, 'WCPay "dev"' ],
+			'no_lt'         => [ false, 'WCPay<dev' ],
+			'no_gt'         => [ false, 'WCPay>dev' ],
 			'req_latin'     => [ false, 'дескриптор' ],
 			'req_letter'    => [ false, '123456' ],
 		];


### PR DESCRIPTION
Fixes #407 

**Note:** Server part (304-gh-woocommerce-payments-server) was already shipped.

#### Changes proposed in this Pull Request

* Allows merchant to edit statement descriptor on the plugin settings page

#### Testing instructions

**Happy path:**
* Launch server from 304-gh-woocommerce-payments-server
* Go to payment settings page. Current payment descriptor should be displayed matching one from Stripe Dashboard.
* Modify statement descriptor and save changes.
* Check changes applied on the site and in the Stripe Dashboard.
* Try to make a purchase. New statement descriptor should be applied.

**Edge cases:**
_Failed to fetch account info:_
* Throw exception either on the server (and clear cache) or in `get_cached_account_data`.
* Go to settings page. Field should not be rendered and exception message should be logged.

_Use invalid descriptor value:_
* Enter invalid descriptor value. See [docs](https://stripe.com/docs/statement-descriptors#requirements) for reference.
* Save changes.
* The dismissable error notice should be displayed at the top.

#### Screenshots
**Default view:**

<img width="1013" alt="Screenshot 2020-08-18 at 18 58 10" src="https://user-images.githubusercontent.com/3139099/90536592-ec9f0a80-e184-11ea-872b-7daa7aa203c7.png">

**With our own error message:** This message is message generated by our own validation logic and can be translated.

<img width="1603" alt="Screenshot 2020-08-18 at 19 00 11" src="https://user-images.githubusercontent.com/3139099/90536689-122c1400-e185-11ea-9f2a-b999657ea858.png">

**With Stripe's message:** This message is from Stripe API. Under normal conditions it won't be displayed to the user, but in case Stripe's validation rules change and invalid value slips through our validation similar message will be displayed.

<img width="1597" alt="image" src="https://user-images.githubusercontent.com/3139099/90537118-9aaab480-e185-11ea-8084-c7ca94d3a8cf.png">



-------------------

- [ ] Tested on mobile (or does not apply).
- [x] Tests are created (or not required).
- [x] Changelog entry is created.

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
