### PR TITLE
Use checkout block config when wcpay_config global is not defined

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Fix - If account is set to manual payouts display 'Temporarily suspended' under Payments > Settings.
 * Add - Add file dropzones to dispute evidence upload fields
 * Fix - Checkout and cart blocks aren't usable when WooCommerce Payments is enabled.
+* Fix - Missing global config error in Checkout block integration, and incompatibility with latest block API.
 
 = 1.9.1 - 2021-02-03 =
 * Fix - Incompatibility with WC Subscriptions.

--- a/client/utils/checkout.js
+++ b/client/utils/checkout.js
@@ -10,7 +10,10 @@ export const getConfig = ( name ) => {
 	// Classic checkout or blocks-based one.
 	const config =
 		// eslint-disable-next-line camelcase
-		wcpay_config || wc.wcSettings.getSetting( 'woocommerce_payments_data' );
+		'undefined' !== typeof wcpay_config
+			? // eslint-disable-next-line camelcase
+			  wcpay_config
+			: wc.wcSettings.getSetting( 'woocommerce_payments_data' );
 
 	return config[ name ] || null;
 };

--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,8 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Added better notices for end users if there are connection errors when making payments. 
 * Fix - If account is set to manual payouts display 'Temporarily suspended' under Payments > Settings.
 * Add - Add file dropzones to dispute evidence upload fields
+* Fix - Checkout and cart blocks aren't usable when WooCommerce Payments is enabled.
+* Fix - Missing global config error in Checkout block integration, and incompatibility with latest block API.
 
 = 1.9.1 - 2021-02-03 =
 * Fix - Incompatibility with WC Subscriptions.


### PR DESCRIPTION
Fixes first bullet of #1284

Branched off of https://github.com/Automattic/woocommerce-payments/pull/1285 (so that the payment method shows up, instead of just throwing a different error)

#### Changes proposed in this Pull Request

Hardens the check for `wcpay_config` when retrieving config, in the case where it isn't defined at all (which can be the case for the blocks integration, despite `global` declaration at top of file).

(_Edit:_ as @RadoslavGeorgiev points out in https://github.com/Automattic/woocommerce-payments/issues/1284#issuecomment-774084049, this simply restores the behavior from 1.8.0 and earlier.)

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In the Checkout block with WCPay enabled, verify that the "Credit card" payment method shows up.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
