### PR TITLE
Add subscriptions unit tests

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -642,7 +642,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @param WC_Order         $order The order.
 	 * @param WC_Payment_Token $token The token to save.
 	 */
-	protected function add_token_to_order( $order, $token ) {
+	public function add_token_to_order( $order, $token ) {
 		$order_tokens = $order->get_payment_tokens();
 
 		// This could lead to tokens being saved twice in an order's payment tokens, but it is needed so that shoppers

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -118,7 +118,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 			Logger::error( 'Failing subscription could not be updated: there is no saved payment token for order #' . $renewal_order->get_id() );
 			return;
 		}
-		$subscription->add_payment_token( $renewal_token );
+		$this->add_token_to_order( $subscription, $renewal_token );
 	}
 
 	/**

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -127,7 +127,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 	 * @param WC_Order         $order The order.
 	 * @param WC_Payment_Token $token The token to save.
 	 */
-	protected function add_token_to_order( $order, $token ) {
+	public function add_token_to_order( $order, $token ) {
 		parent::add_token_to_order( $order, $token );
 
 		// Set payment token for subscriptions, so it can be used for renewals.

--- a/includes/data-types/class-payment-information.php
+++ b/includes/data-types/class-payment-information.php
@@ -156,15 +156,16 @@ class Payment_Information {
 	 * @return \WC_Payment_Token|NULL
 	 */
 	public static function get_token_from_request( array $request ) {
+		$token_request_key = 'wc-' . \WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token';
 		if (
-			! isset( $request[ 'wc-' . \WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] ) ||
-			'new' === $request[ 'wc-' . \WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ]
+			! isset( $request[ $token_request_key ] ) ||
+			'new' === $request[ $token_request_key ]
 		) {
 			return null;
 		}
 
 		//phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		$token = \WC_Payment_Tokens::get( wc_clean( $request[ 'wc-' . \WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] ) );
+		$token = \WC_Payment_Tokens::get( wc_clean( $request[ $token_request_key ] ) );
 
 		// If the token doesn't belong to this gateway or the current user it's invalid.
 		if ( ! $token || \WC_Payment_Gateway_WCPay::GATEWAY_ID !== $token->get_gateway_id() || $token->get_user_id() !== get_current_user_id() ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,6 +39,10 @@ function _manually_load_plugin() {
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-api-client.php';
 	require_once dirname( __FILE__ ) . '/../includes/wc-payment-api/class-wc-payments-http.php';
 
+	// Load the gateway files, so subscriptions can be tested.
+	require_once dirname( __FILE__ ) . '/../includes/class-wc-payment-gateway-wcpay.php';
+	require_once dirname( __FILE__ ) . '/../includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php';
+
 	require_once dirname( __FILE__ ) . '/../includes/exceptions/class-wc-payments-rest-request-exception.php';
 	require_once dirname( __FILE__ ) . '/../includes/admin/class-wc-payments-rest-controller.php';
 	require_once dirname( __FILE__ ) . '/../includes/admin/class-wc-rest-payments-webhook-controller.php';

--- a/tests/data-types/test-class-payment-information.php
+++ b/tests/data-types/test-class-payment-information.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Class Payment_Information_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\DataTypes\Payment_Information;
+
+/**
+ * Payment_Information unit tests.
+ */
+class Payment_Information_Test extends WP_UnitTestCase {
+	const PAYMENT_METHOD_REQUEST_KEY = 'wcpay-payment-method';
+	const PAYMENT_METHOD             = 'pm_mock';
+	const TOKEN_REQUEST_KEY          = 'wc-' . \WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token';
+	const TOKEN                      = 'pm_mock_token';
+
+	/**
+	 * WC token to be used in tests.
+	 * @var WC_Payment_Token_CC
+	 */
+	private $token;
+
+	public function setUp() {
+		parent::setUp();
+
+		$token = new WC_Payment_Token_CC();
+		$token->set_token( self::TOKEN );
+		$token->set_gateway_id( \WC_Payment_Gateway_WCPay::GATEWAY_ID );
+		$token->set_user_id( get_current_user_id() );
+		$token->set_card_type( 'visa' );
+		$token->set_last4( '4242' );
+		$token->set_expiry_month( 6 );
+		$token->set_expiry_year( 2026 );
+		$token->save();
+		$this->token = WC_Payment_Tokens::get( $token->get_id() );
+	}
+
+	public function test_requires_payment_method_or_token() {
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Invalid payment method. Please input a new card number.' );
+
+		$payment_information = new Payment_Information( '' );
+	}
+
+	public function test_is_merchant_initiated_returns_off_session() {
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, true );
+		$this->assertEquals( true, $payment_information->is_merchant_initiated() );
+	}
+
+	public function test_get_payment_method_returns_payment_method() {
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null );
+		$this->assertEquals( self::PAYMENT_METHOD, $payment_information->get_payment_method() );
+	}
+
+	public function test_get_payment_method_returns_token_if_present() {
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, $this->token );
+		$this->assertEquals( self::TOKEN, $payment_information->get_payment_method() );
+	}
+
+	public function test_get_payment_token_returns_token() {
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, $this->token );
+		$this->assertEquals( $this->token, $payment_information->get_payment_token() );
+	}
+
+	public function is_using_saved_payment_method_returns_true_if_token() {
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, $this->token );
+		$this->assertEquals( true, $payment_information->is_using_saved_payment_method() );
+	}
+
+	public function test_set_token_updates_token() {
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD );
+		$this->assertEquals( false, $payment_information->is_using_saved_payment_method() );
+
+		$payment_information->set_token( $this->token );
+		$this->assertEquals( $this->token, $payment_information->get_payment_token() );
+		$this->assertEquals( true, $payment_information->is_using_saved_payment_method() );
+	}
+
+	public function test_get_payment_method_from_request() {
+		$payment_method = Payment_Information::get_payment_method_from_request(
+			[ self::PAYMENT_METHOD_REQUEST_KEY => self::PAYMENT_METHOD ]
+		);
+		$this->assertEquals( self::PAYMENT_METHOD, $payment_method );
+	}
+
+	public function test_get_token_from_request_returns_null_when_not_set() {
+		$token = Payment_Information::get_token_from_request( [] );
+		$this->assertEquals( null, $token );
+	}
+
+	public function test_get_token_from_request_returns_null_when_new() {
+		$token = Payment_Information::get_token_from_request(
+			[ self::TOKEN_REQUEST_KEY => 'new' ]
+		);
+		$this->assertEquals( null, $token );
+	}
+
+	public function test_get_token_from_request_returns_null_when_invalid() {
+		$token = Payment_Information::get_token_from_request(
+			[ self::TOKEN_REQUEST_KEY => $this->token->get_id() + 1 ]
+		);
+		$this->assertEquals( null, $token );
+	}
+
+	public function test_get_token_from_request_returns_null_when_wrong_gateway() {
+		$this->token->set_gateway_id( 'wrong_gateway' );
+		$this->token->save();
+		$token = Payment_Information::get_token_from_request(
+			[ self::TOKEN_REQUEST_KEY => $this->token->get_id() ]
+		);
+		$this->assertEquals( null, $token );
+	}
+
+	public function test_get_token_from_request_returns_null_when_wrong_customer() {
+		$this->token->set_user_id( get_current_user_id() + 1 );
+		$this->token->save();
+		$token = Payment_Information::get_token_from_request(
+			[ self::TOKEN_REQUEST_KEY => $this->token->get_id() ]
+		);
+		$this->assertEquals( null, $token );
+	}
+
+	public function test_get_token_from_request_returns_token() {
+		$token = Payment_Information::get_token_from_request(
+			[ self::TOKEN_REQUEST_KEY => $this->token->get_id() ]
+		);
+		$this->assertEquals( $this->token, $token );
+	}
+
+	public function test_from_payment_request_with_token() {
+		$payment_information = Payment_Information::from_payment_request(
+			[
+				self::PAYMENT_METHOD_REQUEST_KEY => self::PAYMENT_METHOD,
+				self::TOKEN_REQUEST_KEY          => $this->token->get_id(),
+			],
+			true
+		);
+		$this->assertEquals( self::TOKEN, $payment_information->get_payment_method() );
+		$this->assertEquals( true, $payment_information->is_using_saved_payment_method() );
+		$this->assertEquals( $this->token, $payment_information->get_payment_token() );
+		$this->assertEquals( true, $payment_information->is_merchant_initiated() );
+	}
+
+	public function test_from_payment_request_without_token() {
+		$payment_information = Payment_Information::from_payment_request(
+			[ self::PAYMENT_METHOD_REQUEST_KEY => self::PAYMENT_METHOD ]
+		);
+		$this->assertEquals( self::PAYMENT_METHOD, $payment_information->get_payment_method() );
+		$this->assertEquals( false, $payment_information->is_using_saved_payment_method() );
+		$this->assertEquals( false, $payment_information->is_merchant_initiated() );
+	}
+}

