### PR TITLE
Fixed typo puppeter to puppeteer in e2e test's readme.

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -43,11 +43,11 @@ There are two modes for running tests:
 
 1. Headless mode: `npm run test:e2e`. In headless mode test runner executes all or specified specs without launching Chromium interface. This mode is used in CI environment.
 
-2. Dev mode: `npm run test:e2e-dev`. Dev mode is interactive and launches Chromium UI. It's useful for developing, debugging and troubleshooting failing tests. There is a custom config used for `jest-puppeter` to run tests in dev mode.
+2. Dev mode: `npm run test:e2e-dev`. Dev mode is interactive and launches Chromium UI. It's useful for developing, debugging and troubleshooting failing tests. There is a custom config used for `jest-puppeteer` to run tests in dev mode.
 
 ## Writing tests
 
-Package `@automattic/puppeter-utils` overrides `it` method to attach custom reporter for failed tests.
+Package `@automattic/puppeteer-utils` overrides `it` method to attach custom reporter for failed tests.
 It is important to write test cases within `it()` rather than `test()` function to make sure failed tests are reported to Slack channel.
 
 ## Debugging tests


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixed typo `puppeter` to `puppeteer` in `tests/e2e/README.md`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure typos are corrected in `tests/e2e/README.md`.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
