### PR TITLE
Adjust minimum compatible version to WC Subscriptions 2.2

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -108,7 +108,7 @@ class WC_Payments {
 
 		$gateway_class = 'WC_Payment_Gateway_WCPay';
 		// TODO: Remove admin payment method JS hack for Subscriptions <= 3.0.7 when we drop support for those versions.
-		if ( class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '3.0.0', '>=' ) ) {
+		if ( class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '2.2.0', '>=' ) ) {
 			include_once dirname( __FILE__ ) . '/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php';
 			$gateway_class = 'WC_Payment_Gateway_WCPay_Subscriptions_Compat';
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

Expand the set of WooCommerce Subscriptions versions compatible with this gateway (as discussed in p1600411875001600-slack-CGGCLBN58).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Install a version of WooCommerce Subscriptions between >= 2.2 and < 3.0.0, and verify that WooCommerce Payments declares support on the WooCommerce » Settings » Payments screen.

<img width="258" src="https://user-images.githubusercontent.com/1867547/94005541-6c178f00-fd6c-11ea-8bcb-fd0347e4cdc4.png">

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->