### PR TITLE
Updates docker setup with setting up WordPress environment type to 'development' (for wp_get_environment_type() function)

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -67,11 +67,14 @@ cli wp core update --quiet
 echo "Updating the WordPress database..."
 cli wp core update-db --quiet
 
-echo "Configuring paths to work with ngrok...";
+echo "Configuring WordPress to work with ngrok (enables Jetpack and adding Stripe payment)";
 cli config set DOCKER_HOST "\$_SERVER['HTTP_X_ORIGINAL_HOST'] ?? \$_SERVER['HTTP_HOST'] ?? 'localhost'" --raw
 cli config set DOCKER_REQUEST_URL "( ! empty( \$_SERVER['HTTPS'] ) ? 'https://' : 'http://' ) . DOCKER_HOST" --raw
 cli config set WP_SITEURL DOCKER_REQUEST_URL --raw
 cli config set WP_HOME DOCKER_REQUEST_URL --raw
+
+echo "Enabling WordPress development environment (enforces Stripe testing mode)";
+cli config set WP_ENVIRONMENT_TYPE "'development'" --raw
 
 echo "Updating permalink structure"
 cli wp rewrite structure '/%postname%/'

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -67,14 +67,14 @@ cli wp core update --quiet
 echo "Updating the WordPress database..."
 cli wp core update-db --quiet
 
-echo "Configuring WordPress to work with ngrok (enables Jetpack and adding Stripe payment)";
+echo "Configuring WordPress to work with ngrok (in order to allow creating a Jetpack-WPCOM connection)";
 cli config set DOCKER_HOST "\$_SERVER['HTTP_X_ORIGINAL_HOST'] ?? \$_SERVER['HTTP_HOST'] ?? 'localhost'" --raw
 cli config set DOCKER_REQUEST_URL "( ! empty( \$_SERVER['HTTPS'] ) ? 'https://' : 'http://' ) . DOCKER_HOST" --raw
 cli config set WP_SITEURL DOCKER_REQUEST_URL --raw
 cli config set WP_HOME DOCKER_REQUEST_URL --raw
 
 echo "Enabling WordPress development environment (enforces Stripe testing mode)";
-cli config set WP_ENVIRONMENT_TYPE "'development'" --raw
+cli config set WP_ENVIRONMENT_TYPE development
 
 echo "Updating permalink structure"
 cli wp rewrite structure '/%postname%/'


### PR DESCRIPTION
Fixes #841

#### Changes proposed in this Pull Request

* Updated docker setup script: setup WordPress environment to 'development'

#### Testing instructions

* run `npm run up`
* ensure you have `define( 'WP_ENVIRONMENT_TYPE', 'development' );` in wp-config.php

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in the description ☝️)

