### PR TITLE
automattic/jetpack-connection update follow up: a deprecated constant usage

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -57,7 +57,7 @@ class WC_Payments_Http implements WC_Payments_Http_Interface {
 		}
 
 		$args['blog_id'] = Jetpack_Options::get_option( 'id' );
-		$args['user_id'] = Automattic\Jetpack\Connection\Manager::JETPACK_MASTER_USER;
+		$args['user_id'] = Automattic\Jetpack\Connection\Manager::CONNECTION_OWNER;
 
 		if ( $is_site_specific ) {
 			// We expect `url` to include a `%s` placeholder which will allow us inject the blog id.

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -57,7 +57,7 @@ class WC_Payments_Http implements WC_Payments_Http_Interface {
 		}
 
 		$args['blog_id'] = Jetpack_Options::get_option( 'id' );
-		$args['user_id'] = Automattic\Jetpack\Connection\Manager::CONNECTION_OWNER;
+		$args['user_id'] = $this->connection_manager->get_connection_owner_id();
 
 		if ( $is_site_specific ) {
 			// We expect `url` to include a `%s` placeholder which will allow us inject the blog id.


### PR DESCRIPTION
Followup of https://github.com/Automattic/woocommerce-payments/pull/1000, @DanReyLop spotted a constant deprecation.

#### Changes proposed in this Pull Request

* Migrate from using a deprecated constant

#### Testing instructions

* Travis will take care of running tests
