### PR TITLE
Checkout block: allow retrying after a failed payment

### DIFF
--- a/client/checkout/blocks/confirm-card-payment.js
+++ b/client/checkout/blocks/confirm-card-payment.js
@@ -37,6 +37,7 @@ export default async function confirmCardPayment(
 			type: 'error',
 			message: error.message,
 			messageContext: emitResponse.noticeContexts.PAYMENTS,
+			retry: true,
 		};
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3221.

#### Changes proposed in this Pull Request

This PR fixes an issue described in #723 that we originally thought was a bug in WC Blocks (https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3221). The issue was preventing the user to resubmit the form after a failed payment. That can be fixed adding [`retry: true`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/extensibility/checkout-flow-and-events.md#oncheckoutafterprocessingwithsuccess) to the error response.

#### Testing instructions

* Install [WC Blocks](https://github.com/woocommerce/woocommerce-gutenberg-products-block) and create a Checkout page with the Checkout block.
* Submit an order with the card number `4000 0027 6000 3184`, but in the validation popup, press on `Fail authentication` or `Cancel`.
* Verify the `Place Order` button doesn't stay disabled and you can resubmit the order.