### PR TITLE
Add set up refund policy notification

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Fix - Increase timeout for calls to the API server.
 * Fix - Correctly display the fee and net amounts for a charge with an inquiry.
 * Fix - Catch unhandled exceptions when cancelling a payment authorization.
+* Add - Introduced "Set up refund policy" notification in WooCommerce inbox
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
+++ b/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
@@ -24,7 +24,7 @@ class WC_Payments_Notes_Set_Up_Refund_Policy {
 	/**
 	 * Name of the note for use in the database.
 	 */
-	const NOTE_DOCUMENTATION_URL = 'https://docs.woocommerce.com/document/payments/disputes/';
+	const NOTE_DOCUMENTATION_URL = 'https://docs.woocommerce.com/document/woocommerce-refunds#refund-policy-howto';
 
 	/**
 	 * Handle activation scenario and create the note if it not yet created.
@@ -46,15 +46,8 @@ class WC_Payments_Notes_Set_Up_Refund_Policy {
 	public static function get_note() {
 		$note = new WC_Admin_Note();
 
-		/*
-		 * For the documentation:
-		 * - Reference https://woocommerce.com/refund-policy/ as policy example
-		 * - Reference https://woocommerce.com/posts/how-to-customize-emails-in-woocommerce/
-		 * - Add "Managing Disputes with WooCommerce Payments" (-> https://docs.woocommerce.com/documentation/woocommerce-payments/)
-		 */
-
 		$note->set_title( __( 'Set up refund policy', 'woocommerce-payments' ) );
-		$note->set_content( __( 'Protect your merchant account by defining the policy and making it accessible to customers.', 'woocommerce-payments' ) );
+		$note->set_content( __( 'Protect your merchant account from fraudulent disputes by defining the policy and making it accessible to customers.', 'woocommerce-payments' ) );
 		$note->set_content_data( (object) [] );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );

--- a/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
+++ b/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
@@ -51,7 +51,7 @@ class WC_Payments_Notes_Set_Up_Refund_Policy {
 		$note->set_content_data( (object) [] );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
-		$note->set_source( 'woocommerce-admin' );
+		$note->set_source( 'woocommerce-payments' );
 		$note->add_action(
 			self::NOTE_NAME,
 			__( 'Read more', 'woocommerce-payments' ),

--- a/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
+++ b/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
@@ -46,6 +46,13 @@ class WC_Payments_Notes_Set_Up_Refund_Policy {
 	public static function get_note() {
 		$note = new WC_Admin_Note();
 
+		/*
+		 * For the documentation:
+		 * - Reference https://woocommerce.com/refund-policy/ as policy example
+		 * - Reference https://woocommerce.com/posts/how-to-customize-emails-in-woocommerce/
+		 * - Add "Managing Disputes with WooCommerce Payments" (-> https://docs.woocommerce.com/documentation/woocommerce-payments/)
+		 */
+
 		$note->set_title( __( 'Set up refund policy', 'woocommerce-payments' ) );
 		$note->set_content( __( 'Protect your merchant account by defining the policy and making it accessible to customers.', 'woocommerce-payments' ) );
 		$note->set_content_data( (object) [] );

--- a/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
+++ b/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Set up refund policy note for WooCommerce inbox.
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WC_Payments_Notes_Set_Up_Refund_Policy
+ */
+class WC_Payments_Notes_Set_Up_Refund_Policy {
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-payments-notes-set-up-refund-policy';
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_DOCUMENTATION_URL = 'https://docs.woocommerce.com/document/payments/disputes/';
+
+	/**
+	 * Handle activation scenario and create the note if it not yet created.
+	 */
+	public function on_wcpay_activation() {
+		self::possibly_add_note();
+	}
+
+	/**
+	 * Handle deactivation scenario and drop the note.
+	 */
+	public function on_wcpay_deactivation() {
+		self::possibly_delete_note();
+	}
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		$note = new WC_Admin_Note();
+
+		$note->set_title( __( 'Set up refund policy', 'woocommerce-payments' ) );
+		$note->set_content( __( 'Set up and update orders emails pitch here.', 'woocommerce-payments' ) );
+		$note->set_content_data( (object) [] );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			self::NOTE_NAME,
+			__( 'Set up policy', 'woocommerce-payments' ),
+			self::NOTE_DOCUMENTATION_URL,
+			'unactioned',
+			true
+		);
+
+		return $note;
+	}
+}

--- a/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
+++ b/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
@@ -47,14 +47,14 @@ class WC_Payments_Notes_Set_Up_Refund_Policy {
 		$note = new WC_Admin_Note();
 
 		$note->set_title( __( 'Set up refund policy', 'woocommerce-payments' ) );
-		$note->set_content( __( 'Set up and update orders emails pitch here.', 'woocommerce-payments' ) );
+		$note->set_content( __( 'Protect your merchant account by defining the policy and making it accessible to customers.', 'woocommerce-payments' ) );
 		$note->set_content_data( (object) [] );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			self::NOTE_NAME,
-			__( 'Set up policy', 'woocommerce-payments' ),
+			__( 'Read more', 'woocommerce-payments' ),
 			self::NOTE_DOCUMENTATION_URL,
 			'unactioned',
 			true

--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Increase timeout for calls to the API server.
 * Fix - Correctly display the fee and net amounts for a charge with an inquiry.
 * Fix - Catch unhandled exceptions when cancelling a payment authorization.
+* Add - Introduced "Set up refund policy" notification in WooCommerce inbox
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/tests/notes/test-class-wc-payments-notes-set-up-refund-policy.php
+++ b/tests/notes/test-class-wc-payments-notes-set-up-refund-policy.php
@@ -17,7 +17,7 @@ class WC_Payments_Notes_Set_Up_Refund_Policy_Test extends WP_UnitTestCase {
 			$note_id = WC_Payments_Notes_Set_Up_Refund_Policy::NOTE_NAME;
 			$this->assertSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
 		} else {
-			$this->skip( 'The used WC components are not forward compatible' );
+			$this->markTestSkipped( 'The used WC components are not forward compatible' );
 		}
 	}
 
@@ -29,7 +29,7 @@ class WC_Payments_Notes_Set_Up_Refund_Policy_Test extends WP_UnitTestCase {
 			$note_id = WC_Payments_Notes_Set_Up_Refund_Policy::NOTE_NAME;
 			$this->assertNotSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
 		} else {
-			$this->skip( 'The used WC components are not forward compatible' );
+			$this->markTestSkipped( 'The used WC components are not forward compatible' );
 		}
 	}
 }

