### PR TITLE
Add subscription link into payment details view

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Add - Display payment method details on account subscriptions pages.
 * Add - Redact sensitive data before logging.
 * Add - Support for WooCommerce Subscriptions admin-initiated payment method changes.
+* Add - Link to Subscription admin pages from Transactions views.
 
 = 1.4.1 - 2020-09-07 =
 * Fix - Only redirect to the onboarding screen if the plugin has been individually activated using the plugins page.

--- a/client/components/horizontal-list/style.scss
+++ b/client/components/horizontal-list/style.scss
@@ -28,6 +28,14 @@
 			border-bottom: 0;
 		}
 
+		&:hover {
+			background: none;
+
+			.woocommerce-list__item-title {
+				color: $studio-gray-60;
+			}
+		}
+
 		.woocommerce-list__item-inner {
 			margin: 0;
 			padding: 0;
@@ -35,8 +43,14 @@
 
 		.woocommerce-list__item-title,
 		.woocommerce-list__item-content {
-			color: $dark-gray-500;
 			margin-top: 0;
+			@include font-size( 14 );
+		}
+		.woocommerce-list__item-title {
+			color: $studio-gray-60;
+		}
+		.woocommerce-list__item-content {
+			color: $studio-gray-80;
 		}
 	}
 	.woocommerce-list__item:first-child {

--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -48,12 +48,17 @@ const composePaymentSummaryItems = ( { charge } ) =>
 		},
 		wcpaySettings.isSubscriptionsActive && {
 			title: __( 'Subscription', 'woocommerce-payments' ),
-			content: charge.order && charge.order.subscriptions.length ? (
-				charge.order.subscriptions.map( ( subscription, i, all ) => [
-					<OrderLink key={ i } order={ subscription } />,
-					i !== all.length - 1 && ', ',
-				] )
-			) : <OrderLink />,
+			content:
+				charge.order && charge.order.subscriptions.length ? (
+					charge.order.subscriptions.map(
+						( subscription, i, all ) => [
+							<OrderLink key={ i } order={ subscription } />,
+							i !== all.length - 1 && ', ',
+						]
+					)
+				) : (
+					<OrderLink />
+				),
 		},
 		{
 			title: __( 'Payment method', 'woocommerce-payments' ),
@@ -127,8 +132,7 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 					</div>
 				</div>
 				<div className="payment-details-summary__section">
-					{ /* TODO: implement control buttons depending on the transaction status */ }
-					<div className="payment-details-summary__actions">
+					<div className="payment-details-summary__id">
 						<Loadable
 							isLoading={ isLoading }
 							placeholder="Payment ID: ch_xxxxxxxxxxxxxxxxxxxxxxxx"

--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -5,7 +5,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
-import { Button } from '@wordpress/components';
 import { Card } from '@woocommerce/components';
 import Currency from '@woocommerce/currency';
 import moment from 'moment';
@@ -20,6 +19,7 @@ import PaymentMethodDetails from 'components/payment-method-details';
 import HorizontalList from 'components/horizontal-list';
 import Loadable, { LoadableBlock } from 'components/loadable';
 import riskMappings from 'components/risk-level/strings';
+import OrderLink from 'components/order-link';
 import './style.scss';
 
 const currency = new Currency();
@@ -42,6 +42,10 @@ const composePaymentSummaryItems = ( { charge } ) => [
 		content: get( charge, 'billing_details.name' ) || '–',
 	},
 	{
+		title: __( 'Order', 'woocommerce-payments' ),
+		content: <OrderLink order={ charge.order } />,
+	},
+	{
 		title: __( 'Payment method', 'woocommerce-payments' ),
 		content: (
 			<PaymentMethodDetails payment={ charge.payment_method_details } />
@@ -50,10 +54,6 @@ const composePaymentSummaryItems = ( { charge } ) => [
 	{
 		title: __( 'Risk evaluation', 'woocommerce-payments' ),
 		content: riskMappings[ get( charge, 'outcome.risk_level' ) ] || '–',
-	},
-	{
-		title: '',
-		content: charge.id || '–',
 	},
 ];
 
@@ -117,20 +117,16 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 				<div className="payment-details-summary__section">
 					{ /* TODO: implement control buttons depending on the transaction status */ }
 					<div className="payment-details-summary__actions">
-						{ charge.order ? (
-							<Button
-								className="payment-details-summary__actions-item"
-								isDefault
-								isLarge
-								href={ charge.order.url }
-							>
-								{ `${ __( 'View order' ) } #${
-									charge.order.number
-								}` }
-							</Button>
-						) : (
-							''
-						) }
+						<Loadable
+							isLoading={ isLoading }
+							placeholder="Payment ID: ch_xxxxxxxxxxxxxxxxxxxxxxxx"
+						>
+							{ `${ __(
+								'Payment ID',
+								'woocommerce-payments'
+							) }: ` }
+							{ charge.id }
+						</Loadable>
 					</div>
 				</div>
 			</div>

--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -30,32 +30,44 @@ const placeholderValues = {
 	refunded: null,
 };
 
-const composePaymentSummaryItems = ( { charge } ) => [
-	{
-		title: __( 'Date', 'woocommerce-payments' ),
-		content: charge.created
-			? dateI18n( 'M j, Y, g:ia', moment( charge.created * 1000 ) )
-			: '–',
-	},
-	{
-		title: __( 'Customer', 'woocommerce-payments' ),
-		content: get( charge, 'billing_details.name' ) || '–',
-	},
-	{
-		title: __( 'Order', 'woocommerce-payments' ),
-		content: <OrderLink order={ charge.order } />,
-	},
-	{
-		title: __( 'Payment method', 'woocommerce-payments' ),
-		content: (
-			<PaymentMethodDetails payment={ charge.payment_method_details } />
-		),
-	},
-	{
-		title: __( 'Risk evaluation', 'woocommerce-payments' ),
-		content: riskMappings[ get( charge, 'outcome.risk_level' ) ] || '–',
-	},
-];
+const composePaymentSummaryItems = ( { charge } ) =>
+	[
+		{
+			title: __( 'Date', 'woocommerce-payments' ),
+			content: charge.created
+				? dateI18n( 'M j, Y, g:ia', moment( charge.created * 1000 ) )
+				: '–',
+		},
+		{
+			title: __( 'Customer', 'woocommerce-payments' ),
+			content: get( charge, 'billing_details.name' ) || '–',
+		},
+		{
+			title: __( 'Order', 'woocommerce-payments' ),
+			content: <OrderLink order={ charge.order } />,
+		},
+		wcpaySettings.isSubscriptionsActive && {
+			title: __( 'Subscription', 'woocommerce-payments' ),
+			content: charge.order && charge.order.subscriptions.length ? (
+				charge.order.subscriptions.map( ( subscription, i, all ) => [
+					<OrderLink key={ i } order={ subscription } />,
+					i !== all.length - 1 && ', ',
+				] )
+			) : <OrderLink />,
+		},
+		{
+			title: __( 'Payment method', 'woocommerce-payments' ),
+			content: (
+				<PaymentMethodDetails
+					payment={ charge.payment_method_details }
+				/>
+			),
+		},
+		{
+			title: __( 'Risk evaluation', 'woocommerce-payments' ),
+			content: riskMappings[ get( charge, 'outcome.risk_level' ) ] || '–',
+		},
+	].filter( Boolean );
 
 const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 	const { net, fee, refunded } = charge.amount

--- a/client/payment-details/summary/style.scss
+++ b/client/payment-details/summary/style.scss
@@ -39,7 +39,7 @@
 		}
 	}
 
-	.payment-details-summary__actions {
+	.payment-details-summary__id {
 		height: 100%;
 		margin-top: 8px;
 		color: $studio-gray-40;

--- a/client/payment-details/summary/style.scss
+++ b/client/payment-details/summary/style.scss
@@ -58,24 +58,6 @@
 
 .payment-details-summary-details
 	.woocommerce-list--horizontal
-	.woocommerce-list__item:last-child {
-	flex-grow: 1;
-	border-left: 0;
-	.woocommerce-list__item-text {
-		width: 100%;
-		text-transform: none;
-		@include breakpoint( '>800px' ) {
-			text-align: right;
-			color: $studio-gray-40;
-			.woocommerce-list__item-content {
-				@include font-size( 12 );
-			}
-		}
-	}
-}
-
-.payment-details-summary-details
-	.woocommerce-list--horizontal
 	.woocommerce-list__item-inner
 	.woocommerce-list__item-title,
 .payment-details-summary-details

--- a/client/payment-details/summary/style.scss
+++ b/client/payment-details/summary/style.scss
@@ -22,7 +22,7 @@
 		.payment-details-summary__amount-currency {
 			@include font-size( 16 );
 			text-transform: uppercase;
-			margin: 0 0.75rem 0 0.5rem;
+			margin: 0 0.5rem;
 			color: $studio-gray-60;
 		}
 	}

--- a/client/payment-details/summary/style.scss
+++ b/client/payment-details/summary/style.scss
@@ -22,7 +22,7 @@
 		.payment-details-summary__amount-currency {
 			@include font-size( 16 );
 			text-transform: uppercase;
-			margin: 0 1rem 0 0.25rem;
+			margin: 0 0.75rem 0 0.5rem;
 			color: $studio-gray-60;
 		}
 	}
@@ -32,7 +32,7 @@
 			@include font-size( 14 );
 			color: $dark-gray-500;
 			display: inline-block;
-			margin: 0.5rem 0.75rem 0 0;
+			margin: 0.25rem 1rem 0 0;
 		}
 		p:last-child {
 			margin-right: 0;
@@ -41,28 +41,13 @@
 
 	.payment-details-summary__actions {
 		height: 100%;
+		margin-top: 8px;
+		color: $studio-gray-40;
 		display: flex;
-		align-items: center;
+		align-items: start;
 		justify-content: initial;
 		@include breakpoint( '>660px' ) {
 			justify-content: flex-end;
 		}
-		.payment-details-summary__actions-item {
-			margin-top: 1rem;
-			@include breakpoint( '>660px' ) {
-				margin-top: 0;
-			}
-		}
 	}
-}
-
-.payment-details-summary-details
-	.woocommerce-list--horizontal
-	.woocommerce-list__item-inner
-	.woocommerce-list__item-title,
-.payment-details-summary-details
-	.woocommerce-list--horizontal
-	.woocommerce-list__item-inner
-	.woocommerce-list__item-content {
-	@include font-size( 14 );
 }

