### PR TITLE
Warn admin users if HTTPS is not required for checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Fixed issue where an empty alert would appear when trying to refund an authorization charge.
 * Update - Link customer name on transaction detail page to filtered transaction list page.
 * Update - Test mode notice width is now consistent across all pages.
+* Add - New notification to urge setting SSL for checkout pages if store doesn't use HTTPS
 
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -496,6 +496,9 @@ class WC_Payments {
 		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
 			WC_Payments_Notes_Set_Up_Refund_Policy::possibly_add_note();
+
+			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-https-for-checkout.php';
+			WC_Payments_Notes_Set_Https_For_Checkout::possibly_add_note();
 		}
 	}
 
@@ -508,6 +511,9 @@ class WC_Payments {
 		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
 			WC_Payments_Notes_Set_Up_Refund_Policy::possibly_delete_note();
+
+			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-https-for-checkout.php';
+			WC_Payments_Notes_Set_Https_For_Checkout::possibly_delete_note();
 		}
 	}
 }

--- a/includes/notes/class-wc-payments-notes-set-https-for-checkout.php
+++ b/includes/notes/class-wc-payments-notes-set-https-for-checkout.php
@@ -13,7 +13,9 @@ defined( 'ABSPATH' ) || exit;
  * Class WC_Payments_Notes_Set_Https_For_Checkout
  */
 class WC_Payments_Notes_Set_Https_For_Checkout {
-	use NoteTraits;
+	use NoteTraits {
+		can_be_added as protected trait_can_be_added;
+	}
 
 	/**
 	 * Name of the note for use in the database.
@@ -26,15 +28,23 @@ class WC_Payments_Notes_Set_Https_For_Checkout {
 	const NOTE_DOCUMENTATION_URL = 'https://docs.woocommerce.com/document/ssl-and-https/#section-7';
 
 	/**
-	 * Get the note.
+	 * Checks if a note can and should be added.
+	 *
+	 * @return bool
 	 */
-	public static function get_note() {
-
+	public static function can_be_added() {
 		// This note only makes sense if HTTPS is not enforced yet.
 		if ( 'yes' === get_option( 'woocommerce_force_ssl_checkout' ) || wc_site_is_https() ) {
 			return;
 		}
 
+		return self::trait_can_be_added();
+	}
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
 		$note_class = WC_Payment_Woo_Compat_Utils::get_note_class();
 		$note       = new $note_class();
 

--- a/includes/notes/class-wc-payments-notes-set-https-for-checkout.php
+++ b/includes/notes/class-wc-payments-notes-set-https-for-checkout.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Set up ensure https on checkout note for WooCommerce inbox.
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WC_Payments_Notes_Set_Https_For_Checkout
+ */
+class WC_Payments_Notes_Set_Https_For_Checkout {
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-payments-notes-set-https-for-checkout';
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_DOCUMENTATION_URL = 'https://docs.woocommerce.com/document/ssl-and-https/#section-7';
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+
+		// This note only makes sense if HTTPS is not enforced yet.
+		if ( 'yes' === get_option( 'woocommerce_force_ssl_checkout' ) || wc_site_is_https() ) {
+			return;
+		}
+
+		$note_class = WC_Payment_Woo_Compat_Utils::get_note_class();
+		$note       = new $note_class();
+
+		$note->set_title( __( 'Force secure checkout', 'woocommerce-payments' ) );
+		$note->set_content( __( 'Protect your customers data and increase trustworthiness of your store by forcing HTTPS on checkout pages.', 'woocommerce-payments' ) );
+		$note->set_content_data( (object) [] );
+		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-payments' );
+		$note->add_action(
+			self::NOTE_NAME,
+			__( 'Read more', 'woocommerce-payments' ),
+			self::NOTE_DOCUMENTATION_URL,
+			'unactioned',
+			true
+		);
+
+		return $note;
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - New setting to manage whether to enable saving cards during checkout. (Defaults to being enabled).
 * Fix - Fixed issue where an empty alert would appear when trying to refund an authorization charge.
 * Update - Link customer name on transaction detail page to filtered transaction list page.
+* Add - New notification to urge setting SSL for checkout pages if store doesn't use HTTPS
 
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.

--- a/tests/unit/notes/test-class-wc-payments-notes-set-https-for-checkout.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-set-https-for-checkout.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Class WC_Payments_Notes_Set_Https_For_Checkout_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * Class WC_Payments_Notes_Set_Https_For_Checkout tests.
+ */
+class WC_Payments_Notes_Set_Https_For_Checkout_Test extends WP_UnitTestCase {
+	public function test_removes_note_on_extension_deactivation() {
+		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+			// Trigger WCPay extension deactivation callback.
+			wcpay_deactivated();
+
+			$note_id = WC_Payments_Notes_Set_Https_For_Checkout::NOTE_NAME;
+			$this->assertSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
+		} else {
+			$this->markTestSkipped( 'The used WC components are not backward compatible' );
+		}
+	}
+
+	public function test_adds_note_in_hook() {
+		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+			// Trigger WCPay extension woo notes hook.
+			WC_Payments::add_woo_admin_notes();
+
+			$note_id = WC_Payments_Notes_Set_Https_For_Checkout::NOTE_NAME;
+			if ( 'yes' === get_option( 'woocommerce_force_ssl_checkout' ) || wc_site_is_https() ) {
+				$this->assertSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
+			} else {
+				$this->assertNotSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
+			}
+		} else {
+			$this->markTestSkipped( 'The used WC components are not backward compatible' );
+		}
+	}
+}


### PR DESCRIPTION
Fixes #824 

#### Changes proposed in this Pull Request

* On plugin activation check if user has enabled HTTPS for their store or have forced SSL for checkout pages. If both conditions are not met create a WooCommerce notification urging them to force SSL for checkout pages.

#### Testing instructions

* Bootstrap WooCommerce installation on a HTTP site
* Open WooCommerce home page
* There should be a notification like this:

<img width="687" alt="image" src="https://user-images.githubusercontent.com/683297/105393950-42d51580-5c1d-11eb-9c76-aba948b66c1a.png">

 * Bootstrap WooCommerce installation on a HTTPS site
 * Open a WooCommerce home page
 * Notification "Force secure checkout" should not be there

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
