### PR TITLE
Update/1054 transaction details

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 2.0.0 - 2021-xx-xx =
 * Update - Render customer details in transactions list as text instead of link if order missing.
+* Update - Render transaction summary on details page for multi-currency transactions.
 
 = 1.9.2 - 2021-xx-xx =
 * Fix - Added better notices for end users if there are connection errors when making payments.

--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -24,6 +24,8 @@ import CustomerLink from 'components/customer-link';
 import './style.scss';
 
 const placeholderValues = {
+	amount: 0,
+	currency: 'USD',
 	net: 0,
 	fee: 0,
 	refunded: null,
@@ -91,11 +93,11 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 							placeholder="Amount placeholder"
 						>
 							{ formatCurrency(
-								charge.amount || 0,
-								charge.currency || 'USD'
+								balance.amount,
+								balance.currency
 							) }
 							<span className="payment-details-summary__amount-currency">
-								{ charge.currency || 'usd' }
+								{ balance.currency }
 							</span>
 							<PaymentStatusChip
 								status={ getChargeStatus( charge ) }
@@ -106,10 +108,10 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 						{ balance.currency !== charge.currency ? (
 							<p>
 								{ formatCurrency(
-									balance.amount,
-									balance.currency
+									charge.amount,
+									charge.currency
 								) }{ ' ' }
-								{ balance.currency.toUpperCase() }
+								{ ( charge.currency || 'USD' ).toUpperCase() }
 							</p>
 						) : null }
 						{ balance.refunded ? (

--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -82,6 +82,8 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 	const balance = charge.amount
 		? getChargeAmounts( charge )
 		: placeholderValues;
+	const renderCustomerPrice =
+		charge.currency && balance.currency !== charge.currency;
 
 	return (
 		<Card className="payment-details-summary-details">
@@ -105,7 +107,7 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 						</Loadable>
 					</p>
 					<div className="payment-details-summary__breakdown">
-						{ balance.currency !== charge.currency ? (
+						{ renderCustomerPrice ? (
 							<p>
 								{ formatCurrency(
 									charge.amount,

--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -77,7 +77,7 @@ const composePaymentSummaryItems = ( { charge } ) =>
 	].filter( Boolean );
 
 const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
-	const { net, fee, refunded } = charge.amount
+	const balance = charge.amount
 		? getChargeAmounts( charge )
 		: placeholderValues;
 
@@ -103,15 +103,24 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 						</Loadable>
 					</p>
 					<div className="payment-details-summary__breakdown">
-						{ refunded ? (
+						{ balance.currency !== charge.currency ? (
+							<p>
+								{ formatCurrency(
+									balance.amount,
+									balance.currency
+								) }{ ' ' }
+								{ balance.currency.toUpperCase() }
+							</p>
+						) : null }
+						{ balance.refunded ? (
 							<p>
 								{ `${ __(
 									'Refunded',
 									'woocommerce-payments'
 								) }: ` }
 								{ formatCurrency(
-									-refunded,
-									charge.currency || 'USD'
+									-balance.refunded,
+									balance.currency
 								) }
 							</p>
 						) : (
@@ -124,8 +133,8 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 							>
 								{ `${ __( 'Fee', 'woocommerce-payments' ) }: ` }
 								{ formatCurrency(
-									-fee,
-									charge.currency || 'USD'
+									-balance.fee,
+									balance.currency
 								) }
 							</Loadable>
 						</p>
@@ -136,8 +145,8 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 							>
 								{ `${ __( 'Net', 'woocommerce-payments' ) }: ` }
 								{ formatCurrency(
-									net,
-									charge.currency || 'USD'
+									balance.net,
+									balance.currency
 								) }
 							</Loadable>
 						</p>

--- a/client/payment-details/summary/test/index.js
+++ b/client/payment-details/summary/test/index.js
@@ -24,6 +24,14 @@ const getBaseCharge = () => ( {
 	status: 'succeeded',
 	paid: true,
 	captured: true,
+	balance_transaction: {
+		amount: 2000,
+		currency: 'usd',
+		fee: 70,
+	},
+	refunds: {
+		data: [],
+	},
 	order: {
 		number: 45981,
 		url: 'https://somerandomorderurl.com/?edit_order=45981',
@@ -62,6 +70,12 @@ describe( 'PaymentDetailsSummary', () => {
 		charge.refunded = false;
 		// eslint-disable-next-line camelcase
 		charge.amount_refunded = 1200;
+		charge.refunds.data.push( {
+			// eslint-disable-next-line camelcase
+			balance_transaction: {
+				amount: -charge.amount_refunded,
+			},
+		} );
 
 		const paymentDetailsSummary = renderCharge( charge );
 		expect( paymentDetailsSummary ).toMatchSnapshot();
@@ -72,6 +86,12 @@ describe( 'PaymentDetailsSummary', () => {
 		charge.refunded = true;
 		// eslint-disable-next-line camelcase
 		charge.amount_refunded = 2000;
+		charge.refunds.data.push( {
+			// eslint-disable-next-line camelcase
+			balance_transaction: {
+				amount: -charge.amount_refunded,
+			},
+		} );
 
 		const paymentDetailsSummary = renderCharge( charge );
 		expect( paymentDetailsSummary ).toMatchSnapshot();

--- a/client/utils/charge/index.js
+++ b/client/utils/charge/index.js
@@ -74,14 +74,6 @@ export const getChargeAmounts = ( charge ) => {
 		net: 0,
 	};
 
-	if ( isChargeDisputed( charge ) ) {
-		balance.fee += sumBy( charge.dispute.balance_transactions, 'fee' );
-		balance.refunded -= sumBy(
-			charge.dispute.balance_transactions,
-			'amount'
-		);
-	}
-
 	if ( isChargeRefunded( charge ) ) {
 		balance.refunded += charge.amount_refunded;
 	}
@@ -95,8 +87,6 @@ export const getChargeAmounts = ( charge ) => {
 		balance.fee = charge.balance_transaction.fee;
 		balance.refunded = 0;
 
-		// TODO: Calculate disputed amounts.
-
 		if ( isChargeRefunded( charge ) ) {
 			// Refund balance_transactions have negative amount.
 			balance.refunded -= sumBy(
@@ -104,6 +94,15 @@ export const getChargeAmounts = ( charge ) => {
 				'balance_transaction.amount'
 			);
 		}
+	}
+
+	// Dispute balance transactions are always in settlement currency.
+	if ( isChargeDisputed( charge ) ) {
+		balance.fee += sumBy( charge.dispute.balance_transactions, 'fee' );
+		balance.refunded -= sumBy(
+			charge.dispute.balance_transactions,
+			'amount'
+		);
 	}
 
 	// The final net amount equals the original amount, decreased by the fee(s) and refunded amount.

--- a/client/utils/charge/index.js
+++ b/client/utils/charge/index.js
@@ -60,10 +60,10 @@ export const getChargeStatus = ( charge = {} ) => {
 };
 
 /**
- * Calculates display values for charge amounts.
+ * Calculates display values for charge amounts in settlement currency.
  *
  * @param {Object} charge The full charge object.
- * @return {Object} An object, containing the `net`, `fee`, and `refund` amounts in Stripe format (*100).
+ * @return {Object} An object, containing the `currency`, `amount`, `net`, `fee`, and `refunded` amounts in Stripe format (*100).
  */
 export const getChargeAmounts = ( charge ) => {
 	const balance = {
@@ -93,6 +93,17 @@ export const getChargeAmounts = ( charge ) => {
 		balance.currency = charge.balance_transaction.currency;
 		balance.amount = charge.balance_transaction.amount;
 		balance.fee = charge.balance_transaction.fee;
+		balance.refunded = 0;
+
+		// TODO: Calculate disputed amounts.
+
+		if ( isChargeRefunded( charge ) ) {
+			// Refund balance_transactions have negative amount.
+			balance.refunded -= sumBy(
+				charge.refunds.data,
+				'balance_transaction.amount'
+			);
+		}
 	}
 
 	// The final net amount equals the original amount, decreased by the fee(s) and refunded amount.

--- a/client/utils/charge/test/index.js
+++ b/client/utils/charge/test/index.js
@@ -215,12 +215,12 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 		/* eslint-enable camelcase */
 
 		expect( utils.getChargeAmounts( charge ) ).toEqual( {
-			amount: charge.balance_transaction.amount,
-			currency: charge.balance_transaction.currency,
+			amount: 1482,
+			currency: 'eur',
 			net:
 				charge.balance_transaction.amount -
 				charge.balance_transaction.fee,
-			fee: charge.balance_transaction.fee,
+			fee: 68,
 			refunded: 0,
 		} );
 	} );

--- a/client/utils/charge/test/index.js
+++ b/client/utils/charge/test/index.js
@@ -185,6 +185,8 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 		};
 
 		expect( utils.getChargeAmounts( charge ) ).toEqual( {
+			amount: 1800,
+			currency: 'USD',
 			net: charge.amount - charge.application_fee_amount,
 			fee: charge.application_fee_amount,
 			refunded: 0,
@@ -201,6 +203,8 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 		};
 
 		expect( utils.getChargeAmounts( charge ) ).toEqual( {
+			amount: 1800,
+			currency: 'USD',
 			net:
 				charge.amount -
 				charge.application_fee_amount -
@@ -220,6 +224,8 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 		};
 
 		expect( utils.getChargeAmounts( charge ) ).toEqual( {
+			amount: 1800,
+			currency: 'USD',
 			net:
 				charge.amount -
 				charge.application_fee_amount -
@@ -248,6 +254,8 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 		};
 
 		expect( utils.getChargeAmounts( charge ) ).toEqual( {
+			amount: 1800,
+			currency: 'USD',
 			net: 0 - charge.application_fee_amount - 1500,
 			fee: charge.application_fee_amount + 1500,
 			refunded: charge.dispute.amount,
@@ -277,6 +285,8 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 		};
 
 		expect( utils.getChargeAmounts( charge ) ).toEqual( {
+			amount: 1800,
+			currency: 'USD',
 			net: charge.amount - charge.application_fee_amount,
 			fee: charge.application_fee_amount,
 			refunded: 0,
@@ -297,6 +307,8 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 		};
 
 		expect( utils.getChargeAmounts( charge ) ).toEqual( {
+			amount: 1800,
+			currency: 'USD',
 			net: charge.amount - charge.application_fee_amount,
 			fee: charge.application_fee_amount,
 			refunded: 0,

--- a/client/utils/charge/test/index.js
+++ b/client/utils/charge/test/index.js
@@ -182,11 +182,17 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 			amount: 1800,
 			// eslint-disable-next-line camelcase
 			application_fee_amount: 82,
+			// eslint-disable-next-line camelcase
+			balance_transaction: {
+				amount: 1800,
+				currency: 'usd',
+				fee: 82,
+			},
 		};
 
 		expect( utils.getChargeAmounts( charge ) ).toEqual( {
 			amount: 1800,
-			currency: 'USD',
+			currency: 'usd',
 			net: charge.amount - charge.application_fee_amount,
 			fee: charge.application_fee_amount,
 			refunded: 0,
@@ -224,11 +230,27 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 			application_fee_amount: 82,
 			// eslint-disable-next-line camelcase
 			amount_refunded: 300,
+			// eslint-disable-next-line camelcase
+			balance_transaction: {
+				amount: 1800,
+				currency: 'usd',
+				fee: 82,
+			},
+			refunds: {
+				data: [
+					{
+						// eslint-disable-next-line camelcase
+						balance_transaction: {
+							amount: -300,
+						},
+					},
+				],
+			},
 		};
 
 		expect( utils.getChargeAmounts( charge ) ).toEqual( {
 			amount: 1800,
-			currency: 'USD',
+			currency: 'usd',
 			net:
 				charge.amount -
 				charge.application_fee_amount -
@@ -283,11 +305,27 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 			application_fee_amount: 82,
 			// eslint-disable-next-line camelcase
 			amount_refunded: 1800,
+			// eslint-disable-next-line camelcase
+			balance_transaction: {
+				amount: 1800,
+				currency: 'usd',
+				fee: 82,
+			},
+			refunds: {
+				data: [
+					{
+						// eslint-disable-next-line camelcase
+						balance_transaction: {
+							amount: -1800,
+						},
+					},
+				],
+			},
 		};
 
 		expect( utils.getChargeAmounts( charge ) ).toEqual( {
 			amount: 1800,
-			currency: 'USD',
+			currency: 'usd',
 			net:
 				charge.amount -
 				charge.application_fee_amount -
@@ -343,6 +381,12 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 			amount: 1800,
 			// eslint-disable-next-line camelcase
 			application_fee_amount: 82,
+			// eslint-disable-next-line camelcase
+			balance_transaction: {
+				amount: 1800,
+				currency: 'usd',
+				fee: 82,
+			},
 			disputed: true,
 			dispute: {
 				amount: 1800,
@@ -358,7 +402,7 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 
 		expect( utils.getChargeAmounts( charge ) ).toEqual( {
 			amount: 1800,
-			currency: 'USD',
+			currency: 'usd',
 			net: 0 - charge.application_fee_amount - 1500,
 			fee: charge.application_fee_amount + 1500,
 			refunded: charge.dispute.amount,
@@ -370,6 +414,12 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 			amount: 1800,
 			// eslint-disable-next-line camelcase
 			application_fee_amount: 82,
+			// eslint-disable-next-line camelcase
+			balance_transaction: {
+				amount: 1800,
+				currency: 'usd',
+				fee: 82,
+			},
 			disputed: true,
 			dispute: {
 				amount: 1800,
@@ -389,7 +439,7 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 
 		expect( utils.getChargeAmounts( charge ) ).toEqual( {
 			amount: 1800,
-			currency: 'USD',
+			currency: 'usd',
 			net: charge.amount - charge.application_fee_amount,
 			fee: charge.application_fee_amount,
 			refunded: 0,
@@ -445,11 +495,17 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 				// eslint-disable-next-line camelcase
 				balance_transactions: [],
 			},
+			// eslint-disable-next-line camelcase
+			balance_transaction: {
+				amount: 1800,
+				currency: 'usd',
+				fee: 82,
+			},
 		};
 
 		expect( utils.getChargeAmounts( charge ) ).toEqual( {
 			amount: 1800,
-			currency: 'USD',
+			currency: 'usd',
 			net: charge.amount - charge.application_fee_amount,
 			fee: charge.application_fee_amount,
 			refunded: 0,

--- a/client/utils/charge/test/index.js
+++ b/client/utils/charge/test/index.js
@@ -180,6 +180,7 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 	test( 'basic charge', () => {
 		const charge = {
 			amount: 1800,
+			currency: 'usd',
 			// eslint-disable-next-line camelcase
 			application_fee_amount: 82,
 			// eslint-disable-next-line camelcase
@@ -203,10 +204,11 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 		/* eslint-disable camelcase */
 		const charge = {
 			amount: 1800,
+			currency: 'usd',
 			application_fee_amount: 82,
 			balance_transaction: {
-				amount: getExchangedAmount( 1800 ),
-				fee: getExchangedAmount( 82 ),
+				amount: 1482,
+				fee: 68,
 				currency: 'eur',
 			},
 		};
@@ -261,16 +263,17 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 	} );
 
 	test( 'multi-currency partial refund', () => {
-		const refunds = [ 1000, 500 ].map( getExchangedAmount );
+		const refunds = [ 1000, 500 ];
 		/* eslint-disable camelcase */
 		const charge = {
 			amount: 1800,
+			currency: 'usd',
 			application_fee_amount: 82,
 			amount_refunded: 1500,
 			balance_transaction: {
 				currency: 'eur',
-				amount: getExchangedAmount( 1800 ),
-				fee: getExchangedAmount( 82 ),
+				amount: 1482,
+				fee: 68,
 			},
 			refunds: {
 				data: refunds.map( ( refundedAmount ) => ( {
@@ -287,13 +290,13 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 			0
 		);
 		expect( utils.getChargeAmounts( charge ) ).toEqual( {
-			amount: getExchangedAmount( 1800 ),
+			amount: 1482,
 			currency: 'eur',
 			net:
 				charge.balance_transaction.amount -
 				charge.balance_transaction.fee -
 				expectedRefunds,
-			fee: getExchangedAmount( 82 ),
+			fee: 68,
 			refunded: expectedRefunds,
 		} );
 	} );
@@ -337,18 +340,17 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 
 	test( 'multi-currency full refund', () => {
 		// Refund at higher rate
-		const refunds = [ 1000, 800 ].map( ( refund ) =>
-			getExchangedAmount( refund, 1.15 )
-		);
+		const refunds = [ 1000, 800 ];
 		/* eslint-disable camelcase */
 		const charge = {
 			amount: 1800,
+			currency: 'usd',
 			application_fee_amount: 82,
 			amount_refunded: 1800,
 			balance_transaction: {
 				currency: 'eur',
-				amount: getExchangedAmount( 1800 ),
-				fee: getExchangedAmount( 82 ),
+				amount: 1482,
+				fee: 68,
 			},
 			refunds: {
 				data: refunds.map( ( refundedAmount ) => ( {
@@ -365,13 +367,13 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 			0
 		);
 		expect( utils.getChargeAmounts( charge ) ).toEqual( {
-			amount: getExchangedAmount( 1800 ),
+			amount: 1482,
 			currency: 'eur',
 			net:
 				charge.balance_transaction.amount -
 				charge.balance_transaction.fee -
 				expectedRefunds,
-			fee: getExchangedAmount( 82 ),
+			fee: 68,
 			refunded: expectedRefunds,
 		} );
 	} );
@@ -450,18 +452,19 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 		/* eslint-disable camelcase */
 		const charge = {
 			amount: 1800,
+			currency: 'usd',
 			application_fee_amount: 82,
 			balance_transaction: {
 				currency: 'eur',
-				amount: getExchangedAmount( 1800 ),
-				fee: getExchangedAmount( 82 ),
+				amount: 1482,
+				fee: 68,
 			},
 			disputed: true,
 			dispute: {
 				amount: 1800,
 				balance_transactions: [
 					{
-						amount: -getExchangedAmount( 1800, 1.15 ),
+						amount: 1482,
 						fee: 1500,
 						currency: 'eur',
 					},
@@ -472,14 +475,10 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 
 		const disputedAmount = -charge.dispute.balance_transactions[ 0 ].amount;
 		expect( utils.getChargeAmounts( charge ) ).toEqual( {
-			amount: getExchangedAmount( 1800 ),
+			amount: 1482,
 			currency: 'eur',
-			net:
-				charge.balance_transaction.amount -
-				disputedAmount -
-				getExchangedAmount( 82 ) -
-				1500,
-			fee: getExchangedAmount( 82 ) + 1500,
+			net: charge.balance_transaction.amount - disputedAmount - 68 - 1500,
+			fee: 68 + 1500,
 			refunded: disputedAmount,
 		} );
 	} );
@@ -512,7 +511,3 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 		} );
 	} );
 } );
-
-function getExchangedAmount( amount, exchangeRate = 1.1 ) {
-	return Math.round( amount * exchangeRate );
-}

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 2.0.0 - 2021-xx-xx =
 * Update - Render customer details in transactions list as text instead of link if order missing.
+* Update - Render transaction summary on details page for multi-currency transactions.
 
 = 1.9.2 - 2021-xx-xx =
 * Fix - Added better notices for end users if there are connection errors when making payments. 


### PR DESCRIPTION
Part of #1054 . 

Timeline will be updated in its own PR (https://github.com/Automattic/woocommerce-payments/pull/1241).

#### Changes proposed in this Pull Request

* Display transaction details summary amounts at the top of the page in settlement currency.

#### Testing instructions

* Checks should pass.
* Change store currency to something different from USD, e.g. EUR or GBP.
* Make several transactions: successful, partially refunded, several partial refunds, disputed. Use [test cards](https://stripe.com/docs/testing) for different cases.
* Without 528-gh-Automattic/woocommerce-payments-server no changes should be in the UI.
* With 528-gh-Automattic/woocommerce-payments-server all values should be properly rendered (as designed in #1054) and should match Stripe dashboard info.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->