### PR TITLE
Fix checkout when creating an account and using 3DS cards

### DIFF
--- a/assets/js/wcpay-checkout.js
+++ b/assets/js/wcpay-checkout.js
@@ -394,7 +394,7 @@ jQuery( function ( $ ) {
 	 */
 	function maybeShowAuthenticationModal() {
 		var partials = window.location.hash.match(
-			/^#wcpay-confirm-pi:(.+):(.+)$/
+			/^#wcpay-confirm-pi:(.+):(.+):(.+)$/
 		);
 
 		if ( ! partials ) {
@@ -411,6 +411,10 @@ jQuery( function ( $ ) {
 
 		var orderId = partials[ 1 ];
 		var clientSecret = partials[ 2 ];
+		// Update the current order status nonce with the new one to ensure that the update
+		// order status call works when a guest user creates an account during checkout.
+		// eslint-disable-next-line camelcase
+		wcpay_config.updateOrderStatusNonce = partials[ 3 ];
 
 		// If we're on the Pay for Order page, get the order ID
 		// directly from the URL instead of relying on the hash.

--- a/tests/e2e/config/test.json
+++ b/tests/e2e/config/test.json
@@ -10,6 +10,9 @@
       "username": "customer",
       "password": "password",
       "email": "customer@woocommercecoree2etestsuite.com"
+    },
+    "guest": {
+      "email": "guest@woocommercecoree2etestsuite.com"
     }
   },
   "products": {

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -144,6 +144,7 @@ cli wp option set woocommerce_store_postcode "94110"
 cli wp option set woocommerce_currency "USD"
 cli wp option set woocommerce_product_type "both"
 cli wp option set woocommerce_allow_tracking "no"
+cli wp option set woocommerce_enable_signup_and_login_from_checkout "yes"
 
 echo "Importing WooCommerce shop pages..."
 cli wp wc --user=admin tool run install_pages

--- a/tests/e2e/specs/purchase.spec.js
+++ b/tests/e2e/specs/purchase.spec.js
@@ -7,18 +7,36 @@ import config from 'config';
  * Internal dependencies
  */
 import { CustomerFlow } from '../utils';
-import { fillCardDetails, setupProductCheckout } from '../utils/payments';
+import { fillCardDetails, setupProductCheckout, confirmCardAuthentication } from '../utils/payments';
 
 describe( 'Successful purchase', () => {
 	beforeAll( async () => {
 		await page.goto( config.get( 'url' ), { waitUntil: 'networkidle0' } );
 	} );
 
-	it( 'successful purchase', async () => {
-		await setupProductCheckout();
+	it( 'using a basic card', async () => {
+		await setupProductCheckout(
+			config.get( 'addresses.customer.billing' )
+		);
 		const card = config.get( 'cards.basic' );
 		await fillCardDetails( page, card );
 		await CustomerFlow.placeOrder();
+		await expect( page ).toMatch( 'Order received' );
+	} );
+
+	it( 'using a 3DS card and account signup', async () => {
+		await setupProductCheckout( {
+			...config.get( 'addresses.customer.billing' ),
+			...config.get( 'users.guest' ),
+		} );
+		await CustomerFlow.toggleCreateAccount();
+		const card = config.get( 'cards.3ds' );
+		await fillCardDetails( page, card );
+		await expect( page ).toClick( '#place_order' );
+		await confirmCardAuthentication( page, '3DS' );
+		await page.waitForNavigation( {
+			waitUntil: 'networkidle0',
+		} );
 		await expect( page ).toMatch( 'Order received' );
 	} );
 } );

--- a/tests/e2e/specs/saved-cards/saved-cards-checkout.spec.js
+++ b/tests/e2e/specs/saved-cards/saved-cards-checkout.spec.js
@@ -31,7 +31,9 @@ describe( 'Saved cards ', () => {
 			} );
 
 			it( 'should save the card', async () => {
-				await setupProductCheckout();
+				await setupProductCheckout(
+					config.get( 'addresses.customer.billing' )
+				);
 				await CustomerFlow.selectNewPaymentMethod();
 				await fillCardDetails( page, card );
 				await CustomerFlow.toggleSavePaymentMethod();
@@ -57,7 +59,9 @@ describe( 'Saved cards ', () => {
 			} );
 
 			it( 'should process a payment with the saved card', async () => {
-				await setupProductCheckout();
+				await setupProductCheckout(
+					config.get( 'addresses.customer.billing' )
+				);
 				await CustomerFlow.selectSavedPaymentMethod(
 					`${ card.label } (expires ${ card.expires.month }/${ card.expires.year })`
 				);

--- a/tests/e2e/specs/saved-cards/saved-cards-my-account.spec.js
+++ b/tests/e2e/specs/saved-cards/saved-cards-my-account.spec.js
@@ -56,7 +56,9 @@ describe( 'Saved cards ', () => {
 			} );
 
 			it( 'should process a payment with the saved card', async () => {
-				await setupProductCheckout();
+				await setupProductCheckout(
+					config.get( 'addresses.customer.billing' )
+				);
 				await CustomerFlow.selectSavedPaymentMethod(
 					`${ card.label } (expires ${ card.expires.month }/${ card.expires.year })`
 				);

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -125,6 +125,10 @@ const PaymentsCustomerFlow = {
 	selectSavedPaymentMethod: async ( label ) => {
 		await expect( page ).toClick( 'label', { text: label } );
 	},
+
+	toggleCreateAccount: async () => {
+		await expect( page ).toClick( '#createaccount' );
+	},
 };
 
 const CustomerFlow = {

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -55,16 +55,14 @@ export async function confirmCardAuthentication(
 	await button.click();
 }
 
-export async function setupProductCheckout() {
+export async function setupProductCheckout( billingDetails ) {
 	await CustomerFlow.goToShop();
 	await CustomerFlow.addToCartFromShopPage(
 		config.get( 'products.simple.name' )
 	);
 	await CustomerFlow.goToCheckout();
 	await uiUnblocked();
-	await CustomerFlow.fillBillingDetails(
-		config.get( 'addresses.customer.billing' )
-	);
+	await CustomerFlow.fillBillingDetails( billingDetails );
 	await uiUnblocked();
 	await expect( page ).toClick(
 		'.wc_payment_method.payment_method_woocommerce_payments'

--- a/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -493,7 +493,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		// Assert: Returning correct array.
 		$this->assertEquals( 'success', $result['result'] );
 		$this->assertEquals(
-			'#wcpay-confirm-pi:' . $order_id . ':' . $secret,
+			'#wcpay-confirm-pi:' . $order_id . ':' . $secret . ':' . wp_create_nonce( 'wcpay_update_order_status_nonce' ),
 			$result['redirect']
 		);
 	}


### PR DESCRIPTION
Fixes #806 

#### Changes proposed in this Pull Request

* Add an account creation using 3DS card E2E test
* Generate a new update_order_status nonce when the payment intent requires action

#### Testing instructions

Run the automated tests:

* Run the unit tests with `npm run test:php`
* Run the E2E tests with `npm run test:e2e-dev`

To test it manually:

1. Enable account creation during checkout in the WooCommerce settings
2. Without logging in, add a product to cart and go to the checkout page
3. Fill out the checkout form and use a test card that requires authentication (such as `4000002500003155`), don't forget to check the account creation checkbox
4. Submit the order and authorize it
5. The order should be successful
6. Run the same scenario with the save payment method checkbox enabled
7. Run the same scenario without creating an account during checkout

-------------------

- [x] Tested on mobile (or does not apply)


