### PR TITLE
Deposits summary and details: use proper currencies

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
 * Fix - Currency format in non-USD order note when capturing, refunding, and processing subscription renewal.
 * Update - Link customer name from transaction list page to WooCommerce's Customers page filtered by the customer's name.
+* Fix - Use proper currency information when rendering deposits overview and details.
 
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.

--- a/client/data/deposits/resolvers.js
+++ b/client/data/deposits/resolvers.js
@@ -24,6 +24,7 @@ const convertStripePayoutToDeposit = ( stripePayout ) => ( {
 	date: +new Date( stripePayout.arrival_date * 1000 ),
 	type: 0 < stripePayout.amount ? 'deposit' : 'withdrawal',
 	amount: stripePayout.amount,
+	currency: stripePayout.currency,
 	status: stripePayout.status,
 	bankAccount:
 		stripePayout.destination.bank_name &&

--- a/client/deposits/details/index.js
+++ b/client/deposits/details/index.js
@@ -69,7 +69,7 @@ export const DepositOverview = ( { depositId } ) => {
 						placeholder="Amount"
 						display="inline"
 					>
-						{ formatCurrency( deposit.amount ) }
+						{ formatCurrency( deposit.amount, deposit.currency ) }
 					</Loadable>
 				</div>
 			</div>

--- a/client/deposits/list/index.js
+++ b/client/deposits/list/index.js
@@ -83,7 +83,9 @@ export const DepositsList = () => {
 			},
 			amount: {
 				value: deposit.amount / 100,
-				display: clickable( formatCurrency( deposit.amount ) ),
+				display: clickable(
+					formatCurrency( deposit.amount, deposit.currency )
+				),
 			},
 			status: {
 				value: deposit.status,

--- a/client/deposits/overview/index.js
+++ b/client/deposits/overview/index.js
@@ -30,7 +30,7 @@ const formatDate = ( format, date ) =>
 const getAmount = ( obj ) => {
 	return formatCurrency(
 		obj ? obj.amount : 0,
-		obj && obj.currency ? obj.currency : null
+		obj && obj.currency ? obj.currency : undefined
 	);
 };
 const getDepositDate = ( deposit ) =>

--- a/client/deposits/overview/index.js
+++ b/client/deposits/overview/index.js
@@ -27,7 +27,12 @@ const formatDate = ( format, date ) =>
 		moment.utc( date ).toISOString(),
 		true // TODO Change call to gmdateI18n and remove this deprecated param once WP 5.4 support ends.
 	);
-const getAmount = ( obj ) => formatCurrency( obj ? obj.amount : 0 );
+const getAmount = ( obj, defaultCurrency ) => {
+	return formatCurrency(
+		obj ? obj.amount : 0,
+		obj ? obj.currency : defaultCurrency
+	);
+};
 const getDepositDate = ( deposit ) =>
 	deposit ? formatDate( 'F j, Y', deposit.date ) : '—';
 const getBalanceDepositCount = ( balance ) =>
@@ -189,7 +194,10 @@ const DepositsOverview = () => {
 									'Last deposit',
 									'woocommerce-payments'
 								) }
-								value={ getAmount( overview.last_deposit ) }
+								value={ getAmount(
+									overview.last_deposit,
+									overview.account.default_currency
+								) }
 								prevLabel={ getDepositDate(
 									overview.last_deposit
 								) }
@@ -208,7 +216,10 @@ const DepositsOverview = () => {
 									'Next deposit',
 									'woocommerce-payments'
 								) }
-								value={ getAmount( overview.next_deposit ) }
+								value={ getAmount(
+									overview.next_deposit,
+									overview.account.default_currency
+								) }
 								prevLabel={ getNextDepositLabelFormatted(
 									overview.next_deposit
 								) }
@@ -227,7 +238,10 @@ const DepositsOverview = () => {
 									'Pending balance',
 									'woocommerce-payments'
 								) }
-								value={ getAmount( overview.balance.pending ) }
+								value={ getAmount(
+									overview.balance.pending,
+									overview.account.default_currency
+								) }
 								prevLabel={ getBalanceDepositCount(
 									overview.balance.pending
 								) }
@@ -239,7 +253,8 @@ const DepositsOverview = () => {
 									'woocommerce-payments'
 								) }
 								value={ getAmount(
-									overview.balance.available
+									overview.balance.available,
+									overview.account.default_currency
 								) }
 								prevLabel=""
 							/>,

--- a/client/deposits/overview/index.js
+++ b/client/deposits/overview/index.js
@@ -28,7 +28,10 @@ const formatDate = ( format, date ) =>
 		true // TODO Change call to gmdateI18n and remove this deprecated param once WP 5.4 support ends.
 	);
 const getAmount = ( obj ) => {
-	return formatCurrency( obj ? obj.amount : 0, obj ? obj.currency : 'USD' );
+	return formatCurrency(
+		obj ? obj.amount : 0,
+		obj && obj.currency ? obj.currency : null
+	);
 };
 const getDepositDate = ( deposit ) =>
 	deposit ? formatDate( 'F j, Y', deposit.date ) : '—';

--- a/client/deposits/overview/index.js
+++ b/client/deposits/overview/index.js
@@ -27,10 +27,10 @@ const formatDate = ( format, date ) =>
 		moment.utc( date ).toISOString(),
 		true // TODO Change call to gmdateI18n and remove this deprecated param once WP 5.4 support ends.
 	);
