### PR TITLE
Partial SCA support for Subscriptions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.7.0 - 2020-xx-xx =
 * Fix - Fix ordering of payment detail timeline events.
+* Add - Allow signing up for a subscription with free trial with a credit card that requires SCA authentication.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/client/checkout/classic/index.js
+++ b/client/checkout/classic/index.js
@@ -368,7 +368,7 @@ jQuery( function ( $ ) {
 
 	// Handle hash change - used when authenticating payment with SCA on checkout page.
 	window.addEventListener( 'hashchange', () => {
-		if ( window.location.hash.startsWith( '#wcpay-confirm-pi' ) ) {
+		if ( window.location.hash.startsWith( '#wcpay-confirm-' ) ) {
 			maybeShowAuthenticationModal();
 		}
 	} );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -530,8 +530,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			// For $0 orders, we need to save the payment method using a setup intent.
 			$intent = $this->payments_api_client->create_setup_intent(
 				$payment_information->get_payment_method(),
-				$customer_id,
-				'true'
+				$customer_id
 			);
 
 			$intent_id = $intent['id'];

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -321,16 +321,21 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 	/**
 	 * Displays the save to account checkbox.
+	 *
+	 * @param bool $force_checked True if the checkbox must be forced to "checked" state (and invisible).
 	 */
-	public function save_payment_method_checkbox() {
-		printf(
-			'<p class="form-row woocommerce-SavedPaymentMethods-saveNew">
-				<input id="wc-%1$s-new-payment-method" name="wc-%1$s-new-payment-method" type="checkbox" value="true" style="width:auto;" />
-				<label for="wc-%1$s-new-payment-method" style="display:inline;">%2$s</label>
-			</p>',
-			esc_attr( $this->id ),
-			esc_html( apply_filters( 'wc_payments_save_to_account_text', __( 'Save payment information to my account for future purchases.', 'woocommerce-payments' ) ) )
-		);
+	public function save_payment_method_checkbox( $force_checked = false ) {
+		$id = 'wc-' . $this->id . '-new-payment-method';
+		?>
+		<div <?php echo $force_checked ? 'style="display:none;"' : ''; /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>>
+			<p class="form-row woocommerce-SavedPaymentMethods-saveNew">
+				<input id="<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $id ); ?>" type="checkbox" value="true" style="width:auto;" <?php echo $force_checked ? 'checked' : ''; ?> /> // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				<label for="<?php echo esc_attr( $id ); ?>" style="display:inline;">
+					<?php echo esc_html( apply_filters( 'wc_payments_save_to_account_text', __( 'Save payment information to my account for future purchases.', 'woocommerce-payments' ) ) ); ?>
+				</label>
+			</p>
+		</div>
+		<?php
 	}
 
 	/**
@@ -386,11 +391,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				<input id="wcpay-payment-method" type="hidden" name="wcpay-payment-method" />
 
 				<?php
-				if ( apply_filters( 'wc_payments_display_save_payment_method_checkbox', $display_tokenization ) && ! is_add_payment_method_page() ) {
-					echo $this->save_payment_method_checkbox(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				}
+				$force_save_payment = ( $display_tokenization && ! apply_filters( 'wc_payments_display_save_payment_method_checkbox', $display_tokenization ) ) || is_add_payment_method_page();
+				$this->save_payment_method_checkbox( $force_save_payment );
 				?>
-
 
 			</fieldset>
 			<?php

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -534,7 +534,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$client_secret = $intent->get_client_secret();
 		} else {
 			// For $0 orders, we need to save the payment method using a setup intent.
-			$intent = $this->payments_api_client->create_setup_intent(
+			$intent = $this->payments_api_client->create_and_confirm_setup_intent(
 				$payment_information->get_payment_method(),
 				$customer_id
 			);
@@ -1431,7 +1431,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 *
 	 * @throws Exception - When an error occurs in setup intent creation.
 	 */
-	public function create_setup_intent() {
+	public function create_and_confirm_setup_intent() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$payment_information = Payment_Information::from_payment_request( $_POST );
 
@@ -1442,7 +1442,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$customer_id = $this->customer_service->create_customer_for_user( $user, "{$user->first_name} {$user->last_name}", $user->user_email );
 		}
 
-		return $this->payments_api_client->create_setup_intent(
+		return $this->payments_api_client->create_and_confirm_setup_intent(
 			$payment_information->get_payment_method(),
 			$customer_id
 		);
@@ -1463,7 +1463,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				);
 			}
 
-			$setup_intent = $this->create_setup_intent();
+			$setup_intent = $this->create_and_confirm_setup_intent();
 
 			wp_send_json_success( $setup_intent, 200 );
 		} catch ( Exception $e ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -502,14 +502,19 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			}
 		}
 
-		$intent_failed = false;
+		$intent_failed  = false;
+		$payment_needed = $amount > 0;
 
 		// In case amount is 0 and we're not saving the payment method, we won't be using intents and can confirm the order payment.
-		if ( 0 === $amount && ! $save_payment_method ) {
+		if ( ! $payment_needed && ! $save_payment_method ) {
 			$order->payment_complete();
+			return [
+				'result'   => 'success',
+				'redirect' => $this->get_return_url( $order ),
+			];
 		}
 
-		if ( $amount > 0 ) {
+		if ( $payment_needed ) {
 			// Create intention, try to confirm it & capture the charge (if 3DS is not required).
 			$intent = $this->payments_api_client->create_and_confirm_intention(
 				WC_Payments_Utils::prepare_amount( $amount, 'USD' ),
@@ -523,9 +528,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$payment_information->is_merchant_initiated()
 			);
 
-			$intent_id = $intent->get_id();
-			$status    = $intent->get_status();
-			$charge_id = $intent->get_charge_id();
+			$intent_id     = $intent->get_id();
+			$status        = $intent->get_status();
+			$charge_id     = $intent->get_charge_id();
+			$client_secret = $intent->get_client_secret();
 		} else {
 			// For $0 orders, we need to save the payment method using a setup intent.
 			$intent = $this->payments_api_client->create_setup_intent(
@@ -533,18 +539,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$customer_id
 			);
 
-			$intent_id = $intent['id'];
-			$status    = $intent['status'];
-			$charge_id = '';
-
-			// In SCA cases the setup intent status might be requires_action and we should display the authentication modal.
-			// For now, since we're not supporting SCA cards, we can ignore that status.
-			if ( 'succeeded' !== $status ) {
-				throw new Add_Payment_Method_Exception(
-					__( 'Failed to add the provided payment method. Please try again later', 'woocommerce-payments' ),
-					'invalid_response_status'
-				);
-			}
+			$intent_id     = $intent['id'];
+			$status        = $intent['status'];
+			$charge_id     = '';
+			$client_secret = $intent['client_secret'];
 		}
 
 		if ( ! empty( $intent ) ) {
@@ -569,25 +567,19 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			switch ( $status ) {
 				case 'succeeded':
-					$note = sprintf(
-						WC_Payments_Utils::esc_interpolated_html(
-							/* translators: %1: the successfully charged amount, %2: transaction ID of the payment */
-							__( 'A payment of %1$s was <strong>successfully charged</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
-							[
-								'strong' => '<strong>',
-								'code'   => '<code>',
-							]
-						),
-						wc_price( $amount ),
-						$intent_id
-					);
-
-					$order->update_meta_data( '_intent_id', $intent_id );
-					$order->update_meta_data( '_charge_id', $charge_id );
-					$order->update_meta_data( '_intention_status', $status );
-					$order->save();
-
-					if ( $amount > 0 ) {
+					if ( $payment_needed ) {
+						$note = sprintf(
+							WC_Payments_Utils::esc_interpolated_html(
+								/* translators: %1: the successfully charged amount, %2: transaction ID of the payment */
+								__( 'A payment of %1$s was <strong>successfully charged</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
+								[
+									'strong' => '<strong>',
+									'code'   => '<code>',
+								]
+							),
+							wc_price( $amount ),
+							$intent_id
+						);
 						$order->add_order_note( $note );
 					}
 					$order->payment_complete( $intent_id );
@@ -606,48 +598,51 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 						$intent_id
 					);
 
-					$order->update_status( 'on-hold', $note );
-					$order->set_transaction_id( $intent_id );
-
-					$order->update_meta_data( '_intent_id', $intent_id );
-					$order->update_meta_data( '_charge_id', $charge_id );
-					$order->update_meta_data( '_intention_status', $status );
-					$order->save();
+					$order->set_status( 'on-hold', $note );
 
 					break;
 				case 'requires_action':
-					// Add a note in case the customer does not complete the payment (exits the page),
-					// so the store owner has some information about what happened to create an order.
-					$note = sprintf(
-						WC_Payments_Utils::esc_interpolated_html(
+					if ( $payment_needed ) {
+						// Add a note in case the customer does not complete the payment (exits the page),
+						// so the store owner has some information about what happened to create an order.
+						$note = sprintf(
+							WC_Payments_Utils::esc_interpolated_html(
 							/* translators: %1: the authorized amount, %2: transaction ID of the payment */
-							__( 'A payment of %1$s was <strong>started</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
-							[
-								'strong' => '<strong>',
-								'code'   => '<code>',
-							]
-						),
-						wc_price( $amount ),
-						$intent_id
-					);
-					$order->add_order_note( $note );
+								__( 'A payment of %1$s was <strong>started</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
+								[
+									'strong' => '<strong>',
+									'code'   => '<code>',
+								]
+							),
+							wc_price( $amount ),
+							$intent_id
+						);
+						$order->add_order_note( $note );
+					}
 
-					$order->update_meta_data( '_intent_id', $intent_id );
-					$order->update_meta_data( '_intention_status', $status );
-					$order->save();
-
-					return [
+					$response = [
 						'result'   => 'success',
 						// Include a new nonce for update_order_status to ensure the update order
 						// status call works when a guest user creates an account during checkout.
 						'redirect' => sprintf(
-							'#wcpay-confirm-pi:%s:%s:%s',
+							'#wcpay-confirm-%s:%s:%s:%s',
+							$payment_needed ? 'pi' : 'si',
 							$order_id,
-							$intent->get_client_secret(),
+							$client_secret,
 							wp_create_nonce( 'wcpay_update_order_status_nonce' )
 						),
 					];
 			}
+		}
+
+		$order->set_transaction_id( $intent_id );
+		$order->update_meta_data( '_intent_id', $intent_id );
+		$order->update_meta_data( '_charge_id', $charge_id );
+		$order->update_meta_data( '_intention_status', $status );
+		$order->save();
+
+		if ( isset( $response ) ) {
+			return $response;
 		}
 
 		wc_reduce_stock_levels( $order_id );
@@ -1211,79 +1206,108 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				);
 			}
 
-			// An exception is thrown if an intent can't be found for the given intent ID.
-			$intent = $this->payments_api_client->get_intent( $intent_id );
-
-			$status = $intent->get_status();
 			$amount = $order->get_total();
 
-			switch ( $status ) {
-				case 'succeeded':
-					$note = sprintf(
-						WC_Payments_Utils::esc_interpolated_html(
-							/* translators: %1: the successfully charged amount, %2: transaction ID of the payment */
-							__( 'A payment of %1$s was <strong>successfully charged</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
-							[
-								'strong' => '<strong>',
-								'code'   => '<code>',
-							]
-						),
-						wc_price( $amount ),
-						$intent_id
-					);
-					$order->add_order_note( $note );
+			if ( $amount > 0 ) {
+				// An exception is thrown if an intent can't be found for the given intent ID.
+				$intent = $this->payments_api_client->get_intent( $intent_id );
+				$status = $intent->get_status();
 
-					// The order is successful, so update it to reflect that.
-					$order->update_meta_data( '_charge_id', $intent->get_charge_id() );
-					$order->update_meta_data( '_intention_status', $status );
-					$order->save();
+				switch ( $status ) {
+					case 'succeeded':
+						$note = sprintf(
+							WC_Payments_Utils::esc_interpolated_html(
+								/* translators: %1: the successfully charged amount, %2: transaction ID of the payment */
+								__( 'A payment of %1$s was <strong>successfully charged</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
+								[
+									'strong' => '<strong>',
+									'code'   => '<code>',
+								]
+							),
+							wc_price( $amount ),
+							$intent_id
+						);
+						$order->add_order_note( $note );
 
-					$order->payment_complete( $intent_id );
-					break;
-				case 'requires_capture':
-					$note = sprintf(
-						WC_Payments_Utils::esc_interpolated_html(
+						// The order is successful, so update it to reflect that.
+						$order->update_meta_data( '_charge_id', $intent->get_charge_id() );
+
+						$order->payment_complete( $intent_id );
+						break;
+					case 'requires_capture':
+						$note = sprintf(
+							WC_Payments_Utils::esc_interpolated_html(
+								/* translators: %1: the authorized amount, %2: transaction ID of the payment */
+								__( 'A payment of %1$s was <strong>authorized</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
+								[
+									'strong' => '<strong>',
+									'code'   => '<code>',
+								]
+							),
+							wc_price( $amount ),
+							$intent_id
+						);
+						// Save the note separately because if there is no change in status
+						// then the note is not saved using WC_Order::update_status.
+						$order->add_order_note( $note );
+
+						// The order is successful, so update it to reflect that.
+						$order->update_meta_data( '_charge_id', $intent->get_charge_id() );
+
+						$order->set_status( 'on-hold' );
+						$order->set_transaction_id( $intent_id );
+						break;
+					case 'requires_payment_method':
+						$note = sprintf(
+							WC_Payments_Utils::esc_interpolated_html(
+								/* translators: %1: the authorized amount, %2: transaction ID of the payment */
+								__( 'A payment of %1$s <strong>failed</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
+								[
+									'strong' => '<strong>',
+									'code'   => '<code>',
+								]
+							),
+							wc_price( $amount ),
+							$intent_id
+						);
+						// Save the note separately because if there is no change in status
+						// then the note is not saved using WC_Order::update_status.
+						$order->add_order_note( $note );
+						$order->set_status( 'failed' );
+						break;
+				}
+			} else {
+				// For $0 orders, fetch the Setup Intent instead.
+				$intent = $this->payments_api_client->get_setup_intent( $intent_id );
+				$status = $intent['status'];
+
+				switch ( $status ) {
+					case 'succeeded':
+						$order->payment_complete( $intent_id );
+						break;
+					case 'requires_payment_method':
+						$note = sprintf(
+							WC_Payments_Utils::esc_interpolated_html(
 							/* translators: %1: the authorized amount, %2: transaction ID of the payment */
-							__( 'A payment of %1$s was <strong>authorized</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
-							[
-								'strong' => '<strong>',
-								'code'   => '<code>',
-							]
-						),
-						wc_price( $amount ),
-						$intent_id
-					);
-					// Save the note separately because if there is no change in status
-					// then the note is not saved using WC_Order::update_status.
-					$order->add_order_note( $note );
-
-					// The order is successful, so update it to reflect that.
-					$order->update_meta_data( '_charge_id', $intent->get_charge_id() );
-					$order->update_meta_data( '_intention_status', $status );
-					$order->save();
-
-					$order->update_status( 'on-hold' );
-					$order->set_transaction_id( $intent_id );
-					break;
-				case 'requires_payment_method':
-					$note = sprintf(
-						WC_Payments_Utils::esc_interpolated_html(
-							/* translators: %1: the authorized amount, %2: transaction ID of the payment */
-							__( 'A payment of %1$s <strong>failed</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
-							[
-								'strong' => '<strong>',
-								'code'   => '<code>',
-							]
-						),
-						wc_price( $amount ),
-						$intent_id
-					);
-					// Save the note separately because if there is no change in status
-					// then the note is not saved using WC_Order::update_status.
-					$order->add_order_note( $note );
-					$order->update_status( 'failed' );
-					break;
+								__( 'A payment of %1$s <strong>failed</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
+								[
+									'strong' => '<strong>',
+									'code'   => '<code>',
+								]
+							),
+							wc_price( $amount ),
+							$intent_id
+						);
+						// Save the note separately because if there is no change in status
+						// then the note is not saved using WC_Order::update_status.
+						$order->add_order_note( $note );
+						$order->set_status( 'failed' );
+						break;
+				}
 			}
+
+			$order->update_meta_data( '_intention_status', $status );
+			$order->save();
 
 			if ( 'succeeded' === $status || 'requires_capture' === $status ) {
 				wc_reduce_stock_levels( $order_id );

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -257,16 +257,15 @@ class WC_Payments_API_Client {
 	 *
 	 * @param string $payment_method_id      - ID of payment method to be saved.
 	 * @param string $customer_id            - ID of the customer.
-	 * @param bool   $confirm                - Flag to confirm the intent on creation if true.
 	 *
 	 * @return array
 	 * @throws API_Exception - Exception thrown on setup intent creation failure.
 	 */
-	public function create_setup_intent( $payment_method_id, $customer_id, $confirm = 'false' ) {
+	public function create_setup_intent( $payment_method_id, $customer_id ) {
 		$request = [
 			'payment_method' => $payment_method_id,
 			'customer'       => $customer_id,
-			'confirm'        => $confirm,
+			'confirm'        => 'true',
 		];
 
 		return $this->request( $request, self::SETUP_INTENTS_API, self::POST );

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -261,7 +261,7 @@ class WC_Payments_API_Client {
 	 * @return array
 	 * @throws API_Exception - Exception thrown on setup intent creation failure.
 	 */
-	public function create_setup_intent( $payment_method_id, $customer_id ) {
+	public function create_and_confirm_setup_intent( $payment_method_id, $customer_id ) {
 		$request = [
 			'payment_method' => $payment_method_id,
 			'customer'       => $customer_id,

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 1.7.0 - 2020-xx-xx =
 * Fix - Fix ordering of payment detail timeline events.
+* Add - Allow signing up for a subscription with free trial with a credit card that requires SCA authentication.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/tests/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -181,7 +181,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 
 		$this->mock_api_client
 			->expects( $this->once() )
-			->method( 'create_setup_intent' )
+			->method( 'create_and_confirm_setup_intent' )
 			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, 'true' )
 			->willReturn( $this->setup_intent );
 
@@ -214,7 +214,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 
 		$this->mock_api_client
 			->expects( $this->once() )
-			->method( 'create_setup_intent' )
+			->method( 'create_and_confirm_setup_intent' )
 			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, 'true' )
 			->willReturn( $this->setup_intent );
 
@@ -281,7 +281,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 
 		$this->mock_api_client
 			->expects( $this->once() )
-			->method( 'create_setup_intent' )
+			->method( 'create_and_confirm_setup_intent' )
 			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, 'true' )
 			->willReturn( $this->setup_intent );
 
@@ -314,7 +314,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 
 		$this->mock_api_client
 			->expects( $this->once() )
-			->method( 'create_setup_intent' )
+			->method( 'create_and_confirm_setup_intent' )
 			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, 'true' )
 			->willReturn( $this->setup_intent );
 
@@ -352,7 +352,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 
 		$this->mock_api_client
 			->expects( $this->once() )
-			->method( 'create_setup_intent' )
+			->method( 'create_and_confirm_setup_intent' )
 			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, 'true' )
 			->willReturn( $this->setup_intent );
 

--- a/tests/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/test-class-wc-payment-gateway-wcpay.php
@@ -65,7 +65,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					'is_server_connected',
 					'capture_intention',
 					'get_intent',
-					'create_setup_intent',
+					'create_and_confirm_setup_intent',
 					'get_setup_intent',
 					'get_payment_method',
 				]
@@ -435,7 +435,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 		$this->mock_api_client
 			->expects( $this->once() )
-			->method( 'create_setup_intent' )
+			->method( 'create_and_confirm_setup_intent' )
 			->with( 'pm_mock', 'cus_12345' )
 			->willReturn( [ 'id' => 'pm_mock' ] );
 
@@ -459,7 +459,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 		$this->mock_api_client
 			->expects( $this->once() )
-			->method( 'create_setup_intent' )
+			->method( 'create_and_confirm_setup_intent' )
 			->with( 'pm_mock', 'cus_12345' )
 			->willReturn( [ 'id' => 'pm_mock' ] );
 


### PR DESCRIPTION
Important: We shouldn't announce widely that we support Subscriptions with SCA cards yet. This PR only implements part of that. Renewals that trigger a SCA challenge will still fail.

With these changes, you'll be able to sign-up for a Subscription with free trial using a SCA-enabled card.

Commit-by-commit changes:
- https://github.com/Automattic/woocommerce-payments/commit/553e669fb7f285c7b60a9433c9e3c2e51e059e6e Always create SetupIntents with `confirm=true`. There's no reason not to. This way, apart from simplifying the code a bit, will make the flow faster if the SetupIntent can be auto-confirmed (i.e. if it doesn't require SCA auth).
- https://github.com/Automattic/woocommerce-payments/commit/5bfc8d98cad3c665364a0315e8d419c238f47088 Always include the "Save payment method" checkbox in the checkout UI, even if it's redundant and invisible (like for subscriptions). There's some code in `checkout.js` that checks if it's checked, and that will crash or not work as intended if it's not present at all.
- https://github.com/Automattic/woocommerce-payments/commit/d4a0f1ba415eef9f475c6ea3f1e82dde8ed2d48a is the main change. It adds handling for `Setup Intents` in `requires_action` status, which is very-similar-but-not-identical as how a `Payment Intent` in `requires_action` status is handled.

Steps to test:
- Install & enable WC Subscriptions (d'uh...)
- Create a Subscription product with free trial.
- Go purchase that product. In the checkout, use a SCA-enabled card, like `4000002500003155`. It should work.
- Purchse it again, now with a regular card, like `4242424242424242`. It should also work.