### PR TITLE
Temporarily restore USD currency check on payment gateway

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -265,6 +265,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return bool Whether the gateway is enabled and ready to accept payments.
 	 */
 	public function is_available() {
+		if ( 'USD' !== get_woocommerce_currency() ) {
+			return false;
+		}
+
 		return parent::is_available() && ! $this->needs_setup();
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Restore the USD currency check (previously removed [here](https://github.com/Automattic/woocommerce-payments/commit/53175ea38f17238b12311be8ee6b6e9c67e0a2d1#diff-bcfd303d507c33a27671935e724ee64d0df30ff2a18bb6ef4c94f28d48190124L268-L270)) for now, so that the gateway does not declare support for other currencies prior to the dashboard being ready to handle them (e.g. https://github.com/Automattic/woocommerce-payments/issues/1054, https://github.com/Automattic/woocommerce-payments/issues/1200, https://github.com/Automattic/woocommerce-payments/issues/1202). This check will be removed again in an upcoming release.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

After verifying that the WCPay payment method shows up on checkout when the currency is USD, set the cart currency to something other than USD (using an extension such as WooCommerce Multi-currency – see https://github.com/Automattic/woocommerce-payments/pull/1007's testing instructions) and verify that the payment method **does not** show up.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
