### PR TITLE
Remove Docker proxy env variables

### DIFF
--- a/default.env
+++ b/default.env
@@ -12,9 +12,5 @@ MYSQL_DATABASE=wordpress
 MYSQL_USER=wordpress
 MYSQL_PASSWORD=wordpress
 
-# curl proxy
-ALL_PROXY=socks5h://host.docker.internal:8080
-NO_PROXY=localhost,host.docker.internal
-
 # WCPay
 WCPAY_DIR=/var/www/html/wp-content/plugins/woocommerce-payments


### PR DESCRIPTION
See paJDYF-WR-p2#comment-4169

Removing the docker proxy in favor of dev tools controls. It will allow more control over when to proxy and keep the docker env more open to people without the proxy.

#### Changes proposed in this Pull Request

* Remove the environment variables

#### Testing instructions

* Update the dev tools to the latest version, everything should work 