### PR TITLE
Transaction timeline: enabled timestamps rendering for all entries

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Add - Initial support for the checkout block.
 * Add - Support wp_get_environment_type() and enable dev-mode when environment is 'development' or 'staging'.
 * Update - Introduced payments-specific exceptions instead of generic one.
+* Update - Transaction timeline: enabled timestamps rendering for all entries.
 
 = 1.5.0 - 2020-09-24 =
 * Fix - Save payment method checkbox for Subscriptions customer-initiated payment method updates.

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -64,7 +64,7 @@ const getStatusChangeTimelineItem = ( event, status ) => {
 			status
 		),
 		body: [],
-		hideTimestamp: true,
+		hideTimestamp: false,
 	};
 };
 
@@ -134,7 +134,7 @@ const getDepositTimelineItem = (
 		icon: getIcon( isPositive ? 'plus' : 'minus' ),
 		headline,
 		body,
-		hideTimestamp: true,
+		hideTimestamp: false,
 	};
 };
 
@@ -344,7 +344,7 @@ const mapEventToTimelineItems = ( event ) => {
 						'woocommerce-services'
 					),
 				],
-				hideTimestamp: true,
+				hideTimestamp: false,
 			};
 		} else {
 			const formattedTotal = formatCurrency(

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -64,7 +64,6 @@ const getStatusChangeTimelineItem = ( event, status ) => {
 			status
 		),
 		body: [],
-		hideTimestamp: false,
 	};
 };
 
@@ -134,7 +133,6 @@ const getDepositTimelineItem = (
 		icon: getIcon( isPositive ? 'plus' : 'minus' ),
 		headline,
 		body,
-		hideTimestamp: false,
 	};
 };
 
@@ -344,7 +342,6 @@ const mapEventToTimelineItems = ( event ) => {
 						'woocommerce-services'
 					),
 				],
