### PR TITLE
Remove user_ip and user_agent info from ToS acceptance

### DIFF
--- a/includes/admin/class-wc-rest-payments-tos-controller.php
+++ b/includes/admin/class-wc-rest-payments-tos-controller.php
@@ -124,17 +124,11 @@ class WC_REST_Payments_Tos_Controller extends WC_Payments_REST_Controller {
 	private function handle_tos_accepted() {
 		$this->gateway->enable();
 
-		//phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		$user_ip = isset( $_SERVER['REMOTE_ADDR'] ) ? wp_unslash( $_SERVER['REMOTE_ADDR'] ) : '';
-
-		//phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) : '';
-
 		// Accessing directly, because a user must be already logged in.
 		$current_user = wp_get_current_user();
 		$user_name    = $current_user->user_login;
 
-		$this->api_client->add_tos_agreement( 'settings-popup', $user_name, $user_ip, $user_agent );
+		$this->api_client->add_tos_agreement( 'settings-popup', $user_name );
 		$this->account->refresh_account_data();
 	}
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -804,20 +804,16 @@ class WC_Payments_API_Client {
 	 *
 	 * @param string $source     A string, which describes where the merchant agreed to the terms.
 	 * @param string $user_name  The user_login of the current user.
-	 * @param string $user_ip    IP address of the current user.
-	 * @param string $user_agent User agent string for the current user.
 	 *
 	 * @return array An array, containing a `success` flag.
 	 *
 	 * @throws API_Exception If an error occurs.
 	 */
-	public function add_tos_agreement( $source, $user_name, $user_ip, $user_agent ) {
+	public function add_tos_agreement( $source, $user_name ) {
 		return $this->request(
 			[
-				'source'     => $source,
-				'user_name'  => $user_name,
-				'user_ip'    => $user_ip,
-				'user_agent' => $user_agent,
+				'source'    => $source,
+				'user_name' => $user_name,
 			],
 			self::ACCOUNTS_API . '/tos_agreements',
 			self::POST


### PR DESCRIPTION
We probably don't need to store PII (see paJDYF-OD-p2#comment-4071 for context)

#### Changes proposed in this Pull Request

* Do not record `user_ip` and `user_agent` with ToS acceptance request.

#### Testing instructions

Same as in #993 but without params above not being tracked.


-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->