### PR TITLE
Fix changing payment to saved payment for subscriptions order

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 2.0.0 - 2021-xx-xx =
+* Fix - Updating payment method using saved payment for WC Subscriptions orders.
+
 = 1.9.1 - 2021-02-03 =
 * Fix - Incompatibility with WC Subscriptions.
 * Fix - Missing order causing broken transactions list.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -45,7 +45,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 *
 	 * @var WC_Payments_API_Client
 	 */
-	private $payments_api_client;
+	protected $payments_api_client;
 
 	/**
 	 * WC_Payments_Account instance to get information about the account
@@ -59,14 +59,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 *
 	 * @var WC_Payments_Customer_Service
 	 */
-	private $customer_service;
+	protected $customer_service;
 
 	/**
 	 * WC_Payments_Token instance for working with customer tokens
 	 *
 	 * @var WC_Payments_Token_Service
 	 */
-	private $token_service;
+	protected $token_service;
 
 	/**
 	 * WC_Payments_Action_Scheduler_Service instance for scheduling ActionScheduler jobs.
@@ -568,6 +568,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// In case amount is 0 and we're not saving the payment method, we won't be using intents and can confirm the order payment.
 		if ( ! $payment_needed && ! $save_payment_method ) {
 			$order->payment_complete();
+			return [
+				'result'   => 'success',
+				'redirect' => $this->get_return_url( $order ),
+			];
 		}
 
 		if ( $payment_needed ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -514,33 +514,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Upserts customer from user, name, and email.
-	 *
-	 * @param WP_User $user The user associated to customer.
-	 * @param string  $name The customer's name.
-	 * @param string  $email The customer's email.
-	 *
-	 * @return string Customer id.
-	 *
-	 * @throws API_Exception Error creating / updating customer.
-	 */
-	protected function upsert_customer( WP_User $user, string $name, string $email ) {
-		// Determine the customer making the payment, create one if we don't have one already.
-		$customer_id = $this->customer_service->get_customer_id_by_user_id( $user->ID );
-
-		if ( null === $customer_id ) {
-			// Create a new customer.
-			$customer_id = $this->customer_service->create_customer_for_user( $user, $name, $email );
-		} else {
-			// Update the existing customer with the current details. In the event the old customer can't be
-			// found a new one is created, so we update the customer ID here as well.
-			$customer_id = $this->customer_service->update_customer_for_user( $customer_id, $user, $name, $email );
-		}
-
-		return $customer_id;
-	}
-
-	/**
 	 * Process the payment for a given order.
 	 *
 	 * @param WC_Cart                   $cart Cart.
@@ -567,7 +540,17 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'payment_type'   => $payment_information->get_payment_type(),
 		];
 
-		$customer_id = $this->upsert_customer( $user, $name, $email );
+		// Determine the customer making the payment, create one if we don't have one already.
+		$customer_id = $this->customer_service->get_customer_id_by_user_id( $user->ID );
+
+		if ( null === $customer_id ) {
+			// Create a new customer.
+			$customer_id = $this->customer_service->create_customer_for_user( $user, $name, $email );
+		} else {
+			// Update the existing customer with the current details. In the event the old customer can't be
+			// found a new one is created, so we update the customer ID here as well.
+			$customer_id = $this->customer_service->update_customer_for_user( $customer_id, $user, $name, $email );
+		}
 
 		// Update saved payment method information with checkout values, as some saved methods might not have billing details.
 		if ( $payment_information->is_using_saved_payment_method() ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -520,13 +520,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @param string  $name The customer's name.
 	 * @param string  $email The customer's email.
 	 *
-	 * @return string|null Customer id.
+	 * @return string Customer id.
+	 *
+	 * @throws API_Exception Error creating / updating customer.
 	 */
