### PR TITLE
Pass order currency to wc_price() when not in customer's session.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 2.0.0 - 2021-xx-xx =
+* Fix - Currency format in non-USD order note when capturing, refunding, and processing subscription renewal.
+
 = 1.9.0 - 2021-xx-xx =
 * Add - New setting to manage whether to enable saving cards during checkout. (Defaults to being enabled).
 * Fix - Fixed issue where an empty alert would appear when trying to refund an authorization charge.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,5 @@
 *** WooCommerce Payments Changelog ***
 
-= 2.0.0 - 2021-xx-xx =
-* Fix - Currency format in non-USD order note when capturing, refunding, and processing subscription renewal.
-
 = 1.9.0 - 2021-xx-xx =
 * Add - New setting to manage whether to enable saving cards during checkout. (Defaults to being enabled).
 * Fix - Fixed issue where an empty alert would appear when trying to refund an authorization charge.
@@ -13,6 +10,7 @@
 * Fix - Fixed connection timeout configuration.
 * Fix - Specify error code when refund fails in admin to prevent blank alert.
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
+* Fix - Currency format in non-USD order note when capturing, refunding, and processing subscription renewal.
 
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -167,6 +167,8 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 		$charge_id = $this->read_rest_property( $event_object, 'charge' );
 		$refund_id = $this->read_rest_property( $event_object, 'id' );
 		$amount    = $this->read_rest_property( $event_object, 'amount' );
+		$currency  = $this->read_rest_property( $event_object, 'currency' );
+		$currency  = strtoupper( $currency );
 
 		// Look up the order related to this charge.
 		$order = $this->wcpay_db->order_from_charge_id( $charge_id );
@@ -190,7 +192,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 					'code'   => '<code>',
 				]
 			),
-			wc_price( $amount / 100, [ 'currency' => WC_Payments_Utils::get_order_original_currency( $order ) ] ),
+			wc_price( $amount / 100, [ 'currency' => $currency ] ),
 			$refund_id
 		);
 		$order->add_order_note( $note );

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -191,7 +191,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 					'code'   => '<code>',
 				]
 			),
-			wc_price( $amount / 100, [ 'currency' => strtoupper( $currency ) ] ),
+			wc_price( WC_Payments_Utils::interpret_stripe_amount( $amount, $currency ), [ 'currency' => strtoupper( $currency ) ] ),
 			$refund_id
 		);
 		$order->add_order_note( $note );

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -190,7 +190,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 					'code'   => '<code>',
 				]
 			),
-			wc_price( $amount / 100 ),
+			wc_price( $amount / 100, array( 'currency' => $order->get_currency() ) ),
 			$refund_id
 		);
 		$order->add_order_note( $note );

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -190,7 +190,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 					'code'   => '<code>',
 				]
 			),
-			wc_price( $amount / 100, array( 'currency' => $order->get_currency() ) ),
+			wc_price( $amount / 100, [ 'currency' => WC_Payments_Utils::get_order_original_currency( $order ) ] ),
 			$refund_id
 		);
 		$order->add_order_note( $note );

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -168,7 +168,6 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 		$refund_id = $this->read_rest_property( $event_object, 'id' );
 		$amount    = $this->read_rest_property( $event_object, 'amount' );
 		$currency  = $this->read_rest_property( $event_object, 'currency' );
-		$currency  = strtoupper( $currency );
 
 		// Look up the order related to this charge.
 		$order = $this->wcpay_db->order_from_charge_id( $charge_id );
@@ -192,7 +191,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 					'code'   => '<code>',
 				]
 			),
-			wc_price( $amount / 100, [ 'currency' => $currency ] ),
+			wc_price( $amount / 100, [ 'currency' => strtoupper( $currency ) ] ),
 			$refund_id
 		);
 		$order->add_order_note( $note );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -784,7 +784,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$note = sprintf(
 				/* translators: %1: the successfully charged amount, %2: error message */
 				__( 'A refund of %1$s failed to complete: %2$s', 'woocommerce-payments' ),
-				wc_price( $amount ),
+				wc_price( $amount, array( 'currency' => $order->get_currency() ) ),
 				$e->getMessage()
 			);
 
@@ -799,13 +799,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$note = sprintf(
 				/* translators: %1: the successfully charged amount */
 				__( 'A refund of %1$s was successfully processed using WooCommerce Payments.', 'woocommerce-payments' ),
-				wc_price( $amount )
+				wc_price( $amount, array( 'currency' => $order->get_currency() ) )
 			);
 		} else {
 			$note = sprintf(
 				/* translators: %1: the successfully charged amount, %2: reason */
 				__( 'A refund of %1$s was successfully processed using WooCommerce Payments. Reason: %2$s', 'woocommerce-payments' ),
-				wc_price( $amount ),
+				wc_price( $amount, array( 'currency' => $order->get_currency() ) ),
 				$reason
 			);
 		}
@@ -1137,7 +1137,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					),
 					[ 'strong' => '<strong>' ]
 				),
-				wc_price( $amount )
+				wc_price( $amount, array( 'currency' => $order->get_currency() ) )
 			);
 			$order->add_order_note( $note );
 			$order->payment_complete();
@@ -1154,7 +1154,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 						'code'   => '<code>',
 					]
 				),
-				wc_price( $amount ),
+				wc_price( $amount, array( 'currency' => $order->get_currency() ) ),
 				esc_html( $error_message )
 			);
 			$order->add_order_note( $note );
@@ -1165,7 +1165,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					__( 'A capture of %1$s <strong>failed</strong> to complete.', 'woocommerce-payments' ),
 					[ 'strong' => '<strong>' ]
 				),
-				wc_price( $amount )
+				wc_price( $amount, array( 'currency' => $order->get_currency() ) )
 			);
 			$order->add_order_note( $note );
 		}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -784,7 +784,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$note = sprintf(
 				/* translators: %1: the successfully charged amount, %2: error message */
 				__( 'A refund of %1$s failed to complete: %2$s', 'woocommerce-payments' ),
-				wc_price( $amount, array( 'currency' => $order->get_currency() ) ),
+				wc_price( $amount, [ 'currency' => WC_Payments_Utils::get_order_original_currency( $order ) ] ),
 				$e->getMessage()
 			);
 
@@ -799,13 +799,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$note = sprintf(
 				/* translators: %1: the successfully charged amount */
 				__( 'A refund of %1$s was successfully processed using WooCommerce Payments.', 'woocommerce-payments' ),
-				wc_price( $amount, array( 'currency' => $order->get_currency() ) )
+				wc_price( $amount, [ 'currency' => WC_Payments_Utils::get_order_original_currency( $order ) ] )
 			);
 		} else {
 			$note = sprintf(
 				/* translators: %1: the successfully charged amount, %2: reason */
 				__( 'A refund of %1$s was successfully processed using WooCommerce Payments. Reason: %2$s', 'woocommerce-payments' ),
-				wc_price( $amount, array( 'currency' => $order->get_currency() ) ),
+				wc_price( $amount, [ 'currency' => WC_Payments_Utils::get_order_original_currency( $order ) ] ),
 				$reason
 			);
 		}
@@ -1137,7 +1137,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					),
 					[ 'strong' => '<strong>' ]
 				),
-				wc_price( $amount, array( 'currency' => $order->get_currency() ) )
+				wc_price( $amount, [ 'currency' => WC_Payments_Utils::get_order_original_currency( $order ) ] )
 			);
 			$order->add_order_note( $note );
 			$order->payment_complete();
@@ -1154,7 +1154,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 						'code'   => '<code>',
 					]
 				),
-				wc_price( $amount, array( 'currency' => $order->get_currency() ) ),
+				wc_price( $amount, [ 'currency' => WC_Payments_Utils::get_order_original_currency( $order ) ] ),
 				esc_html( $error_message )
 			);
 			$order->add_order_note( $note );
@@ -1165,7 +1165,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					__( 'A capture of %1$s <strong>failed</strong> to complete.', 'woocommerce-payments' ),
 					[ 'strong' => '<strong>' ]
 				),
-				wc_price( $amount, array( 'currency' => $order->get_currency() ) )
+				wc_price( $amount, [ 'currency' => WC_Payments_Utils::get_order_original_currency( $order ) ] )
 			);
 			$order->add_order_note( $note );
 		}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -591,6 +591,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$status        = $intent['status'];
 			$charge_id     = '';
 			$client_secret = $intent['client_secret'];