--- a/client/payment-details/summary/test/__snapshots__/index.js.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.js.snap
@@ -146,6 +146,168 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
 </div>
 `;
 
+exports[`PaymentDetailsSummary renders a charge with subscriptions 1`] = `
+<div>
+  <div
+    class="woocommerce-card payment-details-summary-details"
+  >
+    <div
+      class="woocommerce-card__body"
+    >
+      <div
+        class="payment-details-summary"
+      >
+        <div
+          class="payment-details-summary__section"
+        >
+          <p
+            class="payment-details-summary__amount"
+          >
+            $15.00
+            <span
+              class="payment-details-summary__amount-currency"
+            >
+              usd
+            </span>
+            <span
+              class="chip chip-light"
+            >
+              Paid
+            </span>
+          </p>
+          <div
+            class="payment-details-summary__breakdown"
+          >
+            
+            <p>
+              Fee: 
+              $-0.70
+            </p>
+            <p>
+              Net: 
+              $14.30
+            </p>
+          </div>
+        </div>
+        <div
+          class="payment-details-summary__section"
+        >
+          <div
+            class="payment-details-summary__actions"
+          >
+            Payment ID: 
+            ch_38jdHA39KKA
+          </div>
+        </div>
+      </div>
+      <hr
+        class="full-width"
+      />
+      <ul
+        class="woocommerce-list woocommerce-list--horizontal"
+      >
+        <li
+          aria-disabled="false"
+          class="woocommerce-list__item"
+          role="menuitem"
+          tabindex="0"
+        >
+          <div
+            class="woocommerce-list__item-text"
+          >
+            <span
+              class="woocommerce-list__item-title"
+            >
+              Date
+            </span>
+          </div>
+        </li>
+        <li
+          aria-disabled="false"
+          class="woocommerce-list__item"
+          role="menuitem"
+          tabindex="0"
+        >
+          <div
+            class="woocommerce-list__item-text"
+          >
+            <span
+              class="woocommerce-list__item-title"
+            >
+              Customer
+            </span>
+          </div>
+        </li>
+        <li
+          aria-disabled="false"
+          class="woocommerce-list__item"
+          role="menuitem"
+          tabindex="0"
+        >
+          <div
+            class="woocommerce-list__item-text"
+          >
+            <span
+              class="woocommerce-list__item-title"
+            >
+              Order
+            </span>
+          </div>
+        </li>
+        <li
+          aria-disabled="false"
+          class="woocommerce-list__item"
+          role="menuitem"
+          tabindex="0"
+        >
+          <div
+            class="woocommerce-list__item-text"
+          >
+            <span
+              class="woocommerce-list__item-title"
+            >
+              Subscription
+            </span>
+          </div>
+        </li>
+        <li
+          aria-disabled="false"
+          class="woocommerce-list__item"
+          role="menuitem"
+          tabindex="0"
+        >
+          <div
+            class="woocommerce-list__item-text"
+          >
+            <span
+              class="woocommerce-list__item-title"
+            >
+              Payment method
+            </span>
+          </div>
+        </li>
+        <li
+          aria-disabled="false"
+          class="woocommerce-list__item"
+          role="menuitem"
+          tabindex="0"
+        >
+          <div
+            class="woocommerce-list__item-text"
+          >
+            <span
+              class="woocommerce-list__item-title"
+            >
+              Risk evaluation
+            </span>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`PaymentDetailsSummary renders fully refunded information for a charge 1`] = `
 <div>
   <div

--- a/client/payment-details/summary/test/__snapshots__/index.js.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.js.snap
@@ -47,7 +47,7 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
           class="payment-details-summary__section"
         >
           <div
-            class="payment-details-summary__actions"
+            class="payment-details-summary__id"
           >
             Payment ID: 
             ch_38jdHA39KKA
@@ -193,7 +193,7 @@ exports[`PaymentDetailsSummary renders a charge with subscriptions 1`] = `
           class="payment-details-summary__section"
         >
           <div