--- a/tests/data-types/test-class-payment-information.php
+++ b/tests/data-types/test-class-payment-information.php
@@ -37,7 +37,7 @@ class Payment_Information_Test extends WP_UnitTestCase {
 
 	public function test_is_merchant_initiated_returns_off_session() {
 		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, true );
-		$this->assertEquals( true, $payment_information->is_merchant_initiated() );
+		$this->assertTrue( $payment_information->is_merchant_initiated() );
 	}
 
 	public function test_get_payment_method_returns_payment_method() {
@@ -57,16 +57,16 @@ class Payment_Information_Test extends WP_UnitTestCase {
 
 	public function is_using_saved_payment_method_returns_true_if_token() {
 		$payment_information = new Payment_Information( self::PAYMENT_METHOD, $this->token );
-		$this->assertEquals( true, $payment_information->is_using_saved_payment_method() );
+		$this->assertTrue( $payment_information->is_using_saved_payment_method() );
 	}
 
 	public function test_set_token_updates_token() {
 		$payment_information = new Payment_Information( self::PAYMENT_METHOD );
-		$this->assertEquals( false, $payment_information->is_using_saved_payment_method() );
+		$this->assertFalse( $payment_information->is_using_saved_payment_method() );
 
 		$payment_information->set_token( $this->token );
 		$this->assertEquals( $this->token, $payment_information->get_payment_token() );
-		$this->assertEquals( true, $payment_information->is_using_saved_payment_method() );
+		$this->assertTrue( $payment_information->is_using_saved_payment_method() );
 	}
 
 	public function test_get_payment_method_from_request() {
@@ -78,21 +78,21 @@ class Payment_Information_Test extends WP_UnitTestCase {
 
 	public function test_get_token_from_request_returns_null_when_not_set() {
 		$token = Payment_Information::get_token_from_request( [] );
-		$this->assertEquals( null, $token );
+		$this->assertNull( $token );
 	}
 
 	public function test_get_token_from_request_returns_null_when_new() {
 		$token = Payment_Information::get_token_from_request(
 			[ self::TOKEN_REQUEST_KEY => 'new' ]
 		);
-		$this->assertEquals( null, $token );
+		$this->assertNull( $token );
 	}
 
 	public function test_get_token_from_request_returns_null_when_invalid() {
 		$token = Payment_Information::get_token_from_request(
 			[ self::TOKEN_REQUEST_KEY => $this->token->get_id() + 1 ]
 		);
-		$this->assertEquals( null, $token );
+		$this->assertNull( $token );
 	}
 
 	public function test_get_token_from_request_returns_null_when_wrong_gateway() {
@@ -101,7 +101,7 @@ class Payment_Information_Test extends WP_UnitTestCase {
 		$token = Payment_Information::get_token_from_request(
 			[ self::TOKEN_REQUEST_KEY => $this->token->get_id() ]
 		);
-		$this->assertEquals( null, $token );
+		$this->assertNull( $token );
 	}
 
 	public function test_get_token_from_request_returns_null_when_wrong_customer() {
@@ -110,7 +110,7 @@ class Payment_Information_Test extends WP_UnitTestCase {
 		$token = Payment_Information::get_token_from_request(
 			[ self::TOKEN_REQUEST_KEY => $this->token->get_id() ]
 		);
-		$this->assertEquals( null, $token );
+		$this->assertNull( $token );
 	}
 
 	public function test_get_token_from_request_returns_token() {
@@ -129,9 +129,9 @@ class Payment_Information_Test extends WP_UnitTestCase {
 			true
 		);
 		$this->assertEquals( self::TOKEN, $payment_information->get_payment_method() );
-		$this->assertEquals( true, $payment_information->is_using_saved_payment_method() );
+		$this->assertTrue( $payment_information->is_using_saved_payment_method() );
 		$this->assertEquals( $this->token, $payment_information->get_payment_token() );
-		$this->assertEquals( true, $payment_information->is_merchant_initiated() );
+		$this->assertTrue( $payment_information->is_merchant_initiated() );
 	}
 
 	public function test_from_payment_request_without_token() {
@@ -139,7 +139,7 @@ class Payment_Information_Test extends WP_UnitTestCase {
 			[ self::PAYMENT_METHOD_REQUEST_KEY => self::PAYMENT_METHOD ]
 		);
 		$this->assertEquals( self::PAYMENT_METHOD, $payment_information->get_payment_method() );
-		$this->assertEquals( false, $payment_information->is_using_saved_payment_method() );
-		$this->assertEquals( false, $payment_information->is_merchant_initiated() );
+		$this->assertFalse( $payment_information->is_using_saved_payment_method() );
+		$this->assertFalse( $payment_information->is_merchant_initiated() );
 	}
 }

--- a/tests/data-types/test-class-payment-information.php
+++ b/tests/data-types/test-class-payment-information.php
@@ -25,16 +25,7 @@ class Payment_Information_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$token = new WC_Payment_Token_CC();
-		$token->set_token( self::TOKEN );
-		$token->set_gateway_id( \WC_Payment_Gateway_WCPay::GATEWAY_ID );
-		$token->set_user_id( get_current_user_id() );
-		$token->set_card_type( 'visa' );
-		$token->set_last4( '4242' );
-		$token->set_expiry_month( 6 );
-		$token->set_expiry_year( 2026 );
-		$token->save();
-		$this->token = WC_Payment_Tokens::get( $token->get_id() );
+		$this->token = WC_Helper_Token::create_token( self::TOKEN );
 	}
 
 	public function test_requires_payment_method_or_token() {

--- a/tests/helpers/class-wc-helper-order.php
+++ b/tests/helpers/class-wc-helper-order.php
@@ -39,7 +39,9 @@ class WC_Helper_Order {
 	 * @version 3.0 New parameter $product.
 	 *
 	 * @param int        $customer_id The ID of the customer the order is for.
-	 * @param WC_Product $product The product to add to the order.
+	 * @param int        $total       Total cost of the order. Defaults to 50 (4 x $10 simple helper product + $10 shipping)
+	 *                                and can be modified to test $0 orders.
+	 * @param WC_Product $product     The product to add to the order.
 	 *
 	 * @return WC_Order
 	 */
@@ -114,7 +116,7 @@ class WC_Helper_Order {
 		$order->set_discount_tax( 0 );
 		$order->set_cart_tax( 0 );
 		$order->set_shipping_tax( 0 );
-		$order->set_total( $total ); // 4 x $10 simple helper product
+		$order->set_total( $total );
 		$order->save();
 
 		return $order;

--- a/tests/helpers/class-wc-helper-order.php
+++ b/tests/helpers/class-wc-helper-order.php
@@ -43,7 +43,7 @@ class WC_Helper_Order {
 	 *
 	 * @return WC_Order
 	 */
-	public static function create_order( $customer_id = 1, $product = null ) {
+	public static function create_order( $customer_id = 1, $total = 50, $product = null ) {
 
 		if ( ! is_a( $product, 'WC_Product' ) ) {
 			$product = WC_Helper_Product::create_simple_product();
@@ -114,7 +114,7 @@ class WC_Helper_Order {
 		$order->set_discount_tax( 0 );
 		$order->set_cart_tax( 0 );
 		$order->set_shipping_tax( 0 );
-		$order->set_total( 50 ); // 4 x $10 simple helper product
+		$order->set_total( $total ); // 4 x $10 simple helper product
 		$order->save();
 
 		return $order;

--- a/tests/helpers/class-wc-helper-subscriptions.php
+++ b/tests/helpers/class-wc-helper-subscriptions.php
@@ -10,6 +10,10 @@ function wcs_order_contains_subscription( $order ) {
 	return call_user_func( WCS_Mock::$wcs_order_contains_subscription, $order );
 }
 
+function wcs_get_subscriptions_for_order( $order ) {
+	return call_user_func( WCS_Mock::$wcs_get_subscriptions_for_order, $order );
+}
+
 /**
  * Class WCS_Mock.
  *
@@ -23,7 +27,18 @@ class WCS_Mock {
 	 */
 	public static $wcs_order_contains_subscription = null;
 
+	/**
+	 * wcs_get_subscriptions_for_order mock.
+	 *
+	 * @var function
+	 */
+	public static $wcs_get_subscriptions_for_order = null;
+
 	public static function set_wcs_order_contains_subscription( $function ) {
 		self::$wcs_order_contains_subscription = $function;
+	}
+
+	public static function set_wcs_get_subscriptions_for_order( $function ) {
+		self::$wcs_get_subscriptions_for_order = $function;
 	}
 }

--- a/tests/helpers/class-wc-helper-subscriptions.php
+++ b/tests/helpers/class-wc-helper-subscriptions.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Subscription helpers.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+// Set up subscriptions mocks.
+function wcs_order_contains_subscription( $order ) {
+	return call_user_func( WCS_Mock::$wcs_order_contains_subscription, $order );
+}
+
+/**
+ * Class WCS_Mock.
+ *
+ * This helper class should ONLY be used for unit tests!.
+ */
+class WCS_Mock {
+	/**
+	 * wcs_order_contains_subscription mock.
+	 *
+	 * @var function
+	 */
+	public static $wcs_order_contains_subscription = null;
+
+	public static function set_wcs_order_contains_subscription( $function ) {
+		self::$wcs_order_contains_subscription = $function;
+	}
+}

--- a/tests/helpers/class-wc-helper-token.php
+++ b/tests/helpers/class-wc-helper-token.php
@@ -27,7 +27,7 @@ class WC_Helper_Token {
 		$token->set_card_type( 'visa' );
 		$token->set_last4( '4242' );
 		$token->set_expiry_month( 6 );
-		$token->set_expiry_year( 2026 );
+		$token->set_expiry_year( intval( gmdate( 'Y' ) ) + 1 );
 		$token->save();
 
 		return WC_Payment_Tokens::get( $token->get_id() );

--- a/tests/helpers/class-wc-helper-token.php
+++ b/tests/helpers/class-wc-helper-token.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Token helpers.
+ *
+ * @package WooCommerce/Tests
+ */
+
+/**
+ * Class WC_Helper_Token.
+ *
+ * This helper class should ONLY be used for unit tests!.
+ */
+class WC_Helper_Token {
+
+	/**
+	 * Create a token.
+	 *
+	 * @param string $payment_method Token payment method.
+	 * @param int    $user_id        ID of the token's user, defaults to get_current_user_id().
+	 * @param string $gateway        Token's Gateway ID, default to WC_Payment_Gateway_WCPay::GATEWAY_ID
+	 */
+	public static function create_token( $payment_method, $user_id = null, $gateway = WC_Payment_Gateway_WCPay::GATEWAY_ID ) {
+		$token = new WC_Payment_Token_CC();
+		$token->set_token( $payment_method );
+		$token->set_gateway_id( $gateway );
+		$token->set_user_id( $user_id ?? get_current_user_id() );
+		$token->set_card_type( 'visa' );
+		$token->set_last4( '4242' );
+		$token->set_expiry_month( 6 );
+		$token->set_expiry_year( 2026 );
+		$token->save();
+
+		return WC_Payment_Tokens::get( $token->get_id() );
+	}
+}

--- a/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -560,15 +560,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	}
 
 	private function setup_saved_payment_method() {
-		$token = new WC_Payment_Token_CC();
-		$token->set_token( 'pm_mock' );
-		$token->set_gateway_id( WC_Payment_Gateway_WCPay::GATEWAY_ID );
-		$token->set_card_type( 'visa' );
-		$token->set_last4( '4242' );
-		$token->set_expiry_month( 6 );
-		$token->set_expiry_year( 2026 );
-		$token->set_user_id( get_current_user_id() );
-		$token->save();
+		$token = WC_Helper_Token::create_token( 'pm_mock' );
 
 		return [
 			'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' => (string) $token->get_id(),

--- a/tests/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -1,0 +1,376 @@
+<?php
+/**
+ * Class WC_Payment_Gateway_WCPay_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * WC_Payment_Gateway_WCPay unit tests.
+ */
+class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_UnitTestCase {
+	const USER_ID           = 1;
+	const CUSTOMER_ID       = 'cus_mock';
+	const PAYMENT_METHOD_ID = 'pm_mock';
+	const CHARGE_ID         = 'ch_mock';
+	const SETUP_INTENT_ID   = 'si_mock';
+	const PAYMENT_INTENT_ID = 'pi_mock';
+	const TOKEN_REQUEST_KEY = 'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token';
+
+	/**
+	 * System under test.
+	 *
+	 * @var WC_Payment_Gateway_WCPay_Subscriptions_Compat
+	 */
+	private $mock_wcpay_gateway;
+
+	/**
+	 * Mock WC_Payments_Customer_Service.
+	 *
+	 * @var WC_Payments_Customer_Service|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_customer_service;
+
+	/**
+	 * Mock WC_Payments_Token_Service.
+	 *
+	 * @var WC_Payments_Token_Service|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_token_service;
+
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_API_Client|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_api_client;
+
+	/**
+	 * WC_Payments_Account instance.
+	 *
+	 * @var WC_Payments_Account
+	 */
+	private $wcpay_account;
+
+	/**
+	 * Setup intent to be used during tests.
+	 *
+	 * @var array
+	 */
+	private $setup_intent = [
+		'id'     => self::SETUP_INTENT_ID,
+		'status' => 'succeeded',
+	];
+
+	/**
+	 * Payment intent to be used during tests.
+	 *
+	 * @var WC_Payments_API_Intention
+	 */
+	private $payment_intent;
+
+	public function setUp() {
+		parent::setUp();
+
+		wp_set_current_user( self::USER_ID );
+
+		$this->payment_intent = new WC_Payments_API_Intention(
+			self::PAYMENT_INTENT_ID,
+			1500,
+			new DateTime(),
+			'succeeded',
+			self::CHARGE_ID,
+			''
+		);
+
+		$this->mock_api_client = $this->getMockBuilder( 'WC_Payments_API_Client' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->wcpay_account = new WC_Payments_Account( $this->mock_api_client );
+
+		$this->mock_customer_service = $this->getMockBuilder( 'WC_Payments_Customer_Service' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mock_token_service = $this->getMockBuilder( 'WC_Payments_Token_Service' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mock_wcpay_gateway = $this->getMockBuilder( '\WC_Payment_Gateway_WCPay_Subscriptions_Compat' )
+			->setConstructorArgs(
+				[
+					$this->mock_api_client,
+					$this->wcpay_account,
+					$this->mock_customer_service,
+					$this->mock_token_service,
+				]
+			)
+			->setMethods(
+				[
+					'get_return_url',
+					'mark_payment_complete_for_order',
+					'get_level3_data_from_order', // To avoid needing to mock the order items.
+					'add_token_to_order',
+				]
+			)
+			->getMock();
+
+		$this->mock_customer_service
+			->expects( $this->once() )
+			->method( 'get_customer_id_by_user_id' )
+			->with( get_current_user_id() )
+			->willReturn( self::CUSTOMER_ID );
+
+		$this->mock_customer_service
+			->expects( $this->once() )
+			->method( 'update_customer_for_user' )
+			->willReturn( self::CUSTOMER_ID );
+
+		$_POST = [
+			'wcpay-payment-method' => self::PAYMENT_METHOD_ID,
+		];
+	}
+
+	public function test_new_card_subscription() {
+		$order = WC_Helper_Order::create_order( self::USER_ID );
+
+		$token = new WC_Payment_Token_CC();
+		$token->set_token( self::PAYMENT_METHOD_ID );
+
+		$this->mock_wcs_order_contains_subscription( true );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'create_and_confirm_intention' )
+			->with( $this->anything(), $this->anything(), self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, $this->anything(), true, $this->anything(), $this->anything(), false )
+			->willReturn( $this->payment_intent );
+
+		$this->mock_token_service
+			->expects( $this->once() )
+			->method( 'add_payment_method_to_user' )
+			->with( self::PAYMENT_METHOD_ID, $order->get_user() )
+			->willReturn( $token );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'add_token_to_order' )
+			->with(
+				$this->callback( $this->match_order_id( $order->get_id() ) ),
+				$token
+			);
+
+		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
+		$result_order = wc_get_order( $order->get_id() );
+
+		$this->assertEquals( 'processing', $result_order->get_status() );
+		$this->assertEquals( 'success', $result['result'] );
+	}
+
+	public function test_new_card_zero_dollar_subscription() {
+		$order = WC_Helper_Order::create_order( self::USER_ID, 0 );
+
+		$token = new WC_Payment_Token_CC();
+		$token->set_token( self::PAYMENT_METHOD_ID );
+
+		$this->mock_wcs_order_contains_subscription( true );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'create_setup_intent' )
+			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, 'true' )
+			->willReturn( $this->setup_intent );
+
+		$this->mock_token_service
+			->expects( $this->once() )
+			->method( 'add_payment_method_to_user' )
+			->with( self::PAYMENT_METHOD_ID, $order->get_user() )
+			->willReturn( $token );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'add_token_to_order' )
+			->with(
+				$this->callback( $this->match_order_id( $order->get_id() ) ),
+				$token
+			);
+
+		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
+		$result_order = wc_get_order( $order->get_id() );
+
+		$this->assertEquals( 'processing', $result_order->get_status() );
+		$this->assertEquals( 'success', $result['result'] );
+	}
+
+	public function test_new_card_is_added_before_status_update() {
+		$order = WC_Helper_Order::create_order( self::USER_ID, 0 );
+
+		$token = new WC_Payment_Token_CC();
+		$token->set_token( self::PAYMENT_METHOD_ID );
+
+		$this->mock_wcs_order_contains_subscription( true );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'create_setup_intent' )
+			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, 'true' )
+			->willReturn( $this->setup_intent );
+
+		$this->mock_token_service
+			->expects( $this->once() )
+			->method( 'add_payment_method_to_user' )
+			->with( self::PAYMENT_METHOD_ID, $order->get_user() )
+			->willReturn( $token );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'add_token_to_order' )
+			->with(
+				$this->logicalAnd(
+					$this->callback( $this->match_order_id( $order->get_id() ) ),
+					$this->callback( $this->match_order_status( 'pending' ) )
+				),
+				$token
+			);
+
+		$result = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
+	}
+
+	public function test_saved_card_subscription() {
+		$order = WC_Helper_Order::create_order( self::USER_ID );
+
+		$token = $this->create_saved_payment_method( self::PAYMENT_METHOD_ID );
+		$_POST = [ self::TOKEN_REQUEST_KEY => $token->get_id() ];
+
+		$this->mock_wcs_order_contains_subscription( true );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'create_and_confirm_intention' )
+			->with( $this->anything(), $this->anything(), self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, $this->anything(), false, $this->anything(), $this->anything(), false )
+			->willReturn( $this->payment_intent );
+
+		$this->mock_token_service
+			->expects( $this->never() )
+			->method( 'add_payment_method_to_user' );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'add_token_to_order' )
+			->with(
+				$this->callback( $this->match_order_id( $order->get_id() ) ),
+				$token
+			);
+
+		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
+		$result_order = wc_get_order( $order->get_id() );
+
+		$this->assertEquals( 'processing', $result_order->get_status() );
+		$this->assertEquals( 'success', $result['result'] );
+	}
+
+	public function test_saved_card_zero_dollar_subscription() {
+		$order = WC_Helper_Order::create_order( self::USER_ID, 0 );
+
+		$token = $this->create_saved_payment_method( self::PAYMENT_METHOD_ID );
+		$_POST = [ self::TOKEN_REQUEST_KEY => $token->get_id() ];
+
+		$this->mock_wcs_order_contains_subscription( true );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'create_setup_intent' )
+			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, 'true' )
+			->willReturn( $this->setup_intent );
+
+		$this->mock_token_service
+			->expects( $this->never() )
+			->method( 'add_payment_method_to_user' );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'add_token_to_order' )
+			->with(
+				$this->callback( $this->match_order_id( $order->get_id() ) ),
+				$token
+			);
+
+		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
+		$result_order = wc_get_order( $order->get_id() );
+
+		$this->assertEquals( 'processing', $result_order->get_status() );
+		$this->assertEquals( 'success', $result['result'] );
+	}
+
+	public function test_saved_card_is_added_before_status_update() {
+		$order = WC_Helper_Order::create_order( self::USER_ID, 0 );
+
+		$token = $this->create_saved_payment_method( self::PAYMENT_METHOD_ID );
+		$_POST = [ self::TOKEN_REQUEST_KEY => $token->get_id() ];
+
+		$this->mock_wcs_order_contains_subscription( true );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'create_setup_intent' )
+			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, 'true' )
+			->willReturn( $this->setup_intent );
+
+		$this->mock_token_service
+			->expects( $this->never() )
+			->method( 'add_payment_method_to_user' );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'add_token_to_order' )
+			->with(
+				$this->logicalAnd(
+					$this->callback( $this->match_order_id( $order->get_id() ) ),
+					$this->callback( $this->match_order_status( 'pending' ) )
+				),
+				$token
+			);
+
+		$result = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
+	}
+
+	private function create_saved_payment_method( $payment_method, $gateway = WC_Payment_Gateway_WCPay::GATEWAY_ID, $user_id = self::USER_ID ) {
+		$token = new WC_Payment_Token_CC();
+		$token->set_token( $payment_method );
+		$token->set_gateway_id( $gateway );
+		$token->set_user_id( $user_id );
+		$token->set_card_type( 'visa' );
+		$token->set_last4( '4242' );
+		$token->set_expiry_month( 6 );
+		$token->set_expiry_year( 2026 );
+		$token->save();
+
+		return WC_Payment_Tokens::get( $token->get_id() );
+	}
+
+	private function mock_wcs_order_contains_subscription( $value ) {
+		WCS_Mock::set_wcs_order_contains_subscription(
+			function ( $order ) use ( $value ) {
+				return $value;
+			}
+		);
+	}
+
+	private function match_order_id( $order_id ) {
+		return function ( $order ) use ( $order_id ) {
+			return $order_id === $order->get_id();
+		};
+	}
+
+	private function match_order_status( $status ) {
+		return function ( $order ) use ( $status ) {
+			return $status === $order->get_status();
+		};
+	}
+}

