### PR TITLE
Fix rendering amount in multi-currency transaction summary

### DIFF
--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -82,7 +82,7 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 	const balance = charge.amount
 		? getChargeAmounts( charge )
 		: placeholderValues;
-	const renderCustomerPrice =
+	const renderStorePrice =
 		charge.currency && balance.currency !== charge.currency;
 
 	return (
@@ -94,12 +94,9 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 							isLoading={ isLoading }
 							placeholder="Amount placeholder"
 						>
-							{ formatCurrency(
-								balance.amount,
-								balance.currency
-							) }
+							{ formatCurrency( charge.amount, charge.currency ) }
 							<span className="payment-details-summary__amount-currency">
-								{ balance.currency }
+								{ charge.currency || 'USD' }
 							</span>
 							<PaymentStatusChip
 								status={ getChargeStatus( charge ) }
@@ -107,13 +104,13 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 						</Loadable>
 					</p>
 					<div className="payment-details-summary__breakdown">
-						{ renderCustomerPrice ? (
+						{ renderStorePrice ? (
 							<p>
 								{ formatCurrency(
-									charge.amount,
-									charge.currency
+									balance.amount,
+									balance.currency
 								) }{ ' ' }
-								{ ( charge.currency || 'USD' ).toUpperCase() }
+								{ balance.currency.toUpperCase() }
 							</p>
 						) : null }
 						{ balance.refunded ? (


### PR DESCRIPTION
Relates to #1054 

#### Changes proposed in this Pull Request

Swap transaction amount values in summary for multi-currency transaction: display customer currency as main value and store currency in breakdown.

<img width="350" alt="Screen Shot 2021-02-08 at 3 10 52 PM" src="https://user-images.githubusercontent.com/3139099/107325501-e1d18c80-6aba-11eb-85da-8b0e60a3c371.png">

#### Testing instructions

* Create transaction with any currency different from store currency (USD by default), or open existing transaction details. (see #1228 for instructions if needed).
* Check the summary view matches designs (pc2DNy-9L-p2).

Changelog entry is not needed because there is already one added with #1228.
No new tests needed as well.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->