### PR TITLE
Fixes and adds missing translators comments in JS

### DIFF
--- a/client/components/payment-status-chip/mappings.js
+++ b/client/components/payment-status-chip/mappings.js
@@ -17,8 +17,8 @@ const formattedDisputeStatuses = Object.entries( disputeStatuses ).reduce(
 			type: mapping.type,
 			message: status.startsWith( 'warning_' )
 				? mapping.message
-				: /** translators: %s dispute status, e.g. Won, Lost, Under review, etc. */
-				  sprintf(
+				: sprintf(
+						/** translators: %s dispute status, e.g. Won, Lost, Under review, etc. */
 						__( 'Disputed: %s', 'woocommerce-payments' ),
 						mapping.message
 				  ),

--- a/client/data/disputes/actions.js
+++ b/client/data/disputes/actions.js
@@ -52,6 +52,7 @@ export function* acceptDispute( id ) {
 		window.wcTracks.recordEvent( 'wcpay_dispute_accept_success' );
 		const message = dispute.order
 			? sprintf(
+					/* translators: #%s is an order number, e.g. 15 */
 					__(
 						'You have accepted the dispute for order #%s.',
 						'woocommerce-payments'

--- a/client/disputes/details/index.js
+++ b/client/disputes/details/index.js
@@ -79,8 +79,8 @@ const DisputeDetails = ( { query: { id: disputeId } } ) => {
 						isLoading={ isLoading }
 						value={
 							mapping.display
-								? /* translators: heading for dispute category information section */
-								  sprintf(
+								? sprintf(
+										/* translators: heading for dispute category information section */
 										__(
 											'Dispute: %s',
 											'woocommerce-payments'

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -183,6 +183,7 @@ const mapEventToTimelineItems = ( event ) => {
 			getMainTimelineItem(
 				event,
 				stringWithAmount(
+					/* translators: %s is a monetary amount */
 					__(
 						'A payment of %s was successfully authorized',
 						'woocommerce-payments'
@@ -203,6 +204,7 @@ const mapEventToTimelineItems = ( event ) => {
 				event,
 				stringWithAmount(
 					__(
+						/* translators: %s is a monetary amount */
 						'Authorization for %s was voided',
 						'woocommerce-payments'
 					),
@@ -222,6 +224,7 @@ const mapEventToTimelineItems = ( event ) => {
 				event,
 				stringWithAmount(
 					__(
+						/* translators: %s is a monetary amount */
 						'Authorization for %s expired',
 						'woocommerce-payments'
 					),
@@ -242,6 +245,7 @@ const mapEventToTimelineItems = ( event ) => {
 				event,
 				stringWithAmount(
 					__(
+						/* translators: %s is a monetary amount */
 						'A payment of %s was successfully charged',
 						'woocommerce-payments'
 					),
@@ -251,10 +255,12 @@ const mapEventToTimelineItems = ( event ) => {
 				'is-success',
 				[
 					stringWithAmount(
+						/* translators: %s is a monetary amount */
 						__( 'Fee: %s', 'woocommerce-payments' ),
 						event.fee
 					),
 					sprintf(
+						/* translators: %s is a monetary amount */
 						__( 'Net deposit: %s', 'woocommerce-payments' ),
 						formattedNet
 					),
@@ -273,6 +279,7 @@ const mapEventToTimelineItems = ( event ) => {
 				event,
 				sprintf(
 					__(
+						/* translators: %s is a monetary amount */
 						'A payment of %s was successfully refunded',
 						'woocommerce-payments'
 					),
@@ -294,6 +301,7 @@ const mapEventToTimelineItems = ( event ) => {
 			getMainTimelineItem(
 				event,
 				stringWithAmount(
+					/* translators: %s is a monetary amount */
 					__( 'A payment of %s failed', 'woocommerce-payments' ),
 					event.amount
 				),
@@ -309,6 +317,7 @@ const mapEventToTimelineItems = ( event ) => {
 		let reasonHeadline = __( 'Payment disputed', 'woocommerce-payments' );
 		if ( disputeReasons[ event.reason ] ) {
 			reasonHeadline = sprintf(
+				/* translators: %s is a monetary amount */
 				__( 'Payment disputed as %s', 'woocommerce-payments' ),
 				disputeReasons[ event.reason ].display
 			);
@@ -347,10 +356,12 @@ const mapEventToTimelineItems = ( event ) => {
 				false,
 				[
 					stringWithAmount(
+						/* translators: %s is a monetary amount */
 						__( 'Disputed amount: %s', 'woocommerce-payments' ),
 						event.amount
 					),
 					stringWithAmount(
+						/* translators: %s is a monetary amount */
 						__( 'Fee: %s', 'woocommerce-payments' ),
 						event.fee
 					),
@@ -399,10 +410,12 @@ const mapEventToTimelineItems = ( event ) => {
 			),
 			getDepositTimelineItem( event, formattedTotal, true, [
 				stringWithAmount(
+					/* translators: %s is a monetary amount */
 					__( 'Disputed amount: %s', 'woocommerce-payments' ),
 					event.amount
 				),
 				stringWithAmount(
+					/* translators: %s is a monetary amount */
 					__( 'Fee: %s', 'woocommerce-payments' ),
 					event.fee
 				),


### PR DESCRIPTION

After running prettier we noticed several `translators` comments were misplaced. This PR fixes the ones that were misplaced and adds `translators` comments to all translated strings that have placeholders **in the JavaScript code**.

#### Changes proposed in this Pull Request

* Fix misplaced `translators` comments in JS.
* Add missing `translators` comments to strings with placeholders in JS.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `wp i18n make-pot .` in the root directory and observe that there are no warnings or errors.

-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
