### PR TITLE
Revert Composer to 2.0.6 before install on Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,8 @@ before_install:
   - echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
 
 install:
+  # Revert composer 2.0.7 to prevent error with Jetpack Autoloader
+  - composer self-update 2.0.6
   - npm ci
   - php --version && composer install
   - WCPAY_DIR="/home/travis/build/Automattic/woocommerce-payments/" bash ./bin/install-wp-tests.sh woocommerce_test root '' localhost $WP_VERSION $WC_VERSION false


### PR DESCRIPTION
Composer 2.0.7 introduced a breaking change for PHP versions less than 7.4 and Jetpack Autoloader. This commit reverts the
composer update to 2.0.6 on Travis to avoid this issue.

#### Changes proposed in this Pull Request

* Revert Composer to `2.0.6` before running `composer install` on Travis jobs

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assert that the Travis checks are green 😄 

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