--- a/tests/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -69,7 +69,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 			$this->mock_api_client,
 			$this->wcpay_account,
 			$this->mock_customer_service,
-			$this->mock_token_service,
+			$this->mock_token_service
 		);
 	}
 

--- a/tests/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -84,7 +84,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 
 		$this->mock_wcs_get_subscriptions_for_order( $subscriptions );
 
-		$token = $this->create_saved_payment_method( 'new_payment_method' );
+		$token = WC_Helper_Token::create_token( 'new_payment_method', self::USER_ID );
 
 		$this->wcpay_gateway->add_token_to_order( $original_order, $token );
 
@@ -99,8 +99,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order( self::USER_ID );
 		$this->mock_wcs_get_subscriptions_for_order( [] );
 		$tokens = [
-			$this->create_saved_payment_method( 'new_payment_method_1' ),
-			$this->create_saved_payment_method( 'new_payment_method_2' ),
+			WC_Helper_Token::create_token( 'new_payment_method_1', self::USER_ID ),
+			WC_Helper_Token::create_token( 'new_payment_method_2', self::USER_ID ),
 		];
 
 		foreach ( $tokens as $token ) {
@@ -116,8 +116,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order( self::USER_ID );
 		$this->mock_wcs_get_subscriptions_for_order( [] );
 		$tokens = [
-			$this->create_saved_payment_method( 'new_payment_method_1' ),
-			$this->create_saved_payment_method( 'new_payment_method_2' ),
+			WC_Helper_Token::create_token( 'new_payment_method_1', self::USER_ID ),
+			WC_Helper_Token::create_token( 'new_payment_method_2', self::USER_ID ),
 		];
 		$tokens = array_merge( $tokens, $tokens );
 
@@ -128,20 +128,6 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 			$this->assertEquals( $token->get_id(), end( $payment_methods ) );
 		}
 		$this->assertCount( count( $tokens ), $order->get_payment_tokens() );
