### PR TITLE
Add Gutenberg plugin to the test setup.

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -196,8 +196,21 @@ install_woocommerce() {
 	fi
 }
 
+install_gutenberg() {
+	INSTALLED_GUTENBERG_VERSION=$(wp plugin get gutenberg --field=version)
+
+	if [[ -n $INSTALLED_GUTENBERG_VERSION ]]; then
+		# Gutenberg is already installed, we just must update it to the latest stable version
+		wp plugin update gutenberg
+		wp plugin activate gutenberg
+	else
+		wp plugin install gutenberg --activate
+	fi
+}
+
 install_wp
 install_db
 configure_wp
 install_test_suite
+install_gutenberg
 install_woocommerce

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -128,6 +128,9 @@ cli wp core update-db --quiet
 echo "Updating permalink structure"
 cli wp rewrite structure '/%postname%/'
 
+echo "Installing and activating Gutenberg..."
+cli wp plugin install gutenberg --activate
+
 echo "Installing and activating WooCommerce..."
 cli wp plugin install woocommerce --activate
 


### PR DESCRIPTION
The Gutenberg plugin will use newer versions of the @wordpress/*
libraries, ahead of their use in WordPress core. This will help E2E
catch problems with the newer versions of the libraries (only for the
flows outlined our specs, of course).

Fixes #1233 

#### Changes proposed in this Pull Request

* Include Gutenberg plugin in both local and E2E tests similar to WooCommerce plugin

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch
* Run `npm run test`
* Gutenberg plugin should be installed while running tests

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
