### PR TITLE
Fix saving account statement descriptor with special chars

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - Save payment method checkbox for Subscriptions customer-initiated payment method updates.
 * Fix - Support checkout on Internet Explorer 11.
 * Fix - Webhook processing with no Jetpack plugin installed.
+* Fix - Saving account statement descriptor with an ampersand character.
 * Add - Display payment method details on account subscriptions pages.
 * Add - Redact sensitive data before logging.
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -894,6 +894,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @throws Exception When statement descriptor is invalid.
 	 */
 	public function validate_account_statement_descriptor_field( $key, $value ) {
+		// Since the value is escaped, and we are saving in a place that does not require escaping, apply stripslashes.
+		$value = stripslashes( $value );
+
 		// Validation can be done with a single regex but splitting into multiple for better readability.
 		$valid_length   = '/^.{5,22}$/';
 		$has_one_letter = '/^.*[a-zA-Z]+/';
@@ -907,8 +910,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			throw new Exception( __( 'Customer bank statement is invalid. Statement should be between 5 and 22 characters long, contain at least single Latin character and does not contain special characters: \' " * &lt; &gt;', 'woocommerce-payments' ) );
 		}
 
-		// Perform text validation after own checks to prevent special characters like < > escaped before own validation.
-		return $this->validate_text_field( $key, $value );
+		return $value;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -94,6 +94,7 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 * Fix - Save payment method checkbox for Subscriptions customer-initiated payment method updates.
 * Fix - Support checkout on Internet Explorer 11.
 * Fix - Webhook processing with no Jetpack plugin installed.
+* Fix - Saving account statement descriptor with an ampersand character.
 * Add - Display payment method details on account subscriptions pages.
 * Add - Redact sensitive data before logging.
 

--- a/tests/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/test-class-wc-payment-gateway-wcpay.php
@@ -550,11 +550,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider account_statement_descriptor_validation_provider
 	 */
-	public function test_validate_account_statement_descriptor_field( $is_valid, $value ) {
+	public function test_validate_account_statement_descriptor_field( $is_valid, $value, $expected = null ) {
 		$key = 'account_statement_descriptor';
 		if ( $is_valid ) {
 			$validated_value = $this->wcpay_gateway->validate_account_statement_descriptor_field( $key, $value );
-			$this->assertNotEmpty( $validated_value );
+			$this->assertEquals( $expected ?? $value, $validated_value );
 		} else {
 			$this->expectExceptionMessage( 'Customer bank statement is invalid.' );
 			$this->wcpay_gateway->validate_account_statement_descriptor_field( $key, $value );
@@ -566,6 +566,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			'valid'         => [ true, 'WCPAY dev' ],
 			'allow_digits'  => [ true, 'WCPay dev 2020' ],
 			'allow_special' => [ true, 'WCPay-Dev_2020' ],
+			'allow_amp'     => [ true, 'WCPay&Dev_2020' ],
+			'strip_slashes' => [ true, 'WCPay\\\\Dev_2020', 'WCPay\\Dev_2020' ],
 			'empty'         => [ false, '' ],
 			'short'         => [ false, 'WCP' ],
 			'long'          => [ false, 'WCPay_dev_WCPay_dev_WCPay_dev_WCPay_dev' ],

--- a/tests/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/test-class-wc-payment-gateway-wcpay.php
@@ -563,21 +563,22 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 	public function account_statement_descriptor_validation_provider() {
 		return [
-			'valid'         => [ true, 'WCPAY dev' ],
-			'allow_digits'  => [ true, 'WCPay dev 2020' ],
-			'allow_special' => [ true, 'WCPay-Dev_2020' ],
-			'allow_amp'     => [ true, 'WCPay&Dev_2020' ],
-			'strip_slashes' => [ true, 'WCPay\\\\Dev_2020', 'WCPay\\Dev_2020' ],
-			'empty'         => [ false, '' ],
-			'short'         => [ false, 'WCP' ],
-			'long'          => [ false, 'WCPay_dev_WCPay_dev_WCPay_dev_WCPay_dev' ],
-			'no_*'          => [ false, 'WCPay * dev' ],
-			'no_sqt'        => [ false, 'WCPay \'dev\'' ],
-			'no_dqt'        => [ false, 'WCPay "dev"' ],
-			'no_lt'         => [ false, 'WCPay<dev' ],
-			'no_gt'         => [ false, 'WCPay>dev' ],
-			'req_latin'     => [ false, 'дескриптор' ],
-			'req_letter'    => [ false, '123456' ],
+			'valid'          => [ true, 'WCPAY dev' ],
+			'allow_digits'   => [ true, 'WCPay dev 2020' ],
+			'allow_special'  => [ true, 'WCPay-Dev_2020' ],
+			'allow_amp'      => [ true, 'WCPay&Dev_2020' ],
+			'strip_slashes'  => [ true, 'WCPay\\\\Dev_2020', 'WCPay\\Dev_2020' ],
+			'allow_long_amp' => [ true, 'aaaaaaaaaaaaaaaaaaa&aa' ],
+			'empty'          => [ false, '' ],
+			'short'          => [ false, 'WCP' ],
+			'long'           => [ false, 'WCPay_dev_WCPay_dev_WCPay_dev_WCPay_dev' ],
+			'no_*'           => [ false, 'WCPay * dev' ],
+			'no_sqt'         => [ false, 'WCPay \'dev\'' ],
+			'no_dqt'         => [ false, 'WCPay "dev"' ],
+			'no_lt'          => [ false, 'WCPay<dev' ],
+			'no_gt'          => [ false, 'WCPay>dev' ],
+			'req_latin'      => [ false, 'дескриптор' ],
+			'req_letter'     => [ false, '123456' ],
 		];
 	}
 }


### PR DESCRIPTION
Fixes #923

#### Changes proposed in this Pull Request

* Since we do not accept descriptors with angle brackets, there's no need to `validate_text_field` (which uses `kses` to html-encode special chars)
* Since we're not saving the descriptor in the db, there's no need to escape the backslashes

#### Testing instructions

* Attempt to save the descriptor as `aaaaaaaaaaaaaaaaaaa&a` - it should work
* Attempt to save the descriptor as `aa\aa` - it should work
* With the descriptor already saved as either of the above strings, clicking save again without making any changes to it should not affect it 

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)