### PR TITLE
Second attempt migrating E2E tests to GH actions

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   WP_VERSION:                                  latest
-  WC_VERSION:                                  4.5.0  # the most used version here
-  CI_USER_TOKEN:                               ${{ secrets.CI_USER_TOKEN }}       # TODO: replace with one from CI-user
+  WC_VERSION:                                  4.5.0 # the most used version here
+  CI_USER_TOKEN:                               ${{ secrets.CI_USER_TOKEN }}
   WCP_DEV_TOOLS_REPO:                          ${{ secrets.WCP_DEV_TOOLS_REPO }}
   WCP_SERVER_REPO:                             ${{ secrets.WCP_SERVER_REPO }}
   E2E_WCPAY_STRIPE_ACCOUNT_ID:                 ${{ secrets.E2E_WCPAY_STRIPE_ACCOUNT_ID }}
@@ -31,8 +31,16 @@ jobs:
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
       - uses: actions/cache@v2
         with:
+          path: vendor/
+          key:  ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
+      - uses: actions/cache@v2
+        with:
           path: ~/.npm/
           key:  ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+      - uses: actions/cache@v2
+        with:
+          path: node_modules/
+          key:  ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
       # setup PHP, but without debug extensions for reasonable performance
       - uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Finishes E2E tests migration to GitHub actions (the original problem was in env-variables/secrets)

#### Testing instructions

* Ensure the checks have E2E job now and it passes

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in the description ☝️)
- [x] Tested on mobile (or does not apply)