--- a/tests/notes/test-class-wc-payments-notes-set-up-refund-policy.php
+++ b/tests/notes/test-class-wc-payments-notes-set-up-refund-policy.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Class WC_Payments_Notes_Set_Up_Refund_Policy_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * Class WC_Payments_Notes_Set_Up_Refund_Policy tests.
+ */
+class WC_Payments_Notes_Set_Up_Refund_Policy_Test extends WP_UnitTestCase {
+	public function test_removes_note_on_extension_deactivation() {
+		// Trigger WCPay extension deactivation callback.
+		wcpay_deactivated();
+
+		$note_id = WC_Payments_Notes_Set_Up_Refund_Policy::NOTE_NAME;
+		$this->assertSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
+	}
+
+	public function test_adds_note_on_extension_activation() {
+		// Trigger WCPay extension activation callback.
+		wcpay_activated();
+
+		$note_id = WC_Payments_Notes_Set_Up_Refund_Policy::NOTE_NAME;
+		$this->assertNotSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
+	}
+}

--- a/tests/notes/test-class-wc-payments-notes-set-up-refund-policy.php
+++ b/tests/notes/test-class-wc-payments-notes-set-up-refund-policy.php
@@ -17,7 +17,7 @@ class WC_Payments_Notes_Set_Up_Refund_Policy_Test extends WP_UnitTestCase {
 			$note_id = WC_Payments_Notes_Set_Up_Refund_Policy::NOTE_NAME;
 			$this->assertSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
 		} else {
-			$this->markTestSkipped( 'The used WC components are not forward compatible' );
+			$this->markTestSkipped( 'The used WC components are not backward compatible' );
 		}
 	}
 
@@ -29,7 +29,7 @@ class WC_Payments_Notes_Set_Up_Refund_Policy_Test extends WP_UnitTestCase {
 			$note_id = WC_Payments_Notes_Set_Up_Refund_Policy::NOTE_NAME;
 			$this->assertNotSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
 		} else {
-			$this->markTestSkipped( 'The used WC components are not forward compatible' );
+			$this->markTestSkipped( 'The used WC components are not backward compatible' );
 		}
 	}
 }

