### PR TITLE
Action Scheduler Logic Updates for Order Create/Update Events

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 2.0.0 - 2021-xx-xx =
 * Update - Render customer details in transactions list as text instead of link if order missing.
 * Update - Render transaction summary on details page for multi-currency transactions.
+* Update - Improvements to fraud prevention.
 * Fix - Added better notices for end users if there are connection errors when making payments.
 * Fix - If account is set to manual payouts display 'Temporarily suspended' under Payments > Settings.
 * Add - Add file dropzones to dispute evidence upload fields

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1636,12 +1636,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return;
 		}
 
+		// Check whether this is an order we haven't previously tracked a creation event for.
 		if ( $order->get_meta( '_new_order_tracking_complete' ) !== 'yes' ) {
 			// Schedule the action to send this information to the payment server.
 			$this->action_scheduler_service->schedule_job(
-				strtotime( 'now' ),
+				strtotime( '+10 seconds' ),
 				'wcpay_track_new_order',
-				[ array_merge( $order->get_data(), [ '_intent_id' => $order->get_meta( '_intent_id' ) ] ) ],
+				[ $order_id ],
 				self::GATEWAY_ID
 			);
 
@@ -1649,11 +1650,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$order->add_meta_data( '_new_order_tracking_complete', 'yes' );
 			$order->save_meta_data();
 		} else {
-			// Schedule an update action.
+			// Schedule an update action to send this information to the payment server.
 			$this->action_scheduler_service->schedule_job(
-				strtotime( 'now' ),
+				strtotime( '+10 seconds' ),
 				'wcpay_track_update_order',
-				[ array_merge( $order->get_data(), [ '_intent_id' => $order->get_meta( '_intent_id' ) ] ) ],
+				[ $order_id ],
 				self::GATEWAY_ID
 			);
 		}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1642,7 +1642,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$this->action_scheduler_service->schedule_job(
 				strtotime( '+10 seconds' ),
 				'wcpay_track_new_order',
-				[ $order_id ],
+				[ 'order_id' => $order_id ],
 				self::GATEWAY_ID
 			);
 
