### PR TITLE
Remove a phpcs comment rendered at checkout

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -329,7 +329,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		?>
 		<div <?php echo $force_checked ? 'style="display:none;"' : ''; /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>>
 			<p class="form-row woocommerce-SavedPaymentMethods-saveNew">
-				<input id="<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $id ); ?>" type="checkbox" value="true" style="width:auto;" <?php echo $force_checked ? 'checked' : ''; ?> /> // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				<input id="<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $id ); ?>" type="checkbox" value="true" style="width:auto;" <?php echo $force_checked ? 'checked' : ''; /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?> />
 				<label for="<?php echo esc_attr( $id ); ?>" style="display:inline;">
 					<?php echo esc_html( apply_filters( 'wc_payments_save_to_account_text', __( 'Save payment information to my account for future purchases.', 'woocommerce-payments' ) ) ); ?>
 				</label>


### PR DESCRIPTION
Fixes the comment appearing on the checkout page:

<img width="352" alt="Screenshot 2020-11-03 at 16 29 35" src="https://user-images.githubusercontent.com/800604/98013091-d1da4a80-1df1-11eb-9daf-fc601c024763.png">

#### Changes proposed in this Pull Request

* Move the comment inside the php block

#### Testing instructions

* No comment should appear at checkout
