### PR TITLE
Fix save payment method checkbox for Subscriptions payment method update

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Payments Changelog ***
 
 = 1.x.x - 2020-xx-xx =
+* Fix - Save payment method checkbox for Subscriptions payment method update.
 * Fix - Support checkout on Internet Explorer 11.
 * Add - Display payment method details on account subscriptions pages.
 * Add - Redact sensitive data before logging.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Payments Changelog ***
 
 = 1.x.x - 2020-xx-xx =
-* Fix - Save payment method checkbox for Subscriptions payment method update.
+* Fix - Save payment method checkbox for Subscriptions customer-initiated payment method updates.
 * Fix - Support checkout on Internet Explorer 11.
 * Add - Display payment method details on account subscriptions pages.
 * Add - Redact sensitive data before logging.

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -69,7 +69,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 	 * @return array|null An array with result of payment and redirect URL, or nothing.
 	 */
 	public function process_payment( $order_id, $is_recurring_payment = false ) {
-		return parent::process_payment( $order_id, wcs_order_contains_subscription( $order_id ) );
+		$force_save_payment_method = wcs_order_contains_subscription( $order_id ) || $this->is_changing_payment_method_for_subscription();
+		return parent::process_payment( $order_id, $force_save_payment_method );
 	}
 
 	/**

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -49,6 +49,18 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 	}
 
 	/**
+	 * Returns whether this user is changing the payment method for a subscription.
+	 *
+	 * @return bool
+	 */
+	private function is_changing_payment_method_for_subscription() {
+		if ( isset( $_GET['change_payment_method'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return wcs_is_subscription( wc_clean( wp_unslash( $_GET['change_payment_method'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		}
+		return false;
+	}
+
+	/**
 	 * Process the payment for a given order.
 	 *
 	 * @param int  $order_id Order ID to process the payment for.
@@ -64,15 +76,15 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 	 * Returns a boolean value indicating whether the save payment checkbox should be
 	 * displayed during checkout.
 	 *
-	 * Returns `false` if the cart currently has a subscriptions. Returns the value in
-	 * `$display` otherwise.
+	 * Returns `false` if the cart currently has a subscriptions or if the request has a
+	 * `change_payment_method` GET parameter. Returns the value in `$display` otherwise.
 	 *
 	 * @param bool $display Bool indicating whether to show the save payment checkbox in the absence of subscriptions.
 	 *
 	 * @return bool Indicates whether the save payment method checkbox should be displayed or not.
 	 */
 	public function display_save_payment_method_checkbox( $display ) {
-		if ( WC_Subscriptions_Cart::cart_contains_subscription() ) {
+		if ( WC_Subscriptions_Cart::cart_contains_subscription() || $this->is_changing_payment_method_for_subscription() ) {
 			return false;
 		}
 		// Only render the "Save payment method" checkbox if there are no subscription products in the cart.

--- a/readme.txt
+++ b/readme.txt
@@ -91,7 +91,7 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 == Changelog ==
 
 = 1.x.x - 2020-xx-xx =
-* Fix - Save payment method checkbox for Subscriptions payment method update.
+* Fix - Save payment method checkbox for Subscriptions customer-initiated payment method updates.
 * Fix - Support checkout on Internet Explorer 11.
 * Add - Display payment method details on account subscriptions pages.
 * Add - Redact sensitive data before logging.

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,7 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 == Changelog ==
 
 = 1.x.x - 2020-xx-xx =
+* Fix - Save payment method checkbox for Subscriptions payment method update.
 * Fix - Support checkout on Internet Explorer 11.
 * Add - Display payment method details on account subscriptions pages.
 * Add - Redact sensitive data before logging.

--- a/tests/helpers/class-wc-helper-subscriptions-cart.php
+++ b/tests/helpers/class-wc-helper-subscriptions-cart.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Subscription WC_Subscription_Cart helper.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * Class WC_Subscription_Cart.
+ *
+ * This helper class should ONLY be used for unit tests!.
+ */
+class WC_Subscriptions_Cart {
+	/**
+	 * cart_contains_subscription mock.
+	 *
+	 * @var function
+	 */
+	public static $cart_contains_subscription_result = null;
+
+	public static function cart_contains_subscription() {
+		return self::$cart_contains_subscription_result;
+	}
+
+	public static function set_cart_contains_subscription( $result ) {
+		self::$cart_contains_subscription_result = $result;
+	}
+}

--- a/tests/helpers/class-wc-helper-subscriptions.php
+++ b/tests/helpers/class-wc-helper-subscriptions.php
@@ -14,6 +14,10 @@ function wcs_get_subscriptions_for_order( $order ) {
 	return call_user_func( WCS_Mock::$wcs_get_subscriptions_for_order, $order );
 }
 
+function wcs_is_subscription( $order ) {
+	return call_user_func( WCS_Mock::$wcs_is_subscription, $order );
+}
+
 /**
  * Class WCS_Mock.
  *
@@ -34,11 +38,22 @@ class WCS_Mock {
 	 */
 	public static $wcs_get_subscriptions_for_order = null;
 
+	/**
+	 * wcs_is_subscription mock.
+	 *
+	 * @var function
+	 */
+	public static $wcs_is_subscription = null;
+
 	public static function set_wcs_order_contains_subscription( $function ) {
 		self::$wcs_order_contains_subscription = $function;
 	}
 
 	public static function set_wcs_get_subscriptions_for_order( $function ) {
 		self::$wcs_get_subscriptions_for_order = $function;
+	}
+
+	public static function set_wcs_is_subscription( $function ) {
+		self::$wcs_is_subscription = $function;
 	}
 }

--- a/tests/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -337,6 +337,47 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 		$result = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
 	}
 
+	public function test_card_is_saved_when_updating_subscription_payment_method() {
+		$order = WC_Helper_Order::create_order( self::USER_ID, 0 );
+
+		$_GET = [ 'change_payment_method' => 10 ];
+
+		$this->mock_wcs_order_contains_subscription( false );
+
+		WCS_Mock::set_wcs_is_subscription(
+			function ( $order ) {
+				return true;
+			}
+		);
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'create_setup_intent' )
+			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, 'true' )
+			->willReturn( $this->setup_intent );
+
+		$this->mock_token_service
+			->expects( $this->once() )
+			->method( 'add_payment_method_to_user' )
+			->with( self::PAYMENT_METHOD_ID, $order->get_user() )
+			->willReturn( $this->token );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'add_token_to_order' )
+			->with(
+				$this->callback( $this->match_order_id( $order->get_id() ) ),
+				$this->token
+			);
+
+		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
+		$result_order = wc_get_order( $order->get_id() );
+
+		$this->assertEquals( 'processing', $result_order->get_status() );
+		$this->assertEquals( 'success', $result['result'] );
+	}
+
 	private function mock_wcs_order_contains_subscription( $value ) {
 		WCS_Mock::set_wcs_order_contains_subscription(
 			function ( $order ) use ( $value ) {

--- a/tests/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -268,6 +268,37 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 		$this->assertEquals( $last_token->get_display_name(), $payment_method_to_display );
 	}
 
+	public function test_display_save_payment_method_checkbox_for_subs_cart() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( true );
+
+		$this->assertFalse( $this->wcpay_gateway->display_save_payment_method_checkbox( true ) );
+	}
+
+	public function test_display_save_payment_method_checkbox_for_subs_change() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+
+		WCS_Mock::set_wcs_is_subscription(
+			function ( $order ) {
+				return true;
+			}
+		);
+
+		$_GET = [ 'change_payment_method' => 10 ];
+		$this->assertFalse( $this->wcpay_gateway->display_save_payment_method_checkbox( true ) );
+	}
+
+	public function test_display_save_payment_method_checkbox_for_returns_display() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+
+		WCS_Mock::set_wcs_is_subscription(
+			function ( $order ) {
+				return false;
+			}
+		);
+
+		$this->assertTrue( $this->wcpay_gateway->display_save_payment_method_checkbox( true ) );
+	}
+
 	private function mock_wcs_get_subscriptions_for_order( $subscriptions ) {
 		WCS_Mock::set_wcs_get_subscriptions_for_order(
 			function ( $order ) use ( $subscriptions ) {


### PR DESCRIPTION
Fixes #904 

#### Changes proposed in this Pull Request

* Hide the "save payment method" checkbox when changing the payment method for a subscription
* Save new cards added during the payment method update for a subscription

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Subscribe to a Subscriptions product
2. Go to My account > Subscriptions > View > Change payment
3. Assert that the "save payment method" checkbox is not displayed
4. Inform a new card and click on the Change payment method button
5. You should get a message saying that the subscription was updated
6. Renew that subscription
7. Assert that the renewal was processed using the new payment method

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
