### PR TITLE
Add remote note service

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Add - Introduced "Set up refund policy" notification in WooCommerce inbox.
 * Fix - Fix error when retrying to save a card in the Add Payment Method screen after failing SCA authentication.
 * Add - Allow signing up for a subscription with free trial with a credit card that requires SCA authentication.
+* Add - Remote note service.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -103,6 +103,14 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 				case 'account.updated':
 					$this->account->refresh_account_data();
 					break;
+				case 'wcpay.notification':
+					if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+						require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-remote-note-service.php';
+						$note_service = new WC_Payments_Remote_Note_Service( WC_Data_Store::load( 'admin-note' ) );
+						$note         = $this->read_rest_property( $body, 'data' );
+						$note_service->put_note( $note );
+					}
+					break;
 			}
 		} catch ( Rest_Request_Exception $e ) {
 			Logger::error( $e );

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -46,16 +46,30 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	private $account;
 
 	/**
+	 * WC Payments Remote Note Service.
+	 *
+	 * @var WC_Payments_Remote_Note_Service
+	 */
+	private $remote_note_service;
+
+	/**
 	 * WC_REST_Payments_Webhook_Controller constructor.
 	 *
-	 * @param WC_Payments_API_Client $api_client WC_Payments_API_Client instance.
-	 * @param WC_Payments_DB         $wcpay_db   WC_Payments_DB instance.
-	 * @param WC_Payments_Account    $account    WC_Payments_Account instance.
+	 * @param WC_Payments_API_Client          $api_client          WC_Payments_API_Client instance.
+	 * @param WC_Payments_DB                  $wcpay_db            WC_Payments_DB instance.
+	 * @param WC_Payments_Account             $account             WC_Payments_Account instance.
+	 * @param WC_Payments_Remote_Note_Service $remote_note_service WC_Payments_Remote_Note_Service instance.
 	 */
-	public function __construct( WC_Payments_API_Client $api_client, WC_Payments_DB $wcpay_db, WC_Payments_Account $account ) {
+	public function __construct(
+		WC_Payments_API_Client $api_client,
+		WC_Payments_DB $wcpay_db,
+		WC_Payments_Account $account,
+		WC_Payments_Remote_Note_Service $remote_note_service
+	) {
 		parent::__construct( $api_client );
-		$this->wcpay_db = $wcpay_db;
-		$this->account  = $account;
+		$this->wcpay_db            = $wcpay_db;
+		$this->account             = $account;
+		$this->remote_note_service = $remote_note_service;
 	}
 
 	/**
@@ -104,12 +118,8 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 					$this->account->refresh_account_data();
 					break;
 				case 'wcpay.notification':
-					if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
-						require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-remote-note-service.php';
-						$note_service = new WC_Payments_Remote_Note_Service( WC_Data_Store::load( 'admin-note' ) );
-						$note         = $this->read_rest_property( $body, 'data' );
-						$note_service->put_note( $note );
-					}
+					$note = $this->read_rest_property( $body, 'data' );
+					$this->remote_note_service->put_note( $note );
 					break;
 			}
 		} catch ( Rest_Request_Exception $e ) {

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -59,6 +59,13 @@ class WC_Payments {
 	private static $token_service;
 
 	/**
+	 * Instance of WC_Payments_Remote_Note_Service, created in init function.
+	 *
+	 * @var WC_Payments_Remote_Note_Service
+	 */
+	private static $remote_note_service;
+
+	/**
 	 * Cache for plugin headers to avoid multiple calls to get_file_data
 	 *
 	 * @var array
@@ -109,13 +116,15 @@ class WC_Payments {
 		include_once __DIR__ . '/constants/class-payment-initiated-by.php';
 		include_once __DIR__ . '/constants/class-payment-capture-type.php';
 		include_once __DIR__ . '/class-payment-information.php';
+		require_once __DIR__ . '/notes/class-wc-payments-remote-note-service.php';
 
 		// Always load tracker to avoid class not found errors.
 		include_once WCPAY_ABSPATH . 'includes/admin/tracks/class-tracker.php';
 
-		self::$account          = new WC_Payments_Account( self::$api_client );
-		self::$customer_service = new WC_Payments_Customer_Service( self::$api_client );
-		self::$token_service    = new WC_Payments_Token_Service( self::$api_client, self::$customer_service );
+		self::$account             = new WC_Payments_Account( self::$api_client );
+		self::$customer_service    = new WC_Payments_Customer_Service( self::$api_client );
+		self::$token_service       = new WC_Payments_Token_Service( self::$api_client, self::$customer_service );
+		self::$remote_note_service = new WC_Payments_Remote_Note_Service( WC_Data_Store::load( 'admin-note' ) );
 
 		$gateway_class = 'WC_Payment_Gateway_WCPay';
 		// TODO: Remove admin payment method JS hack for Subscriptions <= 3.0.7 when we drop support for those versions.
@@ -467,7 +476,7 @@ class WC_Payments {
 		$timeline_controller->register_routes();
 
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-webhook-controller.php';
-		$webhook_controller = new WC_REST_Payments_Webhook_Controller( self::$api_client, self::$db_helper, self::$account );
+		$webhook_controller = new WC_REST_Payments_Webhook_Controller( self::$api_client, self::$db_helper, self::$account, self::$remote_note_service );
 		$webhook_controller->register_routes();
 
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-tos-controller.php';
@@ -523,13 +532,11 @@ class WC_Payments {
 	 * Removes WCPay notes from the WC-Admin inbox.
 	 */
 	public static function remove_woo_admin_notes() {
+		self::$remote_note_service->delete_notes();
+
 		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
 			WC_Payments_Notes_Set_Up_Refund_Policy::possibly_delete_note();
-
-			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-remote-note-service.php';
-			$note_service = new WC_Payments_Remote_Note_Service( WC_Data_Store::load( 'admin-note' ) );
-			$note_service->delete_notes();
 		}
 	}
 }

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -526,6 +526,10 @@ class WC_Payments {
 		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
 			WC_Payments_Notes_Set_Up_Refund_Policy::possibly_delete_note();
+
+			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-remote-note-service.php';
+			$note_service = new WC_Payments_Remote_Note_Service( WC_Data_Store::load( 'admin-note' ) );
+			$note_service->delete_notes();
 		}
 	}
 }

