### PR TITLE
Adopt standard payment form structure

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.7.0 - 2020-xx-xx =
 * Fix - Fix ordering of payment detail timeline events.
+* Fix - Payment form hides when saved card is selected.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/client/checkout/style.scss
+++ b/client/checkout/style.scss
@@ -1,29 +1,14 @@
-#payment
-	.payment_methods
-	li
-	.payment_box.payment_method_woocommerce_payments
-	fieldset {
-	padding: 0;
-}
-
-#payment .payment_method_woocommerce_payments > fieldset > legend {
-	padding-top: 0;
-}
-
-#payment .payment_method_woocommerce_payments .testmode-info {
-	margin-bottom: 0.5em;
-}
-
-#payment .payment_method_woocommerce_payments .woocommerce-error {
-	margin: 1em 0 0;
-}
-
 #wcpay-card-element {
 	border: 1px solid #ddd;
 	padding: 5px 7px;
 	min-height: 29px;
+	margin-bottom: 0.5rem;
 }
 
 .wcpay-card-mounted {
 	background-color: #fff;
+}
+
+#payment .payment_method_woocommerce_payments .woocommerce-error {
+	margin: 1rem 0;
 }

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -354,33 +354,33 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			// Output the form HTML.
 			?>
-			<fieldset>
-				<?php if ( ! empty( $this->get_description() ) ) : ?>
-					<legend><?php echo wp_kses_post( $this->get_description() ); ?></legend>
-				<?php endif; ?>
+			<?php if ( ! empty( $this->get_description() ) ) : ?>
+				<p><?php echo wp_kses_post( $this->get_description() ); ?></p>
+			<?php endif; ?>
 
-				<?php if ( $this->is_in_test_mode() ) : ?>
-					<p class="testmode-info">
-					<?php
-						echo WC_Payments_Utils::esc_interpolated_html(
-							/* translators: link to Stripe testing page */
-							__( '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC, or any test card numbers listed <a>here</a>.', 'woocommerce-payments' ),
-							[
-								'strong' => '<strong>',
-								'a'      => '<a href="https://docs.woocommerce.com/document/payments/testing/#test-cards" target="_blank">',
-							]
-						);
-					?>
-					</p>
-				<?php endif; ?>
-
+			<?php if ( $this->is_in_test_mode() ) : ?>
+				<p class="testmode-info">
 				<?php
-				if ( $display_tokenization ) {
-					$this->tokenization_script();
-					echo $this->saved_payment_methods(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				}
+					echo WC_Payments_Utils::esc_interpolated_html(
+						/* translators: link to Stripe testing page */
+						__( '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC, or any test card numbers listed <a>here</a>.', 'woocommerce-payments' ),
+						[
+							'strong' => '<strong>',
+							'a'      => '<a href="https://docs.woocommerce.com/document/payments/testing/#test-cards" target="_blank">',
+						]
+					);
 				?>
+				</p>
+			<?php endif; ?>
 
+			<?php
+			if ( $display_tokenization ) {
+				$this->tokenization_script();
+				echo $this->saved_payment_methods(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
+			?>
+
+			<fieldset id="wc-<?php echo esc_attr( $this->id ); ?>-cc-form" class="wc-credit-card-form wc-payment-form">
 				<div id="wcpay-card-element"></div>
 				<div id="wcpay-errors" role="alert"></div>
 				<input id="wcpay-payment-method" type="hidden" name="wcpay-payment-method" />
@@ -390,7 +390,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					echo $this->save_payment_method_checkbox(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				}
 				?>
-
 
 			</fieldset>
 			<?php

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 1.7.0 - 2020-xx-xx =
 * Fix - Fix ordering of payment detail timeline events.
+* Fix - Payment form hides when saved card is selected.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/335
Fixes https://github.com/Automattic/woocommerce-payments/issues/836

#### Changes proposed in this Pull Request

The primary change is for the markup to wrap with a `fieldset` element (with "form" class names) only the payment fields themselves. This aligns with other payment methods, and specifically with what is anticipated by WC core's behavior to hide the fields when a saved card option is selected.

Also, the `legend` was likely not the most appropriate container for the description, and made it stand out in a slightly strange way in themes other than Storefront.

The styling has been adjusted to adapt to those changes, but also to somewhat improve the appearance across themes… by reducing the custom styling overall – it had previously been optimized for Storefront.

(Not covered by automated tests – is the structure here something we are or should be testing for?)

#### Testing instructions

With cards saved, go to Checkout and verify that payment fields show up only when "Use a new payment method" is selected.

Can also verify acceptable styling across popular themes.

#### Screenshots

No payment fields when a saved card is selected, which should address the root issue in https://github.com/Automattic/woocommerce-payments/issues/836:

<img width="315" src="https://user-images.githubusercontent.com/1867547/94231015-2a542900-fed1-11ea-960a-c1e3baee044f.png">

Appearance changes:

Theme | `master` | this branch
-- | -- | --
Storefront | <img width="357" src="https://user-images.githubusercontent.com/1867547/94229628-0f33ea00-fece-11ea-92e8-7d0cd86396e8.png"> | <img width="353" src="https://user-images.githubusercontent.com/1867547/94229661-28d53180-fece-11ea-8d1d-94da9124f0e8.png">
Twenty Twenty | <img width="564" src="https://user-images.githubusercontent.com/1867547/94229747-620da180-fece-11ea-8339-1380a9a96852.png"> | <img width="567" src="https://user-images.githubusercontent.com/1867547/94229784-781b6200-fece-11ea-9082-5d7dc8fcabf0.png">
Astra | <img width="445" src="https://user-images.githubusercontent.com/1867547/94229696-460a0000-fece-11ea-8ffd-880d45e5711b.png"> | <img width="450" src="https://user-images.githubusercontent.com/1867547/94229570-e7dd1d00-fecd-11ea-89a9-7f121ee80103.png">

(Could also consider having the test mode note inside the `fieldset` [[screenshot](https://cloudup.com/cCS9t4HOmfi)], in which case it would only show up when the fields do.)

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
