### PR TITLE
Add saved cards E2E tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:e2e-cleanup": "./tests/e2e/env/cleanup.sh",
     "test:e2e-reset": "npm run test:e2e-down && npm run test:e2e-cleanup",
     "test:e2e": "NODE_CONFIG_DIR='tests/e2e/config' wp-scripts test-e2e --config tests/e2e/config/jest.config.js",
-    "test:e2e-dev": "NODE_CONFIG_DIR='tests/e2e/config' JEST_PUPPETEER_CONFIG='tests/e2e/config/jest-puppeteer.config.js' wp-scripts test-e2e --puppeteer-interactive",
+    "test:e2e-dev": "NODE_CONFIG_DIR='tests/e2e/config' JEST_PUPPETEER_CONFIG='tests/e2e/config/jest-puppeteer.config.js' wp-scripts test-e2e --config tests/e2e/config/jest.config.js --puppeteer-interactive",
     "test:update-snapshots": "npm test -- --updateSnapshot",
     "test:php": "./bin/run-tests.sh",
     "watch": "webpack --watch",

--- a/tests/e2e/config/test.json
+++ b/tests/e2e/config/test.json
@@ -60,6 +60,35 @@
         "postcode": "94110"
       }
     }
+  },
+  "cards" : {
+    "basic": {
+      "number": "4242424242424242",
+      "expires": {
+        "month": "02",
+        "year": "24"
+      },
+      "cvc": "424",
+      "label": "Visa ending in 4242"
+    },
+    "3ds": {
+      "number": "4000002760003184",
+      "expires": {
+        "month": "03",
+        "year": "25"
+      },
+      "cvc": "525",
+      "label": "Visa ending in 3184"
+    },
+    "3ds2": {
+      "number": "4000000000003220",
+      "expires": {
+        "month": "04",
+        "year": "36"
+      },
+      "cvc": "626",
+      "label": "Visa ending in 3220"
+    }
   }
 }
 

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -145,10 +145,6 @@ cli wp option set woocommerce_currency "USD"
 cli wp option set woocommerce_product_type "both"
 cli wp option set woocommerce_allow_tracking "no"
 
-echo "Creating customer user..."
-cli wp user delete customer --yes
-cli wp user create customer customer@woocommercecoree2etestsuite.com --role=customer --user_pass=password
-
 echo "Importing WooCommerce shop pages..."
 cli wp wc --user=admin tool run install_pages
 

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -145,6 +145,10 @@ cli wp option set woocommerce_currency "USD"
 cli wp option set woocommerce_product_type "both"
 cli wp option set woocommerce_allow_tracking "no"
 
+echo "Creating customer user..."
+cli wp user delete customer --yes
+cli wp user create customer customer@woocommercecoree2etestsuite.com --role=customer --user_pass=password
+
 echo "Importing WooCommerce shop pages..."
 cli wp wc --user=admin tool run install_pages
 

--- a/tests/e2e/setup/jest-setup.js
+++ b/tests/e2e/setup/jest-setup.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { spawnSync } from 'child_process';
+import shell from 'shelljs';
 import config from 'config';
 import { get } from 'lodash';
 import {
@@ -166,29 +166,15 @@ async function createCustomerUser() {
 	const email = config.get( 'users.customer.email' );
 	const password = config.get( 'users.customer.password' );
 
-	const args = [
-		'run',
-		'--rm',
-		'--user',
-		'xfs',
-		'--volumes-from',
-		container,
-		'--network',
-		`container:${ container }`,
-		'wordpress:cli',
-		'wp',
-	];
-	const createArgs = [
-		'user',
-		'create',
-		username,
-		email,
-		'--role=customer',
-		`--user_pass=${ password }`,
-	];
-	const deleteArgs = [ 'user', 'delete', username, '--yes' ];
-	spawnSync( 'docker', [ ...args, ...deleteArgs ] );
-	spawnSync( 'docker', [ ...args, ...createArgs ] );
+	const wpCli = `docker run --rm --user xfs --volumes-from ${ container } --network container:${ container } wordpress:cli`;
+
+	shell.exec( `${ wpCli } wp user delete ${ username } --yes`, {
+		silent: true,
+	} );
+	shell.exec(
+		`${ wpCli } wp user create ${ username } ${ email } --role=customer --user_pass=${ password }`,
+		{ silent: true }
+	);
 }
 
 // Before every test suite run, delete all content created by the test. This ensures

--- a/tests/e2e/setup/jest-setup.js
+++ b/tests/e2e/setup/jest-setup.js
@@ -149,6 +149,15 @@ function observeConsoleLogging() {
 	} );
 }
 
+function setTestTimeouts() {
+	const TIMEOUT = 100000;
+	// Increase default value to avoid test failing due to timeouts.
+	page.setDefaultTimeout( TIMEOUT );
+	// running the login flow takes more than the default timeout of 5 seconds,
+	// so we need to increase it to run the login in the beforeAll hook
+	jest.setTimeout( TIMEOUT );
+}
+
 // Before every test suite run, delete all content created by the test. This ensures
 // other posts/comments/etc. aren't dirtying tests and tests don't depend on
 // each other's side-effects.
@@ -156,6 +165,7 @@ beforeAll( async () => {
 	capturePageEventsForTearDown();
 	enablePageDialogAccept();
 	observeConsoleLogging();
+	setTestTimeouts();
 	await setupBrowser();
 } );
 

