### PR TITLE
Fix invalid number of args error after updating wp core (+refactor)

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -82,6 +82,8 @@ class WC_Payments {
 			return;
 		}
 
+		add_action( 'admin_init', [ __CLASS__, 'add_woo_admin_notes' ] );
+
 		add_filter( 'plugin_action_links_' . plugin_basename( WCPAY_PLUGIN_FILE ), [ __CLASS__, 'add_plugin_links' ] );
 		add_action( 'woocommerce_blocks_payment_method_type_registration', [ __CLASS__, 'register_checkout_gateway' ] );
 
@@ -501,5 +503,25 @@ class WC_Payments {
 		require_once __DIR__ . '/class-wc-payments-blocks-payment-method.php';
 
 		$payment_method_registry->register( new WC_Payments_Blocks_Payment_Method() );
+	}
+
+	/**
+	 * Adds WCPay notes to the WC-Admin inbox.
+	 */
+	public static function add_woo_admin_notes() {
+		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
+			WC_Payments_Notes_Set_Up_Refund_Policy::possibly_add_note();
+		}
+	}
+
+	/**
+	 * Removes WCPay notes from the WC-Admin inbox.
+	 */
+	public static function remove_woo_admin_notes() {
+		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
+			WC_Payments_Notes_Set_Up_Refund_Policy::possibly_delete_note();
+		}
 	}
 }

--- a/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
+++ b/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
@@ -27,20 +27,6 @@ class WC_Payments_Notes_Set_Up_Refund_Policy {
 	const NOTE_DOCUMENTATION_URL = 'https://docs.woocommerce.com/document/woocommerce-refunds#refund-policy-howto';
 
 	/**
-	 * Handle activation scenario and create the note if it not yet created.
-	 */
-	public function on_wcpay_activation() {
-		self::possibly_add_note();
-	}
-
-	/**
-	 * Handle deactivation scenario and drop the note.
-	 */
-	public function on_wcpay_deactivation() {
-		self::possibly_delete_note();
-	}
-
-	/**
 	 * Get the note.
 	 */
 	public static function get_note() {

--- a/tests/notes/test-class-wc-payments-notes-set-up-refund-policy.php
+++ b/tests/notes/test-class-wc-payments-notes-set-up-refund-policy.php
@@ -21,10 +21,10 @@ class WC_Payments_Notes_Set_Up_Refund_Policy_Test extends WP_UnitTestCase {
 		}
 	}
 
-	public function test_adds_note_on_extension_activation() {
+	public function test_adds_note_in_hook() {
 		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
-			// Trigger WCPay extension activation callback.
-			wcpay_activated();
+			// Trigger WCPay extension woo notes hook.
+			WC_Payments::add_woo_admin_notes();
 
 			$note_id = WC_Payments_Notes_Set_Up_Refund_Policy::NOTE_NAME;
 			$this->assertNotSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -76,7 +76,7 @@ function wcpay_updated( $upgrader_object, $options ) {
 
 register_activation_hook( __FILE__, 'wcpay_activated' );
 register_deactivation_hook( __FILE__, 'wcpay_deactivated' );
-add_action( 'upgrader_process_complete', 'wcpay_updated' );
+add_action( 'upgrader_process_complete', 'wcpay_updated', 10, 2 );
 
 /**
  * Initialize the Jetpack connection functionality.

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -40,43 +40,18 @@ function wcpay_activated() {
 	) {
 		update_option( 'wcpay_should_redirect_to_onboarding', true );
 	}
-
-	if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
-		/* add set up refund policy note (if not yet) */
-		require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
-		( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_activation();
-	}
 }
 
 /**
  * Plugin deactivation hook.
  */
 function wcpay_deactivated() {
-	if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
-		/* drop set up refund policy note */
-		require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
-		( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_deactivation();
-	}
-}
-
-/**
- * Plugin update hook: receives information about updated components an ensures WCPay is one of them.
- *
- * @param \WP_Upgrader $upgrader_object The upgrader object.
- * @param array        $options         Extra details regarding updated components.
- */
-function wcpay_updated( $upgrader_object, $options ) {
-	$is_plugin_update = 'update' === $options['action'] && 'plugin' === $options['type'];
-	$is_wcpay_updated = $is_plugin_update && in_array( 'woocommerce-payments', (array) $options['plugins'], true );
-	if ( $is_wcpay_updated && version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
-		require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
-		( new WC_Payments_Notes_Set_Up_Refund_Policy() )->on_wcpay_activation();
-	}
+	require_once WCPAY_ABSPATH . '/includes/class-wc-payments.php';
+	WC_Payments::remove_woo_admin_notes();
 }
 
 register_activation_hook( __FILE__, 'wcpay_activated' );
 register_deactivation_hook( __FILE__, 'wcpay_deactivated' );
-add_action( 'upgrader_process_complete', 'wcpay_updated', 10, 2 );
 
 /**
  * Initialize the Jetpack connection functionality.


### PR DESCRIPTION
Fixes a problem where updating WP core would fail because `wcpay_updated` expects 2 arguments but gets passed only one. Also done some refactoring.

#### Changes proposed in this Pull Request

* Initially I made a simple change in ba79d25 to only call the hook when there are two args, but then I explored a bit more and found that `upgrader_process_complete` calls the **old** version of the file, so this approach wouldn't work anyway and had to do a bigger refactor.
* In ce3ab2b I rely upon the WC-Admin to determine if the note has been already displayed and always call to display it on admin init. I also refactored the `WC_Payments_Notes_Set_Up_Refund_Policy` class to be static since the `possibly_add_note`/`possibly_delete_note`  methods are public and can be called directly and there's no need to initialize it.

#### Testing instructions

* Modify `WC_Payments_Notes_Set_Up_Refund_Policy::NOTE_NAME` (suffix it with a random string) in order to make it appear if it already has been dismissed
* Load any Woo admin page
* Verify the note renders in the inbox
* Dismiss it
* Refresh the page - the note should not re-render

cc @kalessil 