### PR TITLE
Implement Jetpack connection "soft disconnect"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
       }
     },
     "require": {
-      "automattic/jetpack-connection": "^1.13.1",
-      "automattic/jetpack-config": "^1.2.0",
+      "automattic/jetpack-connection": "^1.14.1",
+      "automattic/jetpack-config": "^1.3.0",
       "automattic/jetpack-autoloader": "^1.7.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4539f448451acbd12abcd41f5c64ff86",
+    "content-hash": "2f4a07affd28259f654591d1a402be53",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -44,16 +44,16 @@
         },
         {
             "name": "automattic/jetpack-config",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-config.git",
-                "reference": "4c6ea210ba8fa60f43f0d9eb725f70450f0ba210"
+                "reference": "a7ae4b6f32c964fb7ea0f715aa5ba272a1f06113"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/4c6ea210ba8fa60f43f0d9eb725f70450f0ba210",
-                "reference": "4c6ea210ba8fa60f43f0d9eb725f70450f0ba210",
+                "url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/a7ae4b6f32c964fb7ea0f715aa5ba272a1f06113",
+                "reference": "a7ae4b6f32c964fb7ea0f715aa5ba272a1f06113",
                 "shasum": ""
             },
             "type": "library",
@@ -67,28 +67,30 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
-            "time": "2020-05-20T20:52:06+00:00"
+            "time": "2020-06-26T07:31:13+00:00"
         },
         {
             "name": "automattic/jetpack-connection",
-            "version": "v1.13.1",
+            "version": "v1.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-connection.git",
-                "reference": "9039aaa4ddfac4ae87cbddd8cb8dae39b1ebd620"
+                "reference": "5c1671020b328e9d2eca6a0950b1a1f1ec461b97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/9039aaa4ddfac4ae87cbddd8cb8dae39b1ebd620",
-                "reference": "9039aaa4ddfac4ae87cbddd8cb8dae39b1ebd620",
+                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/5c1671020b328e9d2eca6a0950b1a1f1ec461b97",
+                "reference": "5c1671020b328e9d2eca6a0950b1a1f1ec461b97",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-constants": "1.2.0",
-                "automattic/jetpack-options": "1.5.0",
-                "automattic/jetpack-roles": "1.0.4"
+                "automattic/jetpack-constants": "1.3.0",
+                "automattic/jetpack-options": "1.6.0",
+                "automattic/jetpack-roles": "1.1.0",
+                "automattic/jetpack-status": "1.2.0"
             },
             "require-dev": {
+                "automattic/wordbless": "@dev",
                 "php-mock/php-mock": "^2.1",
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
             },
