### PR TITLE
Add autoloader optimization when building for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postinstall": "composer install",
     "build": "npm run build:deps && npm run build:release",
     "build:client": "NODE_ENV=production webpack",
-    "build:deps": "rm -rf vendor && composer install --no-dev",
+    "build:deps": "rm -rf vendor && composer install --no-dev --optimize-autoloader",
     "build:release": "node tasks/release.js && mv release/$npm_package_name.zip .",
     "test": "wp-scripts test-unit-js --config tests/js/jest.config.json",
     "test:watch": "wp-scripts test-unit-js --config tests/js/jest.config.json --watch",


### PR DESCRIPTION
Fixes #955

#### Changes proposed in this Pull Request

* Add `--optimize-autoloader` option when running install before the release

#### Testing instructions

* Smoke test with various combinations of the Jetpack/client-example plugins installed and confirm that nothing breaks

cc @kalessil 