--- a/includes/notes/class-wc-payments-remote-note-service.php
+++ b/includes/notes/class-wc-payments-remote-note-service.php
@@ -5,7 +5,6 @@
  * @package WooCommerce\Payments\Admin
  */
 
-use Automattic\WooCommerce\Admin\Notes\Notes;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 use WCPay\Exceptions\Rest_Request_Exception;
 

--- a/includes/notes/class-wc-payments-remote-note-service.php
+++ b/includes/notes/class-wc-payments-remote-note-service.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * WooCommerce inbox remote note service.
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+use WCPay\Exceptions\Rest_Request_Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WC_Payments_Remote_Note_Service
+ */
+class WC_Payments_Remote_Note_Service {
+	const NOTE_NAME_PREFIX = 'wc-payments-remote-notes-';
+
+	/**
+	 * Notes data store.
+	 *
+	 * @var WC_Data_Store
+	 */
+	private $note_data_store;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param WC_Data_Store $note_data_store WC Admin note data store.
+	 */
+	public function __construct( WC_Data_Store $note_data_store ) {
+		$this->note_data_store = $note_data_store;
+	}
+
+	/**
+	 * Puts the given note data in the inbox if it hasn't been added before.
+	 *
+	 * @param array $note_data Note data from the API.
+	 *
+	 * @return bool True if the note has been added.
+	 */
+	public function put_note( array $note_data ) : bool {
+		$note = $this->create_note( $note_data );
+
+		if ( ! $this->can_note_be_added( $note->get_name() ) ) {
+			return false;
+		}
+
+		$this->note_data_store->create( $note );
+		return true;
+	}
+
+	/**
+	 * Creates a new instance of a note from API note data.
+	 *
+	 * @param array $note_data The note data to process.
+	 *
+	 * @return WC_Admin_Note Note object.
+	 *
+	 * @throws Rest_Request_Exception If note data is invalid.
+	 */
+	private function create_note( array $note_data ) : WC_Admin_Note {
+		if ( ! isset( $note_data['title'], $note_data['content'] ) ) {
+			throw new Rest_Request_Exception( 'Invalid note.' );
+		}
+
+		$title     = $note_data['title'];
+		$content   = $note_data['content'];
+		$note_name = self::NOTE_NAME_PREFIX . ( $note_data['name'] ?? md5( $title . $content ) );
+
+		$note = new WC_Admin_Note();
+
+		$note->set_title( $title );
+		$note->set_content( $content );
+		$note->set_content_data( (object) [] );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( $note_name );
+		$note->set_source( 'woocommerce-payments' );
+
+		if ( isset( $note_data['actions'] ) && is_array( $note_data['actions'] ) ) {
+			foreach ( $note_data['actions'] as $action_key => $action ) {
+				if ( ! isset( $action['label'], $action['url'] ) ) {
+					throw new Rest_Request_Exception( 'Invalid note.' );
+				}
+
+				if ( 'wcpay_settings' === $action['url'] ) {
+					$url = WC_Payment_Gateway_WCPay::get_settings_url();
+				} else {
+					throw new Rest_Request_Exception( 'Invalid note.' );
+				}
+
+				$note->add_action(
+					$note_name . '-' . $action_key,
+					$action['label'],
+					$url,
+					$action['status'] ?? WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED,
+					$action['primary'] ?? false
+				);
+			}
+		}
+
+		return $note;
+	}
+
+	/**
+	 * Deletes all of the notes where names are prefixed with the value of the NOTE_NAME_PREFIX constant.
+	 *
+	 * @return void
+	 */
+	public function delete_notes() {
+		global $wpdb;
+		$prefix = self::NOTE_NAME_PREFIX;
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_admin_note_actions WHERE name LIKE '{$prefix}%'" );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}wc_admin_notes WHERE name LIKE '{$prefix}%'" );
+	}
+
+	/**
+	 * Checks if the note can be added.
+	 *
+	 * @param string $note_name Name of the note to add.
+	 *
+	 * @return boolean True if the note can be added.
+	 */
+	private function can_note_be_added( string $note_name ) : bool {
+		$note_ids = $this->note_data_store->get_notes_with_name( $note_name );
+		return empty( $note_ids );
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Introduced "Set up refund policy" notification in WooCommerce inbox.
 * Fix - Fix error when retrying to save a card in the Add Payment Method screen after failing SCA authentication.
 * Add - Allow signing up for a subscription with free trial with a credit card that requires SCA authentication.
+* Add - Remote note service.
 
 = 1.6.0 - 2020-10-15 =
 * Fix - Trimming the whitespace when updating the bank statement descriptor.

--- a/tests/admin/test-class-wc-rest-payments-webhook.php
+++ b/tests/admin/test-class-wc-rest-payments-webhook.php
@@ -6,6 +6,7 @@
  */
 
 use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Exceptions\Rest_Request_Exception;
 
 /**
  * WC_REST_Payments_Webhook_Controller unit tests.
@@ -23,6 +24,11 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 	 * @var WC_Payments_DB|MockObject
 	 */
 	private $mock_db_wrapper;
+
+	/**
+	 * @var WC_Payments_Remote_Note_Service|MockObject
+	 */
+	private $mock_remote_note_service;
 
 	/**
 	 * @var WP_REST_Request
@@ -55,7 +61,9 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 			->setMethods( [ 'order_from_charge_id' ] )
 			->getMock();
 
-		$this->controller = new WC_REST_Payments_Webhook_Controller( $mock_api_client, $this->mock_db_wrapper, $account );
+		$this->mock_remote_note_service = $this->createMock( WC_Payments_Remote_Note_Service::class );
+
+		$this->controller = new WC_REST_Payments_Webhook_Controller( $mock_api_client, $this->mock_db_wrapper, $account, $this->mock_remote_note_service );
 
 		// Setup a test request.
 		$this->request = new WP_REST_Request(
@@ -251,5 +259,59 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( [ 'result' => 'success' ], $response_data );
+	}
+
+	/**
+	 * Tests that a remote note webhook puts the note in the inbox.
+	 */
+	public function test_remote_note_puts_note() {
+		// Setup test request data.
+		$this->request_body['type'] = 'wcpay.notification';
+		$this->request_body['data'] = [
+			'title'   => 'test',
+			'content' => 'hello',
+		];
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
+
+		$this->mock_remote_note_service
+			->expects( $this->once() )
+			->method( 'put_note' )
+			->with(
+				[
+					'title'   => 'test',
+					'content' => 'hello',
+				]
+			);
+
+		$response = $this->controller->handle_webhook( $this->request );
+
+		$response_data = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( [ 'result' => 'success' ], $response_data );
+	}
+
+	/**
+	 * Tests that a remote note webhook handles service exceptions.
+	 */
+	public function test_remote_note_fails_returns_response() {
+		// Setup test request data.
+		$this->request_body['type'] = 'wcpay.notification';
+		$this->request_body['data'] = [
+			'foo' => 'bar',
+		];
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
+
+		$this->mock_remote_note_service
+			->expects( $this->once() )
+			->method( 'put_note' )
+			->willThrowException( new Rest_Request_Exception( 'Invalid note.' ) );
+
+		$response = $this->controller->handle_webhook( $this->request );
+
+		$response_data = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( [ 'result' => 'bad_request' ], $response_data );
 	}
 }