@@ -107,20 +109,20 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
-            "time": "2020-06-01T09:03:16+00:00"
+            "time": "2020-07-01T09:47:19+00:00"
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-constants.git",
-                "reference": "881618defb04134ddba120e7835af1a474a11edc"
+                "reference": "77e4a85601c63dc98b3dd282090eb8558a61685c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/881618defb04134ddba120e7835af1a474a11edc",
-                "reference": "881618defb04134ddba120e7835af1a474a11edc",
+                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/77e4a85601c63dc98b3dd282090eb8558a61685c",
+                "reference": "77e4a85601c63dc98b3dd282090eb8558a61685c",
                 "shasum": ""
             },
             "require-dev": {
@@ -138,24 +140,24 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A wrapper for defining constants in a more testable way.",
-            "time": "2020-04-15T18:58:53+00:00"
+            "time": "2020-06-22T11:37:41+00:00"
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-options.git",
-                "reference": "5c9d947ab62bc786adc36b7071b0e3a7dc7470d1"
+                "reference": "43136ad803f7c54e6189a76b7e133176a87ccdc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/5c9d947ab62bc786adc36b7071b0e3a7dc7470d1",
-                "reference": "5c9d947ab62bc786adc36b7071b0e3a7dc7470d1",
+                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/43136ad803f7c54e6189a76b7e133176a87ccdc2",
+                "reference": "43136ad803f7c54e6189a76b7e133176a87ccdc2",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-constants": "1.2.0"
+                "automattic/jetpack-constants": "1.3.0"
             },
             "require-dev": {
                 "10up/wp_mock": "0.4.2",
@@ -172,20 +174,20 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A wrapper for wp-options to manage specific Jetpack options.",
-            "time": "2020-05-26T13:35:15+00:00"
+            "time": "2020-06-30T10:32:06+00:00"
         },
         {
             "name": "automattic/jetpack-roles",
-            "version": "v1.0.4",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-roles.git",
-                "reference": "0cdcff4fdc489c79f20a361c084ec48e326ce483"
+                "reference": "541d17baa86e985dfef921d274a8dd187062e7e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/0cdcff4fdc489c79f20a361c084ec48e326ce483",
-                "reference": "0cdcff4fdc489c79f20a361c084ec48e326ce483",
+                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/541d17baa86e985dfef921d274a8dd187062e7e7",
+                "reference": "541d17baa86e985dfef921d274a8dd187062e7e7",
                 "shasum": ""
             },
             "require-dev": {
@@ -203,7 +205,39 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Utilities, related with user roles and capabilities.",
-            "time": "2019-11-08T21:16:05+00:00"
+            "time": "2020-06-22T11:38:00+00:00"
+        },
+        {
+            "name": "automattic/jetpack-status",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-status.git",
+                "reference": "c0baae6da59a8f86dfdcd28577bd959691492a96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/c0baae6da59a8f86dfdcd28577bd959691492a96",
+                "reference": "c0baae6da59a8f86dfdcd28577bd959691492a96",
+                "shasum": ""
+            },
+            "require-dev": {
+                "brain/monkey": "2.4.0",
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
+            "time": "2020-06-22T11:38:04+00:00"
         }
     ],
     "packages-dev": [
@@ -2162,16 +2196,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.17.0",
+            "version": "v1.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9"
+                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
-                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
+                "reference": "2edd75b8b35d62fd3eeabba73b26b8f1f60ce13d",
                 "shasum": ""
             },
             "require": {
@@ -2184,6 +2218,10 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.17-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2230,7 +2268,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-12T16:14:59+00:00"
+            "time": "2020-06-06T08:46:27+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2274,16 +2312,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.8.0",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6"
+                "reference": "9dc4f203e36f2b486149058bade43c851dd97451"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
-                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/9dc4f203e36f2b486149058bade43c851dd97451",
+                "reference": "9dc4f203e36f2b486149058bade43c851dd97451",
                 "shasum": ""
             },
             "require": {
@@ -2291,6 +2329,7 @@
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
+                "phpstan/phpstan": "<0.12.20",
                 "vimeo/psalm": "<3.9.1"
             },
             "require-dev": {
@@ -2318,7 +2357,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-04-18T12:12:48+00:00"
+            "time": "2020-06-16T10:16:42+00:00"
         },
         {
             "name": "woocommerce/action-scheduler",
@@ -2357,16 +2396,16 @@
         },
         {
             "name": "woocommerce/woocommerce",
-            "version": "4.2.0",
+            "version": "4.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce.git",
-                "reference": "b2a0e738669ce9a9eb299180a02902a4322664b1"
+                "reference": "67cb5cf09db4c092524fe80b9678261ad7c1d9c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce/zipball/b2a0e738669ce9a9eb299180a02902a4322664b1",
-                "reference": "b2a0e738669ce9a9eb299180a02902a4322664b1",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce/zipball/67cb5cf09db4c092524fe80b9678261ad7c1d9c9",
+                "reference": "67cb5cf09db4c092524fe80b9678261ad7c1d9c9",
                 "shasum": ""
             },
             "require": {
@@ -2377,7 +2416,7 @@
                 "pelago/emogrifier": "^3.1",
                 "php": ">=7.0",
                 "woocommerce/action-scheduler": "3.1.6",
-                "woocommerce/woocommerce-admin": "1.2.3",
+                "woocommerce/woocommerce-admin": "1.2.4",
                 "woocommerce/woocommerce-blocks": "2.5.16",
                 "woocommerce/woocommerce-rest-api": "1.0.8"
             },
@@ -2425,20 +2464,20 @@
             ],
             "description": "An eCommerce toolkit that helps you sell anything. Beautifully.",
             "homepage": "https://woocommerce.com/",
-            "time": "2020-06-02T22:58:33+00:00"
+            "time": "2020-06-23T22:18:44+00:00"
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "v1.2.3",
+            "version": "v1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "5560c9b6e31e1d794a55a0eb4ccf040fd2cee4c7"
+                "reference": "52ff00ce76c8d1200e3015a6af9bae2fb31acc29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/5560c9b6e31e1d794a55a0eb4ccf040fd2cee4c7",
-                "reference": "5560c9b6e31e1d794a55a0eb4ccf040fd2cee4c7",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/52ff00ce76c8d1200e3015a6af9bae2fb31acc29",
+                "reference": "52ff00ce76c8d1200e3015a6af9bae2fb31acc29",
                 "shasum": ""
             },
             "require": {
@@ -2472,7 +2511,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2020-05-22T18:45:16+00:00"
+            "time": "2020-06-11T19:20:26+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/750

Updates the Jetpack dependencies, and implements the new "soft disconnect" APIs. WCPay doesn't provide a way to "soft disconnect" its Jetpack connection, but integration with this API will still be useful:
- When the Connection Manager UI is implemented in Jetpack, the user will be able to turn off the WCPay connection without having to disconnect Jetpack-the-plugin or disable WCPay (it doesn't make sense to do that, but whatever).
- It allows Jetpack-the-plugin to recognize that WCPay is using the Jetpack connection. That will make sure that, when Jetpack-the-plugin is disabled or disconnected, it won't affect the WCPay connection.

To test, go through the testing steps in https://github.com/Automattic/jetpack/pull/16112, with the following changes:
- Use the `add/disconnect-it-softly` Jetpack branch, since those changes aren't in `master` yet. Remember to run `composer install && yarn build` in the Jetpack repo folder.
- Where it says `client-example`, use `woocommerce-payments` instead.
- Skip the `Hard Disconnect and Reconnect` section.

cc/ @sergeymitr 