### PR TITLE
Fix error when retrying to save a card in the Add Payment Method screen after failing SCA auth.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,8 +7,9 @@
 * Fix - Increase timeout for calls to the API server.
 * Fix - Correctly display the fee and net amounts for a charge with an inquiry.
 * Fix - Catch unhandled exceptions when cancelling a payment authorization.
-* Add - Introduced "Set up refund policy" notification in WooCommerce inbox
 * Add - Security.md with security and vulnerability reporting guidelines.
+* Add - Introduced "Set up refund policy" notification in WooCommerce inbox.
+* Fix - Fix error when retrying to save a card in the Add Payment Method screen after failing SCA authentication.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Add - Security.md with security and vulnerability reporting guidelines.
 * Add - Introduced "Set up refund policy" notification in WooCommerce inbox.
 * Fix - Fix error when retrying to save a card in the Add Payment Method screen after failing SCA authentication.
+* Add - Allow signing up for a subscription with free trial with a credit card that requires SCA authentication.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/client/checkout/classic/index.js
+++ b/client/checkout/classic/index.js
@@ -125,6 +125,9 @@ jQuery( function ( $ ) {
 		$( document.body ).trigger( 'checkout_error' );
 	};
 
+	// Create payment method on submission.
+	let paymentMethodGenerated;
+
 	/**
 	 * Creates and authorizes a setup intent, saves its ID in a hidden input, and re-submits the form.
 	 *
@@ -155,6 +158,7 @@ jQuery( function ( $ ) {
 				$.blockUI.defaults.ignoreIfBlocked = defaultIgnoreIfBlocked;
 			} )
 			.catch( function ( error ) {
+				paymentMethodGenerated = null;
 				$form.removeClass( 'processing' ).unblock();
 				showError( error.message );
 			} );
@@ -173,9 +177,6 @@ jQuery( function ( $ ) {
 		// Re-submit the form.
 		$form.removeClass( 'processing' ).submit();
 	};
-
-	// Create payment method on submission.
-	let paymentMethodGenerated;
 
 	/**
 	 * Generates a payment method, saves its ID in a hidden input, and re-submits the form.

--- a/client/checkout/classic/index.js
+++ b/client/checkout/classic/index.js
@@ -368,7 +368,7 @@ jQuery( function ( $ ) {
 
 	// Handle hash change - used when authenticating payment with SCA on checkout page.
 	window.addEventListener( 'hashchange', () => {
-		if ( window.location.hash.startsWith( '#wcpay-confirm-pi' ) ) {
+		if ( window.location.hash.startsWith( '#wcpay-confirm-' ) ) {
 			maybeShowAuthenticationModal();
 		}
 	} );

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -91,7 +91,7 @@ class WC_Payments_Token_Service {
 	 * @return array
 	 */
 	public function woocommerce_get_customer_payment_tokens( $tokens, $user_id, $gateway_id ) {
-		if ( WC_Payment_Gateway_WCPay::GATEWAY_ID !== $gateway_id || ! is_user_logged_in() ) {
+		if ( ( ! empty( $gateway_id ) && WC_Payment_Gateway_WCPay::GATEWAY_ID !== $gateway_id ) || ! is_user_logged_in() ) {
 			return $tokens;
 		}
 
@@ -104,7 +104,9 @@ class WC_Payments_Token_Service {
 		$stored_tokens = [];
 
 		foreach ( $tokens as $token ) {
-			$stored_tokens[] = $token->get_token();
+			if ( WC_Payment_Gateway_WCPay::GATEWAY_ID === $token->get_gateway_id() ) {
+				$stored_tokens[] = $token->get_token();
+			}
 		}
 
 		$payment_methods = $this->customer_service->get_payment_methods_for_customer( $customer_id );

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -259,16 +259,15 @@ class WC_Payments_API_Client {
 	 *
 	 * @param string $payment_method_id      - ID of payment method to be saved.
 	 * @param string $customer_id            - ID of the customer.
-	 * @param bool   $confirm                - Flag to confirm the intent on creation if true.
 	 *
 	 * @return array
 	 * @throws API_Exception - Exception thrown on setup intent creation failure.
 	 */
-	public function create_setup_intent( $payment_method_id, $customer_id, $confirm = 'false' ) {
+	public function create_and_confirm_setup_intent( $payment_method_id, $customer_id ) {
 		$request = [
 			'payment_method' => $payment_method_id,
 			'customer'       => $customer_id,
-			'confirm'        => $confirm,
+			'confirm'        => 'true',
 		];
 
 		return $this->request( $request, self::SETUP_INTENTS_API, self::POST );

--- a/readme.txt
+++ b/readme.txt
@@ -108,8 +108,9 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Increase timeout for calls to the API server.
 * Fix - Correctly display the fee and net amounts for a charge with an inquiry.
 * Fix - Catch unhandled exceptions when cancelling a payment authorization.
-* Add - Introduced "Set up refund policy" notification in WooCommerce inbox
 * Add - Security.md with security and vulnerability reporting guidelines.
+* Add - Introduced "Set up refund policy" notification in WooCommerce inbox.
+* Fix - Fix error when retrying to save a card in the Add Payment Method screen after failing SCA authentication.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Security.md with security and vulnerability reporting guidelines.
 * Add - Introduced "Set up refund policy" notification in WooCommerce inbox.
 * Fix - Fix error when retrying to save a card in the Add Payment Method screen after failing SCA authentication.
+* Add - Allow signing up for a subscription with free trial with a credit card that requires SCA authentication.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -282,10 +282,10 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		// - intention id
 		// - amount charged.
 		// Note that the note and the order status are updated at the same
-		// time using `update_status()`.
+		// time using `set_status()`.
 		$mock_order
 			->expects( $this->exactly( 1 ) )
-			->method( 'update_status' )
+			->method( 'set_status' )
 			->with(
 				'on-hold',
 				$this->callback(
@@ -416,7 +416,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 				$this->returnValue( $intent )
 			);
 
-		// Assert: Order charge id meta data was not updated with `update_meta_data()`.
+		// Assert: Order charge id meta data was updated with `update_meta_data()`.
 		// Assert: Order does not have intention status meta data.
 		// Assert: Order has correct intent ID.
 		// This test is a little brittle because we don't really care about the order
@@ -425,17 +425,18 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		// There's an issue open for that here:
 		// https://github.com/sebastianbergmann/phpunit/issues/4026.
 		$mock_order
-			->expects( $this->exactly( 2 ) )
+			->expects( $this->exactly( 3 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
 				[ '_intent_id', $intent_id ],
+				[ '_charge_id', $charge_id ],
 				[ '_intention_status', 'requires_action' ]
 			);
 
 		// Assert: Order status was not updated.
 		$mock_order
-			->expects( $this->exactly( 0 ) )
-			->method( 'update_status' );
+			->expects( $this->never() )
+			->method( 'set_status' );
 
 		// Assert: The order note contains all the information we want:
 		// - status
@@ -456,14 +457,15 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 				)
 			);
 
-		// Assert: Order transaction ID was not set.
+		// Assert: Order has correct transaction ID set.
 		$mock_order
-			->expects( $this->exactly( 0 ) )
-			->method( 'set_transaction_id' );
+			->expects( $this->exactly( 1 ) )
+			->method( 'set_transaction_id' )
+			->with( $intent_id );
 
 		// Assert: empty_cart() was not called.
 		$mock_cart
-			->expects( $this->exactly( 0 ) )
+			->expects( $this->never() )
 			->method( 'empty_cart' );
 
 		// Act: process payment.

--- a/tests/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/test-class-wc-payment-gateway-wcpay.php
@@ -66,7 +66,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					'capture_intention',
 					'cancel_intention',
 					'get_intent',
-					'create_setup_intent',
+					'create_and_confirm_setup_intent',
 					'get_setup_intent',
 					'get_payment_method',
 				]
@@ -501,7 +501,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'error', $result['result'] );
 	}
 
-	public function test_create_setup_intent_existing_customer() {
+	public function test_create_and_confirm_setup_intent_existing_customer() {
 		$_POST = [ 'wcpay-payment-method' => 'pm_mock' ];
 
 		$this->mock_customer_service
@@ -515,16 +515,16 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 		$this->mock_api_client
 			->expects( $this->once() )
-			->method( 'create_setup_intent' )
+			->method( 'create_and_confirm_setup_intent' )
 			->with( 'pm_mock', 'cus_12345' )
 			->willReturn( [ 'id' => 'pm_mock' ] );
 
-		$result = $this->wcpay_gateway->create_setup_intent();
+		$result = $this->wcpay_gateway->create_and_confirm_setup_intent();
 
 		$this->assertEquals( 'pm_mock', $result['id'] );
 	}
 
-	public function test_create_setup_intent_no_customer() {
+	public function test_create_and_confirm_setup_intent_no_customer() {
 		$_POST = [ 'wcpay-payment-method' => 'pm_mock' ];
 
 		$this->mock_customer_service
@@ -539,11 +539,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 		$this->mock_api_client
 			->expects( $this->once() )
-			->method( 'create_setup_intent' )
+			->method( 'create_and_confirm_setup_intent' )
 			->with( 'pm_mock', 'cus_12345' )
 			->willReturn( [ 'id' => 'pm_mock' ] );
 
-		$result = $this->wcpay_gateway->create_setup_intent();
+		$result = $this->wcpay_gateway->create_and_confirm_setup_intent();
 
 		$this->assertEquals( 'pm_mock', $result['id'] );
 	}

--- a/tests/test-class-wc-payments-token-service.php
+++ b/tests/test-class-wc-payments-token-service.php
@@ -201,6 +201,13 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 		$token = new WC_Payment_Token_CC();
 		$token->set_gateway_id( 'woocommerce_payments' );
 		$token->set_token( 'pm_mock0' );
+		$token->set_card_type( 'visa' );
+		$token->set_last4( '4242' );
+		$token->set_expiry_month( 1 );
+		$token->set_expiry_year( 2023 );
+		$token->set_user_id( 1 );
+		$token->set_default( true );
+		$token->save();
 
 		$tokens = [ $token ];
 


### PR DESCRIPTION
Small fix for a bug that I found while implemented network-wide saved cards.

Steps to reproduce:
- While logged in, go to `/my-account/add-payment-method`.
- Input a card that will require SCA authentication, like `4000002500003155`.
- Click `Add payment method`.
- When the SCA modal shows up, click on the `Fail authentication` button.
- You'll see an error telling you to try again.
- Click the `Add payment method` button again without changing anything.
- On `master`, that will fail. On this PR, you'll see the SCA auth modal again and if you accept it, the card will be correctly saved.