### PR TITLE
Avoid fatal errors whenever the server is not available

### DIFF
--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -27,6 +27,14 @@ class WC_Payments_Admin {
 	private $account;
 
 	/**
+	 * Indicates if the connection to the server was not available
+	 * at some stage, in order not to enqueue any scripts.
+	 *
+	 * @var bool
+	 */
+	private $connection_broken = false;
+
+	/**
 	 * Hook in admin menu items.
 	 *
 	 * @param WC_Payment_Gateway_WCPay $gateway WCPay Gateway instance to get information regarding WooCommerce Payments setup.
@@ -54,6 +62,7 @@ class WC_Payments_Admin {
 			$stripe_connected = $this->account->try_is_stripe_connected();
 		} catch ( Exception $e ) {
 			// do not render the menu if the server is unreachable.
+			$this->connection_broken = true;
 			return;
 		}
 
@@ -264,6 +273,11 @@ class WC_Payments_Admin {
 	 */
 	public function enqueue_payments_scripts() {
 		global $current_tab, $current_section;
+
+		// No connection means some scripts cannot be localized.
+		if ( $this->connection_broken ) {
+			return;
+		}
 
 		$this->register_payments_scripts();
 

--- a/includes/class-wc-payments-blocks-payment-method.php
+++ b/includes/class-wc-payments-blocks-payment-method.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+use WCPay\Exceptions\API_Exception;
 
 /**
  * The payment method, which allows the gateway to work with WooCommerce Blocks.
@@ -25,7 +26,12 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 	 * @return boolean True when active.
 	 */
 	public function is_active() {
-		return WC_Payments::get_gateway()->is_available();
+		try {
+			return WC_Payments::get_gateway()->is_available();
+		} catch ( API_Exception $e ) {
+			// An API exception this early means that the server is not available.
+			return false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I noticed that I'm getting fatal PHP errors on my development instance when:

- Using my local server for development, but Docker is not `up`.
- Using my sandbox, but I'm not connected to it (so it's not running).
- My computer is not connected to the internet and requests are not redirected to my local server.

In production it's unlikely that the WCPay API would not be available, but we should still not let an unsuccessful request break the whole site. To achieve this:

- The checkout block is not registered if there's an API error.
- Scripts for the admin are not registered/enqueued, because some localizations require cached account data. 

#### Testing instructions

1. Activate WooCommerce Blocks if you haven't already.
2. Checkout `master`.
3. Either disconnect from the internet or make sure that the selected (in dev tools) server is not available.
4. Clear the `wcpay_account_data` transient.
5. You'll now see an error and will be unable to access the site (or at least `wp-admin`).
6. Checkout this branch and make sure that everything works normally, except WCPay, which should not even be displayed in the admin menu.
7. Deactivate WooCommerce Blocks. The back-end should still be accessible.

In https://github.com/Automattic/woocommerce-payments/pull/308/files#diff-1cf209a1776d0208a1a6125d0ab5d3958b8631909cea0bce44b22f922eb1bdbfR71 @dwainm added an admin notice for such situations, but at some point it seems to have gotten removed. Any idea why and whether I should add one to this PR?

-------------------

- [x] Added changelog entry (does not apply)
- [x] Tested on mobile (does not apply)