### PR TITLE
Format dispute amount with proper currency

### DIFF
--- a/client/disputes/details/test/__snapshots__/index.js.snap
+++ b/client/disputes/details/test/__snapshots__/index.js.snap
@@ -52,7 +52,7 @@ exports[`Dispute details screen renders correctly for bank_cannot_process disput
             <span
               class="wcpay-dispute-info-value"
             >
-              $10.00 USD
+              $10.00
             </span>
           </div>
           <div
@@ -233,7 +233,7 @@ exports[`Dispute details screen renders correctly for check_returned dispute 1`]
             <span
               class="wcpay-dispute-info-value"
             >
-              $10.00 USD
+              $10.00
             </span>
           </div>
           <div
@@ -414,7 +414,7 @@ exports[`Dispute details screen renders correctly for credit_not_processed dispu
             <span
               class="wcpay-dispute-info-value"
             >
-              $10.00 USD
+              $10.00
             </span>
           </div>
           <div
@@ -621,7 +621,7 @@ exports[`Dispute details screen renders correctly for customer_initiated dispute
             <span
               class="wcpay-dispute-info-value"
             >
-              $10.00 USD
+              $10.00
             </span>
           </div>
           <div
@@ -802,7 +802,7 @@ exports[`Dispute details screen renders correctly for debit_not_authorized dispu
             <span
               class="wcpay-dispute-info-value"
             >
-              $10.00 USD
+              $10.00
             </span>
           </div>
           <div
@@ -983,7 +983,7 @@ exports[`Dispute details screen renders correctly for duplicate dispute 1`] = `
             <span
               class="wcpay-dispute-info-value"
             >
-              $10.00 USD
+              $10.00
             </span>
           </div>
           <div
@@ -1196,7 +1196,7 @@ exports[`Dispute details screen renders correctly for fraudulent dispute 1`] = `
             <span
               class="wcpay-dispute-info-value"
             >
-              $10.00 USD
+              $10.00
             </span>
           </div>
           <div
@@ -1406,7 +1406,7 @@ exports[`Dispute details screen renders correctly for general dispute 1`] = `
             <span
               class="wcpay-dispute-info-value"
             >
-              $10.00 USD
+              $10.00
             </span>
           </div>
           <div
@@ -1593,7 +1593,7 @@ exports[`Dispute details screen renders correctly for incorrect_account_details 
             <span
               class="wcpay-dispute-info-value"
             >
-              $10.00 USD
+              $10.00
             </span>
           </div>
           <div
@@ -1774,7 +1774,7 @@ exports[`Dispute details screen renders correctly for insufficient_funds dispute
             <span
               class="wcpay-dispute-info-value"
             >
-              $10.00 USD
+              $10.00
             </span>
           </div>
           <div
@@ -1955,7 +1955,7 @@ exports[`Dispute details screen renders correctly for product_not_received dispu
             <span
               class="wcpay-dispute-info-value"
             >
-              $10.00 USD
+              $10.00
             </span>
           </div>
           <div
@@ -2162,7 +2162,7 @@ exports[`Dispute details screen renders correctly for product_unacceptable dispu
             <span
               class="wcpay-dispute-info-value"
             >
-              $10.00 USD
+              $10.00
             </span>
           </div>
           <div
@@ -2378,7 +2378,7 @@ exports[`Dispute details screen renders correctly for subscription_canceled disp
             <span
               class="wcpay-dispute-info-value"
             >
-              $10.00 USD
+              $10.00
             </span>
           </div>
           <div
@@ -2588,7 +2588,7 @@ exports[`Dispute details screen renders correctly for unrecognized dispute 1`] =
             <span
               class="wcpay-dispute-info-value"
             >
-              $10.00 USD
+              $10.00
             </span>
           </div>
           <div

--- a/client/disputes/details/test/index.js
+++ b/client/disputes/details/test/index.js
@@ -15,6 +15,12 @@ jest.mock( 'data', () => ( {
 } ) );
 
 describe( 'Dispute details screen', () => {
+	beforeEach( () => {
+		global.wcpaySettings = {
+			zeroDecimalCurrencies: [],
+		};
+	} );
+
 	const reasons = [
 		'bank_cannot_process',
 		'check_returned',

--- a/client/disputes/evidence/test/__snapshots__/index.js.snap
+++ b/client/disputes/evidence/test/__snapshots__/index.js.snap
@@ -323,7 +323,7 @@ exports[`Dispute evidence page renders correctly 1`] = `
             <span
               class="wcpay-dispute-info-value"
             >
-              $10.00 USD
+              $10.00
             </span>
           </div>
           <div

--- a/client/disputes/evidence/test/index.js
+++ b/client/disputes/evidence/test/index.js
@@ -145,6 +145,12 @@ describe( 'Dispute evidence form', () => {
 } );
 
 describe( 'Dispute evidence page', () => {
+	beforeEach( () => {
+		global.wcpaySettings = {
+			zeroDecimalCurrencies: [],
+		};
+	} );
+
 	test( 'renders correctly', () => {
 		const { container: form } = render(
 			<DisputeEvidencePage

--- a/client/disputes/index.js
+++ b/client/disputes/index.js
@@ -6,7 +6,6 @@
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
-import Currency from '@woocommerce/currency';
 import { TableCard } from '@woocommerce/components';
 import { onQueryChange, getQuery } from '@woocommerce/navigation';
 
@@ -21,8 +20,7 @@ import DetailsLink, { getDetailsURL } from 'components/details-link';
 import Page from 'components/page';
 import { reasons } from './strings';
 import { formatStringValue } from 'utils';
-
-const currency = new Currency();
+import { formatCurrency } from 'utils/currency';
 
 const headers = [
 	{ key: 'details', label: '', required: true, cellClassName: 'info-button' },
@@ -109,7 +107,10 @@ export const DisputesList = () => {
 			amount: {
 				value: dispute.amount / 100,
 				display: clickable(
-					currency.formatCurrency( dispute.amount / 100 )
+					formatCurrency(
+						dispute.amount || 0,
+						dispute.currency || 'USD'
+					)
 				),
 			},
 			status: {

--- a/client/disputes/info/index.js
+++ b/client/disputes/info/index.js
@@ -6,7 +6,6 @@
 import { __ } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 import moment from 'moment';
-import Currency from '@woocommerce/currency';
 import { Link } from '@woocommerce/components';
 
 /**
@@ -16,10 +15,9 @@ import OrderLink from 'components/order-link';
 import { getDetailsURL } from 'components/details-link';
 import { reasons } from '../strings';
 import { formatStringValue } from 'utils';
+import { formatCurrency } from 'utils/currency';
 import './style.scss';
 import Loadable from 'components/loadable';
-
-const currency = new Currency();
 
 const fields = [
 	{ key: 'created', label: __( 'Dispute date', 'woocommerce-payments' ) },
@@ -67,8 +65,9 @@ const Info = ( { dispute, isLoading } ) => {
 					'M j, Y',
 					moment( dispute.created * 1000 ).toISOString()
 				),
-				amount: `${ currency.formatCurrency(
-					dispute.amount / 100
+				amount: `${ formatCurrency(
+					dispute.amount || 0,
+					dispute.currency || 'USD'
 				) } ${ dispute.currency.toUpperCase() }`,
 				dueBy: dateI18n(
 					'M j, Y - g:iA',

--- a/client/disputes/info/index.js
+++ b/client/disputes/info/index.js
@@ -65,10 +65,10 @@ const Info = ( { dispute, isLoading } ) => {
 					'M j, Y',
 					moment( dispute.created * 1000 ).toISOString()
 				),
-				amount: `${ formatCurrency(
+				amount: formatCurrency(
 					dispute.amount || 0,
 					dispute.currency || 'USD'
-				) } ${ dispute.currency.toUpperCase() }`,
+				),
 				dueBy: dateI18n(
 					'M j, Y - g:iA',
 					moment(

--- a/client/disputes/info/test/__snapshots__/index.js.snap
+++ b/client/disputes/info/test/__snapshots__/index.js.snap
@@ -30,7 +30,7 @@ exports[`Dispute info renders correctly 1`] = `
       <span
         class="wcpay-dispute-info-value"
       >
-        $10.00 USD
+        $10.00
       </span>
     </div>
     <div

--- a/client/disputes/info/test/index.js
+++ b/client/disputes/info/test/index.js
@@ -11,6 +11,12 @@ import { render } from '@testing-library/react';
 import Info from '../';
 
 describe( 'Dispute info', () => {
+	beforeEach( () => {
+		global.wcpaySettings = {
+			zeroDecimalCurrencies: [],
+		};
+	} );
+
 	test( 'renders correctly', () => {
 		/* eslint-disable camelcase */
 		const dispute = {

--- a/client/disputes/test/index.js
+++ b/client/disputes/test/index.js
@@ -15,6 +15,12 @@ jest.mock( 'data', () => ( {
 } ) );
 
 describe( 'Disputes list', () => {
+	beforeEach( () => {
+		global.wcpaySettings = {
+			zeroDecimalCurrencies: [],
+		};
+	} );
+
 	test( 'renders correctly', () => {
 		useDisputes.mockReturnValue( {
 			isLoading: false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As soon as we support charges in many currencies, we can expect disputes in those currencies as well. This change ensures the dispute amount is formatted with the correct currency.

&nbsp; | `trunk` | this branch
-- | -- | --
Disputes list | <img width="272" src="https://user-images.githubusercontent.com/1867547/104564612-229fc800-5619-11eb-8cb1-a74402ed4eb5.png"> | <img width="290" src="https://user-images.githubusercontent.com/1867547/104564622-25022200-5619-11eb-93f5-096e09a2f97a.png">
Dispute info | <img width="362" src="https://user-images.githubusercontent.com/1867547/104564643-2c293000-5619-11eb-8cf3-d8403cc28f6a.png"> | <img width="344" src="https://user-images.githubusercontent.com/1867547/104564648-2cc1c680-5619-11eb-8b3f-77967fd8ef05.png">

Note: the currency code suffix is removed from the dispute info amount, since it could be redundant (with the prefix in the fallback format introduced in https://github.com/Automattic/woocommerce-payments/pull/1007) – cc @LevinMedia

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check out with a currency different from the store currency (following instructions in https://github.com/Automattic/woocommerce-payments/pull/1007) using a dispute test card (e.g. `4000000000000259`), and verify that the currency shows up properly on the dispute that is created (in both the list and the details screen).

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
