### PR TITLE
Subscriptions integration step 1

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -466,7 +466,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// Update saved payment method information with checkout values, as some saved methods might not have billing details.
 		if ( $payment_information->is_using_saved_card() ) {
 			try {
-				$this->customer_service->update_payment_method_with_billing_details_from_order( $payment_information->payment_method(), $order );
+				$this->customer_service->update_payment_method_with_billing_details_from_order( $payment_information->get_payment_method(), $order );
 			} catch ( Exception $e ) {
 				// If updating the payment method fails, log the error message but catch the error to avoid crashing the checkout flow.
 				Logger::log( 'Error when updating saved payment method: ' . $e->getMessage() );
@@ -480,7 +480,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$intent = $this->payments_api_client->create_and_confirm_intention(
 				WC_Payments_Utils::prepare_amount( $amount, 'USD' ),
 				'usd',
-				$payment_information->payment_method(),
+				$payment_information->get_payment_method(),
 				$customer_id,
 				$manual_capture,
 				$save_payment_method,
@@ -581,7 +581,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		if ( $save_payment_method && ! $intent_failed ) {
 			try {
-				$token = $this->token_service->add_payment_method_to_user( $payment_information->payment_method(), $user );
+				$token = $this->token_service->add_payment_method_to_user( $payment_information->get_payment_method(), $user );
 				$order->add_payment_token( $token );
 			} catch ( Exception $e ) {
 				// If saving the token fails, log the error message but catch the error to avoid crashing the checkout flow.
@@ -589,8 +589,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			}
 		}
 
-		if ( $payment_information->has_payment_token() && ! in_array( $payment_information->payment_token()->get_id(), $order->get_payment_tokens(), true ) ) {
-			$order->add_payment_token( $payment_information->payment_token() );
+		if ( $payment_information->has_payment_token() && ! in_array( $payment_information->get_payment_token()->get_id(), $order->get_payment_tokens(), true ) ) {
+			$order->add_payment_token( $payment_information->get_payment_token() );
 		}
 
 		wc_reduce_stock_levels( $order_id );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -584,6 +584,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			try {
 				$token = $this->token_service->add_payment_method_to_user( $payment_information->get_payment_method(), $user );
 				$order->add_payment_token( $token );
+
+				// Set payment token for subscriptions, so it can be used for renewals.
+				$subscriptions = wcs_get_subscriptions_for_order( $order_id );
+				foreach ( $subscriptions as $subscription ) {
+					$subscription->add_payment_token( $token );
+				}
 			} catch ( Exception $e ) {
 				// If saving the token fails, log the error message but catch the error to avoid crashing the checkout flow.
 				Logger::log( 'Error when saving payment method: ' . $e->getMessage() );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -582,6 +582,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if ( $save_payment_method && ! $intent_failed ) {
 			try {
 				$token = $this->token_service->add_payment_method_to_user( $payment_information->payment_method(), $user );
+				$order->add_payment_token( $token );
 			} catch ( Exception $e ) {
 				// If saving the token fails, log the error message but catch the error to avoid crashing the checkout flow.
 				Logger::log( 'Error when saving payment method: ' . $e->getMessage() );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use WCPay\Logger;
+use WCPay\DataTypes\Payment_Information;
 use WCPay\Exceptions\WC_Payments_Intent_Authentication_Exception;
 use WCPay\Tracker;
 
@@ -403,7 +404,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public function process_payment( $order_id, $is_recurring_payment = false ) {
 		try {
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing
-			$payment_information = WC_Payment_Information::from_payment_request( $_POST, $is_recurring_payment );
+			$payment_information = Payment_Information::from_payment_request( $_POST, $is_recurring_payment );
 			$order               = wc_get_order( $order_id );
 			$manual_capture      = 'yes' === $this->get_option( 'manual_capture' );
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -464,7 +464,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		// Update saved payment method information with checkout values, as some saved methods might not have billing details.
-		if ( $is_saved_method ) {
+		if ( $payment_information->is_using_saved_card() ) {
 			try {
 				$this->customer_service->update_payment_method_with_billing_details_from_order( $payment_information->payment_method(), $order );
 			} catch ( Exception $e ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1238,6 +1238,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 				if ( ! empty( $payment_method_id ) ) {
 					try {
+						// TODO: Add token to subscriptions related to this order.
 						$this->token_service->add_payment_method_to_user( $payment_method_id, wp_get_current_user() );
 					} catch ( Exception $e ) {
 						// If saving the token fails, log the error message but catch the error to avoid crashing the checkout flow.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -592,13 +592,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		if ( $payment_information->is_using_saved_payment_method() ) {
 			$token = $payment_information->get_payment_token();
-			$order->add_payment_token( $token );
-
-			// Set payment token for subscriptions, so it can be used for renewals.
-			$subscriptions = wcs_get_subscriptions_for_order( $order_id );
-			foreach ( $subscriptions as $subscription ) {
-				$subscription->add_payment_token( $token );
-			}
+			$this->add_token_to_order( $order, $token );
 		}
 
 		wc_reduce_stock_levels( $order_id );
@@ -610,6 +604,20 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'result'   => 'success',
 			'redirect' => $this->get_return_url( $order ),
 		];
+	}
+
+	/**
+	 * Saves the payment token to the order.
+	 *
+	 * @param WC_Order         $order The order.
+	 * @param WC_Payment_Token $token The token to save.
+	 */
+	protected function add_token_to_order( $order, $token ) {
+		$order_tokens = $order->get_payment_tokens();
+
+		if ( $token->get_id() !== end( $order_tokens ) ) {
+			$order->add_payment_token( $token );
+		}
 	}
 
 	/**

--- a/includes/class-wc-payment-information.php
+++ b/includes/class-wc-payment-information.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Class WC_Payment_Information
+ *
+ * @package WooCommerce\Payments
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Mostly a wrapper containing information on a single payment.
+ */
+class WC_Payment_Information {
+	/**
+	 * The ID of the payment method used for this payment.
+	 *
+	 * @var string
+	 */
+	private $payment_method;
+
+	/**
+	 * The payment token used for this payment.
+	 *
+	 * @var WC_Payment_Token/NULL
+	 */
+	private $token;
+
+	/**
+	 * Indicates whether this payment was made using a saved card.
+	 *
+	 * @var bool
+	 */
+	private $is_saved_method;
+
+	/**
+	 * Indicates whether the payment is merchant-initiated (true) or customer-initiated (false).
+	 *
+	 * @var bool
+	 */
+	private $off_session;
+
+	/**
+	 * Indicates whether this is a one-off payment (false) or the first installment of a recurring payment (true).
+	 *
+	 * @var bool
+	 */
+	private $is_recurring;
+
+	/**
+	 * Payment information constructor.
+	 *
+	 * @param string                $payment_method The ID of the payment method used for this payment.
+	 * @param WC_Payment_Token/NULL $token The payment token used for this payment.
+	 * @param array                 $is_saved_method Indicates whether this payment was made using a saved card.
+	 * @param bool                  $is_recurring Indicates whether this is a one-off payment (false) or the first installment of a recurring payment (true).
+	 * @param bool                  $off_session Indicates whether the payment is merchant-initiated (true) or customer-initiated (false).
+	 *
+	 * @throws Exception - If no payment method is found in the provided request.
+	 */
+	public function __construct( $payment_method, $token, $is_saved_method = false, $is_recurring = false, $off_session = false ) {
+		$this->payment_method  = $payment_method;
+		$this->token           = $token;
+		$this->is_saved_method = $is_saved_method;
+		$this->is_recurring    = $is_recurring;
+		$this->off_session     = $off_session;
+	}
+
+	/**
+	 * Returns true if payment was made with a saved card, false otherwise.
+	 *
+	 * @return bool True if payment was made with a saved card, false otherwise.
+	 */
+	public function is_using_saved_card() {
+		return $this->is_saved_method;
+	}
+
+	/**
+	 * Returns true if this payment is the first installment of a recurring payment,
+	 * false otherwise.
+	 *
+	 * @return bool True if first installment of recurring payment, false otherwise.
+	 */
+	public function is_first_installment() {
+		return $this->is_recurring;
+	}
+
+	/**
+	 * Returns true if payment was initiated by the merchant, false otherwise.
+	 *
+	 * @return bool True if payment was initiated by the merchant, false otherwise.
+	 */
+	public function is_merchant_initiated() {
+		return $this->is_recurring;
+	}
+
+	/**
+	 * Returns the payment method ID.
+	 *
+	 * @return string The payment method ID.
+	 */
+	public function payment_method() {
+		return $this->payment_method;
+	}
+
+	/**
+	 * Returns the payment token.
+	 *
+	 * @return WC_Payment_Token/NULL The payment token.
+	 */
+	public function payment_token() {
+		return $this->token;
+	}
+
+	/**
+	 * Returns true if the payment token is not empty, false otherwise.
+	 *
+	 * @return bool True if payment token is not empty, false otherwise.
+	 */
+	public function has_payment_token() {
+		return ! empty( $this->token );
+	}
+
+	/**
+	 * Payment information constructor.
+	 *
+	 * @param array $request Associative array containing payment request information.
+	 * @param bool  $is_recurring_payment Indicates whether this is a one-off payment (false) or the first installment of a recurring payment (true).
+	 * @param bool  $off_session Indicates whether the payment is merchant-initiated (true) or customer-initiated (false).
+	 *
+	 * @throws Exception - If no payment method is found in the provided request.
+	 */
+	public static function from_payment_request( $request, $is_recurring_payment = false, $off_session = false ) {
+		$payment_method  = self::get_payment_method_from_request( $request );
+		$token           = self::get_token_from_request( $request );
+		$is_saved_method = self::is_request_made_with_saved_method( $request );
+		$is_recurring    = $is_recurring_payment;
+		$off_session     = $off_session;
+
+		return new WC_Payment_Information( $payment_method, $token, $is_saved_method, $is_recurring, $off_session );
+	}
+
+	/**
+	 * Extracts information on whether the payment request was made with a saved card or not.
+	 *
+	 * @param array $request Associative array containing payment request information.
+	 *
+	 * @return bool True if payment was made with a saved card, false otherwise.
+	 */
+	public static function is_request_made_with_saved_method( $request ) {
+		return empty( $request['wcpay-payment-method'] ) && ! empty( $request[ 'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] );
+	}
+
+	/**
+	 * Extracts the payment method from the provided request.
+	 *
+	 * @param array $request Associative array containing payment request information.
+	 *
+	 * @return string
+	 * @throws Exception - If no payment method is found.
+	 */
+	public static function get_payment_method_from_request( $request ) {
+		if ( empty( $request['wcpay-payment-method'] ) && empty( $request[ 'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] ) ) {
+			// If no payment method is set then stop here with an error.
+			throw new Exception( __( 'Payment method not found.', 'woocommerce-payments' ) );
+		}
+
+		//phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		$payment_method = ! empty( $request['wcpay-payment-method'] ) ? wc_clean( $request['wcpay-payment-method'] ) : null;
+
+		if ( empty( $payment_method ) ) {
+			$token = self::get_token_from_request( $request );
+
+			if ( ! $token || WC_Payment_Gateway_WCPay::GATEWAY_ID !== $token->get_gateway_id() || $token->get_user_id() !== get_current_user_id() ) {
+				throw new Exception( __( 'Invalid payment method. Please input a new card number.', 'woocommerce-payments' ) );
+			}
+
+			$payment_method = $token->get_token();
+		}
+
+		return $payment_method;
+	}
+
+	/**
+	 * Extract the payment token from the provided request.
+	 *
+	 * @param array $request Associative array containing payment request information.
+	 *
+	 * @return WC_Payment_Token|NULL
+	 */
+	public static function get_token_from_request( $request ) {
+		if ( ! isset( $request[ 'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] ) ) {
+			return null;
+		}
+
+		//phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		return WC_Payment_Tokens::get( wc_clean( $request[ 'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] ) );
+	}
+}

--- a/includes/class-wc-payment-information.php
+++ b/includes/class-wc-payment-information.php
@@ -100,7 +100,7 @@ class WC_Payment_Information {
 	 *
 	 * @return string The payment method ID.
 	 */
-	public function payment_method() {
+	public function get_payment_method() {
 		return $this->payment_method;
 	}
 
@@ -109,7 +109,7 @@ class WC_Payment_Information {
 	 *
 	 * @return WC_Payment_Token/NULL The payment token.
 	 */
-	public function payment_token() {
+	public function get_payment_token() {
 		return $this->token;
 	}
 

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -51,6 +51,7 @@ class WC_Payments_Token_Service {
 	 *
 	 * @param array   $payment_method Payment method to be added.
 	 * @param WP_User $user           User to attach payment method to.
+	 * @return WC_Payment_Token_CC    The WC object for the payment token.
 	 */
 	public function add_token_to_user( $payment_method, $user ) {
 		// Clear cached payment methods.
@@ -74,6 +75,7 @@ class WC_Payments_Token_Service {
 	 *
 	 * @param string  $payment_method_id Payment method to be added.
 	 * @param WP_User $user              User to attach payment method to.
+	 * @return WC_Payment_Token_CC       The newly created token.
 	 */
 	public function add_payment_method_to_user( $payment_method_id, $user ) {
 		$payment_method_object = $this->payments_api_client->get_payment_method( $payment_method_id );

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -77,7 +77,7 @@ class WC_Payments_Token_Service {
 	 */
 	public function add_payment_method_to_user( $payment_method_id, $user ) {
 		$payment_method_object = $this->payments_api_client->get_payment_method( $payment_method_id );
-		return $this->add_token_to_user( $payment_method_object, wp_get_current_user() );
+		return $this->add_token_to_user( $payment_method_object, $user );
 	}
 
 	/**
@@ -93,7 +93,7 @@ class WC_Payments_Token_Service {
 			return $tokens;
 		}
 
-		$customer_id = $this->customer_service->get_customer_id_by_user_id( get_current_user_id() );
+		$customer_id = $this->customer_service->get_customer_id_by_user_id( $user_id );
 
 		if ( null === $customer_id ) {
 			return $tokens;
@@ -110,7 +110,7 @@ class WC_Payments_Token_Service {
 		foreach ( $payment_methods as $payment_method ) {
 			if ( isset( $payment_method['type'] ) && 'card' === $payment_method['type'] ) {
 				if ( ! in_array( $payment_method['id'], $stored_tokens, true ) ) {
-					$token                      = $this->add_token_to_user( $payment_method, wp_get_current_user() );
+					$token                      = $this->add_token_to_user( $payment_method, get_user_by( 'id', $user_id ) );
 					$tokens[ $token->get_id() ] = $token;
 				}
 			}
@@ -145,7 +145,7 @@ class WC_Payments_Token_Service {
 	 */
 	public function woocommerce_payment_token_set_default( $token_id, $token ) {
 		if ( WC_Payment_Gateway_WCPay::GATEWAY_ID === $token->get_gateway_id() ) {
-			$customer_id = $this->customer_service->get_customer_id_by_user_id( get_current_user_id() );
+			$customer_id = $this->customer_service->get_customer_id_by_user_id( $token->get_user_id() );
 			if ( $customer_id ) {
 				$this->customer_service->set_default_payment_method_for_customer( $customer_id, $token->get_token() );
 				// Clear cached payment methods.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -95,7 +95,7 @@ class WC_Payments {
 		include_once dirname( __FILE__ ) . '/class-wc-payment-gateway-wcpay.php';
 		include_once dirname( __FILE__ ) . '/class-wc-payments-token-service.php';
 		include_once dirname( __FILE__ ) . '/exceptions/class-wc-payments-intent-authentication-exception.php';
-		include_once dirname( __FILE__ ) . '/class-wc-payment-information.php';
+		include_once dirname( __FILE__ ) . '/data-types/class-payment-information.php';
 
 		self::$account          = new WC_Payments_Account( self::$api_client );
 		self::$customer_service = new WC_Payments_Customer_Service( self::$api_client );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -101,7 +101,7 @@ class WC_Payments {
 		self::$token_service    = new WC_Payments_Token_Service( self::$api_client, self::$customer_service );
 
 		$gateway_class = 'WC_Payment_Gateway_WCPay';
-		if ( class_exists( 'WC_Subscriptions' ) ) {
+		if ( class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '3.0.0', '>=' ) ) {
 			include_once dirname( __FILE__ ) . '/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php';
 			$gateway_class = 'WC_Payment_Gateway_WCPay_Subscriptions_Compat';
 		}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -95,6 +95,7 @@ class WC_Payments {
 		include_once dirname( __FILE__ ) . '/class-wc-payment-gateway-wcpay.php';
 		include_once dirname( __FILE__ ) . '/class-wc-payments-token-service.php';
 		include_once dirname( __FILE__ ) . '/exceptions/class-wc-payments-intent-authentication-exception.php';
+		include_once dirname( __FILE__ ) . '/class-wc-payment-information.php';
 
 		self::$account          = new WC_Payments_Account( self::$api_client );
 		self::$customer_service = new WC_Payments_Customer_Service( self::$api_client );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -94,13 +94,19 @@ class WC_Payments {
 		include_once dirname( __FILE__ ) . '/class-logger.php';
 		include_once dirname( __FILE__ ) . '/class-wc-payment-gateway-wcpay.php';
 		include_once dirname( __FILE__ ) . '/class-wc-payments-token-service.php';
-		include_once WCPAY_ABSPATH . 'includes/exceptions/class-wc-payments-intent-authentication-exception.php';
+		include_once dirname( __FILE__ ) . '/exceptions/class-wc-payments-intent-authentication-exception.php';
 
 		self::$account          = new WC_Payments_Account( self::$api_client );
 		self::$customer_service = new WC_Payments_Customer_Service( self::$api_client );
 		self::$token_service    = new WC_Payments_Token_Service( self::$api_client, self::$customer_service );
 
-		self::$gateway = new WC_Payment_Gateway_WCPay( self::$api_client, self::$account, self::$customer_service, self::$token_service );
+		$gateway_class = 'WC_Payment_Gateway_WCPay';
+		if ( class_exists( 'WC_Subscriptions' ) ) {
+			include_once dirname( __FILE__ ) . '/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php';
+			$gateway_class = 'WC_Payment_Gateway_WCPay_Subscriptions_Compat';
+		}
+
+		self::$gateway = new $gateway_class( self::$api_client, self::$account, self::$customer_service, self::$token_service );
 
 		add_filter( 'woocommerce_payment_gateways', [ __CLASS__, 'register_gateway' ] );
 		add_filter( 'option_woocommerce_gateway_order', [ __CLASS__, 'set_gateway_top_of_list' ], 2 );

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use WCPay\Logger;
+use WCPay\DataTypes\Payment_Information;
 
 /**
  * Gateway class for WooCommerce Payments, with added compatibility with WooCommerce Subscriptions.
@@ -92,7 +93,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 			return;
 		}
 
-		$payment_information = new WC_Payment_Information( $token->get_token(), $token, true, true, true );
+		$payment_information = new Payment_Information( $token->get_token(), $token, true, true, true );
 
 		try {
 			$this->process_payment_for_order( $renewal_order, null, $payment_information, false );

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -114,4 +114,20 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 		$renewal_token        = end( $renewal_order_tokens );
 		$subscription->add_payment_token( $renewal_token );
 	}
+
+	/**
+	 * Saves the payment token to the order.
+	 *
+	 * @param WC_Order         $order The order.
+	 * @param WC_Payment_Token $token The token to save.
+	 */
+	protected function add_token_to_order( $order, $token ) {
+		parent::add_token_to_order( $order, $token );
+
+		// Set payment token for subscriptions, so it can be used for renewals.
+		$subscriptions = wcs_get_subscriptions_for_order( $order->get_id() );
+		foreach ( $subscriptions as $subscription ) {
+			parent::add_token_to_order( $subscription, $token );
+		}
+	}
 }

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Class WC_Payment_Gateway_WCPay_Subscriptions_Compat
+ *
+ * @package WooCommerce\Payments
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Gateway class for WooCommerce Payments, with added compatibility with WooCommerce Subscriptions.
+ */
+class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_WCPay {
+
+	/**
+	 * WC_Payment_Gateway_WCPay_Subscriptions_Compat constructor.
+	 *
+	 * @param array ...$args Arguments passed to the main gateway's constructor.
+	 */
+	public function __construct( ...$args ) {
+		parent::__construct( ...$args );
+
+		$this->supports = array_merge(
+			$this->supports,
+			[
+				'subscriptions',
+				'subscription_cancellation',
+				'subscription_suspension',
+				'subscription_reactivation',
+				'subscription_amount_changes',
+				'subscription_date_changes',
+				'subscription_payment_method_change',
+				'subscription_payment_method_change_customer',
+				'subscription_payment_method_change_admin',
+				'multiple_subscriptions',
+			]
+		);
+	}
+}

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+use WCPay\Logger;
+
 /**
  * Gateway class for WooCommerce Payments, with added compatibility with WooCommerce Subscriptions.
  */
@@ -37,5 +39,71 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 				'multiple_subscriptions',
 			]
 		);
+
+		add_action( 'woocommerce_scheduled_subscription_payment_' . $this->id, [ $this, 'scheduled_subscription_payment' ], 10, 2 );
+		add_filter( 'wcs_new_order_created', [ $this, 'copy_token_from_parent_order' ], 10, 2 );
+		add_action( 'woocommerce_subscription_failing_payment_method_updated_' . $this->id, [ $this, 'update_failing_payment_method' ], 10, 2 );
+		add_filter( 'wc_payments_display_save_payment_method_checkbox', [ $this, 'display_save_payment_method_checkbox' ], 10 );
+	}
+
+	public function process_payment( $order_id, $is_recurring_payment = false ) {
+		return parent::process_payment( $order_id, wcs_order_contains_subscription( $order_id ) );
+	}
+
+	public function display_save_payment_method_checkbox( $display ) {
+		if ( WC_Subscriptions_Cart::cart_contains_subscription() ) {
+			return false;
+		}
+		// Only render the "Save payment method" checkbox if there are no subscription products in the cart.
+		return $display;
+	}
+
+	/**
+	 * Scheduled_subscription_payment function.
+	 *
+	 * @param $amount float The amount to charge.
+	 * @param $renewal_order WC_Order A WC_Order object created to record the renewal payment.
+	 */
+	public function scheduled_subscription_payment( $amount, $renewal_order ) {
+		$order_tokens = WC_Payment_Tokens::get_order_tokens( $renewal_order );
+		$token        = empty( $order_tokens ) ? false : end( $order_tokens );
+		if ( ! $token ) {
+			Logger::error( 'There is no saved payment token for order #' . $renewal_order->get_id() );
+			$renewal_order->update_status( 'failed' );
+			return;
+		}
+
+		try {
+			$this->process_payment_for_order(
+				[
+					'order'           => $renewal_order,
+					'cart'            => null,
+					'manual_capture'  => false,
+					'payment_method'  => $token->get_token(),
+					'token'           => $token,
+					'is_saved_method' => true,
+					'off_session'     => true,
+					'is_recurring'    => true,
+				]
+			);
+		} catch ( WC_Payments_API_Exception $e ) {
+			Logger::error( 'Error processing subscription renewal: ' . $e->getMessage() );
+
+			$renewal_order->update_status( 'failed' );
+		}
+	}
+
+	public function copy_token_from_parent_order( $order, $subscription ) {
+		$parent = $subscription->get_parent();
+		if ( $parent ) {
+			$order->update_meta_data( '_payment_tokens', $parent->get_payment_tokens() );
+		}
+		return $order;
+	}
+
+	public function update_failing_payment_method( $subscription, $renewal_order ) {
+		$renewal_order_tokens = WC_Payment_Tokens::get_order_tokens( $renewal_order );
+		$renewal_token        = end( $renewal_order_tokens );
+		$subscription->add_payment_token( $renewal_token );
 	}
 }

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -42,7 +42,6 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 		);
 
 		add_action( 'woocommerce_scheduled_subscription_payment_' . $this->id, [ $this, 'scheduled_subscription_payment' ], 10, 2 );
-		add_filter( 'wcs_new_order_created', [ $this, 'copy_token_from_parent_order' ], 10, 2 );
 		add_action( 'woocommerce_subscription_failing_payment_method_updated_' . $this->id, [ $this, 'update_failing_payment_method' ], 10, 2 );
 		add_filter( 'wc_payments_display_save_payment_method_checkbox', [ $this, 'display_save_payment_method_checkbox' ], 10 );
 	}
@@ -102,22 +101,6 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 
 			$renewal_order->update_status( 'failed' );
 		}
-	}
-
-	/**
-	 * Retrieves the payment token from the subscription's parent order.
-	 *
-	 * @param WC_Order        $order The order that needs to be updated.
-	 * @param WC_Subscription $subscription The subscription used to find the parent order.
-	 *
-	 * @return WC_Order The order with the updated payment token, if a payment token was found.
-	 */
-	public function copy_token_from_parent_order( $order, $subscription ) {
-		$parent = $subscription->get_parent();
-		if ( $parent ) {
-			$order->update_meta_data( '_payment_tokens', $parent->get_payment_tokens() );
-		}
-		return $order;
 	}
 
 	/**

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -92,19 +92,10 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 			return;
 		}
 
+		$payment_information = new WC_Payment_Information( $token->get_token(), $token, true, true, true );
+
 		try {
-			$this->process_payment_for_order(
-				[
-					'order'           => $renewal_order,
-					'cart'            => null,
-					'manual_capture'  => false,
-					'payment_method'  => $token->get_token(),
-					'token'           => $token,
-					'is_saved_method' => true,
-					'off_session'     => true,
-					'is_recurring'    => true,
-				]
-			);
+			$this->process_payment_for_order( $renewal_order, null, $payment_information, false );
 		} catch ( WC_Payments_API_Exception $e ) {
 			Logger::error( 'Error processing subscription renewal: ' . $e->getMessage() );
 

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -92,7 +92,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 			return;
 		}
 
-		$payment_information = new Payment_Information( $token->get_token(), $token, true, true );
+		$payment_information = new Payment_Information( '', $token, true );
 
 		try {
 			// TODO: make `force_saved_card` and adding the 'recurring' metadata 2 distinct features.

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -92,10 +92,11 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 			return;
 		}
 
-		$payment_information = new Payment_Information( $token->get_token(), $token, true, true, true );
+		$payment_information = new Payment_Information( $token->get_token(), $token, true, true );
 
 		try {
-			$this->process_payment_for_order( $renewal_order, null, $payment_information, false );
+			// TODO: make `force_saved_card` and adding the 'recurring' metadata 2 distinct features.
+			$this->process_payment_for_order( $renewal_order, null, $payment_information, false, true );
 		} catch ( WC_Payments_API_Exception $e ) {
 			Logger::error( 'Error processing subscription renewal: ' . $e->getMessage() );
 

--- a/includes/data-types/class-payment-information.php
+++ b/includes/data-types/class-payment-information.php
@@ -1,9 +1,11 @@
 <?php
 /**
- * Class WC_Payment_Information
+ * Class Payment_Information
  *
  * @package WooCommerce\Payments
  */
+
+namespace WCPay\DataTypes;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -12,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Mostly a wrapper containing information on a single payment.
  */
-class WC_Payment_Information {
+class Payment_Information {
 	/**
 	 * The ID of the payment method used for this payment.
 	 *
@@ -23,7 +25,7 @@ class WC_Payment_Information {
 	/**
 	 * The payment token used for this payment.
 	 *
-	 * @var WC_Payment_Token/NULL
+	 * @var \WC_Payment_Token/NULL
 	 */
 	private $token;
 
@@ -51,11 +53,11 @@ class WC_Payment_Information {
 	/**
 	 * Payment information constructor.
 	 *
-	 * @param string                $payment_method The ID of the payment method used for this payment.
-	 * @param WC_Payment_Token/NULL $token The payment token used for this payment.
-	 * @param array                 $is_saved_method Indicates whether this payment was made using a saved card.
-	 * @param bool                  $is_recurring Indicates whether this is a one-off payment (false) or the first installment of a recurring payment (true).
-	 * @param bool                  $off_session Indicates whether the payment is merchant-initiated (true) or customer-initiated (false).
+	 * @param string                 $payment_method The ID of the payment method used for this payment.
+	 * @param \WC_Payment_Token/NULL $token The payment token used for this payment.
+	 * @param array                  $is_saved_method Indicates whether this payment was made using a saved card.
+	 * @param bool                   $is_recurring Indicates whether this is a one-off payment (false) or the first installment of a recurring payment (true).
+	 * @param bool                   $off_session Indicates whether the payment is merchant-initiated (true) or customer-initiated (false).
 	 *
 	 * @throws Exception - If no payment method is found in the provided request.
 	 */
@@ -107,7 +109,7 @@ class WC_Payment_Information {
 	/**
 	 * Returns the payment token.
 	 *
-	 * @return WC_Payment_Token/NULL The payment token.
+	 * @return \WC_Payment_Token/NULL The payment token.
 	 */
 	public function get_payment_token() {
 		return $this->token;
@@ -138,7 +140,7 @@ class WC_Payment_Information {
 		$is_recurring    = $is_recurring_payment;
 		$off_session     = $off_session;
 
-		return new WC_Payment_Information( $payment_method, $token, $is_saved_method, $is_recurring, $off_session );
+		return new Payment_Information( $payment_method, $token, $is_saved_method, $is_recurring, $off_session );
 	}
 
 	/**
@@ -149,7 +151,7 @@ class WC_Payment_Information {
 	 * @return bool True if payment was made with a saved card, false otherwise.
 	 */
 	public static function is_request_made_with_saved_method( $request ) {
-		return empty( $request['wcpay-payment-method'] ) && ! empty( $request[ 'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] );
+		return empty( $request['wcpay-payment-method'] ) && ! empty( $request[ 'wc-' . \WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] );
 	}
 
 	/**
@@ -161,7 +163,7 @@ class WC_Payment_Information {
 	 * @throws Exception - If no payment method is found.
 	 */
 	public static function get_payment_method_from_request( $request ) {
-		if ( empty( $request['wcpay-payment-method'] ) && empty( $request[ 'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] ) ) {
+		if ( empty( $request['wcpay-payment-method'] ) && empty( $request[ 'wc-' . \WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] ) ) {
 			// If no payment method is set then stop here with an error.
 			throw new Exception( __( 'Payment method not found.', 'woocommerce-payments' ) );
 		}
@@ -172,7 +174,7 @@ class WC_Payment_Information {
 		if ( empty( $payment_method ) ) {
 			$token = self::get_token_from_request( $request );
 
-			if ( ! $token || WC_Payment_Gateway_WCPay::GATEWAY_ID !== $token->get_gateway_id() || $token->get_user_id() !== get_current_user_id() ) {
+			if ( ! $token || \WC_Payment_Gateway_WCPay::GATEWAY_ID !== $token->get_gateway_id() || $token->get_user_id() !== get_current_user_id() ) {
 				throw new Exception( __( 'Invalid payment method. Please input a new card number.', 'woocommerce-payments' ) );
 			}
 
@@ -187,14 +189,14 @@ class WC_Payment_Information {
 	 *
 	 * @param array $request Associative array containing payment request information.
 	 *
-	 * @return WC_Payment_Token|NULL
+	 * @return \WC_Payment_Token|NULL
 	 */
 	public static function get_token_from_request( $request ) {
-		if ( ! isset( $request[ 'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] ) ) {
+		if ( ! isset( $request[ 'wc-' . \WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] ) ) {
 			return null;
 		}
 
 		//phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		return WC_Payment_Tokens::get( wc_clean( $request[ 'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] ) );
+		return \WC_Payment_Tokens::get( wc_clean( $request[ 'wc-' . \WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] ) );
 	}
 }

--- a/includes/data-types/class-payment-information.php
+++ b/includes/data-types/class-payment-information.php
@@ -101,6 +101,11 @@ class Payment_Information {
 	 * @return string The payment method ID.
 	 */
 	public function get_payment_method(): string {
+		// Use the token if we have it.
+		if ( $this->is_using_saved_payment_method() ) {
+			return $this->token->get_token();
+		}
+
 		return $this->payment_method;
 	}
 

--- a/includes/data-types/class-payment-information.php
+++ b/includes/data-types/class-payment-information.php
@@ -75,14 +75,6 @@ class Payment_Information {
 		$this->off_session     = $off_session;
 	}
 
-	/**
-	 * Returns true if payment was made with a saved card, false otherwise.
-	 *
-	 * @return bool True if payment was made with a saved card, false otherwise.
-	 */
-	public function is_using_saved_card(): bool {
-		return $this->is_saved_method;
-	}
 
 	/**
 	 * Returns true if this payment is the first installment of a recurring payment,
@@ -139,7 +131,7 @@ class Payment_Information {
 	 *
 	 * @return bool True if payment token is not empty, false otherwise.
 	 */
-	public function has_payment_token(): bool {
+	public function is_using_saved_payment_method(): bool {
 		return ! empty( $this->token );
 	}
 

--- a/includes/data-types/class-payment-information.php
+++ b/includes/data-types/class-payment-information.php
@@ -44,19 +44,11 @@ class Payment_Information {
 	private $off_session;
 
 	/**
-	 * Indicates whether this is a one-off payment (false) or the first installment of a recurring payment (true).
-	 *
-	 * @var bool
-	 */
-	private $is_recurring;
-
-	/**
 	 * Payment information constructor.
 	 *
 	 * @param string            $payment_method The ID of the payment method used for this payment.
 	 * @param \WC_Payment_Token $token The payment token used for this payment.
 	 * @param bool              $is_saved_method Indicates whether this payment was made using a saved card.
-	 * @param bool              $is_recurring Indicates whether this is a one-off payment (false) or the first installment of a recurring payment (true).
 	 * @param bool              $off_session Indicates whether the payment is merchant-initiated (true) or customer-initiated (false).
 	 *
 	 * @throws Exception - If no payment method is found in the provided request.
@@ -65,25 +57,13 @@ class Payment_Information {
 		string $payment_method,
 		\WC_Payment_Token $token = null,
 		bool $is_saved_method = false,
-		bool $is_recurring = false,
 		bool $off_session = false
 	) {
 		$this->payment_method  = $payment_method;
 		$this->token           = $token;
 		$this->is_saved_method = $is_saved_method;
-		$this->is_recurring    = $is_recurring;
 		$this->off_session     = $off_session;
-	}
 
-
-	/**
-	 * Returns true if this payment is the first installment of a recurring payment,
-	 * false otherwise.
-	 *
-	 * @return bool True if first installment of recurring payment, false otherwise.
-	 */
-	public function is_first_installment(): bool {
-		return $this->is_recurring;
 	}
 
 	/**
@@ -144,23 +124,20 @@ class Payment_Information {
 	 * Payment information constructor.
 	 *
 	 * @param array $request Associative array containing payment request information.
-	 * @param bool  $is_recurring_payment Indicates whether this is a one-off payment (false) or the first installment of a recurring payment (true).
 	 * @param bool  $off_session Indicates whether the payment is merchant-initiated (true) or customer-initiated (false).
 	 *
 	 * @throws Exception - If no payment method is found in the provided request.
 	 */
 	public static function from_payment_request(
 		array $request,
-		bool $is_recurring_payment = false,
 		bool $off_session = false
 	): Payment_Information {
 		$payment_method  = self::get_payment_method_from_request( $request );
 		$token           = self::get_token_from_request( $request );
 		$is_saved_method = self::is_request_made_with_saved_method( $request );
-		$is_recurring    = $is_recurring_payment;
 		$off_session     = $off_session;
 
-		return new Payment_Information( $payment_method, $token, $is_saved_method, $is_recurring, $off_session );
+		return new Payment_Information( $payment_method, $token, $is_saved_method, $off_session );
 	}
 
 	/**

--- a/includes/data-types/class-payment-information.php
+++ b/includes/data-types/class-payment-information.php
@@ -126,6 +126,15 @@ class Payment_Information {
 	}
 
 	/**
+	 * Update the payment token associated with this payment.
+	 *
+	 * @param \WC_Payment_Token $token The new payment token.
+	 */
+	public function set_token( \WC_Payment_Token $token ) {
+		$this->token = $token;
+	}
+
+	/**
 	 * Returns true if the payment token is not empty, false otherwise.
 	 *
 	 * @return bool True if payment token is not empty, false otherwise.

--- a/includes/data-types/class-payment-information.php
+++ b/includes/data-types/class-payment-information.php
@@ -92,7 +92,7 @@ class Payment_Information {
 	 * @return bool True if payment was initiated by the merchant, false otherwise.
 	 */
 	public function is_merchant_initiated(): bool {
-		return $this->is_recurring;
+		return $this->off_session;
 	}
 
 	/**

--- a/includes/data-types/class-payment-information.php
+++ b/includes/data-types/class-payment-information.php
@@ -53,15 +53,21 @@ class Payment_Information {
 	/**
 	 * Payment information constructor.
 	 *
-	 * @param string                 $payment_method The ID of the payment method used for this payment.
-	 * @param \WC_Payment_Token/NULL $token The payment token used for this payment.
-	 * @param array                  $is_saved_method Indicates whether this payment was made using a saved card.
-	 * @param bool                   $is_recurring Indicates whether this is a one-off payment (false) or the first installment of a recurring payment (true).
-	 * @param bool                   $off_session Indicates whether the payment is merchant-initiated (true) or customer-initiated (false).
+	 * @param string            $payment_method The ID of the payment method used for this payment.
+	 * @param \WC_Payment_Token $token The payment token used for this payment.
+	 * @param bool              $is_saved_method Indicates whether this payment was made using a saved card.
+	 * @param bool              $is_recurring Indicates whether this is a one-off payment (false) or the first installment of a recurring payment (true).
+	 * @param bool              $off_session Indicates whether the payment is merchant-initiated (true) or customer-initiated (false).
 	 *
 	 * @throws Exception - If no payment method is found in the provided request.
 	 */
-	public function __construct( $payment_method, $token, $is_saved_method = false, $is_recurring = false, $off_session = false ) {
+	public function __construct(
+		string $payment_method,
+		\WC_Payment_Token $token = null,
+		bool $is_saved_method = false,
+		bool $is_recurring = false,
+		bool $off_session = false
+	) {
 		$this->payment_method  = $payment_method;
 		$this->token           = $token;
 		$this->is_saved_method = $is_saved_method;
@@ -74,7 +80,7 @@ class Payment_Information {
 	 *
 	 * @return bool True if payment was made with a saved card, false otherwise.
 	 */
-	public function is_using_saved_card() {
+	public function is_using_saved_card(): bool {
 		return $this->is_saved_method;
 	}
 
@@ -84,7 +90,7 @@ class Payment_Information {
 	 *
 	 * @return bool True if first installment of recurring payment, false otherwise.
 	 */
-	public function is_first_installment() {
+	public function is_first_installment(): bool {
 		return $this->is_recurring;
 	}
 
@@ -93,7 +99,7 @@ class Payment_Information {
 	 *
 	 * @return bool True if payment was initiated by the merchant, false otherwise.
 	 */
-	public function is_merchant_initiated() {
+	public function is_merchant_initiated(): bool {
 		return $this->is_recurring;
 	}
 
@@ -102,16 +108,20 @@ class Payment_Information {
 	 *
 	 * @return string The payment method ID.
 	 */
-	public function get_payment_method() {
+	public function get_payment_method(): string {
 		return $this->payment_method;
 	}
 
 	/**
 	 * Returns the payment token.
 	 *
+	 * TODO: Once php requirement is bumped to >= 7.1.0 change return type to ?\WC_Payment_Token
+	 * since the return type is nullable, as per
+	 * https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+	 *
 	 * @return \WC_Payment_Token/NULL The payment token.
 	 */
-	public function get_payment_token() {
+	public function get_payment_token(): \WC_Payment_Token {
 		return $this->token;
 	}
 
@@ -120,7 +130,7 @@ class Payment_Information {
 	 *
 	 * @return bool True if payment token is not empty, false otherwise.
 	 */
-	public function has_payment_token() {
+	public function has_payment_token(): bool {
 		return ! empty( $this->token );
 	}
 
@@ -133,7 +143,11 @@ class Payment_Information {
 	 *
 	 * @throws Exception - If no payment method is found in the provided request.
 	 */
-	public static function from_payment_request( $request, $is_recurring_payment = false, $off_session = false ) {
+	public static function from_payment_request(
+		array $request,
+		bool $is_recurring_payment = false,
+		bool $off_session = false
+	): Payment_Information {
 		$payment_method  = self::get_payment_method_from_request( $request );
 		$token           = self::get_token_from_request( $request );
 		$is_saved_method = self::is_request_made_with_saved_method( $request );
@@ -150,7 +164,7 @@ class Payment_Information {
 	 *
 	 * @return bool True if payment was made with a saved card, false otherwise.
 	 */
-	public static function is_request_made_with_saved_method( $request ) {
+	public static function is_request_made_with_saved_method( array $request ): bool {
 		return empty( $request['wcpay-payment-method'] ) && ! empty( $request[ 'wc-' . \WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] );
 	}
 
@@ -162,7 +176,7 @@ class Payment_Information {
 	 * @return string
 	 * @throws Exception - If no payment method is found.
 	 */
-	public static function get_payment_method_from_request( $request ) {
+	public static function get_payment_method_from_request( array $request ): string {
 		if ( empty( $request['wcpay-payment-method'] ) && empty( $request[ 'wc-' . \WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] ) ) {
 			// If no payment method is set then stop here with an error.
 			throw new Exception( __( 'Payment method not found.', 'woocommerce-payments' ) );
@@ -187,11 +201,15 @@ class Payment_Information {
 	/**
 	 * Extract the payment token from the provided request.
 	 *
+	 * TODO: Once php requirement is bumped to >= 7.1.0 change return type to ?\WC_Payment_Token
+	 * since the return type is nullable, as per
+	 * https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+	 *
 	 * @param array $request Associative array containing payment request information.
 	 *
 	 * @return \WC_Payment_Token|NULL
 	 */
-	public static function get_token_from_request( $request ) {
+	public static function get_token_from_request( array $request ): \WC_Payment_Token {
 		if ( ! isset( $request[ 'wc-' . \WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] ) ) {
 			return null;
 		}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -121,6 +121,7 @@ class WC_Payments_API_Client {
 	 * @param bool   $save_payment_method    - Whether to save payment method for future purchases.
 	 * @param array  $metadata               - Meta data values to be sent along with payment intent creation.
 	 * @param array  $level3                 - Level 3 data.
+	 * @param bool   $off_session            - Whether the payment is off-session (merchant-initiated), or on-session (customer-initiated).
 	 *
 	 * @return WC_Payments_API_Intention
 	 * @throws WC_Payments_API_Exception - Exception thrown on intention creation failure.
@@ -133,7 +134,8 @@ class WC_Payments_API_Client {
 		$manual_capture = false,
 		$save_payment_method = false,
 		$metadata = [],
-		$level3 = []
+		$level3 = [],
+		$off_session = false
 	) {
 		// TODO: There's scope to have amount and currency bundled up into an object.
 		$request                   = [];
@@ -145,6 +147,10 @@ class WC_Payments_API_Client {
 		$request['capture_method'] = $manual_capture ? 'manual' : 'automatic';
 		$request['metadata']       = $metadata;
 		$request['level3']         = $level3;
+
+		if ( $off_session ) {
+			$request['off_session'] = true;
+		}
 
 		if ( $save_payment_method ) {
 			$request['setup_future_usage'] = 'off_session';

--- a/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -206,7 +206,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->method( 'empty_cart' );
 
 		// Act: process a successful payment.
-		$result = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order, $mock_cart );
+		$payment_information = WCPay\DataTypes\Payment_Information::from_payment_request( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$result              = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order, $mock_cart, $payment_information, false );
 
 		// Assert: Returning correct array.
 		$this->assertEquals( 'success', $result['result'] );
@@ -308,7 +309,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->method( 'empty_cart' );
 
 		// Act: process payment.
-		$result = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order, $mock_cart );
+		$payment_information = WCPay\DataTypes\Payment_Information::from_payment_request( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$result              = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order, $mock_cart, $payment_information, true );
 
 		// Assert: Returning correct array.
 		$this->assertEquals( 'success', $result['result'] );
@@ -322,20 +324,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$total         = 12.23;
 
 		// Arrange: Create an order to test with.
-		$mock_order = $this->createMock( 'WC_Order' );
-
-		// Arrange: Set a good return value for order ID.
-		$mock_order
-			->method( 'get_id' )
-			->willReturn( $order_id );
-
-		// Arrange: Set a good return value for order total.
-		$mock_order
-			->method( 'get_total' )
-			->willReturn( $total );
-
-		// Arrange: Create a mock cart.
-		$mock_cart = $this->createMock( 'WC_Cart' );
+		$order = WC_Helper_Order::create_order();
 
 		// Arrange: Throw an exception in create_and_confirm_intention.
 		$this->mock_api_client
@@ -351,37 +340,25 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 				)
 			);
 
+		// Act: process payment.
+		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id(), false );
+		$result_order = wc_get_order( $order->get_id() );
+
 		// Assert: Order status was updated.
-		$mock_order
-			->expects( $this->exactly( 1 ) )
-			->method( 'update_status' )
-			->with( 'failed' );
+		$this->assertEquals( 'failed', $result_order->get_status() );
 
 		// Assert: Order transaction ID was not set.
-		$mock_order
-			->expects( $this->exactly( 0 ) )
-			->method( 'set_transaction_id' );
+		$this->assertEquals( '', $result_order->get_meta( '_transaction_id' ) );
 
 		// Assert: Order meta was not updated with charge ID, intention status, or intent ID.
-		$mock_order
-		->expects( $this->exactly( 0 ) )
-		->method( 'update_meta_data' );
+		$this->assertEquals( '', $result_order->get_meta( '_intent_id' ) );
+		$this->assertEquals( '', $result_order->get_meta( '_charge_id' ) );
+		$this->assertEquals( '', $result_order->get_meta( '_intention_status' ) );
 
-		// Assert: No order note was added.
-		// - status
-		// - intention id
-		// - amount charged.
-		$mock_order
-			->expects( $this->exactly( 0 ) )
-			->method( 'add_order_note' );
-
-		// Assert: empty_cart() was not called.
-		$mock_cart
-			->expects( $this->exactly( 0 ) )
-			->method( 'empty_cart' );
-
-		// Act: process payment.
-		$result = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order, $mock_cart );
+		// Assert: No order note was added, besides the status change.
+		$notes = wc_get_order_notes( [ 'order_id' => $result_order->get_id() ] );
+		$this->assertEquals( 1, count( $notes ) );
+		$this->assertEquals( 'Order status changed from Pending payment to Failed.', $notes[0]->content );
 
 		// Assert: A WooCommerce notice was added.
 		$this->assertTrue( wc_has_notice( $error_message, 'error' ) );
@@ -488,7 +465,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->method( 'empty_cart' );
 
 		// Act: process payment.
-		$result = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order, $mock_cart );
+		$payment_information = WCPay\DataTypes\Payment_Information::from_payment_request( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$result              = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order, $mock_cart, $payment_information, true );
 
 		// Assert: Returning correct array.
 		$this->assertEquals( 'success', $result['result'] );
@@ -512,7 +490,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$this->mock_token_service
 			->expects( $this->once() )
 			->method( 'add_payment_method_to_user' )
-			->with( 'pm_mock', wp_get_current_user() );
+			->with( 'pm_mock', $order->get_user() )
+			->will( $this->returnValue( new WC_Payment_Token_CC() ) );
 
 		$_POST['wc-woocommerce_payments-new-payment-method'] = 'true';
 		$result = $this->mock_wcpay_gateway->process_payment( $order->get_id() );

--- a/tests/test-class-wc-payments-token-service.php
+++ b/tests/test-class-wc-payments-token-service.php
@@ -155,6 +155,7 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 		$token = new WC_Payment_Token_CC();
 		$token->set_gateway_id( 'woocommerce_payments' );
 		$token->set_token( 'pm_mock' );
+		$token->set_user_id( 1 );
 
 		$this->token_service->woocommerce_payment_token_set_default( 'pm_mock', $token );
 	}
@@ -189,6 +190,7 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 		$token = new WC_Payment_Token_CC();
 		$token->set_gateway_id( 'woocommerce_payments' );
 		$token->set_token( 'pm_mock' );
+		$token->set_user_id( 1 );
 
 		$this->token_service->woocommerce_payment_token_set_default( 'pm_mock', $token );
 	}


### PR DESCRIPTION
Fixes #697

## This PR includes

- WCPay now declares that it supports subscriptions.
- WCPay can be used to sign up for a subscription.
- WCPay will be used correctly for renewals of said subscription.

## Capability checks

- ✅ `subscription`
- ✅ `subscription_cancellation`
- ✅ `subscription_suspension`
- ❓ `subscription_reactivation`
- ❓ `subscription_amount_changes`
- ❓ `subscription_date_changes`
- ❓ `subscription_payment_method_change`
- ❓ `subscription_payment_method_change_customer`
- ❓ `subscription_payment_method_change_admin`
- ❓ `multiple_subscriptions`

## What doesn't work

- SCA (see #833).
- Subscriptions with free trial (see #832).

## Untested, but may work

- Customer-initiated early renewal (via modal).

<hr />

I sprinkled the PR with comments to help guide the person who will keep working on it :)