--- a/tests/e2e/specs/purchase.spec.js
+++ b/tests/e2e/specs/purchase.spec.js
@@ -9,36 +9,28 @@ import config from 'config';
 import { CustomerFlow, uiUnblocked } from '../utils';
 import { fillCardDetails } from '../utils/payments';
 
-const TIMEOUT = 100000;
-
 describe( 'Successful purchase', () => {
 	beforeAll( async () => {
-		// Increase default value to avoid test failing due to timeouts.
-		page.setDefaultTimeout( 20000 );
 		await page.goto( config.get( 'url' ), { waitUntil: 'networkidle0' } );
 	} );
 
-	it(
-		'successful purchase',
-		async () => {
-			await CustomerFlow.goToShop();
-			await CustomerFlow.addToCartFromShopPage(
-				config.get( 'products.simple.name' )
-			);
-			await CustomerFlow.goToCheckout();
-			await uiUnblocked();
-			await CustomerFlow.fillBillingDetails(
-				config.get( 'addresses.customer.billing' )
-			);
-			await uiUnblocked();
-			await expect( page ).toClick(
-				'.wc_payment_method.payment_method_woocommerce_payments'
-			);
-			const card = config.get( 'cards.basic' );
-			await fillCardDetails( page, card );
-			await CustomerFlow.placeOrder();
-			await expect( page ).toMatch( 'Order received' );
-		},
-		TIMEOUT
-	);
+	it( 'successful purchase', async () => {
+		await CustomerFlow.goToShop();
+		await CustomerFlow.addToCartFromShopPage(
+			config.get( 'products.simple.name' )
+		);
+		await CustomerFlow.goToCheckout();
+		await uiUnblocked();
+		await CustomerFlow.fillBillingDetails(
+			config.get( 'addresses.customer.billing' )
+		);
+		await uiUnblocked();
+		await expect( page ).toClick(
+			'.wc_payment_method.payment_method_woocommerce_payments'
+		);
+		const card = config.get( 'cards.basic' );
+		await fillCardDetails( page, card );
+		await CustomerFlow.placeOrder();
+		await expect( page ).toMatch( 'Order received' );
+	} );
 } );

