### PR TITLE
Linking customer name from transaction detail page to filtered list page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.9.0 - 2021-xx-xx =
 * Add - New setting to manage whether to enable saving cards during checkout. (Defaults to being enabled).
+* Update - Link customer name on transaction detail page to filtered transaction list page.
 
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.

--- a/client/components/customer-link/index.js
+++ b/client/components/customer-link/index.js
@@ -1,0 +1,37 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { Link } from '@woocommerce/components';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies.
+ */
+
+const CustomerLink = ( props ) => {
+	const { customer } = props;
+
+	if ( ( customer || {} ).name === undefined ) {
+		return '-';
+	}
+
+	let searchTerm = customer.name;
+	if ( customer.email ) {
+		searchTerm = `${customer.name} (${customer.email})`;
+	}
+	const url = addQueryArgs( 'admin.php', {
+		page: 'wc-admin',
+		path: '/payments/transactions',
+		search: [ searchTerm ]
+	} );
+
+	return (
+		<Link href={ url }>
+			{ customer.name }
+		</Link>
+	);
+};
+
+export default CustomerLink;

--- a/client/components/customer-link/test/__snapshots__/index.js.snap
+++ b/client/components/customer-link/test/__snapshots__/index.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CustomerLink renders a dash if customer name is undefined 1`] = `
+<div>
+  -
+</div>
+`;
+
+exports[`CustomerLink renders a dash if customer name is undefined 2`] = `
+<div>
+  -
+</div>
+`;
+
+exports[`CustomerLink renders a link to a customer with name and email 1`] = `
+<div>
+  <a
+    data-link-type="wc-admin"
+    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&search%5B0%5D=Some%20Name%20%28some%40email.com%29"
+  >
+    Some Name
+  </a>
+</div>
+`;

--- a/client/components/customer-link/test/index.js
+++ b/client/components/customer-link/test/index.js
@@ -1,0 +1,32 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import CustomerLink from '../';
+
+describe( 'CustomerLink', () => {
+	test( 'renders a link to a customer with name and email', () => {
+		const { container: customerLink } = renderCustomer( {
+			name: 'Some Name',
+			email: 'some@email.com',
+		} );
+		expect( customerLink ).toMatchSnapshot();
+	} );
+
+	test( 'renders a dash if customer name is undefined', () => {
+		const { container: customerLink1 } = renderCustomer( null );
+		expect( customerLink1 ).toMatchSnapshot();
+
+		const { container: customerLink2 } = renderCustomer( {} );
+		expect( customerLink2 ).toMatchSnapshot();
+	} );
+
+	function renderCustomer( customer ) {
+		return render( <CustomerLink customer={ customer } /> );
+	}
+} );

--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -5,7 +5,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
-import { Card, Link } from '@woocommerce/components';
+import { Card } from '@woocommerce/components';
 import Currency from '@woocommerce/currency';
 import moment from 'moment';
 import { get } from 'lodash';
@@ -22,6 +22,7 @@ import riskMappings from 'components/risk-level/strings';
 import OrderLink from 'components/order-link';
 import { formatCurrency } from 'utils/currency';
 import { addQueryArgs } from '@wordpress/url';
+import CustomerLink from 'components/customer-link';
 import './style.scss';
 
 const placeholderValues = {
@@ -43,17 +44,7 @@ const composePaymentSummaryItems = ( { charge } ) =>
 		},
 		{
 			title: __( 'Customer', 'woocommerce-payments' ),
-			content: get( charge, 'billing_details.name' ) ? (
-					<Link href={ addQueryArgs( 'admin.php', {
-						page: 'wc-admin',
-						path: '/payments/transactions',
-						search: ['Shendy Kurnia (shendy.kurnia@a8c.com)']
-					} ) }>
-						{ get( charge, 'billing_details.name' ) }
-					</Link>
-				) : (
-					'–'
-				),
+			content: <CustomerLink customer={ charge.billing_details } />,
 		},
 		{
 			title: __( 'Order', 'woocommerce-payments' ),

--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -6,7 +6,6 @@
 import { __ } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 import { Card } from '@woocommerce/components';
-import Currency from '@woocommerce/currency';
 import moment from 'moment';
 import { get } from 'lodash';
 
@@ -21,7 +20,6 @@ import Loadable, { LoadableBlock } from 'components/loadable';
 import riskMappings from 'components/risk-level/strings';
 import OrderLink from 'components/order-link';
 import { formatCurrency } from 'utils/currency';
-import { addQueryArgs } from '@wordpress/url';
 import CustomerLink from 'components/customer-link';
 import './style.scss';
 

--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -5,7 +5,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
-import { Card } from '@woocommerce/components';
+import { Card, Link } from '@woocommerce/components';
+import Currency from '@woocommerce/currency';
 import moment from 'moment';
 import { get } from 'lodash';
 
@@ -20,6 +21,7 @@ import Loadable, { LoadableBlock } from 'components/loadable';
 import riskMappings from 'components/risk-level/strings';
 import OrderLink from 'components/order-link';
 import { formatCurrency } from 'utils/currency';
+import { addQueryArgs } from '@wordpress/url';
 import './style.scss';
 
 const placeholderValues = {
@@ -41,7 +43,17 @@ const composePaymentSummaryItems = ( { charge } ) =>
 		},
 		{
 			title: __( 'Customer', 'woocommerce-payments' ),
-			content: get( charge, 'billing_details.name' ) || '–',
+			content: get( charge, 'billing_details.name' ) ? (
+					<Link href={ addQueryArgs( 'admin.php', {
+						page: 'wc-admin',
+						path: '/payments/transactions',
+						search: ['Shendy Kurnia (shendy.kurnia@a8c.com)']
+					} ) }>
+						{ get( charge, 'billing_details.name' ) }
+					</Link>
+				) : (
+					'–'
+				),
 		},
 		{
 			title: __( 'Order', 'woocommerce-payments' ),

--- a/client/payment-details/summary/test/__snapshots__/index.js.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.js.snap
@@ -100,7 +100,12 @@ exports[`PaymentDetailsSummary correctly renders a charge 1`] = `
               <span
                 class="woocommerce-list__item-content"
               >
