### PR TITLE
Disable automerging for minor updates (renovate bot)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "config:base"
   ],
   "minor": {
-    "automerge": true
+    "automerge": false
   },
   "patch": {
     "automerge": true

--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,6 @@
   "extends": [
     "config:base"
   ],
-  "minor": {
-    "automerge": false
-  },
   "patch": {
     "automerge": true
   },


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As a followup of paJDYF-UD-p2 we are disabling minor updates auto-merging.

#### Testing instructions

* Renovate bot PRs with minor versions bump containing configuration description, we should see automerging is disabled there.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in the description ☝️)
- [x] Tested on mobile (or does not apply)
