### PR TITLE
Remove unused endpoint call

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -181,28 +181,6 @@ class WC_Payments_API_Client {
 	}
 
 	/**
-	 * Confirm an intention
-	 *
-	 * @param WC_Payments_API_Intention $intent            - The intention to confirm.
-	 * @param string                    $payment_method_id - ID of payment method to process charge with.
-	 *
-	 * @return WC_Payments_API_Intention
-	 * @throws API_Exception - Exception thrown on intention confirmation failure.
-	 */
-	public function confirm_intention( WC_Payments_API_Intention $intent, $payment_method_id ) {
-		$request                   = [];
-		$request['payment_method'] = $payment_method_id;
-
-		$response_array = $this->request(
-			$request,
-			self::INTENTIONS_API . '/' . $intent->get_id() . '/confirm',
-			self::POST
-		);
-
-		return $this->deserialize_intention_object_from_array( $response_array );
-	}
-
-	/**
 	 * Refund a charge
 	 *
 	 * @param string $charge_id - The charge to refund.


### PR DESCRIPTION
Just a quick code cleanup here. `confirm_intention` is never called. `Stripe.js` will directly call the `api.stripe.com/payment_intents/.../confirm` endpoint while dealing with the SCA flow, but that request is made directly from the browser to Stripe, it doesn't pass through either the WCPay plugin or the WCPay server.