### PR TITLE
Always load Tracker class at plugin init

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -97,6 +97,9 @@ class WC_Payments {
 		include_once dirname( __FILE__ ) . '/exceptions/class-wc-payments-intent-authentication-exception.php';
 		include_once dirname( __FILE__ ) . '/data-types/class-payment-information.php';
 
+		// Always load tracker to avoid class not found errors.
+		include_once WCPAY_ABSPATH . 'includes/admin/tracks/class-tracker.php';
+
 		self::$account          = new WC_Payments_Account( self::$api_client );
 		self::$customer_service = new WC_Payments_Customer_Service( self::$api_client );
 		self::$token_service    = new WC_Payments_Token_Service( self::$api_client, self::$customer_service );
@@ -118,7 +121,7 @@ class WC_Payments {
 			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin.php';
 			new WC_Payments_Admin( self::$gateway, self::$account );
 
-			include_once WCPAY_ABSPATH . 'includes/admin/tracks/class-tracker.php';
+			// Use tracks loader only in admin screens because it relies on WC_Tracks loaded by WC_Admin.
 			include_once WCPAY_ABSPATH . 'includes/admin/tracks/tracks-loader.php';
 		}
 


### PR DESCRIPTION
Fixes #835 

#### Changes proposed in this Pull Request

* Always load class to avoid Tracker class not exist exceptions when handling REST api requests.

We don't need to use [tracks loader](https://github.com/Automattic/woocommerce-payments/blob/fix%2F835-tracker/includes/admin/tracks/tracks-loader.php#L17) for REST endpoints because `WC_Tracks` is loaded only for admin pages by WC Admin.

#### Testing instructions

Should work both with and without usage tracking option.

* If you have some tools setup and configured to send API request use it. Otherwise see setup instructions below.
* Find some order to be refunded or create one and remember its orderId.
* Send request to `wc/v2/orders/{ID}/refunds` or use script provided below with `node temp.js`.
* Check the request is successful and there is no `CRITICAL Uncaught Error: Class 'WCPay\Tracker' not found` in the logs.

_Sending API requests with `@woocommerce/woocommerce-rest-api` package._

* Install package into existing project or create a new one with `npm install -D @woocommerce/woocommerce-rest-api`
* Create API keys with read/write permissions on WP-Admin > WooCommerce > Settings > Advanced > REST API.
* Create file, e.g. temp.js like this:
```js
const WooCommerceRestApi = require( '@woocommerce/woocommerce-rest-api' )
	.default;

const consumerKey = 'ck_your_consumer_key';
const consumerSecret = 'cs_your_secret_key';
const orderId = '71';

const api = new WooCommerceRestApi( {
	url: 'http://localhost:8082',
	consumerKey,
	consumerSecret,
	version: 'wc/v2',
} );

api
	.post( `orders/${orderId}/refunds`, { amount: '1' } )
	.then( ( response ) => {
		console.log( '*** SUCCESS ***' );
		console.log( JSON.stringify( response.data, null, 2 ) );
	} )
	.catch( ( error ) => {
		console.log( '*** ERROR ***' );
		console.log( JSON.stringify( error.response.data, null, 2 ) );
	} );

```

* Replace keys, order id and site url with values according to your setup.
* Run file with `node temp.js` from command line to send request.

**Notes**:

* No change log is required IMO.
* No test coverage is required as well.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
