### PR TITLE
Direct link to the transaction detail view from the admin order detail page

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1330,4 +1330,23 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			);
 		}
 	}
+
+	/**
+	 * Add a url to the admin order page that links directly to the transactions detail view.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param WC_Order $order The context passed into this function when the user view the order details page in WordPress admin.
+	 */
+	public function get_transaction_url( $order ) {
+		$charge_id = $order->get_meta( '_charge_id' );
+		return add_query_arg(
+			[
+				'page' => 'wc-admin',
+				'path' => '/payments/transactions/details&',
+				'id'   => $charge_id,
+			],
+			admin_url( 'admin.php' )
+		);
+	}
 }

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1337,9 +1337,15 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @since 1.4.0
 	 *
 	 * @param WC_Order $order The context passed into this function when the user view the order details page in WordPress admin.
+	 * @return string
 	 */
 	public function get_transaction_url( $order ) {
 		$charge_id = $order->get_meta( '_charge_id' );
+
+		if ( empty( $charge_id ) ) {
+			return '';
+		}
+
 		return add_query_arg(
 			[
 				'page' => 'wc-admin',

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,9 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 
 == Changelog ==
 
+= 1.x.x - 2020-xx-xx =
+* Fix - Link from order details page to transaction details page.
+
 = 1.3.0 - 2020-08-17 =
 * Add - Support for saved cards.
 * Add - Search bar for transactions.


### PR DESCRIPTION
Fixes #424 

#### Changes proposed in this Pull Request

* Add a gateway message that WooCommerce Core calls to add a link out to the gateway specific transaction information.

#### Testing instructions

- Create a new order with a standard CC.
- Visit the order details page.
- Make sure the charge is captured.
- Click on the transaction link as seen below:
<img width="764" alt="Screenshot 2020-08-25 at 08 51 56" src="https://user-images.githubusercontent.com/1713474/91141816-513ff500-e6b0-11ea-82ac-fa294de16736.png">



Note that the link text is `pi_...` and not `ch_` that we're linking to. This is not easily fixed due to how we set the order's `transaction_id`. We set it to be the payment intent and not the charge id. WooCommerce uses whatever value we set transaction id for the text here. The Stripe gateway sets the charge id.


-------------------

- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
