### PR TITLE
Fixed broken transactions listing when order is missing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.9.1 - 2021-xx-xx =
 * Fix - Incompatibility with WC Subscriptions.
+* Fix - Missing order causing broken transactions list.
 
 = 1.9.0 - 2021-02-02 =
 * Add - Improved fraud prevention.

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -171,7 +171,7 @@ export const TransactionsList = ( props ) => {
 			] );
 		const riskLevel = <RiskLevel risk={ txn.risk_level } />;
 
-		const customerUrl = txn.order.customer_url;
+		const customerUrl = txn.order ? txn.order.customer_url : '#';
 		const customerName = <a href={ customerUrl }>{ txn.customer_name }</a>;
 		const customerEmail = (
 			<a href={ customerUrl }>{ txn.customer_email }</a>

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 1.9.1 - 2021-xx-xx =
 * Fix - Incompatibility with WC Subscriptions.
+* Fix - Missing order causing broken transactions list.
 
 = 1.9.0 - 2021-02-02 =
 * Add - Improved fraud prevention.


### PR DESCRIPTION
Fixes a JS error reported by @jrodger (some transactions might have no orders matching in a shop, e.g. local dev=envoroment).
```log
Uncaught (in promise) TypeError: Cannot read property 'customer_url' of null
    at index.js:177
    at Array.map (<anonymous>)
    at TransactionsList (index.js:155)
    at renderWithHooks (react-dom.js?ver=16.13.1:14938)
    at updateFunctionComponent (react-dom.js?ver=16.13.1:17169)
    at beginWork (react-dom.js?ver=16.13.1:18745)
    at HTMLUnknownElement.callCallback (react-dom.js?ver=16.13.1:182)
    at Object.invokeGuardedCallbackDev (react-dom.js?ver=16.13.1:231)
    at invokeGuardedCallback (react-dom.js?ver=16.13.1:286)
    at beginWork$1 (react-dom.js?ver=16.13.1:23338)
```

#### Changes proposed in this Pull Request

- Hardened customer URL generation

#### Testing instructions

* Transactions listing should work when jumping between Stripe accounts

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

