### PR TITLE
Try running e2e tests without Stripe sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ services:
 
 # Different stages in order to only deploy when everything succeeds
 stages:
-  - test
-  - name: compatibility
-    if: branch = master
-  - name: compatibility-edge
-    if: branch = master
+#  - test
+#  - name: compatibility
+#    if: branch = master
+#  - name: compatibility-edge
+#    if: branch = master
   - e2e-testing
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ services:
 
 # Different stages in order to only deploy when everything succeeds
 stages:
-#  - test
-#  - name: compatibility
-#    if: branch = master
-#  - name: compatibility-edge
-#    if: branch = master
+  - test
+  - name: compatibility
+    if: branch = master
+  - name: compatibility-edge
+    if: branch = master
   - e2e-testing
 
 env:

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -55,7 +55,7 @@ step "Setting up server containers"
 redirect_output local/bin/docker-setup.sh
 
 step "Configuring server with stripe account"
-redirect_output $SERVER_PATH/local/bin/link-account.sh $BLOG_ID $E2E_WCPAY_STRIPE_ACCOUNT_ID
+redirect_output docker-compose exec wordpress wp wcpay link_account_to_blog --blog_id=$BLOG_ID --stripe_id=$$E2E_WCPAY_STRIPE_ACCOUNT_ID --mode=test --skip_sync=1
 
 cd $cwd
 

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -54,7 +54,7 @@ fi
 step "Setting up server containers"
 redirect_output local/bin/docker-setup.sh
 
-step "Configuring server with stripe account (test account, skip sync)"
+step "Configuring server with stripe account"
 redirect_output $SERVER_PATH/local/bin/link-account.sh $BLOG_ID $E2E_WCPAY_STRIPE_ACCOUNT_ID test 1
 
 cd $cwd

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -55,7 +55,7 @@ step "Setting up server containers"
 redirect_output local/bin/docker-setup.sh
 
 step "Configuring server with stripe account"
-redirect_output docker-compose exec wordpress wp wcpay link_account_to_blog --blog_id=$BLOG_ID --stripe_id=$$E2E_WCPAY_STRIPE_ACCOUNT_ID --mode=test --skip_sync=1
+redirect_output $SERVER_PATH/local/bin/link-account.sh $BLOG_ID $E2E_WCPAY_STRIPE_ACCOUNT_ID "test --skip_sync=1"
 
 cd $cwd
 

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -54,8 +54,8 @@ fi
 step "Setting up server containers"
 redirect_output local/bin/docker-setup.sh
 
-step "Configuring server with stripe account"
-redirect_output $SERVER_PATH/local/bin/link-account.sh $BLOG_ID $E2E_WCPAY_STRIPE_ACCOUNT_ID "test --skip_sync=1"
+step "Configuring server with stripe account (test account, skip sync)"
+redirect_output $SERVER_PATH/local/bin/link-account.sh $BLOG_ID $E2E_WCPAY_STRIPE_ACCOUNT_ID test 1
 
 cd $cwd
 


### PR DESCRIPTION
Fixes #1114

#### Changes proposed in this Pull Request

* Adds a flag to skip Stripe account sync when setting E2E tests up (~8 mins instead of 16 mins)
* Depends on 444-gh-Automattic/woocommerce-payments-server

#### Testing instructions

* n/a

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)