-const getAmount = ( obj ) => {
+const getAmount = ( obj, defaultCurrency ) => {
 	return formatCurrency(
 		obj ? obj.amount : 0,
-		obj && obj.currency ? obj.currency : undefined
+		obj && obj.currency ? obj.currency : defaultCurrency
 	);
 };
 const getDepositDate = ( deposit ) =>
@@ -194,7 +194,10 @@ const DepositsOverview = () => {
 									'Last deposit',
 									'woocommerce-payments'
 								) }
-								value={ getAmount( overview.last_deposit ) }
+								value={ getAmount(
+									overview.last_deposit,
+									overview.account.default_currency
+								) }
 								prevLabel={ getDepositDate(
 									overview.last_deposit
 								) }
@@ -213,7 +216,10 @@ const DepositsOverview = () => {
 									'Next deposit',
 									'woocommerce-payments'
 								) }
-								value={ getAmount( overview.next_deposit ) }
+								value={ getAmount(
+									overview.next_deposit,
+									overview.account.default_currency
+								) }
 								prevLabel={ getNextDepositLabelFormatted(
 									overview.next_deposit
 								) }
@@ -232,7 +238,10 @@ const DepositsOverview = () => {
 									'Pending balance',
 									'woocommerce-payments'
 								) }
-								value={ getAmount( overview.balance.pending ) }
+								value={ getAmount(
+									overview.balance.pending,
+									overview.account.default_currency
+								) }
 								prevLabel={ getBalanceDepositCount(
 									overview.balance.pending
 								) }
@@ -244,7 +253,8 @@ const DepositsOverview = () => {
 									'woocommerce-payments'
 								) }
 								value={ getAmount(
-									overview.balance.available
+									overview.balance.available,
+									overview.account.default_currency
 								) }
 								prevLabel=""
 							/>,

--- a/client/deposits/overview/index.js
+++ b/client/deposits/overview/index.js
@@ -27,11 +27,8 @@ const formatDate = ( format, date ) =>
 		moment.utc( date ).toISOString(),
 		true // TODO Change call to gmdateI18n and remove this deprecated param once WP 5.4 support ends.
 	);
-const getAmount = ( obj, defaultCurrency ) => {
-	return formatCurrency(
-		obj ? obj.amount : 0,
-		obj ? obj.currency : defaultCurrency
-	);
+const getAmount = ( obj ) => {
+	return formatCurrency( obj ? obj.amount : 0, obj ? obj.currency : 'USD' );
 };
 const getDepositDate = ( deposit ) =>
 	deposit ? formatDate( 'F j, Y', deposit.date ) : '—';
@@ -194,10 +191,7 @@ const DepositsOverview = () => {
 									'Last deposit',
 									'woocommerce-payments'
 								) }
-								value={ getAmount(
-									overview.last_deposit,
-									overview.account.default_currency
-								) }
+								value={ getAmount( overview.last_deposit ) }
 								prevLabel={ getDepositDate(
 									overview.last_deposit
 								) }
@@ -216,10 +210,7 @@ const DepositsOverview = () => {
 									'Next deposit',
 									'woocommerce-payments'
 								) }
-								value={ getAmount(
-									overview.next_deposit,
-									overview.account.default_currency
-								) }
+								value={ getAmount( overview.next_deposit ) }
 								prevLabel={ getNextDepositLabelFormatted(
 									overview.next_deposit
 								) }
@@ -238,10 +229,7 @@ const DepositsOverview = () => {
 									'Pending balance',
 									'woocommerce-payments'
 								) }
-								value={ getAmount(
-									overview.balance.pending,
-									overview.account.default_currency
-								) }
+								value={ getAmount( overview.balance.pending ) }
 								prevLabel={ getBalanceDepositCount(
 									overview.balance.pending
 								) }
@@ -253,8 +241,7 @@ const DepositsOverview = () => {
 									'woocommerce-payments'
 								) }
 								value={ getAmount(
-									overview.balance.available,
-									overview.account.default_currency
+									overview.balance.available
 								) }
 								prevLabel=""
 							/>,

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -259,31 +259,27 @@ export const TransactionsList = ( props ) => {
 		);
 	} );
 
-	const summaryCurrency =
-		0 < transactions.length
-			? transactions[ 0 ].currency.toUpperCase()
-			: 'USD';
 	const summary = [
 		{ label: 'transactions', value: `${ transactionsSummary.count }` },
 		{
 			label: 'total',
 			value: `${ formatCurrency(
 				transactionsSummary.total,
-				summaryCurrency
+				transactionsSummary.currency
 			) }`,
 		},
 		{
 			label: 'fees',
 			value: `${ formatCurrency(
 				transactionsSummary.fees,
-				summaryCurrency
+				transactionsSummary.currency
 			) }`,
 		},
 		{
 			label: 'net',
 			value: `${ formatCurrency(
 				transactionsSummary.net,
-				summaryCurrency
+				transactionsSummary.currency
 			) }`,
 		},
 	];

--- a/readme.txt
+++ b/readme.txt
@@ -130,6 +130,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
 * Fix - Currency format in non-USD order note when capturing, refunding, and processing subscription renewal.
 * Update - Link customer name from transaction list page to WooCommerce's Customers page filtered by the customer's name.
+* Fix - Use proper currency information when rendering deposits overview and details.
 
 = 1.8.0 - 2020-12-16 =
 * Add - Include information about failing payment into order notes.


### PR DESCRIPTION
Fixes #1254

Relies on server PR 551

#### Changes proposed in this Pull Request

* Render the appropriate currency for values on the deposit overview page
* Where a value is 0 and we don't have a currency, use the account's default settlement currency

#### Testing instructions

* Make sure your server is running PR 551
* Visit the deposit summary page with a non-USD WCPay account
* Ensure the currency is shown correctly in each of the 4 overview sections and in the deposit list
* Check that the account's default currency is used when any of the values are 0
-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