-	}
-
-	private function create_saved_payment_method( $payment_method, $gateway = WC_Payment_Gateway_WCPay::GATEWAY_ID, $user_id = self::USER_ID ) {
-		$token = new WC_Payment_Token_CC();
-		$token->set_token( $payment_method );
-		$token->set_gateway_id( $gateway );
-		$token->set_user_id( $user_id );
-		$token->set_card_type( 'visa' );
-		$token->set_last4( '4242' );
-		$token->set_expiry_month( 6 );
-		$token->set_expiry_year( 2026 );
-		$token->save();
-
-		return WC_Payment_Tokens::get( $token->get_id() );
 	}
 
 	private function mock_wcs_get_subscriptions_for_order( $subscriptions ) {

--- a/tests/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -1,0 +1,376 @@
+<?php
+/**
+ * Class WC_Payment_Gateway_WCPay_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * WC_Payment_Gateway_WCPay unit tests.
+ */
+class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
+	const USER_ID           = 1;
+	const CUSTOMER_ID       = 'cus_mock';
+	const PAYMENT_METHOD_ID = 'pm_mock';
+	const CHARGE_ID         = 'ch_mock';
+	const SETUP_INTENT_ID   = 'si_mock';
+	const PAYMENT_INTENT_ID = 'pi_mock';
+	const TOKEN_REQUEST_KEY = 'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token';
+
+	/**
+	 * System under test.
+	 *
+	 * @var WC_Payment_Gateway_WCPay_Subscriptions_Compat
+	 */
+	private $mock_wcpay_gateway;
+
+	/**
+	 * Mock WC_Payments_Customer_Service.
+	 *
+	 * @var WC_Payments_Customer_Service|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_customer_service;
+
+	/**
+	 * Mock WC_Payments_Token_Service.
+	 *
+	 * @var WC_Payments_Token_Service|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_token_service;
+
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_API_Client|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_api_client;
+
+	/**
+	 * WC_Payments_Account instance.
+	 *
+	 * @var WC_Payments_Account
+	 */
+	private $wcpay_account;
+
+	/**
+	 * Setup intent to be used during tests.
+	 *
+	 * @var array
+	 */
+	private $setup_intent = [
+		'id'     => self::SETUP_INTENT_ID,
+		'status' => 'succeeded',
+	];
+
+	/**
+	 * Payment intent to be used during tests.
+	 *
+	 * @var WC_Payments_API_Intention
+	 */
+	private $payment_intent;
+
+	public function setUp() {
+		parent::setUp();
+
+		wp_set_current_user( self::USER_ID );
+
+		$this->payment_intent = new WC_Payments_API_Intention(
+			self::PAYMENT_INTENT_ID,
+			1500,
+			new DateTime(),
+			'succeeded',
+			self::CHARGE_ID,
+			''
+		);
+
+		$this->mock_api_client = $this->getMockBuilder( 'WC_Payments_API_Client' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->wcpay_account = new WC_Payments_Account( $this->mock_api_client );
+
+		$this->mock_customer_service = $this->getMockBuilder( 'WC_Payments_Customer_Service' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mock_token_service = $this->getMockBuilder( 'WC_Payments_Token_Service' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mock_wcpay_gateway = $this->getMockBuilder( '\WC_Payment_Gateway_WCPay_Subscriptions_Compat' )
+			->setConstructorArgs(
+				[
+					$this->mock_api_client,
+					$this->wcpay_account,
+					$this->mock_customer_service,
+					$this->mock_token_service,
+				]
+			)
+			->setMethods(
+				[
+					'get_return_url',
+					'mark_payment_complete_for_order',
+					'get_level3_data_from_order', // To avoid needing to mock the order items.
+					'add_token_to_order',
+				]
+			)
+			->getMock();
+
+		$this->mock_customer_service
+			->expects( $this->once() )
+			->method( 'get_customer_id_by_user_id' )
+			->with( get_current_user_id() )
+			->willReturn( self::CUSTOMER_ID );
+
+		$this->mock_customer_service
+			->expects( $this->once() )
+			->method( 'update_customer_for_user' )
+			->willReturn( self::CUSTOMER_ID );
+
+		$_POST = [
+			'wcpay-payment-method' => self::PAYMENT_METHOD_ID,
+		];
+	}
+
+	public function test_new_card_subscription() {
+		$order = WC_Helper_Order::create_order( self::USER_ID );
+
+		$token = new WC_Payment_Token_CC();
+		$token->set_token( self::PAYMENT_METHOD_ID );
+
+		$this->mock_wcs_order_contains_subscription( true );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'create_and_confirm_intention' )
+			->with( $this->anything(), $this->anything(), self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, $this->anything(), true, $this->anything(), $this->anything(), false )
+			->willReturn( $this->payment_intent );
+
+		$this->mock_token_service
+			->expects( $this->once() )
+			->method( 'add_payment_method_to_user' )
+			->with( self::PAYMENT_METHOD_ID, $order->get_user() )
+			->willReturn( $token );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'add_token_to_order' )
+			->with(
+				$this->callback( $this->match_order_id( $order->get_id() ) ),
+				$token
+			);
+
+		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
+		$result_order = wc_get_order( $order->get_id() );
+
+		$this->assertEquals( 'processing', $result_order->get_status() );
+		$this->assertEquals( 'success', $result['result'] );
+	}
+
+	public function test_new_card_zero_dollar_subscription() {
+		$order = WC_Helper_Order::create_order( self::USER_ID, 0 );
+
+		$token = new WC_Payment_Token_CC();
+		$token->set_token( self::PAYMENT_METHOD_ID );
+
+		$this->mock_wcs_order_contains_subscription( true );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'create_setup_intent' )
+			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, 'true' )
+			->willReturn( $this->setup_intent );
+
+		$this->mock_token_service
+			->expects( $this->once() )
+			->method( 'add_payment_method_to_user' )
+			->with( self::PAYMENT_METHOD_ID, $order->get_user() )
+			->willReturn( $token );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'add_token_to_order' )
+			->with(
+				$this->callback( $this->match_order_id( $order->get_id() ) ),
+				$token
+			);
+
+		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
+		$result_order = wc_get_order( $order->get_id() );
+
+		$this->assertEquals( 'processing', $result_order->get_status() );
+		$this->assertEquals( 'success', $result['result'] );
+	}
+
+	public function test_new_card_is_added_before_status_update() {
+		$order = WC_Helper_Order::create_order( self::USER_ID, 0 );
+
+		$token = new WC_Payment_Token_CC();
+		$token->set_token( self::PAYMENT_METHOD_ID );
+
+		$this->mock_wcs_order_contains_subscription( true );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'create_setup_intent' )
+			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, 'true' )
+			->willReturn( $this->setup_intent );
+
+		$this->mock_token_service
+			->expects( $this->once() )
+			->method( 'add_payment_method_to_user' )
+			->with( self::PAYMENT_METHOD_ID, $order->get_user() )
+			->willReturn( $token );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'add_token_to_order' )
+			->with(
+				$this->logicalAnd(
+					$this->callback( $this->match_order_id( $order->get_id() ) ),
+					$this->callback( $this->match_order_status( 'pending' ) )
+				),
+				$token
+			);
+
+		$result = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
+	}
+
+	public function test_saved_card_subscription() {
+		$order = WC_Helper_Order::create_order( self::USER_ID );
+
+		$token = $this->create_saved_payment_method( self::PAYMENT_METHOD_ID );
+		$_POST = [ self::TOKEN_REQUEST_KEY => $token->get_id() ];
+
+		$this->mock_wcs_order_contains_subscription( true );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'create_and_confirm_intention' )
+			->with( $this->anything(), $this->anything(), self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, $this->anything(), false, $this->anything(), $this->anything(), false )
+			->willReturn( $this->payment_intent );
+
+		$this->mock_token_service
+			->expects( $this->never() )
+			->method( 'add_payment_method_to_user' );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'add_token_to_order' )
+			->with(
+				$this->callback( $this->match_order_id( $order->get_id() ) ),
+				$token
+			);
+
+		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
+		$result_order = wc_get_order( $order->get_id() );
+
+		$this->assertEquals( 'processing', $result_order->get_status() );
+		$this->assertEquals( 'success', $result['result'] );
+	}
+
+	public function test_saved_card_zero_dollar_subscription() {
+		$order = WC_Helper_Order::create_order( self::USER_ID, 0 );
+
+		$token = $this->create_saved_payment_method( self::PAYMENT_METHOD_ID );
+		$_POST = [ self::TOKEN_REQUEST_KEY => $token->get_id() ];
+
+		$this->mock_wcs_order_contains_subscription( true );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'create_setup_intent' )
+			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, 'true' )
+			->willReturn( $this->setup_intent );
+
+		$this->mock_token_service
+			->expects( $this->never() )
+			->method( 'add_payment_method_to_user' );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'add_token_to_order' )
+			->with(
+				$this->callback( $this->match_order_id( $order->get_id() ) ),
+				$token
+			);
+
+		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
+		$result_order = wc_get_order( $order->get_id() );
+
+		$this->assertEquals( 'processing', $result_order->get_status() );
+		$this->assertEquals( 'success', $result['result'] );
+	}
+
+	public function test_saved_card_is_added_before_status_update() {
+		$order = WC_Helper_Order::create_order( self::USER_ID, 0 );
+
+		$token = $this->create_saved_payment_method( self::PAYMENT_METHOD_ID );
+		$_POST = [ self::TOKEN_REQUEST_KEY => $token->get_id() ];
+
+		$this->mock_wcs_order_contains_subscription( true );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'create_setup_intent' )
+			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, 'true' )
+			->willReturn( $this->setup_intent );
+
+		$this->mock_token_service
+			->expects( $this->never() )
+			->method( 'add_payment_method_to_user' );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'add_token_to_order' )
+			->with(
+				$this->logicalAnd(
+					$this->callback( $this->match_order_id( $order->get_id() ) ),
+					$this->callback( $this->match_order_status( 'pending' ) )
+				),
+				$token
+			);
+
+		$result = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
+	}
+
+	private function create_saved_payment_method( $payment_method, $gateway = WC_Payment_Gateway_WCPay::GATEWAY_ID, $user_id = self::USER_ID ) {
+		$token = new WC_Payment_Token_CC();
+		$token->set_token( $payment_method );
+		$token->set_gateway_id( $gateway );
+		$token->set_user_id( $user_id );
+		$token->set_card_type( 'visa' );
+		$token->set_last4( '4242' );
+		$token->set_expiry_month( 6 );
+		$token->set_expiry_year( 2026 );
+		$token->save();
+
+		return WC_Payment_Tokens::get( $token->get_id() );
+	}
+
+	private function mock_wcs_order_contains_subscription( $value ) {
+		WCS_Mock::set_wcs_order_contains_subscription(
+			function ( $order ) use ( $value ) {
+				return $value;
+			}
+		);
+	}
+
+	private function match_order_id( $order_id ) {
+		return function ( $order ) use ( $order_id ) {
+			return $order_id === $order->get_id();
+		};
+	}
+
+	private function match_order_status( $status ) {
+		return function ( $order ) use ( $status ) {
+			return $status === $order->get_status();
+		};
+	}
+}