--- a/tests/notes/test-class-wc-payments-notes-set-up-refund-policy.php
+++ b/tests/notes/test-class-wc-payments-notes-set-up-refund-policy.php
@@ -10,18 +10,26 @@
  */
 class WC_Payments_Notes_Set_Up_Refund_Policy_Test extends WP_UnitTestCase {
 	public function test_removes_note_on_extension_deactivation() {
-		// Trigger WCPay extension deactivation callback.
-		wcpay_deactivated();
+		if ( version_compare( WC_VERSION, '4.3.0', '>=' ) ) {
+			// Trigger WCPay extension deactivation callback.
+			wcpay_deactivated();
 
-		$note_id = WC_Payments_Notes_Set_Up_Refund_Policy::NOTE_NAME;
-		$this->assertSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
+			$note_id = WC_Payments_Notes_Set_Up_Refund_Policy::NOTE_NAME;
+			$this->assertSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
+		} else {
+			$this->skip( 'The used WC components are not forward compatible' );
+		}
 	}
 
 	public function test_adds_note_on_extension_activation() {
-		// Trigger WCPay extension activation callback.
-		wcpay_activated();
+		if ( version_compare( WC_VERSION, '4.3.0', '>=' ) ) {
+			// Trigger WCPay extension activation callback.
+			wcpay_activated();
 
-		$note_id = WC_Payments_Notes_Set_Up_Refund_Policy::NOTE_NAME;
-		$this->assertNotSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
+			$note_id = WC_Payments_Notes_Set_Up_Refund_Policy::NOTE_NAME;
+			$this->assertNotSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
+		} else {
+			$this->skip( 'The used WC components are not forward compatible' );
+		}
 	}
 }

