### PR TITLE
Add SSH client to our docker file

### DIFF
--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -7,6 +7,7 @@ RUN pecl install xdebug \
 	&& docker-php-ext-enable xdebug
 RUN apt-get update \
 	&& apt-get install --assume-yes --quiet --no-install-recommends gnupg2 subversion mariadb-client less
+RUN apt-get install -y openssh-client
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
 	&& chmod +x wp-cli.phar \
 	&& mv wp-cli.phar /usr/local/bin/wp


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add SSH client which allows us to enable Jurassic tube.  Jurassic tube works by allowing direct access to docker via SSH to avoid many network and security issues. Adding this client paves the way for more testing.

#### Testing instructions
- Check out this branch
- Run `docker-compose build `
- After the build is finished run  `docker-compose exec wordpress bash `
- In the prompt, check that `ssh` is installed `which ssh` and `ssh -T git@github.com`.


- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
