### PR TITLE
Correctly display the Refunded / Net / Fee amounts on all kinds of disputes and inquiries

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.7.0 - 2020-xx-xx =
 * Fix - Fix ordering of payment detail timeline events.
 * Fix - Payment form hides when saved card is selected.
+* Fix - Correctly display the fee and net amounts for a charge with an inquiry.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/client/payment-details/summary/test/__snapshots__/index.js.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.js.snap
@@ -17,7 +17,7 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
           <p
             class="payment-details-summary__amount"
           >
-            $15.00
+            $20.00
             <span
               class="payment-details-summary__amount-currency"
             >
@@ -39,7 +39,7 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
             </p>
             <p>
               Net: 
-              $14.30
+              $19.30
             </p>
           </div>
         </div>
@@ -163,7 +163,7 @@ exports[`PaymentDetailsSummary renders a charge with subscriptions 1`] = `
           <p
             class="payment-details-summary__amount"
           >
-            $15.00
+            $20.00
             <span
               class="payment-details-summary__amount-currency"
             >
@@ -185,7 +185,7 @@ exports[`PaymentDetailsSummary renders a charge with subscriptions 1`] = `
             </p>
             <p>
               Net: 
-              $14.30
+              $19.30
             </p>
           </div>
         </div>
@@ -325,7 +325,7 @@ exports[`PaymentDetailsSummary renders fully refunded information for a charge 1
           <p
             class="payment-details-summary__amount"
           >
-            $15.00
+            $20.00
             <span
               class="payment-details-summary__amount-currency"
             >
@@ -342,7 +342,7 @@ exports[`PaymentDetailsSummary renders fully refunded information for a charge 1
           >
             <p>
               Refunded: 
-              $-15.00
+              $-20.00
             </p>
             <p>
               Fee: 
@@ -553,7 +553,7 @@ exports[`PaymentDetailsSummary renders partially refunded information for a char
           <p
             class="payment-details-summary__amount"
           >
-            $15.00
+            $20.00
             <span
               class="payment-details-summary__amount-currency"
             >
@@ -578,7 +578,7 @@ exports[`PaymentDetailsSummary renders partially refunded information for a char
             </p>
             <p>
               Net: 
-              $2.30
+              $7.30
             </p>
           </div>
         </div>
@@ -702,7 +702,7 @@ exports[`PaymentDetailsSummary renders the information of a disputed charge 1`] 
           <p
             class="payment-details-summary__amount"
           >
-            $15.00
+            $20.00
             <span
               class="payment-details-summary__amount-currency"
             >
@@ -727,7 +727,7 @@ exports[`PaymentDetailsSummary renders the information of a disputed charge 1`] 
             </p>
             <p>
               Net: 
-              $-15.70
+              $-10.70
             </p>
           </div>
         </div>

--- a/client/payment-details/summary/test/index.js
+++ b/client/payment-details/summary/test/index.js
@@ -84,6 +84,12 @@ describe( 'PaymentDetailsSummary', () => {
 		charge.dispute = {
 			amount: 1500,
 			status: 'under_review',
+			balance_transactions: [
+				{
+					amount: -1500,
+					fee: 1500,
+				}
+			]
 		};
 
 		const paymentDetailsSummary = renderCharge( charge );

--- a/client/payment-details/summary/test/index.js
+++ b/client/payment-details/summary/test/index.js
@@ -14,13 +14,11 @@ const getBaseCharge = () => ( {
 	id: 'ch_38jdHA39KKA',
 	/* Stripe data comes in seconds, instead of the default Date milliseconds */
 	created: Date.parse( 'Sep 19, 2019, 5:24 pm' ) / 1000,
-	amount: 1500,
+	amount: 2000,
 	amount_refunded: 0,
 	application_fee_amount: 70,
 	disputed: false,
 	dispute: null,
-	fee: 74,
-	net: 1426,
 	currency: 'usd',
 	type: 'charge',
 	status: 'succeeded',
@@ -72,7 +70,7 @@ describe( 'PaymentDetailsSummary', () => {
 		const charge = getBaseCharge();
 		charge.refunded = true;
 		// eslint-disable-next-line camelcase
-		charge.amount_refunded = 1500;
+		charge.amount_refunded = 2000;
 
 		const paymentDetailsSummary = renderCharge( charge );
 		expect( paymentDetailsSummary ).toMatchSnapshot();

--- a/client/utils/charge/test/index.js
+++ b/client/utils/charge/test/index.js
@@ -239,6 +239,12 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 			disputed: true,
 			dispute: {
 				amount: 1800,
+				balance_transactions: [
+					{
+						amount: -1800,
+						fee: 1500,
+					},
+				],
 			},
 		};
 
@@ -246,6 +252,53 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 			net: 0 - charge.application_fee_amount - 1500,
 			fee: charge.application_fee_amount + 1500,
 			refunded: charge.dispute.amount,
+		} );
+	} );
+
+	test( 'reversed dispute', () => {
+		const charge = {
+			amount: 1800,
+			// eslint-disable-next-line camelcase
+			application_fee_amount: 82,
+			disputed: true,
+			dispute: {
+				amount: 1800,
+				balance_transactions: [
+					{
+						amount: -1800,
+						fee: 1500,
+					},
+					{
+						amount: 1800,
+						fee: -1500,
+					},
+				],
+			},
+		};
+
+		expect( utils.getChargeAmounts( charge ) ).toEqual( {
+			net: charge.amount - charge.application_fee_amount,
+			fee: charge.application_fee_amount,
+			refunded: 0,
+		} );
+	} );
+
+	test( 'inquiry', () => {
+		const charge = {
+			amount: 1800,
+			// eslint-disable-next-line camelcase
+			application_fee_amount: 82,
+			disputed: true,
+			dispute: {
+				amount: 1800,
+				balance_transactions: [],
+			},
+		};
+
+		expect( utils.getChargeAmounts( charge ) ).toEqual( {
+			net: charge.amount - charge.application_fee_amount,
+			fee: charge.application_fee_amount,
+			refunded: 0,
 		} );
 	} );
 } );

--- a/client/utils/charge/test/index.js
+++ b/client/utils/charge/test/index.js
@@ -171,8 +171,6 @@ describe( 'Charge utilities', () => {
 				expect( utils.getChargeStatus( charge ) ).toEqual(
 					'disputed_' + status
 				);
-				expect( charge.refunded ).toEqual( true );
-				expect( charge.amount_refunded ).toEqual( 1500 );
 			}
 		);
 	} );

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ Please note that our support for the checkout block is still experimental and th
 = 1.7.0 - 2020-xx-xx =
 * Fix - Fix ordering of payment detail timeline events.
 * Fix - Payment form hides when saved card is selected.