+			$currency      = $order->get_currency();
 		}
 
 		if ( ! empty( $intent ) ) {
@@ -687,9 +688,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$order->update_meta_data( '_intent_id', $intent_id );
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->update_meta_data( '_intention_status', $status );
-		if ( ! empty( $currency ) ) {
-			WC_Payments_Utils::set_order_intent_currency( $order, $currency );
-		}
+		WC_Payments_Utils::set_order_intent_currency( $order, $currency );
 		$order->save();
 
 		if ( isset( $response ) ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -579,6 +579,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$status        = $intent->get_status();
 			$charge_id     = $intent->get_charge_id();
 			$client_secret = $intent->get_client_secret();
+			$currency      = $intent->get_currency();
 		} else {
 			// For $0 orders, we need to save the payment method using a setup intent.
 			$intent = $this->payments_api_client->create_and_confirm_setup_intent(
@@ -686,6 +687,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$order->update_meta_data( '_intent_id', $intent_id );
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->update_meta_data( '_intention_status', $status );
+		if ( ! empty( $currency ) ) {
+			WC_Payments_Utils::set_order_intent_currency( $order, $currency );
+		}
 		$order->save();
 
 		if ( isset( $response ) ) {

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -347,7 +347,6 @@ class WC_Payments_Utils {
 	 *
 	 * @param WC_Order $order The order whose intent currency we want to set.
 	 * @param string   $currency The intent currency.
-	 *
 	 */
 	public static function set_order_intent_currency( $order, $currency ) {
 		$order->update_meta_data( self::ORDER_INTENT_CURRENCY_META_KEY, $currency );

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -120,6 +120,24 @@ class WC_Payments_Utils {
 	}
 
 	/**
+	 * Interprets amount from Stripe API.
+	 *
+	 * @param float  $amount   The amount returned by Stripe API.
+	 * @param string $currency The currency we get from Stripe API for the amount.
+	 *
+	 * @return int The interpreted amount.
+	 */
+	public static function interpret_stripe_amount( $amount, $currency = 'usd' ) {
+		$conversion_rate = 100;
+
+		if ( in_array( $currency, self::zero_decimal_currencies(), true ) ) {
+			$conversion_rate = 1;
+		}
+
+		return round( (float) $amount / $conversion_rate );
+	}
+
+	/**
 	 * List of currencies supported by Stripe, the amounts for which are already in the smallest unit.
 	 * Sourced directly from https://stripe.com/docs/currencies#zero-decimal
 	 *

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -307,4 +307,19 @@ class WC_Payments_Utils {
 
 		return $result;
 	}
+
+	/**
+	 * Get original order currency stored, or if not found, get order's currency
+	 *
+	 * @param WC_Order $order The order whose currency we want to get.
+	 *
+	 * @return string The currency.
+	 */
+	public static function get_order_original_currency( $order ) {
+		$original_currency = $order->get_meta( '_wcpay_original_order_currency' );
+		if ( $original_currency ) {
+			return $original_currency;
+		}
+		return $order->get_currency();
+	}
 }

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -127,12 +127,12 @@ class WC_Payments_Utils {
 	/**
 	 * Interprets amount from Stripe API.
 	 *
-	 * @param float  $amount   The amount returned by Stripe API.
+	 * @param int    $amount   The amount returned by Stripe API.
 	 * @param string $currency The currency we get from Stripe API for the amount.
 	 *
-	 * @return int The interpreted amount.
+	 * @return float The interpreted amount.
 	 */
-	public static function interpret_stripe_amount( $amount, $currency = 'usd' ) {
+	public static function interpret_stripe_amount( int $amount, string $currency = 'usd' ): float {
 		$conversion_rate = 100;
 
 		if ( in_array( $currency, self::zero_decimal_currencies(), true ) ) {
@@ -338,7 +338,7 @@ class WC_Payments_Utils {
 	 *
 	 * @return string The currency.
 	 */
-	public static function get_order_intent_currency( $order ) {
+	public static function get_order_intent_currency( WC_Order $order ): string {
 		$intent_currency = $order->get_meta( self::ORDER_INTENT_CURRENCY_META_KEY );
 		if ( ! empty( $intent_currency ) ) {
 			return $intent_currency;
@@ -352,7 +352,7 @@ class WC_Payments_Utils {
 	 * @param WC_Order $order The order whose intent currency we want to set.
 	 * @param string   $currency The intent currency.
 	 */
-	public static function set_order_intent_currency( $order, $currency ) {
+	public static function set_order_intent_currency( WC_Order $order, string $currency ) {
 		$order->update_meta_data( self::ORDER_INTENT_CURRENCY_META_KEY, $currency );
 	}
 }

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -139,7 +139,7 @@ class WC_Payments_Utils {
 			$conversion_rate = 1;
 		}
 
-		return round( (float) $amount / $conversion_rate );
+		return (float) $amount / $conversion_rate;
 	}
 
 	/**
@@ -339,7 +339,11 @@ class WC_Payments_Utils {
 	 * @return string The currency.
 	 */
 	public static function get_order_intent_currency( $order ) {
-		return $order->get_meta( self::ORDER_INTENT_CURRENCY_META_KEY ) ?? $order->get_currency();
+		$intent_currency = $order->get_meta( self::ORDER_INTENT_CURRENCY_META_KEY );
+		if ( ! empty( $intent_currency ) ) {
+			return $intent_currency;
+		}
+		return $order->get_currency();
 	}
 
 	/**

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -20,6 +20,11 @@ class WC_Payments_Utils {
 	const MAX_ARRAY_DEPTH = 10;
 
 	/**
+	 * Order meta data key that holds the currency of order's intent transaction.
+	 */
+	const ORDER_INTENT_CURRENCY_META_KEY = '_wcpay_intent_currency';
+
+	/**
 	 * Mirrors JS's createInterpolateElement functionality.
 	 * Returns a string where angle brackets expressions are replaced with unescaped html while the rest is escaped.
 	 *
@@ -327,17 +332,24 @@ class WC_Payments_Utils {
 	}
 
 	/**
-	 * Get original order currency stored, or if not found, get order's currency
+	 * Gets order intent currency from meta data or order currency.
 	 *
-	 * @param WC_Order $order The order whose currency we want to get.
+	 * @param WC_Order $order The order whose intent currency we want to get.
 	 *
 	 * @return string The currency.
 	 */
-	public static function get_order_original_currency( $order ) {
-		$original_currency = $order->get_meta( '_wcpay_original_order_currency' );
-		if ( $original_currency ) {
-			return $original_currency;
-		}
-		return $order->get_currency();
+	public static function get_order_intent_currency( $order ) {
+		return $order->get_meta( self::ORDER_INTENT_CURRENCY_META_KEY ) ?? $order->get_currency();
+	}
+
+	/**
+	 * Saves intent currency in order meta data.
+	 *
+	 * @param WC_Order $order The order whose intent currency we want to set.
+	 * @param string   $currency The intent currency.
+	 *
+	 */
+	public static function set_order_intent_currency( $order, $currency ) {
+		$order->update_meta_data( self::ORDER_INTENT_CURRENCY_META_KEY, $currency );
 	}
 }

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -146,6 +146,22 @@ class WC_Payments {
 		}
 
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );
+		add_action( 'woocommerce_before_order_object_save', [ __CLASS__, 'maybe_set_original_order_currency' ] );
+	}
+
+	/**
+	 * Set order's original currency.
+	 *
+	 * @param WC_Order $order The order whose original currency we want to save.
+	 */
+	public static function maybe_set_original_order_currency( $order ) {
+		$currency          = $order->get_currency();
+		$key               = '_wcpay_original_order_currency';
+		$original_currency = $order->get_meta( $key );
+		if ( ! $currency || $original_currency ) {
+			return;
+		}
+		$order->update_meta_data( $key, $currency );
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -146,22 +146,6 @@ class WC_Payments {
 		}
 
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );
-		add_action( 'woocommerce_before_order_object_save', [ __CLASS__, 'maybe_set_original_order_currency' ] );
-	}
-
-	/**
-	 * Set order's original currency.
-	 *
-	 * @param WC_Order $order The order whose original currency we want to save.
-	 */
-	public static function maybe_set_original_order_currency( $order ) {
-		$currency          = $order->get_currency();
-		$key               = '_wcpay_original_order_currency';
-		$original_currency = $order->get_meta( $key );
-		if ( ! $currency || $original_currency ) {
-			return;
-		}
-		$order->update_meta_data( $key, $currency );
 	}
 
 	/**

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -152,7 +152,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 							'code'   => '<code>',
 						]
 					),
-					wc_price( $amount, [ 'currency' => WC_Payments_Utils::get_order_original_currency( $renewal_order ) ] ),
+					wc_price( $amount, [ 'currency' => WC_Payments_Utils::get_order_intent_currency( $renewal_order ) ] ),
 					esc_html( rtrim( $e->getMessage(), '.' ) )
 				);
 				$renewal_order->add_order_note( $note );

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -152,7 +152,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 							'code'   => '<code>',
 						]
 					),
-					wc_price( $amount, array( 'currency' => $renewal_order->get_currency() ) ),
+					wc_price( $amount, [ 'currency' => WC_Payments_Utils::get_order_original_currency( $renewal_order ) ] ),
 					esc_html( rtrim( $e->getMessage(), '.' ) )
 				);
 				$renewal_order->add_order_note( $note );

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -152,7 +152,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 							'code'   => '<code>',
 						]
 					),
-					wc_price( $amount ),
+					wc_price( $amount, array( 'currency' => $renewal_order->get_currency() ) ),
 					esc_html( rtrim( $e->getMessage(), '.' ) )
 				);
 				$renewal_order->add_order_note( $note );

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1085,7 +1085,8 @@ class WC_Payments_API_Client {
 			$created,
 			$intention_array['status'],
 			$charge ? $charge['id'] : null,
-			$intention_array['client_secret']
+			$intention_array['client_secret'],
+			$intention_array['currency']
 		);
 
 		return $intent;

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1082,11 +1082,11 @@ class WC_Payments_API_Client {
 		$intent = new WC_Payments_API_Intention(
 			$intention_array['id'],
 			$intention_array['amount'],
+			$intention_array['currency'],
 			$created,
 			$intention_array['status'],
 			$charge ? $charge['id'] : null,
-			$intention_array['client_secret'],
-			$intention_array['currency']
+			$intention_array['client_secret']
 		);
 
 		return $intent;

--- a/includes/wc-payment-api/models/class-wc-payments-api-intention.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-intention.php
@@ -59,13 +59,13 @@ class WC_Payments_API_Intention {
 	 *
 	 * @param string   $id            - ID of the intention.
 	 * @param integer  $amount        - Amount charged.
+	 * @param string   $currency      - The currency of the intention.
 	 * @param DateTime $created       - Time charge created.
 	 * @param string   $status        - Intention status.
 	 * @param string   $charge_id     - ID of charge associated with intention.
 	 * @param string   $client_secret - The client secret of the intention.
-	 * @param string   $currency      - The currency of the intention.
 	 */
-	public function __construct( $id, $amount, DateTime $created, $status, $charge_id, $client_secret, $currency ) {
+	public function __construct( $id, $amount, string $currency, DateTime $created, $status, $charge_id, $client_secret ) {
 		$this->id            = $id;
 		$this->amount        = $amount;
 		$this->created       = $created;

--- a/includes/wc-payment-api/models/class-wc-payments-api-intention.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-intention.php
@@ -48,6 +48,13 @@ class WC_Payments_API_Intention {
 	private $client_secret;
 
 	/**
+	 * The currency of the intention
+	 *
+	 * @var string
+	 */
+	private $currency;
+
+	/**
 	 * WC_Payments_API_Intention constructor.
 	 *
 	 * @param string   $id            - ID of the intention.
@@ -56,14 +63,16 @@ class WC_Payments_API_Intention {
 	 * @param string   $status        - Intention status.
 	 * @param string   $charge_id     - ID of charge associated with intention.
 	 * @param string   $client_secret - The client secret of the intention.
+	 * @param string   $currency      - The currency of the intention.
 	 */
-	public function __construct( $id, $amount, DateTime $created, $status, $charge_id, $client_secret ) {
+	public function __construct( $id, $amount, DateTime $created, $status, $charge_id, $client_secret, $currency ) {
 		$this->id            = $id;
 		$this->amount        = $amount;
 		$this->created       = $created;
 		$this->status        = $status;
 		$this->charge_id     = $charge_id;
 		$this->client_secret = $client_secret;
+		$this->currency      = strtoupper( $currency );
 	}
 
 	/**
@@ -118,5 +127,14 @@ class WC_Payments_API_Intention {
 	 */
 	public function get_client_secret() {
 		return $this->client_secret;
+	}
+
+	/**
+	 * Returns the currency of this intention
+	 *
+	 * @return string
+	 */
+	public function get_currency() {
+		return $this->currency;
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 2.0.0 - 2021-xx-xx =
+* Fix - Currency format in non-USD order note when capturing, refunding, and processing subscription renewal.
+
 = 1.9.0 - 2021-xx-xx =
 * Add - New setting to manage whether to enable saving cards during checkout. (Defaults to being enabled).
 * Fix - Fixed issue where an empty alert would appear when trying to refund an authorization charge.

--- a/readme.txt
+++ b/readme.txt
@@ -101,9 +101,6 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
-= 2.0.0 - 2021-xx-xx =
-* Fix - Currency format in non-USD order note when capturing, refunding, and processing subscription renewal.
-
 = 1.9.0 - 2021-xx-xx =
 * Add - New setting to manage whether to enable saving cards during checkout. (Defaults to being enabled).
 * Fix - Fixed issue where an empty alert would appear when trying to refund an authorization charge.
@@ -114,6 +111,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Fixed connection timeout configuration.
 * Fix - Specify error code when refund fails in admin to prevent blank alert.
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
+* Fix - Currency format in non-USD order note when capturing, refunding, and processing subscription renewal.
 
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.

--- a/tests/unit/admin/test-class-wc-rest-payments-webhook.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-webhook.php
@@ -274,7 +274,7 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 			->method( 'add_order_note' )
 			->with(
 				$this->matchesRegularExpression(
-					'~^A refund of <span class="woocommerce-Price-amount amount">(<bdi>)?<span class="woocommerce-Price-currencySymbol">&yen;</span>999(</bdi>)?</span> was <strong>unsuccessful</strong> using WooCommerce Payments \(<code>test_refund_id</code>\).$~'
+					'~^A refund of <span class="woocommerce-Price-amount amount">(<bdi>)?<span class="woocommerce-Price-currencySymbol">&yen;</span>999.00(</bdi>)?</span> was <strong>unsuccessful</strong> using WooCommerce Payments \(<code>test_refund_id</code>\).$~'
 				)
 			);
 

--- a/tests/unit/admin/test-class-wc-rest-payments-webhook.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-webhook.php
@@ -163,10 +163,11 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 		// Setup test request data.
 		$this->request_body['type']           = 'charge.refund.updated';
 		$this->request_body['data']['object'] = [
-			'status' => 'failed',
-			'charge' => 'test_charge_id',
-			'id'     => 'test_refund_id',
-			'amount' => 999,
+			'status'   => 'failed',
+			'charge'   => 'test_charge_id',
+			'id'       => 'test_refund_id',
+			'amount'   => 999,
+			'currency' => 'gbp',
 		];
 
 		$this->request->set_body( wp_json_encode( $this->request_body ) );
@@ -202,16 +203,63 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test a valid failed refund update webhook for non-USD.
+	 */
+	public function test_valid_failed_refund_update_webhook_non_usd() {
+		// Setup test request data.
+		$this->request_body['type']           = 'charge.refund.updated';
+		$this->request_body['data']['object'] = [
+			'status'   => 'failed',
+			'charge'   => 'test_charge_id',
+			'id'       => 'test_refund_id',
+			'amount'   => 999,
+			'currency' => 'eur',
+		];
+
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
+
+		$mock_order = $this->getMockBuilder( WC_Order::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'add_order_note' ] )
+			->getMock();
+
+		$mock_order
+			->expects( $this->once() )
+			->method( 'add_order_note' )
+			->with(
+				$this->matchesRegularExpression(
+					'~^A refund of <span class="woocommerce-Price-amount amount">(<bdi>)?<span class="woocommerce-Price-currencySymbol">&euro;</span>9.99(</bdi>)?</span> was <strong>unsuccessful</strong> using WooCommerce Payments \(<code>test_refund_id</code>\).$~'
+				)
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'test_charge_id' )
+			->willReturn( $mock_order );
+
+		// Run the test.
+		$response = $this->controller->handle_webhook( $this->request );
+
+		// Check the response.
+		$response_data = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( [ 'result' => 'success' ], $response_data );
+	}
+
+	/**
 	 * Test a valid failed refund update webhook with an unknown charge ID.
 	 */
 	public function test_valid_failed_refund_update_webhook_with_unknown_charge_id() {
 		// Setup test request data.
 		$this->request_body['type']           = 'charge.refund.updated';
 		$this->request_body['data']['object'] = [
-			'status' => 'failed',
-			'charge' => 'unknown_charge_id',
-			'id'     => 'test_refund_id',
-			'amount' => 999,
+			'status'   => 'failed',
+			'charge'   => 'unknown_charge_id',
+			'id'       => 'test_refund_id',
+			'amount'   => 999,
+			'currency' => 'gbp',
 		];
 
 		$this->request->set_body( wp_json_encode( $this->request_body ) );

--- a/tests/unit/admin/test-class-wc-rest-payments-webhook.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-webhook.php
@@ -173,15 +173,21 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 
 		$mock_order = $this->getMockBuilder( WC_Order::class )
 			->disableOriginalConstructor()
-			->setMethods( [ 'add_order_note' ] )
+			->setMethods( [ 'add_order_note', 'get_meta' ] )
 			->getMock();
+
+		$mock_order
+			->expects( $this->once() )
+			->method( 'get_meta' )
+			->with( '_wcpay_original_order_currency' )
+			->willReturn( 'EUR' );
 
 		$mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with(
 				$this->matchesRegularExpression(
-					'~^A refund of <span class="woocommerce-Price-amount amount">(<bdi>)?<span class="woocommerce-Price-currencySymbol">&pound;</span>9.99(</bdi>)?</span> was <strong>unsuccessful</strong> using WooCommerce Payments \(<code>test_refund_id</code>\).$~'
+					'~^A refund of <span class="woocommerce-Price-amount amount">(<bdi>)?<span class="woocommerce-Price-currencySymbol">&euro;</span>9.99(</bdi>)?</span> was <strong>unsuccessful</strong> using WooCommerce Payments \(<code>test_refund_id</code>\).$~'
 				)
 			);
 

--- a/tests/unit/admin/test-class-wc-rest-payments-webhook.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-webhook.php
@@ -173,21 +173,15 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 
 		$mock_order = $this->getMockBuilder( WC_Order::class )
 			->disableOriginalConstructor()
-			->setMethods( [ 'add_order_note', 'get_meta' ] )
+			->setMethods( [ 'add_order_note' ] )
 			->getMock();
-
-		$mock_order
-			->expects( $this->once() )
-			->method( 'get_meta' )
-			->with( '_wcpay_original_order_currency' )
-			->willReturn( 'EUR' );
 
 		$mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with(
 				$this->matchesRegularExpression(
-					'~^A refund of <span class="woocommerce-Price-amount amount">(<bdi>)?<span class="woocommerce-Price-currencySymbol">&euro;</span>9.99(</bdi>)?</span> was <strong>unsuccessful</strong> using WooCommerce Payments \(<code>test_refund_id</code>\).$~'
+					'~^A refund of <span class="woocommerce-Price-amount amount">(<bdi>)?<span class="woocommerce-Price-currencySymbol">&pound;</span>9.99(</bdi>)?</span> was <strong>unsuccessful</strong> using WooCommerce Payments \(<code>test_refund_id</code>\).$~'
 				)
 			);
 

--- a/tests/unit/admin/test-class-wc-rest-payments-webhook.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-webhook.php
@@ -265,9 +265,9 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 		$this->request->set_body( wp_json_encode( $this->request_body ) );
 
 		$mock_order = $this->getMockBuilder( WC_Order::class )
-		                   ->disableOriginalConstructor()
-		                   ->setMethods( [ 'add_order_note' ] )
-		                   ->getMock();
+			->disableOriginalConstructor()
+			->setMethods( [ 'add_order_note' ] )
+			->getMock();
 
 		$mock_order
 			->expects( $this->once() )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
@@ -134,7 +134,7 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$this->mock_wcs_order_contains_subscription( false );
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123', 'USD' );
+		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, 'usd', new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_and_confirm_intention' )
@@ -162,7 +162,7 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$this->mock_wcs_order_contains_subscription( true );
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123', 'USD' );
+		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, 'usd', new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_and_confirm_intention' )
@@ -196,7 +196,7 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WP_UnitTestCase {
 		);
 		$order->add_payment_token( $this->token );
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123', 'USD' );
+		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, 'usd', new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_and_confirm_intention' )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
@@ -134,7 +134,7 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$this->mock_wcs_order_contains_subscription( false );
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
+		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123', 'USD' );
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_and_confirm_intention' )
@@ -162,7 +162,7 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$this->mock_wcs_order_contains_subscription( true );
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
+		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123', 'USD' );
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_and_confirm_intention' )
@@ -196,7 +196,7 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WP_UnitTestCase {
 		);
 		$order->add_payment_token( $this->token );
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
+		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123', 'USD' );
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_and_confirm_intention' )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -149,11 +149,11 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$intent = new WC_Payments_API_Intention(
 			$intent_id,
 			1500,
+			'usd',
 			new DateTime(),
 			$status,
 			$charge_id,
-			$secret,
-			'USD'
+			$secret
 		);
 		$this->mock_api_client
 			->expects( $this->any() )
@@ -250,11 +250,11 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$intent = new WC_Payments_API_Intention(
 			$intent_id,
 			1500,
+			'usd',
 			new DateTime(),
 			$status,
 			$charge_id,
-			$secret,
-			'USD'
+			$secret
 		);
 		$this->mock_api_client
 			->expects( $this->any() )
@@ -409,11 +409,11 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$intent = new WC_Payments_API_Intention(
 			$intent_id,
 			1500,
+			'usd',
 			new DateTime(),
 			$status,
 			$charge_id,
-			$secret,
-			'USD'
+			$secret
 		);
 		$this->mock_api_client
 			->expects( $this->any() )
@@ -490,7 +490,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	public function test_saved_card_at_checkout() {
 		$order = WC_Helper_Order::create_order();
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123', 'USD' );
+		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, 'usd', new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
 
 		$this->mock_api_client
 			->expects( $this->any() )
@@ -511,7 +511,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	public function test_not_saved_card_at_checkout() {
 		$order = WC_Helper_Order::create_order();
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123', 'USD' );
+		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, 'usd', new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
 
 		$this->mock_api_client
 			->expects( $this->any() )
@@ -529,7 +529,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	public function test_does_not_update_new_payment_method() {
 		$order = WC_Helper_Order::create_order();
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123', 'USD' );
+		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, 'usd', new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
 
 		$this->mock_api_client
 			->expects( $this->any() )
@@ -548,7 +548,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 
 		$order = WC_Helper_Order::create_order();
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123', 'USD' );
+		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, 'usd', new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
 
 		$this->mock_api_client
 			->expects( $this->any() )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -152,7 +152,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			new DateTime(),
 			$status,
 			$charge_id,
-			$secret
+			$secret,
+			'USD'
 		);
 		$this->mock_api_client
 			->expects( $this->any() )
@@ -251,7 +252,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			new DateTime(),
 			$status,
 			$charge_id,
-			$secret
+			$secret,
+			'USD'
 		);
 		$this->mock_api_client
 			->expects( $this->any() )
@@ -408,7 +410,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			new DateTime(),
 			$status,
 			$charge_id,
-			$secret
+			$secret,
+			'USD'
 		);
 		$this->mock_api_client
 			->expects( $this->any() )
@@ -484,7 +487,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	public function test_saved_card_at_checkout() {
 		$order = WC_Helper_Order::create_order();
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
+		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123', 'USD' );
 
 		$this->mock_api_client
 			->expects( $this->any() )
@@ -505,7 +508,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	public function test_not_saved_card_at_checkout() {
 		$order = WC_Helper_Order::create_order();
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
+		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123', 'USD' );
 
 		$this->mock_api_client
 			->expects( $this->any() )
@@ -523,7 +526,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	public function test_does_not_update_new_payment_method() {
 		$order = WC_Helper_Order::create_order();
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
+		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123', 'USD' );
 
 		$this->mock_api_client
 			->expects( $this->any() )
@@ -542,7 +545,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 
 		$order = WC_Helper_Order::create_order();
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
+		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123', 'USD' );
 
 		$this->mock_api_client
 			->expects( $this->any() )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -171,12 +171,13 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		// There's an issue open for that here:
 		// https://github.com/sebastianbergmann/phpunit/issues/4026.
 		$mock_order
-			->expects( $this->exactly( 3 ) )
+			->expects( $this->exactly( 4 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', $charge_id ],
-				[ '_intention_status', $status ]
+				[ '_intention_status', $status ],
+				[ WC_Payments_Utils::ORDER_INTENT_CURRENCY_META_KEY, 'USD' ]
 			);
 
 		// Assert: The order note contains all the information we want:
@@ -271,12 +272,13 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		// There's an issue open for that here:
 		// https://github.com/sebastianbergmann/phpunit/issues/4026.
 		$mock_order
-			->expects( $this->exactly( 3 ) )
+			->expects( $this->exactly( 4 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', $charge_id ],
-				[ '_intention_status', $status ]
+				[ '_intention_status', $status ],
+				[ WC_Payments_Utils::ORDER_INTENT_CURRENCY_META_KEY, 'USD' ]
 			);
 
 		// Assert: The order note contains all the information we want:
@@ -429,12 +431,13 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		// There's an issue open for that here:
 		// https://github.com/sebastianbergmann/phpunit/issues/4026.
 		$mock_order
-			->expects( $this->exactly( 3 ) )
+			->expects( $this->exactly( 4 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', $charge_id ],
-				[ '_intention_status', 'requires_action' ]
+				[ '_intention_status', 'requires_action' ],
+				[ WC_Payments_Utils::ORDER_INTENT_CURRENCY_META_KEY, 'USD' ]
 			);
 
 		// Assert: Order status was not updated.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -85,11 +85,11 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 		$this->payment_intent = new WC_Payments_API_Intention(
 			self::PAYMENT_INTENT_ID,
 			1500,
+			'usd',
 			new DateTime(),
 			'succeeded',
 			self::CHARGE_ID,
-			'',
-			'USD'
+			''
 		);
 
 		$this->mock_api_client = $this->getMockBuilder( 'WC_Payments_API_Client' )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -88,7 +88,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 			new DateTime(),
 			'succeeded',
 			self::CHARGE_ID,
-			''
+			'',
+			'USD'
 		);
 
 		$this->mock_api_client = $this->getMockBuilder( 'WC_Payments_API_Client' )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -241,8 +241,6 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 
 		$token = WC_Helper_Token::create_token( 'new_payment_method', self::USER_ID );
 		$renewal_order->add_payment_token( $token );
-		$renewal_order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
-		$renewal_order->set_currency( 'EUR' );
 
 		$this->mock_customer_service
 			->expects( $this->once() )
@@ -251,17 +249,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 
 		$this->wcpay_gateway->scheduled_subscription_payment( $renewal_order->get_total(), $renewal_order );
 
-		$notes             = wc_get_order_notes(
-			[
-				'order_id' => $renewal_order->get_id(),
-				'limit'    => 1,
-			]
-		);
-		$latest_wcpay_note = $notes[0];
-
 		$this->assertEquals( 'failed', $renewal_order->get_status() );
-		$this->assertContains( 'failed', $latest_wcpay_note->content );
-		$this->assertContains( wc_price( $renewal_order->get_total(), [ 'currency' => 'EUR' ] ), $latest_wcpay_note->content );
 	}
 
 	public function test_subscription_payment_method_filter_bypass_other_payment_methods() {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -252,6 +252,34 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'failed', $renewal_order->get_status() );
 	}
 
+	public function test_scheduled_subscription_payment_fails_when_payment_processing_fails_non_usd() {
+		$renewal_order = WC_Helper_Order::create_order( self::USER_ID );
+
+		$token = WC_Helper_Token::create_token( 'new_payment_method', self::USER_ID );
+		$renewal_order->add_payment_token( $token );
+		$renewal_order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
+		$renewal_order->set_currency( 'EUR' );
+
+		$this->mock_customer_service
+			->expects( $this->once() )
+			->method( 'get_customer_id_by_user_id' )
+			->willThrowException( new API_Exception( 'Error', 'error', 500 ) );
+
+		$this->wcpay_gateway->scheduled_subscription_payment( $renewal_order->get_total(), $renewal_order );
+
+		$notes             = wc_get_order_notes(
+			[
+				'order_id' => $renewal_order->get_id(),
+				'limit'    => 1,
+			]
+		);
+		$latest_wcpay_note = $notes[0];
+
+		$this->assertEquals( 'failed', $renewal_order->get_status() );
+		$this->assertContains( 'failed', $latest_wcpay_note->content );
+		$this->assertContains( wc_price( $renewal_order->get_total(), [ 'currency' => 'EUR' ] ), $latest_wcpay_note->content );
+	}
+
 	public function test_subscription_payment_method_filter_bypass_other_payment_methods() {
 		$subscription              = WC_Helper_Order::create_order( self::USER_ID );
 		$payment_method_to_display = $this->wcpay_gateway->maybe_render_subscription_payment_method( 'Via Crypto Currency', $subscription );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -241,6 +241,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 
 		$token = WC_Helper_Token::create_token( 'new_payment_method', self::USER_ID );
 		$renewal_order->add_payment_token( $token );
+		$renewal_order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
+		$renewal_order->set_currency( 'EUR' );
 
 		$this->mock_customer_service
 			->expects( $this->once() )
@@ -249,7 +251,17 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 
 		$this->wcpay_gateway->scheduled_subscription_payment( $renewal_order->get_total(), $renewal_order );
 
+		$notes             = wc_get_order_notes(
+			[
+				'order_id' => $renewal_order->get_id(),
+				'limit'    => 1,
+			]
+		);
+		$latest_wcpay_note = $notes[0];
+
 		$this->assertEquals( 'failed', $renewal_order->get_status() );
+		$this->assertContains( 'failed', $latest_wcpay_note->content );
+		$this->assertContains( wc_price( $renewal_order->get_total(), [ 'currency' => 'EUR' ] ), $latest_wcpay_note->content );
 	}
 
 	public function test_subscription_payment_method_filter_bypass_other_payment_methods() {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -196,11 +196,11 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 				new WC_Payments_API_Intention(
 					self::PAYMENT_INTENT_ID,
 					1500,
+					'usd',
 					new DateTime(),
 					'succeeded',
 					self::CHARGE_ID,
-					'',
-					'USD'
+					''
 				)
 			);
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -199,7 +199,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 					new DateTime(),
 					'succeeded',
 					self::CHARGE_ID,
-					''
+					'',
+					'USD'
 				)
 			);
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -258,7 +258,6 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 
 		$token = WC_Helper_Token::create_token( 'new_payment_method', self::USER_ID );
 		$renewal_order->add_payment_token( $token );
-		$renewal_order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
 		$renewal_order->set_currency( 'EUR' );
 
 		$this->mock_customer_service

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -134,6 +134,51 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->assertTrue( $result );
 	}
 
+	public function test_process_refund_non_usd() {
+		$intent_id = 'pi_xxxxxxxxxxxxx';
+		$charge_id = 'ch_yyyyyyyyyyyyy';
+
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( '_intent_id', $intent_id );
+		$order->update_meta_data( '_charge_id', $charge_id );
+		$order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
+		$order->set_currency( 'EUR' );
+		$order->save();
+
+		$this->mock_api_client->expects( $this->once() )->method( 'refund_charge' )->will(
+			$this->returnValue(
+				[
+					'id'                       => 're_123456789',
+					'object'                   => 'refund',
+					'amount'                   => 19.99,
+					'balance_transaction'      => 'txn_987654321',
+					'charge'                   => 'ch_121212121212',
+					'created'                  => 1610123467,
+					'payment_intent'           => 'pi_1234567890',
+					'reason'                   => null,
+					'reciept_number'           => null,
+					'source_transfer_reversal' => null,
+					'status'                   => 'succeeded',
+					'transfer_reversal'        => null,
+				]
+			)
+		);
+
+		$result = $this->wcpay_gateway->process_refund( $order->get_id(), 19.99 );
+
+		$notes             = wc_get_order_notes(
+			[
+				'order_id' => $order->get_id(),
+				'limit'    => 1,
+			]
+		);
+		$latest_wcpay_note = $notes[0];
+
+		$this->assertTrue( $result );
+		$this->assertContains( 'successfully processed', $latest_wcpay_note->content );
+		$this->assertContains( wc_price( 19.99, [ 'currency' => 'EUR' ] ), $latest_wcpay_note->content );
+	}
+
 	public function test_process_refund_with_reason() {
 		$intent_id = 'pi_xxxxxxxxxxxxx';
 		$charge_id = 'ch_yyyyyyyyyyyyy';
@@ -523,6 +568,48 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->assertEquals( $order->get_status(), 'processing' );
 	}
 
+	public function test_capture_charge_success_non_usd() {
+		$intent_id = 'pi_xxxxxxxxxxxxx';
+		$charge_id = 'ch_yyyyyyyyyyyyy';
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_transaction_id( $intent_id );
+		$order->update_meta_data( '_intent_id', $intent_id );
+		$order->update_meta_data( '_charge_id', $charge_id );
+		$order->update_meta_data( '_intention_status', 'requires_capture' );
+		$order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
+		$order->set_currency( 'EUR' );
+		$order->update_status( 'on-hold' );
+
+		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
+			$this->returnValue(
+				new WC_Payments_API_Intention(
+					$intent_id,
+					1500,
+					new DateTime(),
+					'succeeded',
+					$charge_id,
+					'...'
+				)
+			)
+		);
+
+		$this->wcpay_gateway->capture_charge( $order );
+
+		$notes             = wc_get_order_notes(
+			[
+				'order_id' => $order->get_id(),
+				'limit'    => 2,
+			]
+		);
+		$latest_wcpay_note = $notes[1]; // The latest note is the "status changed" message, we want the previous one.
+
+		$this->assertContains( 'successfully captured', $latest_wcpay_note->content );
+		$this->assertContains( wc_price( $order->get_total(), [ 'currency' => 'EUR' ] ), $latest_wcpay_note->content );
+		$this->assertEquals( $order->get_meta( '_intention_status', true ), 'succeeded' );
+		$this->assertEquals( $order->get_status(), 'processing' );
+	}
+
 	public function test_capture_charge_failure() {
 		$intent_id = 'pi_xxxxxxxxxxxxx';
 		$charge_id = 'ch_yyyyyyyyyyyyy';
@@ -558,6 +645,47 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 		$this->assertContains( 'failed', $note->content );
 		$this->assertContains( wc_price( $order->get_total() ), $note->content );
+		$this->assertEquals( $order->get_meta( '_intention_status', true ), 'requires_capture' );
+		$this->assertEquals( $order->get_status(), 'on-hold' );
+	}
+
+	public function test_capture_charge_failure_non_usd() {
+		$intent_id = 'pi_xxxxxxxxxxxxx';
+		$charge_id = 'ch_yyyyyyyyyyyyy';
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_transaction_id( $intent_id );
+		$order->update_meta_data( '_intent_id', $intent_id );
+		$order->update_meta_data( '_charge_id', $charge_id );
+		$order->update_meta_data( '_intention_status', 'requires_capture' );
+		$order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
+		$order->set_currency( 'EUR' );
+		$order->update_status( 'on-hold' );
+
+		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
+			$this->returnValue(
+				new WC_Payments_API_Intention(
+					$intent_id,
+					1500,
+					new DateTime(),
+					'requires_capture',
+					$charge_id,
+					'...'
+				)
+			)
+		);
+
+		$this->wcpay_gateway->capture_charge( $order );
+
+		$note = wc_get_order_notes(
+			[
+				'order_id' => $order->get_id(),
+				'limit'    => 1,
+			]
+		)[0];
+
+		$this->assertContains( 'failed', $note->content );
+		$this->assertContains( wc_price( $order->get_total(), [ 'currency' => 'EUR' ] ), $note->content );
 		$this->assertEquals( $order->get_meta( '_intention_status', true ), 'requires_capture' );
 		$this->assertEquals( $order->get_status(), 'on-hold' );
 	}
@@ -601,6 +729,51 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->assertContains( 'failed', $note->content );
 		$this->assertContains( 'test exception', $note->content );
 		$this->assertContains( wc_price( $order->get_total() ), $note->content );
+		$this->assertEquals( $order->get_meta( '_intention_status', true ), 'requires_capture' );
+		$this->assertEquals( $order->get_status(), 'on-hold' );
+	}
+
+	public function test_capture_charge_api_failure_non_usd() {
+		$intent_id = 'pi_xxxxxxxxxxxxx';
+		$charge_id = 'ch_yyyyyyyyyyyyy';
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_transaction_id( $intent_id );
+		$order->update_meta_data( '_intent_id', $intent_id );
+		$order->update_meta_data( '_charge_id', $charge_id );
+		$order->update_meta_data( '_intention_status', 'requires_capture' );
+		$order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
+		$order->set_currency( 'EUR' );
+		$order->update_status( 'on-hold' );
+
+		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
+			$this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) )
+		);
+		$this->mock_api_client->expects( $this->once() )->method( 'get_intent' )->with( $intent_id )->will(
+			$this->returnValue(
+				new WC_Payments_API_Intention(
+					$intent_id,
+					1500,
+					new DateTime(),
+					'requires_capture',
+					$charge_id,
+					'...'
+				)
+			)
+		);
+
+		$this->wcpay_gateway->capture_charge( $order );
+
+		$note = wc_get_order_notes(
+			[
+				'order_id' => $order->get_id(),
+				'limit'    => 1,
+			]
+		)[0];
+
+		$this->assertContains( 'failed', $note->content );
+		$this->assertContains( 'test exception', $note->content );
+		$this->assertContains( wc_price( $order->get_total(), [ 'currency' => 'EUR' ] ), $note->content );
 		$this->assertEquals( $order->get_meta( '_intention_status', true ), 'requires_capture' );
 		$this->assertEquals( $order->get_status(), 'on-hold' );
 	}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -301,7 +301,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'wcpay_edit_order_refund_failure', $result->get_error_code() );
 		$this->assertEquals( 'Test message', $result->get_error_message() );
 		$this->assertContains( 'failed to complete', $latest_wcpay_note->content );
-		$this->assertContains( 'test exception', $latest_wcpay_note->content );
+		$this->assertContains( 'Test message', $latest_wcpay_note->content );
 		$this->assertContains( wc_price( 19.99, [ 'currency' => 'EUR' ] ), $latest_wcpay_note->content );
 	}
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -547,7 +547,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					new DateTime(),
 					'succeeded',
 					$charge_id,
-					'...'
+					'...',
+					'USD'
 				)
 			)
 		);
@@ -589,7 +590,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					new DateTime(),
 					'succeeded',
 					$charge_id,
-					'...'
+					'...',
+					'USD'
 				)
 			)
 		);
