### PR TITLE
Turn xdebug off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ For setting up a test account follow [these instructions](https://docs.woocommer
 You will need a externally accessible URL to set up the plugin. You can use ngrok for this.
 
 See: https://github.com/Automattic/woocommerce-payments/blob/master/CONTRIBUTING.md (possibly move contents here for visibility sake)
+
+## Debugging
+
+If you are following the Docker setup [here](https://github.com/Automattic/woocommerce-payments/blob/master/docker/README.md), Xdebug is ready to use for debugging.
+
+Install [Xdebug Helper browser extension mentioned here](https://xdebug.org/docs/remote) to enable Xdebug on demand.

--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -3,7 +3,7 @@ RUN pecl install xdebug \
 	&& echo 'xdebug.remote_enable=1' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.remote_port=9000' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.remote_host=host.docker.internal' >> $PHP_INI_DIR/php.ini \
-	&& echo 'xdebug.remote_autostart=1' >> $PHP_INI_DIR/php.ini \
+	&& echo 'xdebug.remote_autostart=0' >> $PHP_INI_DIR/php.ini \
 	&& docker-php-ext-enable xdebug
 RUN apt-get update \
 	&& apt-get install --assume-yes --quiet --no-install-recommends gnupg2 subversion mariadb-client less jq

--- a/tests/e2e/env/wordpress-xdebug/Dockerfile
+++ b/tests/e2e/env/wordpress-xdebug/Dockerfile
@@ -4,5 +4,5 @@ RUN pecl install xdebug \
 	&& echo 'xdebug.remote_enable=1' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.remote_port=9000' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.remote_host=host.docker.internal' >> $PHP_INI_DIR/php.ini \
-	&& echo 'xdebug.remote_autostart=1' >> $PHP_INI_DIR/php.ini \
+	&& echo 'xdebug.remote_autostart=0' >> $PHP_INI_DIR/php.ini \
 	&& docker-php-ext-enable xdebug > /dev/null


### PR DESCRIPTION
Fixes #891

Xdebug is currently always enabled, so when xdebug server is listening, any request becomes relatively slow.
We can utilize [Xdebug Helper browser extension mentioned here](https://xdebug.org/docs/remote) to enable xdebug on demand.

#### Changes proposed in this Pull Request

* Set `xdebug.remote_autostart` to 0 when setting up docker.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install [Xdebug Helper browser extension mentioned here](https://xdebug.org/docs/remote)
* Since this change only affects a fresh setup, if you already have local environment setup, you need to:
  - Set `xdebug.remote_autostart` to 0
```docker-compose exec wordpress bash -c "sed -i 's/xdebug\.remote_autostart=1/xdebug\.remote_autostart=0/' /usr/local/etc/php/php.ini"```
  - Make sure the change is applied to php.ini
```docker-compose exec wordpress bash -c "grep remote_autostart /usr/local/etc/php/php.ini"```
  - Reload web server
```docker-compose exec wordpress service apache2 reload```

* Make sure xdebug server / your IDE is listening to xdebug session.
* Load a page (for example, [wp-admin](http://localhost:8082/wp-admin)) and notice the response time difference when you disable xdebug from the browser extension.

![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/73803630/100218593-8413b680-2f47-11eb-86c1-d6401404c270.gif)

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
