### PR TITLE
Add the order object and the "manual capture" setting to the Payment_Information class

### DIFF
--- a/includes/class-payment-information.php
+++ b/includes/class-payment-information.php
@@ -23,6 +23,13 @@ class Payment_Information {
 	private $payment_method;
 
 	/**
+	 * The order object.
+	 *
+	 * @var \WC_Order/NULL
+	 */
+	private $order;
+
+	/**
 	 * The payment token used for this payment.
 	 *
 	 * @var \WC_Payment_Token/NULL
@@ -37,26 +44,39 @@ class Payment_Information {
 	private $off_session;
 
 	/**
+	 * Indicates whether the payment will be only authorized (true) or captured immediately (false).
+	 *
+	 * @var bool
+	 */
+	private $manual_capture;
+
+	/**
 	 * Payment information constructor.
 	 *
 	 * @param string            $payment_method The ID of the payment method used for this payment.
+	 * @param \WC_Order         $order The order object.
 	 * @param \WC_Payment_Token $token The payment token used for this payment.
 	 * @param bool              $off_session Indicates whether the payment is merchant-initiated (true) or customer-initiated (false).
+	 * @param bool              $manual_capture Indicates whether the payment will be only authorized (true) or captured immediately (false).
 	 *
 	 * @throws \Exception - If no payment method is found in the provided request.
 	 */
 	public function __construct(
 		string $payment_method,
+		\WC_Order $order = null,
 		\WC_Payment_Token $token = null,
-		bool $off_session = false
+		bool $off_session = false,
+		bool $manual_capture = false
 	) {
 		if ( empty( $payment_method ) && empty( $token ) ) {
 			throw new \Exception( __( 'Invalid payment method. Please input a new card number.', 'woocommerce-payments' ) );
 		}
 
 		$this->payment_method = $payment_method;
+		$this->order          = $order;
 		$this->token          = $token;
 		$this->off_session    = $off_session;
+		$this->manual_capture = $manual_capture;
 	}
 
 	/**
@@ -80,6 +100,15 @@ class Payment_Information {
 		}
 
 		return $this->payment_method;
+	}
+
+	/**
+	 * Returns the order object.
+	 *
+	 * @return \WC_Order The order object.
+	 */
+	public function get_order(): \WC_Order {
+		return $this->order;
 	}
 
 	/**
@@ -114,22 +143,34 @@ class Payment_Information {
 	}
 
 	/**
+	 * Returns true if the payment should be only authorized, false if it should be captured immediately.
+	 *
+	 * @return bool True if the payment should be only authorized, false if it should be captured immediately.
+	 */
+	public function is_using_manual_capture(): bool {
+		return $this->manual_capture;
+	}
+
+	/**
 	 * Payment information constructor.
 	 *
-	 * @param array $request Associative array containing payment request information.
-	 * @param bool  $off_session Indicates whether the payment is merchant-initiated (true) or customer-initiated (false).
+	 * @param array     $request Associative array containing payment request information.
+	 * @param \WC_Order $order The order object.
+	 * @param bool      $off_session Indicates whether the payment is merchant-initiated (true) or customer-initiated (false).
+	 * @param bool      $manual_capture Indicates whether the payment will be only authorized (true) or captured immediately (false).
 	 *
-	 * @throws Exception - If no payment method is found in the provided request.
+	 * @throws \Exception - If no payment method is found in the provided request.
 	 */
 	public static function from_payment_request(
 		array $request,
-		bool $off_session = false
+		\WC_Order $order = null,
+		bool $off_session = false,
+		bool $manual_capture = false
 	): Payment_Information {
 		$payment_method = self::get_payment_method_from_request( $request );
 		$token          = self::get_token_from_request( $request );
-		$off_session    = $off_session;
 
-		return new Payment_Information( $payment_method, $token, $off_session );
+		return new Payment_Information( $payment_method, $order, $token, $off_session, $manual_capture );
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -398,11 +398,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$order = wc_get_order( $order_id );
 
 		try {
+			$manual_capture = 'yes' === $this->get_option( 'manual_capture' );
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing
-			$payment_information = Payment_Information::from_payment_request( $_POST );
-			$manual_capture      = 'yes' === $this->get_option( 'manual_capture' );
+			$payment_information = Payment_Information::from_payment_request( $_POST, $order, false, $manual_capture );
 
-			return $this->process_payment_for_order( $order, WC()->cart, $payment_information, $manual_capture, $force_save_payment_method );
+			return $this->process_payment_for_order( WC()->cart, $payment_information, $force_save_payment_method );
 		} catch ( Exception $e ) {
 			// TODO: Create plugin specific exceptions so that we can be smarter about what we create notices for.
 			wc_add_notice( $e->getMessage(), 'error' );
@@ -419,18 +419,17 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	/**
 	 * Process the payment for a given order.
 	 *
-	 * @param WC_Order               $order Order.
-	 * @param WC_Cart                $cart Cart.
-	 * @param WC_Payment_Information $payment_information Payment info.
-	 * @param bool                   $manual_capture Indicates whether this payment is merchant-initiated (true) or customer-initated (false).
-	 * @param bool                   $force_save_payment_method Whether this is a one-off payment (false) or it's the first installment of a recurring payment (true).
+	 * @param WC_Cart                   $cart Cart.
+	 * @param WCPay\Payment_Information $payment_information Payment info.
+	 * @param bool                      $force_save_payment_method Whether this is a one-off payment (false) or it's the first installment of a recurring payment (true).
 	 *
 	 * @return array|null An array with result of payment and redirect URL, or nothing.
 	 * @throws WC_Payments_API_Exception Error processing the payment.
 	 */
-	public function process_payment_for_order( $order, $cart, $payment_information, $manual_capture, $force_save_payment_method = false ) {
+	public function process_payment_for_order( $cart, $payment_information, $force_save_payment_method = false ) {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$save_payment_method = ! $payment_information->is_using_saved_payment_method() && ( ! empty( $_POST[ 'wc-' . self::GATEWAY_ID . '-new-payment-method' ] ) || $force_save_payment_method );
+		$order               = $payment_information->get_order();
 
 		$order_id = $order->get_id();
 		$amount   = $order->get_total();
@@ -486,7 +485,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'usd',
 				$payment_information->get_payment_method(),
 				$customer_id,
-				$manual_capture,
+				$payment_information->is_using_manual_capture(),
 				$save_payment_method,
 				$metadata,
 				$this->get_level3_data_from_order( $order ),

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -92,11 +92,11 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 			return;
 		}
 
-		$payment_information = new Payment_Information( '', $token, true );
+		$payment_information = new Payment_Information( '', $renewal_order, $token, true );
 
 		try {
 			// TODO: make `force_saved_card` and adding the 'recurring' metadata 2 distinct features.
-			$this->process_payment_for_order( $renewal_order, null, $payment_information, false, true );
+			$this->process_payment_for_order( null, $payment_information, true );
 		} catch ( WC_Payments_API_Exception $e ) {
 			Logger::error( 'Error processing subscription renewal: ' . $e->getMessage() );
 

--- a/tests/test-class-payment-information.php
+++ b/tests/test-class-payment-information.php
@@ -36,27 +36,27 @@ class Payment_Information_Test extends WP_UnitTestCase {
 	}
 
 	public function test_is_merchant_initiated_returns_off_session() {
-		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, true );
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, null, true );
 		$this->assertTrue( $payment_information->is_merchant_initiated() );
 	}
 
 	public function test_get_payment_method_returns_payment_method() {
-		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null );
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, null );
 		$this->assertEquals( self::PAYMENT_METHOD, $payment_information->get_payment_method() );
 	}
 
 	public function test_get_payment_method_returns_token_if_present() {
-		$payment_information = new Payment_Information( self::PAYMENT_METHOD, $this->token );
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, $this->token );
 		$this->assertEquals( self::TOKEN, $payment_information->get_payment_method() );
 	}
 
 	public function test_get_payment_token_returns_token() {
-		$payment_information = new Payment_Information( self::PAYMENT_METHOD, $this->token );
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, $this->token );
 		$this->assertEquals( $this->token, $payment_information->get_payment_token() );
 	}
 
 	public function is_using_saved_payment_method_returns_true_if_token() {
-		$payment_information = new Payment_Information( self::PAYMENT_METHOD, $this->token );
+		$payment_information = new Payment_Information( self::PAYMENT_METHOD, null, $this->token );
 		$this->assertTrue( $payment_information->is_using_saved_payment_method() );
 	}
 