@@ -629,7 +631,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					new DateTime(),
 					'requires_capture',
 					$charge_id,
-					'...'
+					'...',
+					'USD'
 				)
 			)
 		);
@@ -670,7 +673,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					new DateTime(),
 					'requires_capture',
 					$charge_id,
-					'...'
+					'...',
+					'USD'
 				)
 			)
 		);
@@ -712,7 +716,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					new DateTime(),
 					'requires_capture',
 					$charge_id,
-					'...'
+					'...',
+					'USD'
 				)
 			)
 		);
@@ -757,7 +762,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					new DateTime(),
 					'requires_capture',
 					$charge_id,
-					'...'
+					'...',
+					'USD'
 				)
 			)
 		);
@@ -800,7 +806,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					new DateTime(),
 					'canceled',
 					$charge_id,
-					'...'
+					'...',
+					'USD'
 				)
 			)
 		);
@@ -845,7 +852,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					new DateTime(),
 					'canceled',
 					$charge_id,
-					'...'
+					'...',
+					'USD'
 				)
 			);
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -542,11 +542,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 				new WC_Payments_API_Intention(
 					$intent_id,
 					1500,
+					$order->get_currency(),
 					new DateTime(),
 					'succeeded',
 					$charge_id,
-					'...',
-					$order->get_currency()
+					'...'
 				)
 			)
 		);
