### PR TITLE
Add Transactions list column with Subscription link

### DIFF
--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { uniq } from 'lodash';
+import { useMemo } from '@wordpress/element';
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
@@ -31,88 +32,101 @@ import './style.scss';
 
 const currency = new Currency();
 
-const columns = [
-	{ key: 'details', label: '', required: true },
-	{
-		key: 'date',
-		label: __( 'Date / Time', 'woocommerce-payments' ),
-		screenReaderLabel: __( 'Date and time', 'woocommerce-payments' ),
-		required: true,
-		isLeftAligned: true,
-		defaultOrder: 'desc',
-		cellClassName: 'date-time',
-		isSortable: true,
-		defaultSort: true,
-	},
-	{
-		key: 'type',
-		label: __( 'Type', 'woocommerce-payments' ),
-		screenReaderLabel: __( 'Type', 'woocommerce-payments' ),
-		required: true,
-	},
-	{
-		key: 'amount',
-		label: __( 'Amount', 'woocommerce-payments' ),
-		screenReaderLabel: __( 'Amount', 'woocommerce-payments' ),
-		isNumeric: true,
-		isSortable: true,
-	},
-	{
-		key: 'fees',
-		label: __( 'Fees', 'woocommerce-payments' ),
-		screenReaderLabel: __( 'Fees', 'woocommerce-payments' ),
-		isNumeric: true,
-		isSortable: true,
-	},
-	{
-		key: 'net',
-		label: __( 'Net', 'woocommerce-payments' ),
-		screenReaderLabel: __( 'Net', 'woocommerce-payments' ),
-		isNumeric: true,
-		required: true,
-		isSortable: true,
-	},
-	{
-		key: 'order',
-		label: __( 'Order #', 'woocommerce-payments' ),
-		screenReaderLabel: __( 'Order number', 'woocommerce-payments' ),
-		required: true,
-	},
-	{
-		key: 'source',
-		label: __( 'Source', 'woocommerce-payments' ),
-		screenReaderLabel: __( 'Source', 'woocommerce-payments' ),
-	},
-	{
-		key: 'customer_name',
-		label: __( 'Customer', 'woocommerce-payments' ),
-		screenReaderLabel: __( 'Customer', 'woocommerce-payments' ),
-	},
-	{
-		key: 'customer_email',
-		label: __( 'Email', 'woocommerce-payments' ),
-		screenReaderLabel: __( 'Email', 'woocommerce-payments' ),
-		visible: false,
-	},
-	{
-		key: 'customer_country',
-		label: __( 'Country', 'woocommerce-payments' ),
-		screenReaderLabel: __( 'Country', 'woocommerce-payments' ),
-		visible: false,
-	},
-	{
-		key: 'risk_level',
-		label: __( 'Risk level', 'woocommerce-payments' ),
-		screenReaderLabel: __( 'Risk level', 'woocommerce-payments' ),
-		visible: false,
-	},
-];
-const depositColumn = {
-	key: 'deposit',
-	label: __( 'Deposit', 'woocommerce-payments' ),
-	screenReaderLabel: __( 'Deposit', 'woocommerce-payments' ),
-	cellClassName: 'deposit',
-};
+const getColumns = ( includeDeposit, includeSubscription ) =>
+	[
+		{
+			key: 'details',
+			label: '',
+			required: true,
+		},
+		{
+			key: 'date',
+			label: __( 'Date / Time', 'woocommerce-payments' ),
+			screenReaderLabel: __( 'Date and time', 'woocommerce-payments' ),
+			required: true,
+			isLeftAligned: true,
+			defaultOrder: 'desc',
+			cellClassName: 'date-time',
+			isSortable: true,
+			defaultSort: true,
+		},
+		{
+			key: 'type',
+			label: __( 'Type', 'woocommerce-payments' ),
+			screenReaderLabel: __( 'Type', 'woocommerce-payments' ),
+			required: true,
+		},
+		{
+			key: 'amount',
+			label: __( 'Amount', 'woocommerce-payments' ),
+			screenReaderLabel: __( 'Amount', 'woocommerce-payments' ),
+			isNumeric: true,
+			isSortable: true,
+		},
+		{
+			key: 'fees',
+			label: __( 'Fees', 'woocommerce-payments' ),
+			screenReaderLabel: __( 'Fees', 'woocommerce-payments' ),
+			isNumeric: true,
+			isSortable: true,
+		},
+		{
+			key: 'net',
+			label: __( 'Net', 'woocommerce-payments' ),
+			screenReaderLabel: __( 'Net', 'woocommerce-payments' ),
+			isNumeric: true,
+			required: true,
+			isSortable: true,
+		},
+		{
+			key: 'order',
+			label: __( 'Order #', 'woocommerce-payments' ),
+			screenReaderLabel: __( 'Order number', 'woocommerce-payments' ),
+			required: true,
+		},
+		includeSubscription && {
+			key: 'subscriptions',
+			label: __( 'Subscription #', 'woocommerce-payments' ),
+			screenReaderLabel: __(
+				'Subscription number',
+				'woocommerce-payments'
+			),
+		},
+		{
+			key: 'source',
+			label: __( 'Source', 'woocommerce-payments' ),
+			screenReaderLabel: __( 'Source', 'woocommerce-payments' ),
+		},
+		{
+			key: 'customer_name',
+			label: __( 'Customer', 'woocommerce-payments' ),
+			screenReaderLabel: __( 'Customer', 'woocommerce-payments' ),
+		},
+		{
+			key: 'customer_email',
+			label: __( 'Email', 'woocommerce-payments' ),
+			screenReaderLabel: __( 'Email', 'woocommerce-payments' ),
+			visible: false,
+		},
+		{
+			key: 'customer_country',
+			label: __( 'Country', 'woocommerce-payments' ),
+			screenReaderLabel: __( 'Country', 'woocommerce-payments' ),
+			visible: false,
+		},
+		{
+			key: 'risk_level',
+			label: __( 'Risk level', 'woocommerce-payments' ),
+			screenReaderLabel: __( 'Risk level', 'woocommerce-payments' ),
+			visible: false,
+		},
+		includeDeposit && {
+			key: 'deposit',
+			label: __( 'Deposit', 'woocommerce-payments' ),
+			screenReaderLabel: __( 'Deposit', 'woocommerce-payments' ),
+			cellClassName: 'deposit',
+		},
+	].filter( Boolean );
 
 export const TransactionsList = ( props ) => {
 	const { transactions, isLoading } = useTransactions(
@@ -124,9 +138,12 @@ export const TransactionsList = ( props ) => {
 		isLoading: isSummaryLoading,
 	} = useTransactionsSummary( getQuery(), props.depositId );
 
-	const columnsToDisplay = props.depositId
-		? columns
-		: [ ...columns, depositColumn ];
+	const columnsToDisplay = useMemo( () => {
+		return getColumns(
+			! props.depositId,
+			wcpaySettings.isSubscriptionsActive
+		);
+	}, [ props.depositId, wcpaySettings.isSubscriptionsActive ] );
 
 	// match background of details and date when sorting
 	const detailsColumn =
@@ -146,6 +163,13 @@ export const TransactionsList = ( props ) => {
 			<DetailsLink id={ txn.charge_id } parentSegment="transactions" />
 		);
 		const orderUrl = <OrderLink order={ txn.order } />;
+		const subscriptions =
+			txn.order &&
+			wcpaySettings.isSubscriptionsActive &&
+			txn.order.subscriptions.map( ( subscription, i, all ) => [
+				<OrderLink key={ i } order={ subscription } />,
+				i !== all.length - 1 && ', ',
+			] );
 		const riskLevel = <RiskLevel risk={ txn.risk_level } />;
 		const deposit = (
 			<Deposit
@@ -178,6 +202,7 @@ export const TransactionsList = ( props ) => {
 				),
 			},
 			order: { value: txn.order_id, display: orderUrl },
+			subscriptions: { value: txn.order_id, display: subscriptions },
 			// eslint-disable-next-line camelcase
 			customer_name: {
 				value: txn.customer_name,

--- a/client/transactions/list/test/__snapshots__/index.js.snap
+++ b/client/transactions/list/test/__snapshots__/index.js.snap
@@ -589,6 +589,816 @@ exports[`Transactions list renders correctly when filtered to deposit 1`] = `
 </div>
 `;
 
+exports[`Transactions list subscription column renders correctly 1`] = `
+<div>
+  <div
+    class="woocommerce-card woocommerce-analytics__card woocommerce-table has-menu has-action"
+  >
+    <div
+      class="woocommerce-card__header"
+    >
+      <div
+        class="woocommerce-card__title-wrapper"
+      >
+        <h2
+          class="woocommerce-card__title woocommerce-card__header-item"
+        >
+          Transactions
+        </h2>
+      </div>
+      <div
+        class="woocommerce-card__action woocommerce-card__header-item"
+      />
+      <div
+        class="woocommerce-card__menu woocommerce-card__header-item"
+      >
+        <div
+          class="woocommerce-ellipsis-menu"
+        >
+          <div>
+            <button
+              aria-expanded="false"
+              class="components-button components-icon-button woocommerce-ellipsis-menu__toggle"
+              title="Choose which values to display"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="dashicon dashicons-ellipsis"
+                focusable="false"
+                height="20"
+                role="img"
+                viewBox="0 0 20 20"
+                width="20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5 10c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm12-2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-7 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="woocommerce-card__body"
+    >
+      <div
+        aria-hidden="false"
+        aria-labelledby="caption-6"
+        class="woocommerce-table__table"
+        role="group"
+      >
+        <table>
+          <caption
+            class="woocommerce-table__caption screen-reader-text"
+            id="caption-6"
+          >
+            Transactions
+          </caption>
+          <tbody>
+            <tr>
+              <th
+                class="woocommerce-table__header info-button is-sorted"
+                role="columnheader"
+                scope="col"
+              >
+                <span
+                  aria-hidden="false"
+                />
+              </th>
+              <th
+                aria-sort="descending"
+                class="woocommerce-table__header date-time is-left-aligned is-sortable is-sorted"
+                role="columnheader"
+                scope="col"
+              >
+                <button
+                  aria-describedby="header-6-1"
+                  class="components-button components-icon-button has-text is-button is-default"
+                  type="button"
+                >
+                  <svg
+                    class="gridicon gridicons-chevron-down"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    width="18"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g>
+                      <path
+                        d="M20 9l-8 8-8-8 1.414-1.414L12 14.172l6.586-6.586"
+                      />
+                    </g>
+                  </svg>
+                  <span
+                    aria-hidden="true"
+                  >
+                    Date / Time
+                  </span>
+                  <span
+                    class="screen-reader-text"
+                  >
+                    Date and time
+                  </span>
+                </button>
+                <span
+                  class="screen-reader-text"
+                  id="header-6-1"
+                >
+                  Sort by Date and time in ascending order
+                </span>
+              </th>
+              <th
+                class="woocommerce-table__header"
+                role="columnheader"
+                scope="col"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  Type
+                </span>
+                <span
+                  class="screen-reader-text"
+                >
+                  Type
+                </span>
+              </th>
+              <th
+                aria-sort="none"
+                class="woocommerce-table__header is-sortable is-numeric"
+                role="columnheader"
+                scope="col"
+              >
+                <button
+                  aria-describedby="header-6-3"
+                  class="components-button components-icon-button has-text is-button is-default"
+                  type="button"
+                >
+                  <svg
+                    class="gridicon gridicons-chevron-down"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    width="18"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g>
+                      <path
+                        d="M20 9l-8 8-8-8 1.414-1.414L12 14.172l6.586-6.586"
+                      />
+                    </g>
+                  </svg>
+                  <span
+                    aria-hidden="true"
+                  >
+                    Amount
+                  </span>
+                  <span
+                    class="screen-reader-text"
+                  >
+                    Amount
+                  </span>
+                </button>
+                <span
+                  class="screen-reader-text"
+                  id="header-6-3"
+                >
+                  Sort by Amount in descending order
+                </span>
+              </th>
+              <th
+                aria-sort="none"
+                class="woocommerce-table__header is-sortable is-numeric"
+                role="columnheader"
+                scope="col"
+              >
+                <button
+                  aria-describedby="header-6-4"
+                  class="components-button components-icon-button has-text is-button is-default"
+                  type="button"
+                >
+                  <svg
+                    class="gridicon gridicons-chevron-down"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    width="18"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g>
+                      <path
+                        d="M20 9l-8 8-8-8 1.414-1.414L12 14.172l6.586-6.586"
+                      />
+                    </g>
+                  </svg>
+                  <span
+                    aria-hidden="true"
+                  >
+                    Fees
+                  </span>
+                  <span
+                    class="screen-reader-text"
+                  >
+                    Fees
+                  </span>
+                </button>
+                <span
+                  class="screen-reader-text"
+                  id="header-6-4"
+                >
+                  Sort by Fees in descending order
+                </span>
+              </th>
+              <th
+                aria-sort="none"
+                class="woocommerce-table__header is-sortable is-numeric"
+                role="columnheader"
+                scope="col"
+              >
+                <button
+                  aria-describedby="header-6-5"
+                  class="components-button components-icon-button has-text is-button is-default"
+                  type="button"
+                >
+                  <svg
+                    class="gridicon gridicons-chevron-down"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    width="18"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g>
+                      <path
+                        d="M20 9l-8 8-8-8 1.414-1.414L12 14.172l6.586-6.586"
+                      />
+                    </g>
+                  </svg>
+                  <span
+                    aria-hidden="true"
+                  >
+                    Net
+                  </span>
+                  <span
+                    class="screen-reader-text"
+                  >
+                    Net
+                  </span>
+                </button>
+                <span
+                  class="screen-reader-text"
+                  id="header-6-5"
+                >
+                  Sort by Net in descending order
+                </span>
+              </th>
+              <th
+                class="woocommerce-table__header"
+                role="columnheader"
+                scope="col"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  Order #
+                </span>
+                <span
+                  class="screen-reader-text"
+                >
+                  Order number
+                </span>
+              </th>
+              <th
+                class="woocommerce-table__header"
+                role="columnheader"
+                scope="col"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  Subscription #
+                </span>
+                <span
+                  class="screen-reader-text"
+                >
+                  Subscription number
+                </span>
+              </th>
+              <th
+                class="woocommerce-table__header"
+                role="columnheader"
+                scope="col"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  Source
+                </span>
+                <span
+                  class="screen-reader-text"
+                >
+                  Source
+                </span>
+              </th>
+              <th
+                class="woocommerce-table__header"
+                role="columnheader"
+                scope="col"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  Customer
+                </span>
+                <span
+                  class="screen-reader-text"
+                >
+                  Customer
+                </span>
+              </th>
+              <th
+                class="woocommerce-table__header"
+                role="columnheader"
+                scope="col"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  Email
+                </span>
+                <span
+                  class="screen-reader-text"
+                >
+                  Email
+                </span>
+              </th>
+              <th
+                class="woocommerce-table__header"
+                role="columnheader"
+                scope="col"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  Country
+                </span>
+                <span
+                  class="screen-reader-text"
+                >
+                  Country
+                </span>
+              </th>
+              <th
+                class="woocommerce-table__header"
+                role="columnheader"
+                scope="col"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  Risk level
+                </span>
+                <span
+                  class="screen-reader-text"
+                >
+                  Risk level
+                </span>
+              </th>
+              <th
+                class="woocommerce-table__header deposit"
+                role="columnheader"
+                scope="col"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  Deposit
+                </span>
+                <span
+                  class="screen-reader-text"
+                >
+                  Deposit
+                </span>
+              </th>
+            </tr>
+            <tr>
+              <th
+                class="woocommerce-table__item info-button is-sorted"
+                scope="row"
+              >
+                <a
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
+                >
+                  <svg
+                    class="gridicon gridicons-info-outline needs-offset"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    width="18"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g>
+                      <path
+                        d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.41 0-8 3.59-8 8s3.59 8 8 8 8-3.59 8-8-3.59-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z"
+                      />
+                    </g>
+                  </svg>
+                </a>
+              </th>
+              <td
+                class="woocommerce-table__item date-time is-left-aligned is-sorted"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
+                  tabindex="-1"
+                >
+                  Jan 2, 2020 / 12:46PM
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
+                  tabindex="-1"
+                >
+                  Refund
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item is-numeric"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
+                  tabindex="-1"
+                >
+                  $10.00
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item is-numeric"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
+                  tabindex="-1"
+                >
+                  $-0.50
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item is-numeric"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
+                  tabindex="-1"
+                >
+                  $9.50
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item"
+              >
+                <a
+                  data-link-type="external"
+                  href="https://example.com/order/123"
+                >
+                  123
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item"
+              >
+                <a
+                  data-link-type="external"
+                  href="https://example.com/subscription/246"
+                >
+                  246
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
+                  tabindex="-1"
+                >
+                  <span
+                    class="payment-method__brand payment-method__brand--visa"
+                  />
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
+                  tabindex="-1"
+                >
+                  Another customer
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
+                  tabindex="-1"
+                >
+                  another@customer.com
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
+                  tabindex="-1"
+                >
+                  US
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
+                  tabindex="-1"
+                >
+                  <span
+                    style="color: green;"
+                  >
+                    Normal
+                  </span>
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item deposit"
+              >
+                Pending
+              </td>
+            </tr>
+            <tr>
+              <th
+                class="woocommerce-table__item info-button is-sorted"
+                scope="row"
+              >
+                <a
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
+                >
+                  <svg
+                    class="gridicon gridicons-info-outline needs-offset"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    width="18"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g>
+                      <path
+                        d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.41 0-8 3.59-8 8s3.59 8 8 8 8-3.59 8-8-3.59-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z"
+                      />
+                    </g>
+                  </svg>
+                </a>
+              </th>
+              <td
+                class="woocommerce-table__item date-time is-left-aligned is-sorted"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
+                  tabindex="-1"
+                >
+                  Jan 4, 2020 / 11:22PM
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
+                  tabindex="-1"
+                >
+                  Charge
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item is-numeric"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
+                  tabindex="-1"
+                >
+                  $15.00
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item is-numeric"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
+                  tabindex="-1"
+                >
+                  $-0.50
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item is-numeric"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
+                  tabindex="-1"
+                >
+                  $14.50
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item"
+              >
+                <a
+                  data-link-type="external"
+                  href="https://example.com/order/125"
+                >
+                  125
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item"
+              />
+              <td
+                class="woocommerce-table__item"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
+                  tabindex="-1"
+                >
+                  <span
+                    class="payment-method__brand payment-method__brand--mastercard"
+                  />
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
+                  tabindex="-1"
+                >
+                  My name
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
+                  tabindex="-1"
+                >
+                  a@b.com
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
+                  tabindex="-1"
+                >
+                  US
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item"
+              >
+                <a
+                  class="woocommerce-table__clickable-cell"
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
+                  tabindex="-1"
+                >
+                  <span
+                    style="color: red;"
+                  >
+                    Highest
+                  </span>
+                </a>
+              </td>
+              <td
+                class="woocommerce-table__item deposit"
+              >
+                <a
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=po_mock"
+                >
+                  Jan 7, 2020
+                </a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <ul
+        class="woocommerce-table__summary"
+      >
+        <li
+          class="woocommerce-table__summary-item"
+        >
+          <span
+            class="woocommerce-table__summary-value"
+          >
+            10
+          </span>
+          <span
+            class="woocommerce-table__summary-label"
+          >
+            transactions
+          </span>
+        </li>
+        <li
+          class="woocommerce-table__summary-item"
+        >
+          <span
+            class="woocommerce-table__summary-value"
+          >
+            $10.00
+          </span>
+          <span
+            class="woocommerce-table__summary-label"
+          >
+            total
+          </span>
+        </li>
+        <li
+          class="woocommerce-table__summary-item"
+        >
+          <span
+            class="woocommerce-table__summary-value"
+          >
+            $1.00
+          </span>
+          <span
+            class="woocommerce-table__summary-label"
+          >
+            fees
+          </span>
+        </li>
+        <li
+          class="woocommerce-table__summary-item"
+        >
+          <span
+            class="woocommerce-table__summary-value"
+          >
+            $9.00
+          </span>
+          <span
+            class="woocommerce-table__summary-label"
+          >
+            net
+          </span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Transactions list when not filtered by deposit renders correctly 1`] = `
 <div>
   <div

--- a/client/transactions/list/test/index.js
+++ b/client/transactions/list/test/index.js
@@ -19,7 +19,7 @@ jest.mock( 'data', () => ( {
 	useTransactionsSummary: jest.fn(),
 } ) );
 
-const mockTransactions = [
+const getMockTransactions = () => [
 	{
 		// eslint-disable-next-line camelcase
 		transaction_id: 'txn_j23jda9JJa',
@@ -89,12 +89,13 @@ describe( 'Transactions list', () => {
 			featureFlags: {
 				customSearch: true,
 			},
+			isSubscriptionsActive: false,
 		};
 	} );
 
 	test( 'renders correctly when filtered to deposit', () => {
 		useTransactions.mockReturnValue( {
-			transactions: mockTransactions.filter(
+			transactions: getMockTransactions().filter(
 				( txn ) => txn.deposit_id === 'po_mock'
 			),
 			isLoading: false,
@@ -121,7 +122,7 @@ describe( 'Transactions list', () => {
 		let container, rerender;
 		beforeEach( () => {
 			useTransactions.mockReturnValue( {
-				transactions: mockTransactions,
+				transactions: getMockTransactions(),
 				isLoading: false,
 			} );
 
@@ -189,5 +190,37 @@ describe( 'Transactions list', () => {
 			expect( useTransactionsCall[ 0 ].orderby ).toEqual( field );
 			expect( useTransactionsCall[ 0 ].order ).toEqual( direction );
 		}
+	} );
+
+	test( 'subscription column renders correctly', () => {
+		global.wcpaySettings.isSubscriptionsActive = true;
+
+		const mockTransactions = getMockTransactions();
+		mockTransactions[ 0 ].order.subscriptions = [
+			{
+				number: 246,
+				url: 'https://example.com/subscription/246',
+			},
+		];
+		mockTransactions[ 1 ].order.subscriptions = [];
+
+		useTransactions.mockReturnValue( {
+			transactions: mockTransactions,
+			isLoading: false,
+		} );
+
+		useTransactionsSummary.mockReturnValue( {
+			transactionsSummary: {
+				count: 10,
+				fees: 100,
+				total: 1000,
+				net: 900,
+			},
+			isLoading: false,
+		} );
+
+		const { container } = render( <TransactionsList /> );
+
+		expect( container ).toMatchSnapshot();
 	} );
 } );

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -181,11 +181,11 @@ class WC_Payments_Admin {
 			'WCPAY_DASH_APP',
 			'wcpaySettings',
 			[
-				'connectUrl'         => WC_Payments_Account::get_connect_url(),
-				'testMode'           => $this->wcpay_gateway->is_in_test_mode(),
-				'onBoardingDisabled' => $on_boarding_disabled,
-				'errorMessage'       => $error_message,
-				'featureFlags'       => $this->get_frontend_feature_flags(),
+				'testMode'              => $this->wcpay_gateway->is_in_test_mode(),
+				'onBoardingDisabled'    => $on_boarding_disabled,
+				'errorMessage'          => $error_message,
+				'featureFlags'          => $this->get_frontend_feature_flags(),
+				'isSubscriptionsActive' => class_exists( 'WC_Payment_Gateway_WCPay_Subscriptions_Compat' ),
 			]
 		);
 

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -181,6 +181,7 @@ class WC_Payments_Admin {
 			'WCPAY_DASH_APP',
 			'wcpaySettings',
 			[
+				'connectUrl'            => WC_Payments_Account::get_connect_url(),
 				'testMode'              => $this->wcpay_gateway->is_in_test_mode(),
 				'onBoardingDisabled'    => $on_boarding_disabled,
 				'errorMessage'          => $error_message,

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1009,6 +1009,18 @@ class WC_Payments_API_Client {
 				'number' => $order->get_order_number(),
 				'url'    => $order->get_edit_order_url(),
 			];
+
+			if ( function_exists( 'wcs_get_subscriptions_for_order' ) ) {
+				$object['order']['subscriptions'] = [];
+
+				$subscriptions = wcs_get_subscriptions_for_order( $order, [ 'order_type' => [ 'parent', 'renewal' ] ] );
+				foreach ( $subscriptions as $subscription ) {
+					$object['order']['subscriptions'][] = [
+						'number' => $subscription->get_order_number(),
+						'url'    => $subscription->get_edit_order_url(),
+					];
+				}
+			}
 		}
 
 		return $object;


### PR DESCRIPTION
Fixes #866

#### Changes proposed in this Pull Request

If WooCommerce Subscriptions is active, add links to any Subscription(s) associated with the relevant Order from a new cell in each row of the Transactions list.

<img width="997" alt="subscription-link" src="https://user-images.githubusercontent.com/1867547/93871375-8d10af00-fc9c-11ea-89f8-b54a2ade0579.png">

(Note: most orders would likely have 0 or 1 subscriptions – multiple subscriptions would result from checking out with 2 or more subscriptions that have different renewal schedules.)

If there is no related subscription, then the cell is left empty.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Purchase subscription(s) via WooCommerce Payments, and verify:
- Admin links to the subscription(s) appear in the Transactions list
- Payments that don't involve subscriptions should show nothing in that column
- If the subscriptions extension is not active, the column should not appear

-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
