### PR TITLE
Convert all moment objects to ISO strings before formatting

### DIFF
--- a/client/account-fees/index.js
+++ b/client/account-fees/index.js
@@ -45,7 +45,7 @@ const ExpirationDescription = ( {
 				'woocommerce-payments'
 			),
 			currency.formatCurrency( volumeAllowance / 100 ),
-			dateI18n( 'F j, Y', moment( endTime ) )
+			dateI18n( 'F j, Y', moment( endTime ).toISOString() )
 		);
 	} else if ( volumeAllowance ) {
 		description = sprintf(
@@ -63,7 +63,7 @@ const ExpirationDescription = ( {
 				'Discounted base fee expires on %1$s.',
 				'woocommerce-payments'
 			),
-			dateI18n( 'F j, Y', moment( endTime ) )
+			dateI18n( 'F j, Y', moment( endTime ).toISOString() )
 		);
 	} else {
 		return null;

--- a/client/account-status/index.js
+++ b/client/account-status/index.js
@@ -108,7 +108,10 @@ const renderAccountStatusDescription = ( accountStatus ) => {
 					'To avoid disrupting deposits, <a>update this account</a> by %s with more information about the business.',
 					'woocommerce-payments'
 				),
-				dateI18n( 'ga M j, Y', moment( currentDeadline * 1000 ) )
+				dateI18n(
+					'ga M j, Y',
+					moment( currentDeadline * 1000 ).toISOString()
+				)
 			),
 			// eslint-disable-next-line jsx-a11y/anchor-has-content
 			{ a: <a href={ accountLink } /> }

--- a/client/deposits/details/index.js
+++ b/client/deposits/details/index.js
@@ -41,7 +41,10 @@ export const DepositOverview = ( { depositId } ) => {
 							'Deposit date',
 							'woocommerce-payments'
 						) }: ` }
-						{ dateI18n( 'M j, Y', moment.utc( deposit.date ) ) }
+						{ dateI18n(
+							'M j, Y',
+							moment.utc( deposit.date ).toISOString()
+						) }
 					</Loadable>
 				</div>
 				<div className="wcpay-deposit-status">

--- a/client/deposits/details/index.js
+++ b/client/deposits/details/index.js
@@ -43,7 +43,8 @@ export const DepositOverview = ( { depositId } ) => {
 						) }: ` }
 						{ dateI18n(
 							'M j, Y',
-							moment.utc( deposit.date ).toISOString()
+							moment.utc( deposit.date ).toISOString(),
+							true // TODO Change call to gmdateI18n and remove this deprecated param once WP 5.4 support ends.
 						) }
 					</Loadable>
 				</div>