@@ -1654,7 +1654,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$this->action_scheduler_service->schedule_job(
 				strtotime( '+10 seconds' ),
 				'wcpay_track_update_order',
-				[ $order_id ],
+				[
+					'order_id'      => $order_id,
+					'date_modified' => $order->get_date_modified(),
+				],
 				self::GATEWAY_ID
 			);
 		}

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -61,7 +61,7 @@ class WC_Payments_Action_Scheduler_Service {
 		// Send the order data to the Payments API to track it.
 		$result = $this->payments_api_client->track_order(
 			array_merge( $order->get_data(), [ '_intent_id' => $order->get_meta( '_intent_id' ) ] ),
-			true
+			false
 		);
 
 		return $result;
@@ -93,7 +93,9 @@ class WC_Payments_Action_Scheduler_Service {
 	}
 
 	/**
-	 * Schedule an action scheduler job.
+	 * Schedule an action scheduler job. Also unschedules (replaces) any previous instances of the same job.
+	 * This prevents duplicate jobs, for example when multiple events fire as part of the order update process.
+	 * The `as_unschedule_action` function will only replace a job which has the same $hook, $args AND $group.
 	 *
 	 * @param int    $timestamp - When the job will run.
 	 * @param string $hook      - The hook to trigger.

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -46,17 +46,23 @@ class WC_Payments_Action_Scheduler_Service {
 	 * This function is a hook that will be called by ActionScheduler when an order is created.
 	 * It will make a request to the Payments API to track this event.
 	 *
-	 * @param array $order_data  The data for the order which has been created.
+	 * @param array $order_id  The ID of the order that has been created.
 	 *
 	 * @return bool
 	 */
-	public function track_new_order_action( $order_data ) {
-		// Ensure that we have the order data to send.
-		if ( empty( $order_data ) ) {
+	public function track_new_order_action( $order_id ) {
+		// Get the order details.
+		$order = wc_get_order( $order_id );
+
+		if ( ! $order ) {
 			return false;
 		}
 
-		$result = $this->payments_api_client->track_order( $order_data, false );
+		// Send the order data to the Payments API to track it.
+		$result = $this->payments_api_client->track_order(
+			array_merge( $order->get_data(), [ '_intent_id' => $order->get_meta( '_intent_id' ) ] ),
+			true
+		);
 
 		return $result;
 	}
@@ -65,17 +71,23 @@ class WC_Payments_Action_Scheduler_Service {
 	 * This function is a hook that will be called by ActionScheduler when an order is updated.
 	 * It will make a request to the Payments API to track this event.
 	 *
-	 * @param array $order_data  The data for the order which has been updated.
+	 * @param int $order_id  The ID of the order which has been updated.
 	 *
 	 * @return bool
 	 */
-	public function track_update_order_action( $order_data ) {
-		// Ensure that we have the order data to send.
-		if ( empty( $order_data ) ) {
+	public function track_update_order_action( $order_id ) {
+		// Get the order details.
+		$order = wc_get_order( $order_id );
+
+		if ( ! $order ) {
 			return false;
 		}
 
-		$result = $this->payments_api_client->track_order( $order_data, true );
+		// Send the order data to the Payments API to track it.
+		$result = $this->payments_api_client->track_order(
+			array_merge( $order->get_data(), [ '_intent_id' => $order->get_meta( '_intent_id' ) ] ),
+			true
+		);
 
 		return $result;
 	}
@@ -91,6 +103,10 @@ class WC_Payments_Action_Scheduler_Service {
 	 * @return void
 	 */
 	public function schedule_job( $timestamp, $hook, $args = [], $group = '' ) {
+		// Unschedule any previously scheduled instances of this particular job.
+		as_unschedule_action( $hook, $args, $group );
+
+		// Schedule the job.
 		as_schedule_single_action( $timestamp, $hook, $args, $group );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ Please note that our support for the checkout block is still experimental and th
 = 2.0.0 - 2021-xx-xx =
 * Update - Render customer details in transactions list as text instead of link if order missing.
 * Update - Render transaction summary on details page for multi-currency transactions.
+* Update - Improvements to fraud prevention.
 * Fix - Added better notices for end users if there are connection errors when making payments. 
 * Fix - If account is set to manual payouts display 'Temporarily suspended' under Payments > Settings.
 * Add - Add file dropzones to dispute evidence upload fields

--- a/tests/unit/test-class-wc-payments-action-scheduler-service.php
+++ b/tests/unit/test-class-wc-payments-action-scheduler-service.php
@@ -37,14 +37,6 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 		$this->action_scheduler_service = new WC_Payments_Action_Scheduler_Service( $this->mock_api_client );
 	}
 
-	public function test_track_new_order_action_with_invalid_order_id() {
-		$this->assertFalse( $this->action_scheduler_service->track_new_order_action( -4 ) );
-	}
-
-	public function test_track_update_order_action_with_invalid_order_id() {
-		$this->assertFalse( $this->action_scheduler_service->track_update_order_action( -4 ) );
-	}
-
 	public function test_track_new_order_action() {
 		$order = WC_Helper_Order::create_order();
 
@@ -56,6 +48,16 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 		$this->assertTrue( $this->action_scheduler_service->track_new_order_action( $order->get_id() ) );
 	}
 
+	public function test_track_new_order_action_with_invalid_order_id() {
+		$this->assertFalse( $this->action_scheduler_service->track_new_order_action( -4 ) );
+	}
+
+	public function test_track_new_order_action_with_invalid_input() {
+		$order = WC_Helper_Order::create_order();
+
+		$this->assertFalse( $this->action_scheduler_service->track_new_order_action( $order->get_data() ) );
+	}
+
 	public function test_track_update_order_action() {
 		$order = WC_Helper_Order::create_order();
 
@@ -65,6 +67,16 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 			->willReturn( true );
 
 		$this->assertTrue( $this->action_scheduler_service->track_update_order_action( $order->get_id() ) );
+	}
+
+	public function test_track_update_order_action_with_invalid_order_id() {
+		$this->assertFalse( $this->action_scheduler_service->track_update_order_action( -4 ) );
+	}
+
+	public function test_track_update_order_action_with_invalid_input() {
+		$order = WC_Helper_Order::create_order();
+
+		$this->assertFalse( $this->action_scheduler_service->track_update_order_action( $order->get_data() ) );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-action-scheduler-service.php
+++ b/tests/unit/test-class-wc-payments-action-scheduler-service.php
@@ -37,12 +37,12 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 		$this->action_scheduler_service = new WC_Payments_Action_Scheduler_Service( $this->mock_api_client );
 	}
 
-	public function test_track_new_order_action_with_empty_order() {
-		$this->assertFalse( $this->action_scheduler_service->track_new_order_action( [] ) );
+	public function test_track_new_order_action_with_invalid_order_id() {
+		$this->assertFalse( $this->action_scheduler_service->track_new_order_action( -4 ) );
 	}
 
-	public function test_track_update_order_action_with_empty_order() {
-		$this->assertFalse( $this->action_scheduler_service->track_update_order_action( [] ) );
+	public function test_track_update_order_action_with_invalid_order_id() {
+		$this->assertFalse( $this->action_scheduler_service->track_update_order_action( -4 ) );
 	}
 
 	public function test_track_new_order_action() {
@@ -50,10 +50,10 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 		$this->mock_api_client->expects( $this->once() )
 			->method( 'track_order' )
-			->with( $order->get_data(), false )
+			->with( $this->get_order_data_mock( $order->get_id() ), false )
 			->willReturn( true );
 
-		$this->assertTrue( $this->action_scheduler_service->track_new_order_action( $order->get_data() ) );
+		$this->assertTrue( $this->action_scheduler_service->track_new_order_action( $order->get_id() ) );
 	}
 
 	public function test_track_update_order_action() {
@@ -61,9 +61,23 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 		$this->mock_api_client->expects( $this->once() )
 			->method( 'track_order' )
-			->with( $order->get_data(), true )
+			->with( $this->get_order_data_mock( $order->get_id() ), true )
 			->willReturn( true );
 
-		$this->assertTrue( $this->action_scheduler_service->track_update_order_action( $order->get_data() ) );
+		$this->assertTrue( $this->action_scheduler_service->track_update_order_action( $order->get_id() ) );
+	}
+
+	/**
+	 * Get a mock of the order data expected to be passed into the `track_order` function.
+	 *
+	 * @return array
+	 */
+	private function get_order_data_mock( $order_id ) {
+		$order = wc_get_order( $order_id );
+
+		return array_merge(
+			$order->get_data(),
+			[ '_intent_id' => $order->get_meta( '_intent_id' ) ]
+		);
 	}
 }


### PR DESCRIPTION
Fixes #1292

#### Changes proposed in this Pull Request

Action Scheduler Logic Updates for Order Create/Update Events

This PR addresses the issue that multiple update order events are fired off during the process of updating an event. This leads to us sending more requests than necessary to our server and to fraud integrations. The solution is to replace the previous ActionScheduler job for a particular hook/args combo every time the event gets fired. This means that if an update is made, when the 3 calls to the update hook get made, only the **last** update event will actually get sent to our server. This is the desired behaviour, because the first 2 events are not guaranteed to actually contain the changes (they are fired before the updated event is actually saved). 

#### Testing instructions

* Pull the latest server `trunk` and make sure that WC Payments is pointed at your sandbox and that the Sandbox is set up to process async jobs and has the necessary SIFT constants by following the instructions here: 554-gh-Automattic/woocommerce-payments-server.
* Checkout trunk, create an order via the checkout process, and then go to **WooCommerce > Orders** and make an edit to the order (for example, updating the shipping address). Note the order ID.
* Go to **Tools > Scheduled Actions** and verify that there are ~3 pending actions with the hook `wcpay_track_update_order` and the order ID as the `arg`. (note that on trunk, this will also have all of the other order data in an array as the `arg` value.
* Checkout this branch. Repeat this process, making another new order and then making an update to it. 
* Verify that there is only 1 pending action with the hook `wcpay_track_update_order` and the order ID as the `arg`.
* Make another update to the same order. Verify that another pending action was created in **Tools > Scheduled Actions**. There should now be two, one from the original update you made, and one from this update. They should both have different timestamps.
* Click "Run" under the pending action(s) and verify that the job appears in your sandbox watcher file, and then goes to the [Sift API console](https://console.sift.com) (these should appear in the API logs).

#### Note

There is a known issue where some Subscriptions related events (usually related to user related actions on Subscriptions, such as renewing/cancelling a subscription, or dealing with a free trial of a subscription) do not get tracked as expected. There is [a PR](https://github.com/Automattic/woocommerce-payments/pull/1312) in place to resolve this, but I think that we should get this PR resolved first because #1312 also requires server changes and is awaiting completion of tests which are currently in progress.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) 

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->