--- a/tests/notes/test-class-wc-payments-remote-note-service.php
+++ b/tests/notes/test-class-wc-payments-remote-note-service.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Class WC_Payments_Remote_Note_Service_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\Exceptions\Rest_Request_Exception;
+
+/**
+ * Class WC_Payments_Remote_Note_Service tests.
+ */
+class WC_Payments_Remote_Note_Service_Test extends WP_UnitTestCase {
+
+	/**
+	 * Instance of WC_Payments_Remote_Note_Service under test.
+	 *
+	 * @var WC_Payments_Remote_Note_Service
+	 */
+	private $note_service;
+
+	/**
+	 * Mock of the data store.
+	 *
+	 * @var object
+	 */
+	private $mock_data_store;
+
+	public function setUp() {
+		parent::setUp();
+
+		if ( version_compare( WC_VERSION, '4.4.0', '<=' ) ) {
+			$this->markTestSkipped( 'The used WC components are not backward compatible' );
+			return;
+		}
+
+		require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-remote-note-service.php';
+
+		$this->mock_data_store = $this->getMockBuilder( WC_Data_Store::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'get_notes_with_name', 'create' ] )
+			->getMock();
+		$this->note_service    = new WC_Payments_Remote_Note_Service( $this->mock_data_store );
+	}
+
+	public function test_puts_simple_note() {
+		$note_data = [
+			'title'   => 'test',
+			'content' => 'hello_world',
+		];
+
+		$this->mock_data_store
+			->expects( $this->once() )
+			->method( 'get_notes_with_name' )
+			->willReturn( [] );
+
+		$this->mock_data_store
+			->expects( $this->once() )
+			->method( 'create' )
+			->with(
+				$this->callback(
+					function( $note ) use ( $note_data ) {
+						return $note->get_name() === 'wc-payments-remote-notes-4cb476ca6ef0efd3ab9cf8d7e76d5083'
+							&& $note->get_title() === $note_data['title']
+							&& $note->get_content() === $note_data['content'];
+					}
+				),
+			);
+
+		$result = $this->note_service->put_note( $note_data );
+
+		$this->assertTrue( $result );
+	}
+
+	public function test_puts_note_with_name_and_actions() {
+		$note_data = [
+			'name'    => 'test_name',
+			'title'   => 'test',
+			'content' => 'hello_world',
+			'actions' => [
+				[
+					'label'   => 'Settings',
+					'status'  => 'unactioned',
+					'url'     => 'wcpay_settings',
+					'primary' => true,
+				],
+			],
+		];
+
+		$this->mock_data_store
+			->expects( $this->once() )
+			->method( 'get_notes_with_name' )
+			->willReturn( [] );
+
+		$this->mock_data_store
+			->expects( $this->once() )
+			->method( 'create' )
+			->with(
+				$this->callback(
+					function( $note ) use ( $note_data ) {
+						return $note->get_name() === 'wc-payments-remote-notes-' . $note_data['name']
+							&& $note->get_title() === $note_data['title']
+							&& $note->get_content() === $note_data['content']
+							&& 1 === count( $note->get_actions() );
+					}
+				),
+			);
+
+		$result = $this->note_service->put_note( $note_data );
+
+		$this->assertTrue( $result );
+	}
+
+	public function test_does_not_put_duplicate_notes() {
+		$note_data = [
+			'title'   => 'test',
+			'content' => 'hello_world',
+		];
+
+		$this->mock_data_store
+			->expects( $this->once() )
+			->method( 'get_notes_with_name' )
+			->willReturn( [ 'not_empty' ] );
+
+		$this->mock_data_store
+			->expects( $this->never() )
+			->method( 'create' );
+
+		$result = $this->note_service->put_note( $note_data );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_throws_on_malformed_data() {
+		$note_data = [
+			'title' => 'test',
+		];
+
+		$this->mock_data_store
+			->expects( $this->never() )
+			->method( 'get_notes_with_name' );
+
+		$this->mock_data_store
+			->expects( $this->never() )
+			->method( 'create' );
+
+		$this->expectException( Rest_Request_Exception::class );
+		$this->note_service->put_note( $note_data );
+	}
+}

