### PR TITLE
Server API: override additional timeout settings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Update - Link customer name on transaction detail page to filtered transaction list page.
 * Update - Test mode notice width is now consistent across all pages.
 * Add - New notification to urge setting SSL for checkout pages if store doesn't use HTTPS
+* Fix - Fixed connection timeout configuration.
 
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -884,10 +884,11 @@ class WC_Payments_API_Client {
 
 		$response = $this->http_client->remote_request(
 			[
-				'url'     => $url,
-				'method'  => $method,
-				'headers' => apply_filters( 'wcpay_api_request_headers', $headers ),
-				'timeout' => self::API_TIMEOUT_SECONDS,
+				'url'             => $url,
+				'method'          => $method,
+				'headers'         => apply_filters( 'wcpay_api_request_headers', $headers ),
+				'timeout'         => self::API_TIMEOUT_SECONDS,
+				'connect_timeout' => self::API_TIMEOUT_SECONDS,
 			],
 			$body,
 			$is_site_specific

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Fixed issue where an empty alert would appear when trying to refund an authorization charge.
 * Update - Link customer name on transaction detail page to filtered transaction list page.
 * Add - New notification to urge setting SSL for checkout pages if store doesn't use HTTPS
+* Fix - Fixed connection timeout configuration.
 
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -327,13 +327,14 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 			->method( 'remote_request' )
 			->with(
 				[
-					'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/%s/wcpay/customers/cus_test12345',
-					'method'  => 'POST',
-					'headers' => [
+					'url'             => 'https://public-api.wordpress.com/wpcom/v2/sites/%s/wcpay/customers/cus_test12345',
+					'method'          => 'POST',
+					'headers'         => [
 						'Content-Type' => 'application/json; charset=utf-8',
 						'User-Agent'   => 'Unit Test Agent/0.1.0',
 					],
-					'timeout' => 70,
+					'timeout'         => 70,
+					'connect_timeout' => 70,
 				],
 				wp_json_encode(
 					[
@@ -434,13 +435,14 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 			->method( 'remote_request' )
 			->with(
 				[
-					'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/%s/wcpay/oauth/init',
-					'method'  => 'POST',
-					'headers' => [
+					'url'             => 'https://public-api.wordpress.com/wpcom/v2/sites/%s/wcpay/oauth/init',
+					'method'          => 'POST',
+					'headers'         => [
 						'Content-Type' => 'application/json; charset=utf-8',
 						'User-Agent'   => 'Unit Test Agent/0.1.0',
 					],
-					'timeout' => 70,
+					'timeout'         => 70,
+					'connect_timeout' => 70,
 				],
 				wp_json_encode(
 					[


### PR DESCRIPTION
Complimentary changes for 511-gh-Automattic/woocommerce-payments-server

Fixes timeouts settings setup.

#### Changes proposed in this Pull Request

* Set additional timeout options (connection timeouts)

#### Testing instructions

* Done on the server-side, here we apply the same approach.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->