### PR TITLE
Update to add setting to enable/disable saving cards

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Payments Changelog ***
 
-= 1.8.1 - 2021-01-06 =
+= 1.9.0 - 2021-xx-xx  =
 * Add - New setting to manage whether to enable saving cards during checkout. (Defaults to being enabled).
 
 = 1.8.0 - 2020-12-16 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 1.8.1 - 2021-01-06 =
+* Add - New setting to manage whether to enable saving cards during checkout. (Defaults to being enabled).
+
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.
 * Fix - Fix crash when a user has 10 or more saved credit cards.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -99,11 +99,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'refunds',
 		];
 
-		// If the setting to enable saved cards is enabled, then we should support tokenization and adding payment methods.
-		if ( $this->is_saved_cards_enabled() ) {
-			$this->supports = array_merge( $this->supports, [ 'tokenization', 'add_payment_method' ] );
-		}
-
 		// Define setting fields.
 		$this->form_fields = [
 			'enabled'                      => [
@@ -141,7 +136,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'title'       => __( 'Saved Cards', 'woocommerce-payments' ),
 				'label'       => __( 'Enable Payment via Saved Cards', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
-				'description' => __( 'If enabled, users will be able to pay with a saved card during checkout. Card details are saved on Stripe servers, not on your store.', 'woocommerce-payments' ),
+				'description' => __( 'If enabled, users will be able to pay with a saved card during checkout. Card details are saved on our platform, not on your store.', 'woocommerce-payments' ),
 				'default'     => 'yes',
 				'desc_tip'    => true,
 			],
@@ -164,6 +159,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// Load the settings.
 		$this->init_settings();
+
+		// If the setting to enable saved cards is enabled, then we should support tokenization and adding payment methods.
+		if ( $this->is_saved_cards_enabled() ) {
+			$this->supports = array_merge( $this->supports, [ 'tokenization', 'add_payment_method' ] );
+		}
 
 		add_filter( 'woocommerce_settings_api_sanitized_fields_' . $this->id, [ $this, 'sanitize_plugin_settings' ] );
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -391,16 +391,16 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			<?php if ( $this->is_in_test_mode() ) : ?>
 				<p class="testmode-info">
-					<?php
+				<?php
 					echo WC_Payments_Utils::esc_interpolated_html(
-					/* translators: link to Stripe testing page */
+						/* translators: link to Stripe testing page */
 						__( '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC, or any test card numbers listed <a>here</a>.', 'woocommerce-payments' ),
 						[
 							'strong' => '<strong>',
 							'a'      => '<a href="https://docs.woocommerce.com/document/payments/testing/#test-cards" target="_blank">',
 						]
 					);
-					?>
+				?>
 				</p>
 			<?php endif; ?>
 
@@ -416,12 +416,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				<div id="wcpay-errors" role="alert"></div>
 				<input id="wcpay-payment-method" type="hidden" name="wcpay-payment-method" />
 
-				<?php
-				if ( $this->is_saved_cards_enabled() ) {
-					$force_save_payment = ( $display_tokenization && ! apply_filters( 'wc_payments_display_save_payment_method_checkbox', $display_tokenization ) ) || is_add_payment_method_page();
-					$this->save_payment_method_checkbox( $force_save_payment );
-				}
-				?>
+			<?php
+			if ( $this->is_saved_cards_enabled() ) {
+				$force_save_payment = ( $display_tokenization && ! apply_filters( 'wc_payments_display_save_payment_method_checkbox', $display_tokenization ) ) || is_add_payment_method_page();
+				$this->save_payment_method_checkbox( $force_save_payment );
+			}
+			?>
 
 			</fieldset>
 			<?php
@@ -459,7 +459,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			if ( ! empty( $payment_information ) ) {
 				$note = sprintf(
 					WC_Payments_Utils::esc_interpolated_html(
-					/* translators: %1: the failed payment amount, %2: error message  */
+						/* translators: %1: the failed payment amount, %2: error message  */
 						__(
 							'A payment of %1$s <strong>failed</strong> to complete with the following message: <code>%2$s</code>.',
 							'woocommerce-payments'
@@ -617,7 +617,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					if ( $payment_needed ) {
 						$note = sprintf(
 							WC_Payments_Utils::esc_interpolated_html(
-							/* translators: %1: the successfully charged amount, %2: transaction ID of the payment */
+								/* translators: %1: the successfully charged amount, %2: transaction ID of the payment */
 								__( 'A payment of %1$s was <strong>successfully charged</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
 								[
 									'strong' => '<strong>',
@@ -634,7 +634,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				case 'requires_capture':
 					$note = sprintf(
 						WC_Payments_Utils::esc_interpolated_html(
-						/* translators: %1: the authorized amount, %2: transaction ID of the payment */
+							/* translators: %1: the authorized amount, %2: transaction ID of the payment */
 							__( 'A payment of %1$s was <strong>authorized</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
 							[
 								'strong' => '<strong>',
@@ -773,7 +773,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		} catch ( Exception $e ) {
 
 			$note = sprintf(
-			/* translators: %1: the successfully charged amount, %2: error message */
+				/* translators: %1: the successfully charged amount, %2: error message */
 				__( 'A refund of %1$s failed to complete: %2$s', 'woocommerce-payments' ),
 				wc_price( $amount ),
 				$e->getMessage()
@@ -788,13 +788,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		if ( empty( $reason ) ) {
 			$note = sprintf(
-			/* translators: %1: the successfully charged amount */
+				/* translators: %1: the successfully charged amount */
 				__( 'A refund of %1$s was successfully processed using WooCommerce Payments.', 'woocommerce-payments' ),
 				wc_price( $amount )
 			);
 		} else {
 			$note = sprintf(
-			/* translators: %1: the successfully charged amount, %2: reason */
+				/* translators: %1: the successfully charged amount, %2: reason */
 				__( 'A refund of %1$s was successfully processed using WooCommerce Payments. Reason: %2$s', 'woocommerce-payments' ),
 				wc_price( $amount ),
 				$reason
@@ -1120,7 +1120,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if ( 'succeeded' === $status ) {
 			$note = sprintf(
 				WC_Payments_Utils::esc_interpolated_html(
-				/* translators: %1: the successfully charged amount */
+					/* translators: %1: the successfully charged amount */
 					__(
 						'A payment of %1$s was <strong>successfully captured</strong> using WooCommerce Payments.',
 						'woocommerce-payments'
@@ -1134,7 +1134,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		} elseif ( ! empty( $error_message ) ) {
 			$note = sprintf(
 				WC_Payments_Utils::esc_interpolated_html(
-				/* translators: %1: the failed capture amount, %2: error message  */
+					/* translators: %1: the failed capture amount, %2: error message  */
 					__(
 						'A capture of %1$s <strong>failed</strong> to complete with the following message: <code>%2$s</code>.',
 						'woocommerce-payments'
@@ -1151,7 +1151,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		} else {
 			$note = sprintf(
 				WC_Payments_Utils::esc_interpolated_html(
-				/* translators: %1: the failed capture amount */
+					/* translators: %1: the failed capture amount */
 					__( 'A capture of %1$s <strong>failed</strong> to complete.', 'woocommerce-payments' ),
 					[ 'strong' => '<strong>' ]
 				),
@@ -1207,7 +1207,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		} elseif ( ! empty( $error_message ) ) {
 			$note = sprintf(
 				WC_Payments_Utils::esc_interpolated_html(
-				/* translators: %1: error message  */
+					/* translators: %1: error message  */
 					__(
 						'Canceling authorization <strong>failed</strong> to complete with the following message: <code>%1$s</code>.',
 						'woocommerce-payments'
@@ -1317,9 +1317,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			$intent_id          = $order->get_meta( '_intent_id', true );
 			$intent_id_received = isset( $_POST['intent_id'] )
-				? sanitize_text_field( wp_unslash( $_POST['intent_id'] ) )
-				/* translators: This will be used to indicate an unknown value for an ID. */
-				: __( 'unknown', 'woocommerce-payments' );
+			? sanitize_text_field( wp_unslash( $_POST['intent_id'] ) )
+			/* translators: This will be used to indicate an unknown value for an ID. */
+			: __( 'unknown', 'woocommerce-payments' );
 
 			if ( empty( $intent_id ) ) {
 				throw new Intent_Authentication_Exception(
@@ -1353,7 +1353,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					case 'succeeded':
 						$note = sprintf(
 							WC_Payments_Utils::esc_interpolated_html(
-							/* translators: %1: the successfully charged amount, %2: transaction ID of the payment */
+								/* translators: %1: the successfully charged amount, %2: transaction ID of the payment */
 								__( 'A payment of %1$s was <strong>successfully charged</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
 								[
 									'strong' => '<strong>',
@@ -1373,7 +1373,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					case 'requires_capture':
 						$note = sprintf(
 							WC_Payments_Utils::esc_interpolated_html(
-							/* translators: %1: the authorized amount, %2: transaction ID of the payment */
+								/* translators: %1: the authorized amount, %2: transaction ID of the payment */
 								__( 'A payment of %1$s was <strong>authorized</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
 								[
 									'strong' => '<strong>',
@@ -1396,7 +1396,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					case 'requires_payment_method':
 						$note = sprintf(
 							WC_Payments_Utils::esc_interpolated_html(
-							/* translators: %1: the authorized amount, %2: transaction ID of the payment */
+								/* translators: %1: the authorized amount, %2: transaction ID of the payment */
 								__( 'A payment of %1$s <strong>failed</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
 								[
 									'strong' => '<strong>',
@@ -1475,7 +1475,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				case 'empty_intent_id': // The empty_intent_id case needs the same handling.
 					$note = sprintf(
 						WC_Payments_Utils::esc_interpolated_html(
-						/* translators: %1: transaction ID of the payment or a translated string indicating an unknown ID. */
+							/* translators: %1: transaction ID of the payment or a translated string indicating an unknown ID. */
 							__( 'A payment with ID <code>%1$s</code> was used in an attempt to pay for this order. This payment intent ID does not match any payments for this order, so it was ignored and the order was not updated.', 'woocommerce-payments' ),
 							[
 								'code' => '<code>',

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 1.8.1 - 2021-01-06 =
+* Add - New setting to manage whether to enable saving cards during checkout. (Defaults to being enabled).
+
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.
 * Fix - Fix crash when a user has 10 or more saved credit cards.

--- a/readme.txt
+++ b/readme.txt
@@ -101,7 +101,7 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
-= 1.8.1 - 2021-01-06 =
+= 1.9.0 - 2021-xx-xx =
 * Add - New setting to manage whether to enable saving cards during checkout. (Defaults to being enabled).
 
 = 1.8.0 - 2020-12-16 =

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -97,6 +97,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 		// Fall back to an US store.
 		update_option( 'woocommerce_store_postcode', '94110' );
+		$this->wcpay_gateway->update_option( 'saved_cards', 'yes' );
 	}
 
 	public function test_payment_fields_outputs_fields() {
@@ -115,6 +116,21 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->wcpay_gateway->payment_fields();
 
 		$this->expectOutputRegex( '/<div id="wcpay-card-element"><\/div>/' );
+	}
+
+	public function test_save_card_checkbox_not_displayed_when_saved_cards_disabled() {
+		$this->wcpay_gateway->update_option( 'saved_cards', 'no' );
+
+		// Use a callback to get and test the output (also suppresses the output buffering being printed to the CLI).
+		$this->setOutputCallback(
+			function( $output ) {
+				$result = preg_match_all( '/.*<input.*id="wc-woocommerce_payments-new-payment-method".*\/>.*/', $output );
+
+				$this->assertEquals( 0, $result );
+			}
+		);
+
+		$this->wcpay_gateway->payment_fields();
 	}
 
 	protected function mock_level_3_order( $shipping_postcode ) {


### PR DESCRIPTION
This update adds a new setting which will enable/disable the ability to save cards on a site. If it is enabled, it will behave exactly as it currently does. If it is disabled, users will not be prompted to save their card for future purchases at the checkout, and will not be able to view/manage saved cards in their account.

Fixes #1055

#### Changes proposed in this Pull Request

* Adds new setting for enabling/disabling saved cards

#### Testing instructions

* Verify that the 'Saved Cards' setting is present in WP Admin -> Payments -> Settings
* Verify that this setting can be toggled on/off
* When 'Saved Cards' is enabled, a user of the site should be able to manage their payment methods in their account section, and should see a checkbox to 'save card for future purchases' in the checkout.
* When 'Saved Cards' is disabled, the 'manage payment methods' option should not be visible in a user's account section, and no option to 'save card for future payments' should appear in the checkout.
* Unit tests have also been added to verify this.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