--- a/tests/e2e/specs/purchase.spec.js
+++ b/tests/e2e/specs/purchase.spec.js
@@ -34,14 +34,7 @@ describe( 'Successful purchase', () => {
 			await expect( page ).toClick(
 				'.wc_payment_method.payment_method_woocommerce_payments'
 			);
-			const card = {
-				number: '4242424242424242',
-				expires: {
-					month: '02',
-					year: '24',
-				},
-				cvc: '424',
-			};
+			const card = config.get( 'cards.basic' );
 			await fillCardDetails( page, card );
 			await CustomerFlow.placeOrder();
 			await expect( page ).toMatch( 'Order received' );

--- a/tests/e2e/specs/purchase.spec.js
+++ b/tests/e2e/specs/purchase.spec.js
@@ -6,8 +6,8 @@ import config from 'config';
 /**
  * Internal dependencies
  */
-import { CustomerFlow, uiUnblocked } from '../utils';
-import { fillCardDetails } from '../utils/payments';
+import { CustomerFlow } from '../utils';
+import { fillCardDetails, setupProductCheckout } from '../utils/payments';
 
 describe( 'Successful purchase', () => {
 	beforeAll( async () => {
@@ -15,19 +15,7 @@ describe( 'Successful purchase', () => {
 	} );
 
 	it( 'successful purchase', async () => {
-		await CustomerFlow.goToShop();
-		await CustomerFlow.addToCartFromShopPage(
-			config.get( 'products.simple.name' )
-		);
-		await CustomerFlow.goToCheckout();
-		await uiUnblocked();
-		await CustomerFlow.fillBillingDetails(
-			config.get( 'addresses.customer.billing' )
-		);
-		await uiUnblocked();
-		await expect( page ).toClick(
-			'.wc_payment_method.payment_method_woocommerce_payments'
-		);
+		await setupProductCheckout();
 		const card = config.get( 'cards.basic' );
 		await fillCardDetails( page, card );
 		await CustomerFlow.placeOrder();

--- a/tests/e2e/specs/saved-cards/saved-cards-checkout.spec.js
+++ b/tests/e2e/specs/saved-cards/saved-cards-checkout.spec.js
@@ -12,8 +12,6 @@ import {
 	confirmCardAuthentication,
 } from '../../utils/payments';
 
-const TIMEOUT = 100000;
-
 const cards = [
 	[ 'basic', config.get( 'cards.basic' ) ],
 	[ '3DS', config.get( 'cards.3ds' ) ],
@@ -24,11 +22,6 @@ describe( 'Saved cards ', () => {
 		'when using a %s card added on checkout',
 		( cardType, card ) => {
 			beforeAll( async () => {
-				// Increase default value to avoid test failing due to timeouts.
-				page.setDefaultTimeout( 30000 );
-				// running the login flow takes more than the default timeout of 5 seconds,
-				// so we need to increase it to run the login in the beforeAll hook
-				jest.setTimeout( TIMEOUT );
 				await CustomerFlow.login();
 			} );
 
@@ -36,68 +29,56 @@ describe( 'Saved cards ', () => {
 				await CustomerFlow.logout();
 			} );
 
-			it(
-				'should save the card',
-				async () => {
-					await setupProductCheckout();
-					await CustomerFlow.selectNewPaymentMethod();
-					await fillCardDetails( page, card );
-					await CustomerFlow.toggleSavePaymentMethod();
+			it( 'should save the card', async () => {
+				await setupProductCheckout();
+				await CustomerFlow.selectNewPaymentMethod();
+				await fillCardDetails( page, card );
+				await CustomerFlow.toggleSavePaymentMethod();
 
-					if ( 'basic' === cardType ) {
-						await CustomerFlow.placeOrder();
-					} else {
-						await expect( page ).toClick( '#place_order' );
-						await confirmCardAuthentication( page, cardType );
-						await page.waitForNavigation( {
-							waitUntil: 'networkidle0',
-						} );
-					}
+				if ( 'basic' === cardType ) {
+					await CustomerFlow.placeOrder();
+				} else {
+					await expect( page ).toClick( '#place_order' );
+					await confirmCardAuthentication( page, cardType );
+					await page.waitForNavigation( {
+						waitUntil: 'networkidle0',
+					} );
+				}
 
-					await expect( page ).toMatch( 'Order received' );
+				await expect( page ).toMatch( 'Order received' );
 
-					// validate that the payment method has been added to the customer.
-					await CustomerFlow.goToPaymentMethods();
-					await expect( page ).toMatch( card.label );
-					await expect( page ).toMatch(
-						`${ card.expires.month }/${ card.expires.year }`
-					);
-				},
-				TIMEOUT
-			);
+				// validate that the payment method has been added to the customer.
+				await CustomerFlow.goToPaymentMethods();
+				await expect( page ).toMatch( card.label );
+				await expect( page ).toMatch(
+					`${ card.expires.month }/${ card.expires.year }`
+				);
+			} );
 
-			it(
-				'should process a payment with the saved card',
-				async () => {
-					await setupProductCheckout();
-					await CustomerFlow.selectSavedPaymentMethod(
-						`${ card.label } (expires ${ card.expires.month }/${ card.expires.year })`
-					);
+			it( 'should process a payment with the saved card', async () => {
+				await setupProductCheckout();
+				await CustomerFlow.selectSavedPaymentMethod(
+					`${ card.label } (expires ${ card.expires.month }/${ card.expires.year })`
+				);
 
-					if ( 'basic' === cardType ) {
-						await CustomerFlow.placeOrder();
-					} else {
-						await expect( page ).toClick( '#place_order' );
-						await confirmCardAuthentication( page, cardType );
-						await page.waitForNavigation( {
-							waitUntil: 'networkidle0',
-						} );
-					}
+				if ( 'basic' === cardType ) {
+					await CustomerFlow.placeOrder();
+				} else {
+					await expect( page ).toClick( '#place_order' );
+					await confirmCardAuthentication( page, cardType );
+					await page.waitForNavigation( {
+						waitUntil: 'networkidle0',
+					} );
+				}
 
-					await expect( page ).toMatch( 'Order received' );
-				},
-				TIMEOUT
-			);
+				await expect( page ).toMatch( 'Order received' );
+			} );
 
-			it(
-				'should delete the card',
-				async () => {
-					await CustomerFlow.goToPaymentMethods();
-					await CustomerFlow.deleteSavedPaymentMethod( card.label );
-					await expect( page ).toMatch( 'Payment method deleted' );
-				},
-				TIMEOUT
-			);
+			it( 'should delete the card', async () => {
+				await CustomerFlow.goToPaymentMethods();
+				await CustomerFlow.deleteSavedPaymentMethod( card.label );
+				await expect( page ).toMatch( 'Payment method deleted' );
+			} );
 		}
 	);
 

--- a/tests/e2e/specs/saved-cards/saved-cards-checkout.spec.js
+++ b/tests/e2e/specs/saved-cards/saved-cards-checkout.spec.js
@@ -1,0 +1,139 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import { CustomerFlow, uiUnblocked } from '../../utils';
+import {
+	fillCardDetails,
+	confirmCardAuthentication,
+} from '../../utils/payments';
+
+const TIMEOUT = 100000;
+
+const CARD_BASIC = {
+	number: '4242424242424242',
+	expires: {
+		month: '02',
+		year: '24',
+	},
+	cvc: '424',
+	label: 'Visa ending in 4242',
+};
+
+const CARD_3DS = {
+	number: '4000002760003184',
+	expires: {
+		month: '03',
+		year: '25',
+	},
+	cvc: '525',
+	label: 'Visa ending in 3184',
+};
+
+const cards = [
+	[ 'basic', CARD_BASIC ],
+	[ '3DS', CARD_3DS ],
+];
+
+describe( 'Saved cards ', () => {
+	describe.each( cards )(
+		'when using a %s card added on checkout',
+		( cardType, card ) => {
+			beforeAll( async () => {
+				// Increase default value to avoid test failing due to timeouts.
+				page.setDefaultTimeout( 30000 );
+				// running the login flow takes more than the default timeout of 5 seconds,
+				// so we need to increase it to run the login in the beforeAll hook
+				jest.setTimeout( TIMEOUT );
+				await CustomerFlow.login();
+			} );
+
+			afterAll( async () => {
+				await CustomerFlow.logout();
+			} );
+
+			it(
+				'should save the card',
+				async () => {
+					await setupProductCheckout();
+					await CustomerFlow.selectNewPaymentMethod();
+					await fillCardDetails( page, card );
+					await CustomerFlow.toggleSavePaymentMethod();
+
+					if ( 'basic' === cardType ) {
+						await CustomerFlow.placeOrder();
+					} else {
+						await expect( page ).toClick( '#place_order' );
+						await confirmCardAuthentication( page, cardType );
+						await page.waitForNavigation( {
+							waitUntil: 'networkidle0',
+						} );
+					}
+
+					await expect( page ).toMatch( 'Order received' );
+
+					// validate that the payment method has been added to the customer.
+					await CustomerFlow.goToPaymentMethods();
+					await expect( page ).toMatch( card.label );
+					await expect( page ).toMatch(
+						`${ card.expires.month }/${ card.expires.year }`
+					);
+				},
+				TIMEOUT
+			);
+
+			it(
+				'should process a payment with the saved card',
+				async () => {
+					await setupProductCheckout();
+					await CustomerFlow.selectSavedPaymentMethod(
+						`${ card.label } (expires ${ card.expires.month }/${ card.expires.year })`
+					);
+
+					if ( 'basic' === cardType ) {
+						await CustomerFlow.placeOrder();
+					} else {
+						await expect( page ).toClick( '#place_order' );
+						await confirmCardAuthentication( page, cardType );
+						await page.waitForNavigation( {
+							waitUntil: 'networkidle0',
+						} );
+					}
+
+					await expect( page ).toMatch( 'Order received' );
+				},
+				TIMEOUT
+			);
+
+			it(
+				'should delete the card',
+				async () => {
+					await CustomerFlow.goToPaymentMethods();
+					await CustomerFlow.deleteSavedPaymentMethod( card.label );
+					await expect( page ).toMatch( 'Payment method deleted' );
+				},
+				TIMEOUT
+			);
+		}
+	);
+
+	async function setupProductCheckout() {
+		await CustomerFlow.goToShop();
+		await CustomerFlow.addToCartFromShopPage(
+			config.get( 'products.simple.name' )
+		);
+		await CustomerFlow.goToCheckout();
+		await uiUnblocked();
+		await CustomerFlow.fillBillingDetails(
+			config.get( 'addresses.customer.billing' )
+		);
+		await uiUnblocked();
+		await expect( page ).toClick(
+			'.wc_payment_method.payment_method_woocommerce_payments'
+		);
+	}
+} );

--- a/tests/e2e/specs/saved-cards/saved-cards-checkout.spec.js
+++ b/tests/e2e/specs/saved-cards/saved-cards-checkout.spec.js
@@ -14,29 +14,9 @@ import {
 
 const TIMEOUT = 100000;
 
-const CARD_BASIC = {
-	number: '4242424242424242',
-	expires: {
-		month: '02',
-		year: '24',
-	},
-	cvc: '424',
-	label: 'Visa ending in 4242',
-};
-
-const CARD_3DS = {
-	number: '4000002760003184',
-	expires: {
-		month: '03',
-		year: '25',
-	},
-	cvc: '525',
-	label: 'Visa ending in 3184',
-};
-
 const cards = [
-	[ 'basic', CARD_BASIC ],
-	[ '3DS', CARD_3DS ],
+	[ 'basic', config.get( 'cards.basic' ) ],
+	[ '3DS', config.get( 'cards.3ds' ) ],
 ];
 
 describe( 'Saved cards ', () => {

--- a/tests/e2e/specs/saved-cards/saved-cards-checkout.spec.js
+++ b/tests/e2e/specs/saved-cards/saved-cards-checkout.spec.js
@@ -6,10 +6,11 @@ import config from 'config';
 /**
  * Internal dependencies
  */
-import { CustomerFlow, uiUnblocked } from '../../utils';
+import { CustomerFlow } from '../../utils';
 import {
 	fillCardDetails,
 	confirmCardAuthentication,
+	setupProductCheckout,
 } from '../../utils/payments';
 
 const cards = [
@@ -81,20 +82,4 @@ describe( 'Saved cards ', () => {
 			} );
 		}
 	);
-
-	async function setupProductCheckout() {
-		await CustomerFlow.goToShop();
-		await CustomerFlow.addToCartFromShopPage(
-			config.get( 'products.simple.name' )
-		);
-		await CustomerFlow.goToCheckout();
-		await uiUnblocked();
-		await CustomerFlow.fillBillingDetails(
-			config.get( 'addresses.customer.billing' )
-		);
-		await uiUnblocked();
-		await expect( page ).toClick(
-			'.wc_payment_method.payment_method_woocommerce_payments'
-		);
-	}
 } );

--- a/tests/e2e/specs/saved-cards/saved-cards-my-account.spec.js
+++ b/tests/e2e/specs/saved-cards/saved-cards-my-account.spec.js
@@ -14,29 +14,9 @@ import {
 
 const TIMEOUT = 100000;
 
-const CARD_BASIC = {
-	number: '4242424242424242',
-	expires: {
-		month: '02',
-		year: '24',
-	},
-	cvc: '424',
-	label: 'Visa ending in 4242',
-};
-
-const CARD_3DS2 = {
-	number: '4000000000003220',
-	expires: {
-		month: '04',
-		year: '36',
-	},
-	cvc: '626',
-	label: 'Visa ending in 3220',
-};
-
 const cards = [
-	[ 'basic', CARD_BASIC ],
-	[ '3DS2', CARD_3DS2 ],
+	[ 'basic', config.get( 'cards.basic' ) ],
+	[ '3DS2', config.get( 'cards.3ds2' ) ],
 ];
 
 describe( 'Saved cards ', () => {

--- a/tests/e2e/specs/saved-cards/saved-cards-my-account.spec.js
+++ b/tests/e2e/specs/saved-cards/saved-cards-my-account.spec.js
@@ -12,8 +12,6 @@ import {
 	confirmCardAuthentication,
 } from '../../utils/payments';
 
-const TIMEOUT = 100000;
-
 const cards = [
 	[ 'basic', config.get( 'cards.basic' ) ],
 	[ '3DS2', config.get( 'cards.3ds2' ) ],
@@ -24,11 +22,6 @@ describe( 'Saved cards ', () => {
 		'when using a %s card added through my account',
 		( cardType, card ) => {
 			beforeAll( async () => {
-				// Increase default value to avoid test failing due to timeouts.
-				page.setDefaultTimeout( 30000 );
-				// running the login flow takes more than the default timeout of 5 seconds,
-				// so we need to increase it to run the login in the beforeAll hook
-				jest.setTimeout( TIMEOUT );
 				await CustomerFlow.login();
 			} );
 
@@ -36,67 +29,55 @@ describe( 'Saved cards ', () => {
 				await CustomerFlow.logout();
 			} );
 
-			it(
-				'should save the card',
-				async () => {
-					await CustomerFlow.goToPaymentMethods();
-					await expect( page ).toClick( 'a', {
-						text: 'Add payment method',
-					} );
+			it( 'should save the card', async () => {
+				await CustomerFlow.goToPaymentMethods();
+				await expect( page ).toClick( 'a', {
+					text: 'Add payment method',
+				} );
+				await page.waitForNavigation( {
+					waitUntil: 'networkidle0',
+				} );
+				await fillCardDetails( page, card );
+				await expect( page ).toClick( 'button', {
+					text: 'Add payment method',
+				} );
+
+				if ( 'basic' !== cardType ) {
+					await confirmCardAuthentication( page, cardType );
+				}
+				await page.waitForNavigation( {
+					waitUntil: 'networkidle0',
+				} );
+
+				await expect( page ).toMatch(
+					'Payment method successfully added'
+				);
+			} );
+
+			it( 'should process a payment with the saved card', async () => {
+				await setupProductCheckout();
+				await CustomerFlow.selectSavedPaymentMethod(
+					`${ card.label } (expires ${ card.expires.month }/${ card.expires.year })`
+				);
+
+				if ( 'basic' === cardType ) {
+					await CustomerFlow.placeOrder();
+				} else {
+					await expect( page ).toClick( '#place_order' );
+					await confirmCardAuthentication( page, cardType );
 					await page.waitForNavigation( {
 						waitUntil: 'networkidle0',
 					} );
-					await fillCardDetails( page, card );
-					await expect( page ).toClick( 'button', {
-						text: 'Add payment method',
-					} );
+				}
 
-					if ( 'basic' !== cardType ) {
-						await confirmCardAuthentication( page, cardType );
-					}
-					await page.waitForNavigation( {
-						waitUntil: 'networkidle0',
-					} );
+				await expect( page ).toMatch( 'Order received' );
+			} );
 
-					await expect( page ).toMatch(
-						'Payment method successfully added'
-					);
-				},
-				TIMEOUT
-			);
-
-			it(
-				'should process a payment with the saved card',
-				async () => {
-					await setupProductCheckout();
-					await CustomerFlow.selectSavedPaymentMethod(
-						`${ card.label } (expires ${ card.expires.month }/${ card.expires.year })`
-					);
-
-					if ( 'basic' === cardType ) {
-						await CustomerFlow.placeOrder();
-					} else {
-						await expect( page ).toClick( '#place_order' );
-						await confirmCardAuthentication( page, cardType );
-						await page.waitForNavigation( {
-							waitUntil: 'networkidle0',
-						} );
-					}
-
-					await expect( page ).toMatch( 'Order received' );
-				},
-				TIMEOUT
-			);
-
-			it(
-				'should delete the card',
-				async () => {
-					await CustomerFlow.goToPaymentMethods();
-					await CustomerFlow.deleteSavedPaymentMethod( card.label );
-					await expect( page ).toMatch( 'Payment method deleted' );
-				},
-				TIMEOUT
-			);
+			it( 'should delete the card', async () => {
+				await CustomerFlow.goToPaymentMethods();
+				await CustomerFlow.deleteSavedPaymentMethod( card.label );
+				await expect( page ).toMatch( 'Payment method deleted' );
+			} );
 		}
 	);
 

--- a/tests/e2e/specs/saved-cards/saved-cards-my-account.spec.js
+++ b/tests/e2e/specs/saved-cards/saved-cards-my-account.spec.js
@@ -1,0 +1,138 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import { CustomerFlow, uiUnblocked } from '../../utils';
+import {
+	fillCardDetails,
+	confirmCardAuthentication,
+} from '../../utils/payments';
+
+const TIMEOUT = 100000;
+
+const CARD_BASIC = {
+	number: '4242424242424242',
+	expires: {
+		month: '02',
+		year: '24',
+	},
+	cvc: '424',
+	label: 'Visa ending in 4242',
+};
+
+const CARD_3DS2 = {
+	number: '4000000000003220',
+	expires: {
+		month: '04',
+		year: '36',
+	},
+	cvc: '626',
+	label: 'Visa ending in 3220',
+};
+
+const cards = [
+	[ 'basic', CARD_BASIC ],
+	[ '3DS2', CARD_3DS2 ],
+];
+
+describe( 'Saved cards ', () => {
+	describe.each( cards )(
+		'when using a %s card added through my account',
+		( cardType, card ) => {
+			beforeAll( async () => {
+				// Increase default value to avoid test failing due to timeouts.
+				page.setDefaultTimeout( 30000 );
+				// running the login flow takes more than the default timeout of 5 seconds,
+				// so we need to increase it to run the login in the beforeAll hook
+				jest.setTimeout( TIMEOUT );
+				await CustomerFlow.login();
+			} );
+
+			afterAll( async () => {
+				await CustomerFlow.logout();
+			} );
+
+			it(
+				'should save the card',
+				async () => {
+					await CustomerFlow.goToPaymentMethods();
+					await expect( page ).toClick( 'a', {
+						text: 'Add payment method',
+					} );
+					await page.waitForNavigation( {
+						waitUntil: 'networkidle0',
+					} );
+					await fillCardDetails( page, card );
+					await expect( page ).toClick( 'button', {
+						text: 'Add payment method',
+					} );
+
+					if ( 'basic' !== cardType ) {
+						await confirmCardAuthentication( page, cardType );
+					}
+					await page.waitForNavigation( {
+						waitUntil: 'networkidle0',
+					} );
+
+					await expect( page ).toMatch(
+						'Payment method successfully added'
+					);
+				},
+				TIMEOUT
+			);
+
+			it(
+				'should process a payment with the saved card',
+				async () => {
+					await setupProductCheckout();
+					await CustomerFlow.selectSavedPaymentMethod(
+						`${ card.label } (expires ${ card.expires.month }/${ card.expires.year })`
+					);
+
+					if ( 'basic' === cardType ) {
+						await CustomerFlow.placeOrder();
+					} else {
+						await expect( page ).toClick( '#place_order' );
+						await confirmCardAuthentication( page, cardType );
+						await page.waitForNavigation( {
+							waitUntil: 'networkidle0',
+						} );
+					}
+
+					await expect( page ).toMatch( 'Order received' );
+				},
+				TIMEOUT
+			);
+
+			it(
+				'should delete the card',
+				async () => {
+					await CustomerFlow.goToPaymentMethods();
+					await CustomerFlow.deleteSavedPaymentMethod( card.label );
+					await expect( page ).toMatch( 'Payment method deleted' );
+				},
+				TIMEOUT
+			);
+		}
+	);
+
+	async function setupProductCheckout() {
+		await CustomerFlow.goToShop();
+		await CustomerFlow.addToCartFromShopPage(
+			config.get( 'products.simple.name' )
+		);
+		await CustomerFlow.goToCheckout();
+		await uiUnblocked();
+		await CustomerFlow.fillBillingDetails(
+			config.get( 'addresses.customer.billing' )
+		);
+		await uiUnblocked();
+		await expect( page ).toClick(
+			'.wc_payment_method.payment_method_woocommerce_payments'
+		);
+	}
+} );

--- a/tests/e2e/specs/saved-cards/saved-cards-my-account.spec.js
+++ b/tests/e2e/specs/saved-cards/saved-cards-my-account.spec.js
@@ -6,10 +6,11 @@ import config from 'config';
 /**
  * Internal dependencies
  */
-import { CustomerFlow, uiUnblocked } from '../../utils';
+import { CustomerFlow } from '../../utils';
 import {
 	fillCardDetails,
 	confirmCardAuthentication,
+	setupProductCheckout,
 } from '../../utils/payments';
 
 const cards = [
@@ -80,20 +81,4 @@ describe( 'Saved cards ', () => {
 			} );
 		}
 	);
-
-	async function setupProductCheckout() {
-		await CustomerFlow.goToShop();
-		await CustomerFlow.addToCartFromShopPage(
-			config.get( 'products.simple.name' )
-		);
-		await CustomerFlow.goToCheckout();
-		await uiUnblocked();
-		await CustomerFlow.fillBillingDetails(
-			config.get( 'addresses.customer.billing' )
-		);
-		await uiUnblocked();
-		await expect( page ).toClick(
-			'.wc_payment_method.payment_method_woocommerce_payments'
-		);
-	}
 } );

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -224,6 +224,23 @@ const CustomerFlow = {
 		await page.waitForNavigation( { waitUntil: 'networkidle0' } );
 	},
 
+	selectNewPaymentMethod: async () => {
+		if (
+			( await page.$( '#wc-woocommerce_payments-payment-token-new' ) ) !==
+			null
+		) {
+			await expect( page ).toClick(
+				'#wc-woocommerce_payments-payment-token-new'
+			);
+		}
+	},
+
+	toggleSavePaymentMethod: async () => {
+		await expect( page ).toClick(
+			'#wc-woocommerce_payments-new-payment-method'
+		);
+	},
+
 	selectSavedPaymentMethod: async ( label ) => {
 		await expect( page ).toClick( 'label', { text: label } );
 	},

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -41,6 +41,7 @@ const MY_ACCOUNT_ORDERS = baseUrl + 'my-account/orders';
 const MY_ACCOUNT_DOWNLOADS = baseUrl + 'my-account/downloads';
 const MY_ACCOUNT_ADDRESSES = baseUrl + 'my-account/edit-address';
 const MY_ACCOUNT_ACCOUNT_DETAILS = baseUrl + 'my-account/edit-account';
+const MY_ACCOUNT_PAYMENT_METHODS = baseUrl + 'my-account/payment-methods';
 
 const getProductColumnExpression = ( productTitle ) =>
 	'td[@class="product-name" and ' +
@@ -130,6 +131,12 @@ const CustomerFlow = {
 		} );
 	},
 
+	goToPaymentMethods: async () => {
+		await page.goto( MY_ACCOUNT_PAYMENT_METHODS, {
+			waitUntil: 'networkidle0',
+		} );
+	},
+
 	goToShop: async () => {
 		await page.goto( SHOP_PAGE, {
 			waitUntil: 'networkidle0',
@@ -185,6 +192,20 @@ const CustomerFlow = {
 		] );
 	},
 
+	logout: async () => {
+		await page.goto( SHOP_MY_ACCOUNT_PAGE, {
+			waitUntil: 'networkidle0',
+		} );
+
+		await expect( page.title() ).resolves.toMatch( 'My account' );
+		await Promise.all( [
+			page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+			page.click(
+				'.woocommerce-MyAccount-navigation-link--customer-logout a'
+			),
+		] );
+	},
+
 	productIsInCart: async ( productTitle, quantity = null ) => {
 		const cartItemArgs = quantity ? { qty: quantity } : {};
 		const cartItemXPath = getCartItemExpression(
@@ -193,6 +214,18 @@ const CustomerFlow = {
 		);
 
 		await expect( page.$x( cartItemXPath ) ).resolves.toHaveLength( 1 );
+	},
+
+	deleteSavedPaymentMethod: async ( label ) => {
+		const [ paymentMethodRow ] = await page.$x(
+			`//tr[contains(., '${ label }')]`
+		);
+		await expect( paymentMethodRow ).toClick( '.button.delete' );
+		await page.waitForNavigation( { waitUntil: 'networkidle0' } );
+	},
+
+	selectSavedPaymentMethod: async ( label ) => {
+		await expect( page ).toClick( 'label', { text: label } );
 	},
 
 	fillBillingDetails: async ( customerBillingDetails ) => {

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -74,6 +74,57 @@ const getCartItemExpression = ( productTitle, args ) =>
 const getRemoveExpression = () =>
 	'td[@class="product-remove"]//a[@class="remove"]';
 
+const PaymentsCustomerFlow = {
+	goToPaymentMethods: async () => {
+		await page.goto( MY_ACCOUNT_PAYMENT_METHODS, {
+			waitUntil: 'networkidle0',
+		} );
+	},
+
+	logout: async () => {
+		await page.goto( SHOP_MY_ACCOUNT_PAGE, {
+			waitUntil: 'networkidle0',
+		} );
+
+		await expect( page.title() ).resolves.toMatch( 'My account' );
+		await Promise.all( [
+			page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+			page.click(
+				'.woocommerce-MyAccount-navigation-link--customer-logout a'
+			),
+		] );
+	},
+
+	deleteSavedPaymentMethod: async ( label ) => {
+		const [ paymentMethodRow ] = await page.$x(
+			`//tr[contains(., '${ label }')]`
+		);
+		await expect( paymentMethodRow ).toClick( '.button.delete' );
+		await page.waitForNavigation( { waitUntil: 'networkidle0' } );
+	},
+
+	selectNewPaymentMethod: async () => {
+		if (
+			( await page.$( '#wc-woocommerce_payments-payment-token-new' ) ) !==
+			null
+		) {
+			await expect( page ).toClick(
+				'#wc-woocommerce_payments-payment-token-new'
+			);
+		}
+	},
+
+	toggleSavePaymentMethod: async () => {
+		await expect( page ).toClick(
+			'#wc-woocommerce_payments-new-payment-method'
+		);
+	},
+
+	selectSavedPaymentMethod: async ( label ) => {
+		await expect( page ).toClick( 'label', { text: label } );
+	},
+};
+
 const CustomerFlow = {
 	addToCart: async () => {
 		await Promise.all( [
@@ -127,12 +178,6 @@ const CustomerFlow = {
 
 	goToProduct: async ( postID ) => {
 		await page.goto( SHOP_PRODUCT_PAGE + postID, {
-			waitUntil: 'networkidle0',
-		} );
-	},
-
-	goToPaymentMethods: async () => {
-		await page.goto( MY_ACCOUNT_PAYMENT_METHODS, {
 			waitUntil: 'networkidle0',
 		} );
 	},
@@ -192,20 +237,6 @@ const CustomerFlow = {
 		] );
 	},
 
-	logout: async () => {
-		await page.goto( SHOP_MY_ACCOUNT_PAGE, {
-			waitUntil: 'networkidle0',
-		} );
-
-		await expect( page.title() ).resolves.toMatch( 'My account' );
-		await Promise.all( [
-			page.waitForNavigation( { waitUntil: 'networkidle0' } ),
-			page.click(
-				'.woocommerce-MyAccount-navigation-link--customer-logout a'
-			),
-		] );
-	},
-
 	productIsInCart: async ( productTitle, quantity = null ) => {
 		const cartItemArgs = quantity ? { qty: quantity } : {};
 		const cartItemXPath = getCartItemExpression(
@@ -214,35 +245,6 @@ const CustomerFlow = {
 		);
 
 		await expect( page.$x( cartItemXPath ) ).resolves.toHaveLength( 1 );
-	},
-
-	deleteSavedPaymentMethod: async ( label ) => {
-		const [ paymentMethodRow ] = await page.$x(
-			`//tr[contains(., '${ label }')]`
-		);
-		await expect( paymentMethodRow ).toClick( '.button.delete' );
-		await page.waitForNavigation( { waitUntil: 'networkidle0' } );
-	},
-
-	selectNewPaymentMethod: async () => {
-		if (
-			( await page.$( '#wc-woocommerce_payments-payment-token-new' ) ) !==
-			null
-		) {
-			await expect( page ).toClick(
-				'#wc-woocommerce_payments-payment-token-new'
-			);
-		}
-	},
-
-	toggleSavePaymentMethod: async () => {
-		await expect( page ).toClick(
-			'#wc-woocommerce_payments-new-payment-method'
-		);
-	},
-
-	selectSavedPaymentMethod: async ( label ) => {
-		await expect( page ).toClick( 'label', { text: label } );
 	},
 
 	fillBillingDetails: async ( customerBillingDetails ) => {
@@ -349,6 +351,8 @@ const CustomerFlow = {
 		await pressKeyWithModifier( 'primary', 'a' );
 		await quantityInput.type( quantityValue.toString() );
 	},
+
+	...PaymentsCustomerFlow,
 };
 
 const StoreOwnerFlow = {

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -74,6 +74,8 @@ const getCartItemExpression = ( productTitle, args ) =>
 const getRemoveExpression = () =>
 	'td[@class="product-remove"]//a[@class="remove"]';
 
+// The generic flows will be moved to their own package soon (more details in p7bje6-2gV-p2), so we're
+// keeping our customizations grouped here so it's easier to extend the flows once the move happens.
 const PaymentsCustomerFlow = {
 	goToPaymentMethods: async () => {
 		await page.goto( MY_ACCOUNT_PAYMENT_METHODS, {

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -1,3 +1,13 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import { CustomerFlow, uiUnblocked } from '../utils';
+
 export async function fillCardDetails( page, card ) {
 	const frameHandle = await page.waitForSelector(
 		'iframe[name^="__privateStripeFrame"]'
@@ -43,4 +53,20 @@ export async function confirmCardAuthentication(
 	}
 	const button = await challengeFrame.waitForSelector( target );
 	await button.click();
+}
+
+export async function setupProductCheckout() {
+	await CustomerFlow.goToShop();
+	await CustomerFlow.addToCartFromShopPage(
+		config.get( 'products.simple.name' )
+	);
+	await CustomerFlow.goToCheckout();
+	await uiUnblocked();
+	await CustomerFlow.fillBillingDetails(
+		config.get( 'addresses.customer.billing' )
+	);
+	await uiUnblocked();
+	await expect( page ).toClick(
+		'.wc_payment_method.payment_method_woocommerce_payments'
+	);
 }

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -6,7 +6,7 @@ import config from 'config';
 /**
  * Internal dependencies
  */
-import { CustomerFlow, uiUnblocked } from '../utils';
+import { CustomerFlow, uiUnblocked } from './index';
 
 export async function fillCardDetails( page, card ) {
 	const frameHandle = await page.waitForSelector(

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -12,3 +12,35 @@ export async function fillCardDetails( page, card ) {
 	} );
 	await cardCvcInput.type( card.cvc, { delay: 20 } );
 }
+
+export async function confirmCardAuthentication(
+	page,
+	cardType = '3DS',
+	authorize = true
+) {
+	const target = authorize
+		? '#test-source-authorize-3ds'
+		: '#test-source-fail-3ds';
+	// we need to add a slight delay here so the authorization iframe has time to spin up
+	// otherwise, this would return the __privateStripeFrame related to the card input
+	await page.waitForFunction(
+		'document.querySelectorAll( \'iframe[name^="__privateStripeFrame"]\' ).length >= 2'
+	);
+	const frameHandle = await page.waitForSelector(
+		'iframe[name^="__privateStripeFrame"]'
+	);
+	const stripeFrame = await frameHandle.contentFrame();
+	const challengeFrameHandle = await stripeFrame.waitForSelector(
+		'iframe#challengeFrame'
+	);
+	let challengeFrame = await challengeFrameHandle.contentFrame();
+	// 3DS 1 cards have another iframe enclosing the authorize form
+	if ( '3DS' === cardType ) {
+		const acsFrameHandle = await challengeFrame.waitForSelector(
+			'iframe[name="acsFrame"]'
+		);
+		challengeFrame = await acsFrameHandle.contentFrame();
+	}
+	const button = await challengeFrame.waitForSelector( target );
+	await button.click();
+}


### PR DESCRIPTION
Fixes #682 

#### Changes proposed in this Pull Request

* Create test customer user on e2e-setup
* Add customer flow and confirm authentication utilities
* Add E2E tests for my account and checkout saved cards

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Setup the E2E test environment if you haven't yet
* Run the tests by running `npm run test:e2e` or `npm run test:e2e-dev`. The latter will run interactive tests and display what the browser is doing
* Check that the tests pass in Travis as well

-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
