### PR TITLE
Add connection tokens endpoint

### DIFF
--- a/includes/admin/class-wc-rest-payments-connection-tokens-controller.php
+++ b/includes/admin/class-wc-rest-payments-connection-tokens-controller.php
@@ -40,6 +40,17 @@ class WC_REST_Payments_Connection_Tokens_Controller extends WC_Payments_REST_Con
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	public function create_token( $request ) {
-		return $this->forward_request( 'create_token', [ $request ] );
+		$response = $this->forward_request( 'create_token', [ $request ] );
+
+		// As an aid to mobile clients, tuck in the test_mode flag in the response returned to the request.
+		if ( is_a( $response, 'WP_REST_Response' ) ) {
+			if ( property_exists( $response, 'data' ) ) {
+				if ( is_array( $response->data ) ) {
+					$response->data['test_mode'] = WC_Payments::get_gateway()->is_in_test_mode();
+				}
+			}
+		}
+
+		return $response;
 	}
 }

--- a/includes/admin/class-wc-rest-payments-connection-tokens-controller.php
+++ b/includes/admin/class-wc-rest-payments-connection-tokens-controller.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Class WC_REST_Payments_Connection_Tokens_Controller
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST controller for disputes.
+ */
+class WC_REST_Payments_Connection_Tokens_Controller extends WC_Payments_REST_Controller {
+
+	/**
+	 * Endpoint path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'payments/connection_tokens';
+
+	/**
+	 * Configure REST API routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/payments/connection_tokens',
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'create_token' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+	}
+
+	/**
+	 * Create a connection token via API.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public function create_token( $request ) {
+		return $this->forward_request( 'create_token', [ $request ] );
+	}
+}

--- a/includes/admin/class-wc-rest-payments-connection-tokens-controller.php
+++ b/includes/admin/class-wc-rest-payments-connection-tokens-controller.php
@@ -8,7 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * REST controller for disputes.
+ * REST controller for terminal tokens.
  */
 class WC_REST_Payments_Connection_Tokens_Controller extends WC_Payments_REST_Controller {
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -460,6 +460,10 @@ class WC_Payments {
 		$charges_controller = new WC_REST_Payments_Charges_Controller( self::$api_client );
 		$charges_controller->register_routes();
 
+		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-connection-tokens-controller.php';
+		$conn_tokens_controller = new WC_REST_Payments_Connection_Tokens_Controller( self::$api_client, self::$gateway, self::$account );
+		$conn_tokens_controller->register_routes();
+
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-timeline-controller.php';
 		$timeline_controller = new WC_REST_Payments_Timeline_Controller( self::$api_client );
 		$timeline_controller->register_routes();

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -26,6 +26,7 @@ class WC_Payments_API_Client {
 
 	const ACCOUNTS_API        = 'accounts';
 	const CHARGES_API         = 'charges';
+	const CONN_TOKENS_API     = 'terminal/connection_tokens';
 	const CUSTOMERS_API       = 'customers';
 	const INTENTIONS_API      = 'intentions';
 	const REFUNDS_API         = 'refunds';
@@ -601,6 +602,29 @@ class WC_Payments_API_Client {
 				$e->get_http_code()
 			);
 		}
+	}
+
+	/**
+	 * Create a connection token.
+	 *
+	 * @param string $request request object received.
+	 *
+	 * @return array
+	 * @throws API_Exception - If request throws.
+	 */
+	public function create_token( $request ) {
+		$response = $this->request( [], self::CONN_TOKENS_API, self::POST );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		// As an aid to mobile clients, tuck in the test_mode flag (added by the request method call above) in the response.
+		if ( is_array( $response ) ) {
+			$response['test_mode'] = WC_Payments::get_gateway()->is_in_test_mode();
+		}
+
+		return $response;
 	}
 
 	/**

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -613,18 +613,7 @@ class WC_Payments_API_Client {
 	 * @throws API_Exception - If request throws.
 	 */
 	public function create_token( $request ) {
-		$response = $this->request( [], self::CONN_TOKENS_API, self::POST );
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		// As an aid to mobile clients, tuck in the test_mode flag (added by the request method call above) in the response.
-		if ( is_array( $response ) ) {
-			$response['test_mode'] = WC_Payments::get_gateway()->is_in_test_mode();
-		}
-
-		return $response;
+		return $this->request( [], self::CONN_TOKENS_API, self::POST );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1260

#### Changes proposed in this Pull Request

Adds to the WooCommerce Payments a forwarding endpoint for connection tokens, for use by mobile apps.

#### Testing instructions

- Build the plugin ZIP using `npm install` and `npm run build`
- Install on a site with a WooCommerce Payments account in test or dev mode
- Upload the following test plugin to the site (e.g. into wp-content/plugins/wcpay-test/wcpay-test.php)

```
<?php
/*
Plugin Name: WCPay Test
*/

function wcpay_test_notice() {
?>
        <div class="notice">
                <span class="wcpaytest">Loading...</span>
        <script>
                jQuery( document ).ready( function() {
                        jQuery(".wcpaytest").html( "Requesting..." );
                        jQuery.ajax({
                                url: "/wp-json/wc/v3/payments/connection_tokens",
                                method: 'POST',
                                beforeSend: function ( xhr ) {
                                        xhr.setRequestHeader( 'X-WP-Nonce', wpApiSettings.nonce );
                                }
                        })
                        .done( function( data ) {
                                var dataAsJSON = JSON.stringify( data );
                                jQuery(".wcpaytest").html( 'Success: ' + dataAsJSON );
                        })
                        .fail( function( xhr, textStatus, msg ) {
                                jQuery(".wcpaytest").html( 'Error: ' + textStatus + ' ' + msg );
                        });
                });
                </script>
        </div>
<?php
}

add_action( 'admin_notices', 'wcpay_test_notice' );
```

- Activate the test plugin and proceed to a wp-admin page (e.g. the Plugins page)
- Ensure the test plugin is able to fetch a connection token for the site (it will be dispayed in a notice near the top of the page)
- Ensure that the site test mode is correctly reflected
- Repeat on a site with a live WooCommerce Payments account
- Ensure that the site test mode is correctly reflected
- Repeat on a site which has never had a WooCommerce Payments account
- Ensure that the endpoint returns an error

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

cc @ctarda 
