### PR TITLE
Add constants for payment information constructor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require": {
       "automattic/jetpack-connection": "1.17.2",
       "automattic/jetpack-config": "1.4.1",
-      "automattic/jetpack-autoloader": "2.3.0"
+      "automattic/jetpack-autoloader": "2.3.0",
+        "myclabs/php-enum": "^1.6"
     },
     "require-dev": {
       "composer/installers": "1.9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9bcb6f7eec5ce9d82538d9e2468e5af6",
+    "content-hash": "8a8edd409bd13da29c8f45633e78d4fd",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -376,6 +376,51 @@
             ],
             "description": "Tracking for Jetpack",
             "time": "2020-09-09T10:04:48+00:00"
+        },
+        {
+            "name": "myclabs/php-enum",
+            "version": "1.6.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/php-enum.git",
+                "reference": "32c4202886c51fbe5cc3a7c34ec5c9a4a790345e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/32c4202886c51fbe5cc3a7c34ec5c9a4a790345e",
+                "reference": "32c4202886c51fbe5cc3a7c34ec5c9a4a790345e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35|^5.7|^6.0",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MyCLabs\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP Enum contributors",
+                    "homepage": "https://github.com/myclabs/php-enum/graphs/contributors"
+                }
+            ],
+            "description": "PHP Enum implementation",
+            "homepage": "http://github.com/myclabs/php-enum",
+            "keywords": [
+                "enum"
+            ],
+            "time": "2019-02-04T21:18:49+00:00"
         }
     ],
     "packages-dev": [

--- a/includes/class-payment-information.php
+++ b/includes/class-payment-information.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use WCPay\Constants\Payment_Initiated_By;
+use WCPay\Constants\Payment_Capture_Type;
 
 /**
  * Mostly a wrapper containing information on a single payment.
@@ -48,7 +49,7 @@ class Payment_Information {
 	/**
 	 * Indicates whether the payment will be only authorized (true) or captured immediately (false).
 	 *
-	 * @var bool
+	 * @var Capture_Type
 	 */
 	private $manual_capture;
 
@@ -59,7 +60,7 @@ class Payment_Information {
 	 * @param \WC_Order            $order The order object.
 	 * @param \WC_Payment_Token    $token The payment token used for this payment.
 	 * @param Payment_Initiated_By $payment_initiated_by Indicates whether the payment is merchant-initiated or customer-initiated.
-	 * @param bool                 $manual_capture Indicates whether the payment will be only authorized (true) or captured immediately (false).
+	 * @param Payment_Capture_Type $manual_capture Indicates whether the payment will be only authorized or captured immediately.
 	 *
 	 * @throws \Exception - If no payment method is found in the provided request.
 	 */
@@ -68,7 +69,7 @@ class Payment_Information {
 		\WC_Order $order = null,
 		\WC_Payment_Token $token = null,
 		Payment_Initiated_By $payment_initiated_by = null,
-		bool $manual_capture = false
+		Payment_Capture_Type $manual_capture = null
 	) {
 		if ( empty( $payment_method ) && empty( $token ) ) {
 			throw new \Exception( __( 'Invalid payment method. Please input a new card number.', 'woocommerce-payments' ) );
@@ -78,7 +79,7 @@ class Payment_Information {
 		$this->order                = $order;
 		$this->token                = $token;
 		$this->payment_initiated_by = $payment_initiated_by ?? Payment_Initiated_By::CUSTOMER();
-		$this->manual_capture       = $manual_capture;
+		$this->manual_capture       = $manual_capture ?? Payment_Capture_Type::AUTOMATIC();
 	}
 
 	/**
@@ -150,7 +151,7 @@ class Payment_Information {
 	 * @return bool True if the payment should be only authorized, false if it should be captured immediately.
 	 */
 	public function is_using_manual_capture(): bool {
-		return $this->manual_capture;
+		return $this->manual_capture->equals( Payment_Capture_Type::MANUAL() );
 	}
 
 	/**
@@ -158,8 +159,8 @@ class Payment_Information {
 	 *
 	 * @param array                $request Associative array containing payment request information.
 	 * @param \WC_Order            $order The order object.
-	 * @param Payment_Initiated_By $payment_initiated_by Indicates whether the payment is merchant-initiated (true) or customer-initiated (false).
-	 * @param bool                 $manual_capture Indicates whether the payment will be only authorized (true) or captured immediately (false).
+	 * @param Payment_Initiated_By $payment_initiated_by Indicates whether the payment is merchant-initiated or customer-initiated.
+	 * @param Payment_Capture_Type $manual_capture Indicates whether the payment will be only authorized or captured immediately.
 	 *
 	 * @throws \Exception - If no payment method is found in the provided request.
 	 */
@@ -167,12 +168,12 @@ class Payment_Information {
 		array $request,
 		\WC_Order $order = null,
 		Payment_Initiated_By $payment_initiated_by = null,
-		bool $manual_capture = false
+		Payment_Capture_Type $manual_capture = null
 	): Payment_Information {
 		$payment_method = self::get_payment_method_from_request( $request );
 		$token          = self::get_token_from_request( $request );
 
-		return new Payment_Information( $payment_method, $order, $token, $payment_initiated_by ?? Payment_Initiated_By::CUSTOMER(), $manual_capture );
+		return new Payment_Information( $payment_method, $order, $token, $payment_initiated_by ?? Payment_Initiated_By::CUSTOMER(), $manual_capture ?? Payment_Capture_Type::AUTOMATIC() );
 	}
 
 	/**

--- a/includes/class-payment-information.php
+++ b/includes/class-payment-information.php
@@ -41,7 +41,7 @@ class Payment_Information {
 	/**
 	 * Indicates whether the payment is merchant-initiated (true) or customer-initiated (false).
 	 *
-	 * @var string
+	 * @var Payment_Initiated_By
 	 */
 	private $payment_initiated_by;
 
@@ -55,11 +55,11 @@ class Payment_Information {
 	/**
 	 * Payment information constructor.
 	 *
-	 * @param string            $payment_method The ID of the payment method used for this payment.
-	 * @param \WC_Order         $order The order object.
-	 * @param \WC_Payment_Token $token The payment token used for this payment.
-	 * @param string            $payment_initiated_by Indicates whether the payment is merchant-initiated or customer-initiated.
-	 * @param bool              $manual_capture Indicates whether the payment will be only authorized (true) or captured immediately (false).
+	 * @param string               $payment_method The ID of the payment method used for this payment.
+	 * @param \WC_Order            $order The order object.
+	 * @param \WC_Payment_Token    $token The payment token used for this payment.
+	 * @param Payment_Initiated_By $payment_initiated_by Indicates whether the payment is merchant-initiated or customer-initiated.
+	 * @param bool                 $manual_capture Indicates whether the payment will be only authorized (true) or captured immediately (false).
 	 *
 	 * @throws \Exception - If no payment method is found in the provided request.
 	 */
@@ -67,7 +67,7 @@ class Payment_Information {
 		string $payment_method,
 		\WC_Order $order = null,
 		\WC_Payment_Token $token = null,
-		string $payment_initiated_by = Payment_Initiated_By::CUSTOMER
+		Payment_Initiated_By $payment_initiated_by = null,
 		bool $manual_capture = false
 	) {
 		if ( empty( $payment_method ) && empty( $token ) ) {
@@ -77,7 +77,7 @@ class Payment_Information {
 		$this->payment_method       = $payment_method;
 		$this->order                = $order;
 		$this->token                = $token;
-		$this->payment_initiated_by = $payment_initiated_by;
+		$this->payment_initiated_by = $payment_initiated_by ?? Payment_Initiated_By::CUSTOMER();
 		$this->manual_capture       = $manual_capture;
 	}
 
@@ -87,7 +87,7 @@ class Payment_Information {
 	 * @return bool True if payment was initiated by the merchant, false otherwise.
 	 */
 	public function is_merchant_initiated(): bool {
-		return Payment_Initiated_By::MERCHANT === $this->payment_initiated_by;
+		return $this->payment_initiated_by->equals( Payment_Initiated_By::MERCHANT() );
 	}
 
 	/**
@@ -156,23 +156,23 @@ class Payment_Information {
 	/**
 	 * Payment information constructor.
 	 *
-	 * @param array     $request Associative array containing payment request information.
-	 * @param \WC_Order $order The order object.
-	 * @param string    $payment_initiated_by Indicates whether the payment is merchant-initiated (true) or customer-initiated (false).
-	 * @param bool      $manual_capture Indicates whether the payment will be only authorized (true) or captured immediately (false).
+	 * @param array                $request Associative array containing payment request information.
+	 * @param \WC_Order            $order The order object.
+	 * @param Payment_Initiated_By $payment_initiated_by Indicates whether the payment is merchant-initiated (true) or customer-initiated (false).
+	 * @param bool                 $manual_capture Indicates whether the payment will be only authorized (true) or captured immediately (false).
 	 *
 	 * @throws \Exception - If no payment method is found in the provided request.
 	 */
 	public static function from_payment_request(
 		array $request,
 		\WC_Order $order = null,
-		string $payment_initiated_by = Payment_Initiated_By::CUSTOMER
+		Payment_Initiated_By $payment_initiated_by = null,
 		bool $manual_capture = false
 	): Payment_Information {
 		$payment_method = self::get_payment_method_from_request( $request );
 		$token          = self::get_token_from_request( $request );
 
-		return new Payment_Information( $payment_method, $order, $token, $payment_initiated_by, $manual_capture );
+		return new Payment_Information( $payment_method, $order, $token, $payment_initiated_by ?? Payment_Initiated_By::CUSTOMER(), $manual_capture );
 	}
 
 	/**

--- a/includes/class-payment-information.php
+++ b/includes/class-payment-information.php
@@ -173,7 +173,7 @@ class Payment_Information {
 		$payment_method = self::get_payment_method_from_request( $request );
 		$token          = self::get_token_from_request( $request );
 
-		return new Payment_Information( $payment_method, $order, $token, $payment_initiated_by ?? Payment_Initiated_By::CUSTOMER(), $manual_capture ?? Payment_Capture_Type::AUTOMATIC() );
+		return new Payment_Information( $payment_method, $order, $token, $payment_initiated_by, $manual_capture );
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 use WCPay\Logger;
 use WCPay\Payment_Information;
 use WCPay\Constants\Payment_Initiated_By;
+use WCPay\Constants\Payment_Capture_Type;
 use WCPay\Exceptions\WC_Payments_Intent_Authentication_Exception;
 use WCPay\Tracker;
 
@@ -406,7 +407,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$order = wc_get_order( $order_id );
 
 		try {
-			$manual_capture = 'yes' === $this->get_option( 'manual_capture' );
+			$manual_capture = 'yes' === $this->get_option( 'manual_capture' ) ? Payment_Capture_Type::MANUAL() : Payment_Capture_Type::AUTOMATIC();
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing
 			$payment_information = Payment_Information::from_payment_request( $_POST, $order, Payment_Initiated_By::CUSTOMER(), $manual_capture );
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use WCPay\Logger;
 use WCPay\Payment_Information;
+use WCPay\Constants\Payment_Initiated_By;
 use WCPay\Exceptions\WC_Payments_Intent_Authentication_Exception;
 use WCPay\Tracker;
 
@@ -407,7 +408,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		try {
 			$manual_capture = 'yes' === $this->get_option( 'manual_capture' );
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing
-			$payment_information = Payment_Information::from_payment_request( $_POST, $order, false, $manual_capture );
+			$payment_information = Payment_Information::from_payment_request( $_POST, $order, Payment_Initiated_By::CUSTOMER(), $manual_capture );
 
 			return $this->process_payment_for_order( WC()->cart, $payment_information, $force_save_payment_method );
 		} catch ( Exception $e ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -407,9 +407,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$order = wc_get_order( $order_id );
 
 		try {
-			$manual_capture = 'yes' === $this->get_option( 'manual_capture' ) ? Payment_Capture_Type::MANUAL() : Payment_Capture_Type::AUTOMATIC();
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing
-			$payment_information = Payment_Information::from_payment_request( $_POST, $order, Payment_Initiated_By::CUSTOMER(), $manual_capture );
+			$payment_information = Payment_Information::from_payment_request( $_POST, $order, Payment_Initiated_By::CUSTOMER(), $this->get_capture_type() );
 
 			return $this->process_payment_for_order( WC()->cart, $payment_information, $force_save_payment_method );
 		} catch ( Exception $e ) {
@@ -824,6 +823,15 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			default:
 				return parent::get_option( $key, $empty_value );
 		}
+	}
+
+	/**
+	 * Get payment capture type from WCPay settings.
+	 *
+	 * @return Payment_Capture_Type MANUAL or AUTOMATIC depending on the settings.
+	 */
+	private function get_capture_type() {
+		return 'yes' === $this->get_option( 'manual_capture' ) ? Payment_Capture_Type::MANUAL() : Payment_Capture_Type::AUTOMATIC();
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -95,8 +95,8 @@ class WC_Payments {
 		include_once dirname( __FILE__ ) . '/class-wc-payment-gateway-wcpay.php';
 		include_once dirname( __FILE__ ) . '/class-wc-payments-token-service.php';
 		include_once dirname( __FILE__ ) . '/exceptions/class-wc-payments-intent-authentication-exception.php';
-		include_once dirname( __FILE__ ) . '/class-payment-information.php';
 		include_once dirname( __FILE__ ) . '/constants/class-payment-initiated-by.php';
+		include_once dirname( __FILE__ ) . '/class-payment-information.php';
 
 		// Always load tracker to avoid class not found errors.
 		include_once WCPAY_ABSPATH . 'includes/admin/tracks/class-tracker.php';

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -96,6 +96,7 @@ class WC_Payments {
 		include_once dirname( __FILE__ ) . '/class-wc-payments-token-service.php';
 		include_once dirname( __FILE__ ) . '/exceptions/class-wc-payments-intent-authentication-exception.php';
 		include_once dirname( __FILE__ ) . '/constants/class-payment-initiated-by.php';
+		include_once dirname( __FILE__ ) . '/constants/class-payment-capture-type.php';
 		include_once dirname( __FILE__ ) . '/class-payment-information.php';
 
 		// Always load tracker to avoid class not found errors.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -96,6 +96,7 @@ class WC_Payments {
 		include_once dirname( __FILE__ ) . '/class-wc-payments-token-service.php';
 		include_once dirname( __FILE__ ) . '/exceptions/class-wc-payments-intent-authentication-exception.php';
 		include_once dirname( __FILE__ ) . '/class-payment-information.php';
+		include_once dirname( __FILE__ ) . '/constants/class-payment-initiated-by.php';
 
 		// Always load tracker to avoid class not found errors.
 		include_once WCPAY_ABSPATH . 'includes/admin/tracks/class-tracker.php';

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use WCPay\Logger;
 use WCPay\Payment_Information;
+use WCPay\Constants\Payment_Initiated_By;
 
 /**
  * Gateway class for WooCommerce Payments, with added compatibility with WooCommerce Subscriptions.
@@ -119,7 +120,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 			return;
 		}
 
-		$payment_information = new Payment_Information( '', $renewal_order, $token, true );
+		$payment_information = new Payment_Information( '', $renewal_order, $token, Payment_Initiated_By::MERCHANT );
 
 		try {
 			// TODO: make `force_saved_card` and adding the 'recurring' metadata 2 distinct features.

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -120,7 +120,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 			return;
 		}
 
-		$payment_information = new Payment_Information( '', $renewal_order, $token, Payment_Initiated_By::MERCHANT );
+		$payment_information = new Payment_Information( '', $renewal_order, $token, Payment_Initiated_By::MERCHANT() );
 
 		try {
 			// TODO: make `force_saved_card` and adding the 'recurring' metadata 2 distinct features.

--- a/includes/constants/class-payment-capture-type.php
+++ b/includes/constants/class-payment-capture-type.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Class Capture_Type
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Constants;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Enum used in WCPay\Payment_Information to determine whether a payment was
+ * initated by a merchant or a customer.
+ */
+class Payment_Capture_Type extends Enum {
+	const AUTOMATIC = 'automatic_capture';
+	const MANUAL    = 'manual_capture';
+};

--- a/includes/constants/class-payment-initiated-by.php
+++ b/includes/constants/class-payment-initiated-by.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Class Payment_Information
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Constants;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Constants used in WCPay\Payment_Information to determine whether a payment was
+ * initated by a merchant or a customer.
+ */
+class Payment_Initiated_By {
+	const MERCHANT = 'initiated_by_merchant';
+	const CUSTOMER = 'initiated_by_customer';
+};

--- a/includes/constants/class-payment-initiated-by.php
+++ b/includes/constants/class-payment-initiated-by.php
@@ -11,11 +11,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+use MyCLabs\Enum\Enum;
+
 /**
- * Constants used in WCPay\Payment_Information to determine whether a payment was
+ * Enum used in WCPay\Payment_Information to determine whether a payment was
  * initated by a merchant or a customer.
  */
-class Payment_Initiated_By {
+class Payment_Initiated_By extends Enum {
 	const MERCHANT = 'initiated_by_merchant';
 	const CUSTOMER = 'initiated_by_customer';
 };

--- a/tests/test-class-payment-information.php
+++ b/tests/test-class-payment-information.php
@@ -7,6 +7,7 @@
 
 use WCPay\Payment_Information;
 use WCPay\Constants\Payment_Initiated_By;
+use WCPay\Constants\Payment_Capture_Type;
 
 /**
  * Payment_Information unit tests.
@@ -49,6 +50,21 @@ class Payment_Information_Test extends WP_UnitTestCase {
 	public function test_is_merchant_initiated_returns_false_when_payment_initiated_by_customer() {
 		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, null, Payment_Initiated_By::CUSTOMER() );
 		$this->assertFalse( $payment_information->is_merchant_initiated() );
+	}
+
+	public function test_is_using_manual_capture_defaults_to_false() {
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, null );
+		$this->assertFalse( $payment_information->is_using_manual_capture() );
+	}
+
+	public function test_is_using_manual_capture_returns_true_when_set_to_manual_capture() {
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, null, null, Payment_Capture_Type::MANUAL() );
+		$this->assertTrue( $payment_information->is_using_manual_capture() );
+	}
+
+	public function test_is_using_manual_capture_returns_false_when_set_to_automatic_capture() {
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, null, null, Payment_Capture_Type::AUTOMATIC() );
+		$this->assertFalse( $payment_information->is_using_manual_capture() );
 	}
 
 	public function test_get_payment_method_returns_payment_method() {

--- a/tests/test-class-payment-information.php
+++ b/tests/test-class-payment-information.php
@@ -6,6 +6,7 @@
  */
 
 use WCPay\Payment_Information;
+use WCPay\Constants\Payment_Initiated_By;
 
 /**
  * Payment_Information unit tests.
@@ -35,9 +36,19 @@ class Payment_Information_Test extends WP_UnitTestCase {
 		$payment_information = new Payment_Information( '' );
 	}
 
-	public function test_is_merchant_initiated_returns_off_session() {
-		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, null, true );
+	public function test_is_merchant_initiated_defaults_to_false() {
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, null );
+		$this->assertFalse( $payment_information->is_merchant_initiated() );
+	}
+
+	public function test_is_merchant_initiated_returns_true_when_payment_initiated_by_merchant() {
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, null, Payment_Initiated_By::MERCHANT );
 		$this->assertTrue( $payment_information->is_merchant_initiated() );
+	}
+
+	public function test_is_merchant_initiated_returns_false_when_payment_initiated_by_customer() {
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, null, Payment_Initiated_By::CUSTOMER );
+		$this->assertFalse( $payment_information->is_merchant_initiated() );
 	}
 
 	public function test_get_payment_method_returns_payment_method() {
@@ -127,7 +138,7 @@ class Payment_Information_Test extends WP_UnitTestCase {
 				self::TOKEN_REQUEST_KEY          => $this->token->get_id(),
 			],
 			null,
-			true
+			Payment_Initiated_By::MERCHANT
 		);
 		$this->assertEquals( self::TOKEN, $payment_information->get_payment_method() );
 		$this->assertTrue( $payment_information->is_using_saved_payment_method() );

--- a/tests/test-class-payment-information.php
+++ b/tests/test-class-payment-information.php
@@ -42,12 +42,12 @@ class Payment_Information_Test extends WP_UnitTestCase {
 	}
 
 	public function test_is_merchant_initiated_returns_true_when_payment_initiated_by_merchant() {
-		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, null, Payment_Initiated_By::MERCHANT );
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, null, Payment_Initiated_By::MERCHANT() );
 		$this->assertTrue( $payment_information->is_merchant_initiated() );
 	}
 
 	public function test_is_merchant_initiated_returns_false_when_payment_initiated_by_customer() {
-		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, null, Payment_Initiated_By::CUSTOMER );
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, null, Payment_Initiated_By::CUSTOMER() );
 		$this->assertFalse( $payment_information->is_merchant_initiated() );
 	}
 
@@ -138,7 +138,7 @@ class Payment_Information_Test extends WP_UnitTestCase {
 				self::TOKEN_REQUEST_KEY          => $this->token->get_id(),
 			],
 			null,
-			Payment_Initiated_By::MERCHANT
+			Payment_Initiated_By::MERCHANT()
 		);
 		$this->assertEquals( self::TOKEN, $payment_information->get_payment_method() );
 		$this->assertTrue( $payment_information->is_using_saved_payment_method() );

--- a/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -309,7 +309,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->method( 'empty_cart' );
 
 		// Act: process payment.
-		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST, $mock_order, false, true ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST, $mock_order, WCPay\Constants\Payment_Initiated_By::CUSTOMER(), true ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$result              = $this->mock_wcpay_gateway->process_payment_for_order( $mock_cart, $payment_information );
 
 		// Assert: Returning correct array.

--- a/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -309,7 +309,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->method( 'empty_cart' );
 
 		// Act: process payment.
-		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST, $mock_order, WCPay\Constants\Payment_Initiated_By::CUSTOMER(), true ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST, $mock_order, WCPay\Constants\Payment_Initiated_By::CUSTOMER(), WCPay\Constants\Payment_Capture_Type::MANUAL() ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$result              = $this->mock_wcpay_gateway->process_payment_for_order( $mock_cart, $payment_information );
 
 		// Assert: Returning correct array.


### PR DESCRIPTION
Fixes #860

- [x] #883 should be merged before this PR is merged, which is why I'm tagging this with the `Blocked` label.

#### Changes proposed in this Pull Request

* Removes boolean paremeters for the `Payment_Information` constructor in favor of string constants in a different class.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run unit tests; `npm run test:php`
* Test subscriptions:
    * Create new subscription
    * Renew subscription as a customer
    * Renew subscription as a merchant

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
