### PR TITLE
Fix Docker image name and tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3'
 services:
   wordpress:
     build: ./docker/wordpress_xdebug
-    image: wordpress-xdebug
     container_name: woocommerce_payments_wordpress
     restart: always
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   wordpress:
     build: ./docker/wordpress_xdebug
     container_name: woocommerce_payments_wordpress
+    image: woocommerce_payments_wordpress
     restart: always
     depends_on:
       - db

--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress
+FROM wordpress:php7.3
 RUN pecl install xdebug \
 	&& docker-php-ext-enable xdebug
 RUN apt-get update \

--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -1,4 +1,6 @@
 FROM wordpress
 RUN pecl install xdebug \
 	&& docker-php-ext-enable xdebug
+RUN apt-get update \
+	&& apt-get install --assume-yes --quiet --no-install-recommends gnupg2 subversion mariadb-client
 COPY custom.ini $PHP_INI_DIR/conf.d/

--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -1,6 +1,9 @@
 FROM wordpress:php7.3
 RUN pecl install xdebug \
+	&& echo 'xdebug.remote_enable=1' >> $PHP_INI_DIR/php.ini \
+	&& echo 'xdebug.remote_port=9000' >> $PHP_INI_DIR/php.ini \
+	&& echo 'xdebug.remote_host=host.docker.internal' >> $PHP_INI_DIR/php.ini \
+	&& echo 'xdebug.remote_autostart=1' >> $PHP_INI_DIR/php.ini \
 	&& docker-php-ext-enable xdebug
 RUN apt-get update \
 	&& apt-get install --assume-yes --quiet --no-install-recommends gnupg2 subversion mariadb-client
-COPY custom.ini $PHP_INI_DIR/conf.d/

--- a/docker/wordpress_xdebug/custom.ini
+++ b/docker/wordpress_xdebug/custom.ini
@@ -1,3 +1,0 @@
-xdebug.remote_enable = 1
-xdebug.remote_host = host.docker.internal
-

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "watch": "webpack --watch",
     "start": "npm run watch",
     "dev": "npm run up && npm run watch",
-    "up": "docker-compose up -d",
+    "up": "docker-compose up --build --force-recreate -d",
     "down": "docker-compose down",
     "install-if-deps-outdated": "node bin/install-if-deps-outdated.js",
     "lint": "npm run lint:js && npm run lint:css",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
 	<testsuites>
 		<testsuite>
 			<directory suffix=".php">./tests/</directory>
+			<exclude>./tests/e2e</exclude>
 		</testsuite>
 	</testsuites>
 

--- a/tests/e2e/env/docker-compose.yml
+++ b/tests/e2e/env/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   wordpress:
     build: ./wordpress-xdebug
-    image: wordpress-xdebug
+    image: wcp_e2e_wordpress
     container_name: wcp_e2e_wordpress
     depends_on:
       - db


### PR DESCRIPTION
Fixes #811 

#### Changes proposed in this Pull Request

* Fix docker wordpress-xdebug image name clash
* Install test dependencies on docker container
* Set wordpress image version to 7.3 to avoid PHPUnit errors
* Remove E2E test files from PHPUnit test suite
* Add container recreation to up script
* Fix image name clash for E2E tests
* Include xdebug config at image build Dockerfile


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `npm run down` and `npm run up` to recreate the containers
* Verify using `docker ps` that the image name for the `woocommerce_payments_wordpress` container is the same as the container name
* Run the unit tests on the docker container with `npm run test:php` - all tests should succeed
* Setup the E2E tests
* Verify using `docker ps` that the image name for the `wcp_e2e_wordpress` container is the same as the container name
* Run the E2E tests - they should pass as well
* Setup a breakpoint and test if Xdebug is still working

-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->

cc @jrodger 