--- a/tests/notes/test-class-wc-payments-remote-note-service.php
+++ b/tests/notes/test-class-wc-payments-remote-note-service.php
@@ -64,7 +64,7 @@ class WC_Payments_Remote_Note_Service_Test extends WP_UnitTestCase {
 							&& $note->get_title() === $note_data['title']
 							&& $note->get_content() === $note_data['content'];
 					}
-				),
+				)
 			);
 
 		$result = $this->note_service->put_note( $note_data );
@@ -103,7 +103,7 @@ class WC_Payments_Remote_Note_Service_Test extends WP_UnitTestCase {
 							&& $note->get_content() === $note_data['content']
 							&& 1 === count( $note->get_actions() );
 					}
-				),
+				)
 			);
 
 		$result = $this->note_service->put_note( $note_data );

--- a/tests/notes/test-class-wc-payments-remote-note-service.php
+++ b/tests/notes/test-class-wc-payments-remote-note-service.php
@@ -29,13 +29,6 @@ class WC_Payments_Remote_Note_Service_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		if ( version_compare( WC_VERSION, '4.4.0', '<=' ) ) {
-			$this->markTestSkipped( 'The used WC components are not backward compatible' );
-			return;
-		}
-
-		require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-remote-note-service.php';
-
 		$this->mock_data_store = $this->getMockBuilder( WC_Data_Store::class )
 			->disableOriginalConstructor()
 			->setMethods( [ 'get_notes_with_name', 'create' ] )


### PR DESCRIPTION
Adds a mechanism to allow our server to put notes in the specific site's inbox using webhooks.

#### Changes proposed in this Pull Request

* Add `WC_Payments_Remote_Note_Service` + tests
* Allow for the following note schema:
```
{
   "name": string, optional, will be calculated based on the title and content if missing
   "title": string, required
   "content": string, required
   "actions": array, optional: [
        "label": string, required,
        "url": string, required. Only supports linking to the settings page
        "status": string, optional, whether the note should be actioned or not when clicking on the action. Defaults to actioned
        "primary": bool, defaults to false
   ]
}
```

#### Testing instructions

* Either test with the server PR (coming soon)
* Or with the following curl command:
```
curl "http://localhost:8082/?rest_route=/wc/v3/payments/webhook&_for=mock_jetpack" \ 
-X POST \
--header "Content-Type: application/json" \
--data '{"type":"wcpay.notification","data":{"title":"test","content":"hello world"}}'
```

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