--- a/tests/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -94,7 +94,6 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 
 		foreach ( $orders as $order ) {
 			$payment_methods = $order->get_payment_tokens();
-			$this->assertNotFalse( end( $payment_methods ) );
 			$this->assertEquals( $token->get_id(), end( $payment_methods ) );
 		}
 	}
@@ -110,7 +109,6 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 		foreach ( $tokens as $token ) {
 			$this->wcpay_gateway->add_token_to_order( $order, $token );
 			$payment_methods = $order->get_payment_tokens();
-			$this->assertNotFalse( end( $payment_methods ) );
 			$this->assertEquals( $token->get_id(), end( $payment_methods ) );
 		}
 		$this->assertCount( count( $tokens ), $order->get_payment_tokens() );
@@ -128,7 +126,6 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 		foreach ( $tokens as $token ) {
 			$this->wcpay_gateway->add_token_to_order( $order, $token );
 			$payment_methods = $order->get_payment_tokens();
-			$this->assertNotFalse( end( $payment_methods ) );
 			$this->assertEquals( $token->get_id(), end( $payment_methods ) );
 		}
 		$this->assertCount( count( $tokens ), $order->get_payment_tokens() );

--- a/tests/test-class-wc-payments-token-service.php
+++ b/tests/test-class-wc-payments-token-service.php
@@ -65,13 +65,14 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 	 * Test add token to user.
 	 */
 	public function test_add_token_to_user() {
+		$expiry_year         = intval( gmdate( 'Y' ) ) + 1;
 		$mock_payment_method = [
 			'id'   => 'pm_mock',
 			'card' => [
 				'brand'     => 'visa',
 				'last4'     => '4242',
 				'exp_month' => 6,
-				'exp_year'  => 2026,
+				'exp_year'  => $expiry_year,
 			],
 		];
 
@@ -83,17 +84,18 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'visa', $token->get_card_type() );
 		$this->assertEquals( '4242', $token->get_last4() );
 		$this->assertEquals( '06', $token->get_expiry_month() );
