### PR TITLE
Prevent exceptions from WC_Payments_Account::get_cached_account_data

### DIFF
--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -51,13 +51,13 @@ class WC_Payments_Admin {
 		global $submenu;
 
 		try {
-			$stripe_connected = $this->account->try_is_stripe_connected();
+			$should_render_full_menu = $this->account->try_is_stripe_connected();
 		} catch ( Exception $e ) {
-			// do not render the menu if the server is unreachable.
-			return;
+			// There is an issue with connection but render full menu anyways to provide access to settings.
+			$should_render_full_menu = true;
 		}
 
-		$top_level_link = $stripe_connected ? '/payments/deposits' : '/payments/connect';
+		$top_level_link = $should_render_full_menu ? '/payments/deposits' : '/payments/connect';
 
 		wc_admin_register_page(
 			[
@@ -69,7 +69,7 @@ class WC_Payments_Admin {
 			]
 		);
 
-		if ( $stripe_connected ) {
+		if ( $should_render_full_menu ) {
 			wc_admin_register_page(
 				[
 					'id'     => 'wc-payments-deposits',

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -251,10 +251,9 @@ class WC_Payments_Account {
 			return;
 		}
 
-		try {
-			$account = $this->get_cached_account_data();
-		} catch ( Exception $e ) {
-			// Return early. The exceptions have been logged in the http client.
+		$account = $this->get_cached_account_data();
+		if ( false === $account ) {
+			// Failed to retrieve account data. Exception is logged in http client.
 			return false;
 		}
 
@@ -523,9 +522,7 @@ class WC_Payments_Account {
 	/**
 	 * Gets and caches the data for the account connected to this site.
 	 *
-	 * @return array Account data;
-	 *
-	 * @throws API_Exception Bubbles up if get_account_data call fails.
+	 * @return array|bool Account data or false if failed to retrieve account data.
 	 */
 	private function get_cached_account_data() {
 		if ( ! $this->payments_api_client->is_server_connected() ) {
@@ -555,7 +552,9 @@ class WC_Payments_Account {
 				$account = [];
 				set_transient( self::ON_BOARDING_DISABLED_TRANSIENT, true, 2 * HOUR_IN_SECONDS );
 			} else {
-				throw $e;
+				// Failed to retrieve account data. Exception is logged in http client.
+				// Return immediately to signal account retrieval error.
+				return false;
 			}
 		}
 
@@ -677,7 +676,7 @@ class WC_Payments_Account {
 	/**
 	 * Retrieves the latest ToS agreement for the account.
 	 *
-	 * @return array|null Eiter the agreement or null if unavailable.
+	 * @return array|null Either the agreement or null if unavailable.
 	 */
 	public function get_latest_tos_agreement() {
 		try {

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -55,8 +55,6 @@ class WC_Payments_Account {
 	 * Return connected account ID
 	 *
 	 * @return string|null Account ID if connected, null if not connected or on error
-	 *
-	 * @throws Exception Bubbles up if get_account_data call fails.
 	 */
 	public function get_stripe_account_id() {
 		$account = $this->get_cached_account_data();
@@ -74,8 +72,6 @@ class WC_Payments_Account {
 	 * @param bool $is_test true to get the test key, false otherwise.
 	 *
 	 * @return string|null public key if connected, null if not connected.
-	 *
-	 * @throws Exception Bubbles up if get_account_data call fails.
 	 */
 	public function get_publishable_key( $is_test ) {
 		$account = $this->get_cached_account_data();
@@ -110,14 +106,12 @@ class WC_Payments_Account {
 	 * Checks if the account is connected, throws on server error
 	 *
 	 * @return bool True if the account is connected, false otherwise.
-	 *
-	 * @throws Exception Bubbles up if get_account_data call fails.
 	 */
 	public function try_is_stripe_connected() {
 		$account = $this->get_cached_account_data();
 
-		if ( is_array( $account ) && empty( $account ) ) {
-			// empty array means no account.
+		if ( empty( $account ) ) {
+			// empty means no account.
 			return false;
 		}
 
@@ -130,16 +124,10 @@ class WC_Payments_Account {
 	 * @return array An array containing the status data.
 	 */
 	public function get_account_status_data() {
-		try {
-			$account = $this->get_cached_account_data();
-		} catch ( Exception $e ) {
-			return [
-				'error' => true,
-			];
-		}
+		$account = $this->get_cached_account_data();
 
-		if ( is_array( $account ) && empty( $account ) ) {
-			// empty array means no account. This data should not be used when the account is not connected.
+		if ( empty( $account ) ) {
+			// empty means no account. This data should not be used when the account is not connected.
 			return [
 				'error' => true,
 			];
@@ -167,38 +155,31 @@ class WC_Payments_Account {
 	/**
 	 * Gets the account statement descriptor for rendering on the settings page.
 	 *
-	 * @return string        Account statement descriptor.
-	 * @throws API_Exception Bubbles up from get_cached_account_data.
+	 * @return string Account statement descriptor.
 	 */
 	public function get_statement_descriptor() {
 		$account = $this->get_cached_account_data();
-		return isset( $account['statement_descriptor'] ) ? $account['statement_descriptor'] : '';
+		return ! empty( $account ) && isset( $account['statement_descriptor'] ) ? $account['statement_descriptor'] : '';
 	}
 
 	/**
 	 * Gets the current account fees for rendering on the settings page.
 	 *
-	 * @return array        Fees.
-	 * @throws API_Exception Bubbles up from get_cached_account_data.
+	 * @return array Fees.
 	 */
 	public function get_fees() {
-		try {
-			$account = $this->get_cached_account_data();
-			return isset( $account['fees'] ) ? $account['fees'] : [];
-		} catch ( API_Exception $e ) {
-			return [];
-		}
+		$account = $this->get_cached_account_data();
+		return ! empty( $account ) && isset( $account['fees'] ) ? $account['fees'] : [];
 	}
 
 	/**
 	 * Gets the account live mode value.
 	 *
-	 * @return bool|null     Account is_live value.
-	 * @throws API_Exception Bubbles up from get_cached_account_data.
+	 * @return bool|null Account is_live value.
 	 */
 	public function get_is_live() {
 		$account = $this->get_cached_account_data();
-		return isset( $account['is_live'] ) ? $account['is_live'] : null;
+		return ! empty( $account ) && isset( $account['is_live'] ) ? $account['is_live'] : null;
 	}
 
 	/**
@@ -578,12 +559,8 @@ class WC_Payments_Account {
 	 * @return mixed Either the new account data or false if unavailable.
 	 */
 	public function refresh_account_data() {
-		try {
-			delete_transient( self::ACCOUNT_TRANSIENT );
-			return $this->get_cached_account_data();
-		} catch ( Exception $e ) {
-			Logger::error( "Failed to refresh account data. Error: $e" );
-		}
+		delete_transient( self::ACCOUNT_TRANSIENT );
+		return $this->get_cached_account_data();
 	}
 
 	/**
@@ -679,12 +656,7 @@ class WC_Payments_Account {
 	 * @return array|null Either the agreement or null if unavailable.
 	 */
 	public function get_latest_tos_agreement() {
-		try {
-			$account = $this->get_cached_account_data();
-		} catch ( API_Exception $e ) {
-			return null;
-		}
-
+		$account = $this->get_cached_account_data();
 		return ! empty( $account ) && isset( $account['latest_tos_agreement'] )
 			? $account['latest_tos_agreement']
 			: null;

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -182,8 +182,12 @@ class WC_Payments_Account {
 	 * @throws API_Exception Bubbles up from get_cached_account_data.
 	 */
 	public function get_fees() {
-		$account = $this->get_cached_account_data();
-		return isset( $account['fees'] ) ? $account['fees'] : [];
+		try {
+			$account = $this->get_cached_account_data();
+			return isset( $account['fees'] ) ? $account['fees'] : [];
+		} catch ( API_Exception $e ) {
+			return [];
+		}
 	}
 
 	/**

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -88,7 +88,7 @@ class WC_Payments_Account {
 	}
 
 	/**
-	 * Checks if the account is connected, assumes the value of $on_error on server error
+	 * Checks if the account is connected, assumes the value of $on_error on server error.
 	 *
 	 * @param bool $on_error Value to return on server error, defaults to false.
 	 *
@@ -103,14 +103,19 @@ class WC_Payments_Account {
 	}
 
 	/**
-	 * Checks if the account is connected, throws on server error
+	 * Checks if the account is connected, throws on server error.
 	 *
-	 * @return bool True if the account is connected, false otherwise.
+	 * @return bool      True if the account is connected, false otherwise.
+	 * @throws Exception Throws exception when unable to detect connection status.
 	 */
 	public function try_is_stripe_connected() {
 		$account = $this->get_cached_account_data();
 
-		if ( empty( $account ) ) {
+		if ( false === $account ) {
+			throw new Exception( __( 'Failed to detect connection status', 'woocommerce-payments' ) );
+		}
+
+		if ( is_array( $account ) && empty( $account ) ) {
 			// empty means no account.
 			return false;
 		}

--- a/tests/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/test-class-wc-payment-gateway-wcpay.php
@@ -117,16 +117,6 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->expectOutputRegex( '/<div id="wcpay-card-element"><\/div>/' );
 	}
 
-	public function test_payment_fields_outputs_error() {
-		$this->mock_api_client->expects( $this->once() )->method( 'get_account_data' )->will(
-			$this->throwException( new API_Exception( 'test', 'test', 123 ) )
-		);
-
-		$this->wcpay_gateway->payment_fields();
-
-		$this->expectOutputRegex( '/An error was encountered when preparing the payment form\. Please try again later\./' );
-	}
-
 	protected function mock_level_3_order( $shipping_postcode ) {
 		// Setup the item.
 		$mock_item = $this->getMockBuilder( WC_Order_Item::class )

--- a/tests/test-class-wc-payments-account.php
+++ b/tests/test-class-wc-payments-account.php
@@ -189,7 +189,10 @@ class WC_Payments_Account_Test extends WP_UnitTestCase {
 			$this->throwException( new API_Exception( 'test', 'server_error', 500 ) )
 		);
 
-		$this->assertFalse( $this->wcpay_account->try_is_stripe_connected() );
+		// Server exception is masked by generic exception.
+		$this->expectException( Exception::class );
+
+		$this->wcpay_account->try_is_stripe_connected();
 	}
 
 	public function test_try_is_stripe_connected_returns_false() {

--- a/tests/test-class-wc-payments-account.php
+++ b/tests/test-class-wc-payments-account.php
@@ -85,6 +85,8 @@ class WC_Payments_Account_Test extends WP_UnitTestCase {
 			$this->throwException( new Exception() )
 		);
 
+		$this->expectException( Exception::class );
+
 		$this->assertFalse( $this->wcpay_account->check_stripe_account_status() );
 	}
 
@@ -187,9 +189,7 @@ class WC_Payments_Account_Test extends WP_UnitTestCase {
 			$this->throwException( new API_Exception( 'test', 'server_error', 500 ) )
 		);
 
-		$this->expectException( API_Exception::class );
-
-		$this->wcpay_account->try_is_stripe_connected();
+		$this->assertFalse( $this->wcpay_account->try_is_stripe_connected() );
 	}
 
 	public function test_try_is_stripe_connected_returns_false() {
@@ -272,9 +272,7 @@ class WC_Payments_Account_Test extends WP_UnitTestCase {
 			$this->throwException( new API_Exception( 'test', 'test', 123 ) )
 		);
 
-		$this->expectException( API_Exception::class );
-
-		$this->wcpay_account->get_publishable_key( true );
+		$this->assertNull( $this->wcpay_account->get_publishable_key( true ) );
 	}
 
 	public function test_get_stripe_account_id() {
@@ -299,9 +297,7 @@ class WC_Payments_Account_Test extends WP_UnitTestCase {
 			$this->throwException( new API_Exception( 'test', 'test', 123 ) )
 		);
 
-		$this->expectException( API_Exception::class );
-
-		$this->wcpay_account->get_stripe_account_id();
+		$this->assertNull( $this->wcpay_account->get_stripe_account_id() );
 	}
 
 	public function test_try_is_stripe_connected_returns_true_when_connected_with_dev_account_in_dev_mode() {


### PR DESCRIPTION
Fixes #551 
Fixes #1162 

#### Changes proposed in this Pull Request

* Update `get_cached_account_data` to prevent throwing exceptions and return explicit `false` when there are issues with fetching data from the server.
* Update `get_cached_account_data` usage to accommodate changes.

#### Testing instructions

Changes need to be tested in two modes.

1. When server works correctly. Need to check that plugin works as expected especially for the following flows:

* Redirects to connect page when there is no account.
* Onboarding / connecting new account.

2. When server connection is broken (use instructions from #1129 to break the server):

On master the site blows up.
On this branch:

* Before clearing cache account status should appear on settings page.
* After clearing cache:
* `Payments` menus should remain in the sidebar.
* Settings page should display error for account status.
* Checkout should not offer WC Pay as payment method.

-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
