### PR TITLE
Specific error messaging for dispute evidence form

### DIFF
--- a/client/disputes/details/actions.js
+++ b/client/disputes/details/actions.js
@@ -35,13 +35,11 @@ const Actions = ( { id, needsResponse, isSubmitted, onAccept } ) => {
 				href={ challengeUrl }
 				className="components-button is-button is-primary is-large"
 				onClick={ () =>
-					needsResponse
-						? window.wcTracks.recordEvent(
-								'wcpay_dispute_challenge_clicked'
-						  )
-						: window.wcTracks.recordEvent(
-								'wcpay_view_submitted_evidence_clicked'
-						  )
+					window.wcTracks.recordEvent(
+						needsResponse
+							? 'wcpay_dispute_challenge_clicked'
+							: 'wcpay_view_submitted_evidence_clicked'
+					)
 				}
 			>
 				{ needsResponse

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect, useMemo } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -454,10 +454,10 @@ export default ( { query } ) => {
 		getHistory().push( href );
 	};
 
-	const handleSaveError = ( submit ) => {
+	const handleSaveError = ( err, submit ) => {
 		const message = submit
-			? __( 'Failed to submit evidence!', 'woocommerce-payments' )
-			: __( 'Failed to save evidence!', 'woocommerce-payments' );
+			? __( 'Failed to submit evidence. (%s)', 'woocommerce-payments' )
+			: __( 'Failed to save evidence. (%s)', 'woocommerce-payments' );
 
 		submit
 			? window.wcTracks.recordEvent(
@@ -466,7 +466,7 @@ export default ( { query } ) => {
 			: window.wcTracks.recordEvent(
 					'wcpay_dispute_save_evidence_failed'
 			  );
-		createErrorNotice( message );
+		createErrorNotice( sprintf( message, err.message ) );
 	};
 
 	const { updateDispute: updateDisputeInStore } = useDisputeEvidence();
@@ -508,7 +508,7 @@ export default ( { query } ) => {
 			setEvidence( {} );
 			updateDisputeInStore( updatedDispute );
 		} catch ( err ) {
-			handleSaveError( submit );
+			handleSaveError( err, submit );
 		} finally {
 			setLoading( false );
 		}

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -438,13 +438,11 @@ export default ( { query } ) => {
 			path: '/payments/disputes',
 		} );
 
-		submit
-			? window.wcTracks.recordEvent(
-					'wcpay_dispute_submit_evidence_success'
-			  )
-			: window.wcTracks.recordEvent(
-					'wcpay_dispute_save_evidence_success'
-			  );
+		window.wcTracks.recordEvent(
+			submit
+				? 'wcpay_dispute_submit_evidence_success'
+				: 'wcpay_dispute_save_evidence_success'
+		);
 		/*
 			We rely on WC-Admin Transient notices to display success message.
 			https://github.com/woocommerce/woocommerce-admin/tree/master/client/layout/transient-notices.
@@ -455,17 +453,15 @@ export default ( { query } ) => {
 	};
 
 	const handleSaveError = ( err, submit ) => {
+		window.wcTracks.recordEvent(
+			submit
+				? 'wcpay_dispute_submit_evidence_failed'
+				: 'wcpay_dispute_save_evidence_failed'
+		);
+
 		const message = submit
 			? __( 'Failed to submit evidence. (%s)', 'woocommerce-payments' )
 			: __( 'Failed to save evidence. (%s)', 'woocommerce-payments' );
-
-		submit
-			? window.wcTracks.recordEvent(
-					'wcpay_dispute_submit_evidence_failed'
-			  )
-			: window.wcTracks.recordEvent(
-					'wcpay_dispute_save_evidence_failed'
-			  );
 		createErrorNotice( sprintf( message, err.message ) );
 	};
 
@@ -484,13 +480,11 @@ export default ( { query } ) => {
 		setLoading( true );
 
 		try {
-			submit
-				? window.wcTracks.recordEvent(
-						'wcpay_dispute_submit_evidence_clicked'
-				  )
-				: window.wcTracks.recordEvent(
-						'wcpay_dispute_save_evidence_clicked'
-				  );
+			window.wcTracks.recordEvent(
+				submit
+					? 'wcpay_dispute_submit_evidence_clicked'
+					: 'wcpay_dispute_save_evidence_clicked'
+			);
 
 			const { metadata } = dispute;
 			const updatedDispute = await apiFetch( {

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -606,10 +606,8 @@ class WC_Payments_API_Client {
 		try {
 			return $this->request( $body, self::FILES_API, self::POST );
 		} catch ( API_Exception $e ) {
-			// TODO - Send better error messages to the client once the server is updated.
-			// Throw generic error without details to the client.
 			throw new API_Exception(
-				__( 'Upload failed.', 'woocommerce-payments' ),
+				$e->getMessage(),
 				'wcpay_evidence_file_upload_error',
 				$e->get_http_code()
 			);


### PR DESCRIPTION
Fixes first and third bullets of https://github.com/Automattic/woocommerce-payments/issues/555

#### Changes proposed in this Pull Request

Presents more information in the dispute evidence form UI in the event of _file upload_ or _evidence save/submission_ errors.

&nbsp; | Main branch | This branch
-- | -- | --
File upload | <img width="717" alt="file-upload-error-before" src="https://user-images.githubusercontent.com/1867547/96123515-eb5a3780-0ec0-11eb-93ed-722a89b08073.png"> | <img width="724" alt="file-upload-error-after" src="https://user-images.githubusercontent.com/1867547/96123517-ebf2ce00-0ec0-11eb-8d45-ed07dcc167c4.png">
Whole form | <img width="650" alt="dispute-evidence-error-before" src="https://user-images.githubusercontent.com/1867547/96123509-e8f7dd80-0ec0-11eb-9717-d421278cdb1f.png"> | <img width="650" alt="dispute-evidence-error-after" src="https://user-images.githubusercontent.com/1867547/96123512-ea290a80-0ec0-11eb-8105-98d7cc21563b.png">

(Could perhaps use automated testing but there's none in place for these behaviors so far and the data layer's set to be upgraded in https://github.com/Automattic/woocommerce-payments/issues/903.)

Also includes a refactor for code conciseness of some conditional Tracks calls, but let me know if there's reason not to do this, such as desirability of having one explicit `recordEvent` call per distinct event. cc @dwainm

Also cc @LevinMedia for thoughts on the presentation, if you have any.

#### Testing instructions

- Check out with a dispute test card (e.g. `4000000000000259`)
- Navigate to the Payments » Disputes » Dispute Details » Challenge Dispute screen for the new dispute
- Upload a file that doesn't work
  - Verify that the failure reason is displayed
- Upload files of enough combined size to make the save fail (~5 MB or so – see https://github.com/Automattic/woocommerce-payments/issues/559)
  - Save or submit the form
  - Verify that the failure reason is displayed

(Some sample images in p1602772778271900-slack-CGGCLBN58.)

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->