### PR TITLE
Onboarding: Do not redirect if installed in the WC setup wizard

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 1.4.1 - 2020-xx-xx =
+* Fix - Only redirect to the onboarding screen if the plugin has been individually activated using the plugins page.
+
 = 1.4.0 - 2020-09-02 =
 * Add - Initial support for WooCommerce Subscriptions: Signing up for subscriptions, scheduled payments, and customer-initiated payment method changes.
 * Add - Added a link to transaction details from order screens.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -225,20 +225,14 @@ class WC_Payments_Account {
 			return false;
 		}
 
-		// Don't redirect if the user is in the WC setup wizard.
-		$current_page = isset( $_GET['page'] ) ? wp_unslash( $_GET['page'] ) : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		if ( 'wc-setup' === $current_page ) {
-			return false;
-		}
-
-		// Don't redirect if the user is on the WC-Admin setup profiler or WC-Admin dashboard with the task list.
-		if ( 'wc-admin' === $current_page && empty( $_GET['path'] )
-			&& ( Onboarding::should_show_profiler() || Onboarding::should_show_tasks() ) ) {
-			return false;
-		}
-
-		// Don't redirect if the user is on Jetpack pages.
-		if ( 'jetpack' === $current_page ) {
+		// Do not redirect if the plugin was installed via the WC setup wizard.
+		$onboarding_profile = get_option( Onboarding::PROFILE_DATA_OPTION );
+		if (
+			is_array( $onboarding_profile )
+			&& isset( $onboarding_profile['business_extensions'] )
+			&& is_array( $onboarding_profile['business_extensions'] )
+			&& in_array( 'woocommerce-payments', $onboarding_profile['business_extensions'], true )
+		) {
 			return false;
 		}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -210,33 +210,7 @@ class WC_Payments_Account {
 			return true;
 		}
 
-		// If already redirected to onboarding in the past, don't do it again.
-		if ( get_option( 'wcpay_redirected_to_onboarding', false ) ) {
-			return false;
-		}
-
-		// If onboarding new accounts is disabled, so it's pointless to redirect users to the splash page.
-		if ( self::is_on_boarding_disabled() ) {
-			return false;
-		}
-
-		// Don't hijack WP-Admin if the user is bulk-activating plugins.
-		if ( isset( $_GET['activate-multi'] ) ) {
-			return false;
-		}
-
-		// Do not redirect if the plugin was installed via the WC setup wizard.
-		$onboarding_profile = get_option( Onboarding::PROFILE_DATA_OPTION );
-		if (
-			is_array( $onboarding_profile )
-			&& isset( $onboarding_profile['business_extensions'] )
-			&& is_array( $onboarding_profile['business_extensions'] )
-			&& in_array( 'woocommerce-payments', $onboarding_profile['business_extensions'], true )
-		) {
-			return false;
-		}
-
-		return true;
+		return get_option( 'wcpay_should_redirect_to_onboarding', false );
 	}
 
 	/**
@@ -258,7 +232,7 @@ class WC_Payments_Account {
 
 		if ( empty( $account ) ) {
 			if ( $this->should_redirect_to_onboarding() ) {
-				update_option( 'wcpay_redirected_to_onboarding', true );
+				update_option( 'wcpay_should_redirect_to_onboarding', false );
 				$this->redirect_to_onboarding_page();
 			}
 			return false;

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,9 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 
 == Changelog ==
 
+= 1.4.1 - 2020-xx-xx =
+* Fix - Only redirect to the onboarding screen if the plugin has been individually activated using the plugins page.
+
 = 1.4.0 - 2020-09-02 =
 * Add - Initial support for WooCommerce Subscriptions: Signing up for subscriptions, scheduled payments, and customer-initiated payment method changes.
 * Add - Added a link to transaction details from order screens.

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -26,6 +26,27 @@ define( 'WCPAY_MIN_WC_ADMIN_VERSION', '0.23.2' );
 require_once WCPAY_ABSPATH . 'vendor/autoload_packages.php';
 
 /**
+ * Plugin activation hook.
+ */
+function wcpay_activate() {
+	// Do not take any action if activated in a REST request (via wc-admin).
+	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		return;
+	}
+
+	if (
+		// Only redirect to onboarding when activated on its own. Either with a link...
+		isset( $_GET['action'] ) && 'activate' === $_GET['action'] // phpcs:ignore WordPress.Security.NonceVerification
+		// ...or with a bulk action.
+		|| isset( $_POST['checked'] ) && is_array( $_POST['checked'] ) && 1 === count( $_POST['checked'] ) // phpcs:ignore WordPress.Security.NonceVerification
+	) {
+		update_option( 'wcpay_should_redirect_to_onboarding', true );
+	}
+}
+
+register_activation_hook( __FILE__, 'wcpay_activate' );
+
+/**
  * Initialize the Jetpack connection functionality.
  */
 function wcpay_jetpack_init() {


### PR DESCRIPTION
Fixes #856 

#### Changes proposed in this Pull Request

* Instead of checking all the urls, we just check if the plugin was installed as a part of the Woo setup wizard and then skip the redirect if it was

#### Testing instructions

* On a new site:
  * Install woocommerce but no wcpay
* On an existing site:
  * Use wcpay dev tools to force the plugin to act as disconnected
  * Deactivate the wcpay plugin
  * Delete `wcpay_redirected_to_onboarding` from `wp_options` or set it to 0
  * Delete `woocommerce_onboarding_profile` from `wp_options`
  * Navigate to `/wp-admin/admin.php?page=wc-admin&reset_profiler=1`
* Go through the onboarding wizard, select `Fashion` as the industry, then in the next step choose to `Install recommended free business features`
* Finish the wizard, you should never be redirected to WCPay afterward, even when navigating to other wp-admin pages
* Repeat the "existing site" steps (mainly the deleting options part)
* Deactivate the wcpay plugin
* Activate the wcpay plugin
* You should get redirected to wcpay onboarding page after activating

-------------------

- [x] Added changelog entry (does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