@@ -583,11 +583,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 				new WC_Payments_API_Intention(
 					$intent_id,
 					1500,
+					'eur',
 					new DateTime(),
 					'succeeded',
 					$charge_id,
-					'...',
-					'eur'
+					'...'
 				)
 			)
 		);
@@ -624,11 +624,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 				new WC_Payments_API_Intention(
 					$intent_id,
 					1500,
+					$order->get_currency(),
 					new DateTime(),
 					'requires_capture',
 					$charge_id,
-					'...',
-					$order->get_currency()
+					'...'
 				)
 			)
 		);
@@ -664,11 +664,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 				new WC_Payments_API_Intention(
 					$intent_id,
 					1500,
+					'eur',
 					new DateTime(),
 					'requires_capture',
 					$charge_id,
-					'...',
-					'eur'
+					'...'
 				)
 			)
 		);
@@ -707,11 +707,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 				new WC_Payments_API_Intention(
 					$intent_id,
 					1500,
+					'usd',
 					new DateTime(),
 					'requires_capture',
 					$charge_id,
-					'...',
-					'USD'
+					'...'
 				)
 			)
 		);
@@ -752,11 +752,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 				new WC_Payments_API_Intention(
 					$intent_id,
 					1500,
+					'jpy',
 					new DateTime(),
 					'requires_capture',
 					$charge_id,
-					'...',
-					'JPY'
+					'...'
 				)
 			)
 		);
