### PR TITLE
Render the correct currency symbol on the deposits detail page

### DIFF
--- a/client/data/deposits/resolvers.js
+++ b/client/data/deposits/resolvers.js
@@ -24,6 +24,7 @@ const convertStripePayoutToDeposit = ( stripePayout ) => ( {
 	date: +new Date( stripePayout.arrival_date * 1000 ),
 	type: 0 < stripePayout.amount ? 'deposit' : 'withdrawal',
 	amount: stripePayout.amount,
+	currency: stripePayout.currency,
 	status: stripePayout.status,
 	bankAccount:
 		stripePayout.destination.bank_name &&

--- a/client/deposits/details/index.js
+++ b/client/deposits/details/index.js
@@ -69,7 +69,7 @@ export const DepositOverview = ( { depositId } ) => {
 						placeholder="Amount"
 						display="inline"
 					>
-						{ formatCurrency( deposit.amount ) }
+						{ formatCurrency( deposit.amount, deposit.currency ) }
 					</Loadable>
 				</div>
 			</div>


### PR DESCRIPTION
Fixes #1255

#### Changes proposed in this Pull Request

The currency is already sent back from the server, so we simply pass the it through to the formatCurrency function

#### Testing instructions

Using a non-USD WooCommerce Payments account, make sure that the currency rendered on the payout details screen is correct.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)