### PR TITLE
Register Stripe JS before using it as a dependency in block checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Fix - Added better notices for end users if there are connection errors when making payments.
 * Fix - If account is set to manual payouts display 'Temporarily suspended' under Payments > Settings.
 * Add - Add file dropzones to dispute evidence upload fields
+* Fix - Checkout and cart blocks aren't usable when WooCommerce Payments is enabled.
 
 = 1.9.1 - 2021-02-03 =
 * Fix - Incompatibility with WC Subscriptions.

--- a/includes/class-wc-payments-blocks-payment-method.php
+++ b/includes/class-wc-payments-blocks-payment-method.php
@@ -35,6 +35,14 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 	 */
 	public function get_payment_method_script_handles() {
 		wp_register_script(
+			'stripe',
+			'https://js.stripe.com/v3/',
+			[],
+			'3.0',
+			true
+		);
+
+		wp_register_script(
 			'wc-payment-method-wcpay',
 			plugins_url( 'dist/blocks-checkout.js', WCPAY_PLUGIN_FILE ),
 			[ 'stripe' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Since reworking how some of our JavaScript gets enqueued in https://github.com/Automattic/woocommerce-payments/pull/1207 the checkout block was failing to load in the page editor due to a missing Stripe JS dependency.

This PR explicitly registers the required Stripe JavaScript before adding it as a dependency to the block integration code.

#### Testing instructions
* Edit any page and try adding the WooCommerce checkout and cart blocks
* Make a purchase through the block checkout

We don't have automated tests for the block checkout, we should develop some, but it's outside the scope of this fix.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)