### PR TITLE
Add subscriber payment method changes

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -645,6 +645,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	protected function add_token_to_order( $order, $token ) {
 		$order_tokens = $order->get_payment_tokens();
 
+		// This could lead to tokens being saved twice in an order's payment tokens, but it is needed so that shoppers
+		// may re-use a previous card for the same subscription, as we consider the last token to be the active one.
+		// We can't remove the previous entry for the token because WC_Order does not support removal of tokens [1] and
+		// we can't delete the token as it might be used somewhere else.
+		// [1] https://github.com/woocommerce/woocommerce/issues/11857.
 		if ( $token->get_id() !== end( $order_tokens ) ) {
 			$order->add_payment_token( $token );
 		}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -562,7 +562,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					$order->update_meta_data( '_intention_status', $status );
 					$order->save();
 
-					$order->add_order_note( $note );
+					if ( $amount > 0 ) {
+						$order->add_order_note( $note );
+					}
 					$order->payment_complete( $intent_id );
 					break;
 				case 'requires_capture':

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -85,9 +85,9 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 	 */
 	public function scheduled_subscription_payment( $amount, $renewal_order ) {
 		$order_tokens = $renewal_order->get_payment_tokens();
-		$token_id     = empty( $order_tokens ) ? false : end( $order_tokens );
-		$token        = WC_Payment_Tokens::get( $token_id );
-		if ( ! $token ) {
+		$token_id     = end( $order_tokens );
+		$token        = ! $token_id ? null : WC_Payment_Tokens::get( $token_id );
+		if ( is_null( $token ) ) {
 			Logger::error( 'There is no saved payment token for order #' . $renewal_order->get_id() );
 			$renewal_order->update_status( 'failed' );
 			return;
@@ -114,7 +114,11 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 	public function update_failing_payment_method( $subscription, $renewal_order ) {
 		$renewal_order_tokens = $renewal_order->get_payment_tokens();
 		$renewal_token_id     = end( $renewal_order_tokens );
-		$renewal_token        = WC_Payment_Tokens::get( $renewal_token_id );
+		$renewal_token        = ! $renewal_token_id ? null : WC_Payment_Tokens::get( $renewal_token_id );
+		if ( is_null( $renewal_token ) ) {
+			Logger::error( 'Failing subscription could not be updated: there is no saved payment token for order #' . $renewal_order->get_id() );
+			return;
+		}
 		$subscription->add_payment_token( $renewal_token );
 	}
 

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -84,8 +84,9 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 	 * @param WC_Order $renewal_order A WC_Order object created to record the renewal payment.
 	 */
 	public function scheduled_subscription_payment( $amount, $renewal_order ) {
-		$order_tokens = WC_Payment_Tokens::get_order_tokens( $renewal_order );
-		$token        = empty( $order_tokens ) ? false : end( $order_tokens );
+		$order_tokens = $renewal_order->get_payment_tokens();
+		$token_id     = empty( $order_tokens ) ? false : end( $order_tokens );
+		$token        = WC_Payment_Tokens::get( $token_id );
 		if ( ! $token ) {
 			Logger::error( 'There is no saved payment token for order #' . $renewal_order->get_id() );
 			$renewal_order->update_status( 'failed' );
@@ -111,8 +112,9 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 	 * @param WC_Order        $renewal_order The failed renewal order.
 	 */
 	public function update_failing_payment_method( $subscription, $renewal_order ) {
-		$renewal_order_tokens = WC_Payment_Tokens::get_order_tokens( $renewal_order );
-		$renewal_token        = end( $renewal_order_tokens );
+		$renewal_order_tokens = $renewal_order->get_payment_tokens();
+		$renewal_token_id     = end( $renewal_order_tokens );
+		$renewal_token        = WC_Payment_Tokens::get( $renewal_token_id );
 		$subscription->add_payment_token( $renewal_token );
 	}
 

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -36,7 +36,6 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 				'subscription_date_changes',
 				'subscription_payment_method_change',
 				'subscription_payment_method_change_customer',
-				'subscription_payment_method_change_admin',
 				'multiple_subscriptions',
 			]
 		);

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -260,14 +260,16 @@ class WC_Payments_API_Client {
 	 *
 	 * @param string $payment_method_id      - ID of payment method to be saved.
 	 * @param string $customer_id            - ID of the customer.
+	 * @param bool   $confirm                - Flag to confirm the intent on creation if true.
 	 *
 	 * @return array
 	 * @throws WC_Payments_API_Exception - Exception thrown on setup intent creation failure.
 	 */
-	public function create_setup_intent( $payment_method_id, $customer_id ) {
+	public function create_setup_intent( $payment_method_id, $customer_id, $confirm = 'false' ) {
 		$request = [
 			'payment_method' => $payment_method_id,
 			'customer'       => $customer_id,
+			'confirm'        => $confirm,
 		];
 
 		return $this->request( $request, self::SETUP_INTENTS_API, self::POST );


### PR DESCRIPTION
Fixes #698 

#### Changes proposed in this Pull Request

* Add support for trial subscriptions and payment method changes
* Remove copy of payment methods from the parent order
* Ensure tokens are retrieved in the order they were added
* Update payment method saving to verify active token instead of history
* Fix failed payment token update by saving token before order update

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There are three scenarios that need to be tested in this PR:

**Free trial subscription**

1. Create a subscription product with a free trial
2. Go to checkout and place the order using a basic card, such as `4242424242424242`
3. Assert that the order is placed successfully
4. Go to the subscriptions admin page and click on the subscription
5. Run the `Process renewal` action
6. Assert that the renewal is successful and the transaction is listed in the WCPay transactions page 

**Payment method changes**

1. With an already existing subscription, go to My Account > Subscriptions
2. Click on the subscription and then on Change payment
3. Insert another basic card details and save it
3. Assert that the payment method is updated successfully
4. Go to the subscriptions admin page and click on the subscription
5. Run the `Process renewal` action
6. Assert that the renewal used the new card and that the transaction is listed in the WCPay transactions page 

**Failed payment update**

1. Place an order for a free-trial subscription product or update an existing subscription with an attachable but declined card, such as `4000000000000341`
2. Assert that the order or update is successful
4. Go to the subscriptions admin page and click on the subscription
5. Run the `Process renewal` action
6. Assert that the renewal fails
7. Go to My Account > Subscriptions and click on the subscription
8. Scroll down to the order list and click on Pay for the failed order
9. Insert another basic card details (or use a saved card) and update the failed order
10. Assert that the payment for the renewal order is successful
11. Go to the subscriptions admin page, click on the subscription and run the `Process renewal` action
13. Assert that the renewal used the card used in the failed renewal and that the transaction is listed in the WCPay transactions page 

-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
