### PR TITLE
Specify error code when refund fails in admin to prevent blank alert

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Update - Test mode notice width is now consistent across all pages.
 * Add - New notification to urge setting SSL for checkout pages if store doesn't use HTTPS
 * Fix - Fixed connection timeout configuration.
+* Fix - Specify error code when refund fails in admin to prevent blank alert.
 
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -788,7 +788,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$order->add_order_note( $note );
 
 			Tracker::track_admin( 'wcpay_edit_order_refund_failure', [ 'reason' => $note ] );
-			return new WP_Error( $e->getCode(), $e->getMessage() );
+			return new WP_Error( 'wcpay_edit_order_refund_failure', $e->getMessage() );
 		}
 
 		if ( empty( $reason ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -105,8 +105,10 @@ Please note that our support for the checkout block is still experimental and th
 * Add - New setting to manage whether to enable saving cards during checkout. (Defaults to being enabled).
 * Fix - Fixed issue where an empty alert would appear when trying to refund an authorization charge.
 * Update - Link customer name on transaction detail page to filtered transaction list page.
+* Update - Test mode notice width is now consistent across all pages.
 * Add - New notification to urge setting SSL for checkout pages if store doesn't use HTTPS
 * Fix - Fixed connection timeout configuration.
+* Fix - Specify error code when refund fails in admin to prevent blank alert.
 
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -153,6 +153,30 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'uncaptured-payment', $result->get_error_code() );
 	}
 
+	public function test_process_refund_on_api_error() {
+		$intent_id = 'pi_xxxxxxxxxxxxx';
+		$charge_id = 'ch_yyyyyyyyyyyyy';
+
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( '_intent_id', $intent_id );
+		$order->update_meta_data( '_charge_id', $charge_id );
+		$order->update_status( 'processing' );
+		$order->save();
+
+		$order_id = $order->get_id();
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'refund_charge' )
+			->willThrowException( new \Exception( 'Test message' ) );
+
+		$result = $this->wcpay_gateway->process_refund( $order_id, 19.99 );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'wcpay_edit_order_refund_failure', $result->get_error_code() );
+		$this->assertEquals( 'Test message', $result->get_error_message() );
+	}
+
 	public function test_payment_fields_outputs_fields() {
 		$this->mock_api_client->expects( $this->once() )->method( 'get_account_data' )->will(
 			$this->returnValue(


### PR DESCRIPTION
Fixes #1203

#### Changes proposed in this Pull Request

* Added an error code to be returned when there is an API error when refunding a charge.

#### Testing instructions

1. Place and order with a test card `4000000000000259` that will be disputed right away.
2. Go to the order admin page and issue a refund.
3. Modal will now have an error message and not be empty.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