--- a/tests/notes/test-class-wc-payments-notes-set-up-refund-policy.php
+++ b/tests/notes/test-class-wc-payments-notes-set-up-refund-policy.php
@@ -10,7 +10,7 @@
  */
 class WC_Payments_Notes_Set_Up_Refund_Policy_Test extends WP_UnitTestCase {
 	public function test_removes_note_on_extension_deactivation() {
-		if ( version_compare( WC_VERSION, '4.3.0', '>=' ) ) {
+		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
 			// Trigger WCPay extension deactivation callback.
 			wcpay_deactivated();
 
@@ -22,7 +22,7 @@ class WC_Payments_Notes_Set_Up_Refund_Policy_Test extends WP_UnitTestCase {
 	}
 
 	public function test_adds_note_on_extension_activation() {
-		if ( version_compare( WC_VERSION, '4.3.0', '>=' ) ) {
+		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
 			// Trigger WCPay extension activation callback.
 			wcpay_activated();
 

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -42,7 +42,7 @@ function wcpay_activated() {
 		update_option( 'wcpay_should_redirect_to_onboarding', true );
 	}
 
-	if ( version_compare( WC_VERSION, '4.3.0', '>=' ) ) {
+	if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
 		/* add set up refund policy note (if not yet) */
 		( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_activation();
 	}
@@ -52,7 +52,7 @@ function wcpay_activated() {
  * Plugin deactivation hook.
  */
 function wcpay_deactivated() {
-	if ( version_compare( WC_VERSION, '4.3.0', '>=' ) ) {
+	if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
 		/* drop set up refund policy note */
 		( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_deactivation();
 	}
@@ -67,7 +67,7 @@ function wcpay_deactivated() {
 function wcpay_updated( $upgrader_object, $options ) {
 	$is_plugin_update = 'update' === $options['action'] && 'plugin' === $options['type'];
 	$is_wcpay_updated = $is_plugin_update && in_array( 'woocommerce-payments', (array) $options['plugins'], true );
-	if ( $is_wcpay_updated && version_compare( WC_VERSION, '4.3.0', '>=' ) ) {
+	if ( $is_wcpay_updated && version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
 		( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_activation();
 	}
 }

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -42,16 +42,20 @@ function wcpay_activated() {
 		update_option( 'wcpay_should_redirect_to_onboarding', true );
 	}
 
-	/* add set up refund policy note (if not yet) */
-	( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_activation();
+	if ( version_compare( WC_VERSION, '4.3.0', '>=' ) ) {
+		/* add set up refund policy note (if not yet) */
+		( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_activation();
+	}
 }
 
 /**
  * Plugin deactivation hook.
  */
 function wcpay_deactivated() {
-	/* drop set up refund policy note */
-	( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_deactivation();
+	if ( version_compare( WC_VERSION, '4.3.0', '>=' ) ) {
+		/* drop set up refund policy note */
+		( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_deactivation();
+	}
 }
 
 /**
@@ -63,7 +67,7 @@ function wcpay_deactivated() {
 function wcpay_updated( $upgrader_object, $options ) {
 	$is_plugin_update = 'update' === $options['action'] && 'plugin' === $options['type'];
 	$is_wcpay_updated = $is_plugin_update && in_array( 'woocommerce-payments', (array) $options['plugins'], true );
-	if ( $is_wcpay_updated ) {
+	if ( $is_wcpay_updated && version_compare( WC_VERSION, '4.3.0', '>=' ) ) {
 		( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_activation();
 	}
 }

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -15,20 +15,19 @@
  * @package WooCommerce\Payments
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
-}
+defined( 'ABSPATH' ) || exit;
 
 define( 'WCPAY_PLUGIN_FILE', __FILE__ );
-define( 'WCPAY_ABSPATH', dirname( WCPAY_PLUGIN_FILE ) . '/' );
+define( 'WCPAY_ABSPATH', __DIR__ . '/' );
 define( 'WCPAY_MIN_WC_ADMIN_VERSION', '0.23.2' );
 
 require_once WCPAY_ABSPATH . 'vendor/autoload_packages.php';
+require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
 
 /**
  * Plugin activation hook.
  */
-function wcpay_activate() {
+function wcpay_activated() {
 	// Do not take any action if activated in a REST request (via wc-admin).
 	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
 		return;
@@ -42,9 +41,36 @@ function wcpay_activate() {
 	) {
 		update_option( 'wcpay_should_redirect_to_onboarding', true );
 	}
+
+	/* add set up refund policy note (if not yet) */
+	( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_activation();
 }
 
-register_activation_hook( __FILE__, 'wcpay_activate' );
+/**
+ * Plugin deactivation hook.
+ */
+function wcpay_deactivated() {
+	/* drop set up refund policy note */
+	( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_deactivation();
+}
+
+/**
+ * Plugin update hook: receives information about updated components an ensures WCPay is one of them.
+ *
+ * @param \WP_Upgrader $upgrader_object The upgrader object.
+ * @param array        $options         Extra details regarding updated components.
+ */
+function wcpay_updated( $upgrader_object, $options ) {
+	$is_plugin_update = 'update' === $options['action'] && 'plugin' === $options['type'];
+	$is_wcpay_updated = $is_plugin_update && in_array( 'woocommerce-payments', (array) $options['plugins'], true );
+	if ( $is_wcpay_updated ) {
+		( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_activation();
+	}
+}
+
+register_activation_hook( __FILE__, 'wcpay_activated' );
+register_deactivation_hook( __FILE__, 'wcpay_deactivated' );
+add_action( 'upgrader_process_complete', 'wcpay_updated' );
 
 /**
  * Initialize the Jetpack connection functionality.

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -22,7 +22,6 @@ define( 'WCPAY_ABSPATH', __DIR__ . '/' );
 define( 'WCPAY_MIN_WC_ADMIN_VERSION', '0.23.2' );
 
 require_once WCPAY_ABSPATH . 'vendor/autoload_packages.php';
-require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
 
 /**
  * Plugin activation hook.
@@ -44,6 +43,7 @@ function wcpay_activated() {
 
 	if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
 		/* add set up refund policy note (if not yet) */
+		require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
 		( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_activation();
 	}
 }
@@ -54,6 +54,7 @@ function wcpay_activated() {
 function wcpay_deactivated() {
 	if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
 		/* drop set up refund policy note */
+		require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
 		( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_deactivation();
 	}
 }
@@ -68,6 +69,7 @@ function wcpay_updated( $upgrader_object, $options ) {
 	$is_plugin_update = 'update' === $options['action'] && 'plugin' === $options['type'];
 	$is_wcpay_updated = $is_plugin_update && in_array( 'woocommerce-payments', (array) $options['plugins'], true );
 	if ( $is_wcpay_updated && version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+		require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
 		( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_activation();
 	}
 }


### PR DESCRIPTION
Fixes #817

#### Changes proposed in this Pull Request

* Adds new WooCommerce inbox notification

#### Testing instructions

* Deactivate and Activate the extension
* Navigate to WooCommerce in WP administration area:
    - Ensure "Set up refund policy" notification is presented
    - Ensure "Read more" button redirects you to a link with `refund-policy-howto` anchor

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
