### PR TITLE
Hardened composer manifest verification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,11 +52,6 @@ matrix:
     stage: e2e-testing
     script:
       - npm run build:client && npm run test:e2e-setup && npm run test:e2e
-  - name: "Dependencies validation"
-    stage: secure-dependecies
-    script:
-      - composer require --dev kalessil/production-dependencies-guard:dev-master roave/security-advisories:dev-master
-      - npm audit --audit-level=moderate --production
 
 before_install:
   - nvm install lts/erbium

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,8 @@ matrix:
     stage: e2e-testing
     script:
       - npm run build:client && npm run test:e2e-setup && npm run test:e2e
-  - stage: validate-composer-manifest
+  - name: "composer.json validation"
+    stage: validate-composer-manifest
     script:
       - composer validate --strict --no-check-all
       - composer require --dev kalessil/production-dependencies-guard:dev-master roave/security-advisories:dev-master

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,11 +52,11 @@ matrix:
     stage: e2e-testing
     script:
       - npm run build:client && npm run test:e2e-setup && npm run test:e2e
-  - name: "composer.json validation"
-    stage: validate-composer-manifest
+  - name: "Dependencies validation"
+    stage: secure-dependecies
     script:
-      - composer validate --strict --no-check-all
       - composer require --dev kalessil/production-dependencies-guard:dev-master roave/security-advisories:dev-master
+      - npm audit --audit-level=moderate --production
 
 before_install:
   - nvm install lts/erbium

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
   - name: "E2E tests"
     stage: e2e-testing
     script:
-      - npm run build:client && npm run test:e2e-setup && npm run test:e2e  - name: "E2E tests"
+      - npm run build:client && npm run test:e2e-setup && npm run test:e2e
   - stage: validate-composer-manifest
     script:
       - composer validate --strict --no-check-all

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,11 @@ matrix:
   - name: "E2E tests"
     stage: e2e-testing
     script:
-      - npm run build:client && npm run test:e2e-setup && npm run test:e2e
+      - npm run build:client && npm run test:e2e-setup && npm run test:e2e  - name: "E2E tests"
+  - stage: validate-composer-manifest
+    script:
+      - composer validate --strict --no-check-all
+      - composer require --dev kalessil/production-dependencies-guard:dev-master roave/security-advisories:dev-master
 
 before_install:
   - nvm install lts/erbium

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,13 @@
       "automattic/jetpack-connection": "1.17.2",
       "automattic/jetpack-config": "1.4.1",
       "automattic/jetpack-autoloader": "2.3.0",
-        "myclabs/php-enum": "^1.6"
+      "myclabs/php-enum": "^1.6"
     },
     "require-dev": {
       "composer/installers": "1.9.0",
       "phpunit/phpunit": "6.5.14",
-      "woocommerce/woocommerce-sniffs": "0.0.10"
+      "woocommerce/woocommerce-sniffs": "0.0.10",
+      "kalessil/production-dependencies-guard": "dev-master"
     },
     "scripts": {
       "test": [

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,10 @@
         "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
         "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
       },
-      "installer-disable": true
+      "installer-disable": true,
+      "production-dependencies-guard": [
+        "check-lock-file",
+        "check-abandoned"
+      ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8a8edd409bd13da29c8f45633e78d4fd",
+    "content-hash": "798fd66d12f05af3f146d6eb27c62211",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "798fd66d12f05af3f146d6eb27c62211",
+    "content-hash": "9f9b85a3b24ce4866df016c7579cbaf5",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -680,6 +680,58 @@
                 "instantiate"
             ],
             "time": "2015-06-14T21:17:01+00:00"
+        },
+        {
+            "name": "kalessil/production-dependencies-guard",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kalessil/production-dependencies-guard.git",
+                "reference": "684c0374a2f0af31ea27de4107b28344d1bbc0d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kalessil/production-dependencies-guard/zipball/684c0374a2f0af31ea27de4107b28344d1bbc0d3",
+                "reference": "684c0374a2f0af31ea27de4107b28344d1bbc0d3",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1",
+                "ext-json": "*",
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.8",
+                "ext-xdebug": "*",
+                "infection/infection": "^0.9",
+                "phpunit/phpunit": "^6.5",
+                "rregeer/phpunit-coverage-check": "^0.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Kalessil\\Composer\\Plugins\\ProductionDependenciesGuard\\Guard"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Kalessil\\Composer\\Plugins\\ProductionDependenciesGuard\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Vladimir Reznichenko",
+                    "email": "kalessil@gmail.com",
+                    "role": "maintainer"
+                }
+            ],
+            "description": "Prevents adding of development packages into require-section (should be require-dev).",
+            "homepage": "https://github.com/kalessil/production-dependencies-guard",
+            "time": "2019-05-14T11:33:20+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2459,7 +2511,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "kalessil/production-dependencies-guard": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
       "npm run format:provided",
       "npm run lint:css"
     ],
-    "*.php": "./vendor/bin/phpcs --standard=phpcs.xml.dist --basepath=. --colors"
+    "*.php": "./vendor/bin/phpcs --standard=phpcs.xml.dist --basepath=. --colors",
+    "composer.json": "composer validate --strict --no-check-all"
   },
   "dependencies": {
     "@stripe/react-stripe-js": "^1.1.2",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR :
    * adds composer.json validation
    * ensures that no dev-packages specified in "require" (see [kalessil/production-dependencies-guard](https://github.com/kalessil/production-dependencies-guard))
        * I also enabled abandoned packages check to the guard settings as this can not be covered by existing tools

#### Testing instructions

- N/A