-	protected function upsert_customer( $user, $name, $email ) {
-		if ( ! $user ) {
-			return;
-		}
-
+	protected function upsert_customer( WP_User $user, string $name, string $email ) {
 		// Determine the customer making the payment, create one if we don't have one already.
 		$customer_id = $this->customer_service->get_customer_id_by_user_id( $user->ID );
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -568,10 +568,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// In case amount is 0 and we're not saving the payment method, we won't be using intents and can confirm the order payment.
 		if ( ! $payment_needed && ! $save_payment_method ) {
 			$order->payment_complete();
-			return [
-				'result'   => 'success',
-				'redirect' => $this->get_return_url( $order ),
-			];
 		}
 
 		if ( $payment_needed ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -513,7 +513,20 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		return $payment_information;
 	}
 
-	protected function upsert_customer($user, $name, $email) {
+	/**
+	 * Upserts customer from user, name, and email.
+	 *
+	 * @param WP_User $user The user associated to customer.
+	 * @param string  $name The customer's name.
+	 * @param string  $email The customer's email.
+	 *
+	 * @return string|null Customer id.
+	 */
+	protected function upsert_customer( $user, $name, $email ) {
+		if ( ! $user ) {
+			return;
+		}
+
 		// Determine the customer making the payment, create one if we don't have one already.
 		$customer_id = $this->customer_service->get_customer_id_by_user_id( $user->ID );
 
@@ -525,6 +538,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			// found a new one is created, so we update the customer ID here as well.
 			$customer_id = $this->customer_service->update_customer_for_user( $customer_id, $user, $name, $email );
 		}
+
+		return $customer_id;
 	}
 
 	/**
@@ -554,7 +569,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'payment_type'   => $payment_information->get_payment_type(),
 		];
 
-		$this->upsert_customer($user,$name,$email);
+		$customer_id = $this->upsert_customer( $user, $name, $email );
 
 		// Update saved payment method information with checkout values, as some saved methods might not have billing details.
 		if ( $payment_information->is_using_saved_payment_method() ) {

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -96,8 +96,15 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 		$email               = sanitize_email( $order->get_billing_email() );
 
 		try {
-			$customer_id = $this->upsert_customer( $user, $name, $email );
-			$intent      = $this->payments_api_client->create_and_confirm_setup_intent(
+			// Determine the customer making the payment, create one if we don't have one already.
+			$customer_id = $this->customer_service->get_customer_id_by_user_id( $user->ID );
+
+			if ( null === $customer_id ) {
+				// Create a new customer.
+				$customer_id = $this->customer_service->create_customer_for_user( $user, $name, $email );
+			}
+
+			$intent = $this->payments_api_client->create_and_confirm_setup_intent(
 				$payment_information->get_payment_method(),
 				$customer_id
 			);

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -98,7 +98,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 
 			$note = sprintf(
 				WC_Payments_Utils::esc_interpolated_html(
-				/* translators: %1: the last 4 digit of the credit card */
+					/* translators: %1: the last 4 digit of the credit card */
 					__( 'Payment method is changed to: <strong>Credit Card ending in %1$s</strong>.', 'woocommerce-payments' ),
 					[
 						'strong' => '<strong>',
@@ -124,8 +124,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 			wc_add_notice( $e->getMessage(), 'error' );
 
 			if ( ! empty( $payment_information ) ) {
-				$payment_method_id = WCPay\Payment_Information::get_payment_method_from_request( $request );
-				$payment_method    = $this->payments_api_client->get_payment_method( $payment_method_id );
+				$payment_method    = $this->payments_api_client->get_payment_method( $payment_information->get_payment_method() );
 				$last4             = $payment_method['card']['last4'];
 
 				$note = sprintf(
@@ -154,9 +153,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 		$intent_id = $intent['id'];
 		$status    = $intent['status'];
 
-		if ( ! in_array( $status, ['succeeded', 'processing', 'requires_action'], true ) ) {
-			$payment_method_id = WCPay\Payment_Information::get_payment_method_from_request( $request );
-			$payment_method    = $this->payments_api_client->get_payment_method( $payment_method_id );
+		if ( ! in_array( $status, [ 'succeeded', 'processing', 'requires_action' ], true ) ) {
+			$payment_method    = $this->payments_api_client->get_payment_method( $payment_information->get_payment_method() );
 			$last4             = $payment_method['card']['last4'];
 
 			$note = sprintf(

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -113,7 +113,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 							'woocommerce-payments'
 						),
 						[
-							'code'   => '<code>',
+							'code' => '<code>',
 						]
 					),
 					esc_html( rtrim( $e->getMessage(), '.' ) )

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 2.0.0 - 2021-xx-xx =
+* Fix - Updating payment method using saved payment for WC Subscriptions orders.
+
 = 1.9.1 - 2021-02-03 =
 * Fix - Incompatibility with WC Subscriptions.
 * Fix - Missing order causing broken transactions list.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -354,6 +354,41 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 		$this->assertEquals( 'success', $result['result'] );
 	}
 
+	public function test_card_is_saved_when_updating_subscription_using_saved_payment_method() {
+		$order = WC_Helper_Order::create_order( self::USER_ID, 0 );
+
+		$_POST = [ self::TOKEN_REQUEST_KEY => $this->token->get_id() ];
+		$_GET = [ 'change_payment_method' => 10 ];
+
+		$this->mock_wcs_order_contains_subscription( false );
+
+		WC_Subscriptions::set_wcs_is_subscription(
+			function ( $order ) {
+				return true;
+			}
+		);
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'create_and_confirm_setup_intent' )
+			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID )
+			->willReturn( $this->setup_intent );
+
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'add_token_to_order' )
+			->with(
+				$this->callback( $this->match_order_id( $order->get_id() ) ),
+				$this->token
+			);
+
+		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
+		$result_order = wc_get_order( $order->get_id() );
+
+		$this->assertEquals( 'processing', $result_order->get_status() );
+		$this->assertEquals( 'success', $result['result'] );
+	}
+
 	private function mock_wcs_order_contains_subscription( $value ) {
 		WC_Subscriptions::set_wcs_order_contains_subscription(
 			function ( $order ) use ( $value ) {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -358,7 +358,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 		$order = WC_Helper_Order::create_order( self::USER_ID, 0 );
 
 		$_POST = [ self::TOKEN_REQUEST_KEY => $this->token->get_id() ];
-		$_GET = [ 'change_payment_method' => 10 ];
+		$_GET  = [ 'change_payment_method' => 10 ];
 
 		$this->mock_wcs_order_contains_subscription( false );
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -368,11 +368,13 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 			}
 		);
 
+		$this->mock_customer_service
+			->expects( $this->never() )
+			->method( 'get_customer_id_by_user_id' );
+
 		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'create_and_confirm_setup_intent' )
-			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID )
-			->willReturn( $this->setup_intent );
+			->expects( $this->never() )
+			->method( 'create_and_confirm_setup_intent' );
 
 		$this->mock_wcpay_gateway
 			->expects( $this->once() )


### PR DESCRIPTION
Fixes #1185

#### Changes proposed in this Pull Request

* Override `WC_Payment_Gateway_WCPay::process_payment()` in `WC_Payment_Gateway_WCPay_Subscriptions_Compat::process_payment()` to handle specifically payment method change for subscription order, because:
  * [On caught exception, it updates the order's status to failed](https://github.com/Automattic/woocommerce-payments/blob/trunk/includes/class-wc-payment-gateway-wcpay.php#L470).
  * Taking out [this return statement](https://github.com/Automattic/woocommerce-payments/blob/62516cdcee37993cae25999c6256d5c574e53124/includes/class-wc-payment-gateway-wcpay.php#L571-L574) per [suggested here](https://github.com/Automattic/woocommerce-payments/pull/1148#issuecomment-750410406) is not enough because [stock will be reduced and cart will be emptied on success](https://github.com/Automattic/woocommerce-payments/blob/62516cdcee37993cae25999c6256d5c574e53124/includes/class-wc-payment-gateway-wcpay.php#L711-L714).
  * `WC_Payment_Gateway_WCPay` shouldn't know the nuts and bolts of subscription, so doing something like "if changing payment method for subscription, do not reduce stock", for example, IMO breaks the abstraction.

#### Testing instructions

Shamelessly copied from [1185](https://github.com/Automattic/woocommerce-payments/issues/1185).
1. Purchase subscription product.
2. Go to My account > Add one more payment method.
3. Go to My account > Subscription > Purchased subscription.
4. Try to change payment method to saved on step 2.
5. Success message is displayed. With `trunk`, payment method is not changed. With this branch, payment method should be changed.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