@@ -796,11 +796,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 				new WC_Payments_API_Intention(
 					$intent_id,
 					1500,
+					'usd',
 					new DateTime(),
 					'canceled',
 					$charge_id,
-					'...',
-					'USD'
+					'...'
 				)
 			)
 		);
@@ -842,11 +842,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 				new WC_Payments_API_Intention(
 					$intent_id,
 					1500,
+					'usd',
 					new DateTime(),
 					'canceled',
 					$charge_id,
-					'...',
-					'USD'
+					'...'
 				)
 			);
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -108,8 +108,6 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$order->update_meta_data( '_intent_id', $intent_id );
 		$order->update_meta_data( '_charge_id', $charge_id );
-		$order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
-		$order->set_currency( 'EUR' );
 		$order->save();
 
 		$this->mock_api_client->expects( $this->once() )->method( 'refund_charge' )->will(
@@ -133,16 +131,6 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 		$result = $this->wcpay_gateway->process_refund( $order->get_id(), 19.99 );
 
-		$notes             = wc_get_order_notes(
-			[
-				'order_id' => $order->get_id(),
-				'limit'    => 1,
-			]
-		);
-		$latest_wcpay_note = $notes[0];
-
-		$this->assertContains( 'successfully processed', $latest_wcpay_note->content );
-		$this->assertContains( wc_price( 19.99, [ 'currency' => 'EUR' ] ), $latest_wcpay_note->content );
 		$this->assertTrue( $result );
 	}
 