--- a/client/deposits/list/index.js
+++ b/client/deposits/list/index.js
@@ -67,7 +67,10 @@ export const DepositsList = () => {
 
 		const dateDisplay = (
 			<Link href={ getDetailsURL( deposit.id, 'deposits' ) }>
-				{ dateI18n( 'M j, Y', moment.utc( deposit.date ) ) }
+				{ dateI18n(
+					'M j, Y',
+					moment.utc( deposit.date ).toISOString()
+				) }
 			</Link>
 		);
 

--- a/client/deposits/list/index.js
+++ b/client/deposits/list/index.js
@@ -69,7 +69,8 @@ export const DepositsList = () => {
 			<Link href={ getDetailsURL( deposit.id, 'deposits' ) }>
 				{ dateI18n(
 					'M j, Y',
-					moment.utc( deposit.date ).toISOString()
+					moment.utc( deposit.date ).toISOString(),
+					true // TODO Change call to gmdateI18n and remove this deprecated param once WP 5.4 support ends.
 				) }
 			</Link>
 		);

--- a/client/deposits/overview/index.js
+++ b/client/deposits/overview/index.js
@@ -22,7 +22,8 @@ import Loadable from 'components/loadable';
 import { getDetailsURL } from 'components/details-link';
 
 const currency = new Currency();
-const formatDate = ( format, date ) => dateI18n( format, moment.utc( date ) );
+const formatDate = ( format, date ) =>
+	dateI18n( format, moment.utc( date ).toISOString() );
 const getAmount = ( obj ) =>
 	currency.formatCurrency( ( obj ? obj.amount : 0 ) / 100 );
 const getDepositDate = ( deposit ) =>

--- a/client/deposits/overview/index.js
+++ b/client/deposits/overview/index.js
@@ -23,7 +23,11 @@ import { getDetailsURL } from 'components/details-link';
 
 const currency = new Currency();
 const formatDate = ( format, date ) =>
-	dateI18n( format, moment.utc( date ).toISOString() );
+	dateI18n(
+		format,
+		moment.utc( date ).toISOString(),
+		true // TODO Change call to gmdateI18n and remove this deprecated param once WP 5.4 support ends.
+	);
 const getAmount = ( obj ) =>
 	currency.formatCurrency( ( obj ? obj.amount : 0 ) / 100 );
 const getDepositDate = ( deposit ) =>

--- a/client/disputes/index.js
+++ b/client/disputes/index.js
@@ -133,7 +133,10 @@ export const DisputesList = () => {
 			created: {
 				value: dispute.created * 1000,
 				display: clickable(
-					dateI18n( 'M j, Y', moment( dispute.created * 1000 ) )
+					dateI18n(
+						'M j, Y',
+						moment( dispute.created * 1000 ).toISOString()
+					)
 				),
 			},
 			dueBy: {
@@ -141,7 +144,9 @@ export const DisputesList = () => {
 				display: clickable(
 					dateI18n(
 						'M j, Y / g:iA',
-						moment( dispute.evidence_details.due_by * 1000 )
+						moment(
+							dispute.evidence_details.due_by * 1000
+						).toISOString()
 					)
 				),
 			},

--- a/client/disputes/info/index.js
+++ b/client/disputes/info/index.js
@@ -63,13 +63,18 @@ const Info = ( { dispute, isLoading } ) => {
 				transactionId: 'Transaction link',
 		  }
 		: {
-				created: dateI18n( 'M j, Y', moment( dispute.created * 1000 ) ),
+				created: dateI18n(
+					'M j, Y',
+					moment( dispute.created * 1000 ).toISOString()
+				),
 				amount: `${ currency.formatCurrency(
 					dispute.amount / 100
 				) } ${ dispute.currency.toUpperCase() }`,
 				dueBy: dateI18n(
 					'M j, Y - g:iA',
-					moment( dispute.evidence_details.due_by * 1000 )
+					moment(
+						dispute.evidence_details.due_by * 1000
+					).toISOString()
 				),
 				reason: composeDisputeReason( dispute ),
 				order: dispute.order ? (

--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -35,7 +35,10 @@ const composePaymentSummaryItems = ( { charge } ) =>
 		{
 			title: __( 'Date', 'woocommerce-payments' ),
 			content: charge.created
-				? dateI18n( 'M j, Y, g:ia', moment( charge.created * 1000 ) )
+				? dateI18n(
+						'M j, Y, g:ia',
+						moment( charge.created * 1000 ).toISOString()
+				  )
 				: '–',
 		},
 		{

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -98,7 +98,10 @@ const getDepositTimelineItem = (
 						'woocommerce-payments'
 				  ),
 			formattedAmount,
-			dateI18n( 'M j, Y', moment( event.deposit.arrival_date * 1000 ) )
+			dateI18n(
+				'M j, Y',
+				moment( event.deposit.arrival_date * 1000 ).toISOString()
+			)
 		);
 
 		const depositUrl = addQueryArgs( 'admin.php', {

--- a/client/transactions/list/deposit.js
+++ b/client/transactions/list/deposit.js
@@ -20,7 +20,7 @@ const Deposit = ( { depositId, dateAvailable } ) => {
 	const formattedDateAvailable =
 		dateAvailable != null &&
 		// Do not localize because it is intended as a date only, without time information.
-		dateI18n( 'M j, Y', moment.utc( dateAvailable ) );
+		dateI18n( 'M j, Y', moment.utc( dateAvailable ).toISOString() );
 
 	return depositId ? (
 		<Link href={ depositUrl }>

--- a/client/transactions/list/deposit.js
+++ b/client/transactions/list/deposit.js
@@ -20,7 +20,11 @@ const Deposit = ( { depositId, dateAvailable } ) => {
 	const formattedDateAvailable =
 		dateAvailable != null &&
 		// Do not localize because it is intended as a date only, without time information.
-		dateI18n( 'M j, Y', moment.utc( dateAvailable ).toISOString() );
+		dateI18n(
+			'M j, Y',
+			moment.utc( dateAvailable ).toISOString(),
+			true // TODO Change call to gmdateI18n and remove this deprecated param once WP 5.4 support ends.
+		);
 
 	return depositId ? (
 		<Link href={ depositUrl }>

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -184,7 +184,10 @@ export const TransactionsList = ( props ) => {
 			date: {
 				value: txn.date,
 				display: clickable(
-					dateI18n( 'M j, Y / g:iA', moment.utc( txn.date ).local() )
+					dateI18n(
+						'M j, Y / g:iA',
+						moment.utc( txn.date ).local().toISOString()
+					)
 				),
 			},
 			type: {

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -69,5 +69,12 @@ export const formatDateValue = ( date, upperBound = false ) => {
 	const adjustedDate = upperBound
 		? moment( date ).endOf( 'day' ).utc().toISOString()
 		: moment( date ).startOf( 'day' ).utc().toISOString();
-	return date && dateI18n( 'Y-m-d H:i:s', adjustedDate );
+	return (
+		date &&
+		dateI18n(
+			'Y-m-d H:i:s',
+			adjustedDate,
+			true // TODO Change call to gmdateI18n and remove this deprecated param once WP 5.4 support ends.
+		)
+	);
 };

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -67,7 +67,7 @@ export const formatStringValue = ( value ) =>
  */
 export const formatDateValue = ( date, upperBound = false ) => {
 	const adjustedDate = upperBound
-		? moment( date ).endOf( 'day' ).utc()
-		: moment( date ).startOf( 'day' ).utc();
+		? moment( date ).endOf( 'day' ).utc().toISOString()
+		: moment( date ).startOf( 'day' ).utc().toISOString();
 	return date && dateI18n( 'Y-m-d H:i:s', adjustedDate );
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/1145
Fixes https://github.com/Automattic/woocommerce-payments/issues/609

#### Changes proposed in this Pull Request

Convert date to ISO string – which is accepted by the `dateI18n` util – before formatting.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

With Gutenberg 9.4.0+ installed, verify that all screens load and that dates are formatted properly on them.

Potentially affected views:

- Deposits overview + list
- Deposit details
- Transactions list (incl. date filters)
- Payment details
- Disputes list
- Dispute info (on details and challenge screens)
- Settings, if there's a discount that will expire at a certain time or if account needs to be updated by a certain time

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
