### PR TITLE
Add user saved cards list to user edit page

### DIFF
--- a/client/saved-cards/index.js
+++ b/client/saved-cards/index.js
@@ -1,0 +1,18 @@
+/** @format */
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+
+export const SavedCards = ( { cards } ) => {
+	return (
+		<div class="wcpay-saved-cards">
+			<pre>{ JSON.stringify( cards, null, 2 ) }</pre>
+		</div>
+	);
+};
+
+export default SavedCards;

--- a/client/saved-cards/index.js
+++ b/client/saved-cards/index.js
@@ -9,6 +9,7 @@ import { useResizeObserver } from '@wordpress/compose';
  */
 import './style.scss';
 import SavedCard from './saved-card';
+import { __ } from '@wordpress/i18n';
 
 const getWidthClassName = ( width ) => {
 	if ( width > 651 ) {
@@ -20,18 +21,34 @@ const getWidthClassName = ( width ) => {
 	}
 };
 
-export const SavedCards = ( { cards } ) => {
+export const SavedCards = ( { cards, customerId } ) => {
 	const [ resizeListener, { width } ] = useResizeObserver();
 	return (
 		<div className={ `wcpay-saved-cards ${ getWidthClassName( width ) }` }>
 			{ resizeListener }
-			{ cards.map( ( card ) => (
-				<SavedCard
-					key={ card.tokenId }
-					{ ...card }
-					className={ getWidthClassName( width ) }
-				/>
-			) ) }
+			<p className="wcpay-saved-cards__customer-id">
+				<span className="label">
+					{ __( 'Customer ID:', 'woocommerce-payments' ) }
+				</span>{ ' ' }
+				{ customerId ||
+					__(
+						'No customer found for this user',
+						'woocommerce-payments'
+					) }
+			</p>
+			<div
+				className={ `wcpay-saved-cards__cards-list ${ getWidthClassName(
+					width
+				) }` }
+			>
+				{ cards.map( ( card ) => (
+					<SavedCard
+						key={ card.tokenId }
+						{ ...card }
+						className={ getWidthClassName( width ) }
+					/>
+				) ) }
+			</div>
 		</div>
 	);
 };

--- a/client/saved-cards/index.js
+++ b/client/saved-cards/index.js
@@ -6,11 +6,15 @@
 /**
  * Internal dependencies
  */
+import './style.scss';
+import SavedCard from './saved-card';
 
 export const SavedCards = ( { cards } ) => {
 	return (
 		<div class="wcpay-saved-cards">
-			<pre>{ JSON.stringify( cards, null, 2 ) }</pre>
+			{ cards.map( ( card ) => (
+				<SavedCard { ...card } />
+			) ) }
 		</div>
 	);
 };

--- a/client/saved-cards/index.js
+++ b/client/saved-cards/index.js
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import { useResizeObserver } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -9,11 +10,26 @@
 import './style.scss';
 import SavedCard from './saved-card';
 
+const getWidthClassName = ( width ) => {
+	if ( width > 651 ) {
+		return 'is-large';
+	} else if ( width > 374 ) {
+		return 'is-medium';
+	} else if ( width ) {
+		return 'is-small';
+	}
+};
+
 export const SavedCards = ( { cards } ) => {
+	const [ resizeListener, { width } ] = useResizeObserver();
 	return (
-		<div className="wcpay-saved-cards">
+		<div className={ `wcpay-saved-cards ${ getWidthClassName( width ) }` }>
+			{ resizeListener }
 			{ cards.map( ( card ) => (
-				<SavedCard { ...card } />
+				<SavedCard
+					{ ...card }
+					className={ getWidthClassName( width ) }
+				/>
 			) ) }
 		</div>
 	);

--- a/client/saved-cards/index.js
+++ b/client/saved-cards/index.js
@@ -27,6 +27,7 @@ export const SavedCards = ( { cards } ) => {
 			{ resizeListener }
 			{ cards.map( ( card ) => (
 				<SavedCard
+					key={ card.tokenId }
 					{ ...card }
 					className={ getWidthClassName( width ) }
 				/>

--- a/client/saved-cards/index.js
+++ b/client/saved-cards/index.js
@@ -11,7 +11,7 @@ import SavedCard from './saved-card';
 
 export const SavedCards = ( { cards } ) => {
 	return (
-		<div class="wcpay-saved-cards">
+		<div className="wcpay-saved-cards">
 			{ cards.map( ( card ) => (
 				<SavedCard { ...card } />
 			) ) }

--- a/client/saved-cards/saved-card/index.js
+++ b/client/saved-cards/saved-card/index.js
@@ -18,13 +18,14 @@ export const SavedCard = ( {
 	last4,
 	expiryMonth,
 	expiryYear,
+	className,
 } ) => {
 	const formattedBrand = brand.charAt( 0 ).toUpperCase() + brand.slice( 1 );
 	const formattedExpiryMonth = moment()
 		.month( expiryMonth - 1 )
 		.format( 'MMM' );
 	return (
-		<div className="wcpay-saved-cards__card">
+		<div className={ `wcpay-saved-cards__card ${ className }` }>
 			<span
 				className={ `payment-method__brand payment-method__brand--${ brand }` }
 			></span>

--- a/client/saved-cards/saved-card/index.js
+++ b/client/saved-cards/saved-card/index.js
@@ -45,12 +45,10 @@ export const SavedCard = ( {
 				) : null }
 			</span>
 			<span className="wcpay-saved-cards__card-id">
-				<span className="wcpay-saved-cards__card-id--method">
-					<span class="label">
-						{ __( 'Card ID:', 'woocommerce-payments' ) }
-					</span>{ ' ' }
-					{ paymentMethodId }
-				</span>
+				<span class="label">
+					{ __( 'Card ID:', 'woocommerce-payments' ) }
+				</span>{ ' ' }
+				{ paymentMethodId }
 			</span>
 		</div>
 	);

--- a/client/saved-cards/saved-card/index.js
+++ b/client/saved-cards/saved-card/index.js
@@ -1,0 +1,65 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import Chip from 'components/chip';
+
+export const SavedCard = ( {
+	tokenId,
+	paymentMethodId,
+	isDefault,
+	brand,
+	last4,
+	expiryMonth,
+	expiryYear,
+} ) => {
+	const formattedBrand = brand.charAt( 0 ).toUpperCase() + brand.slice( 1 );
+	const formattedExpiryMonth = moment()
+		.month( expiryMonth - 1 )
+		.format( 'MMM' );
+	return (
+		<div class="wcpay-saved-cards__card">
+			<span
+				className={ `payment-method__brand payment-method__brand--${ brand }` }
+			></span>
+			<span className="wcpay-saved-cards__card-info">
+				<span className="wcpay-saved-cards__card-info--card">
+					{ `${ formattedBrand } •••• ${ last4 }` }
+				</span>
+				<span className="wcpay-saved-cards__card-info--expiry">
+					{ `${ __(
+						'Expires',
+						'woocommerce-payments'
+					) } ${ formattedExpiryMonth } ${ expiryYear }` }
+				</span>
+			</span>
+			<span className="wcpay-saved-cards__card-default">
+				{ isDefault ? (
+					<Chip message={ __( 'Default', 'woocommerce-payments' ) } />
+				) : null }
+			</span>
+			<span className="wcpay-saved-cards__card-id">
+				<span className="wcpay-saved-cards__card-id--token">
+					<span class="label">
+						{ __( 'Token ID:', 'woocommerce-payments' ) }
+					</span>{ ' ' }
+					{ tokenId }
+				</span>
+				<span className="wcpay-saved-cards__card-id--method">
+					<span class="label">
+						{ __( 'Card ID:', 'woocommerce-payments' ) }
+					</span>{ ' ' }
+					{ paymentMethodId }
+				</span>
+			</span>
+		</div>
+	);
+};
+export default SavedCard;

--- a/client/saved-cards/saved-card/index.js
+++ b/client/saved-cards/saved-card/index.js
@@ -24,7 +24,7 @@ export const SavedCard = ( {
 		.month( expiryMonth - 1 )
 		.format( 'MMM' );
 	return (
-		<div class="wcpay-saved-cards__card">
+		<div className="wcpay-saved-cards__card">
 			<span
 				className={ `payment-method__brand payment-method__brand--${ brand }` }
 			></span>
@@ -45,7 +45,7 @@ export const SavedCard = ( {
 				) : null }
 			</span>
 			<span className="wcpay-saved-cards__card-id">
-				<span class="label">
+				<span className="label">
 					{ __( 'Card ID:', 'woocommerce-payments' ) }
 				</span>{ ' ' }
 				{ paymentMethodId }

--- a/client/saved-cards/saved-card/index.js
+++ b/client/saved-cards/saved-card/index.js
@@ -12,7 +12,6 @@ import './style.scss';
 import Chip from 'components/chip';
 
 export const SavedCard = ( {
-	tokenId,
 	paymentMethodId,
 	isDefault,
 	brand,
@@ -46,12 +45,6 @@ export const SavedCard = ( {
 				) : null }
 			</span>
 			<span className="wcpay-saved-cards__card-id">
-				<span className="wcpay-saved-cards__card-id--token">
-					<span class="label">
-						{ __( 'Token ID:', 'woocommerce-payments' ) }
-					</span>{ ' ' }
-					{ tokenId }
-				</span>
 				<span className="wcpay-saved-cards__card-id--method">
 					<span class="label">
 						{ __( 'Card ID:', 'woocommerce-payments' ) }

--- a/client/saved-cards/saved-card/style.scss
+++ b/client/saved-cards/saved-card/style.scss
@@ -11,8 +11,7 @@
 		width: 53px;
 	}
 
-	.wcpay-saved-cards__card-info,
-	.wcpay-saved-cards__card-id {
+	.wcpay-saved-cards__card-info {
 		display: flex;
 		flex-direction: column;
 		white-space: nowrap;

--- a/client/saved-cards/saved-card/style.scss
+++ b/client/saved-cards/saved-card/style.scss
@@ -1,0 +1,46 @@
+.wcpay-saved-cards__card {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	align-items: center;
+	border: 1px solid $g2-lighter-grey;
+	padding: 14px 16px;
+
+	.payment-method__brand {
+		height: 32px;
+		width: 53px;
+	}
+
+	.wcpay-saved-cards__card-info,
+	.wcpay-saved-cards__card-id {
+		display: flex;
+		flex-direction: column;
+		white-space: nowrap;
+	}
+
+	.wcpay-saved-cards__card-info {
+		margin: 0 15px;
+
+		font-size: 14px;
+		line-height: 20px;
+		.wcpay-saved-cards__card-info--card {
+			font-weight: 600;
+		}
+
+		.wcpay-saved-cards__card-info--expiry {
+			font-weight: 400;
+		}
+	}
+
+	.wcpay-saved-cards__card-id {
+		flex: 1;
+		text-align: right;
+		font-size: 12px;
+		line-height: 16px;
+		font-weight: 400;
+
+		.label {
+			font-weight: 600;
+		}
+	}
+}

--- a/client/saved-cards/saved-card/style.scss
+++ b/client/saved-cards/saved-card/style.scss
@@ -18,10 +18,11 @@
 	}
 
 	.wcpay-saved-cards__card-info {
-		margin: 0 15px;
+		margin: 0 15px 0 12px;
 
 		font-size: 14px;
 		line-height: 20px;
+
 		.wcpay-saved-cards__card-info--card {
 			font-weight: 600;
 		}
@@ -32,14 +33,23 @@
 	}
 
 	.wcpay-saved-cards__card-id {
-		flex: 1;
-		text-align: right;
+		width: 100%;
+		margin-top: 16px;
+
 		font-size: 12px;
 		line-height: 16px;
 		font-weight: 400;
 
 		.label {
 			font-weight: 600;
+		}
+	}
+
+	&.is-large {
+		.wcpay-saved-cards__card-id {
+			flex: 1;
+			text-align: right;
+			margin-top: 0;
 		}
 	}
 }

--- a/client/saved-cards/saved-card/test/__snapshots__/index.js.snap
+++ b/client/saved-cards/saved-card/test/__snapshots__/index.js.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Saved Card renders default card correctly 1`] = `
+<div>
+  <div
+    class="wcpay-saved-cards__card undefined"
+  >
+    <span
+      class="payment-method__brand payment-method__brand--visa"
+    />
+    <span
+      class="wcpay-saved-cards__card-info"
+    >
+      <span
+        class="wcpay-saved-cards__card-info--card"
+      >
+        Visa •••• 4242
+      </span>
+      <span
+        class="wcpay-saved-cards__card-info--expiry"
+      >
+        Expires Apr 2024
+      </span>
+    </span>
+    <span
+      class="wcpay-saved-cards__card-default"
+    >
+      <span
+        class="chip chip-primary"
+      >
+        Default
+      </span>
+    </span>
+    <span
+      class="wcpay-saved-cards__card-id"
+    >
+      <span
+        class="label"
+      >
+        Card ID:
+      </span>
+       
+      pm_mock_1
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Saved Card renders non-default card correctly 1`] = `
+<div>
+  <div
+    class="wcpay-saved-cards__card undefined"
+  >
+    <span
+      class="payment-method__brand payment-method__brand--visa"
+    />
+    <span
+      class="wcpay-saved-cards__card-info"
+    >
+      <span
+        class="wcpay-saved-cards__card-info--card"
+      >
+        Visa •••• 4242
+      </span>
+      <span
+        class="wcpay-saved-cards__card-info--expiry"
+      >
+        Expires Apr 2024
+      </span>
+    </span>
+    <span
+      class="wcpay-saved-cards__card-default"
+    />
+    <span
+      class="wcpay-saved-cards__card-id"
+    >
+      <span
+        class="label"
+      >
+        Card ID:
+      </span>
+       
+      pm_mock_1
+    </span>
+  </div>
+</div>
+`;

--- a/client/saved-cards/saved-card/test/index.js
+++ b/client/saved-cards/saved-card/test/index.js
@@ -1,0 +1,39 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { SavedCard } from '../';
+
+const mockCard = {
+	tokenId: 1,
+	paymentMethodId: 'pm_mock_1',
+	isDefault: true,
+	brand: 'visa',
+	last4: '4242',
+	expiryMonth: '04',
+	expiryYear: '2024',
+};
+
+describe( 'Saved Card', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders default card correctly', () => {
+		const { container } = render( <SavedCard { ...mockCard } /> );
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders non-default card correctly', () => {
+		const { container } = render(
+			<SavedCard { ...mockCard } { ...{ isDefault: false } } />
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+} );

--- a/client/saved-cards/style.scss
+++ b/client/saved-cards/style.scss
@@ -3,4 +3,6 @@
 	background: $studio-white;
 	border-radius: 2px;
 	border: 1px solid $g2-lighter-grey;
+	/* position needs to be relative so resizeListener measures the container size */
+	position: relative;
 }

--- a/client/saved-cards/style.scss
+++ b/client/saved-cards/style.scss
@@ -1,0 +1,6 @@
+.wcpay-saved-cards {
+	max-width: 800px;
+	background: $studio-white;
+	border-radius: 2px;
+	border: 1px solid $g2-lighter-grey;
+}

--- a/client/saved-cards/style.scss
+++ b/client/saved-cards/style.scss
@@ -1,8 +1,21 @@
 .wcpay-saved-cards {
 	max-width: 800px;
-	background: $studio-white;
-	border-radius: 2px;
-	border: 1px solid $g2-lighter-grey;
 	/* position needs to be relative so resizeListener measures the container size */
 	position: relative;
+
+	.wcpay-saved-cards__customer-id {
+		margin-bottom: 18px;
+		font-size: 14px;
+		line-height: 20px;
+
+		.label {
+			font-weight: 600;
+		}
+	}
+
+	.wcpay-saved-cards__cards-list {
+		background: $studio-white;
+		border-radius: 2px;
+		border: 1px solid $g2-lighter-grey;
+	}
 }

--- a/client/saved-cards/test/__snapshots__/index.js.snap
+++ b/client/saved-cards/test/__snapshots__/index.js.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Saved Cards renders correctly 1`] = `
+<div>
+  <div
+    class="wcpay-saved-cards is-large"
+  >
+    <div
+      class="wcpay-saved-cards__card is-large"
+    >
+      <span
+        class="payment-method__brand payment-method__brand--visa"
+      />
+      <span
+        class="wcpay-saved-cards__card-info"
+      >
+        <span
+          class="wcpay-saved-cards__card-info--card"
+        >
+          Visa •••• 4242
+        </span>
+        <span
+          class="wcpay-saved-cards__card-info--expiry"
+        >
+          Expires Apr 2024
+        </span>
+      </span>
+      <span
+        class="wcpay-saved-cards__card-default"
+      >
+        <span
+          class="chip chip-primary"
+        >
+          Default
+        </span>
+      </span>
+      <span
+        class="wcpay-saved-cards__card-id"
+      >
+        <span
+          class="label"
+        >
+          Card ID:
+        </span>
+         
+        pm_mock_1
+      </span>
+    </div>
+    <div
+      class="wcpay-saved-cards__card is-large"
+    >
+      <span
+        class="payment-method__brand payment-method__brand--mastercard"
+      />
+      <span
+        class="wcpay-saved-cards__card-info"
+      >
+        <span
+          class="wcpay-saved-cards__card-info--card"
+        >
+          Mastercard •••• 4444
+        </span>
+        <span
+          class="wcpay-saved-cards__card-info--expiry"
+        >
+          Expires Apr 2044
+        </span>
+      </span>
+      <span
+        class="wcpay-saved-cards__card-default"
+      />
+      <span
+        class="wcpay-saved-cards__card-id"
+      >
+        <span
+          class="label"
+        >
+          Card ID:
+        </span>
+         
+        pm_mock_2
+      </span>
+    </div>
+  </div>
+</div>
+`;

--- a/client/saved-cards/test/__snapshots__/index.js.snap
+++ b/client/saved-cards/test/__snapshots__/index.js.snap
@@ -5,82 +5,120 @@ exports[`Saved Cards renders correctly 1`] = `
   <div
     class="wcpay-saved-cards is-large"
   >
-    <div
-      class="wcpay-saved-cards__card is-large"
+    <p
+      class="wcpay-saved-cards__customer-id"
     >
       <span
-        class="payment-method__brand payment-method__brand--visa"
-      />
-      <span
-        class="wcpay-saved-cards__card-info"
+        class="label"
       >
-        <span
-          class="wcpay-saved-cards__card-info--card"
-        >
-          Visa •••• 4242
-        </span>
-        <span
-          class="wcpay-saved-cards__card-info--expiry"
-        >
-          Expires Apr 2024
-        </span>
+        Customer ID:
       </span>
-      <span
-        class="wcpay-saved-cards__card-default"
-      >
-        <span
-          class="chip chip-primary"
-        >
-          Default
-        </span>
-      </span>
-      <span
-        class="wcpay-saved-cards__card-id"
-      >
-        <span
-          class="label"
-        >
-          Card ID:
-        </span>
-         
-        pm_mock_1
-      </span>
-    </div>
+       
+      cus_SomeCustomer
+    </p>
     <div
-      class="wcpay-saved-cards__card is-large"
+      class="wcpay-saved-cards__cards-list is-large"
+    >
+      <div
+        class="wcpay-saved-cards__card is-large"
+      >
+        <span
+          class="payment-method__brand payment-method__brand--visa"
+        />
+        <span
+          class="wcpay-saved-cards__card-info"
+        >
+          <span
+            class="wcpay-saved-cards__card-info--card"
+          >
+            Visa •••• 4242
+          </span>
+          <span
+            class="wcpay-saved-cards__card-info--expiry"
+          >
+            Expires Apr 2024
+          </span>
+        </span>
+        <span
+          class="wcpay-saved-cards__card-default"
+        >
+          <span
+            class="chip chip-primary"
+          >
+            Default
+          </span>
+        </span>
+        <span
+          class="wcpay-saved-cards__card-id"
+        >
+          <span
+            class="label"
+          >
+            Card ID:
+          </span>
+           
+          pm_mock_1
+        </span>
+      </div>
+      <div
+        class="wcpay-saved-cards__card is-large"
+      >
+        <span
+          class="payment-method__brand payment-method__brand--mastercard"
+        />
+        <span
+          class="wcpay-saved-cards__card-info"
+        >
+          <span
+            class="wcpay-saved-cards__card-info--card"
+          >
+            Mastercard •••• 4444
+          </span>
+          <span
+            class="wcpay-saved-cards__card-info--expiry"
+          >
+            Expires Apr 2044
+          </span>
+        </span>
+        <span
+          class="wcpay-saved-cards__card-default"
+        />
+        <span
+          class="wcpay-saved-cards__card-id"
+        >
+          <span
+            class="label"
+          >
+            Card ID:
+          </span>
+           
+          pm_mock_2
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Saved Cards renders customerId fallback 1`] = `
+<div>
+  <div
+    class="wcpay-saved-cards is-large"
+  >
+    <p
+      class="wcpay-saved-cards__customer-id"
     >
       <span
-        class="payment-method__brand payment-method__brand--mastercard"
-      />
-      <span
-        class="wcpay-saved-cards__card-info"
+        class="label"
       >
-        <span
-          class="wcpay-saved-cards__card-info--card"
-        >
-          Mastercard •••• 4444
-        </span>
-        <span
-          class="wcpay-saved-cards__card-info--expiry"
-        >
-          Expires Apr 2044
-        </span>
+        Customer ID:
       </span>
-      <span
-        class="wcpay-saved-cards__card-default"
-      />
-      <span
-        class="wcpay-saved-cards__card-id"
-      >
-        <span
-          class="label"
-        >
-          Card ID:
-        </span>
-         
-        pm_mock_2
-      </span>
-    </div>
+       
+      No customer found for this user
+    </p>
+    <div
+      class="wcpay-saved-cards__cards-list is-large"
+    />
   </div>
 </div>
 `;

--- a/client/saved-cards/test/index.js
+++ b/client/saved-cards/test/index.js
@@ -1,0 +1,74 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { useResizeObserver } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { SavedCards } from '../';
+
+jest.mock( '@wordpress/compose', () => ( { useResizeObserver: jest.fn() } ) );
+const mockUseResizeObserverWidth = ( width ) => {
+	useResizeObserver.mockReturnValue( [ null, { width } ] );
+};
+
+const mockCards = [
+	{
+		tokenId: 1,
+		paymentMethodId: 'pm_mock_1',
+		isDefault: true,
+		brand: 'visa',
+		last4: '4242',
+		expiryMonth: '04',
+		expiryYear: '2024',
+	},
+	{
+		tokenId: 2,
+		paymentMethodId: 'pm_mock_2',
+		isDefault: false,
+		brand: 'mastercard',
+		last4: '4444',
+		expiryMonth: '04',
+		expiryYear: '2044',
+	},
+];
+
+describe( 'Saved Cards', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders correctly', () => {
+		mockUseResizeObserverWidth( 800 );
+		const { container } = render( <SavedCards cards={ mockCards } /> );
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'adds is-small class for small viewports', () => {
+		mockUseResizeObserverWidth( 374 );
+		const { container } = render( <SavedCards cards={ mockCards } /> );
+		expect( container.firstChild ).toHaveClass( 'is-small' );
+	} );
+
+	test( 'adds is-medium class for medium viewports lower-bound', () => {
+		mockUseResizeObserverWidth( 375 );
+		const { container } = render( <SavedCards cards={ mockCards } /> );
+		expect( container.firstChild ).toHaveClass( 'is-medium' );
+	} );
+
+	test( 'adds is-medium class for medium viewports upper-bound', () => {
+		mockUseResizeObserverWidth( 651 );
+		const { container } = render( <SavedCards cards={ mockCards } /> );
+		expect( container.firstChild ).toHaveClass( 'is-medium' );
+	} );
+
+	test( 'adds is-large class for large viewports', () => {
+		mockUseResizeObserverWidth( 652 );
+		const { container } = render( <SavedCards cards={ mockCards } /> );
+		expect( container.firstChild ).toHaveClass( 'is-large' );
+	} );
+} );

--- a/client/saved-cards/test/index.js
+++ b/client/saved-cards/test/index.js
@@ -16,6 +16,7 @@ const mockUseResizeObserverWidth = ( width ) => {
 	useResizeObserver.mockReturnValue( [ null, { width } ] );
 };
 
+const customerId = 'cus_SomeCustomer';
 const mockCards = [
 	{
 		tokenId: 1,
@@ -44,31 +45,49 @@ describe( 'Saved Cards', () => {
 
 	test( 'renders correctly', () => {
 		mockUseResizeObserverWidth( 800 );
-		const { container } = render( <SavedCards cards={ mockCards } /> );
+		const { container } = render(
+			<SavedCards customerId={ customerId } cards={ mockCards } />
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test( 'renders customerId fallback', () => {
+		mockUseResizeObserverWidth( 800 );
+		const { container } = render(
+			<SavedCards customerId={ null } cards={ [] } />
+		);
 		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'adds is-small class for small viewports', () => {
 		mockUseResizeObserverWidth( 374 );
-		const { container } = render( <SavedCards cards={ mockCards } /> );
+		const { container } = render(
+			<SavedCards customerId={ customerId } cards={ mockCards } />
+		);
 		expect( container.firstChild ).toHaveClass( 'is-small' );
 	} );
 
 	test( 'adds is-medium class for medium viewports lower-bound', () => {
 		mockUseResizeObserverWidth( 375 );
-		const { container } = render( <SavedCards cards={ mockCards } /> );
+		const { container } = render(
+			<SavedCards customerId={ customerId } cards={ mockCards } />
+		);
 		expect( container.firstChild ).toHaveClass( 'is-medium' );
 	} );
 
 	test( 'adds is-medium class for medium viewports upper-bound', () => {
 		mockUseResizeObserverWidth( 651 );
-		const { container } = render( <SavedCards cards={ mockCards } /> );
+		const { container } = render(
+			<SavedCards customerId={ customerId } cards={ mockCards } />
+		);
 		expect( container.firstChild ).toHaveClass( 'is-medium' );
 	} );
 
 	test( 'adds is-large class for large viewports', () => {
 		mockUseResizeObserverWidth( 652 );
-		const { container } = render( <SavedCards cards={ mockCards } /> );
+		const { container } = render(
+			<SavedCards customerId={ customerId } cards={ mockCards } />
+		);
 		expect( container.firstChild ).toHaveClass( 'is-large' );
 	} );
 } );

--- a/client/stylesheets/abstracts/_colors.scss
+++ b/client/stylesheets/abstracts/_colors.scss
@@ -2,3 +2,7 @@
 
 @import 'node_modules/@automattic/color-studio/dist/color-variables.scss';
 @import 'node_modules/@wordpress/base-styles/colors.scss';
+
+$g2-lighter-grey: #ddd;
+$g2-dark-grey: #1e1e1e;
+$g2-grey: #40464d;

--- a/client/user-page-settings.js
+++ b/client/user-page-settings.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+/**
+ * Internal dependencies
+ */
+import SavedCards from 'saved-cards';
+
+const savedCardsContainer = document.getElementById(
+	'wcpay-saved-cards-container'
+);
+
+if ( savedCardsContainer ) {
+	const cards =
+		JSON.parse( savedCardsContainer.getAttribute( 'data-cards' ) ) || [];
+	ReactDOM.render( <SavedCards cards={ cards } />, savedCardsContainer );
+}

--- a/client/user-page-settings.js
+++ b/client/user-page-settings.js
@@ -15,5 +15,10 @@ const savedCardsContainer = document.getElementById(
 if ( savedCardsContainer ) {
 	const cards =
 		JSON.parse( savedCardsContainer.getAttribute( 'data-cards' ) ) || [];
-	ReactDOM.render( <SavedCards cards={ cards } />, savedCardsContainer );
+	const customerId =
+		savedCardsContainer.getAttribute( 'data-customer' ) || null;
+	ReactDOM.render(
+		<SavedCards cards={ cards } customerId={ customerId } />,
+		savedCardsContainer
+	);
 }

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -234,18 +234,14 @@ class WC_Payments_Admin {
 			WC_Payments::get_file_version( 'dist/settings.css' )
 		);
 
-		$user_page_settings_src_url      = plugins_url( 'dist/user-page-settings.js', WCPAY_PLUGIN_FILE );
-		$user_page_settings_asset_path   = WCPAY_ABSPATH . 'dist/user-page-settings.asset.php';
-		$user_page_settings_asset        = file_exists( $user_page_settings_asset_path ) ? require_once $user_page_settings_asset_path : null;
-		$user_page_settings_dependencies = array_merge(
-			$user_page_settings_asset['dependencies'],
-			[ 'stripe' ]
-		);
+		$user_page_settings_src_url    = plugins_url( 'dist/user-page-settings.js', WCPAY_PLUGIN_FILE );
+		$user_page_settings_asset_path = WCPAY_ABSPATH . 'dist/user-page-settings.asset.php';
+		$user_page_settings_asset      = file_exists( $user_page_settings_asset_path ) ? require_once $user_page_settings_asset_path : [ 'dependencies' => [] ];
 
 		wp_register_script(
 			'WCPAY_USER_PAGE_SETTINGS',
 			$user_page_settings_src_url,
-			$user_page_settings_dependencies,
+			$user_page_settings_asset['dependencies'],
 			WC_Payments::get_file_version( 'dist/user-page-settings.js' ),
 			true
 		);
@@ -274,7 +270,8 @@ class WC_Payments_Admin {
 		}
 
 		// Enqueue user page setting scripts if in the user-edit page.
-		if ( get_current_screen() && 'user-edit' === get_current_screen()->id ) {
+		$user_edit_pages = [ 'user-edit', 'profile' ];
+		if ( get_current_screen() && in_array( get_current_screen()->id, $user_edit_pages, true ) ) {
 			wp_enqueue_script( 'WCPAY_USER_PAGE_SETTINGS' );
 			wp_enqueue_style( 'WCPAY_USER_PAGE_SETTINGS' );
 		}

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -249,6 +249,13 @@ class WC_Payments_Admin {
 			WC_Payments::get_file_version( 'dist/user-page-settings.js' ),
 			true
 		);
+
+		wp_register_style(
+			'WCPAY_USER_PAGE_SETTINGS',
+			plugins_url( 'dist/user-page-settings.css', WCPAY_PLUGIN_FILE ),
+			[ 'wc-components' ],
+			WC_Payments::get_file_version( 'dist/user-page-settings.css' )
+		);
 	}
 
 	/**

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -233,6 +233,22 @@ class WC_Payments_Admin {
 			[ 'wc-components' ],
 			WC_Payments::get_file_version( 'dist/settings.css' )
 		);
+
+		$user_page_settings_src_url      = plugins_url( 'dist/user-page-settings.js', WCPAY_PLUGIN_FILE );
+		$user_page_settings_asset_path   = WCPAY_ABSPATH . 'dist/user-page-settings.asset.php';
+		$user_page_settings_asset        = file_exists( $user_page_settings_asset_path ) ? require_once $user_page_settings_asset_path : null;
+		$user_page_settings_dependencies = array_merge(
+			$user_page_settings_asset['dependencies'],
+			[ 'stripe' ]
+		);
+
+		wp_register_script(
+			'WCPAY_USER_PAGE_SETTINGS',
+			$user_page_settings_src_url,
+			$user_page_settings_dependencies,
+			WC_Payments::get_file_version( 'dist/user-page-settings.js' ),
+			true
+		);
 	}
 
 	/**
@@ -248,6 +264,12 @@ class WC_Payments_Admin {
 			// Output the settings JS and CSS only on the settings page.
 			wp_enqueue_script( 'WCPAY_ADMIN_SETTINGS' );
 			wp_enqueue_style( 'WCPAY_ADMIN_SETTINGS' );
+		}
+
+		// Enqueue user page setting scripts if in the user-edit page.
+		if ( get_current_screen() && 'user-edit' === get_current_screen()->id ) {
+			wp_enqueue_script( 'WCPAY_USER_PAGE_SETTINGS' );
+			wp_enqueue_style( 'WCPAY_USER_PAGE_SETTINGS' );
 		}
 
 		// TODO: Try to enqueue the JS and CSS bundles lazily (will require changes on WC-Admin).

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -320,12 +320,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 							<label for="wcpay-saved-cards">Saved cards</label>
 						</th>
 						<td>
-							<div id="wcpay-saved-cards-container" data-cards="%1$s"></div>
+							<div id="wcpay-saved-cards-container" data-cards="%1$s" data-customer="%2$s"></div>
 						</td>
 					</tr>
 				</tbody>
 			</table>',
-			esc_attr( wp_json_encode( $formatted_tokens ) )
+			esc_attr( wp_json_encode( $formatted_tokens ) ),
+			esc_attr( $this->customer_service->get_customer_id_by_user_id( $user->ID ) )
 		);
 	}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -325,7 +325,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					</tr>
 				</tbody>
 			</table>',
-			esc_js( wp_json_encode( $formatted_tokens ) )
+			esc_attr( wp_json_encode( $formatted_tokens ) )
 		);
 	}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -163,6 +163,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// Display user tokens so admins can reference them when updating a subscription payment methods.
 		add_action( 'show_user_profile', [ $this, 'display_user_saved_payment_methods' ], 50 );
+		add_action( 'edit_user_profile', [ $this, 'display_user_saved_payment_methods' ], 50 );
 	}
 
 	/**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ const webpackConfig = {
 	entry: {
 		index: './client/index.js',
 		settings: './client/settings.js',
+		'user-page-settings': './client/user-page-settings.js',
 	},
 	output: {
 		filename: '[name].js',


### PR DESCRIPTION
Fixes #909 

I'm pushing this PR as-is for now, with the changes that I made in #700 when we planned to have the merchants copy and paste the payment method. Now that we provide a select element with all the customer's tokens, there's no need for this code in #892.

Some elements should've used the [`<Text />` component](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/text), but it is not included in the `@wordpress/components` version that we bundle (`8.3.2`). Once #717 lands we're going to be able to use it and remove some CSS from this PR. 

#### Changes proposed in this Pull Request

* Add a saved cards list for the user when viewing the user edit page (paJDYF-Kq-p2, [figma](https://www.figma.com/file/9NwRO4ifgd18sJn8XEMKma/Saved-Cards))

<p float="left">
    <img src="https://user-images.githubusercontent.com/7714042/93514477-a234b900-f8fd-11ea-992b-56a56d6e9123.png" width="73%" style="display: inline-block;" />
    <img src="https://user-images.githubusercontent.com/7714042/93514485-a5c84000-f8fd-11ea-8120-849d143723e0.png" width="24%" style="display: inline-block;" />
</p>

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add some saved cards to a customer
* As an admin, go to the user edit page and scroll down until de WC Payments section
* Assert that the card list is displayed correctly

-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->