### PR TITLE
Install WPCLI with docker and add the command to npm scripts

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -30,8 +30,8 @@ You will see it give a forwarding address like this one:
 Copy the address and use it in the following command (replacing <url>)
 
 ```
-docker-compose exec -u www-data wordpress wp option update home <url>
-docker-compose exec -u www-data wordpress wp option update siteurl <url>
+npm run wp option update home <url>
+npm run wp option update siteurl <url>
 ```
 
 Visit the <url> , login and connect to Jetpack. If this doesn't work, visit `localhost:8082` and you will be redirected 
@@ -44,8 +44,8 @@ Activate Jetpack and setup WCPay.
 Turn off Ngrok by running:
 
 ```
-docker-compose exec -u www-data wordpress wp option update home http://localhost:8082
-docker-compose exec -u www-data wordpress wp option update siteurl http://localhost:8082
+npm run wp option update home http://localhost:8082
+npm run wp option update siteurl http://localhost:8082
 ```
 
 After this succeeds you can access the local site at
@@ -57,7 +57,7 @@ http://localhost:8082/
 To get your blog ID run:
 
 ```
-docker-compose exec -u www-data wordpress wp eval 'echo Jetpack_Options::get_option( "id" );'
+npm run wp eval 'echo Jetpack_Options::get_option( "id" );'
 ```
 
 For the rest of the setup instructions see this link:

--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -6,7 +6,7 @@ RUN pecl install xdebug \
 	&& echo 'xdebug.remote_autostart=1' >> $PHP_INI_DIR/php.ini \
 	&& docker-php-ext-enable xdebug
 RUN apt-get update \
-	&& apt-get install --assume-yes --quiet --no-install-recommends gnupg2 subversion mariadb-client
+	&& apt-get install --assume-yes --quiet --no-install-recommends gnupg2 subversion mariadb-client less
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
 	&& chmod +x wp-cli.phar \
 	&& mv wp-cli.phar /usr/local/bin/wp

--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -7,3 +7,6 @@ RUN pecl install xdebug \
 	&& docker-php-ext-enable xdebug
 RUN apt-get update \
 	&& apt-get install --assume-yes --quiet --no-install-recommends gnupg2 subversion mariadb-client
+RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+	&& chmod +x wp-cli.phar \
+	&& mv wp-cli.phar /usr/local/bin/wp

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "dev": "npm run up && npm run watch",
     "up": "docker-compose up --build --force-recreate -d",
     "down": "docker-compose down",
+    "wp": "docker-compose exec -u www-data wordpress wp",
     "install-if-deps-outdated": "node bin/install-if-deps-outdated.js",
     "lint": "npm run lint:js && npm run lint:css",
     "lint:css": "stylelint 'client/**/*.scss' 'client/**/*.css' 'assets/**/*.scss' 'assets/**/*.css'",


### PR DESCRIPTION
Fixes #828

#### Changes proposed in this Pull Request

* Adds WP CLI installation to the docker build file.
* Adds a npm script shortcut for running it: `npm run wp....`
* Updates readme instruction to use npm script to interact with wp.

#### Testing instructions
- run `npm install`
- run `npm run up`
- Check that WPCLI was installed: `npm run wp -- --info `

-------------------

- [x] Tested on mobile (or does not apply)