### PR TITLE
Try: decouple test and live mode customers

### DIFF
--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -147,7 +147,9 @@ class WC_Payments_Customer_Service {
 	 * @param string $customer_id The customer ID.
 	 * @param string $type        Type of payment methods to fetch.
 	 *
-	 * @throws WC_Payments_API_Exception We only handle 'resource_missing' code types and rethrow anything else.
+	 * @return array Customer's payment methods.
+	 *
+	 * @throws WC_Payments_API_Exception When API request fails.
 	 */
 	public function get_payment_methods_for_customer( $customer_id, $type = 'card' ) {
 		if ( ! $customer_id ) {
@@ -160,21 +162,11 @@ class WC_Payments_Customer_Service {
 			return $payment_methods;
 		}
 
-		try {
-			$payment_methods = $this->payments_api_client->get_payment_methods( $customer_id, $type )['data'];
-			set_transient( self::PAYMENT_METHODS_TRANSIENT . $customer_id, $payment_methods, DAY_IN_SECONDS );
-			return $payment_methods;
+		$payment_methods = $this->payments_api_client->get_payment_methods( $customer_id, $type )['data'];
 
-		} catch ( WC_Payments_API_Exception $e ) {
-			// If we failed to find the we can simply return empty payment methods as this customer will
-			// be recreated when the user succesfuly adds a payment method.
-			if ( $e->get_error_code() === 'resource_missing' ) {
-				return [];
-			}
+		set_transient( self::PAYMENT_METHODS_TRANSIENT . $customer_id, $payment_methods, DAY_IN_SECONDS );
 
-			// Rethrow for error codes we don't care about in this function.
-			throw $e;
-		}
+		return $payment_methods;
 	}
 
 	/**

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -14,8 +14,9 @@ defined( 'ABSPATH' ) || exit;
  */
 class WC_Payments_Customer_Service {
 
-	const WCPAY_CUSTOMER_ID_OPTION  = '_wcpay_customer_id';
-	const PAYMENT_METHODS_TRANSIENT = 'wcpay_payment_methods_';
+	const WCPAY_LIVE_CUSTOMER_ID_OPTION = '_wcpay_customer_id_live';
+	const WCPAY_TEST_CUSTOMER_ID_OPTION = '_wcpay_customer_id_test';
+	const PAYMENT_METHODS_TRANSIENT     = 'wcpay_payment_methods_';
 
 	/**
 	 * Client for making requests to the WooCommerce Payments API
@@ -267,7 +268,7 @@ class WC_Payments_Customer_Service {
 	private function get_customer_id_option( $test_mode = null ) {
 		$test_mode = $test_mode ?? WC_Payments::get_gateway()->is_in_test_mode();
 		return $test_mode
-			? self::WCPAY_CUSTOMER_ID_OPTION . '_test'
-			: self::WCPAY_CUSTOMER_ID_OPTION;
+			? self::WCPAY_TEST_CUSTOMER_ID_OPTION
+			: self::WCPAY_LIVE_CUSTOMER_ID_OPTION;
 	}
 }

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -46,7 +46,7 @@ class WC_Payments_Customer_Service {
 			return null;
 		}
 
-		$customer_id = get_user_option( self::WCPAY_CUSTOMER_ID_OPTION, $user_id );
+		$customer_id = get_user_option( $this->get_customer_id_option(), $user_id );
 		if ( false === $customer_id ) {
 			return null;
 		}
@@ -72,7 +72,7 @@ class WC_Payments_Customer_Service {
 		$customer_id = $this->payments_api_client->create_customer( $name, $email, $description );
 
 		if ( $user->ID > 0 ) {
-			$result = update_user_option( $user->ID, self::WCPAY_CUSTOMER_ID_OPTION, $customer_id );
+			$result = update_user_option( $user->ID, $this->get_customer_id_option(), $customer_id );
 			if ( ! $result ) {
 				// Log the error, but continue since we have the customer ID we need.
 				Logger::error( 'Failed to store new customer ID for user ' . $user->ID );
@@ -239,7 +239,7 @@ class WC_Payments_Customer_Service {
 	 */
 	private function recreate_customer( $user, $name, $email ) {
 		if ( $user->ID > 0 ) {
-			$result = delete_user_option( $user->ID, self::WCPAY_CUSTOMER_ID_OPTION );
+			$result = delete_user_option( $user->ID, $this->get_customer_id_option() );
 			if ( ! $result ) {
 				// Log the error, but continue since we'll be trying to update this option in create_customer.
 				Logger::error( 'Failed to delete old customer ID for user ' . $user->ID );
@@ -247,5 +247,12 @@ class WC_Payments_Customer_Service {
 		}
 
 		return $this->create_customer_for_user( $user, $name, $email );
+	}
+
+	/**
+	 * Returns the name of the customer option meta, taking test mode into account.
+	 */
+	private function get_customer_id_option() {
+		return self::WCPAY_CUSTOMER_ID_OPTION . ( WC_Payments::get_gateway()->is_in_test_mode() ? '_test' : '' );
 	}
 }

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -125,6 +125,24 @@ class WC_Payments_Customer_Service {
 	}
 
 	/**
+	 * Modifies the customer live/test mode value for $test_mode.
+	 *
+	 * @param int     $user_id     User ID.
+	 * @param string  $customer_id Customer ID.
+	 * @param boolean $test_mode   Test mode flag to change customer to.
+	 */
+	public function change_customer_mode( $user_id, $customer_id, $test_mode ) {
+		$new_option = $this->get_customer_id_option( $test_mode );
+		$old_option = $this->get_customer_id_option( ! $test_mode );
+
+		update_user_option( $user_id, $new_option, $customer_id );
+
+		if ( get_user_option( $old_option, $user_id ) === $customer_id ) {
+			delete_user_option( $user_id, $old_option );
+		}
+	}
+
+	/**
 	 * Sets a payment method as default for a customer.
 	 *
 	 * @param string $customer_id       The customer ID.
@@ -243,9 +261,12 @@ class WC_Payments_Customer_Service {
 
 	/**
 	 * Returns the name of the customer option meta, taking test mode into account.
+	 *
+	 * @param boolean $test_mode Test mode to be used in the option. Defaults to current gateway mode.
 	 */
-	private function get_customer_id_option() {
-		return WC_Payments::get_gateway()->is_in_test_mode()
+	private function get_customer_id_option( $test_mode = null ) {
+		$test_mode = $test_mode ?? WC_Payments::get_gateway()->is_in_test_mode();
+		return $test_mode
 			? self::WCPAY_CUSTOMER_ID_OPTION . '_test'
 			: self::WCPAY_CUSTOMER_ID_OPTION;
 	}

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -253,6 +253,8 @@ class WC_Payments_Customer_Service {
 	 * Returns the name of the customer option meta, taking test mode into account.
 	 */
 	private function get_customer_id_option() {
-		return self::WCPAY_CUSTOMER_ID_OPTION . ( WC_Payments::get_gateway()->is_in_test_mode() ? '_test' : '' );
+		return WC_Payments::get_gateway()->is_in_test_mode()
+			? self::WCPAY_CUSTOMER_ID_OPTION . '_test'
+			: self::WCPAY_CUSTOMER_ID_OPTION;
 	}
 }

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -89,7 +89,7 @@ class WC_Payments_Token_Service {
 	}
 
 	/**
-	 * Gets saved tokens from API if they don't already exist in WooCommerce.
+	 * Filters tokens based on customer ID and imports saved tokens from API if they don't already exist in WooCommerce.
 	 *
 	 * @param array  $tokens     Array of tokens.
 	 * @param string $user_id    WC user ID.
@@ -103,6 +103,7 @@ class WC_Payments_Token_Service {
 
 		$customer_id = $this->customer_service->get_customer_id_by_user_id( $user_id );
 
+		$tokens = $this->remove_unavailable_tokens( $tokens, $customer_id );
 		$tokens = $this->import_customer_tokens( $tokens, $customer_id, $user_id );
 
 		return $tokens;
@@ -175,5 +176,22 @@ class WC_Payments_Token_Service {
 		}
 
 		return $tokens;
+	}
+
+	/**
+	 * Clears unavailable tokens from the token list.
+	 *
+	 * @param array  $tokens      Token list.
+	 * @param string $customer_id Customer ID.
+	 *
+	 * @return array Token list with tokens for $customer_id.
+	 */
+	private function remove_unavailable_tokens( $tokens, $customer_id ) {
+		return array_filter(
+			$tokens,
+			function ( $token ) use ( $customer_id ) {
+				return $token->get_meta( self::CUSTOMER_ID_META_KEY ) === $customer_id;
+			}
+		);
 	}
 }

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -18,6 +18,7 @@ use WCPay\Logger;
 class WC_Payments_Token_Service {
 
 	const CUSTOMER_ID_META_KEY = '_wcpay_customer_id';
+	const TEST_MODE_META_KEY   = '_wcpay_test_mode';
 
 	/**
 	 * Client for making requests to the WooCommerce Payments API
@@ -70,6 +71,10 @@ class WC_Payments_Token_Service {
 		$token->add_meta_data(
 			self::CUSTOMER_ID_META_KEY,
 			$this->customer_service->get_customer_id_by_user_id( $user->ID )
+		);
+		$token->add_meta_data(
+			self::TEST_MODE_META_KEY,
+			WC_Payments::get_gateway()->is_in_test_mode()
 		);
 		$token->save();
 

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -225,7 +225,7 @@ class WC_Payments_Token_Service {
 			$tokens,
 			function ( $token ) use ( $customer_id ) {
 				return $token->get_meta( self::CUSTOMER_ID_META_KEY ) === $customer_id &&
-					$token->get_meta( self::TEST_MODE_META_KEY ) === WC_Payments::get_gateway()->is_in_test_mode();
+					$token->get_meta( self::TEST_MODE_META_KEY ) === strval( WC_Payments::get_gateway()->is_in_test_mode() );
 			}
 		);
 	}
@@ -245,7 +245,11 @@ class WC_Payments_Token_Service {
 		foreach ( $tokens as $token ) {
 			if (
 				! $token->meta_exists( self::CUSTOMER_ID_META_KEY ) ||
-				$token->get_meta( self::CUSTOMER_ID_META_KEY ) === $customer_id
+				(
+					$token->meta_exists( self::TEST_MODE_META_KEY ) &&
+					$token->get_meta( self::CUSTOMER_ID_META_KEY ) === $customer_id &&
+					$token->get_meta( self::TEST_MODE_META_KEY ) !== strval( $test_mode )
+				)
 			) {
 				$token->update_meta_data(
 					self::CUSTOMER_ID_META_KEY,

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -74,7 +74,7 @@ class WC_Payments_Token_Service {
 		);
 		$token->add_meta_data(
 			self::TEST_MODE_META_KEY,
-			WC_Payments::get_gateway()->is_in_test_mode()
+			strval( WC_Payments::get_gateway()->is_in_test_mode() )
 		);
 		$token->save();
 
@@ -258,7 +258,7 @@ class WC_Payments_Token_Service {
 
 				$token->update_meta_data(
 					self::TEST_MODE_META_KEY,
-					$test_mode
+					strval( $test_mode )
 				);
 
 				$token->save();

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -17,6 +17,8 @@ use WCPay\Logger;
  */
 class WC_Payments_Token_Service {
 
+	const CUSTOMER_ID_META_KEY = '_wcpay_customer_id';
+
 	/**
 	 * Client for making requests to the WooCommerce Payments API
 	 *
@@ -65,6 +67,10 @@ class WC_Payments_Token_Service {
 		$token->set_expiry_month( $payment_method['card']['exp_month'] );
 		$token->set_expiry_year( $payment_method['card']['exp_year'] );
 		$token->set_user_id( $user->ID );
+		$token->add_meta_data(
+			self::CUSTOMER_ID_META_KEY,
+			$this->customer_service->get_customer_id_by_user_id( $user->ID )
+		);
 		$token->save();
 
 		return $token;

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -108,12 +108,14 @@ class WC_Payments_Token_Service {
 
 		$customer_id = $this->customer_service->get_customer_id_by_user_id( $user_id );
 
-		$tokens = $this->migrate_existing_tokens( $tokens, $customer_id, WC_Payments::get_gateway()->is_in_test_mode() );
-		$tokens = $this->import_customer_tokens( $tokens, $customer_id, $user_id );
+		if ( ! is_null( $customer_id ) ) {
+			$tokens = $this->migrate_existing_tokens( $tokens, $customer_id, WC_Payments::get_gateway()->is_in_test_mode() );
+			$tokens = $this->import_customer_tokens( $tokens, $customer_id, $user_id );
 
-		// import_customer_tokens might change the customer ID if it doesn't match
-		// current test mode, so we need to update it.
-		$customer_id = $this->customer_service->get_customer_id_by_user_id( $user_id );
+			// import_customer_tokens might change the customer ID if it doesn't match
+			// current test mode, so we need to update it.
+			$customer_id = $this->customer_service->get_customer_id_by_user_id( $user_id );
+		}
 
 		$tokens = $this->remove_unavailable_tokens( $tokens, $customer_id );
 

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -108,6 +108,7 @@ class WC_Payments_Token_Service {
 
 		$customer_id = $this->customer_service->get_customer_id_by_user_id( $user_id );
 
+		$tokens = $this->migrate_existing_tokens( $tokens, $customer_id, WC_Payments::get_gateway()->is_in_test_mode() );
 		$tokens = $this->remove_unavailable_tokens( $tokens, $customer_id );
 		$tokens = $this->import_customer_tokens( $tokens, $customer_id, $user_id );
 
@@ -198,5 +199,38 @@ class WC_Payments_Token_Service {
 				return $token->get_meta( self::CUSTOMER_ID_META_KEY ) === $customer_id;
 			}
 		);
+	}
+
+	/**
+	 * Adds customer and test_mode to tokens that have none.
+	 * This takes an optimistic approach based on the customer ID and current
+	 * test mode flag.
+	 *
+	 * @param array   $tokens      Token list.
+	 * @param string  $customer_id Customer ID.
+	 * @param boolean $test_mode   Customer test mode flag.
+	 *
+	 * @return array Token list with tokens for $customer_id.
+	 */
+	private function migrate_existing_tokens( $tokens, $customer_id, $test_mode ) {
+		foreach ( $tokens as $token ) {
+			if (
+				! $token->meta_exists( self::CUSTOMER_ID_META_KEY ) ||
+				$token->get_meta( self::CUSTOMER_ID_META_KEY ) === $customer_id
+			) {
+				$token->update_meta_data(
+					self::CUSTOMER_ID_META_KEY,
+					$customer_id
+				);
+
+				$token->update_meta_data(
+					self::TEST_MODE_META_KEY,
+					$test_mode
+				);
+
+				$token->save();
+			}
+		}
+		return $tokens;
 	}
 }

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -209,7 +209,8 @@ class WC_Payments_Token_Service {
 		return array_filter(
 			$tokens,
 			function ( $token ) use ( $customer_id ) {
-				return $token->get_meta( self::CUSTOMER_ID_META_KEY ) === $customer_id;
+				return $token->get_meta( self::CUSTOMER_ID_META_KEY ) === $customer_id &&
+					$token->get_meta( self::TEST_MODE_META_KEY ) === WC_Payments::get_gateway()->is_in_test_mode();
 			}
 		);
 	}

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -181,7 +181,7 @@ class WC_Payments_Token_Service {
 			if ( 'resource_missing' === $e->get_error_code() ) {
 				// However, if we can find the customer in a different mode (based on the exception
 				// message) we need to migrate it to the new meta, along with their tokens.
-				if ( $this->customer_exists_in_other_mode( $e ) ) {
+				if ( $this->payments_api_client->customer_exists_in_other_mode( $e ) ) {
 					$actual_user_mode = ! WC_Payments::get_gateway()->is_in_test_mode();
 					$this->customer_service->change_customer_mode( $user_id, $customer_id, $actual_user_mode );
 					$this->migrate_existing_tokens( $tokens, $customer_id, $actual_user_mode );
@@ -265,17 +265,5 @@ class WC_Payments_Token_Service {
 			}
 		}
 		return $tokens;
-	}
-
-	/**
-	 * Check exception for customer in wrong mode message.
-	 *
-	 * @param WC_Payments_API_Exception $e The WCPay API exception.
-	 *
-	 * @return boolean Whether customer was searched in wrong mode.
-	 */
-	private function customer_exists_in_other_mode( $e ) {
-		$regex = '/No such customer: \'cus\_.*\'; a similar object exists in (test|live) mode, but a (test|live) mode key .*/';
-		return preg_match( $regex, $e->getMessage() );
 	}
 }

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -816,6 +816,19 @@ class WC_Payments_API_Client {
 		);
 	}
 
+
+	/**
+	 * Check exception for customer in wrong mode message.
+	 *
+	 * @param WC_Payments_API_Exception $e The WCPay API exception.
+	 *
+	 * @return boolean Whether customer was searched in wrong mode.
+	 */
+	public function customer_exists_in_other_mode( $e ) {
+		$regex = '/No such customer: \'cus\_.*\'; a similar object exists in (test|live) mode, but a (test|live) mode key .*/';
+		return 'resource_missing' === $e->get_error_code() && 1 === preg_match( $regex, $e->getMessage() );
+	}
+
 	/**
 	 * Send the request to the WooCommerce Payment API
 	 *

--- a/tests/test-class-wc-payments-customer-service.php
+++ b/tests/test-class-wc-payments-customer-service.php
@@ -366,19 +366,4 @@ class WC_Payments_Customer_Service_Test extends WP_UnitTestCase {
 
 		$this->customer_service->update_payment_method_with_billing_details_from_order( 'pm_mock', $order );
 	}
-
-	public function test_get_payment_methods_for_customer_not_throw_resource_missing_code_exception() {
-		$this->mock_api_client->expects( $this->once() )
-			->method( 'get_payment_methods' )
-			->with( 'cus_test12345' )
-			->willThrowException( new WC_Payments_API_Exception( 'Error Message', 'resource_missing', 400 ) );
-
-		try {
-			$methods = $this->customer_service->get_payment_methods_for_customer( 'cus_test12345' );
-			// We return an empty array as the exception was handled in the function and not bubbled up.
-			$this->assertEquals( $methods, [] );
-		} catch ( WC_Payments_API_Exception $e ) {
-			$this->fail( 'customer_service->get_payment_methods_for_customer not handling the resource_missing code of WC_Payments_API_Exception.' );
-		}
-	}
 }

--- a/tests/test-class-wc-payments-customer-service.php
+++ b/tests/test-class-wc-payments-customer-service.php
@@ -115,6 +115,7 @@ class WC_Payments_Customer_Service_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'cus_test12345', $customer_id );
 		$this->assertEquals( 'cus_test12345', get_user_option( '_wcpay_customer_id', $user->ID ) );
+		$this->assertEquals( false, get_user_option( '_wcpay_customer_id_test', $user->ID ) );
 	}
 
 	/**
@@ -136,6 +137,7 @@ class WC_Payments_Customer_Service_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'cus_test12345', $customer_id );
 		$this->assertEquals( 'cus_test12345', get_user_option( '_wcpay_customer_id_test', $user->ID ) );
+		$this->assertEquals( false, get_user_option( '_wcpay_customer_id', $user->ID ) );
 	}
 
 	/**

--- a/tests/test-class-wc-payments-customer-service.php
+++ b/tests/test-class-wc-payments-customer-service.php
@@ -281,6 +281,24 @@ class WC_Payments_Customer_Service_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_change_customer_mode_to_test() {
+		update_user_option( 1, '_wcpay_customer_id', 'cus_12345' );
+
+		$this->customer_service->change_customer_mode( 1, 'cus_12345', true );
+
+		$this->assertEquals( 'cus_12345', get_user_option( '_wcpay_customer_id_test', 1 ) );
+		$this->assertEquals( false, get_user_option( '_wcpay_customer_id', 1 ) );
+	}
+
+	public function test_change_customer_mode_to_live() {
+		update_user_option( 1, '_wcpay_customer_id_test', 'cus_12345' );
+
+		$this->customer_service->change_customer_mode( 1, 'cus_12345', false );
+
+		$this->assertEquals( 'cus_12345', get_user_option( '_wcpay_customer_id', 1 ) );
+		$this->assertEquals( false, get_user_option( '_wcpay_customer_id_test', 1 ) );
+	}
+
 	public function test_set_default_payment_method_for_customer() {
 		$this->mock_api_client
 			->expects( $this->once() )

--- a/tests/test-class-wc-payments-customer-service.php
+++ b/tests/test-class-wc-payments-customer-service.php
@@ -74,6 +74,29 @@ class WC_Payments_Customer_Service_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'cus_test12345', $customer_id );
 	}
 
+	public function test_get_customer_id_by_user_id_migrates_deprecated_meta() {
+		update_user_option( 1, '_wcpay_customer_id', 'cus_12345' );
+
+		$customer_id = $this->customer_service->get_customer_id_by_user_id( 1 );
+
+		$this->assertEquals( 'cus_12345', $customer_id );
+		$this->assertEquals( 'cus_12345', get_user_option( self::CUSTOMER_LIVE_META_KEY, 1 ) );
+		$this->assertFalse( get_user_option( self::CUSTOMER_TEST_META_KEY, 1 ) );
+		$this->assertFalse( get_user_option( '_wcpay_customer_id', 1 ) );
+	}
+
+	public function test_get_customer_id_by_user_id_migrates_deprecated_meta_test_mode() {
+		WC_Payments::get_gateway()->update_option( 'test_mode', 'yes' );
+		update_user_option( 1, '_wcpay_customer_id', 'cus_12345' );
+
+		$customer_id = $this->customer_service->get_customer_id_by_user_id( 1 );
+
+		$this->assertEquals( 'cus_12345', $customer_id );
+		$this->assertFalse( get_user_option( self::CUSTOMER_LIVE_META_KEY, 1 ) );
+		$this->assertEquals( 'cus_12345', get_user_option( self::CUSTOMER_TEST_META_KEY, 1 ) );
+		$this->assertFalse( get_user_option( '_wcpay_customer_id', 1 ) );
+	}
+
 	/**
 	 * Test get customer ID by user ID when no stored customer ID.
 	 */

--- a/tests/test-class-wc-payments-customer-service.php
+++ b/tests/test-class-wc-payments-customer-service.php
@@ -12,6 +12,9 @@ use PHPUnit\Framework\MockObject\MockObject;
  */
 class WC_Payments_Customer_Service_Test extends WP_UnitTestCase {
 
+	const CUSTOMER_LIVE_META_KEY = '_wcpay_customer_id_live';
+	const CUSTOMER_TEST_META_KEY = '_wcpay_customer_id_test';
+
 	/**
 	 * System under test.
 	 *
@@ -41,8 +44,9 @@ class WC_Payments_Customer_Service_Test extends WP_UnitTestCase {
 	 * Post-test teardown
 	 */
 	public function tearDown() {
+		delete_user_option( 1, self::CUSTOMER_LIVE_META_KEY );
+		delete_user_option( 1, self::CUSTOMER_TEST_META_KEY );
 		delete_user_option( 1, '_wcpay_customer_id' );
-		delete_user_option( 1, '_wcpay_customer_id_test' );
 		WC_Payments::get_gateway()->update_option( 'test_mode', 'no' );
 		parent::tearDown();
 	}
@@ -51,7 +55,7 @@ class WC_Payments_Customer_Service_Test extends WP_UnitTestCase {
 	 * Test get customer ID by user ID for live mode.
 	 */
 	public function test_get_customer_id_by_user_id() {
-		update_user_option( 1, '_wcpay_customer_id', 'cus_test12345' );
+		update_user_option( 1, self::CUSTOMER_LIVE_META_KEY, 'cus_test12345' );
 
 		$customer_id = $this->customer_service->get_customer_id_by_user_id( 1 );
 
@@ -63,7 +67,7 @@ class WC_Payments_Customer_Service_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_customer_id_by_user_id_test_mode() {
 		WC_Payments::get_gateway()->update_option( 'test_mode', 'yes' );
-		update_user_option( 1, '_wcpay_customer_id_test', 'cus_test12345' );
+		update_user_option( 1, self::CUSTOMER_TEST_META_KEY, 'cus_test12345' );
 
 		$customer_id = $this->customer_service->get_customer_id_by_user_id( 1 );
 
@@ -114,8 +118,8 @@ class WC_Payments_Customer_Service_Test extends WP_UnitTestCase {
 		$customer_id = $this->customer_service->create_customer_for_user( $user, 'Test User', 'test.user@example.com' );
 
 		$this->assertEquals( 'cus_test12345', $customer_id );
-		$this->assertEquals( 'cus_test12345', get_user_option( '_wcpay_customer_id', $user->ID ) );
-		$this->assertEquals( false, get_user_option( '_wcpay_customer_id_test', $user->ID ) );
+		$this->assertEquals( 'cus_test12345', get_user_option( self::CUSTOMER_LIVE_META_KEY, $user->ID ) );
+		$this->assertEquals( false, get_user_option( self::CUSTOMER_TEST_META_KEY, $user->ID ) );
 	}
 
 	/**
@@ -136,8 +140,8 @@ class WC_Payments_Customer_Service_Test extends WP_UnitTestCase {
 		$customer_id = $this->customer_service->create_customer_for_user( $user, 'Test User', 'test.user@example.com' );
 
 		$this->assertEquals( 'cus_test12345', $customer_id );
-		$this->assertEquals( 'cus_test12345', get_user_option( '_wcpay_customer_id_test', $user->ID ) );
-		$this->assertEquals( false, get_user_option( '_wcpay_customer_id', $user->ID ) );
+		$this->assertEquals( 'cus_test12345', get_user_option( self::CUSTOMER_TEST_META_KEY, $user->ID ) );
+		$this->assertEquals( false, get_user_option( self::CUSTOMER_LIVE_META_KEY, $user->ID ) );
 	}
 
 	/**
@@ -205,7 +209,7 @@ class WC_Payments_Customer_Service_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals( 'cus_test67890', $customer_id );
-		$this->assertEquals( 'cus_test67890', get_user_option( '_wcpay_customer_id', $user->ID ) );
+		$this->assertEquals( 'cus_test67890', get_user_option( self::CUSTOMER_LIVE_META_KEY, $user->ID ) );
 	}
 
 	/**
@@ -245,7 +249,7 @@ class WC_Payments_Customer_Service_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals( 'cus_test67890', $customer_id );
-		$this->assertEquals( 'cus_test67890', get_user_option( '_wcpay_customer_id_test', $user->ID ) );
+		$this->assertEquals( 'cus_test67890', get_user_option( self::CUSTOMER_TEST_META_KEY, $user->ID ) );
 	}
 
 	/**
@@ -282,21 +286,21 @@ class WC_Payments_Customer_Service_Test extends WP_UnitTestCase {
 	}
 
 	public function test_change_customer_mode_to_test() {
-		update_user_option( 1, '_wcpay_customer_id', 'cus_12345' );
+		update_user_option( 1, self::CUSTOMER_LIVE_META_KEY, 'cus_12345' );
 
 		$this->customer_service->change_customer_mode( 1, 'cus_12345', true );
 
-		$this->assertEquals( 'cus_12345', get_user_option( '_wcpay_customer_id_test', 1 ) );
-		$this->assertEquals( false, get_user_option( '_wcpay_customer_id', 1 ) );
+		$this->assertEquals( 'cus_12345', get_user_option( self::CUSTOMER_TEST_META_KEY, 1 ) );
+		$this->assertEquals( false, get_user_option( self::CUSTOMER_LIVE_META_KEY, 1 ) );
 	}
 
 	public function test_change_customer_mode_to_live() {
-		update_user_option( 1, '_wcpay_customer_id_test', 'cus_12345' );
+		update_user_option( 1, self::CUSTOMER_TEST_META_KEY, 'cus_12345' );
 
 		$this->customer_service->change_customer_mode( 1, 'cus_12345', false );
 
-		$this->assertEquals( 'cus_12345', get_user_option( '_wcpay_customer_id', 1 ) );
-		$this->assertEquals( false, get_user_option( '_wcpay_customer_id_test', 1 ) );
+		$this->assertEquals( 'cus_12345', get_user_option( self::CUSTOMER_LIVE_META_KEY, 1 ) );
+		$this->assertEquals( false, get_user_option( self::CUSTOMER_TEST_META_KEY, 1 ) );
 	}
 
 	public function test_set_default_payment_method_for_customer() {

--- a/tests/test-class-wc-payments-token-service.php
+++ b/tests/test-class-wc-payments-token-service.php
@@ -76,6 +76,12 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 			],
 		];
 
+		$this->mock_customer_service
+			->expects( $this->atLeastOnce() )
+			->method( 'get_customer_id_by_user_id' )
+			->with( 1 )
+			->willReturn( 'cus_12345' );
+
 		$token = $this->token_service->add_token_to_user( $mock_payment_method, wp_get_current_user() );
 
 		$this->assertEquals( 'woocommerce_payments', $token->get_gateway_id() );
@@ -85,6 +91,7 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 		$this->assertEquals( '4242', $token->get_last4() );
 		$this->assertEquals( '06', $token->get_expiry_month() );
 		$this->assertEquals( $expiry_year, $token->get_expiry_year() );
+		$this->assertEquals( 'cus_12345', $token->get_meta( '_wcpay_customer_id' ) );
 	}
 
 	public function test_add_payment_method_to_user() {

--- a/tests/test-class-wc-payments-token-service.php
+++ b/tests/test-class-wc-payments-token-service.php
@@ -319,15 +319,16 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 	}
 
 	public function test_woocommerce_get_customer_payment_tokens_no_customer() {
-		$token = WC_Helper_Token::create_token( 'pm_mock0' );
-		$token->add_meta_data( '_wcpay_customer_id', 'cus_12345' );
+		$token1 = WC_Helper_Token::create_token( 'pm_mock0' );
+		$token1->add_meta_data( '_wcpay_customer_id', 'cus_12345' );
+		$token2 = WC_Helper_Token::create_token( 'pm_mock0' );
 
 		$this->mock_customer_service
-			->expects( $this->exactly( 2 ) )
+			->expects( $this->once() )
 			->method( 'get_customer_id_by_user_id' )
 			->willReturn( null );
 
-		$result = $this->token_service->woocommerce_get_customer_payment_tokens( [ $token ], 1, 'woocommerce_payments' );
+		$result = $this->token_service->woocommerce_get_customer_payment_tokens( [ $token1, $token2 ], 1, 'woocommerce_payments' );
 		$this->assertCount( 0, $result );
 	}
 

--- a/tests/test-class-wc-payments-token-service.php
+++ b/tests/test-class-wc-payments-token-service.php
@@ -248,7 +248,10 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 
 		$token1->add_meta_data( '_wcpay_customer_id', 'cus_12345' );
 		$token2->add_meta_data( '_wcpay_customer_id', 'cus_12345' );
+		$token1->add_meta_data( '_wcpay_test_mode', false );
+		$token2->add_meta_data( '_wcpay_test_mode', false );
 		$unavailable_token->add_meta_data( '_wcpay_customer_id', 'cus_67890' );
+		$unavailable_token->add_meta_data( '_wcpay_test_mode', false );
 
 		$tokens = [
 			$token1,
@@ -277,6 +280,7 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 	public function test_woocommerce_get_customer_payment_tokens_imports_tokens() {
 		$token = WC_Helper_Token::create_token( 'pm_mock0' );
 		$token->add_meta_data( '_wcpay_customer_id', 'cus_12345' );
+		$token->add_meta_data( '_wcpay_test_mode', false );
 
 		$tokens = [ $token ];
 

--- a/tests/test-class-wc-payments-token-service.php
+++ b/tests/test-class-wc-payments-token-service.php
@@ -64,8 +64,12 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 
 	/**
 	 * Test add token to user.
+	 *
+	 * @dataProvider gateway_test_mode_provider
 	 */
-	public function test_add_token_to_user() {
+	public function test_add_token_to_user( $current_test_mode ) {
+		WC_Payments::get_gateway()->update_option( 'test_mode', $current_test_mode ? 'yes' : 'no' );
+
 		$expiry_year         = intval( gmdate( 'Y' ) ) + 1;
 		$mock_payment_method = [
 			'id'   => 'pm_mock',
@@ -93,42 +97,7 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 		$this->assertEquals( '06', $token->get_expiry_month() );
 		$this->assertEquals( $expiry_year, $token->get_expiry_year() );
 		$this->assertEquals( 'cus_12345', $token->get_meta( '_wcpay_customer_id' ) );
-		$this->assertEquals( false, $token->get_meta( '_wcpay_test_mode' ) );
-	}
-
-	/**
-	 * Test add token to user.
-	 */
-	public function test_add_token_to_user_test_mode() {
-		WC_Payments::get_gateway()->update_option( 'test_mode', 'yes' );
-		$expiry_year         = intval( gmdate( 'Y' ) ) + 1;
-		$mock_payment_method = [
-			'id'   => 'pm_mock',
-			'card' => [
-				'brand'     => 'visa',
-				'last4'     => '4242',
-				'exp_month' => 6,
-				'exp_year'  => $expiry_year,
-			],
-		];
-
-		$this->mock_customer_service
-			->expects( $this->atLeastOnce() )
-			->method( 'get_customer_id_by_user_id' )
-			->with( 1 )
-			->willReturn( 'cus_12345' );
-
-		$token = $this->token_service->add_token_to_user( $mock_payment_method, wp_get_current_user() );
-
-		$this->assertEquals( 'woocommerce_payments', $token->get_gateway_id() );
-		$this->assertEquals( 1, $token->get_user_id() );
-		$this->assertEquals( 'pm_mock', $token->get_token() );
-		$this->assertEquals( 'visa', $token->get_card_type() );
-		$this->assertEquals( '4242', $token->get_last4() );
-		$this->assertEquals( '06', $token->get_expiry_month() );
-		$this->assertEquals( $expiry_year, $token->get_expiry_year() );
-		$this->assertEquals( 'cus_12345', $token->get_meta( '_wcpay_customer_id' ) );
-		$this->assertEquals( true, $token->get_meta( '_wcpay_test_mode' ) );
+		$this->assertEquals( $current_test_mode, $token->get_meta( '_wcpay_test_mode' ) );
 	}
 
 	public function test_add_payment_method_to_user() {

--- a/tests/test-class-wc-payments-token-service.php
+++ b/tests/test-class-wc-payments-token-service.php
@@ -426,14 +426,16 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 			->method( 'get_customer_id_by_user_id' )
 			->willReturn( 'cus_67890' );
 
-		$message = 'No such customer: \'cus_12345\'; a similar object exists in test mode, but a live mode key was used to make this request.';
 		$this->mock_customer_service
 			->expects( $this->once() )
 			->method( 'get_payment_methods_for_customer' )
 			->with( 'cus_12345' )
-			->willThrowException(
-				new WC_Payments_API_Exception( $message, 'resource_missing', 400 )
-			);
+			->willThrowException( new WC_Payments_API_Exception( 'Error message', 'resource_missing', 400 ) );
+
+		$this->mock_api_client
+			->expects( $this->atLeastOnce() )
+			->method( 'customer_exists_in_other_mode' )
+			->willReturn( true );
 
 		$this->mock_customer_service
 			->expects( $this->once() )

--- a/tests/test-class-wc-payments-token-service.php
+++ b/tests/test-class-wc-payments-token-service.php
@@ -204,10 +204,42 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 		$this->token_service->woocommerce_payment_token_set_default( 'pm_mock', $token );
 	}
 
-	public function test_woocommerce_get_customer_payment_tokens() {
-		$token = new WC_Payment_Token_CC();
-		$token->set_gateway_id( 'woocommerce_payments' );
-		$token->set_token( 'pm_mock0' );
+	public function test_woocommerce_get_customer_payment_tokens_removes_unavailable_tokens() {
+		$token1            = WC_Helper_Token::create_token( 'pm_mock0' );
+		$unavailable_token = WC_Helper_Token::create_token( 'pm_mock1' );
+		$token2            = WC_Helper_Token::create_token( 'pm_mock2' );
+
+		$token1->add_meta_data( '_wcpay_customer_id', 'cus_12345' );
+		$token2->add_meta_data( '_wcpay_customer_id', 'cus_12345' );
+		$unavailable_token->add_meta_data( '_wcpay_customer_id', 'cus_67890' );
+
+		$tokens = [
+			$token1,
+			$unavailable_token,
+			$token2,
+		];
+
+		$this->mock_customer_service
+			->expects( $this->any() )
+			->method( 'get_customer_id_by_user_id' )
+			->willReturn( 'cus_12345' );
+
+		$this->mock_customer_service
+			->expects( $this->once() )
+			->method( 'get_payment_methods_for_customer' )
+			->with( 'cus_12345' )
+			->willReturn( [] );
+
+		$result        = $this->token_service->woocommerce_get_customer_payment_tokens( $tokens, 1, 'woocommerce_payments' );
+		$result_tokens = array_values( $result );
+		$this->assertCount( 2, $result_tokens );
+		$this->assertEquals( 'pm_mock0', $result_tokens[0]->get_token() );
+		$this->assertEquals( 'pm_mock2', $result_tokens[1]->get_token() );
+	}
+
+	public function test_woocommerce_get_customer_payment_tokens_imports_tokens() {
+		$token = WC_Helper_Token::create_token( 'pm_mock0' );
+		$token->add_meta_data( '_wcpay_customer_id', 'cus_12345' );
 
 		$tokens = [ $token ];
 
@@ -247,6 +279,7 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 
 		$result        = $this->token_service->woocommerce_get_customer_payment_tokens( $tokens, 1, 'woocommerce_payments' );
 		$result_tokens = array_values( $result );
+		$this->assertCount( 3, $result_tokens );
 		$this->assertEquals( 'pm_mock0', $result_tokens[0]->get_token() );
 		$this->assertEquals( 'pm_mock1', $result_tokens[1]->get_token() );
 		$this->assertEquals( 'pm_mock2', $result_tokens[2]->get_token() );
@@ -276,12 +309,15 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 	}
 
 	public function test_woocommerce_get_customer_payment_tokens_no_customer() {
+		$token = WC_Helper_Token::create_token( 'pm_mock0' );
+		$token->add_meta_data( '_wcpay_customer_id', 'cus_12345' );
+
 		$this->mock_customer_service
 			->expects( $this->once() )
 			->method( 'get_customer_id_by_user_id' )
 			->willReturn( null );
 
-		$result = $this->token_service->woocommerce_get_customer_payment_tokens( [ new WC_Payment_Token_CC() ], 1, 'woocommerce_payments' );
-		$this->assertEquals( [ new WC_Payment_Token_CC() ], $result );
+		$result = $this->token_service->woocommerce_get_customer_payment_tokens( [ $token ], 1, 'woocommerce_payments' );
+		$this->assertCount( 0, $result );
 	}
 }

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -420,6 +420,24 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 		$this->payments_api_client->update_customer( ' ' );
 	}
 
+	public function test_customer_exists_in_other_mode_right_code_and_message() {
+		$message   = 'No such customer: \'cus_12345\'; a similar object exists in test mode, but a live mode key was used to make this request.';
+		$exception = new WC_Payments_API_Exception( $message, 'resource_missing', 400 );
+		$this->assertTrue( $this->payments_api_client->customer_exists_in_other_mode( $exception ) );
+	}
+
+	public function test_customer_exists_in_other_mode_wrong_message() {
+		$message   = 'No such customer: \'cus_12345\'.';
+		$exception = new WC_Payments_API_Exception( $message, 'resource_missing', 400 );
+		$this->assertFalse( $this->payments_api_client->customer_exists_in_other_mode( $exception ) );
+	}
+
+	public function test_customer_exists_in_other_mode_wrong_error_code() {
+		$message   = 'No such customer: \'cus_12345\'; a similar object exists in test mode, but a live mode key was used to make this request.';
+		$exception = new WC_Payments_API_Exception( $message, 'wrong_code', 400 );
+		$this->assertFalse( $this->payments_api_client->customer_exists_in_other_mode( $exception ) );
+	}
+
 	/**
 	 * Set up http mock response.
 	 *


### PR DESCRIPTION
Fixes #

This PR is an attempt at validating and fixing the concerns raised in https://github.com/Automattic/woocommerce-payments/pull/899#discussion_r490269452. 

New customers and payment methods are created in the correct metadata according to the current test mode setting. The payment methods displayed in the checkout are filtered to match the customer and test mode setting, preventing customers from using unavailable payment methods.

For older customers, this PR attempts to add the customer present in the old `wcpay_customer_id` metadata to `wcpay_customer_id_test` or `wcpay_customer_id_live` based on the current test mode setting. While that works for most cases, it is possible that a customer was created in another mode and shoppers would get an error.

To prevent and fix that, we catch the `resource_missing` exception and move the customer to the right mode if the error message indicates that the customer exists in the other mode.

#### Changes proposed in this Pull Request

* Decouple test and live customers into two separate meta keys
* Filter a user's tokens based on the `customer_id` and `test_mode`
* Migrate old customers to the new meta keys
* Check for customers saved in the wrong environment when fetching their payment methods
* Check for customers saved in the wrong environment when adding new cards from My account

<!--
- [x] Store test and live mode customer IDs in separate options
- [x] Add customer ID to token when creating it
- [x] Remove tokens from other customer IDs before displaying them
- [x] Add test mode information to tokens
- [x] ~Tweak customer creation logic to ensure a user always has a customer~
    * ~Perhaps create a customer in `get_customer_id_by_user_id` if there's no customer in the meta~
    * ~Continue to update the customer during checkout~
    * Will check to see how we do it on stripe: Stripe does it similarly to what we do now, so I don't think we should change it in this PR
- [x] Figure out a migration path for existing customers and tokens
    * ~We'd need to check in which mode (test or live) they were created, which could not match the current mode~
    * Or we could assume that they're live. It shouldn't be too bad to lose some test customers
        * By going that route we still need to figure out a way to migrate the payment methods created before this PR
- [ ] ~Take into account the mode in which a subscription was created when processing off-site payments~
    * ~If a subscription was set up in live mode, but the site is in test mode when the renewal happens, it could lead to issues charging the saved token~
    * This should be handled in another issue and PR
-->

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There are a few scenarios that need to be tested:
1. Test customer created on master and migrated with this PR on test mode 
2. Test customer created on master and migrated with this PR on live mode 
3. Live customer created on master and migrated with this PR on live mode 
4. Live customer created on master and migrated with this PR on test mode

For each scenario we should:

*If you don't want to make a purchase, just add a payment method using the My account page. It should be enough to create the customer and check if the payment methods are migrated successfully. Don't forget to at least add something to the cart and go to the checkout page to see the shopper's payment methods.*

1. Checkout `master`
2. Login with a WC User
2. Make a purchase or add a payment method
3. Switch to this branch
4. Apply the test mode change (if applicable) and go to the checkout page
5. Assert that it doesn't break when the current mode is different than the one in which the customer was created
6. Assert that the customer's payment methods are displayed correctly. They should only be displayed in the mode they were created
    - If the migration happens in the same mode as the customer creation, the customer and their tokens should be automatically imported
    - If the migration happens in a different mode, then the customer and their tokens should be migrated the right mode. Unless a user already has a `customer_id` in the current mode, no payment methods should be displayed
7. If live/test mode were switched, make another purchase or add a payment method
8. Once a single WC User has both a test and live customer, go to the checkout page in test and in live modes
9. Assert that the cards displayed on checkout are the ones for the current mode

**To test the add cards from My account fix, don't load the checkout page before adding a new card, as that would trigger the migration**

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
