### PR TITLE
Link order notes to transaction details

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Fix - If account is set to manual payouts display 'Temporarily suspended' under Payments > Settings.
 * Add - Add file dropzones to dispute evidence upload fields
 * Add - Transaction timeline details for multi-currency transactions.  
+* Update - Link order note with transaction details page. 
 
 = 1.9.2 - 2021-02-05 =
 * Fix - Checkout and cart blocks aren't usable in editor when WooCommerce Payments is enabled.

--- a/client/utils/charge/index.js
+++ b/client/utils/charge/index.js
@@ -66,13 +66,21 @@ export const getChargeStatus = ( charge = {} ) => {
  * @return {Object} An object, containing the `currency`, `amount`, `net`, `fee`, and `refunded` amounts in Stripe format (*100).
  */
 export const getChargeAmounts = ( charge ) => {
-	const balance = {
-		currency: charge.balance_transaction.currency,
-		amount: charge.balance_transaction.amount,
-		fee: charge.balance_transaction.fee,
-		refunded: 0,
-		net: 0,
-	};
+	const balance = charge.balance_transaction
+		? {
+				currency: charge.balance_transaction.currency,
+				amount: charge.balance_transaction.amount,
+				fee: charge.balance_transaction.fee,
+				refunded: 0,
+				net: 0,
+		  }
+		: {
+				currency: charge.currency,
+				amount: charge.amount,
+				fee: charge.application_fee_amount,
+				refunded: 0,
+				net: 0,
+		  };
 
 	if ( isChargeRefunded( charge ) ) {
 		// Refund balance_transactions have negative amount.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -673,17 +673,15 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					break;
 				case 'requires_action':
 					if ( $payment_needed ) {
-						$transaction_url = $this->compose_transaction_url( $charge_id );
-
 						// Add a note in case the customer does not complete the payment (exits the page),
 						// so the store owner has some information about what happened to create an order.
 						$note = sprintf(
 							WC_Payments_Utils::esc_interpolated_html(
 							/* translators: %1: the authorized amount, %2: transaction ID of the payment */
-								__( 'A payment of %1$s was <strong>started</strong> using WooCommerce Payments (<a>%2$s</a>).', 'woocommerce-payments' ),
+								__( 'A payment of %1$s was <strong>started</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
 								[
 									'strong' => '<strong>',
-									'a'      => ! empty( $transaction_url ) ? '<a href="' . $transaction_url . '" target="_blank" rel="noopener noreferrer">' : '<code>',
+									'code'   => '<code>',
 								]
 							),
 							wc_price( $amount ),

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -636,13 +636,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			switch ( $status ) {
 				case 'succeeded':
 					if ( $payment_needed ) {
-						$note = sprintf(
+						$transaction_url = $this->compose_transaction_url( $charge_id );
+						$note            = sprintf(
 							WC_Payments_Utils::esc_interpolated_html(
 								/* translators: %1: the successfully charged amount, %2: transaction ID of the payment */
-								__( 'A payment of %1$s was <strong>successfully charged</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
+								__( 'A payment of %1$s was <strong>successfully charged</strong> using WooCommerce Payments (<a>%2$s</a>).', 'woocommerce-payments' ),
 								[
 									'strong' => '<strong>',
-									'code'   => '<code>',
+									'a'      => ! empty( $transaction_url ) ? '<a href="' . $transaction_url . '" target="_blank" rel="noopener noreferrer">' : '<code>',
 								]
 							),
 							wc_price( $amount ),
@@ -653,13 +654,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					$order->payment_complete( $intent_id );
 					break;
 				case 'requires_capture':
-					$note = sprintf(
+					$transaction_url = $this->compose_transaction_url( $charge_id );
+					$note            = sprintf(
 						WC_Payments_Utils::esc_interpolated_html(
 							/* translators: %1: the authorized amount, %2: transaction ID of the payment */
-							__( 'A payment of %1$s was <strong>authorized</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
+							__( 'A payment of %1$s was <strong>authorized</strong> using WooCommerce Payments (<a>%2$s</a>).', 'woocommerce-payments' ),
 							[
 								'strong' => '<strong>',
-								'code'   => '<code>',
+								'a'      => ! empty( $transaction_url ) ? '<a href="' . $transaction_url . '" target="_blank" rel="noopener noreferrer">' : '<code>',
 							]
 						),
 						wc_price( $amount ),
@@ -671,15 +673,17 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					break;
 				case 'requires_action':
 					if ( $payment_needed ) {
+						$transaction_url = $this->compose_transaction_url( $charge_id );
+
 						// Add a note in case the customer does not complete the payment (exits the page),
 						// so the store owner has some information about what happened to create an order.
 						$note = sprintf(
 							WC_Payments_Utils::esc_interpolated_html(
 							/* translators: %1: the authorized amount, %2: transaction ID of the payment */
-								__( 'A payment of %1$s was <strong>started</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
+								__( 'A payment of %1$s was <strong>started</strong> using WooCommerce Payments (<a>%2$s</a>).', 'woocommerce-payments' ),
 								[
 									'strong' => '<strong>',
-									'code'   => '<code>',
+									'a'      => ! empty( $transaction_url ) ? '<a href="' . $transaction_url . '" target="_blank" rel="noopener noreferrer">' : '<code>',
 								]
 							),
 							wc_price( $amount ),
@@ -1396,13 +1400,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 				switch ( $status ) {
 					case 'succeeded':
-						$note = sprintf(
+						$transaction_url = $this->compose_transaction_url( $intent->get_charge_id() );
+						$note            = sprintf(
 							WC_Payments_Utils::esc_interpolated_html(
 								/* translators: %1: the successfully charged amount, %2: transaction ID of the payment */
-								__( 'A payment of %1$s was <strong>successfully charged</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
+								__( 'A payment of %1$s was <strong>successfully charged</strong> using WooCommerce Payments (<a>%2$s</a>).', 'woocommerce-payments' ),
 								[
 									'strong' => '<strong>',
-									'code'   => '<code>',
+									'a'      => ! empty( $transaction_url ) ? '<a href="' . $transaction_url . '" target="_blank" rel="noopener noreferrer">' : '<code>',
 								]
 							),
 							wc_price( $amount ),
@@ -1416,13 +1421,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 						$order->payment_complete( $intent_id );
 						break;
 					case 'requires_capture':
-						$note = sprintf(
+						$transaction_url = $this->compose_transaction_url( $intent->get_charge_id() );
+						$note            = sprintf(
 							WC_Payments_Utils::esc_interpolated_html(
 								/* translators: %1: the authorized amount, %2: transaction ID of the payment */
-								__( 'A payment of %1$s was <strong>authorized</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
+								__( 'A payment of %1$s was <strong>authorized</strong> using WooCommerce Payments (<a>%2$s</a>).', 'woocommerce-payments' ),
 								[
 									'strong' => '<strong>',
-									'code'   => '<code>',
+									'a'      => ! empty( $transaction_url ) ? '<a href="' . $transaction_url . '" target="_blank" rel="noopener noreferrer">' : '<code>',
 								]
 							),
 							wc_price( $amount ),
@@ -1439,13 +1445,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 						$order->set_transaction_id( $intent_id );
 						break;
 					case 'requires_payment_method':
-						$note = sprintf(
+						$transaction_url = $this->compose_transaction_url( $intent->get_charge_id() );
+						$note            = sprintf(
 							WC_Payments_Utils::esc_interpolated_html(
 								/* translators: %1: the authorized amount, %2: transaction ID of the payment */
-								__( 'A payment of %1$s <strong>failed</strong> using WooCommerce Payments (<code>%2$s</code>).', 'woocommerce-payments' ),
+								__( 'A payment of %1$s <strong>failed</strong> using WooCommerce Payments (<a>%2$s</a>).', 'woocommerce-payments' ),
 								[
 									'strong' => '<strong>',
-									'code'   => '<code>',
+									'a'      => ! empty( $transaction_url ) ? '<a href="' . $transaction_url . '" target="_blank" rel="noopener noreferrer">' : '<code>',
 								]
 							),
 							wc_price( $amount ),
@@ -1721,7 +1728,16 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	public function get_transaction_url( $order ) {
 		$charge_id = $order->get_meta( '_charge_id' );
+		return $this->compose_transaction_url( $charge_id );
+	}
 
+	/**
+	 * Composes url for transaction details page.
+	 *
+	 * @param  string $charge_id Charge id.
+	 * @return string            Transaction details page url.
+	 */
+	private function compose_transaction_url( $charge_id ) {
 		if ( empty( $charge_id ) ) {
 			return '';
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - If account is set to manual payouts display 'Temporarily suspended' under Payments > Settings.
 * Add - Add file dropzones to dispute evidence upload fields
 * Add - Transaction timeline details for multi-currency transactions.
+* Update - Link order note with transaction details page.
 
 = 1.9.2 - 2021-02-05 =
 * Fix - Checkout and cart blocks aren't usable in editor when WooCommerce Payments is enabled.


### PR DESCRIPTION
Fixes #1307 

#### Changes proposed in this Pull Request

* Make payment intent id in order notes a link pointing to transaction details page.
* Fix rendering transaction summary on details page for authorized but not captured transactions.

#### Testing instructions

* Create various transaction according to changes in `class-wc-payment-gateway-wcpay.php`.
* Check that order notes has link to transactions details page. Clicking the link should open the transaction details page.
* Test that authorized but not captured transaction details page renders without errors.

No new tests added.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
