### PR TITLE
Fix e2e setup script

### DIFF
--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -43,7 +43,16 @@ printf "$SECRETS" > "local/secrets.php"
 echo "Secrets created"
 
 step "Starting server containers"
-redirect_output local/bin/start.sh
+redirect_output docker-compose up --build --force-recreate -d
+
+if [[ -n $CI ]]; then
+	echo "Setting docker folder permissions"
+	redirect_output sudo chown www-data:www-data -R ./docker/wordpress
+	redirect_output ls -al ./docker
+fi
+
+step "Setting up server containers"
+redirect_output local/bin/docker-setup.sh
 
 step "Configuring server with stripe account"
 redirect_output $SERVER_PATH/local/bin/link-account.sh $BLOG_ID $E2E_WCPAY_STRIPE_ACCOUNT_ID


### PR DESCRIPTION
Setup script failed due to wrong folder permissions when server required
WordPress version update.

#### Changes proposed in this Pull Request

* Set permissions on server's docker folder during setup.

#### Testing instructions

* Travis checks should pass successfully.

-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
