### PR TITLE
Support transaction search by Subscription number

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Add - Display payment method details on account subscriptions pages.
 * Add - Redact sensitive data before logging.
 * Add - Support for WooCommerce Subscriptions admin-initiated payment method changes.
+* Add - Support for Subscriptions in transaction search.
 
 = 1.4.1 - 2020-09-07 =
 * Fix - Only redirect to the onboarding screen if the plugin has been individually activated using the plugins page.

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -285,6 +285,22 @@ export const TransactionsList = ( props ) => {
 		} );
 	};
 
+	let searchPlaceholder = wcpaySettings.isSubscriptionsActive
+		? __(
+				'Search by order number, subscription number, customer name, or billing email',
+				'woocommerce-payments'
+		  )
+		: __(
+				'Search by order number, customer name, or billing email',
+				'woocommerce-payments'
+		  );
+	if ( ! wcpaySettings.featureFlags.customSearch ) {
+		searchPlaceholder = __(
+			'Search by customer name',
+			'woocommerce-payments'
+		);
+	}
+
 	return (
 		<TableCard
 			className="transactions-list woocommerce-report-table has-search"
@@ -307,17 +323,7 @@ export const TransactionsList = ( props ) => {
 					inlineTags
 					key="search"
 					onChange={ onSearchChange }
-					placeholder={
-						wcpaySettings.featureFlags.customSearch
-							? __(
-									'Search by order number, customer name, or billing email',
-									'woocommerce-payments'
-							  )
-							: __(
-									'Search by customer name',
-									'woocommerce-payments'
-							  )
-					}
+					placeholder={ searchPlaceholder }
 					selected={ searchedLabels }
 					showClearButton={ true }
 					type={

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -157,7 +157,7 @@ class WC_Payments_Utils {
 	 * @return array|null The charge_id(s) for the order or subscription, or null if no charges are found.
 	 */
 	public static function get_charge_ids_from_search_term( $term ) {
-		$order_term = 'Order #';
+		$order_term = __( 'Order #', 'woocommerce-payments' );
 		if ( substr( $term, 0, strlen( $order_term ) ) === $order_term ) {
 			$term_parts = explode( '#', $term, 2 );
 			$order_id   = isset( $term_parts[1] ) ? $term_parts[1] : '';
@@ -167,7 +167,7 @@ class WC_Payments_Utils {
 			}
 		}
 
-		$subscription_term = 'Subscription #';
+		$subscription_term = __( 'Subscription #', 'woocommerce-payments' );
 		if ( function_exists( 'wcs_get_subscription' ) && substr( $term, 0, strlen( $subscription_term ) ) === $subscription_term ) {
 			$term_parts      = explode( '#', $term, 2 );
 			$subscription_id = isset( $term_parts[1] ) ? $term_parts[1] : '';

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -154,7 +154,7 @@ class WC_Payments_Utils {
 	 *
 	 * @param string $term Search term.
 	 *
-	 * @return array|null The charge_id(s) for the order or subscription, or null if no charges are found.
+	 * @return array The charge_id(s) for the order or subscription.
 	 */
 	public static function get_charge_ids_from_search_term( $term ) {
 		$order_term = __( 'Order #', 'woocommerce-payments' );
@@ -182,7 +182,7 @@ class WC_Payments_Utils {
 			}
 		}
 
-		return null;
+		return [];
 	}
 
 	/**
@@ -193,7 +193,7 @@ class WC_Payments_Utils {
 	 * @return array Processed search strings.
 	 */
 	public static function map_search_orders_to_charge_ids( $search ) {
-		// Map Order # and Subscription # terms to the actual charge id to be used in the server.
+		// Map Order # and Subscription # terms to the actual charge IDs to be used in the server.
 		$terms = [];
 		foreach ( $search as $term ) {
 			$charge_ids = self::get_charge_ids_from_search_term( $term );

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -149,51 +149,62 @@ class WC_Payments_Utils {
 	}
 
 	/**
-	 * Returns a charge_id for an "Order #" search term.
+	 * Returns the charge_id for an "Order #" search term
+	 * or all charge_ids for a "Subscription #" search term.
 	 *
 	 * @param string $term Search term.
 	 *
-	 * @return string The charge_id for the order, or empty if no order is found.
+	 * @return array|null The charge_id(s) for the order or subscription, or null if no charges are found.
 	 */
-	public static function get_charge_id_from_search_term( $term ) {
+	public static function get_charge_ids_from_search_term( $term ) {
 		$order_term = 'Order #';
 		if ( substr( $term, 0, strlen( $order_term ) ) === $order_term ) {
 			$term_parts = explode( '#', $term, 2 );
 			$order_id   = isset( $term_parts[1] ) ? $term_parts[1] : '';
-		}
-		if ( ! isset( $order_id ) || empty( $order_id ) ) {
-			return '';
-		}
-
-		$order = wc_get_order( $order_id );
-
-		if ( ! $order ) {
-			return '';
+			$order      = wc_get_order( $order_id );
+			if ( $order ) {
+				return [ $order->get_meta( '_charge_id' ) ];
+			}
 		}
 
-		return $order->get_meta( '_charge_id' );
+		$subscription_term = 'Subscription #';
+		if ( function_exists( 'wcs_get_subscription' ) && substr( $term, 0, strlen( $subscription_term ) ) === $subscription_term ) {
+			$term_parts      = explode( '#', $term, 2 );
+			$subscription_id = isset( $term_parts[1] ) ? $term_parts[1] : '';
+			$subscription    = wcs_get_subscription( $subscription_id );
+			if ( $subscription ) {
+				return array_map(
+					function ( $order ) {
+						return $order->get_meta( '_charge_id' );
+					},
+					$subscription->get_related_orders( 'all' )
+				);
+			}
+		}
+
+		return null;
 	}
 
 	/**
-	 * Swaps "Order #" search terms with available charge_ids.
+	 * Swaps "Order #" and "Subscription #" search terms with available charge_ids.
 	 *
-	 * @param string $search Search query.
+	 * @param array $search Raw search query terms.
 	 *
-	 * @return string Processed search string.
+	 * @return array Processed search strings.
 	 */
 	public static function map_search_orders_to_charge_ids( $search ) {
-		// Map Order # terms to the actual charge id to be used in the server.
-		$terms = array_map(
-			function ( $term ) {
-				$charge_id = self::get_charge_id_from_search_term( $term );
-				if ( ! empty( $charge_id ) ) {
-					return $charge_id;
-				} else {
-					return $term;
+		// Map Order # and Subscription # terms to the actual charge id to be used in the server.
+		$terms = [];
+		foreach ( $search as $term ) {
+			$charge_ids = self::get_charge_ids_from_search_term( $term );
+			if ( ! empty( $charge_ids ) ) {
+				foreach ( $charge_ids as $charge_id ) {
+					$terms[] = $charge_id;
 				}
-			},
-			$search
-		);
+			} else {
+				$terms[] = $term;
+			}
+		}
 		return $terms;
 	}
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -447,7 +447,12 @@ class WC_Payments_API_Client {
 		);
 
 		if ( $order ) {
-			array_unshift( $results, [ 'label' => __( 'Order #', 'woocommerce-payments' ) . $search_term ] );
+			if ( function_exists( 'wcs_is_subscription' ) && wcs_is_subscription( $order ) ) {
+				$prefix = __( 'Subscription #', 'woocommerce-payments' );
+			} else {
+				$prefix = __( 'Order #', 'woocommerce-payments' );
+			}
+			array_unshift( $results, [ 'label' => $prefix . $search_term ] );
 		}
 
 		return $results;

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,7 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 * Add - Display payment method details on account subscriptions pages.
 * Add - Redact sensitive data before logging.
 * Add - Support for WooCommerce Subscriptions admin-initiated payment method changes.
+* Add - Support for Subscriptions in transaction search.
 
 = 1.4.1 - 2020-09-07 =
 * Fix - Only redirect to the onboarding screen if the plugin has been individually activated using the plugins page.

--- a/tests/helpers/class-wc-helper-subscription.php
+++ b/tests/helpers/class-wc-helper-subscription.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Subscription helpers.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * Class WC_Subscription.
+ *
+ * This helper class should ONLY be used for unit tests!.
+ */
+class WC_Subscription {
+	/**
+	 * Helper variable for mocking get_related_orders.
+	 *
+	 * @var array
+	 */
+	public $related_orders;
+
+	public function get_related_orders( $type ) {
+		return $this->related_orders;
+	}
+
+	public function set_related_orders( $array ) {
+		$this->related_orders = $array;
+	}
+}

--- a/tests/helpers/class-wc-helper-subscriptions.php
+++ b/tests/helpers/class-wc-helper-subscriptions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Subscription helpers.
+ * Subscriptions helpers.
  *
  * @package WooCommerce\Payments\Tests
  */
@@ -16,6 +16,10 @@ function wcs_get_subscriptions_for_order( $order ) {
 
 function wcs_is_subscription( $order ) {
 	return call_user_func( WC_Subscriptions::$wcs_is_subscription, $order );
+}
+
+function wcs_get_subscription( $subscription ) {
+	return call_user_func( WC_Subscriptions::$wcs_get_subscription, $subscription );
 }
 
 /**
@@ -52,6 +56,13 @@ class WC_Subscriptions {
 	 */
 	public static $wcs_is_subscription = null;
 
+	/**
+	 * wcs_get_subscription mock.
+	 *
+	 * @var function
+	 */
+	public static $wcs_get_subscription = null;
+
 	public static function set_wcs_order_contains_subscription( $function ) {
 		self::$wcs_order_contains_subscription = $function;
 	}
@@ -62,5 +73,9 @@ class WC_Subscriptions {
 
 	public static function set_wcs_is_subscription( $function ) {
 		self::$wcs_is_subscription = $function;
+	}
+
+	public static function set_wcs_get_subscription( $function ) {
+		self::$wcs_get_subscription = $function;
 	}
 }

--- a/tests/test-class-wc-payments-utils.php
+++ b/tests/test-class-wc-payments-utils.php
@@ -193,12 +193,12 @@ class WC_Payments_Utils_Test extends WP_UnitTestCase {
 
 	public function test_get_charge_ids_from_search_term_skips_invalid_terms() {
 		$result = WC_Payments_Utils::get_charge_ids_from_search_term( 'invalid term' );
-		$this->assertEquals( null, $result );
+		$this->assertEquals( [], $result );
 	}
 
 	public function test_get_charge_ids_from_search_term_handles_invalid_order() {
 		$result = WC_Payments_Utils::get_charge_ids_from_search_term( 'Order #897' );
-		$this->assertEquals( null, $result );
+		$this->assertEquals( [], $result );
 	}
 
 	public function test_get_charge_ids_from_search_term_handles_invalid_subscription() {
@@ -208,7 +208,7 @@ class WC_Payments_Utils_Test extends WP_UnitTestCase {
 			}
 		);
 		$result = WC_Payments_Utils::get_charge_ids_from_search_term( 'Subscription #897' );
-		$this->assertEquals( null, $result );
+		$this->assertEquals( [], $result );
 	}
 
 	public function test_map_search_orders_to_charge_ids() {


### PR DESCRIPTION
Fixes #867

#### Changes proposed in this Pull Request

Suggests and supports "Subscription #xxxx" terms in the Transaction search box, filtering the view down to transactions associated with orders that are related to the given subscription.

<img width="953" alt="subscription-search-1" src="https://user-images.githubusercontent.com/1867547/93897617-492fa100-fcc0-11ea-9b2f-9d6d95275d7b.png">

<img width="959" alt="subscription-search-2" src="https://user-images.githubusercontent.com/1867547/93897614-47fe7400-fcc0-11ea-9093-9d1885cd5108.png">

<img width="879" alt="subscription-search-3" src="https://user-images.githubusercontent.com/1867547/93897620-4a60ce00-fcc0-11ea-8004-56a82760a4ff.png">

(Note: the visual glitch in the latter screenshot appears for me in other WooCommerce Admin search fields, and I intend to propose a fix upstream for that and a couple of other minor things.)

https://github.com/Automattic/woocommerce-payments/commit/ce0c4fefac12a17a8427301c836d750a5ed479ef fixes the order term prefix association for the translated case.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- With Subscriptions having been purchased via WCPay…
- Type a Subscription number into the search field and select the corresponding term suggestion
  - Alternatively, type "Subscription #xxxx" as a free text term
- Observe that only those transactions having an association with the queried subscription now appear

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
