### PR TITLE
Fix nightly tests

### DIFF
--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Automattic\WooCommerce\Admin\Notes\DataStore;
+use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Logger;
@@ -700,11 +701,17 @@ class WC_Payments_Account {
 			return $where_clause . " AND name like 'wcpay-promo-%'";
 		};
 
+		if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Note' ) ) {
+			$note_class = Note::class;
+		} else {
+			$note_class = WC_Admin_Note::class;
+		}
+
 		add_filter( 'woocommerce_note_where_clauses', $add_like_clause );
 
 		$wcpay_promo_notes = $data_store->get_notes(
 			[
-				'status'     => [ WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED ],
+				'status'     => [ $note_class::E_WC_ADMIN_NOTE_ACTIONED ],
 				'is_deleted' => false,
 				'per_page'   => 10,
 			]
@@ -719,7 +726,7 @@ class WC_Payments_Account {
 
 		// Copy the name of each note into the results.
 		foreach ( (array) $wcpay_promo_notes as $wcpay_note ) {
-			$note               = new WC_Admin_Note( $wcpay_note->note_id );
+			$note               = new $note_class( $wcpay_note->note_id );
 			$wcpay_note_names[] = $note->get_name();
 		}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -10,8 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Automattic\WooCommerce\Admin\Notes\DataStore;
-use Automattic\WooCommerce\Admin\Notes\Note;
-use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Logger;
 use \Automattic\WooCommerce\Admin\Features\Onboarding;
@@ -701,11 +699,7 @@ class WC_Payments_Account {
 			return $where_clause . " AND name like 'wcpay-promo-%'";
 		};
 
-		if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Note' ) ) {
-			$note_class = Note::class;
-		} else {
-			$note_class = WC_Admin_Note::class;
-		}
+		$note_class = WC_Payment_Woo_Compat_Utils::get_note_class();
 
 		add_filter( 'woocommerce_note_where_clauses', $add_like_clause );
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -112,6 +112,7 @@ class WC_Payments {
 		include_once __DIR__ . '/exceptions/class-intent-authentication-exception.php';
 		include_once __DIR__ . '/exceptions/class-invalid-payment-method-exception.php';
 		include_once __DIR__ . '/exceptions/class-process-payment-exception.php';
+		include_once __DIR__ . '/compat/class-wc-payment-woo-compat-utils.php';
 		include_once __DIR__ . '/constants/class-payment-type.php';
 		include_once __DIR__ . '/constants/class-payment-initiated-by.php';
 		include_once __DIR__ . '/constants/class-payment-capture-type.php';

--- a/includes/compat/class-wc-payment-woo-compat-utils.php
+++ b/includes/compat/class-wc-payment-woo-compat-utils.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Class WC_Payment_Woo_Compat_Utils
+ *
+ * @package WooCommerce\Payments
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+
+/**
+ * Util class for handling compatibilities with different versions of WooCommerce core.
+ */
+class WC_Payment_Woo_Compat_Utils {
+	/**
+	 * Return non-deprecated class for instantiating WC-Admin notes.
+	 *
+	 * @return string
+	 */
+	public static function get_note_class() : string {
+		if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Note' ) ) {
+			return Note::class;
+		} else {
+			return WC_Admin_Note::class;
+		}
+	}
+}

--- a/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
+++ b/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
@@ -6,8 +6,6 @@
  */
 
 use Automattic\WooCommerce\Admin\Notes\NoteTraits;
-use Automattic\WooCommerce\Admin\Notes\Note;
-use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -31,13 +29,8 @@ class WC_Payments_Notes_Set_Up_Refund_Policy {
 	 * Get the note.
 	 */
 	public static function get_note() {
-		if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Note' ) ) {
-			$note_class = Note::class;
-		} else {
-			$note_class = WC_Admin_Note::class;
-		}
-
-		$note = new $note_class();
+		$note_class = WC_Payment_Woo_Compat_Utils::get_note_class();
+		$note       = new $note_class();
 
 		$note->set_title( __( 'Set up refund policy', 'woocommerce-payments' ) );
 		$note->set_content( __( 'Protect your merchant account from fraudulent disputes by defining the policy and making it accessible to customers.', 'woocommerce-payments' ) );

--- a/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
+++ b/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 
 defined( 'ABSPATH' ) || exit;
@@ -30,12 +31,18 @@ class WC_Payments_Notes_Set_Up_Refund_Policy {
 	 * Get the note.
 	 */
 	public static function get_note() {
-		$note = new WC_Admin_Note();
+		if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Note' ) ) {
+			$note_class = Note::class;
+		} else {
+			$note_class = WC_Admin_Note::class;
+		}
+
+		$note = new $note_class();
 
 		$note->set_title( __( 'Set up refund policy', 'woocommerce-payments' ) );
 		$note->set_content( __( 'Protect your merchant account from fraudulent disputes by defining the policy and making it accessible to customers.', 'woocommerce-payments' ) );
 		$note->set_content_data( (object) [] );
-		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-payments' );
 		$note->add_action(

--- a/includes/notes/class-wc-payments-remote-note-service.php
+++ b/includes/notes/class-wc-payments-remote-note-service.php
@@ -5,8 +5,6 @@
  * @package WooCommerce\Payments\Admin
  */
 
-use Automattic\WooCommerce\Admin\Notes\Note;
-use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 use WCPay\Exceptions\Rest_Request_Exception;
 
 defined( 'ABSPATH' ) || exit;
@@ -69,13 +67,8 @@ class WC_Payments_Remote_Note_Service {
 		$content   = $note_data['content'];
 		$note_name = self::NOTE_NAME_PREFIX . ( $note_data['name'] ?? md5( $title . $content ) );
 
-		if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Note' ) ) {
-			$note_class = Note::class;
-		} else {
-			$note_class = WC_Admin_Note::class;
-		}
-
-		$note = new $note_class();
+		$note_class = WC_Payment_Woo_Compat_Utils::get_note_class();
+		$note       = new $note_class();
 
 		$note->set_title( $title );
 		$note->set_content( $content );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/pull/1104#issuecomment-729736441

#### Changes proposed in this Pull Request

* `WC_Admin_Note` has been deprecated in the more recent versions of Woo core in favor of `Note`
* Checks if `Note` exists, and if it does, uses it instead of `WC_Admin_Note`

#### Testing instructions

* Either CI tests should pass
* Or
  * Make sure WP_DEBUG is on
  * Using [WooCommerce Beta Tester](https://wordpress.org/plugins/woocommerce-beta-tester/) switch to 4.8.0-beta.1
  * No deprecated class notices should be shown in wp-admin
  * Place a debug point in `WC_Payments_Account::get_actioned_notes` and attempt to reonboard (no need to finish the flow) - no notices should be thrown.
  * Run the command below, no notices should be thrown, the note should appear in woo inbox:
```
curl "http://localhost:8082/?rest_route=/wc/v3/payments/webhook&_for=mock_jetpack" \
-X POST \
--header "Content-Type: application/json" \
--data '{"type":"wcpay.notification","data":{"title":"aaaa122222test","content":"1111 hello worldaaa"}}'
```

cc @kalessil 

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