-            class="payment-details-summary__actions"
+            class="payment-details-summary__id"
           >
             Payment ID: 
             ch_38jdHA39KKA
@@ -358,7 +358,7 @@ exports[`PaymentDetailsSummary renders fully refunded information for a charge 1
           class="payment-details-summary__section"
         >
           <div
-            class="payment-details-summary__actions"
+            class="payment-details-summary__id"
           >
             Payment ID: 
             ch_38jdHA39KKA
@@ -507,7 +507,7 @@ exports[`PaymentDetailsSummary renders loading state 1`] = `
           class="payment-details-summary__section"
         >
           <div
-            class="payment-details-summary__actions"
+            class="payment-details-summary__id"
           >
             <span
               aria-busy="true"
@@ -586,7 +586,7 @@ exports[`PaymentDetailsSummary renders partially refunded information for a char
           class="payment-details-summary__section"
         >
           <div
-            class="payment-details-summary__actions"
+            class="payment-details-summary__id"
           >
             Payment ID: 
             ch_38jdHA39KKA
@@ -735,7 +735,7 @@ exports[`PaymentDetailsSummary renders the information of a disputed charge 1`] 
           class="payment-details-summary__section"
         >
           <div
-            class="payment-details-summary__actions"
+            class="payment-details-summary__id"
           >
             Payment ID: 
             ch_38jdHA39KKA

--- a/client/payment-details/summary/test/__snapshots__/index.js.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.js.snap
@@ -49,12 +49,8 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
           <div
             class="payment-details-summary__actions"
           >
-            <a
-              class="components-button payment-details-summary__actions-item is-button is-default is-large"
-              href="https://somerandomorderurl.com/?edit_order=45981"
-            >
-              View order #45981
-            </a>
+            Payment ID: 
+            ch_38jdHA39KKA
           </div>
         </div>
       </div>
@@ -108,6 +104,22 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
             <span
               class="woocommerce-list__item-title"
             >
+              Order
+            </span>
+          </div>
+        </li>
+        <li
+          aria-disabled="false"
+          class="woocommerce-list__item"
+          role="menuitem"
+          tabindex="0"
+        >
+          <div
+            class="woocommerce-list__item-text"
+          >
+            <span
+              class="woocommerce-list__item-title"
+            >
               Payment method
             </span>
           </div>
@@ -126,20 +138,6 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
             >
               Risk evaluation
             </span>
-          </div>
-        </li>
-        <li
-          aria-disabled="false"
-          class="woocommerce-list__item"
-          role="menuitem"
-          tabindex="0"
-        >
-          <div
-            class="woocommerce-list__item-text"
-          >
-            <span
-              class="woocommerce-list__item-title"
-            />
           </div>
         </li>
       </ul>
@@ -200,12 +198,8 @@ exports[`PaymentDetailsSummary renders fully refunded information for a charge 1
           <div
             class="payment-details-summary__actions"
           >
-            <a
-              class="components-button payment-details-summary__actions-item is-button is-default is-large"
-              href="https://somerandomorderurl.com/?edit_order=45981"
-            >
-              View order #45981
-            </a>
+            Payment ID: 
+            ch_38jdHA39KKA
           </div>
         </div>
       </div>
@@ -259,6 +253,22 @@ exports[`PaymentDetailsSummary renders fully refunded information for a charge 1
             <span
               class="woocommerce-list__item-title"
             >
+              Order
+            </span>
+          </div>
+        </li>
+        <li
+          aria-disabled="false"
+          class="woocommerce-list__item"
+          role="menuitem"
+          tabindex="0"
+        >
+          <div
+            class="woocommerce-list__item-text"
+          >
+            <span
+              class="woocommerce-list__item-title"
+            >
               Payment method
             </span>
           </div>
@@ -277,20 +287,6 @@ exports[`PaymentDetailsSummary renders fully refunded information for a charge 1
             >
               Risk evaluation
             </span>
-          </div>
-        </li>
-        <li
-          aria-disabled="false"
-          class="woocommerce-list__item"
-          role="menuitem"
-          tabindex="0"
-        >
-          <div
-            class="woocommerce-list__item-text"
-          >
-            <span
-              class="woocommerce-list__item-title"
-            />
           </div>
         </li>
       </ul>
@@ -350,7 +346,14 @@ exports[`PaymentDetailsSummary renders loading state 1`] = `
         >
           <div
             class="payment-details-summary__actions"
-          />
+          >
+            <span
+              aria-busy="true"
+              class="is-loadable-placeholder"
+            >
+              Payment ID: ch_xxxxxxxxxxxxxxxxxxxxxxxx
+            </span>
+          </div>
         </div>
       </div>
       <hr
@@ -423,12 +426,8 @@ exports[`PaymentDetailsSummary renders partially refunded information for a char
           <div
             class="payment-details-summary__actions"
           >
-            <a
-              class="components-button payment-details-summary__actions-item is-button is-default is-large"
-              href="https://somerandomorderurl.com/?edit_order=45981"
-            >
-              View order #45981
-            </a>
+            Payment ID: 
+            ch_38jdHA39KKA
           </div>
         </div>
       </div>
@@ -482,6 +481,22 @@ exports[`PaymentDetailsSummary renders partially refunded information for a char
             <span
               class="woocommerce-list__item-title"
             >
+              Order
+            </span>
+          </div>
+        </li>
+        <li
+          aria-disabled="false"
+          class="woocommerce-list__item"
+          role="menuitem"
+          tabindex="0"
+        >
+          <div
+            class="woocommerce-list__item-text"
+          >
+            <span
+              class="woocommerce-list__item-title"
+            >
               Payment method
             </span>
           </div>
@@ -500,20 +515,6 @@ exports[`PaymentDetailsSummary renders partially refunded information for a char
             >
               Risk evaluation
             </span>
-          </div>
-        </li>
-        <li
-          aria-disabled="false"
-          class="woocommerce-list__item"
-          role="menuitem"
-          tabindex="0"
-        >
-          <div
-            class="woocommerce-list__item-text"
-          >
-            <span
-              class="woocommerce-list__item-title"
-            />
           </div>
         </li>
       </ul>
@@ -574,12 +575,8 @@ exports[`PaymentDetailsSummary renders the information of a disputed charge 1`] 
           <div
             class="payment-details-summary__actions"
           >
-            <a
-              class="components-button payment-details-summary__actions-item is-button is-default is-large"
-              href="https://somerandomorderurl.com/?edit_order=45981"
-            >
-              View order #45981
-            </a>
+            Payment ID: 
+            ch_38jdHA39KKA
           </div>
         </div>
       </div>
@@ -633,6 +630,22 @@ exports[`PaymentDetailsSummary renders the information of a disputed charge 1`] 
             <span
               class="woocommerce-list__item-title"
             >
+              Order
+            </span>
+          </div>
+        </li>
+        <li
+          aria-disabled="false"
+          class="woocommerce-list__item"
+          role="menuitem"
+          tabindex="0"
+        >
+          <div
+            class="woocommerce-list__item-text"
+          >
+            <span
+              class="woocommerce-list__item-title"
+            >
               Payment method
             </span>
           </div>
@@ -651,20 +664,6 @@ exports[`PaymentDetailsSummary renders the information of a disputed charge 1`] 
             >
               Risk evaluation
             </span>
-          </div>
-        </li>
-        <li
-          aria-disabled="false"
-          class="woocommerce-list__item"
-          role="menuitem"
-          tabindex="0"
-        >
-          <div
-            class="woocommerce-list__item-text"
-          >
-            <span
-              class="woocommerce-list__item-title"
-            />
           </div>
         </li>
       </ul>

--- a/client/payment-details/summary/test/index.js
+++ b/client/payment-details/summary/test/index.js
@@ -47,6 +47,12 @@ const getBaseCharge = () => ( {
 /* eslint-enable camelcase */
 
 describe( 'PaymentDetailsSummary', () => {
+	beforeEach( () => {
+		global.wcpaySettings = {
+			isSubscriptionsActive: false,
+		};
+	} );
+
 	test( 'correctly renders a charge', () => {
 		const paymentDetailsSummary = renderCharge( getBaseCharge() );
 		expect( paymentDetailsSummary ).toMatchSnapshot();
@@ -79,6 +85,21 @@ describe( 'PaymentDetailsSummary', () => {
 			amount: 1500,
 			status: 'under_review',
 		};
+
+		const paymentDetailsSummary = renderCharge( charge );
+		expect( paymentDetailsSummary ).toMatchSnapshot();
+	} );
+
+	test( 'renders a charge with subscriptions', () => {
+		global.wcpaySettings.isSubscriptionsActive = true;
+
+		const charge = getBaseCharge();
+		charge.order.subscriptions = [
+			{
+				number: 246,
+				url: 'https://example.com/subscription/246',
+			},
+		];
 
 		const paymentDetailsSummary = renderCharge( charge );
 		expect( paymentDetailsSummary ).toMatchSnapshot();

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,7 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 * Add - Display payment method details on account subscriptions pages.
 * Add - Redact sensitive data before logging.
 * Add - Support for WooCommerce Subscriptions admin-initiated payment method changes.
+* Add - Link to Subscription admin pages from Transactions views.
 
 = 1.4.1 - 2020-09-07 =
 * Fix - Only redirect to the onboarding screen if the plugin has been individually activated using the plugins page.


### PR DESCRIPTION
Fixes #868

#### Changes proposed in this Pull Request

- https://github.com/Automattic/woocommerce-payments/commit/c134e346fb11a5feb98dc268032484cecb36fa0e alters the payment summary layout in accordance with designed change (aside from Subscription)
- https://github.com/Automattic/woocommerce-payments/commit/f232b75f9804f4c43fd504dbad86cdb3ca3e4de4 adds link(s) to Subscriptions associated with the order, if that extension is activated
- https://github.com/Automattic/woocommerce-payments/commit/5b6f8106d26dd0a61845de546e981710d2257fcb contains several color and spacing tweaks to move the appearance a bit closer to the static design

`master`:

<img width="1055" alt="master-summary" src="https://user-images.githubusercontent.com/1867547/93889892-bf7bd580-fcb7-11ea-8f60-4a095992dc26.png">

This branch:

<img width="1057" alt="this-branch-summary" src="https://user-images.githubusercontent.com/1867547/93889899-c276c600-fcb7-11ea-9b2b-0e49ba55f68d.png">

If there are no associated subscriptions, the value is rendered as "–". If there are multiple, they are comma-separated.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check out with one or more Subscriptions via WooCommerce Payments, and verify that the Payment Details screen contains a link to the Subscription admin view. If WC Subscriptions isn't activated, verify that nothing appears.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
