### PR TITLE
Update copy of set up page

### DIFF
--- a/client/connect-account-page/strings.js
+++ b/client/connect-account-page/strings.js
@@ -14,7 +14,7 @@ export default {
 		),
 		{
 			// eslint-disable-next-line jsx-a11y/anchor-has-content
-			a: <a href="https://docs.woocommerce.com/document/payments/faq/fees/" target="_blank" />,
+			a: <a href="https://docs.woocommerce.com/document/payments/faq/fees/" target="_blank" rel="noopener noreferrer" />,
 		}
 	),
 	terms: createInterpolateElement(
@@ -24,7 +24,7 @@ export default {
 		),
 		{
 			// eslint-disable-next-line jsx-a11y/anchor-has-content
-			a: <a href="https://wordpress.com/tos" target="_blank" />,
+			a: <a href="https://wordpress.com/tos" target="_blank" rel="noopener noreferrer" />,
 		}
 	),
 	onboardingDisabled: [

--- a/client/connect-account-page/strings.js
+++ b/client/connect-account-page/strings.js
@@ -14,7 +14,7 @@ export default {
 		),
 		{
 			// eslint-disable-next-line jsx-a11y/anchor-has-content
-			a: <a href="https://docs.woocommerce.com/document/payments/faq/fees/" />,
+			a: <a href="https://docs.woocommerce.com/document/payments/faq/fees/" target="_blank" />,
 		}
 	),
 	terms: createInterpolateElement(
@@ -24,7 +24,7 @@ export default {
 		),
 		{
 			// eslint-disable-next-line jsx-a11y/anchor-has-content
-			a: <a href="https://wordpress.com/tos" />,
+			a: <a href="https://wordpress.com/tos" target="_blank" />,
 		}
 	),
 	onboardingDisabled: [

--- a/client/connect-account-page/strings.js
+++ b/client/connect-account-page/strings.js
@@ -7,9 +7,15 @@ import { __experimentalCreateInterpolateElement as createInterpolateElement } fr
 
 export default {
 	heading: __( 'WooCommerce Payments', 'woocommerce-payments' ),
-	description: __(
-		'Accept credit card payments the easy way! No set up fees. No monthly fees. Just 2.9% + $0.30 per transaction on U.S.-issued cards.',
-		'woocommerce-payments'
+	description: createInterpolateElement(
+		__(
+			'Accept credit card payments the easy way! <a>No set up fees. No monthly fees.</a>',
+			'woocommerce-payments'
+		),
+		{
+			// eslint-disable-next-line jsx-a11y/anchor-has-content
+			a: <a href="https://docs.woocommerce.com/document/payments/faq/fees/" />,
+		}
 	),
 	terms: createInterpolateElement(
 		__(

--- a/client/connect-account-page/test/__snapshots__/index.js.snap
+++ b/client/connect-account-page/test/__snapshots__/index.js.snap
@@ -180,6 +180,7 @@ exports[`ConnectAccountPage should render correctly 1`] = `
           Accept credit card payments the easy way! 
           <a
             href="https://docs.woocommerce.com/document/payments/faq/fees/"
+            rel="noopener noreferrer"
             target="_blank"
           >
             No set up fees. No monthly fees.
@@ -191,6 +192,7 @@ exports[`ConnectAccountPage should render correctly 1`] = `
           By clicking “Set up,” you agree to the 
           <a
             href="https://wordpress.com/tos"
+            rel="noopener noreferrer"
             target="_blank"
           >
             Terms of Service
@@ -395,6 +397,7 @@ exports[`ConnectAccountPage should render correctly when on-boarding disabled 1`
           Accept credit card payments the easy way! 
           <a
             href="https://docs.woocommerce.com/document/payments/faq/fees/"
+            rel="noopener noreferrer"
             target="_blank"
           >
             No set up fees. No monthly fees.

--- a/client/connect-account-page/test/__snapshots__/index.js.snap
+++ b/client/connect-account-page/test/__snapshots__/index.js.snap
@@ -180,6 +180,7 @@ exports[`ConnectAccountPage should render correctly 1`] = `
           Accept credit card payments the easy way! 
           <a
             href="https://docs.woocommerce.com/document/payments/faq/fees/"
+            target="_blank"
           >
             No set up fees. No monthly fees.
           </a>
@@ -190,6 +191,7 @@ exports[`ConnectAccountPage should render correctly 1`] = `
           By clicking “Set up,” you agree to the 
           <a
             href="https://wordpress.com/tos"
+            target="_blank"
           >
             Terms of Service
           </a>
@@ -393,6 +395,7 @@ exports[`ConnectAccountPage should render correctly when on-boarding disabled 1`
           Accept credit card payments the easy way! 
           <a
             href="https://docs.woocommerce.com/document/payments/faq/fees/"
+            target="_blank"
           >
             No set up fees. No monthly fees.
           </a>

--- a/client/connect-account-page/test/__snapshots__/index.js.snap
+++ b/client/connect-account-page/test/__snapshots__/index.js.snap
@@ -177,7 +177,12 @@ exports[`ConnectAccountPage should render correctly 1`] = `
         <p
           class="connect-account__description"
         >
-          Accept credit card payments the easy way! No set up fees. No monthly fees. Just 2.9% + $0.30 per transaction on U.S.-issued cards.
+          Accept credit card payments the easy way! 
+          <a
+            href="https://docs.woocommerce.com/document/payments/faq/fees/"
+          >
+            No set up fees. No monthly fees.
+          </a>
         </p>
         <p
           class="connect-account__terms"
@@ -385,7 +390,12 @@ exports[`ConnectAccountPage should render correctly when on-boarding disabled 1`
         <p
           class="connect-account__description"
         >
-          Accept credit card payments the easy way! No set up fees. No monthly fees. Just 2.9% + $0.30 per transaction on U.S.-issued cards.
+          Accept credit card payments the easy way! 
+          <a
+            href="https://docs.woocommerce.com/document/payments/faq/fees/"
+          >
+            No set up fees. No monthly fees.
+          </a>
         </p>
         <p>
           We've temporarily paused new account creation.

--- a/client/tos/modal/index.js
+++ b/client/tos/modal/index.js
@@ -20,6 +20,7 @@ const TosLink = ( props ) => (
 		{ ...props }
 		href="https://wordpress.com/tos"
 		target="_blank"
+		rel="noopener noreferrer"
 		type="external"
 	/>
 );

--- a/client/tos/modal/test/__snapshots__/index.js.snap
+++ b/client/tos/modal/test/__snapshots__/index.js.snap
@@ -35,6 +35,7 @@ exports[`ToS modal should render ToS modal 1`] = `
         <a
           data-link-type="external"
           href="https://wordpress.com/tos"
+          rel="noopener noreferrer"
           target="_blank"
         >
           Terms of Service
@@ -97,6 +98,7 @@ exports[`ToS modal should render disable plugin modal on decline 1`] = `
         <a
           data-link-type="external"
           href="https://wordpress.com/tos"
+          rel="noopener noreferrer"
           target="_blank"
         >
           Terms of Service


### PR DESCRIPTION
Fixes #1100

#### Changes proposed in this Pull Request

* Change set up screen to add link to fees doc

<img width="1015" alt="Screen Shot 2020-11-13 at 12 36 39" src="https://user-images.githubusercontent.com/235523/99021661-e1555280-25ac-11eb-891d-42539cfefa13.png">

#### Testing instructions

* Visit set up page
* Click "No set up fees. No monthly fees." and confirm it links to: https://docs.woocommerce.com/document/payments/faq/fees/

-------------------

- [x] Added changelog entry (or do
es not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
