### PR TITLE
Update formatCurrency usage

### DIFF
--- a/client/account-fees/index.js
+++ b/client/account-fees/index.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import Currency from '@woocommerce/currency';
 import { __experimentalCreateInterpolateElement as createInterpolateElement } from 'wordpress-element';
 import { dateI18n } from '@wordpress/date';
 import moment from 'moment';
@@ -12,8 +11,7 @@ import moment from 'moment';
  * Internal dependencies
  */
 import ProgressBar from 'components/progress-bar';
-
-const currency = new Currency();
+import { formatCurrency } from 'utils/currency';
 
 const ExpirationBar = ( {
 	feeData: {
@@ -26,8 +24,8 @@ const ExpirationBar = ( {
 	}
 	return (
 		<ProgressBar
-			progressLabel={ currency.formatCurrency( currentVolume / 100 ) }
-			totalLabel={ currency.formatCurrency( volumeAllowance / 100 ) }
+			progressLabel={ formatCurrency( currentVolume ) }
+			totalLabel={ formatCurrency( volumeAllowance ) }
 			progress={ currentVolume / volumeAllowance }
 		/>
 	);
@@ -44,7 +42,7 @@ const ExpirationDescription = ( {
 				'Discounted base fee expires after the first %1$s of total payment volume or on %2$s.',
 				'woocommerce-payments'
 			),
-			currency.formatCurrency( volumeAllowance / 100 ),
+			formatCurrency( volumeAllowance ),
 			dateI18n( 'F j, Y', moment( endTime ).toISOString() )
 		);
 	} else if ( volumeAllowance ) {
@@ -54,7 +52,7 @@ const ExpirationDescription = ( {
 				'Discounted base fee expires after the first %1$s of total payment volume.',
 				'woocommerce-payments'
 			),
-			currency.formatCurrency( volumeAllowance / 100 )
+			formatCurrency( volumeAllowance )
 		);
 	} else if ( endTime ) {
 		description = sprintf(
@@ -79,7 +77,7 @@ const AccountFees = ( { accountFees } ) => {
 		/* translators: %1: Percentage part of the fee. %2: Fixed part of the fee */
 		__( '%1$.1f%% + %2$s per transaction', 'woocommerce-payments' ),
 		currentFee.percentage_rate * 100,
-		currency.formatCurrency( currentFee.fixed_rate / 100 )
+		formatCurrency( currentFee.fixed_rate )
 	);
 
 	if ( accountFees.discount.length ) {
@@ -105,7 +103,7 @@ const AccountFees = ( { accountFees } ) => {
 			),
 			feeDescription,
 			percentage * 100,
-			currency.formatCurrency( fixed / 100 )
+			formatCurrency( fixed )
 		);
 
 		if ( currentFee.discount ) {

--- a/client/account-fees/test/index.js
+++ b/client/account-fees/test/index.js
@@ -15,6 +15,10 @@ describe( 'AccountFees', () => {
 		return render( <AccountFees accountFees={ accountFees } /> );
 	};
 
+	beforeEach( () => {
+		global.wcpaySettings = { zeroDecimalCurrencies: [] };
+	} );
+
 	test( 'renders normal base fee', () => {
 		const { container: accountFees } = renderAccountFees( {
 			base: {

--- a/client/deposits/details/index.js
+++ b/client/deposits/details/index.js
@@ -6,7 +6,6 @@
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
-import Currency from '@woocommerce/currency';
 import { Card, OrderStatus } from '@woocommerce/components';
 
 /**
@@ -18,9 +17,8 @@ import TransactionsList from 'transactions/list';
 import Page from 'components/page';
 import Loadable from 'components/loadable';
 import { TestModeNotice, topics } from 'components/test-mode-notice';
+import { formatCurrency } from 'utils/currency';
 import './style.scss';
-
-const currency = new Currency();
 
 const Status = ( { status } ) => (
 	// Re-purpose order status indicator for deposit status.
@@ -71,7 +69,7 @@ export const DepositOverview = ( { depositId } ) => {
 						placeholder="Amount"
 						display="inline"
 					>
-						{ currency.formatCurrency( deposit.amount / 100 ) }
+						{ formatCurrency( deposit.amount ) }
 					</Loadable>
 				</div>
 			</div>

--- a/client/deposits/details/test/index.js
+++ b/client/deposits/details/test/index.js
@@ -27,6 +27,9 @@ const mockDeposit = {
 describe( 'Deposit overview', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		global.wcpaySettings = {
+			zeroDecimalCurrencies: [],
+		};
 	} );
 
 	test( 'renders correctly', () => {

--- a/client/deposits/list/index.js
+++ b/client/deposits/list/index.js
@@ -6,7 +6,6 @@
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
-import Currency from '@woocommerce/currency';
 import { TableCard, Link } from '@woocommerce/components';
 import { onQueryChange, getQuery } from '@woocommerce/navigation';
 
@@ -16,10 +15,9 @@ import { onQueryChange, getQuery } from '@woocommerce/navigation';
 import { useDeposits } from 'data';
 import { displayType, displayStatus } from '../strings';
 import { formatStringValue } from 'util';
+import { formatCurrency } from 'utils/currency';
 import DetailsLink, { getDetailsURL } from 'components/details-link';
 import ClickableCell from 'components/clickable-cell';
-
-const currency = new Currency();
 
 // TODO make date, amount sortable - when date is sortable, the background of the info buttons should match
 const columns = [
@@ -85,9 +83,7 @@ export const DepositsList = () => {
 			},
 			amount: {
 				value: deposit.amount / 100,
-				display: clickable(
-					currency.formatCurrency( deposit.amount / 100 )
-				),
+				display: clickable( formatCurrency( deposit.amount ) ),
 			},
 			status: {
 				value: deposit.status,

--- a/client/deposits/list/test/index.js
+++ b/client/deposits/list/test/index.js
@@ -37,6 +37,7 @@ const mockDeposits = [
 describe( 'Deposits list', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		global.wcpaySettings = { zeroDecimalCurrencies: [] };
 	} );
 
 	test( 'renders correctly', () => {

--- a/client/deposits/overview/index.js
+++ b/client/deposits/overview/index.js
@@ -6,7 +6,6 @@ import {
 	SummaryList,
 	SummaryNumber,
 } from '@woocommerce/components';
-import Currency from '@woocommerce/currency';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 import Gridicon from 'gridicons';
@@ -20,16 +19,15 @@ import './style.scss';
 import { useDepositsOverview } from 'data';
 import Loadable from 'components/loadable';
 import { getDetailsURL } from 'components/details-link';
+import { formatCurrency } from 'utils/currency';
 
-const currency = new Currency();
 const formatDate = ( format, date ) =>
 	dateI18n(
 		format,
 		moment.utc( date ).toISOString(),
 		true // TODO Change call to gmdateI18n and remove this deprecated param once WP 5.4 support ends.
 	);
-const getAmount = ( obj ) =>
-	currency.formatCurrency( ( obj ? obj.amount : 0 ) / 100 );
+const getAmount = ( obj ) => formatCurrency( obj ? obj.amount : 0 );
 const getDepositDate = ( deposit ) =>
 	deposit ? formatDate( 'F j, Y', deposit.date ) : '—';
 const getBalanceDepositCount = ( balance ) =>

--- a/client/deposits/overview/test/index.js
+++ b/client/deposits/overview/test/index.js
@@ -57,6 +57,9 @@ const getMockedOverview = ( additionalData ) =>
 	);
 
 describe( 'Deposits overview', () => {
+	beforeEach( () => {
+		global.wcpaySettings = { zeroDecimalCurrencies: [] };
+	} );
 	afterEach( () => {
 		jest.clearAllMocks();
 	} );

--- a/client/utils/currency/index.js
+++ b/client/utils/currency/index.js
@@ -64,7 +64,7 @@ export const formatCurrency = ( amount, currencyCode = 'USD' ) => {
 	}
 };
 
-function composeFallbackCurrency( amount, currencyCode = '', isZeroDecimal ) {
+function composeFallbackCurrency( amount, currencyCode, isZeroDecimal ) {
 	// Fallback for unsupported currencies: currency code and amount
 	return sprintf(
 		isZeroDecimal ? '%s %i' : '%s %.2f',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8614,49 +8614,49 @@
       }
     },
     "@woocommerce/currency": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@woocommerce/currency/-/currency-2.0.0.tgz",
-      "integrity": "sha512-zoQbVBZTlgqT5uGTrEHhqQ5iUFZHuYZDyf/+nit3v2a9vUzZAQm1zuqRgu1cd8LbaAQgNHumEUArvXFzacsyVQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/currency/-/currency-3.0.0.tgz",
+      "integrity": "sha512-uNck3JUgGo1RGoWJ/3qm1mhpikNAeTtVCgR0qb3/jti5Mm7pTM6WInGqQV8uP63PMDlPq2dnuhbvmXEER04jBQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime-corejs2": "7.7.4",
-        "@woocommerce/number": "2.0.0"
+        "@babel/runtime-corejs2": "7.10.5",
+        "@woocommerce/number": "2.0.0",
+        "@wordpress/deprecated": "^2.9.0"
       },
       "dependencies": {
-        "@babel/runtime-corejs2": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.4.tgz",
-          "integrity": "sha512-hKNcmHQbBSJFnZ82ewYtWDZ3fXkP/l1XcfRtm7c8gHPM/DMecJtFFBEp7KMLZTuHwwb7RfemHdsEnd7L916Z6A==",
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
           "dev": true,
           "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.2"
+            "regenerator-runtime": "^0.13.4"
           }
         },
-        "@woocommerce/number": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-2.0.0.tgz",
-          "integrity": "sha512-/YFkF0wwYmF0M58wPVrTtFopVwqdsmMAcrgQGnUFIj3JwXQumKR1co99DhDkjJm9vDMYXFTniwKqwvhBxdviSw==",
+        "@wordpress/deprecated": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.11.0.tgz",
+          "integrity": "sha512-2wfl5J8Y3hZeqkD9QAuXTRxPeXm6x5rxsz+CAFG+SS1E9FYZdB0FnRmm26iza7oDo0n917SuM+QDJ5R8P0UxlA==",
           "dev": true,
           "requires": {
-            "@babel/runtime-corejs2": "7.7.4",
-            "locutus": "2.0.11"
+            "@babel/runtime": "^7.12.5",
+            "@wordpress/hooks": "^2.11.0"
           }
         },
-        "core-js": {
-          "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+        "@wordpress/hooks": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.11.0.tgz",
+          "integrity": "sha512-TbvCrHcMiSZoyiflegEqVS3DDytDTpkms+yLUaGN4sMvNdR/Mv5s0WnNKyM0T49lbmZYPWlbWhwJ1F6hr/FQDg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.12.5"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
           "dev": true
-        },
-        "locutus": {
-          "version": "2.0.11",
-          "resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz",
-          "integrity": "sha512-C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==",
-          "dev": true,
-          "requires": {
-            "es6-promise": "^4.2.5"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@testing-library/react": "11.1.2",
     "@testing-library/user-event": "10.4.1",
     "@woocommerce/components": "5.1.2",
-    "@woocommerce/currency": "2.0.0",
+    "@woocommerce/currency": "^3.0.0",
     "@woocommerce/date": "2.1.0",
     "@woocommerce/eslint-plugin": "1.0.0-beta.0",
     "@wordpress/api-fetch": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@testing-library/react": "11.1.2",
     "@testing-library/user-event": "10.4.1",
     "@woocommerce/components": "5.1.2",
-    "@woocommerce/currency": "^3.0.0",
+    "@woocommerce/currency": "3.0.0",
     "@woocommerce/date": "2.1.0",
     "@woocommerce/eslint-plugin": "1.0.0-beta.0",
     "@wordpress/api-fetch": "3.3.0",


### PR DESCRIPTION
Fixes #809 

#### Changes proposed in this Pull Request

* Use `currency.formatAmount` method instead of depricated `currency.formatCurrency` method.
* Bump `@woocommerce/currency` dependency to the latest version

#### Testing instructions

* Checks should be green.
* Install latest WC and check all pages where .formatCurrency was used before. Currencies should be properly displayed.

**Note: changelog entry is not needed because it's an internal change.**

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
