### PR TITLE
Catch exceptions when cancelling an intent

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Render dispute evidence file upload errors.
 * Fix - Increase timeout for calls to the API server.
 * Fix - Correctly display the fee and net amounts for a charge with an inquiry.
+* Fix - Catch unhandled exceptions when cancelling a payment authorization.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/readme.txt
+++ b/readme.txt
@@ -107,6 +107,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Render dispute evidence file upload errors.
 * Fix - Increase timeout for calls to the API server.
 * Fix - Correctly display the fee and net amounts for a charge with an inquiry.
+* Fix - Catch unhandled exceptions when cancelling a payment authorization.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/tests/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/test-class-wc-payment-gateway-wcpay.php
@@ -346,7 +346,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_status( 'on-hold' );
 
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->throwException( new API_Exception( 'test', 'server_error', 500 ) )
+			$this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) )
 		);
 		$this->mock_api_client->expects( $this->once() )->method( 'get_intent' )->with( $intent_id )->will(
 			$this->returnValue(
@@ -371,6 +371,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		)[0];
 
 		$this->assertContains( 'failed', $note->content );
+		$this->assertContains( 'test exception', $note->content );
 		$this->assertContains( wc_price( $order->get_total() ), $note->content );
 		$this->assertEquals( $order->get_meta( '_intention_status', true ), 'requires_capture' );
 		$this->assertEquals( $order->get_status(), 'on-hold' );
@@ -388,7 +389,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_status( 'on-hold' );
 
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->throwException( new API_Exception( 'test', 'server_error', 500 ) )
+			$this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) )
 		);
 		$this->mock_api_client->expects( $this->once() )->method( 'get_intent' )->with( $intent_id )->will(
 			$this->returnValue(
@@ -431,7 +432,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'cancel_intention' )
-			->will( $this->throwException( new API_Exception( 'test', 'test', 123 ) ) );
+			->will( $this->throwException( new API_Exception( 'test exception', 'test', 123 ) ) );
 
 		$this->mock_api_client
 			->expects( $this->once() )
@@ -474,12 +475,12 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'cancel_intention' )
-			->will( $this->throwException( new API_Exception( 'test', 'test', 123 ) ) );
+			->will( $this->throwException( new API_Exception( 'test exception', 'test', 123 ) ) );
 
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'get_intent' )
-			->will( $this->throwException( new API_Exception( 'test', 'test', 123 ) ) );
+			->will( $this->throwException( new API_Exception( 'ignore this', 'test', 123 ) ) );
 
 		$this->wcpay_gateway->cancel_authorization( $order );
 
@@ -491,6 +492,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		)[0];
 
 		$this->assertContains( 'failed', $note->content );
+		$this->assertContains( 'test exception', $note->content );
 		$this->assertEquals( $order->get_status(), 'on-hold' );
 	}
 

--- a/tests/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/test-class-wc-payment-gateway-wcpay.php
@@ -64,6 +64,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					'get_account_data',
 					'is_server_connected',
 					'capture_intention',
+					'cancel_intention',
 					'get_intent',
 					'create_setup_intent',
 					'get_setup_intent',
@@ -414,6 +415,83 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->assertContains( 'expired', $note->content );
 		$this->assertEquals( $order->get_meta( '_intention_status', true ), 'canceled' );
 		$this->assertEquals( $order->get_status(), 'cancelled' );
+	}
+
+	public function test_cancel_authorization_handles_api_exception_when_canceling() {
+		$intent_id = 'pi_xxxxxxxxxxxxx';
+		$charge_id = 'ch_yyyyyyyyyyyyy';
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_transaction_id( $intent_id );
+		$order->update_meta_data( '_intent_id', $intent_id );
+		$order->update_meta_data( '_charge_id', $charge_id );
+		$order->update_meta_data( '_intention_status', 'requires_capture' );
+		$order->update_status( 'on-hold' );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'cancel_intention' )
+			->will( $this->throwException( new API_Exception( 'test', 'test', 123 ) ) );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->willReturn(
+				new WC_Payments_API_Intention(
+					$intent_id,
+					1500,
+					new DateTime(),
+					'canceled',
+					$charge_id,
+					'...'
+				)
+			);
+
+		$this->wcpay_gateway->cancel_authorization( $order );
+
+		$note = wc_get_order_notes(
+			[
+				'order_id' => $order->get_id(),
+				'limit'    => 1,
+			]
+		)[0];
+
+		$this->assertContains( 'cancelled', $note->content );
+		$this->assertEquals( $order->get_status(), 'cancelled' );
+	}
+
+	public function test_cancel_authorization_handles_all_api_exceptions() {
+		$intent_id = 'pi_xxxxxxxxxxxxx';
+		$charge_id = 'ch_yyyyyyyyyyyyy';
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_transaction_id( $intent_id );
+		$order->update_meta_data( '_intent_id', $intent_id );
+		$order->update_meta_data( '_charge_id', $charge_id );
+		$order->update_meta_data( '_intention_status', 'requires_capture' );
+		$order->update_status( 'on-hold' );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'cancel_intention' )
+			->will( $this->throwException( new API_Exception( 'test', 'test', 123 ) ) );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->will( $this->throwException( new API_Exception( 'test', 'test', 123 ) ) );
+
+		$this->wcpay_gateway->cancel_authorization( $order );
+
+		$note = wc_get_order_notes(
+			[
+				'order_id' => $order->get_id(),
+				'limit'    => 1,
+			]
+		)[0];
+
+		$this->assertContains( 'failed', $note->content );
+		$this->assertEquals( $order->get_status(), 'on-hold' );
 	}
 
 	public function test_add_payment_method_no_method() {


### PR DESCRIPTION
Fixes #494

#### Changes proposed in this Pull Request

* Add exception handling to the API requests
* Add extra exception handling to `capture_charge` in case intent retrieval also fails

#### Testing instructions

* Turn on "Manual Capture" in your WooCommerce Payments settings
* Place an order as normal
* Either:
  * In the Stripe Dashboard, find the payment, click the menu button associated with it and pick "Cancel Payment"
* Or:
  * Modify the local server to throw a bad request exception in the cancel intent handler
* Open the order in wp-admin
* In the "Order Actions" pane, select "Cancel Authorization" and click the update button
* A note should appear that the canceling failed, but the order page should refresh without errors

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
