### PR TITLE
Do not attempt to get a timeline if there's no intention ID

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Support checkout on Internet Explorer 11.
 * Fix - Webhook processing with no Jetpack plugin installed.
 * Fix - Saving account statement descriptor with an ampersand character.
+* Fix - Do not attempt to render the payment timeline if the intention ID is missing.
 * Add - Display payment method details on account subscriptions pages.
 * Add - Redact sensitive data before logging.
 * Add - Support for WooCommerce Subscriptions admin-initiated payment method changes.

--- a/client/data/timeline/hooks.js
+++ b/client/data/timeline/hooks.js
@@ -28,6 +28,14 @@ export const useTimeline = ( chargeId ) =>
 			}
 
 			const { payment_intent: intentionId } = getCharge( chargeId );
+			if ( ! intentionId ) {
+				// If intention ID is not available, do not render the timeline, but also don't indicate the API error.
+				return {
+					timeline: null,
+					timelineError: null,
+					isLoading: false,
+				};
+			}
 
 			return {
 				timeline: getTimeline( intentionId ),

--- a/readme.txt
+++ b/readme.txt
@@ -95,6 +95,7 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 * Fix - Support checkout on Internet Explorer 11.
 * Fix - Webhook processing with no Jetpack plugin installed.
 * Fix - Saving account statement descriptor with an ampersand character.
+* Fix - Do not attempt to render the payment timeline if the intention ID is missing.
 * Add - Display payment method details on account subscriptions pages.
 * Add - Redact sensitive data before logging.
 * Add - Support for WooCommerce Subscriptions admin-initiated payment method changes.


### PR DESCRIPTION
Part of a fix for server issue 345

Fixes an edge case where there's no `payment_intent` set on the Charge object, so we end up sending a request with the ID value of `undefined`.

#### Changes proposed in this Pull Request

* Check for empty intent ID and return early.

#### Testing instructions

I could not manage to reproduce this, even when linking to accounts that triggered the error and then checking their transactions - all of them had the intent ID set on them. I suspect what happens here is there's a small window between the creation of a charge and the intent being set on it - if the charge is viewed quickly enough, this would happen.

* Replace this line: https://github.com/Automattic/woocommerce-payments/blob/5312e87a264429146f9be3b0236f36b596fd48f8/client/data/timeline/hooks.js#L30
* With `const intentionId = undefined`
* View any transaction in wp-admin with dev tools open
* The timeline should not be rendered (showing "no data to display" message) and no request for it should be sent

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Tested on mobile (or does not apply)