### PR TITLE
Add payment features configuration to WooCommerce Blocks registration.

### DIFF
--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -34,6 +34,9 @@ registerPaymentMethod(
 			paymentMethodId: PAYMENT_METHOD_NAME,
 			label: __( 'Credit Card', 'woocommerce-payments' ),
 			ariaLabel: __( 'Credit Card', 'woocommerce-payments' ),
+			supports: {
+				features: getConfig( 'features' ),
+			},
 		} )
 );
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -328,6 +328,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'createSetupIntentNonce' => wp_create_nonce( 'wcpay_create_setup_intent_nonce' ),
 			'genericErrorMessage'    => __( 'There was a problem processing the payment. Please check your email inbox and refresh the page to try again.', 'woocommerce-payments' ),
 			'fraudServices'          => $this->account->get_fraud_services_config(),
+			'features'               => $this->supports,
 		];
 	}
 


### PR DESCRIPTION
Fixes partially  #1284 ( this Issue has also two separate bugs described )

#### Changes proposed in this Pull Request
Add features configuration to payment method registration for WooCommerce Blocks integration.
Changes in WooCommerce blocks require payment methods to register supported features array. This is used by the Cart and Checkout block to decide if a particular payment method can be used for the items in the cart.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
This should be tested with WooCommerce Blocks 4.4.0

* The error from #1284 should be gone and the payments should work.

### Warning
I have not tested this, I don't have a wcommerce-payments setup. 

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