-		$this->assertEquals( '2026', $token->get_expiry_year() );
+		$this->assertEquals( $expiry_year, $token->get_expiry_year() );
 	}
 
 	public function test_add_payment_method_to_user() {
+		$expiry_year         = intval( gmdate( 'Y' ) ) + 1;
 		$mock_payment_method = [
 			'id'   => 'pm_mock',
 			'card' => [
 				'brand'     => 'visa',
 				'last4'     => '4242',
 				'exp_month' => 6,
-				'exp_year'  => 2026,
+				'exp_year'  => $expiry_year,
 			],
 		];
 
@@ -111,7 +113,7 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'visa', $token->get_card_type() );
 		$this->assertEquals( '4242', $token->get_last4() );
 		$this->assertEquals( '06', $token->get_expiry_month() );
-		$this->assertEquals( '2026', $token->get_expiry_year() );
+		$this->assertEquals( $expiry_year, $token->get_expiry_year() );
 	}
 
 	public function test_woocommerce_payment_token_deleted() {


### PR DESCRIPTION
Fixes #839 

#### Changes proposed in this Pull Request

* Add unit tests for changes made in #826 and #832 
* [Update `update_failing_payment_method` to use the gateway's `add_token_to_order` method](https://github.com/Automattic/woocommerce-payments/pull/875/commits/96fac5359fd4281eeae6110308ed09ea61718f04)
* [Add token request key variable to get_token_from_request](https://github.com/Automattic/woocommerce-payments/pull/875/commits/20136e833d79bc860dbaa5df50ec4044948f9991)

I didn't make huge refactorings in this PR to avoid complicating the review, as it's already adding a good amount of code for the tests. However, I made a couple of very small changes, which are documented above.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assert that all client unit tests are passing

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
