### PR TITLE
Added new Connection_Exception class to be used to catch connection errors for better notices/logging

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 1.9.2 - 2021-xx-xx =
+* Fix - Added better notices for end users if there are connection errors when making payments. 
+
 = 1.9.1 - 2021-02-03 =
 * Fix - Incompatibility with WC Subscriptions.
 * Fix - Missing order causing broken transactions list.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -107,8 +107,9 @@ class WC_Payments {
 		include_once __DIR__ . '/class-wc-payments-db.php';
 		self::$db_helper = new WC_Payments_DB();
 
-		require_once __DIR__ . '/exceptions/class-base-exception.php';
-		require_once __DIR__ . '/exceptions/class-api-exception.php';
+		include_once __DIR__ . '/exceptions/class-base-exception.php';
+		include_once __DIR__ . '/exceptions/class-api-exception.php';
+		include_once __DIR__ . '/exceptions/class-connection-exception.php';
 
 		self::$api_client = self::create_api_client();
 
@@ -117,7 +118,6 @@ class WC_Payments {
 		include_once __DIR__ . '/class-logger.php';
 		include_once __DIR__ . '/class-wc-payment-gateway-wcpay.php';
 		include_once __DIR__ . '/class-wc-payments-token-service.php';
-		include_once __DIR__ . '/exceptions/class-base-exception.php';
 		include_once __DIR__ . '/exceptions/class-add-payment-method-exception.php';
 		include_once __DIR__ . '/exceptions/class-intent-authentication-exception.php';
 		include_once __DIR__ . '/exceptions/class-invalid-payment-method-exception.php';

--- a/includes/exceptions/class-connection-exception.php
+++ b/includes/exceptions/class-connection-exception.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Class Connection_Exception
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Exceptions;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class representing Connection_Exception
+ */
+class Connection_Exception extends API_Exception {
+}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -15,7 +15,7 @@ use WCPay\Logger;
  */
 class WC_Payments_API_Client {
 
-	const ENDPOINT_BASE          = 'https://public-api.wordpress.com/wpcom/v2';
+	const ENDPOINT_BASE          = 'https://public-api.wordpress.com:123/wpcom/v2';
 	const ENDPOINT_SITE_FRAGMENT = 'sites/%s';
 	const ENDPOINT_REST_BASE     = 'wcpay';
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -15,7 +15,7 @@ use WCPay\Logger;
  */
 class WC_Payments_API_Client {
 
-	const ENDPOINT_BASE          = 'https://public-api.wordpress.com:123/wpcom/v2';
+	const ENDPOINT_BASE          = 'https://public-api.wordpress.com/wpcom/v2';
 	const ENDPOINT_SITE_FRAGMENT = 'sites/%s';
 	const ENDPOINT_REST_BASE     = 'wcpay';
 

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -8,6 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use WCPay\Exceptions\API_Exception;
+use WCPay\Exceptions\Connection_Exception;
 use WCPay\Logger;
 
 /**
@@ -76,7 +77,7 @@ class WC_Payments_Http implements WC_Payments_Http_Interface {
 	 * @param string $body - The body passed to the HTTP request.
 	 *
 	 * @return array HTTP response on success.
-	 * @throws API_Exception - If request returns WP_Error.
+	 * @throws Connection_Exception - If request returns WP_Error.
 	 */
 	private static function make_request( $args, $body ) {
 		$response = Automattic\Jetpack\Connection\Client::remote_request( $args, $body );
@@ -88,7 +89,7 @@ class WC_Payments_Http implements WC_Payments_Http_Interface {
 				__( 'Http request failed. Reason: %1$s', 'woocommerce-payments' ),
 				$response->get_error_message()
 			);
-			throw new API_Exception( $message, 'wcpay_http_request_failed', 500 );
+			throw new Connection_Exception( $message, 'wcpay_http_request_failed', 500 );
 		}
 
 		return $response;

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 1.9.2 - 2021-xx-xx =
+* Fix - Added better notices for end users if there are connection errors when making payments. 
+
 = 1.9.1 - 2021-02-03 =
 * Fix - Incompatibility with WC Subscriptions.
 * Fix - Missing order causing broken transactions list.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -391,9 +391,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 
 	public function test_connection_exception_thrown() {
 		// Arrange: Reusable data.
-		$error_message = 'There was an error while processing the payment. If you continue to see this notice, please contact the admin.';
-		$order_id      = 123;
-		$total         = 12.23;
+		$error_message = 'Test error.';
+		$error_notice  = 'There was an error while processing the payment. If you continue to see this notice, please contact the admin.';
 
 		// Arrange: Create an order to test with.
 		$order = WC_Helper_Order::create_order();
@@ -419,22 +418,14 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		// Assert: Order status was updated.
 		$this->assertEquals( 'failed', $result_order->get_status() );
 
-		// Assert: Order transaction ID was not set.
-		$this->assertEquals( '', $result_order->get_meta( '_transaction_id' ) );
-
-		// Assert: Order meta was not updated with charge ID, intention status, or intent ID.
-		$this->assertEquals( '', $result_order->get_meta( '_intent_id' ) );
-		$this->assertEquals( '', $result_order->get_meta( '_charge_id' ) );
-		$this->assertEquals( '', $result_order->get_meta( '_intention_status' ) );
-
 		// Assert: No order note was added, besides the status change and failed transaction details.
 		$notes = wc_get_order_notes( [ 'order_id' => $result_order->get_id() ] );
 		$this->assertCount( 2, $notes );
 		$this->assertEquals( 'Order status changed from Pending payment to Failed.', $notes[1]->content );
-		$this->assertContains( 'A payment of &pound;50.00 failed to complete with the following message: ', strip_tags( $notes[0]->content, '' ) );
+		$this->assertContains( 'A payment of &pound;50.00 failed to complete with the following message: Test error.', strip_tags( $notes[0]->content, '' ) );
 
 		// Assert: A WooCommerce notice was added.
-		$this->assertTrue( wc_has_notice( $error_message, 'error' ) );
+		$this->assertTrue( wc_has_notice( $error_notice, 'error' ) );
 
 		// Assert: Returning correct array.
 		$this->assertEquals( 'fail', $result['result'] );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -6,6 +6,7 @@
  */
 
 use WCPay\Exceptions\API_Exception;
+use WCPay\Exceptions\Connection_Exception;
 
 /**
  * WC_Payment_Gateway_WCPay unit tests.
@@ -387,6 +388,59 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'fail', $result['result'] );
 		$this->assertEquals( '', $result['redirect'] );
 	}
+
+	public function test_connection_exception_thrown() {
+		// Arrange: Reusable data.
+		$error_message = 'There was an error while processing the payment. If you continue to see this notice, please contact the admin.';
+		$order_id      = 123;
+		$total         = 12.23;
+
+		// Arrange: Create an order to test with.
+		$order = WC_Helper_Order::create_order();
+
+		// Arrange: Throw an exception in create_and_confirm_intention.
+		$this->mock_api_client
+			->expects( $this->any() )
+			->method( 'create_and_confirm_intention' )
+			->will(
+				$this->throwException(
+					new Connection_Exception(
+						$error_message,
+						'wcpay_http_request_failed',
+						500
+					)
+				)
+			);
+
+		// Act: process payment.
+		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id(), false );
+		$result_order = wc_get_order( $order->get_id() );
+
+		// Assert: Order status was updated.
+		$this->assertEquals( 'failed', $result_order->get_status() );
+
+		// Assert: Order transaction ID was not set.
+		$this->assertEquals( '', $result_order->get_meta( '_transaction_id' ) );
+
+		// Assert: Order meta was not updated with charge ID, intention status, or intent ID.
+		$this->assertEquals( '', $result_order->get_meta( '_intent_id' ) );
+		$this->assertEquals( '', $result_order->get_meta( '_charge_id' ) );
+		$this->assertEquals( '', $result_order->get_meta( '_intention_status' ) );
+
+		// Assert: No order note was added, besides the status change and failed transaction details.
+		$notes = wc_get_order_notes( [ 'order_id' => $result_order->get_id() ] );
+		$this->assertCount( 2, $notes );
+		$this->assertEquals( 'Order status changed from Pending payment to Failed.', $notes[1]->content );
+		$this->assertContains( 'A payment of &pound;50.00 failed to complete with the following message: ', strip_tags( $notes[0]->content, '' ) );
+
+		// Assert: A WooCommerce notice was added.
+		$this->assertTrue( wc_has_notice( $error_message, 'error' ) );
+
+		// Assert: Returning correct array.
+		$this->assertEquals( 'fail', $result['result'] );
+		$this->assertEquals( '', $result['redirect'] );
+	}
+
 
 	/**
 	 * Test processing payment with the status "requires_action".


### PR DESCRIPTION
Fixes #670 

#### Changes proposed in this Pull Request

Added new Connection_Exception class to be used to catch connection errors for better notices/logging

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. You have to purposely break the API connection. We did this by adding port 123 to the `ENDPOINT_BASE`, like shown here: https://github.com/Automattic/woocommerce-payments/commit/6536ccac84ade444c45b0db5b72a9f7782b8e15f
2. Once that is done, add an item to your cart.
3. Proceed to checkout, and attempt to check out.
4. Receive error notice.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
