### PR TITLE
Fix including of a renamed exception file

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -73,6 +73,12 @@ cli config set DOCKER_REQUEST_URL "( ! empty( \$_SERVER['HTTPS'] ) ? 'https://' 
 cli config set WP_SITEURL DOCKER_REQUEST_URL --raw
 cli config set WP_HOME DOCKER_REQUEST_URL --raw
 
+echo "Enabling WP_DEBUG"
+cli config set WP_DEBUG true --raw
+cli config set WP_DEBUG_DISPLAY true --raw
+cli config set WP_DEBUG_LOG true --raw
+cli config set SCRIPT_DEBUG true --raw
+
 echo "Enabling WordPress development environment (enforces Stripe testing mode)";
 cli config set WP_ENVIRONMENT_TYPE development
 

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -73,7 +73,7 @@ cli config set DOCKER_REQUEST_URL "( ! empty( \$_SERVER['HTTPS'] ) ? 'https://' 
 cli config set WP_SITEURL DOCKER_REQUEST_URL --raw
 cli config set WP_HOME DOCKER_REQUEST_URL --raw
 
-echo "Enabling WP_DEBUG"
+echo "Enabling WordPress debug flags"
 cli config set WP_DEBUG true --raw
 cli config set WP_DEBUG_DISPLAY true --raw
 cli config set WP_DEBUG_LOG true --raw

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -440,7 +440,7 @@ class WC_Payments {
 	 * Initialize the REST API controllers.
 	 */
 	public static function init_rest_api() {
-		include_once WCPAY_ABSPATH . 'includes/exceptions/class-wc-payments-rest-request-exception.php';
+		include_once WCPAY_ABSPATH . 'includes/exceptions/class-rest-request-exception.php';
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-rest-controller.php';
 
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-deposits-controller.php';


### PR DESCRIPTION
Fixes #967

#### Changes proposed in this Pull Request

* Updated the included path
* Tried searching for any other missed paths with `wc-payments.*exception`, couldn't find any
* Updated the `docker-setup` to make sure WP_DEBUG is enabled together with other debug options 

#### Testing instructions

* Make sure your wp-config.php contains the following lines:
```
define( 'WP_DEBUG', true);
define( 'WP_DEBUG_DISPLAY', true );
define( 'WP_DEBUG_LOG', true );
define( 'SCRIPT_DEBUG', true );
```
* Load any wcpay admin page (transactions, deposits etc)
* No notices should be displayed

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
