### PR TITLE
update tables to be fluid width

### DIFF
--- a/client/components/page/style.scss
+++ b/client/components/page/style.scss
@@ -1,6 +1,5 @@
 .woocommerce-payments-page {
 	margin: 0 auto;
-	max-width: 1200px;
 
 	&.is-narrow {
 		max-width: 680px;


### PR DESCRIPTION
Fixes #1153 

Small change to make tables run full width. This aligns them with the analytics / table styles in wc-admin.

Updated table style:

<img width="1613" alt="Screen Shot 2020-12-11 at 9 44 32 AM" src="https://user-images.githubusercontent.com/4500952/101936637-a3d8ea80-3b95-11eb-8844-a799a3f4bf4a.png">