-                Customer name
+                <a
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&search%5B0%5D=Customer%20name"
+                >
+                  Customer name
+                </a>
               </span>
             </div>
           </div>
@@ -290,7 +295,12 @@ exports[`PaymentDetailsSummary renders a charge with subscriptions 1`] = `
               <span
                 class="woocommerce-list__item-content"
               >
-                Customer name
+                <a
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&search%5B0%5D=Customer%20name"
+                >
+                  Customer name
+                </a>
               </span>
             </div>
           </div>
@@ -510,7 +520,12 @@ exports[`PaymentDetailsSummary renders fully refunded information for a charge 1
               <span
                 class="woocommerce-list__item-content"
               >
-                Customer name
+                <a
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&search%5B0%5D=Customer%20name"
+                >
+                  Customer name
+                </a>
               </span>
             </div>
           </div>
@@ -782,7 +797,12 @@ exports[`PaymentDetailsSummary renders partially refunded information for a char
               <span
                 class="woocommerce-list__item-content"
               >
-                Customer name
+                <a
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&search%5B0%5D=Customer%20name"
+                >
+                  Customer name
+                </a>
               </span>
             </div>
           </div>
@@ -975,7 +995,12 @@ exports[`PaymentDetailsSummary renders the information of a disputed charge 1`] 
               <span
                 class="woocommerce-list__item-content"
               >
-                Customer name
+                <a
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&search%5B0%5D=Customer%20name"
+                >
+                  Customer name
+                </a>
               </span>
             </div>
           </div>

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 1.9.0 - 2021-xx-xx =
 * Add - New setting to manage whether to enable saving cards during checkout. (Defaults to being enabled).
+* Update - Link customer name on transaction detail page to filtered transaction list page.
 
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.


### PR DESCRIPTION
Fixes #1154

#### Changes proposed in this Pull Request

* Creates a new component: CustomerLink to display link on transaction detail page back to transaction list page filtered by the customer's name.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `npm start`.
* Open the [transaction list page](http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions).
* Open one of the transaction's detail page by clicking on of the transaction row.
* With branch `master`, customer name is displayed as a text.
* With this branch, customer name is displayed as a link.
* Click on the customer name.
* Confirm you are back on the transaction list page but filtered by customer's name.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
