### PR TITLE
Link customer name on transaction list page to Woo Customers page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@
 * Fix - Specify error code when refund fails in admin to prevent blank alert.
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
 * Fix - Currency format in non-USD order note when capturing, refunding, and processing subscription renewal.
+* Update - Link customer name from transaction list page to WooCommerce's Customers page filtered by the customer's name.
 
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -9,7 +9,7 @@ import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
 import { formatCurrency } from 'utils/currency';
-import { TableCard, Search } from '@woocommerce/components';
+import { TableCard, Search, Link } from '@woocommerce/components';
 import {
 	onQueryChange,
 	getQuery,
@@ -28,6 +28,7 @@ import { displayType } from 'transactions/strings';
 import { formatStringValue } from 'utils';
 import Deposit from './deposit';
 import autocompleter from 'transactions/autocompleter';
+import { addQueryArgs } from '@wordpress/url';
 import './style.scss';
 
 const getColumns = ( includeDeposit, includeSubscription ) =>
@@ -170,6 +171,18 @@ export const TransactionsList = ( props ) => {
 				i !== all.length - 1 && ', ',
 			] );
 		const riskLevel = <RiskLevel risk={ txn.risk_level } />;
+
+		const customerUrl = addQueryArgs( 'admin.php', {
+			page: 'wc-admin',
+			path: '/customers',
+			search: txn.customer_name,
+		} );
+		const customerName = (
+			<Link href={ customerUrl }>
+				{ txn.customer_name }
+			</Link>
+		);
+
 		const deposit = (
 			<Deposit
 				depositId={ txn.deposit_id }
@@ -209,7 +222,7 @@ export const TransactionsList = ( props ) => {
 			// eslint-disable-next-line camelcase
 			customer_name: {
 				value: txn.customer_name,
-				display: clickable( txn.customer_name ),
+				display: customerName
 			},
 			// eslint-disable-next-line camelcase
 			customer_email: {

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -28,7 +28,6 @@ import { displayType } from 'transactions/strings';
 import { formatStringValue } from 'utils';
 import Deposit from './deposit';
 import autocompleter from 'transactions/autocompleter';
-import { addQueryArgs } from '@wordpress/url';
 import './style.scss';
 
 const getColumns = ( includeDeposit, includeSubscription ) =>
@@ -172,9 +171,7 @@ export const TransactionsList = ( props ) => {
 			] );
 		const riskLevel = <RiskLevel risk={ txn.risk_level } />;
 
-		const customerUrl = addQueryArgs( 'admin.php', {
-			'wcpay-customer-by-order': txn.order.number,
-		} );
+		const customerUrl = txn.order.customer_url;
 		const customerName = <a href={ customerUrl }>{ txn.customer_name }</a>;
 		const customerEmail = (
 			<a href={ customerUrl }>{ txn.customer_email }</a>

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -9,7 +9,7 @@ import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
 import { formatCurrency } from 'utils/currency';
-import { TableCard, Search, Link } from '@woocommerce/components';
+import { TableCard, Search } from '@woocommerce/components';
 import {
 	onQueryChange,
 	getQuery,
@@ -173,14 +173,11 @@ export const TransactionsList = ( props ) => {
 		const riskLevel = <RiskLevel risk={ txn.risk_level } />;
 
 		const customerUrl = addQueryArgs( 'admin.php', {
-			page: 'wc-admin',
-			path: '/customers',
-			search: txn.customer_name,
+			'wcpay-customer-by-order': txn.order.number,
 		} );
-		const customerName = (
-			<Link href={ customerUrl }>
-				{ txn.customer_name }
-			</Link>
+		const customerName = <a href={ customerUrl }>{ txn.customer_name }</a>;
+		const customerEmail = (
+			<a href={ customerUrl }>{ txn.customer_email }</a>
 		);
 
 		const deposit = (
@@ -222,12 +219,12 @@ export const TransactionsList = ( props ) => {
 			// eslint-disable-next-line camelcase
 			customer_name: {
 				value: txn.customer_name,
-				display: customerName
+				display: customerName,
 			},
 			// eslint-disable-next-line camelcase
 			customer_email: {
 				value: txn.customer_email,
-				display: clickable( txn.customer_email ),
+				display: customerEmail,
 			},
 			// eslint-disable-next-line camelcase
 			customer_country: {

--- a/client/transactions/list/test/__snapshots__/index.js.snap
+++ b/client/transactions/list/test/__snapshots__/index.js.snap
@@ -485,10 +485,8 @@ exports[`Transactions list renders correctly when filtered to deposit 1`] = `
                 class="woocommerce-table__item"
               >
                 <a
-                  class="woocommerce-table__clickable-cell"
                   data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
-                  tabindex="-1"
+                  href="admin.php?page=wc-admin&path=%2Fcustomers&search=My%20name"
                 >
                   My name
                 </a>
@@ -1089,10 +1087,8 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                 class="woocommerce-table__item"
               >
                 <a
-                  class="woocommerce-table__clickable-cell"
                   data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
-                  tabindex="-1"
+                  href="admin.php?page=wc-admin&path=%2Fcustomers&search=Another%20customer"
                 >
                   Another customer
                 </a>
@@ -1218,10 +1214,8 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                 class="woocommerce-table__item"
               >
                 <a
-                  class="woocommerce-table__clickable-cell"
                   data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
-                  tabindex="-1"
+                  href="admin.php?page=wc-admin&path=%2Fcustomers&search=My%20name"
                 >
                   My name
                 </a>
@@ -1806,10 +1800,8 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                 class="woocommerce-table__item"
               >
                 <a
-                  class="woocommerce-table__clickable-cell"
                   data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
-                  tabindex="-1"
+                  href="admin.php?page=wc-admin&path=%2Fcustomers&search=Another%20customer"
                 >
                   Another customer
                 </a>
@@ -1932,10 +1924,8 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                 class="woocommerce-table__item"
               >
                 <a
-                  class="woocommerce-table__clickable-cell"
                   data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
-                  tabindex="-1"
+                  href="admin.php?page=wc-admin&path=%2Fcustomers&search=My%20name"
                 >
                   My name
                 </a>

--- a/client/transactions/list/test/__snapshots__/index.js.snap
+++ b/client/transactions/list/test/__snapshots__/index.js.snap
@@ -485,8 +485,7 @@ exports[`Transactions list renders correctly when filtered to deposit 1`] = `
                 class="woocommerce-table__item"
               >
                 <a
-                  data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fcustomers&search=My%20name"
+                  href="admin.php?wcpay-customer-by-order=125"
                 >
                   My name
                 </a>
@@ -1087,8 +1086,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                 class="woocommerce-table__item"
               >
                 <a
-                  data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fcustomers&search=Another%20customer"
+                  href="admin.php?wcpay-customer-by-order=123"
                 >
                   Another customer
                 </a>
@@ -1214,8 +1212,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                 class="woocommerce-table__item"
               >
                 <a
-                  data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fcustomers&search=My%20name"
+                  href="admin.php?wcpay-customer-by-order=125"
                 >
                   My name
                 </a>
@@ -1800,8 +1797,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                 class="woocommerce-table__item"
               >
                 <a
-                  data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fcustomers&search=Another%20customer"
+                  href="admin.php?wcpay-customer-by-order=123"
                 >
                   Another customer
                 </a>
@@ -1924,8 +1920,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                 class="woocommerce-table__item"
               >
                 <a
-                  data-link-type="wc-admin"
-                  href="admin.php?page=wc-admin&path=%2Fcustomers&search=My%20name"
+                  href="admin.php?wcpay-customer-by-order=125"
                 >
                   My name
                 </a>

--- a/client/transactions/list/test/__snapshots__/index.js.snap
+++ b/client/transactions/list/test/__snapshots__/index.js.snap
@@ -484,9 +484,7 @@ exports[`Transactions list renders correctly when filtered to deposit 1`] = `
               <td
                 class="woocommerce-table__item"
               >
-                <a
-                  href="admin.php?wcpay-customer-by-order=125"
-                >
+                <a>
                   My name
                 </a>
               </td>
@@ -1085,9 +1083,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
               <td
                 class="woocommerce-table__item"
               >
-                <a
-                  href="admin.php?wcpay-customer-by-order=123"
-                >
+                <a>
                   Another customer
                 </a>
               </td>
@@ -1211,9 +1207,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
               <td
                 class="woocommerce-table__item"
               >
-                <a
-                  href="admin.php?wcpay-customer-by-order=125"
-                >
+                <a>
                   My name
                 </a>
               </td>
@@ -1796,9 +1790,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
               <td
                 class="woocommerce-table__item"
               >
-                <a
-                  href="admin.php?wcpay-customer-by-order=123"
-                >
+                <a>
                   Another customer
                 </a>
               </td>
@@ -1919,9 +1911,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
               <td
                 class="woocommerce-table__item"
               >
-                <a
-                  href="admin.php?wcpay-customer-by-order=125"
-                >
+                <a>
                   My name
                 </a>
               </td>

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -69,7 +69,7 @@ class WC_Payments_Customer_Service {
 	}
 
 	/**
-	 * Handle customer related routes
+	 * Handle customer related routes.
 	 */
 	public function maybe_handle_routes() {
 		if ( ! is_admin() ) {

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -64,54 +64,6 @@ class WC_Payments_Customer_Service {
 	public function __construct( WC_Payments_API_Client $payments_api_client, WC_Payments_Account $account ) {
 		$this->payments_api_client = $payments_api_client;
 		$this->account             = $account;
-
-		add_action( 'admin_init', [ $this, 'maybe_handle_routes' ] );
-	}
-
-	/**
-	 * Handle customer related routes.
-	 */
-	public function maybe_handle_routes() {
-		if ( ! is_admin() ) {
-			return;
-		}
-
-		if ( isset( $_GET['wcpay-customer-by-order'] ) && check_admin_referer() ) {
-			try {
-				$order_id = sanitize_text_field( wp_unslash( $_GET['wcpay-customer-by-order'] ) );
-				$this->redirect_to_single_customer( $order_id );
-			} catch ( Exception $e ) {
-				$this->add_notice_to_settings_page(
-					__( 'There was a problem redirecting you to the customer page. Please try again.', 'woocommerce-payments' ),
-					'notice-error'
-				);
-			}
-			return;
-		}
-	}
-
-	/**
-	 * Given order id, redirect to single customer page.
-	 *
-	 * @param string $order_id The order ID to look for a customer ID with.
-	 */
-	private function redirect_to_single_customer( string $order_id ) {
-		$order       = wc_get_order( $order_id );
-		$customer_id = $order->get_customer_id();
-
-		$url = admin_url(
-			add_query_arg(
-				[
-					'page'      => 'wc-admin',
-					'path'      => '/customers',
-					'filter'    => 'single_customer',
-					'customers' => $customer_id,
-				],
-				'admin.php'
-			)
-		);
-		wp_safe_redirect( $url );
-		exit;
 	}
 
 	/**

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -64,6 +64,54 @@ class WC_Payments_Customer_Service {
 	public function __construct( WC_Payments_API_Client $payments_api_client, WC_Payments_Account $account ) {
 		$this->payments_api_client = $payments_api_client;
 		$this->account             = $account;
+
+		add_action( 'admin_init', [ $this, 'maybe_handle_routes' ] );
+	}
+
+	/**
+	 * Handle customer related routes
+	 */
+	public function maybe_handle_routes() {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		if ( isset( $_GET['wcpay-customer-by-order'] ) && check_admin_referer() ) {
+			try {
+				$order_id = sanitize_text_field( wp_unslash( $_GET['wcpay-customer-by-order'] ) );
+				$this->redirect_to_single_customer( $order_id );
+			} catch ( Exception $e ) {
+				$this->add_notice_to_settings_page(
+					__( 'There was a problem redirecting you to the customer page. Please try again.', 'woocommerce-payments' ),
+					'notice-error'
+				);
+			}
+			return;
+		}
+	}
+
+	/**
+	 * Given order id, redirect to single customer page.
+	 *
+	 * @param string $order_id The order ID to look for a customer ID with.
+	 */
+	private function redirect_to_single_customer( string $order_id ) {
+		$order       = wc_get_order( $order_id );
+		$customer_id = $order->get_customer_id();
+
+		$url = admin_url(
+			add_query_arg(
+				[
+					'page'      => 'wc-admin',
+					'path'      => '/customers',
+					'filter'    => 'single_customer',
+					'customers' => $customer_id,
+				],
+				'admin.php'
+			)
+		);
+		wp_safe_redirect( $url );
+		exit;
 	}
 
 	/**

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1072,8 +1072,19 @@ class WC_Payments_API_Client {
 		$object['order'] = null;
 		if ( $order ) {
 			$object['order'] = [
-				'number' => $order->get_order_number(),
-				'url'    => $order->get_edit_order_url(),
+				'number'       => $order->get_order_number(),
+				'url'          => $order->get_edit_order_url(),
+				'customer_url' => admin_url(
+					add_query_arg(
+						[
+							'page'      => 'wc-admin',
+							'path'      => '/customers',
+							'filter'    => 'single_customer',
+							'customers' => $order->get_customer_id(),
+						],
+						'admin.php'
+					)
+				),
 			];
 
 			if ( function_exists( 'wcs_get_subscriptions_for_order' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Specify error code when refund fails in admin to prevent blank alert.
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
 * Fix - Currency format in non-USD order note when capturing, refunding, and processing subscription renewal.
+* Update - Link customer name from transaction list page to WooCommerce's Customers page filtered by the customer's name.
 
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.


### PR DESCRIPTION
Fixes #1155

#### Changes proposed in this Pull Request

* Link customer name and email on transaction list page to Woo Customers page showing the customer of that transaction.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `npm start`.
* Open the [transaction list page](http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions).
* With branch `trunk`, customer name and email (you have to toggle to show email column) are displayed as a text.
* With this branch, they are displayed as links.
* Click on the customer name or email.
* Confirm you are directed to WooCommerce's Customers page filtered by the customer of that transaction.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
