### PR TITLE
Add fees as line items sent to Stripe to prevent Level 3 errors

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Add - New notification to urge setting SSL for checkout pages if store doesn't use HTTPS
 * Fix - Fixed connection timeout configuration.
 * Fix - Specify error code when refund fails in admin to prevent blank alert.
+* Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
 
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - New notification to urge setting SSL for checkout pages if store doesn't use HTTPS
 * Fix - Fixed connection timeout configuration.
 * Fix - Specify error code when refund fails in admin to prevent blank alert.
+* Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
 
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -329,7 +329,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$mock_order   = $this->mock_level_3_order( '98012' );
 		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( $mock_order );
 
-		$this->assertEquals( $level_3_data, $expected_data );
+		$this->assertEquals( $expected_data, $level_3_data );
 	}
 
 	public function test_full_level3_data_with_fee() {
@@ -363,7 +363,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$mock_order   = $this->mock_level_3_order( '98012', true );
 		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( $mock_order );
 
-		$this->assertEquals( $level_3_data, $expected_data );
+		$this->assertEquals( $expected_data, $level_3_data );
 	}
 
 	public function test_us_store_level_3_data() {
@@ -397,7 +397,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$mock_order   = $this->mock_level_3_order( '98012' );
 		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( $mock_order );
 
-		$this->assertEquals( $level_3_data, $expected_data );
+		$this->assertEquals( $expected_data, $level_3_data );
 	}
 
 	public function test_capture_charge_success() {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -210,9 +210,9 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->wcpay_gateway->payment_fields();
 	}
 
-	protected function mock_level_3_order( $shipping_postcode ) {
+	protected function mock_level_3_order( $shipping_postcode, $with_fee = false ) {
 		// Setup the item.
-		$mock_item = $this->getMockBuilder( WC_Order_Item::class )
+		$mock_item = $this->getMockBuilder( WC_Order_Item_Product::class )
 			->disableOriginalConstructor()
 			->setMethods( [ 'get_name', 'get_quantity', 'get_subtotal', 'get_total_tax', 'get_total', 'get_variation_id', 'get_product_id' ] )
 			->getMock();
@@ -245,6 +245,34 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			->method( 'get_product_id' )
 			->will( $this->returnValue( 30 ) );
 
+		$mock_items[] = $mock_item;
+
+		if ( $with_fee ) {
+			// Setup the fee.
+			$mock_fee = $this->getMockBuilder( WC_Order_Item_Fee::class )
+				->disableOriginalConstructor()
+				->setMethods( [ 'get_name', 'get_quantity', 'get_total_tax', 'get_total' ] )
+				->getMock();
+
+			$mock_fee
+				->method( 'get_name' )
+				->will( $this->returnValue( 'fee' ) );
+
+			$mock_fee
+				->method( 'get_quantity' )
+				->will( $this->returnValue( 1 ) );
+
+			$mock_fee
+				->method( 'get_total' )
+				->will( $this->returnValue( 10 ) );
+
+			$mock_fee
+				->method( 'get_total_tax' )
+				->will( $this->returnValue( 1.5 ) );
+
+			$mock_items[] = $mock_fee;
+		}
+
 		// Setup the order.
 		$mock_order = $this->getMockBuilder( WC_Order::class )
 			->disableOriginalConstructor()
@@ -257,7 +285,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 		$mock_order
 			->method( 'get_items' )
-			->will( $this->returnValue( [ $mock_item ] ) );
+			->will( $this->returnValue( $mock_items ) );
 
 		$mock_order
 			->method( 'get_currency' )
@@ -299,6 +327,40 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		update_option( 'woocommerce_store_postcode', '94110' );
 
 		$mock_order   = $this->mock_level_3_order( '98012' );
+		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( $mock_order );
+
+		$this->assertEquals( $level_3_data, $expected_data );
+	}
+
+	public function test_full_level3_data_with_fee() {
+		$expected_data = [
+			'merchant_reference'   => '210',
+			'shipping_amount'      => 3800,
+			'line_items'           => [
+				(object) [
+					'product_code'        => 30,
+					'product_description' => 'Beanie with Logo',
+					'unit_cost'           => 1800,
+					'quantity'            => 1,
+					'tax_amount'          => 270,
+					'discount_amount'     => 0,
+				],
+				(object) [
+					'product_code'        => 'fee',
+					'product_description' => 'fee',
+					'unit_cost'           => 1000,
+					'quantity'            => 1,
+					'tax_amount'          => 150,
+					'discount_amount'     => 0,
+				],
+			],
+			'shipping_address_zip' => '98012',
+			'shipping_from_zip'    => '94110',
+		];
+
+		update_option( 'woocommerce_store_postcode', '94110' );
+
+		$mock_order   = $this->mock_level_3_order( '98012', true );
 		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( $mock_order );
 
 		$this->assertEquals( $level_3_data, $expected_data );


### PR DESCRIPTION
Fixes #1190 

#### Changes proposed in this Pull Request

* Add fees as line items sent to Stripe in Level 3 data to prevent errors.

#### Testing instructions

1. Use snippet below to add fees at checkout.
2. Add any product to cart.
3. Verify fee at checkout, then check out.
4. Check logs for any Level 3 errors.

Also:
1. Create order in admin.
2. Choose _Add item(s)_, and then only add a fee.
3. Save/Create as Pending Payment
4. Use _Customer payment page_ link in order to go to checkout.
5. Check out. (previously you could not)

```
add_action( 'woocommerce_cart_calculate_fees', function() { 
	if ( is_admin() && ! defined( 'DOING_AJAX' ) ) {
		return;
	}

	WC()->cart->add_fee( 'Surcharge', '10.00', true, 'standard' );
});
```
-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
