### PR TITLE
Do not redirect to onboarding from Jetpack pages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@
 
 = 1.3.1 - 2020-xx-xx =
 * Add - Allow merchant to edit statement descriptor
+* Fix - Link from order details page to transaction details page.
+* Fix - Do not redirect to the onboarding page after completing the WC4.5-beta wizard
 
 = 1.3.0 - 2020-08-17 =
 * Add - Support for saved cards.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Payments Changelog ***
 
-= 1.3.1 - 2020-xx-xx =
+= 1.4.0 - 2020-xx-xx =
 * Add - Allow merchant to edit statement descriptor
 * Fix - Link from order details page to transaction details page.
 * Fix - Do not redirect to the onboarding page after completing the WC4.5-beta wizard

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -237,6 +237,11 @@ class WC_Payments_Account {
 			return false;
 		}
 
+		// Don't redirect if the user is on Jetpack pages.
+		if ( 'jetpack' === $current_page ) {
+			return false;
+		}
+
 		return true;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -91,7 +91,9 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 == Changelog ==
 
 = 1.x.x - 2020-xx-xx =
+* Add - Allow merchant to edit statement descriptor
 * Fix - Link from order details page to transaction details page.
+* Fix - Do not redirect to the onboarding page after completing the WC4.5-beta wizard
 
 = 1.3.0 - 2020-08-17 =
 * Add - Support for saved cards.

--- a/readme.txt
+++ b/readme.txt
@@ -90,7 +90,7 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 
 == Changelog ==
 
-= 1.x.x - 2020-xx-xx =
+= 1.4.0 - 2020-xx-xx =
 * Add - Allow merchant to edit statement descriptor
 * Fix - Link from order details page to transaction details page.
 * Fix - Do not redirect to the onboarding page after completing the WC4.5-beta wizard


### PR DESCRIPTION
Fixes #834

The updated Woo wizard redirects to Jetpack after completion. While this might be a bug, I think it doesn't hurt to be more careful when redirecting and there's no need to force the users to connect WCPay when they somehow expect to be on a Jetpack page.

#### Changes proposed in this Pull Request

* Check if the user is on any Jetpack page and do not redirect if so

#### Testing instructions

* On fresh install:
  * Install [WooCommerce Beta Tester](https://wordpress.org/plugins/woocommerce-beta-tester/)
  * Switch to WC 4.5-beta or rc1
  * Make sure Jetpack is not connected (or not installed at all)
  * Follow the woo wizard and at the `Business details` step, make sure `Install recommended free business features` is checked. Complete the wizard.
  * You should not be redirected to the wcpay onboarding
* On an existing install
  * Install [WooCommerce Beta Tester](https://wordpress.org/plugins/woocommerce-beta-tester/)
  * Switch to WC 4.5-beta or rc1
  * Use WCPay dev tools and set `Force the plugin to act as disconnected from WCPay`
  * Deactivate the WCPay plugin
  * Disconnect and deactivate Jetpack if it's installed
  * Navigate to `/wp-admin/admin.php?page=wc-admin&reset_profiler=1`
  * Follow the woo wizard and at the `Business details` step, make sure `Install recommended free business features` is checked. Complete the wizard.
  * You should not be redirected to the wcpay onboarding



-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
