### PR TITLE
(PHP 8) Fix optional method argument before required ones

### DIFF
--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -90,7 +90,7 @@ class WC_Payments_Token_Service {
 	 * @param string $gateway_id WC gateway ID.
 	 * @return array
 	 */
-	public function woocommerce_get_customer_payment_tokens( $tokens = [], $user_id, $gateway_id ) {
+	public function woocommerce_get_customer_payment_tokens( $tokens, $user_id, $gateway_id ) {
 		if ( WC_Payment_Gateway_WCPay::GATEWAY_ID !== $gateway_id || ! is_user_logged_in() ) {
 			return $tokens;
 		}


### PR DESCRIPTION
Related to #982

PHP8 throws a deprecation notice if optional arguments (with a default value) are specified before the required ones (without a default value).

#### Changes proposed in this Pull Request

* Change the signature of `woocommerce_get_customer_payment_tokens` to not specify the default value for `$tokens`
  * WC core always provides an array for this, it might be empty, but that's handled inside the function body

#### Testing instructions

* Unit tests should pass

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
