### PR TITLE
Support wp_get_environment_type() when detecting dev-mode

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.x.x - 2020-xx-xx =
 * Add - Initial support for the checkout block.
+* Add - Support wp_get_environment_type() and enable dev-mode when environment is 'development' or 'staging'.
 
 = 1.5.0 - 2020-09-24 =
 * Fix - Save payment method checkbox for Subscriptions customer-initiated payment method updates.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -221,7 +221,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return bool
 	 */
 	public function is_in_dev_mode() {
-		return apply_filters( 'wcpay_dev_mode', defined( 'WCPAY_DEV_MODE' ) && WCPAY_DEV_MODE );
+		$is_extension_dev_mode        = defined( 'WCPAY_DEV_MODE' ) && WCPAY_DEV_MODE;
+		$is_wordpress_dev_environment = function_exists( 'wp_get_environment_type' ) && in_array( wp_get_environment_type(), [ 'development', 'staging' ], true );
+		return apply_filters( 'wcpay_dev_mode', $is_extension_dev_mode || $is_wordpress_dev_environment );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,7 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 
 = 1.x.x - 2020-xx-xx =
 * Add - Initial support for the checkout block.
+* Add - Support wp_get_environment_type() and enable dev-mode when environment is 'development' or 'staging'.
 
 = 1.5.0 - 2020-09-24 =
 * Fix - Save payment method checkbox for Subscriptions customer-initiated payment method updates.


### PR DESCRIPTION
The wp_get_environment_type() was introduced in WordPress 5.5 and returns instance environment (staging, production and etc.). We are using it (if available) to ensure that test Stripe accounts will be used in development and staging environments.

Fixes #840

#### Changes proposed in this Pull Request

* If `wp_get_environment_type()` is available and returns `development` or `staging`, enable dev-mode.

#### Testing instructions

* disable `woocommerce-payments-dev-tools` extension
* ensure you have `define( 'WP_ENVIRONMENT_TYPE', 'development' );` in wp-config.php
* start adding new payment method: Stripe should indicate you are int testing mode

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in the description ☝️)
