### PR TITLE
Do not render the filename while reuploading evidence

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.7.0 - 2020-xx-xx =
 * Fix - Fix ordering of payment detail timeline events.
 * Fix - Payment form hides when saved card is selected.
+* Fix - Render dispute evidence file upload errors.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -391,6 +391,7 @@ export default ( { query } ) => {
 
 		// Set request status for UI.
 		updateDispute( {
+			metadata: { [ key ]: '' },
 			isUploading: { [ key ]: true },
 			uploadingErrors: { [ key ]: '' },
 		} );
@@ -420,6 +421,7 @@ export default ( { query } ) => {
 			} );
 
 			updateDispute( {
+				metadata: { [ key ]: '' },
 				isUploading: { [ key ]: false },
 				uploadingErrors: { [ key ]: err.message },
 			} );

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ Please note that our support for the checkout block is still experimental and th
 = 1.7.0 - 2020-xx-xx =
 * Fix - Fix ordering of payment detail timeline events.
 * Fix - Payment form hides when saved card is selected.
+* Fix - Render dispute evidence file upload errors.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.


### PR DESCRIPTION
Fixes #555 - the remaining work (rendering the file name when reuploading, and the trash icon if reupload failed). The main problem was fixed in #995 by @dechov 

#### Changes proposed in this Pull Request

* Clear the uploaded file when the upload has been started again
  * This has a side effect where the previous file gets discarded - I think it makes sense. We don't want the merchants to accidentally submit files that they wanted to overwrite.
* Also added a generic changelog entry for this and #995

#### Testing instructions

* Upload any good file as evidence
  * You should see the filename and the trash icon
* Upload a failing file as evidence (see p1602772778271900-slack-CGGCLBN58)
  * As the file is uploading, no filename should be rendered
  * Once the error is rendered, there should be no trash icon next to it

-------------------

- [x] Added changelog entry (or does not apply)
