### PR TITLE
Add action hooks to allow custom webhook handling

### DIFF
--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -107,6 +107,8 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 				. var_export( WC_Payments_Utils::redact_array( $body, WC_Payments_API_Client::API_KEYS_TO_REDACT ), true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 			);
 
+			do_action( 'woocommerce_payments_before_webhook_delivery', $event_type, $body );
+
 			switch ( $event_type ) {
 				case 'charge.refund.updated':
 					$this->process_webhook_refund_updated( $body );
@@ -122,6 +124,9 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 					$this->remote_note_service->put_note( $note );
 					break;
 			}
+
+			do_action( 'woocommerce_payments_after_webhook_delivery', $event_type, $body );
+
 		} catch ( Rest_Request_Exception $e ) {
 			Logger::error( $e );
 			return new WP_REST_Response( [ 'result' => self::RESULT_BAD_REQUEST ], 400 );

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -107,7 +107,11 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 				. var_export( WC_Payments_Utils::redact_array( $body, WC_Payments_API_Client::API_KEYS_TO_REDACT ), true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 			);
 
-			do_action( 'woocommerce_payments_before_webhook_delivery', $event_type, $body );
+			try {
+				do_action( 'woocommerce_payments_before_webhook_delivery', $event_type, $body );
+			} catch ( Exception $e ) {
+				Logger::error( $e );
+			}
 
 			switch ( $event_type ) {
 				case 'charge.refund.updated':
@@ -125,8 +129,11 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 					break;
 			}
 
-			do_action( 'woocommerce_payments_after_webhook_delivery', $event_type, $body );
-
+			try {
+				do_action( 'woocommerce_payments_after_webhook_delivery', $event_type, $body );
+			} catch ( Exception $e ) {
+				Logger::error( $e );
+			}
 		} catch ( Rest_Request_Exception $e ) {
 			Logger::error( $e );
 			return new WP_REST_Response( [ 'result' => self::RESULT_BAD_REQUEST ], 400 );


### PR DESCRIPTION
Fixes #1143

There is no way to extend how WC Pay handles webhooks at the moment.
This PR will add action hooks before and after webhook delivery to allow another plugin to customise how that webhook is handled.

#### Changes proposed in this Pull Request

* Add actions for `woocommerce_payments_before_webhook_delivery` and `woocommerce_payments_after_webhook_delivery` in `\WC_REST_Payments_Webhook_Controller::handle_webhook`

#### Testing instructions

* Assume existing webhook tests will cover this change

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
