### PR TITLE
Detect actioned notes and pass additional parameters to onboarding URL

### DIFF
--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+use Automattic\WooCommerce\Admin\Notes\DataStore;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Logger;
 use \Automattic\WooCommerce\Admin\Features\Onboarding;
@@ -436,7 +438,8 @@ class WC_Payments_Account {
 				'email'         => $current_user->user_email,
 				'business_name' => get_bloginfo( 'name' ),
 				'url'           => get_home_url(),
-			]
+			],
+			$this->get_actioned_notes()
 		);
 
 		// If an account already exists for this site, we're done.
@@ -657,5 +660,47 @@ class WC_Payments_Account {
 		return ! empty( $account ) && isset( $account['latest_tos_agreement'] )
 			? $account['latest_tos_agreement']
 			: null;
+	}
+
+	/**
+	 * Returns an array containing the names of all the WCPay related notes that have be actioned.
+	 *
+	 * @return array
+	 */
+	private function get_actioned_notes() : array {
+		$wcpay_promo_notes = [];
+
+		try {
+			/**
+			 * Data Store for admin notes
+			 *
+			 * @var DataStore $data_store
+			 */
+			$data_store = WC_Data_Store::load( 'admin-note' );
+		} catch ( Exception $e ) {
+			// Don't stop the on-boarding process if something goes wrong here. Log the error and return the empty array
+			// of actioned notes.
+			Logger::error( $e );
+			return $wcpay_promo_notes;
+		}
+
+		// Fetch the last 10 actioned wcpay-promo admin notifications.
+		$add_like_clause = function( $where_clause ) {
+			return $where_clause . " AND name like 'wcpay-promo-%'";
+		};
+
+		add_filter( 'woocommerce_note_where_clauses', $add_like_clause );
+
+		$wcpay_promo_notes = $data_store->get_notes(
+			[
+				'status'     => [ WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED ],
+				'is_deleted' => false,
+				'per_page'   => 10,
+			]
+		);
+
+		remove_filter( 'woocommerce_note_where_clauses', $add_like_clause );
+
+		return (array) $wcpay_promo_notes;
 	}
 }

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -708,7 +708,7 @@ class WC_Payments_Account {
 
 		// Copy the name of each note into the results.
 		foreach ( (array) $wcpay_promo_notes as $wcpay_note ) {
-			$note = new WC_Admin_Note( $wcpay_note->note_id );
+			$note               = new WC_Admin_Note( $wcpay_note->note_id );
 			$wcpay_note_names[] = $note->get_name();
 		}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -708,7 +708,8 @@ class WC_Payments_Account {
 
 		// Copy the name of each note into the results.
 		foreach ( (array) $wcpay_promo_notes as $wcpay_note ) {
-			$wcpay_note_names[] = $wcpay_note->name;
+			$note = new WC_Admin_Note( $wcpay_note->note_id );
+			$wcpay_note_names[] = $note->get_name();
 		}
 
 		return $wcpay_note_names;

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -667,8 +667,8 @@ class WC_Payments_Account {
 	 *
 	 * @return array
 	 */
-	private function get_actioned_notes() : array {
-		$wcpay_promo_notes = [];
+	private function get_actioned_notes(): array {
+		$wcpay_note_names = [];
 
 		try {
 			/**
@@ -681,7 +681,7 @@ class WC_Payments_Account {
 			// Don't stop the on-boarding process if something goes wrong here. Log the error and return the empty array
 			// of actioned notes.
 			Logger::error( $e );
-			return $wcpay_promo_notes;
+			return $wcpay_note_names;
 		}
 
 		// Fetch the last 10 actioned wcpay-promo admin notifications.
@@ -701,6 +701,16 @@ class WC_Payments_Account {
 
 		remove_filter( 'woocommerce_note_where_clauses', $add_like_clause );
 
-		return (array) $wcpay_promo_notes;
+		// If we didn't get an array back from the data store, return an empty array of results.
+		if ( ! is_array( $wcpay_promo_notes ) ) {
+			return $wcpay_note_names;
+		}
+
+		// Copy the name of each note into the results.
+		foreach ( (array) $wcpay_promo_notes as $wcpay_note ) {
+			$wcpay_note_names[] = $wcpay_note->name;
+		}
+
+		return $wcpay_note_names;
 	}
 }

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -639,22 +639,22 @@ class WC_Payments_API_Client {
 	/**
 	 * Get data needed to initialize the OAuth flow
 	 *
-	 * @param string $return_url    - URL to redirect to at the end of the flow.
-	 * @param array  $business_data - Data to prefill the form.
-	 * @param array  $additional    - Additional data to be sent to the on-boarding flow.
+	 * @param string $return_url     - URL to redirect to at the end of the flow.
+	 * @param array  $business_data  - Data to prefill the form.
+	 * @param array  $actioned_notes - Actioned WCPay note names to be sent to the on-boarding flow.
 	 *
 	 * @return array An array containing the url and state fields.
 	 *
 	 * @throws API_Exception Exception thrown on request failure.
 	 */
-	public function get_oauth_data( $return_url, $business_data = [], array $additional = [] ) {
+	public function get_oauth_data( $return_url, $business_data = [], array $actioned_notes = [] ) {
 		$request_args = apply_filters(
 			'wc_payments_get_oauth_data_args',
 			[
 				'return_url'          => $return_url,
 				'business_data'       => $business_data,
 				'create_live_account' => ! WC_Payments::get_gateway()->is_in_dev_mode(),
-				'additional'          => $additional,
+				'actioned_notes'      => $actioned_notes,
 			]
 		);
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -640,17 +640,21 @@ class WC_Payments_API_Client {
 	 * Get data needed to initialize the OAuth flow
 	 *
 	 * @param string $return_url    - URL to redirect to at the end of the flow.
-	 * @param array  $business_data - data to prefill the form.
+	 * @param array  $business_data - Data to prefill the form.
+	 * @param array  $additional    - Additional data to be sent to the on-boarding flow.
 	 *
 	 * @return array An array containing the url and state fields.
+	 *
+	 * @throws API_Exception Exception thrown on request failure.
 	 */
-	public function get_oauth_data( $return_url, $business_data = [] ) {
+	public function get_oauth_data( $return_url, $business_data = [], array $additional = [] ) {
 		$request_args = apply_filters(
 			'wc_payments_get_oauth_data_args',
 			[
 				'return_url'          => $return_url,
 				'business_data'       => $business_data,
 				'create_live_account' => ! WC_Payments::get_gateway()->is_in_dev_mode(),
+				'additional'          => $additional,
 			]
 		);
 

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -452,7 +452,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 							'c' => 3,
 						],
 						'create_live_account' => true,
-						'additional'          => [
+						'actioned_notes'      => [
 							'd' => 4,
 							'e' => 5,
 							'f' => 6,

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -424,6 +424,72 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test getting initial oauth data.
+	 *
+	 * @throws API_Exception
+	 */
+	public function test_get_oauth_data() {
+		$this->mock_http_client
+			->expects( $this->once() )
+			->method( 'remote_request' )
+			->with(
+				[
+					'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/%s/wcpay/oauth/init',
+					'method'  => 'POST',
+					'headers' => [
+						'Content-Type' => 'application/json; charset=utf-8',
+						'User-Agent'   => 'Unit Test Agent/0.1.0',
+					],
+					'timeout' => 70,
+				],
+				wp_json_encode(
+					[
+						'test_mode'           => false,
+						'return_url'          => 'http://localhost',
+						'business_data'       => [
+							'a' => 1,
+							'b' => 2,
+							'c' => 3,
+						],
+						'create_live_account' => true,
+						'additional'          => [
+							'd' => 4,
+							'e' => 5,
+							'f' => 6,
+						],
+					]
+				)
+			)
+			->willReturn(
+				[
+					'body'     => wp_json_encode( [ 'url' => false ] ),
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+				]
+			);
+
+		// Call the method under test.
+		$result = $this->payments_api_client->get_oauth_data(
+			'http://localhost',
+			[
+				'a' => 1,
+				'b' => 2,
+				'c' => 3,
+			],
+			[
+				'd' => 4,
+				'e' => 5,
+				'f' => 6,
+			]
+		);
+
+		// Assert the response is correct.
+		$this->assertEquals( [ 'url' => false ], $result );
+	}
+
+	/**
 	 * Set up http mock response.
 	 *
 	 * @param int   $status_code status code for the mocked response.


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-payments/issues/998

#### Changes proposed in this Pull Request

* If any WCPay admin notes have been actioned, add a list of them to the state data we pass through the onboarding flow

#### Testing instructions

* Requires some server-side changes, so this is best tested along with 410-gh-woocommerce-payments-server using the test instructions from that PR. 

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)