### PR TITLE
Proxy all docker requests through a8c proxy

### DIFF
--- a/default.env
+++ b/default.env
@@ -14,6 +14,7 @@ MYSQL_PASSWORD=wordpress
 
 # curl proxy
 ALL_PROXY=socks5h://host.docker.internal:8080
+NO_PROXY=localhost,host.docker.internal
 
 # WCPay
 WCPAY_DIR=/var/www/html/wp-content/plugins/woocommerce-payments

--- a/default.env
+++ b/default.env
@@ -12,5 +12,8 @@ MYSQL_DATABASE=wordpress
 MYSQL_USER=wordpress
 MYSQL_PASSWORD=wordpress
 
+# curl proxy
+ALL_PROXY=socks5h://host.docker.internal:8080
+
 # WCPay
 WCPAY_DIR=/var/www/html/wp-content/plugins/woocommerce-payments


### PR DESCRIPTION
See paJDYF-WR-p2

When sandboxing public-api, we now need to make sure it is accessible from outside the proxy or use the proxy. This assumes every dev has a proxy set up on port 8080 and redirects all the requests through it.

#### Changes proposed in this Pull Request

* Add proxy configuration variables to the docker container

#### Testing instructions

* `npm run down && npm run up`
* SSH into the sandbox
* Make sure your hosts file points public-api to the sandbox
* Go to http://localhost:8082/
* If using dev tools and redirecting to a local env, disable that option temporarily
* If using dev tools, clear the account cache
* Everything should still work, the payment menus should be visibe