-				hideTimestamp: false,
 			};
 		} else {
 			const formattedTotal = formatCurrency(

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -16,7 +16,7 @@ Array [
     "body": Array [],
     "date": 2020-03-31T21:58:40.000Z,
     "headline": "Payment status changed to Authorization Expired",
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -42,7 +42,7 @@ Array [
     "body": Array [],
     "date": 2020-03-31T10:57:59.000Z,
     "headline": "Payment status changed to Authorization Voided",
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -68,7 +68,7 @@ Array [
     "body": Array [],
     "date": 2020-03-30T17:33:16.000Z,
     "headline": "Payment status changed to Authorized",
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -104,7 +104,7 @@ Array [
         Apr 2, 2020 deposit
       </a>
     </React.Fragment>,
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="plus"
@@ -115,7 +115,7 @@ Array [
     "body": Array [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "Payment status changed to Paid",
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -141,7 +141,7 @@ Array [
     "body": Array [],
     "date": 2020-04-01T03:35:13.000Z,
     "headline": "Payment status changed to Failed",
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -182,7 +182,7 @@ Array [
     "body": Array [],
     "date": 2020-04-02T20:26:47.000Z,
     "headline": "Payment status changed to Disputed: In Review",
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -208,7 +208,7 @@ Array [
     "body": Array [],
     "date": 2020-04-05T02:56:10.000Z,
     "headline": "Payment status changed to Disputed: Lost",
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -243,7 +243,7 @@ Array [
     ],
     "date": 2020-04-02T02:06:14.000Z,
     "headline": "$110.00 will be deducted from a future deposit",
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="minus"
@@ -254,7 +254,7 @@ Array [
     "body": Array [],
     "date": 2020-04-02T02:06:14.000Z,
     "headline": "Payment status changed to Disputed: Needs Response",
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -288,7 +288,7 @@ Array [
     ],
     "date": 2020-04-02T02:06:14.000Z,
     "headline": "No funds have been withdrawn yet",
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="info-outline"
@@ -299,7 +299,7 @@ Array [
     "body": Array [],
     "date": 2020-04-02T02:06:14.000Z,
     "headline": "Payment status changed to Disputed: Needs Response",
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -350,7 +350,7 @@ Array [
         Apr 5, 2020 deposit
       </a>
     </React.Fragment>,
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="plus"
@@ -361,7 +361,7 @@ Array [
     "body": Array [],
     "date": 2020-04-04T16:20:50.000Z,
     "headline": "Payment status changed to Disputed: Won",
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -387,7 +387,7 @@ Array [
     "body": Array [],
     "date": 2020-04-04T13:51:06.000Z,
     "headline": "$100.00 will be deducted from a future deposit",
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="minus"
@@ -398,7 +398,7 @@ Array [
     "body": Array [],
     "date": 2020-04-04T13:51:06.000Z,
     "headline": "Payment status changed to Refunded",
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -424,7 +424,7 @@ Array [
     "body": Array [],
     "date": 2020-04-03T18:58:01.000Z,
     "headline": "$50.00 will be deducted from a future deposit",
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="minus"
@@ -435,7 +435,7 @@ Array [
     "body": Array [],
     "date": 2020-04-03T18:58:01.000Z,
     "headline": "Payment status changed to Partial Refund",
-    "hideTimestamp": true,
+    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -16,7 +16,6 @@ Array [
     "body": Array [],
     "date": 2020-03-31T21:58:40.000Z,
     "headline": "Payment status changed to Authorization Expired",
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -42,7 +41,6 @@ Array [
     "body": Array [],
     "date": 2020-03-31T10:57:59.000Z,
     "headline": "Payment status changed to Authorization Voided",
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -68,7 +66,6 @@ Array [
     "body": Array [],
     "date": 2020-03-30T17:33:16.000Z,
     "headline": "Payment status changed to Authorized",
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -104,7 +101,6 @@ Array [
         Apr 2, 2020 deposit
       </a>
     </React.Fragment>,
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="plus"
@@ -115,7 +111,6 @@ Array [
     "body": Array [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "Payment status changed to Paid",
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -141,7 +136,6 @@ Array [
     "body": Array [],
     "date": 2020-04-01T03:35:13.000Z,
     "headline": "Payment status changed to Failed",
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -182,7 +176,6 @@ Array [
     "body": Array [],
     "date": 2020-04-02T20:26:47.000Z,
     "headline": "Payment status changed to Disputed: In Review",
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -208,7 +201,6 @@ Array [
     "body": Array [],
     "date": 2020-04-05T02:56:10.000Z,
     "headline": "Payment status changed to Disputed: Lost",
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -243,7 +235,6 @@ Array [
     ],
     "date": 2020-04-02T02:06:14.000Z,
     "headline": "$110.00 will be deducted from a future deposit",
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="minus"
@@ -254,7 +245,6 @@ Array [
     "body": Array [],
     "date": 2020-04-02T02:06:14.000Z,
     "headline": "Payment status changed to Disputed: Needs Response",
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -288,7 +278,6 @@ Array [
     ],
     "date": 2020-04-02T02:06:14.000Z,
     "headline": "No funds have been withdrawn yet",
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="info-outline"
@@ -299,7 +288,6 @@ Array [
     "body": Array [],
     "date": 2020-04-02T02:06:14.000Z,
     "headline": "Payment status changed to Disputed: Needs Response",
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -350,7 +338,6 @@ Array [
         Apr 5, 2020 deposit
       </a>
     </React.Fragment>,
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="plus"
@@ -361,7 +348,6 @@ Array [
     "body": Array [],
     "date": 2020-04-04T16:20:50.000Z,
     "headline": "Payment status changed to Disputed: Won",
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -387,7 +373,6 @@ Array [
     "body": Array [],
     "date": 2020-04-04T13:51:06.000Z,
     "headline": "$100.00 will be deducted from a future deposit",
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="minus"
@@ -398,7 +383,6 @@ Array [
     "body": Array [],
     "date": 2020-04-04T13:51:06.000Z,
     "headline": "Payment status changed to Refunded",
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"
@@ -424,7 +408,6 @@ Array [
     "body": Array [],
     "date": 2020-04-03T18:58:01.000Z,
     "headline": "$50.00 will be deducted from a future deposit",
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="minus"
@@ -435,7 +418,6 @@ Array [
     "body": Array [],
     "date": 2020-04-03T18:58:01.000Z,
     "headline": "Payment status changed to Partial Refund",
-    "hideTimestamp": false,
     "icon": <t
       className=""
       icon="sync"

--- a/readme.txt
+++ b/readme.txt
@@ -95,6 +95,7 @@ You can read our Terms of Service [here](https://en.wordpress.com/tos).
 * Add - Initial support for the checkout block.
 * Add - Support wp_get_environment_type() and enable dev-mode when environment is 'development' or 'staging'.
 * Update - Introduced payments-specific exceptions instead of generic one.
+* Update - Transaction timeline: enabled timestamps rendering for all entries.
 
 = 1.5.0 - 2020-09-24 =
 * Fix - Save payment method checkbox for Subscriptions customer-initiated payment method updates.


### PR DESCRIPTION
Fixes #791

#### Changes proposed in this Pull Request

* Enables timestamps rendering for all entries in the timeline

#### Testing instructions

* navigate to "Payments -> Transactions" in WP administration area
* click on i-icon on the left of any transaction
* ensure all entries in the Timeline section (including gray-colored) has time displayed on the right side

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in the description ☝️)
