### PR TITLE
Fix the order of timeline events

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 1.7.0 - 2020-xx-xx =
+* Fix - Fix ordering of payment detail timeline events.
+
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.
 * Add - Initial support for the checkout block.

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -178,6 +178,10 @@ const mapEventToTimelineItems = ( event ) => {
 
 	if ( 'authorized' === type ) {
 		return [
+			getStatusChangeTimelineItem(
+				event,
+				__( 'Authorized', 'woocommerce-payments' )
+			),
 			getMainTimelineItem(
 				event,
 				stringWithAmount(
@@ -191,13 +195,13 @@ const mapEventToTimelineItems = ( event ) => {
 				'checkmark',
 				'is-warning'
 			),
-			getStatusChangeTimelineItem(
-				event,
-				__( 'Authorized', 'woocommerce-payments' )
-			),
 		];
 	} else if ( 'authorization_voided' === type ) {
 		return [
+			getStatusChangeTimelineItem(
+				event,
+				__( 'Authorization Voided', 'woocommerce-payments' )
+			),
 			getMainTimelineItem(
 				event,
 				stringWithAmount(
@@ -211,13 +215,13 @@ const mapEventToTimelineItems = ( event ) => {
 				'checkmark',
 				'is-warning'
 			),
-			getStatusChangeTimelineItem(
-				event,
-				__( 'Authorization Voided', 'woocommerce-payments' )
-			),
 		];
 	} else if ( 'authorization_expired' === type ) {
 		return [
+			getStatusChangeTimelineItem(
+				event,
+				__( 'Authorization Expired', 'woocommerce-payments' )
+			),
 			getMainTimelineItem(
 				event,
 				stringWithAmount(
@@ -231,14 +235,15 @@ const mapEventToTimelineItems = ( event ) => {
 				'cross',
 				'is-error'
 			),
-			getStatusChangeTimelineItem(
-				event,
-				__( 'Authorization Expired', 'woocommerce-payments' )
-			),
 		];
 	} else if ( 'captured' === type ) {
 		const formattedNet = formatCurrency( event.amount - event.fee );
 		return [
+			getStatusChangeTimelineItem(
+				event,
+				__( 'Paid', 'woocommerce-payments' )
+			),
+			getDepositTimelineItem( event, formattedNet, true ),
 			getMainTimelineItem(
 				event,
 				stringWithAmount(
@@ -264,15 +269,17 @@ const mapEventToTimelineItems = ( event ) => {
 					),
 				]
 			),
-			getDepositTimelineItem( event, formattedNet, true ),
-			getStatusChangeTimelineItem(
-				event,
-				__( 'Paid', 'woocommerce-payments' )
-			),
 		];
 	} else if ( 'partial_refund' === type || 'full_refund' === type ) {
 		const formattedAmount = formatCurrency( event.amount_refunded );
 		return [
+			getStatusChangeTimelineItem(
+				event,
+				'full_refund' === type
+					? __( 'Refunded', 'woocommerce-payments' )
+					: __( 'Partial Refund', 'woocommerce-payments' )
+			),
+			getDepositTimelineItem( event, formattedAmount, false ),
 			getMainTimelineItem(
 				event,
 				sprintf(
@@ -286,16 +293,13 @@ const mapEventToTimelineItems = ( event ) => {
 				'checkmark',
 				'is-success'
 			),
-			getDepositTimelineItem( event, formattedAmount, false ),
-			getStatusChangeTimelineItem(
-				event,
-				'full_refund' === type
-					? __( 'Refunded', 'woocommerce-payments' )
-					: __( 'Partial Refund', 'woocommerce-payments' )
-			),
 		];
 	} else if ( 'failed' === type ) {
 		return [
+			getStatusChangeTimelineItem(
+				event,
+				__( 'Failed', 'woocommerce-payments' )
+			),
 			getMainTimelineItem(
 				event,
 				stringWithAmount(
@@ -305,10 +309,6 @@ const mapEventToTimelineItems = ( event ) => {
 				),
 				'cross',
 				'is-error'
-			),
-			getStatusChangeTimelineItem(
-				event,
-				__( 'Failed', 'woocommerce-payments' )
 			),
 		];
 	} else if ( 'dispute_needs_response' === type ) {
@@ -367,28 +367,28 @@ const mapEventToTimelineItems = ( event ) => {
 		}
 
 		return [
+			getStatusChangeTimelineItem(
+				event,
+				__( 'Disputed: Needs Response', 'woocommerce-payments' )
+			),
+			depositTimelineItem,
 			getMainTimelineItem( event, reasonHeadline, 'cross', 'is-error', [
 				<a href={ disputeUrl }>
 					{ __( 'View dispute', 'woocommerce-payments' ) }
 				</a>,
 			] ),
-			depositTimelineItem,
-			getStatusChangeTimelineItem(
-				event,
-				__( 'Disputed: Needs Response', 'woocommerce-payments' )
-			),
 		];
 	} else if ( 'dispute_in_review' === type ) {
 		return [
+			getStatusChangeTimelineItem(
+				event,
+				__( 'Disputed: In Review', 'woocommerce-payments' )
+			),
 			getMainTimelineItem(
 				event,
 				__( 'Challenge evidence submitted', 'woocommerce-payments' ),
 				'checkmark',
 				'is-success'
-			),
-			getStatusChangeTimelineItem(
-				event,
-				__( 'Disputed: In Review', 'woocommerce-payments' )
 			),
 		];
 	} else if ( 'dispute_won' === type ) {
@@ -396,14 +396,9 @@ const mapEventToTimelineItems = ( event ) => {
 			Math.abs( event.amount ) + Math.abs( event.fee )
 		);
 		return [
-			getMainTimelineItem(
+			getStatusChangeTimelineItem(
 				event,
-				__(
-					'Dispute won! The bank ruled in your favor',
-					'woocommerce-payments'
-				),
-				'notice-outline',
-				'is-success'
+				__( 'Disputed: Won', 'woocommerce-payments' )
 			),
 			getDepositTimelineItem( event, formattedTotal, true, [
 				stringWithAmount(
@@ -417,13 +412,22 @@ const mapEventToTimelineItems = ( event ) => {
 					event.fee
 				),
 			] ),
-			getStatusChangeTimelineItem(
+			getMainTimelineItem(
 				event,
-				__( 'Disputed: Won', 'woocommerce-payments' )
+				__(
+					'Dispute won! The bank ruled in your favor',
+					'woocommerce-payments'
+				),
+				'notice-outline',
+				'is-success'
 			),
 		];
 	} else if ( 'dispute_lost' === type ) {
 		return [
+			getStatusChangeTimelineItem(
+				event,
+				__( 'Disputed: Lost', 'woocommerce-payments' )
+			),
 			getMainTimelineItem(
 				event,
 				__(
@@ -432,10 +436,6 @@ const mapEventToTimelineItems = ( event ) => {
 				),
 				'cross',
 				'is-error'
-			),
-			getStatusChangeTimelineItem(
-				event,
-				__( 'Disputed: Lost', 'woocommerce-payments' )
 			),
 		];
 	} else if ( 'dispute_warning_closed' === type ) {

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -5,20 +5,20 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-03-31T21:58:40.000Z,
-    "headline": "Authorization for $86.00 expired",
+    "headline": "Payment status changed to Authorization Expired",
     "icon": <t
-      className="is-error"
-      icon="cross"
+      className=""
+      icon="sync"
       size={24}
     />,
   },
   Object {
     "body": Array [],
     "date": 2020-03-31T21:58:40.000Z,
-    "headline": "Payment status changed to Authorization Expired",
+    "headline": "Authorization for $86.00 expired",
     "icon": <t
-      className=""
-      icon="sync"
+      className="is-error"
+      icon="cross"
       size={24}
     />,
   },
@@ -30,20 +30,20 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-03-31T10:57:59.000Z,
-    "headline": "Authorization for $59.00 was voided",
+    "headline": "Payment status changed to Authorization Voided",
     "icon": <t
-      className="is-warning"
-      icon="checkmark"
+      className=""
+      icon="sync"
       size={24}
     />,
   },
   Object {
     "body": Array [],
     "date": 2020-03-31T10:57:59.000Z,
-    "headline": "Payment status changed to Authorization Voided",
+    "headline": "Authorization for $59.00 was voided",
     "icon": <t
-      className=""
-      icon="sync"
+      className="is-warning"
+      icon="checkmark"
       size={24}
     />,
   },
@@ -55,20 +55,20 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-03-30T17:33:16.000Z,
-    "headline": "A payment of $79.00 was successfully authorized",
+    "headline": "Payment status changed to Authorized",
     "icon": <t
-      className="is-warning"
-      icon="checkmark"
+      className=""
+      icon="sync"
       size={24}
     />,
   },
   Object {
     "body": Array [],
     "date": 2020-03-30T17:33:16.000Z,
-    "headline": "Payment status changed to Authorized",
+    "headline": "A payment of $79.00 was successfully authorized",
     "icon": <t
-      className=""
-      icon="sync"
+      className="is-warning"
+      icon="checkmark"
       size={24}
     />,
   },
@@ -78,15 +78,12 @@ Array [
 exports[`mapTimelineEvents formats captured events 1`] = `
 Array [
   Object {
-    "body": Array [
-      "Fee: $3.50",
-      "Net deposit: $59.50",
-    ],
+    "body": Array [],
     "date": 2020-04-01T14:37:54.000Z,
-    "headline": "A payment of $63.00 was successfully charged",
+    "headline": "Payment status changed to Paid",
     "icon": <t
-      className="is-success"
-      icon="checkmark"
+      className=""
+      icon="sync"
       size={24}
     />,
   },
@@ -108,12 +105,15 @@ Array [
     />,
   },
   Object {
-    "body": Array [],
+    "body": Array [
+      "Fee: $3.50",
+      "Net deposit: $59.50",
+    ],
     "date": 2020-04-01T14:37:54.000Z,
-    "headline": "Payment status changed to Paid",
+    "headline": "A payment of $63.00 was successfully charged",
     "icon": <t
-      className=""
-      icon="sync"
+      className="is-success"
+      icon="checkmark"
       size={24}
     />,
   },
@@ -125,20 +125,20 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-01T03:35:13.000Z,
-    "headline": "A payment of $77.00 failed",
+    "headline": "Payment status changed to Failed",
     "icon": <t
-      className="is-error"
-      icon="cross"
+      className=""
+      icon="sync"
       size={24}
     />,
   },
   Object {
     "body": Array [],
     "date": 2020-04-01T03:35:13.000Z,
-    "headline": "Payment status changed to Failed",
+    "headline": "A payment of $77.00 failed",
     "icon": <t
-      className=""
-      icon="sync"
+      className="is-error"
+      icon="cross"
       size={24}
     />,
   },
@@ -165,20 +165,20 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-02T20:26:47.000Z,
-    "headline": "Challenge evidence submitted",
+    "headline": "Payment status changed to Disputed: In Review",
     "icon": <t
-      className="is-success"
-      icon="checkmark"
+      className=""
+      icon="sync"
       size={24}
     />,
   },
   Object {
     "body": Array [],
     "date": 2020-04-02T20:26:47.000Z,
-    "headline": "Payment status changed to Disputed: In Review",
+    "headline": "Challenge evidence submitted",
     "icon": <t
-      className=""
-      icon="sync"
+      className="is-success"
+      icon="checkmark"
       size={24}
     />,
   },
@@ -190,20 +190,20 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-05T02:56:10.000Z,
-    "headline": "Dispute lost. The bank ruled favor of your customer",
+    "headline": "Payment status changed to Disputed: Lost",
     "icon": <t
-      className="is-error"
-      icon="cross"
+      className=""
+      icon="sync"
       size={24}
     />,
   },
   Object {
     "body": Array [],
     "date": 2020-04-05T02:56:10.000Z,
-    "headline": "Payment status changed to Disputed: Lost",
+    "headline": "Dispute lost. The bank ruled favor of your customer",
     "icon": <t
-      className=""
-      icon="sync"
+      className="is-error"
+      icon="cross"
       size={24}
     />,
   },
@@ -213,18 +213,12 @@ Array [
 exports[`mapTimelineEvents formats dispute_needs_response events 1`] = `
 Array [
   Object {
-    "body": Array [
-      <a
-        href="admin.php?page=wc-admin&path=%2Fpayments%2Fdisputes%2Fdetails&id=some_id"
-      >
-        View dispute
-      </a>,
-    ],
+    "body": Array [],
     "date": 2020-04-02T02:06:14.000Z,
-    "headline": "Payment disputed as Fraudulent",
+    "headline": "Payment status changed to Disputed: Needs Response",
     "icon": <t
-      className="is-error"
-      icon="cross"
+      className=""
+      icon="sync"
       size={24}
     />,
   },
@@ -242,21 +236,6 @@ Array [
     />,
   },
   Object {
-    "body": Array [],
-    "date": 2020-04-02T02:06:14.000Z,
-    "headline": "Payment status changed to Disputed: Needs Response",
-    "icon": <t
-      className=""
-      icon="sync"
-      size={24}
-    />,
-  },
-]
-`;
-
-exports[`mapTimelineEvents formats dispute_needs_response events with no amount 1`] = `
-Array [
-  Object {
     "body": Array [
       <a
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdisputes%2Fdetails&id=some_id"
@@ -269,6 +248,21 @@ Array [
     "icon": <t
       className="is-error"
       icon="cross"
+      size={24}
+    />,
+  },
+]
+`;
+
+exports[`mapTimelineEvents formats dispute_needs_response events with no amount 1`] = `
+Array [
+  Object {
+    "body": Array [],
+    "date": 2020-04-02T02:06:14.000Z,
+    "headline": "Payment status changed to Disputed: Needs Response",
+    "icon": <t
+      className=""
+      icon="sync"
       size={24}
     />,
   },
@@ -285,12 +279,18 @@ Array [
     />,
   },
   Object {
-    "body": Array [],
+    "body": Array [
+      <a
+        href="admin.php?page=wc-admin&path=%2Fpayments%2Fdisputes%2Fdetails&id=some_id"
+      >
+        View dispute
+      </a>,
+    ],
     "date": 2020-04-02T02:06:14.000Z,
-    "headline": "Payment status changed to Disputed: Needs Response",
+    "headline": "Payment disputed as Fraudulent",
     "icon": <t
-      className=""
-      icon="sync"
+      className="is-error"
+      icon="cross"
       size={24}
     />,
   },
@@ -317,10 +317,10 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-04T16:20:50.000Z,
-    "headline": "Dispute won! The bank ruled in your favor",
+    "headline": "Payment status changed to Disputed: Won",
     "icon": <t
-      className="is-success"
-      icon="notice-outline"
+      className=""
+      icon="sync"
       size={24}
     />,
   },
@@ -347,10 +347,10 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-04T16:20:50.000Z,
-    "headline": "Payment status changed to Disputed: Won",
+    "headline": "Dispute won! The bank ruled in your favor",
     "icon": <t
-      className=""
-      icon="sync"
+      className="is-success"
+      icon="notice-outline"
       size={24}
     />,
   },
@@ -362,10 +362,10 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-04T13:51:06.000Z,
-    "headline": "A payment of $100.00 was successfully refunded",
+    "headline": "Payment status changed to Refunded",
     "icon": <t
-      className="is-success"
-      icon="checkmark"
+      className=""
+      icon="sync"
       size={24}
     />,
   },
@@ -382,10 +382,10 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-04T13:51:06.000Z,
-    "headline": "Payment status changed to Refunded",
+    "headline": "A payment of $100.00 was successfully refunded",
     "icon": <t
-      className=""
-      icon="sync"
+      className="is-success"
+      icon="checkmark"
       size={24}
     />,
   },
@@ -397,10 +397,10 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-03T18:58:01.000Z,
-    "headline": "A payment of $50.00 was successfully refunded",
+    "headline": "Payment status changed to Partial Refund",
     "icon": <t
-      className="is-success"
-      icon="checkmark"
+      className=""
+      icon="sync"
       size={24}
     />,
   },
@@ -417,10 +417,10 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-03T18:58:01.000Z,
-    "headline": "Payment status changed to Partial Refund",
+    "headline": "A payment of $50.00 was successfully refunded",
     "icon": <t
-      className=""
-      icon="sync"
+      className="is-success"
+      icon="checkmark"
       size={24}
     />,
   },

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 1.7.0 - 2020-xx-xx =
+* Fix - Fix ordering of payment detail timeline events.
+
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.
 * Add - Initial support for the checkout block.


### PR DESCRIPTION
Fixes #790

#### Changes proposed in this Pull Request

* We receive the events from the server, and then, depending on the event type, break them up. The fix is simply to reverse the order of broken up items
* The order should be now:
  * human or bank initiated events first (lowest in the list, colorful icon)
  * Changes to the merchants balance (stays in the same place)
  * Updates to payment status last (top of the list)

#### Testing instructions

* View a few transactions, regular ones, disputed, refunded etc.
* Confirm the event order is right

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
