### PR TITLE
Fix settings UI in dev mode

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -142,13 +142,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			],
 		];
 
-		if ( $this->is_in_dev_mode() ) {
-			$this->form_fields['test_mode']['custom_attributes']['disabled']      = 'disabled';
-			$this->form_fields['test_mode']['label']                              = __( 'Dev mode is active so all transactions will be in test mode. This setting is only available to live accounts.', 'woocommerce-payments' );
-			$this->form_fields['enable_logging']['custom_attributes']['disabled'] = 'disabled';
-			$this->form_fields['enable_logging']['label']                         = __( 'Dev mode is active so logging is on by default.', 'woocommerce-payments' );
-		}
-
 		// Load the settings.
 		$this->init_settings();
 
@@ -738,6 +731,19 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if ( 'enabled' === $key && ! $this->is_connected() ) {
 			return '';
 		}
+
+		$in_dev_mode = $this->is_in_dev_mode();
+
+		if ( 'test_mode' === $key && $in_dev_mode ) {
+			$data['custom_attributes']['disabled'] = 'disabled';
+			$data['label']                         = __( 'Dev mode is active so all transactions will be in test mode. This setting is only available to live accounts.', 'woocommerce-payments' );
+		}
+
+		if ( 'enable_logging' === $key && $in_dev_mode ) {
+			$data['custom_attributes']['disabled'] = 'disabled';
+			$data['label']                         = __( 'Dev mode is active so logging is on by default.', 'woocommerce-payments' );
+		}
+
 		return parent::generate_checkbox_html( $key, $data );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable `Test mode` and `Logging` checkboxes on settings page when dev mode is enabled by
wcpay dev tools plugin.


#### Testing instructions

* Install dev tools plugin and activate dev mode.
* Go to settings page and verify checkboxes are disabled.

<img width="979" alt="image" src="https://user-images.githubusercontent.com/3139099/92447004-5b3d1a00-f1bf-11ea-9101-c14ae4ada2f8.png">


-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