+* Fix - Correctly display the fee and net amounts for a charge with an inquiry.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.


### PR DESCRIPTION
Fixes #794 

@reykjalin Thanks for such a detailed issue! A little context. You said:

> From what I can tell, a refund isn't actually issued until the inquiry has been closed and lost.

Inquiries don't result in any monetary transactions one way or the other. An inquiry is basically the bank saying "hey, this looks fishy, do you have any proof you aren't a scammer?". An inquiry can be "promoted" to a full chargeback dispute if the merchant doesn't reply to it though.

#### Changes proposed in this Pull Request

* In https://github.com/Automattic/woocommerce-payments/commit/760ca13676ad359998fb2139ae8b66ffec171ddc , fix the `Refunded / Fee / Net` calculation to take into account all the dispute/inquiry cases.
* In https://github.com/Automattic/woocommerce-payments/commit/531f3da1f35f78fae36d26abaa608192d53a156c , it was bothering me that the charge amount in the test was $15. It got confusing in the dispute test cases because the dispute fee is also $15. Not a big deal, but I hope there's no objection that change :)

I've used the `charge.dispute.balance_transactions` array to calculate the amounts. When there's an inquiry, that array is empty. When a full dispute is in-progress/lost, the standard `fee: $15, amount:-$X` transaction is the only item on that array. If the dispute has been won, there will be 2 balance_transactions that will cancel eachother out. It just seems to me a bit more robust than the previous logic (checking which status the dispute is on, and hardcoding the $15 fee).

#### Testing instructions

Test that all these cases behave correctly:
- In-progress dispute. Use the `4000000000002685` credit card number to pay for something, then go to the Transactions view. You should see 2 transactions: the charge itself and the dispute charge ($15 fee plus the full amount of the order). Click on any row, [this is what you should see](https://user-images.githubusercontent.com/1715800/97118946-f6a13480-1704-11eb-9573-6780055afff0.png) (in my case, the order amount was $8).
- Won dispute. Go to the Dispute page for that dispute, submit it writing `winning_evidence` in the "Additional details" textfield. If you go back to the Transactions view, you should see 3 transactions: the original purchase, the dispute charge, and the dispute rollback. Click on any row, [this is what you should see](https://user-images.githubusercontent.com/1715800/97119007-5ac3f880-1705-11eb-897c-85fadb72af61.png).
- Lost dispute. If you repeat the process but you submit `losing_evidence` or you just "yield" (accept the dispute) you'll get the same numbers as in the `In-progress dispute` case, because Stripe substracts the money when the dispute is opened, so when the dispute is lost there's nothing else to do.
- Inquiry. Use the `4000000000001976` credit card this time. Because it's an inquiry instead of a full chargeback dispute, money will never change hands. It doesn't matter if you leave the "dispute" in-progress, you "win" it, you "accept" it, etc. The result will always be the same as if there was no dispute at all. [Example](https://user-images.githubusercontent.com/1715800/97119095-dd4cb800-1705-11eb-807d-2cba244846a0.png).

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)