### PR TITLE
Redact sensitive data before logging

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.x.x - 2020-xx-xx =
 * Add - Display payment method details on account subscriptions pages.
+* Add - Redact sensitive data before logging.
 
 = 1.4.1 - 2020-09-07 =
 * Fix - Only redirect to the onboarding screen if the plugin has been individually activated using the plugins page.

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -87,7 +87,10 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 			$event_type = $this->read_rest_property( $body, 'type' );
 
 			Logger::debug( 'Webhook recieved: ' . $event_type );
-			Logger::redact_and_log( 'Webhook body: ', $body );
+			Logger::debug(
+				'Webhook body: '
+				. var_export( WC_Payments_Utils::redact_array( $body, WC_Payments_API_Client::API_KEYS_TO_REDACT ), true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+			);
 
 			switch ( $event_type ) {
 				case 'charge.refund.updated':

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -87,7 +87,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 			$event_type = $this->read_rest_property( $body, 'type' );
 
 			Logger::debug( 'Webhook recieved: ' . $event_type );
-			Logger::debug( 'Webhook body: ' . var_export( $body, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+			Logger::redact_and_log( 'Webhook body: ', $body );
 
 			switch ( $event_type ) {
 				case 'charge.refund.updated':

--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -24,23 +24,6 @@ class Logger {
 
 	const LOG_FILENAME = 'woocommerce-payments';
 
-	const STRIPE_KEYS_TO_REDACT = [
-		'client_secret',
-		'email',
-		'name',
-		'phone',
-		'line1',
-		'line2',
-		'postal_code',
-		'state',
-		'city',
-		'country',
-		'customer_name',
-		'customer_email',
-	];
-
-	const LOG_MAX_RECURSION = 10;
-
 	/**
 	 * Add a log entry.
 	 *
@@ -169,63 +152,5 @@ class Logger {
 	 */
 	public static function debug( $message ) {
 		self::log( $message, 'debug' );
-	}
-
-	/**
-	 * Redacts the provided assoc array and logs it using the ::log() method.
-	 *
-	 * @param string $prefix Log message prefix.
-	 * @param array  $array  The array to log.
-	 */
-	public static function redact_and_log( $prefix, $array ) {
-		// Check if logging is enabled to avoid unneccessary redact calls.
-		if ( ! self::can_log() ) {
-			return;
-		}
-
-		$redacted = self::redact_array( $array );
-
-		self::log( $prefix . var_export( $redacted, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
-	}
-
-	/**
-	 * Redacts the provided array, removing the sensitive information, and limits its depth to LOG_MAX_RECURSION.
-	 *
-	 * @param array   $array The array to redact.
-	 * @param integer $level The current recursion level.
-	 *
-	 * @return array The redacted array.
-	 */
-	private static function redact_array( $array, $level = 0 ) {
-		if ( $level >= self::LOG_MAX_RECURSION ) {
-			return '(recursion limit reached)';
-		}
-
-		if ( is_object( $array ) ) {
-			// TODO: if we ever want to log objects, they could implement a method returning an array or string.
-			return get_class( $array );
-		}
-
-		if ( ! is_array( $array ) ) {
-			return $array;
-		}
-
-		$result = [];
-
-		foreach ( $array as $key => $value ) {
-			if ( in_array( $key, self::STRIPE_KEYS_TO_REDACT, true ) ) {
-				$result[ $key ] = '(redacted)';
-				continue;
-			}
-
-			if ( is_array( $value ) ) {
-				$result[ $key ] = self::redact_array( $value, $level + 1 );
-				continue;
-			}
-
-			$result[ $key ] = $value;
-		}
-
-		return $result;
 	}
 }

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -848,7 +848,7 @@ class WC_Payments_API_Client {
 
 		Logger::log( "REQUEST $method $url" );
 		if ( 'POST' === $method || 'PUT' === $method ) {
-			Logger::log( 'BODY: ' . var_export( $body, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+			Logger::redact_and_log( 'BODY: ', $params );
 		}
 
 		$response = $this->http_client->remote_request(
@@ -862,7 +862,7 @@ class WC_Payments_API_Client {
 		);
 
 		$response_body = $this->extract_response_body( $response );
-		Logger::log( 'RESPONSE ' . var_export( $response_body, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		Logger::redact_and_log( 'RESPONSE ', $response_body );
 
 		return $response_body;
 	}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -36,6 +36,24 @@ class WC_Payments_API_Client {
 	const SETUP_INTENTS_API   = 'setup_intents';
 
 	/**
+	 * Common keys in API requests/responses that we might want to redact.
+	 */
+	const API_KEYS_TO_REDACT = [
+		'client_secret',
+		'email',
+		'name',
+		'phone',
+		'line1',
+		'line2',
+		'postal_code',
+		'state',
+		'city',
+		'country',
+		'customer_name',
+		'customer_email',
+	];
+
+	/**
 	 * User agent string to report in requests.
 	 *
 	 * @var string
@@ -848,7 +866,10 @@ class WC_Payments_API_Client {
 
 		Logger::log( "REQUEST $method $url" );
 		if ( 'POST' === $method || 'PUT' === $method ) {
-			Logger::redact_and_log( 'BODY: ', $params );
+			Logger::log(
+				'BODY: '
+				. var_export( WC_Payments_Utils::redact_array( $params, self::API_KEYS_TO_REDACT ), true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+			);
 		}
 
 		$response = $this->http_client->remote_request(
@@ -862,7 +883,10 @@ class WC_Payments_API_Client {
 		);
 
 		$response_body = $this->extract_response_body( $response );
-		Logger::redact_and_log( 'RESPONSE ', $response_body );
+		Logger::log(
+			'RESPONSE: '
+			. var_export( WC_Payments_Utils::redact_array( $response_body, self::API_KEYS_TO_REDACT ), true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		);
 
 		return $response_body;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,7 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 
 = 1.x.x - 2020-xx-xx =
 * Add - Display payment method details on account subscriptions pages.
+* Add - Redact sensitive data before logging.
 
 = 1.4.1 - 2020-09-07 =
 * Fix - Only redirect to the onboarding screen if the plugin has been individually activated using the plugins page.


### PR DESCRIPTION
Fixes #878

#### Changes proposed in this Pull Request

* When logging an array redact sensitive keys
* Added some guards against recursion, such as not logging objects or recursive arrays (`var_export` doesn't handle it well)

#### Testing instructions

* Make a payment
* Check your logs (dev tools has a handy link to the most recent log)
* The sensitive data should be redacted

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
