### PR TITLE
Transactions: render customer details as text when order is missing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 2.0.0 - 2021-xx-xx =
+* Update - Render customer details in transactions list as text instead of link if order missing.
+
 = 1.9.2 - 2021-xx-xx =
 * Fix - Added better notices for end users if there are connection errors when making payments. 
 * Fix - If account is set to manual payouts display 'Temporarily suspended' under Payments > Settings.

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -171,10 +171,15 @@ export const TransactionsList = ( props ) => {
 			] );
 		const riskLevel = <RiskLevel risk={ txn.risk_level } />;
 
-		const customerUrl = txn.order ? txn.order.customer_url : '#';
-		const customerName = <a href={ customerUrl }>{ txn.customer_name }</a>;
-		const customerEmail = (
-			<a href={ customerUrl }>{ txn.customer_email }</a>
+		const customerName = txn.order ? (
+			<a href={ txn.order.customer_url }>{ txn.customer_name }</a>
+		) : (
+			txn.customer_name
+		);
+		const customerEmail = txn.order ? (
+			<a href={ txn.order.customer_url }>{ txn.customer_email }</a>
+		) : (
+			txn.customer_email
 		);
 
 		const deposit = (

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 2.0.0 - 2021-xx-xx =
+* Update - Render customer details in transactions list as text instead of link if order missing.
+
 = 1.9.2 - 2021-xx-xx =
 * Fix - Added better notices for end users if there are connection errors when making payments. 
 * Fix - If account is set to manual payouts display 'Temporarily suspended' under Payments > Settings.


### PR DESCRIPTION
Follow up of https://github.com/Automattic/woocommerce-payments/pull/1270, if an order is missing we are rendering customer details as text instead of a link.

#### Changes proposed in this Pull Request

See above

#### Testing instructions

- In `\WC_Payments_API_Client::add_order_info_to_object` replace `if ( $order )` to `if ( false )`
- Open transactions list. Customer and Email columns expected to render as text
- Revert changes in `\WC_Payments_API_Client::add_order_info_to_object`
- Open transactions list. Customer and Email columns expected to render as link if order is presented

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)


