### PR TITLE
Add site username to OAuth data

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Fix - Store Stripe customer for test and live mode.
 * Fix - Display Payments menu in the sidebar if there's a problem connecting to the server.
 * Add - Display fee structure in transaction timelines.
+* Add - Use site username for recording ToS acceptance.
 
 = 1.7.1 - 2020-12-03 =
 * Fix - Pass ISO strings instead of Moment objects to dateI18n.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -449,6 +449,9 @@ class WC_Payments_Account {
 				'business_name' => get_bloginfo( 'name' ),
 				'url'           => get_home_url(),
 			],
+			[
+				'site_username' => $current_user->user_login,
+			],
 			$this->get_actioned_notes()
 		);
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -641,18 +641,20 @@ class WC_Payments_API_Client {
 	 *
 	 * @param string $return_url     - URL to redirect to at the end of the flow.
 	 * @param array  $business_data  - Data to prefill the form.
+	 * @param array  $site_data      - Data to track ToS agreement.
 	 * @param array  $actioned_notes - Actioned WCPay note names to be sent to the on-boarding flow.
 	 *
 	 * @return array An array containing the url and state fields.
 	 *
 	 * @throws API_Exception Exception thrown on request failure.
 	 */
-	public function get_oauth_data( $return_url, $business_data = [], array $actioned_notes = [] ) {
+	public function get_oauth_data( $return_url, $business_data = [], $site_data, array $actioned_notes = [] ) {
 		$request_args = apply_filters(
 			'wc_payments_get_oauth_data_args',
 			[
 				'return_url'          => $return_url,
 				'business_data'       => $business_data,
+				'site_data'           => $site_data,
 				'create_live_account' => ! WC_Payments::get_gateway()->is_in_dev_mode(),
 				'actioned_notes'      => $actioned_notes,
 			]

--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Store Stripe customer for test and live mode.
 * Fix - Display Payments menu in the sidebar if there's a problem connecting to the server.
 * Add - Display fee structure in transaction timelines.
+* Add - Use site username for recording ToS acceptance.
 
 = 1.7.1 - 2020-12-03 =
 * Fix - Pass ISO strings instead of Moment objects to dateI18n.

--- a/tests/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/wc-payment-api/test-class-wc-payments-api-client.php
@@ -451,6 +451,9 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 							'b' => 2,
 							'c' => 3,
 						],
+						'site_data'           => [
+							'site_username' => 'admin',
+						],
 						'create_live_account' => true,
 						'actioned_notes'      => [
 							'd' => 4,
@@ -477,6 +480,9 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 				'a' => 1,
 				'b' => 2,
 				'c' => 3,
+			],
+			[
+				'site_username' => 'admin',
 			],
 			[
 				'd' => 4,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add site username to OAuth data for tracking ToS agreements on account creation

#### Testing instructions

* Test with main branch of the server (without 404-gh-Automattic/woocommerce-payments-server merged).
* Disconnect site from WC Pay and remove/alter current stripe account  record to go through KYC flow.
* Complete KYC flow.
* New stripe account should be created successfully.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->