### PR TITLE
Fix "Stripe.js loaded more than one time" warning

### DIFF
--- a/client/fraud-scripts/index.js
+++ b/client/fraud-scripts/index.js
@@ -20,7 +20,7 @@ export default ( config ) => {
 			service.init( config[ serviceName ] );
 		}
 
-		if ( ! document.querySelector( `[src="${ service.src }"]` ) ) {
+		if ( ! document.querySelector( `[src^="${ service.src }"]` ) ) {
 			const script = document.createElement( 'script' );
 			script.src = service.src;
 			script.async = true;


### PR DESCRIPTION
The "fraud scripts loader" JS checks that a given fraud script (in this case, `Stripe.js`) isn't already present in the page. For that, it checked if there was a script with the same `src` attribute. However, the Stripe.js script is enqueued from PHP using a cache-busting querystring param: `https://js.stripe.com/v3/?ver=3.0` , so the logic to prevent duplication wasn't working.

The solution in the short-term is to relax the matching, using the "attribute starts with" CSS selector instead of the "attribute matches exactly" selector. The longer-term solution is to scrap this "fraud loader system" entirely, I'll do that as part of the clean-up once we decide which fraud provider we'll end up using.

To test:
- Go to the checkout.
- Note that you don't see a warning on the console saying "It looks like Stripe.js was loaded more than one time".