### PR TITLE
Fix woocommerce_update_order incompatibility with WC Subscriptions 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 1.9.1 - 2021-xx-xx =
+* Fix - Incompatibility with WC Subscriptions.
+
 = 1.9.0 - 2021-02-02 =
 * Add - Improved fraud prevention.
 * Add - New setting to manage whether to enable saving cards during checkout. (Defaults to being enabled).

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1605,13 +1605,19 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * When an order is created, we want to add an ActionScheduler job to send this data to
 	 * the payment server.
 	 *
-	 * @param int      $order_id  The ID of the order that has been created.
-	 * @param WC_Order $order     The order that has been created.
+	 * @param int           $order_id  The ID of the order that has been created.
+	 * @param WC_Order|null $order     The order that has been created.
 	 */
-	public function schedule_order_tracking( $order_id, $order ) {
+	public function schedule_order_tracking( $order_id, $order = null ) {
 		// If Sift is not enabled, exit out and don't do the tracking here.
 		if ( ! isset( $this->account->get_fraud_services_config()['sift'] ) ) {
 			return;
+		}
+
+		// Sometimes the woocommerce_update_order hook might be called with just the order ID parameter,
+		// so we need to fetch the order here.
+		if ( is_null( $order ) ) {
+			$order = wc_get_order( $order_id );
 		}
 
 		// We only want to track orders created by our payment gateway.

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 1.9.1 - 2021-xx-xx =
+* Fix - Incompatibility with WC Subscriptions.
+
 = 1.9.0 - 2021-02-02 =
 * Add - Improved fraud prevention.
 * Add - New setting to manage whether to enable saving cards during checkout. (Defaults to being enabled).


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

* Make the `$order` parameter optional in `schedule_order_tracking` to avoid issues when `woocommerce_update_order` is called with just the `$order_id`

#### Testing instructions

1. Purchase a Subscriptions product
2. Assert that no errors happen during checkout
3. Purchase a regular product
4. Assert that no errors happen during checkout
5. Enable the fraud prevention integration on a sandbox or local server
6. Make sure checkout and order creation works for Subscriptions and Simple products

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
