### PR TITLE
Set changelog and readme version to prepare for 1.6.0 release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Payments Changelog ***
 
-= 1.x.x - 2020-xx-xx =
+= 1.6.0 - 2020-xx-xx =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.
 * Add - Initial support for the checkout block.
 * Add - Support wp_get_environment_type() and enable dev-mode when environment is 'development' or 'staging'.

--- a/readme.txt
+++ b/readme.txt
@@ -101,7 +101,7 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
-= 1.x.x - 2020-xx-xx =
+= 1.6.0 - 2020-xx-xx =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.
 * Add - Initial support for the checkout block.
 * Add - Support wp_get_environment_type() and enable dev-mode when environment is 'development' or 'staging'.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic
 Tags: woocommerce, payment, payment request, credit card, automattic
 Requires at least: 5.3
-Tested up to: 5.4
+Tested up to: 5.5
 Requires PHP: 7.0
 Stable tag: 1.5.0
 License: GPLv2 or later

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 4.0
- * WC tested up to: 4.5
+ * WC tested up to: 4.6
  * Requires WP: 5.3
  * Version: 1.5.0
  *

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 4.0
- * WC tested up to: 4.4
+ * WC tested up to: 4.5
  * Requires WP: 5.3
  * Version: 1.5.0
  *


### PR DESCRIPTION
Fixes #952 

#### Changes proposed in this Pull Request

* Prepares changelog and readme for running woorelease.
* Bump tested up to versions.

Woorelease script should take care of the remaining version bumps.

#### Testing instructions

* Check version number.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
