### PR TITLE
Fix wcpaySettings is not defined on the settings page

### DIFF
--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -276,6 +276,14 @@ class WC_Payments_Admin {
 			]
 		);
 
+		// wcpaySettings.zeroDecimalCurrencies must be included as part of the WCPAY_ADMIN_SETTINGS as
+		// it's used in the settings page by the AccountFees component.
+		wp_localize_script(
+			'WCPAY_ADMIN_SETTINGS',
+			'wcpaySettings',
+			[ 'zeroDecimalCurrencies' => WC_Payments_Utils::zero_decimal_currencies() ]
+		);
+
 		wp_register_style(
 			'WCPAY_ADMIN_SETTINGS',
 			plugins_url( 'dist/settings.css', WCPAY_PLUGIN_FILE ),


### PR DESCRIPTION
With the introduction of zero decimal currency support, the `AccountFees` component could not be rendered on the settings
page. That was caused due to `wcpaySettings` being added as part of the `WCPAY_DASH_APP` script, which is only enqueued on registered WC Admin pages.

This commit includes `wcpaySettings.zeroDecimalCurrencies` as part of the `WCPAY_ADMIN_SETTINGS`, fixing the error.

Fixes #1236 

#### Changes proposed in this Pull Request

* Add `wcpaySettings.zeroDecimalCurrencies` to the `WCPAY_ADMIN_SETTINGS` script

*I don't think we need to include a changelog because #1236 wasn't shipped yet, so no customers should run into this error.*

#### Testing instructions

1. Using `trunk`, navigate to the WC Pay settings page
2. The `Base fee` should not render and you should see a `Uncaught ReferenceError: wcpaySettings is not defined` in the console
3. Apply this branch and reload the settings page
4. Assert that the `Base fee` is rendered and no errors pop up in the JS console

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
