### PR TITLE
Bump versions for 1.2.0 release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Payments Changelog ***
 
-= 1.2.0 - 2020-07-xx =
+= 1.2.0 - 2020-07-20 =
 * Add - 3DS support when using the pay for order page
 * Add - Display confirmation dialog when enabling manual captures
 * Add - Update the order when an authorised payment has expired

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-payments",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -714,6 +714,12 @@
             "type-check": "~0.3.2",
             "word-wrap": "~1.2.3"
           }
+        },
+        "prettier": {
+          "version": "npm:wp-prettier@1.19.1",
+          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
+          "integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
+          "dev": true
         },
         "puppeteer": {
           "version": "2.1.1",
@@ -20034,12 +20040,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-      "dev": true
-    },
-    "prettier": {
-      "version": "npm:wp-prettier@1.19.1",
-      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
-      "integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-payments",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "webpack.config.js",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, payment, payment request, credit card, automattic
 Requires at least: 5.3
 Tested up to: 5.4
 Requires PHP: 7.0
-Stable tag: 1.1.0
+Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -90,7 +90,7 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 
 == Changelog ==
 
-= 1.2.0 - 2020-07-xx =
+= 1.2.0 - 2020-07-20 =
 * Add - 3DS support when using the pay for order page
 * Add - Display confirmation dialog when enabling manual captures
 * Add - Update the order when an authorised payment has expired

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -10,7 +10,7 @@
  * WC requires at least: 4.0
  * WC tested up to: 4.3
  * Requires WP: 5.3
- * Version: 1.1.0
+ * Version: 1.2.0
  *
  * @package WooCommerce\Payments
  */


### PR DESCRIPTION
Bump versions for 1.2.0 release manually.

I was planning to let the release tool handle this, but I created the changelog placeholders in the wrong format and we don't have a way to tell the tool that our version number is in a comment block.

So for now we can bump versions manually and tell the tool to just release what we have committed. I'll create issues to look into the the version number detection issue.