### PR TITLE
Currencies: allow non-usd order in dev-environment

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -265,7 +265,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return bool Whether the gateway is enabled and ready to accept payments.
 	 */
 	public function is_available() {
-		if ( 'USD' !== get_woocommerce_currency() ) {
+		if ( ! $this->is_in_dev_mode() && 'USD' !== get_woocommerce_currency() ) {
 			return false;
 		}
 


### PR DESCRIPTION
Follows up https://github.com/Automattic/woocommerce-payments/pull/1247

#### Changes proposed in this Pull Request

* Allows using the gateway for non-USD orders in dev environment

#### Testing instructions

* Change shop currency to e.g. EUR
* Create order
* Proceed to checkout and ensure block with card data inputs presented in your dev. system.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

