### PR TITLE
Don't redirect to the WCPay onboarding page if the WC core wizard should open instead

### DIFF
--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -36,7 +36,7 @@ class WC_Payments_Account {
 		$this->payments_api_client = $payments_api_client;
 
 		add_action( 'admin_init', [ $this, 'maybe_handle_oauth' ] );
-		add_action( 'admin_init', [ $this, 'check_stripe_account_status' ] );
+		add_action( 'admin_init', [ $this, 'check_stripe_account_status' ], 11 ); // Run this after the WC setup wizard redirection logic.
 		add_filter( 'allowed_redirect_hosts', [ $this, 'allowed_redirect_hosts' ] );
 		add_action( 'jetpack_site_registered', [ $this, 'clear_cache' ] );
 	}


### PR DESCRIPTION
Fixes #762
Fixes https://github.com/Automattic/woocommerce-payments/issues/808

The isue is not exclusive to Multisite installations, but the circumstances to reproduce will happen only if both WooCommerce and WCPay are installed and activated at the same time. So, to reproduce, you must either:
- Follow the steps described in #762 (create a multisite, network activate WC and WCPay, create a new site). Instructions to create a multisite are [unsurprisingly simple](https://wordpress.org/support/article/create-a-network/#step-2-allow-multisite) (this is WordPress after all).
- On a clean site, install and activate WooCommerce and WCPay using a CLI tool.
- On a clean site, install WooCommerce and WCPay, and bulk activate them both at the same time.

Once you do that, on `master` you would get redirected to the WCPay onboarding page. On this PR, you'll get to the WC setup wizard instead. If you click `Not now` or otherwise navigate away from it, **then** you'll get to the WCPay onboarding page.

The issue is caused by both the WCPay onboarding redirection logic running before the WC setup wizard redirection logic. They both run on the `admin_init` filter. The solution is simply to make the WCPay logic run on a lower priority.