### PR TITLE
Docker Env: Removing the recursive `docker` directory from the plugin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ docker/data
 docker/wordpress
 docker/logs
 
+# Tunneling scripts
+/docker/bin/jt
+
 # Test coverage report
 /coverage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,9 @@
 version: '3'
 
+volumes:
+  ## Kludge for not having the ./docker directory bound recursively
+  dockerdirectory:
+
 services:
   wordpress:
     build: ./docker/wordpress_xdebug
@@ -19,6 +23,8 @@ services:
       - ./docker/logs/apache2/:/var/log/apache2
       - .:/var/www/html/wp-content/plugins/woocommerce-payments
       - ./docker/wc-payments-php.ini:/usr/local/etc/php/conf.d/wc-payments-php.ini
+      - dockerdirectory:/var/www/html/wp-content/plugins/woocommerce-payments/docker
+      - ./docker/bin:/var/scripts
   db:
     container_name: woocommerce_payments_mysql
     image: mysql:5.7


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The whole dev environment is available in the plugin directory: `/var/www/html/wp-content/plugins/woocommerce-payments/docker`.

This commit creates an empty volume and assigns it to the `woocommerce-payments/docker/` directory to make it empty inside the container.
It also creates another volume for `docker/bin`, which points to `/var/scripts` and is not accessible through the web.

The main goal of the commit is to create a directory to safely store the tunneling keys.

#### Testing instructions
1. Run `docker-compose up -d` to rebuild the wordpress container.
2. Make sure that the `docker` directory is empty in the plugin dir:
```shell
docker-compose exec wordpress ls -la /var/www/html/wp-content/plugins/woocommerce-payments/docker
```
