### PR TITLE
Tweak docker scripts and documentation

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -31,6 +31,17 @@ while [[ $? -ne 0 ]]; do
 	cli wp db check --path=/var/www/html --quiet > /dev/null
 done
 
+# If the plugin is already active then return early
+cli wp plugin is-active woocommerce-payments > /dev/null
+if [[ $? -eq 0 ]]; then
+	set -e
+	echo
+	echo "WCPay is installed and active"
+	echo "SUCCESS! You should now be able to access http://${SITE_URL}/wp-admin/"
+	echo "You can login by using the username and password both as 'admin'"
+	exit 0
+fi
+
 set -e
 
 echo
@@ -57,7 +68,8 @@ echo "Updating the WordPress database..."
 cli wp core update-db --quiet
 
 echo "Configuring paths to work with ngrok...";
-cli config set DOCKER_REQUEST_URL "( ! empty( \$_SERVER['HTTPS'] ) ? 'https://' : 'http://' ) . ( ! empty( \$_SERVER['HTTP_HOST'] ) ? \$_SERVER['HTTP_HOST'] : 'localhost' )" --raw
+cli config set DOCKER_HOST "\$_SERVER['HTTP_X_ORIGINAL_HOST'] ?? \$_SERVER['HTTP_HOST'] ?? 'localhost'" --raw
+cli config set DOCKER_REQUEST_URL "( ! empty( \$_SERVER['HTTPS'] ) ? 'https://' : 'http://' ) . DOCKER_HOST" --raw
 cli config set WP_SITEURL DOCKER_REQUEST_URL --raw
 cli config set WP_HOME DOCKER_REQUEST_URL --raw
 
@@ -100,6 +112,17 @@ else
 	echo "Updating WooCommerce Payments settings"
 	cli wp option update woocommerce_woocommerce_payments_settings --format=json '{"enabled":"yes"}'
 fi
+
+echo "Installing dev tools plugin..."
+set +e
+git clone git@github.com:Automattic/woocommerce-payments-dddddddev-tools.git docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools
+if [[ $? -eq 0 ]]; then
+	cli wp plugin activate woocommerce-payments-dev-tools
+else
+	echo
+	echo "WARN: Could not access the dev tools repository. Skipping the install."
+fi;
+set -e
 
 echo
 echo "SUCCESS! You should now be able to access http://${SITE_URL}/wp-admin/"

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/bash
 
 # Exit if any command fails.
 set -e

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -115,7 +115,7 @@ fi
 
 echo "Installing dev tools plugin..."
 set +e
-git clone git@github.com:Automattic/woocommerce-payments-dddddddev-tools.git docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools
+git clone git@github.com:Automattic/woocommerce-payments-dev-tools.git docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools
 if [[ $? -eq 0 ]]; then
 	cli wp plugin activate woocommerce-payments-dev-tools
 else

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,31 +1,14 @@
 ### Setting up the Docker environment
 
+Make sure everything has been installed:
+
+`npm install`
+
 To start a local development environment with the plugin locally enter this command:
 
-`npm run dev`
+`npm run up`
 
-Install the core:
-
-```
-docker run -it --rm --volumes-from woocommerce_payments_wordpress --network woocommerce-payments_default wordpress:cli core install --url=localhost:8082 --title=test --admin_user=admin --admin_email=wordpress@example.com --admin_password=admin
-```
-
-Install and activate WooCommerce and Jetpack by running:
-
-```
-docker run -it --rm --volumes-from woocommerce_payments_wordpress --network woocommerce-payments_default  wordpress:cli plugin install woocommerce jetpack --activate
-```
-
-Install dev tools plugin:
-https://github.com/automattic/woocommerce-payments-dev-tools
-
-```sh
-git clone git@github.com:Automattic/woocommerce-payments-dev-tools.git docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools
-
-docker run -it --rm --volumes-from woocommerce_payments_wordpress --network woocommerce-payments_default  wordpress:cli plugin activate woocommerce-payments woocommerce-payments-dev-tools
-```
-
-If you will be using our local Docker server environment as well, be sure check "Enable API request redirection" in the dev mode settings
+Remember to either build the JS (`npm run build`) or watch for JS changes (`npm start`)
 
 ### Connect Jetpack by using Ngrok
 You don't need a paid plan for this.
@@ -38,39 +21,5 @@ ngrok http 8082 --host-header=rewrite
 
 You will see it give a forwarding address like this one:
  http://e0747cffd8a3.ngrok.io
- 
-Copy the address and use it in the following command (replacing `<url>`)
 
-```
-npm run wp option update home <url>
-npm run wp option update siteurl <url>
-```
-
-Visit the `<url>` , login and connect to Jetpack. If this doesn't work, visit `localhost:8082` and you will be redirected 
-to `<url>`.
-
-
-Activate Jetpack and setup WCPay.
-
-
-Turn off Ngrok by running:
-
-```
-npm run wp option update home http://localhost:8082
-npm run wp option update siteurl http://localhost:8082
-```
-
-After this succeeds you can access the local site at
-
-http://localhost:8082/
-
-### Connect to the Server running locally
-
-To get your blog ID run:
-
-```
-npm run wp eval 'echo Jetpack_Options::get_option( "id" );'
-```
-
-For the rest of the setup instructions see this link:
-https://github.com/Automattic/woocommerce-payments-server/tree/master/local
+Visit the `<url>` , login and setup WCPay.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "wp_org_slug": "woocommerce-payments"
   },
   "scripts": {
+    "postinstall": "composer install",
     "build": "npm run build:deps && npm run build:release",
     "build:client": "NODE_ENV=production webpack",
     "build:deps": "rm -rf vendor && composer install --no-dev",
@@ -31,7 +32,7 @@
     "watch": "webpack --watch",
     "start": "npm run watch",
     "dev": "npm run up && npm run watch",
-    "up": "docker-compose up --build --force-recreate -d",
+    "up": "docker-compose up --build --force-recreate -d && ./bin/docker-setup.sh",
     "down": "docker-compose down",
     "wp": "docker-compose exec -u www-data wordpress wp",
     "install-if-deps-outdated": "node bin/install-if-deps-outdated.js",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make `bin/docker-setup.sh` run as a part of `npm up`
* Add wp-config lines to handle ngrok with docker
* Run `composer install` every time after `npm install` is run
* Make the docker setup script exit early if everything is already set up
* Attempt to install dev tools as a part of docker setup

#### Testing instructions

* If you had this running before, you will need to clone the repo to a new directory
* `npm run up`
* Wait for a long time, make yourself a cup of tea
* The script should complete its run
* Visit `http://localhost:8082/wp-admin/` - the plugins should be installed and active
* Run `ngrok http 8082 --host-header=rewrite`
* Visit `<NGROK_URL>.ngrok.io/wp-admin` - you shouldn't be redirected to localhost
* Connect wcpay - it should work
