### PR TITLE
Initialize JP::Rest_Authentication on plugin load

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 1.4.1 - 2020-xx-xx =
+* Fix - Webhook processing with no Jetpack plugin installed
+
 = 1.4.0 - 2020-xx-xx =
 * Add - Allow merchant to edit statement descriptor
 * Fix - Link from order details page to transaction details page.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -122,9 +122,6 @@ class WC_Payments {
 			include_once WCPAY_ABSPATH . 'includes/admin/tracks/tracks-loader.php';
 		}
 
-		// Init Jetpack connection package REST Auth - needs to happen on plugin load, before rest_api_init.
-		\Automattic\Jetpack\Connection\Rest_Authentication::init();
-
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );
 	}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -122,6 +122,9 @@ class WC_Payments {
 			include_once WCPAY_ABSPATH . 'includes/admin/tracks/tracks-loader.php';
 		}
 
+		// Init Jetpack connection package REST Auth - needs to happen on plugin load, before rest_api_init.
+		\Automattic\Jetpack\Connection\Rest_Authentication::init();
+
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,9 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 
 == Changelog ==
 
+= 1.4.1 - 2020-xx-xx =
+* Fix - Webhook processing with no Jetpack plugin installed
+
 = 1.4.0 - 2020-xx-xx =
 * Add - Allow merchant to edit statement descriptor
 * Fix - Link from order details page to transaction details page.

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -37,9 +37,9 @@ function wcpay_jetpack_init() {
 			'name' => __( 'WooCommerce Payments', 'woocommerce-payments' ),
 		]
 	);
-
-	Automattic\Jetpack\Connection\Rest_Authentication::init();
 }
+// Jetpack's Rest_Authentication needs to be initialized even before plugins_loaded.
+Automattic\Jetpack\Connection\Rest_Authentication::init();
 
 // Jetpack-config will initialize the modules on "plugins_loaded" with priority 2, so this code needs to be run before that.
 add_action( 'plugins_loaded', 'wcpay_jetpack_init', 1 );

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -37,6 +37,8 @@ function wcpay_jetpack_init() {
 			'name' => __( 'WooCommerce Payments', 'woocommerce-payments' ),
 		]
 	);
+
+	Automattic\Jetpack\Connection\Rest_Authentication::init();
 }
 
 // Jetpack-config will initialize the modules on "plugins_loaded" with priority 2, so this code needs to be run before that.


### PR DESCRIPTION
Fixes #876

#### Changes proposed in this Pull Request

* Add a line to init the rest auth

#### Testing instructions

* `rm -rf vendor/`
* `composer install`
* Checkout https://github.com/Automattic/woocommerce-payments-server/pull/336, sync to sandbox, and run the command in the sandbox
* Confirm the response is `{"result": "success"}`

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
