### PR TITLE
Allow renovate bot to merge patch/pin version PRs automatically

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,14 @@
 {
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "updateTypes": [
+        "patch",
+        "pin"
+      ],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
Summing up recent bulk handling of renovate bot PRs, we are safe to automerge patch and pin versions PRs.

#### Changes proposed in this Pull Request

* Allow the bot automatically merge pin/patch release PRs.

#### Testing instructions

n/a, the renovate expected to create a merge some of PRs automatically.