@@ -504,8 +492,6 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_intent_id', $intent_id );
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->update_meta_data( '_intention_status', 'requires_capture' );
-		$order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
-		$order->set_currency( 'EUR' );
 		$order->update_status( 'on-hold' );
 
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
@@ -532,7 +518,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$latest_wcpay_note = $notes[1]; // The latest note is the "status changed" message, we want the previous one.
 
 		$this->assertContains( 'successfully captured', $latest_wcpay_note->content );
-		$this->assertContains( wc_price( $order->get_total(), [ 'currency' => 'EUR' ] ), $latest_wcpay_note->content );
+		$this->assertContains( wc_price( $order->get_total() ), $latest_wcpay_note->content );
 		$this->assertEquals( $order->get_meta( '_intention_status', true ), 'succeeded' );
 		$this->assertEquals( $order->get_status(), 'processing' );
 	}
@@ -546,8 +532,6 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_intent_id', $intent_id );
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->update_meta_data( '_intention_status', 'requires_capture' );
-		$order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
-		$order->set_currency( 'EUR' );
 		$order->update_status( 'on-hold' );
 
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
@@ -573,7 +557,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		)[0];
 
 		$this->assertContains( 'failed', $note->content );
-		$this->assertContains( wc_price( $order->get_total(), [ 'currency' => 'EUR' ] ), $note->content );
+		$this->assertContains( wc_price( $order->get_total() ), $note->content );
 		$this->assertEquals( $order->get_meta( '_intention_status', true ), 'requires_capture' );
 		$this->assertEquals( $order->get_status(), 'on-hold' );
 	}
