### PR TITLE
Denote "sign in" action in dashboard link setting description

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1006,6 +1006,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 						'a' => '<a href="' . WC_Payments_Account::get_login_url() . '">',
 					]
 				);
+				$description .= wp_kses_post( '<p class="description">' . __( 'You will automatically be <em>signed in to Stripe</em> with your WooCommerce Payments account.', 'woocommerce-payments' ) . '</p>' );
 			} else {
 				// This should never happen, if the account is not connected the merchant should have been redirected to the onboarding screen.
 				// @see WC_Payments_Account::check_stripe_account_status.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a short description to the dashboard link about being "signed in":

<img width="868" src="https://user-images.githubusercontent.com/1867547/101215257-819e1480-364b-11eb-9fee-5b9a17f54b19.png">

…to help contextualize the "Sign out" action in the Express dashboard:

<img width="752" src="https://user-images.githubusercontent.com/1867547/101215361-b5793a00-364b-11eb-84f9-7a966b4ba21e.png">

Open to other ideas for mitigating confusion around what "Sign out" does, and/or revised copy for this description.

(Some discussion in paJDYF-p4-p2#comment-4228.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

View the gateway settings and verify that there is mention of being "signed in" alongside the dashboard link.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->