### PR TITLE
Add changelog entries for release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 *** WooCommerce Payments Changelog ***
 
+= 1.3.0 - 2020-xx-xx =
+* Add - Support for saved cards.
+* Add - Search bar for transactions.
+* Fix - Redirect to WC core onboarding instead of WC Payments onboarding when appropriate.
+* Fix - Creating an account during checkout with 3DS cards.
+* Fix - Missing payment statuses for certain disputes.
+* Fix - Missing translators comments.
+
 = 1.2.0 - 2020-07-20 =
 * Add - 3DS support when using the pay for order page
 * Add - Display confirmation dialog when enabling manual captures

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,14 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 
 == Changelog ==
 
+= 1.3.0 - 2020-xx-xx =
+* Add - Support for saved cards.
+* Add - Search bar for transactions.
+* Fix - Redirect to WC core onboarding instead of WC Payments onboarding when appropriate.
+* Fix - Creating an account during checkout with 3DS cards.
+* Fix - Missing payment statuses for certain disputes.
+* Fix - Missing translators comments.
+
 = 1.2.0 - 2020-07-20 =
 * Add - 3DS support when using the pay for order page
 * Add - Display confirmation dialog when enabling manual captures


### PR DESCRIPTION
Just adds changelog entries in preparation for releasing v1.3.0.

`woorelease` is successfully dry-run with `woorelease simulate --product_version=1.3.0 https://github.com/Automattic/woocommerce-payments/tree/release/1.3.0`.

Preliminary testing results look good, but I'll test this further come Monday morning before doing the release.