### PR TITLE
Catch exceptions in the get_latest_tos_agreement function

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 1.8.0 - 2020-xx-xx =
 * Add - Include information about failing payment into order notes.
 * Fix - Fix crash when a user has 10 or more saved credit cards.
+* Fix - Fix crash if there's a problem connecting to the server.
 
 = 1.7.0 - 2020-11-17 =
 * Fix - Fix ordering of payment detail timeline events.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -665,7 +665,11 @@ class WC_Payments_Account {
 	 * @return array|null Eiter the agreement or null if unavailable.
 	 */
 	public function get_latest_tos_agreement() {
-		$account = $this->get_cached_account_data();
+		try {
+			$account = $this->get_cached_account_data();
+		} catch ( API_Exception $e ) {
+			return null;
+		}
 
 		return ! empty( $account ) && isset( $account['latest_tos_agreement'] )
 			? $account['latest_tos_agreement']

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ Please note that our support for the checkout block is still experimental and th
 = 1.8.0 - 2020-xx-xx =
 * Add - Include information about failing payment into order notes.
 * Fix - Fix crash when a user has 10 or more saved credit cards.
+* Fix - Fix crash if there's a problem connecting to the server.
 
 = 1.7.0 - 2020-11-17 =
 * Fix - Fix ordering of payment detail timeline events.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Wrap the `get_cached_account_data()` function call on a `try ... catch`. The `get_cached_account_data()` can throw an exception if the server is unreachable or there's any problem with the connection, so in that case a `try ... catch` is needed. That's how it's already implemented in every function that calls `get_cached_account_data()`, except for `get_latest_tos_agreement()`.

#### Testing instructions

- Tweak the WCPay server so API requests fail. For example, you could change the function `check_wordpress_account_permissions` to always return a `WP_Error`.
- Clear the account cache transient in the WCPay plugin. You can either wait 2 hours, delete the transient from the database, or use the WCPay Dev Tools plugin.
- Navigate anywhere on WP-Admin.

On `master`, the site would blow up. On this branch, nothing will happen.

-------------------

- [x] Added changelog entry (or does not apply)