@@ -126,6 +126,7 @@ class Payment_Information_Test extends WP_UnitTestCase {
 				self::PAYMENT_METHOD_REQUEST_KEY => self::PAYMENT_METHOD,
 				self::TOKEN_REQUEST_KEY          => $this->token->get_id(),
 			],
+			null,
 			true
 		);
 		$this->assertEquals( self::TOKEN, $payment_information->get_payment_method() );

--- a/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -206,8 +206,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->method( 'empty_cart' );
 
 		// Act: process a successful payment.
-		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$result              = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order, $mock_cart, $payment_information, false );
+		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST, $mock_order ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$result              = $this->mock_wcpay_gateway->process_payment_for_order( $mock_cart, $payment_information );
 
 		// Assert: Returning correct array.
 		$this->assertEquals( 'success', $result['result'] );
@@ -309,8 +309,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->method( 'empty_cart' );
 
 		// Act: process payment.
-		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$result              = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order, $mock_cart, $payment_information, true );
+		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST, $mock_order, false, true ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$result              = $this->mock_wcpay_gateway->process_payment_for_order( $mock_cart, $payment_information );
 
 		// Assert: Returning correct array.
 		$this->assertEquals( 'success', $result['result'] );
@@ -465,8 +465,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->method( 'empty_cart' );
 
 		// Act: process payment.
-		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$result              = $this->mock_wcpay_gateway->process_payment_for_order( $mock_order, $mock_cart, $payment_information, true );
+		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST, $mock_order ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$result              = $this->mock_wcpay_gateway->process_payment_for_order( $mock_cart, $payment_information );
 
 		// Assert: Returning correct array.
 		$this->assertEquals( 'success', $result['result'] );


### PR DESCRIPTION
Fixes #862 
Fixes #863

#### Changes proposed in this Pull Request

Added the order object and the "manual capture" setting to the Payment_Information class. It makes the `Payment_Information::from_request()` signature to have 2 more parameters (because those parameters can't be derived from the `$_POST` array), but I think it's still preferred.

The alternative would be to keep the `from_request()` method and constructor as-is, and instead have setters for the order and the manual capture setting, but I think it's better to avoid that and keep the Payment_Information object as immutable as possible once it's initialized.

I fixed some tests that broke with this change but I didn't add new ones, since the only changes made to the `Payment_Information` class was to add 2 trivial `get_*` methods.