@@ -587,8 +571,6 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_intent_id', $intent_id );
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->update_meta_data( '_intention_status', 'requires_capture' );
-		$order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
-		$order->set_currency( 'EUR' );
 		$order->update_status( 'on-hold' );
 
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
@@ -618,7 +600,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 		$this->assertContains( 'failed', $note->content );
 		$this->assertContains( 'test exception', $note->content );
-		$this->assertContains( wc_price( $order->get_total(), [ 'currency' => 'EUR' ] ), $note->content );
+		$this->assertContains( wc_price( $order->get_total() ), $note->content );
 		$this->assertEquals( $order->get_meta( '_intention_status', true ), 'requires_capture' );
 		$this->assertEquals( $order->get_status(), 'on-hold' );
 	}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -125,6 +125,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					'source_transfer_reversal' => null,
 					'status'                   => 'succeeded',
 					'transfer_reversal'        => null,
+					'currency'                 => 'usd',
 				]
 			)
 		);
@@ -141,8 +142,6 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$order->update_meta_data( '_intent_id', $intent_id );
 		$order->update_meta_data( '_charge_id', $charge_id );
-		$order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
-		$order->set_currency( 'EUR' );
 		$order->save();
 
 		$this->mock_api_client->expects( $this->once() )->method( 'refund_charge' )->will(
@@ -160,6 +159,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					'source_transfer_reversal' => null,
 					'status'                   => 'succeeded',
 					'transfer_reversal'        => null,
+					'currency'                 => 'eur',
 				]
 			)
 		);
@@ -179,15 +179,13 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->assertContains( wc_price( 19.99, [ 'currency' => 'EUR' ] ), $latest_wcpay_note->content );
 	}
 
-	public function test_process_refund_with_reason() {
+	public function test_process_refund_with_reason_non_usd() {
 		$intent_id = 'pi_xxxxxxxxxxxxx';
 		$charge_id = 'ch_yyyyyyyyyyyyy';
 
 		$order = WC_Helper_Order::create_order();
 		$order->update_meta_data( '_intent_id', $intent_id );
 		$order->update_meta_data( '_charge_id', $charge_id );
-		$order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
-		$order->set_currency( 'EUR' );
 		$order->save();
 
 		$this->mock_api_client->expects( $this->once() )->method( 'refund_charge' )->will(
@@ -205,6 +203,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					'source_transfer_reversal' => null,
 					'status'                   => 'succeeded',
 					'transfer_reversal'        => null,
+					'currency'                 => 'eur',
 				]
 			)
 		);
@@ -275,8 +274,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$order->update_meta_data( '_intent_id', $intent_id );
 		$order->update_meta_data( '_charge_id', $charge_id );
-		$order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
-		$order->set_currency( 'EUR' );
+		WC_Payments_Utils::set_order_intent_currency( $order, 'EUR' );
 		$order->update_status( 'processing' );
 		$order->save();
 
@@ -548,7 +546,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					'succeeded',
 					$charge_id,
 					'...',
-					'USD'
+					$order->get_currency()
 				)
 			)
 		);
@@ -578,8 +576,6 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_intent_id', $intent_id );
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->update_meta_data( '_intention_status', 'requires_capture' );
-		$order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
-		$order->set_currency( 'EUR' );
 		$order->update_status( 'on-hold' );
 
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
@@ -591,7 +587,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					'succeeded',
 					$charge_id,
 					'...',
-					'USD'
+					'eur'
 				)
 			)
 		);
@@ -632,7 +628,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					'requires_capture',
 					$charge_id,
 					'...',
-					'USD'
+					$order->get_currency()
 				)
 			)
 		);
@@ -661,8 +657,6 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_intent_id', $intent_id );
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->update_meta_data( '_intention_status', 'requires_capture' );
-		$order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
-		$order->set_currency( 'EUR' );
 		$order->update_status( 'on-hold' );
 
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
@@ -674,7 +668,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					'requires_capture',
 					$charge_id,
 					'...',
-					'USD'
+					'eur'
 				)
 			)
 		);
@@ -747,9 +741,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_intent_id', $intent_id );
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->update_meta_data( '_intention_status', 'requires_capture' );
-		$order->update_meta_data( '_wcpay_original_order_currency', 'EUR' );
-		$order->set_currency( 'EUR' );
 		$order->update_status( 'on-hold' );
+		WC_Payments_Utils::set_order_intent_currency( $order, 'EUR' );
 
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
 			$this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) )
@@ -763,7 +756,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 					'requires_capture',
 					$charge_id,
 					'...',
-					'USD'
+					'JPY'
 				)
 			)
 		);

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -334,4 +334,9 @@ class WC_Payments_Utils_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_wcpay_original_order_currency', 'CAD' );
 		$this->assertEquals( WC_Payments_Utils::get_order_original_currency( $order ), 'CAD' );
 	}
+
+	public function test_interpret_stripe_amount() {
+		$this->assertEquals( WC_Payments_Utils::interpret_stripe_amount( 100, 'USD' ), 1 );
+		$this->assertEquals( WC_Payments_Utils::interpret_stripe_amount( 100, 'JPY' ), 100 );
+	}
 }

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -317,26 +317,17 @@ class WC_Payments_Utils_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $result );
 	}
 
