### PR TITLE
Bump WP and WC tested to versions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic
 Tags: woocommerce, payment, payment request, credit card, automattic
 Requires at least: 5.3
-Tested up to: 5.5
+Tested up to: 5.6
 Requires PHP: 7.0
 Stable tag: 1.7.1
 License: GPLv2 or later

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 4.0
- * WC tested up to: 4.6
+ * WC tested up to: 4.8
  * Requires WP: 5.3
  * Version: 1.7.1
  *


### PR DESCRIPTION
Bump the tested to versions for WordPress and WooCommerce.

WooCommerce won't output messages for plugins that don't declare support anymore, but since we're doing the WP one as well...

In addition to our usual CI tests (and the fact most of us have probably been developing against these version for a while) I've given everything a test with these latest versions. Everything looks good 👍 