### PR TITLE
Trim whitespace on the statement descriptor

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Payments Changelog ***
 
 = 1.x.x - 2020-xx-xx =
+* Fix - Trimming the whitespace when updating the bank statement descriptor
 * Add - Initial support for the checkout block.
 
 = 1.5.0 - 2020-09-24 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Payments Changelog ***
 
 = 1.x.x - 2020-xx-xx =
-* Fix - Trimming the whitespace when updating the bank statement descriptor
+* Fix - Trimming the whitespace when updating the bank statement descriptor.
 * Add - Initial support for the checkout block.
 
 = 1.5.0 - 2020-09-24 =

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -913,8 +913,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	public function validate_account_statement_descriptor_field( $key, $value ) {
 		// Since the value is escaped, and we are saving in a place that does not require escaping, apply stripslashes.
-		$value = stripslashes( $value );
-		$value = trim( $value );
+		$value = trim( stripslashes( $value ) );
 
 		// Validation can be done with a single regex but splitting into multiple for better readability.
 		$valid_length   = '/^.{5,22}$/';

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -914,6 +914,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public function validate_account_statement_descriptor_field( $key, $value ) {
 		// Since the value is escaped, and we are saving in a place that does not require escaping, apply stripslashes.
 		$value = stripslashes( $value );
+		$value = trim( $value );
 
 		// Validation can be done with a single regex but splitting into multiple for better readability.
 		$valid_length   = '/^.{5,22}$/';

--- a/readme.txt
+++ b/readme.txt
@@ -91,7 +91,7 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 == Changelog ==
 
 = 1.x.x - 2020-xx-xx =
-* Fix - Trimming the whitespace when updating the bank statement descriptor
+* Fix - Trimming the whitespace when updating the bank statement descriptor.
 * Add - Initial support for the checkout block.
 
 = 1.5.0 - 2020-09-24 =

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,7 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 == Changelog ==
 
 = 1.x.x - 2020-xx-xx =
+* Fix - Trimming the whitespace when updating the bank statement descriptor
 * Add - Initial support for the checkout block.
 
 = 1.5.0 - 2020-09-24 =

--- a/tests/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/test-class-wc-payment-gateway-wcpay.php
@@ -569,6 +569,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			'allow_amp'      => [ true, 'WCPay&Dev_2020' ],
 			'strip_slashes'  => [ true, 'WCPay\\\\Dev_2020', 'WCPay\\Dev_2020' ],
 			'allow_long_amp' => [ true, 'aaaaaaaaaaaaaaaaaaa&aa' ],
+			'trim_valid'     => [ true, '   good_descriptor  ', 'good_descriptor' ],
 			'empty'          => [ false, '' ],
 			'short'          => [ false, 'WCP' ],
 			'long'           => [ false, 'WCPay_dev_WCPay_dev_WCPay_dev_WCPay_dev' ],
@@ -579,6 +580,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			'no_gt'          => [ false, 'WCPay>dev' ],
 			'req_latin'      => [ false, 'дескриптор' ],
 			'req_letter'     => [ false, '123456' ],
+			'trim_too_short' => [ false, '  aaa    ' ],
 		];
 	}
 }


### PR DESCRIPTION
Fixes #957 

#### Changes proposed in this Pull Request

* Trim the whitespace and add unit tests

#### Testing instructions

* In the settings page:
* Try updating the statement descriptor to `aaa` prefixed or suffixed with spaces, so the overall length is between 5 and 22
  * You should get an error notice beginning with `Customer bank statement is invalid. Statement should be between 5 and 22 characters long...`
  * The descriptor shouldn't save
* Try updating the statement descriptor to `aaaaa` prefixed or suffixed with spaces as long as the length is less than 5
  * The descriptor should save, but the whitespace should be removed

cc @kalessil 

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)