-	public function test_get_order_original_currency() {
-		$order             = WC_Helper_Order::create_order();
-		$original_currency = $order->get_currency();
+	public function get_order_intent_currency() {
+		$order = WC_Helper_Order::create_order();
 
-		// make sure WC_Payments::maybe_set_original_order_currency() sets _wcpay_original_order_currency.
-		$this->assertEquals( $order->get_meta( '_wcpay_original_order_currency' ), $original_currency );
+		$this->assertEquals( WC_Payments_Utils::get_order_intent_currency( $order ), $order->get_currency() );
 
-		$order->set_currency( 'EUR' );
-		// make sure the value of _wcpay_original_order_currency does not change.
-		$this->assertEquals( $order->get_meta( '_wcpay_original_order_currency' ), $original_currency );
-
-		$order->delete_meta_data( '_wcpay_original_order_currency' );
-		$this->assertEquals( WC_Payments_Utils::get_order_original_currency( $order ), 'EUR' );
-
-		$order->update_meta_data( '_wcpay_original_order_currency', 'CAD' );
-		$this->assertEquals( WC_Payments_Utils::get_order_original_currency( $order ), 'CAD' );
+		WC_Payments_Utils::set_order_intent_currency( $order, 'EUR' );
+		$this->assertEquals( WC_Payments_Utils::get_order_intent_currency( $order ), 'EUR' );
 	}
 
 	public function test_interpret_stripe_amount() {
-		$this->assertEquals( WC_Payments_Utils::interpret_stripe_amount( 100, 'USD' ), 1 );
-		$this->assertEquals( WC_Payments_Utils::interpret_stripe_amount( 100, 'JPY' ), 100 );
+		$this->assertEquals( WC_Payments_Utils::interpret_stripe_amount( 100, 'usd' ), 1 );
+		$this->assertEquals( WC_Payments_Utils::interpret_stripe_amount( 100, 'jpy' ), 100 );
 	}
 }

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -318,13 +318,20 @@ class WC_Payments_Utils_Test extends WP_UnitTestCase {
 	}
 
 	public function test_get_order_original_currency() {
-		$order = WC_Helper_Order::create_order();
-		$order->update_meta_data( '_order_currency', 'EUR' );
-		$order->save();
+		$order             = WC_Helper_Order::create_order();
+		$original_currency = $order->get_currency();
+
+		// make sure WC_Payments::maybe_set_original_order_currency() sets _wcpay_original_order_currency.
+		$this->assertEquals( $order->get_meta( '_wcpay_original_order_currency' ), $original_currency );
+
+		$order->set_currency( 'EUR' );
+		// make sure the value of _wcpay_original_order_currency does not change.
+		$this->assertEquals( $order->get_meta( '_wcpay_original_order_currency' ), $original_currency );
+
+		$order->delete_meta_data( '_wcpay_original_order_currency' );
 		$this->assertEquals( WC_Payments_Utils::get_order_original_currency( $order ), 'EUR' );
 
 		$order->update_meta_data( '_wcpay_original_order_currency', 'CAD' );
-		$order->save();
 		$this->assertEquals( WC_Payments_Utils::get_order_original_currency( $order ), 'CAD' );
 	}
 }

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -316,4 +316,15 @@ class WC_Payments_Utils_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $result );
 	}
+
+	public function test_get_order_original_currency() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( '_order_currency', 'EUR' );
+		$order->save();
+		$this->assertEquals( WC_Payments_Utils::get_order_original_currency( $order ), 'EUR' );
+
+		$order->update_meta_data( '_wcpay_original_order_currency', 'CAD' );
+		$order->save();
+		$this->assertEquals( WC_Payments_Utils::get_order_original_currency( $order ), 'CAD' );
+	}
 }

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -317,7 +317,7 @@ class WC_Payments_Utils_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $result );
 	}
 
-	public function get_order_intent_currency() {
+	public function test_get_order_intent_currency() {
 		$order = WC_Helper_Order::create_order();
 
 		$this->assertEquals( WC_Payments_Utils::get_order_intent_currency( $order ), $order->get_currency() );

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -83,6 +83,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 					],
 				],
 				'client_secret' => 'test_client_secret',
+				'currency'      => 'usd',
 			]
 		);
 
@@ -164,6 +165,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 					],
 				],
 				'client_secret' => 'test_client_secret',
+				'currency'      => 'usd',
 			]
 		);
 
@@ -201,6 +203,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 					],
 				],
 				'client_secret'   => 'test_client_secret',
+				'currency'        => 'usd',
 			]
 		);
 
@@ -235,6 +238,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 					],
 				],
 				'client_secret' => 'test_client_secret',
+				'currency'      => 'usd',
 			]
 		);
 


### PR DESCRIPTION
Fixes #1200

#### Changes proposed in this Pull Request

* Passing order currency to `wc_price()`.
* Get intent currency from the response we get from the server.
* Save order intent currency as a fallback in case we cannot get the transaction currency from the server (for order note created from within catch block, for example).
* Handle zero decimal currency in failed refund webhook handler.

#### Testing instructions

1. Testing `capture_charge()`. Steps:
- Admin > Payments > Settings > Make sure `Issue an authorization on checkout, and capture later.` is checked.
- Install plugin that can change customer currency, like [WooCommerce Multi-Currency](https://woocommerce.com/products/multi-currency/).
- Setup currency plugin to the point where you can see non-USD currency from the front store, for example, for [WooCommerce Multi-Currency](https://woocommerce.com/products/multi-currency/), follow their [docs](https://docs.woocommerce.com/document/multi-currency) and open front store with parameter `?currency=EUR` to see prices in Euro (if you setup Euro as one of the customer currencies).
- Buy a product with certain credit card numbers listed below for each test case:
  - Success: 4242424242424242 with any expired date in the future and any 3-digit CVC code.
  - Error: (I cannot find suitable testing card number that can get us to the 2 possible non-success cases [[#](https://github.com/Automattic/woocommerce-payments/pull/1227/files#diff-bcfd303d507c33a27671935e724ee64d0df30ff2a18bb6ef4c94f28d48190124R1161)] [[#](https://github.com/Automattic/woocommerce-payments/pull/1227/files#diff-bcfd303d507c33a27671935e724ee64d0df30ff2a18bb6ef4c94f28d48190124R1172)], it has to be one that passes auth step but fails capture).
- Open the newly created order from admin.
- Select 'Capture charge' from the Order actions dropdown.
- Click the 'Update' button.
- With this branch, expect order note shows amount with correct order currency. With base branch, order note will use store currency.
- Test more cases where you change the order currency from the admin order page, for example [WooCommerce Multi-Currency](https://woocommerce.com/products/multi-currency/) can do that. Go to the very bottom of the order admin page and you will see a dropdown to change the order currency. Make sure to click the 'Update' button at the top right. After changing the order currency, go through the above steps again and make sure order note still uses the currency when the order was placed.

2. Testing `process_refund()`. Steps:
- Install plugin that can change customer currency, like [WooCommerce Multi-Currency](https://woocommerce.com/products/multi-currency/).
- Setup currency plugin to the point where you can see non-USD currency from the front store, for example, for [WooCommerce Multi-Currency](https://woocommerce.com/products/multi-currency/), follow their [docs](https://docs.woocommerce.com/document/multi-currency) and open front store with parameter `?currency=EUR` to see prices in Euro (if you setup Euro as one of the customer currencies).
- Buy a product with certain credit card numbers listed below for each test case:
  - Success refund: 4242424242424242 with any expired date in the future and any 3-digit CVC code.
  - Failed refund: 4000000000000259 with any expired date in the future and any 3-digit CVC code. This is to test the failed case. You will see an empty alert (filed already as [separate issue](https://github.com/Automattic/woocommerce-payments/issues/1203)). Refresh the page to see the order note. That should be to test the [failed case](https://github.com/Automattic/woocommerce-payments/pull/1227/files#diff-bcfd303d507c33a27671935e724ee64d0df30ff2a18bb6ef4c94f28d48190124R789).
- Open the newly created order from admin.
- Issue a refund, without and with reason, to test success cases respectively [[#](https://github.com/Automattic/woocommerce-payments/pull/1227/files#diff-bcfd303d507c33a27671935e724ee64d0df30ff2a18bb6ef4c94f28d48190124R804)] [[#](https://github.com/Automattic/woocommerce-payments/pull/1227/files#diff-bcfd303d507c33a27671935e724ee64d0df30ff2a18bb6ef4c94f28d48190124R810)].
- With this branch, expect order note shows amount with correct order currency. With base branch, order note will use store currency.
- Test more cases where you change the order currency from the admin order page, for example [WooCommerce Multi-Currency](https://woocommerce.com/products/multi-currency/) can do that. Go to the very bottom of the order admin page and you will see a dropdown to change the order currency. Make sure to click the 'Update' button at the top right. After changing the order currency, go through the above steps again and make sure order note still uses the currency when the order was placed.

3. Testing [refund failure webhook handler](https://github.com/Automattic/woocommerce-payments/pull/1227/files#diff-cea8dab22a014dc0e668f8fd148aaeecd2863b3eb09cbe1f9408092c9b8d6391R194) case.
- Purchase with testing card 4000000000005126 to make refund fail.
- Test with zero decimal currency like JPY to make sure amount is correct.
<img width="289" alt="Screen Shot 2021-02-01 at 09 19 53" src="https://user-images.githubusercontent.com/73803630/106407498-c937f580-646e-11eb-82fd-6ced8ca8fdfd.png">

4. Testing [subscription renewal hook](https://github.com/Automattic/woocommerce-payments/pull/1227/files#diff-a5e8d94b5af9b7536f23cf436b4eef1fb76da3069f34a63b4cf35c46051e417bR155).
I am not sure how to set this up. I just tested it with [unit test](https://github.com/Automattic/woocommerce-payments/pull/1227/files#diff-933977839629fb49196cf683653de08b29c2f319c0cc0edb91ecac15d1e747a6R256-R282).

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
