### PR TITLE
Increase the api request timeouts

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - Fix ordering of payment detail timeline events.
 * Fix - Payment form hides when saved card is selected.
 * Fix - Render dispute evidence file upload errors.
+* Fix - Increase timeout for calls to the API server.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -22,6 +22,8 @@ class WC_Payments_API_Client {
 	const POST = 'POST';
 	const GET  = 'GET';
 
+	const API_TIMEOUT_SECONDS = 70;
+
 	const ACCOUNTS_API        = 'accounts';
 	const CHARGES_API         = 'charges';
 	const CUSTOMERS_API       = 'customers';
@@ -859,6 +861,7 @@ class WC_Payments_API_Client {
 				'url'     => $url,
 				'method'  => $method,
 				'headers' => apply_filters( 'wcpay_api_request_headers', $headers ),
+				'timeout' => self::API_TIMEOUT_SECONDS,
 			],
 			$body,
 			$is_site_specific

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Fix ordering of payment detail timeline events.
 * Fix - Payment form hides when saved card is selected.
 * Fix - Render dispute evidence file upload errors.
+* Fix - Increase timeout for calls to the API server.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -333,6 +333,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 						'Content-Type' => 'application/json; charset=utf-8',
 						'User-Agent'   => 'Unit Test Agent/0.1.0',
 					],
+					'timeout' => 70,
 				],
 				wp_json_encode(
 					[


### PR DESCRIPTION
Fixes #915

#### Changes proposed in this Pull Request

* Bump the timeout from the default 10s to 70s

#### Testing instructions

* Unit tests should pass
* Try uploading the large pdf file from the first point in #555 - it should succeed

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
