### PR TITLE
Install a specific version of xdebug (2.9.8)

### DIFF
--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -1,5 +1,5 @@
 FROM wordpress:php7.3
-RUN pecl install xdebug \
+RUN pecl install xdebug-2.9.8 \
 	&& echo 'xdebug.remote_enable=1' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.remote_port=9000' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.remote_host=host.docker.internal' >> $PHP_INI_DIR/php.ini \


### PR DESCRIPTION
Running `pecl install xdebug` will now install version 3 of xdebug. This breaks our existing configuration and will prevent people debugging. We can fix it to 2.9.8 until we update the config and confirm that the version of PHPUnit we're using will work OK with version 3.

The main concern at the moment is difficulties we've had running unit tests with coverage enabled in other repositories. Not something we're doing here just yet, but I don't want to get into a state where we can't.

We previously unpinned this in https://github.com/Automattic/woocommerce-payments/pull/107, but since we started using a specific version of the WordPress image in https://github.com/Automattic/woocommerce-payments/pull/812 we should be OK to pin it again.

#### Testing instructions

* Run `npm run up` which will rebuild the WordPress container and install this version of xdebug
* Try debugging something