### PR TITLE
Added Jurassic Tube setup script

### DIFF
--- a/bin/jurassic-tube-setup.sh
+++ b/bin/jurassic-tube-setup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Exit if any command fails.
+set -e
+
+echo "Checking if ${PWD}/docker/bin/jt directory exists..."
+
+if [ -d "${PWD}/docker/bin/jt" ]; then
+    echo "${PWD}/docker/bin/jt already exists."
+else
+    echo "Creating ${PWD}/docker/bin/jt directory..."
+    mkdir "${PWD}/docker/bin/jt"
+fi
+
+echo "Downloading the latest version of the installer script..."
+echo 
+
+# Download the installer (if it's not already present):
+if [ ! -f "${PWD}/docker/bin/jt/installer.sh" ]; then
+    # Download the installer script:
+    curl "https://jurassic.tube/get-installer.php?env=wcpay" -o ${PWD}/docker/bin/jt/installer.sh && chmod +x ${PWD}/docker/bin/jt/installer.sh
+fi
+
+echo "Running the installation script..."
+echo 
+
+# Run the installer script
+source $PWD/docker/bin/jt/installer.sh
+
+echo
+read -p "Go to https://jurassic.tube/ in a browser, paste your public key which was printed above into the box, and click 'Add Public Key'. Press enter to continue"
+echo 
+
+read -p "Go to https://jurassic.tube/ in a browser, add a subdomain using the desired name for your subdomain, and click 'Add Subdomain'. The subdomain name is what you will use to access WC Payments in a browser. When this is done, type the subdomain name here and press enter. Please just type in the subdomain, not the full URL: " subdomain
+echo 
+
+# npm run wp option update home https://${subdomain}.jurassic.tube/
+# npm run wp option update siteurl https://${subdomain}.jurassic.tube/
+
+read -p "Please enter your Automattic/WordPress.com username: " username
+echo 
+
+${PWD}/docker/bin/jt/config.sh username ${username}
+${PWD}/docker/bin/jt/config.sh subdomain ${subdomain}
+
+echo "Setup complete!" 
+echo "Use the command: docker/bin/jt/tunnel.sh from the root directory of your WC Payments project to start running Jurassic Tube."
+echo 
+
+

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "format": "npm run format:js && npm run format:css",
     "format:js": "npm run format:provided '**/*.js'",
     "format:css": "npm run format:provided '**/*.scss' '**/*.css'",
-    "format:provided": "prettier --write"
+    "format:provided": "prettier --write",
+    "setup:jurassic-tube": "./bin/jurassic-tube-setup.sh"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Fixes #1181 

#### Changes proposed in this Pull Request

* Adds shell script to handle Jurassic Tube setup
* Documentation of script and add method of running through `npm run` to `package.json`.

#### Testing instructions

* `git checkout -b update/1181-jt-setup`
* Run the command `npm run setup:jurassic-tube`
* Follow the steps in the script. Verify that it correctly sets up Jurassic Tube.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

Note: currently in draft form awaiting discussion and documentation.