### PR TITLE
Subscriptions compatibility for order tracking updates

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1636,7 +1636,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * When an order is created, we want to add an ActionScheduler job to send this data to
+	 * When an order is created/updated, we want to add an ActionScheduler job to send this data to
 	 * the payment server.
 	 *
 	 * @param int           $order_id  The ID of the order that has been created.
@@ -1659,15 +1659,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return;
 		}
 
-		$payment_token = $this->get_payment_token( $order );
-		if ( is_null( $payment_token ) ) {
-			return;
-		}
-
 		// Make sure that the order meta data key for payment_token is set to the most recent token.
-		if ( $order->get_meta( '_payment_method_token' ) !== $payment_token->get_token() ) {
-			$order->add_meta_data( '_payment_method_token', $payment_token->get_token(), true );
-			$order->save_meta_data();
+		$payment_token = $this->get_payment_token( $order );
+		if ( ! is_null( $payment_token ) && $order->get_meta( '_payment_method_token' ) !== $payment_token->get_token() ) {
+				$order->add_meta_data( '_payment_method_token', $payment_token->get_token(), true );
+				$order->save_meta_data();
 		}
 
 		// Check whether this is an order we haven't previously tracked a creation event for.
@@ -1683,7 +1679,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				self::GATEWAY_ID
 			);
 
-			// Update the metadata to reflect that the order creation event has finished.
+			// Update the metadata to reflect that the order creation event has been fired.
 			$order->add_meta_data( '_new_order_tracking_complete', 'yes' );
 			$order->save_meta_data();
 		} else {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -578,7 +578,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// Make sure that we attach the payment method and the customer ID to the order meta data.
 		$payment_method = $payment_information->get_payment_method();
-		$order->update_meta_data( '_payment_method_token', $payment_method );
+		$order->update_meta_data( '_payment_method_id', $payment_method );
 		$order->update_meta_data( '_stripe_customer_id', $customer_id );
 
 		// In case amount is 0 and we're not saving the payment method, we won't be using intents and can confirm the order payment.
@@ -1660,30 +1660,23 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		// We only want to track orders created by our payment gateway, and orders with a payment method set.
-		if ( $order->get_payment_method() !== self::GATEWAY_ID || empty( $order->get_meta_data( '_payment_method_token' ) ) ) {
+		if ( $order->get_payment_method() !== self::GATEWAY_ID || empty( $order->get_meta_data( '_payment_method_id' ) ) ) {
 			return;
 		}
 
 		// Check whether this is an order we haven't previously tracked a creation event for.
-		if ( $order->get_meta( '_new_order_tracking_complete' ) !== 'yes' ) {
+		if ( $order->get_meta( '_new_order_tracking_complete' ) !== 'yes' || is_null( $order->get_date_modified() ) ) {
 			// Schedule the action to send this information to the payment server.
 			$this->action_scheduler_service->schedule_job(
-				strtotime( '+10 seconds' ),
+				strtotime( '+5 seconds' ),
 				'wcpay_track_new_order',
-				[
-					'order_id'     => $order_id,
-					'date_created' => $order->get_date_created(),
-				],
+				[ 'order_id' => $order_id ],
 				self::GATEWAY_ID
 			);
-
-			// Update the metadata to reflect that the order creation event has been fired.
-			$order->add_meta_data( '_new_order_tracking_complete', 'yes' );
-			$order->save_meta_data();
 		} else {
 			// Schedule an update action to send this information to the payment server.
 			$this->action_scheduler_service->schedule_job(
-				strtotime( '+10 seconds' ),
+				strtotime( '+5 seconds' ),
 				'wcpay_track_update_order',
 				[ 'order_id' => $order_id ],
 				self::GATEWAY_ID

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1665,7 +1665,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		// Check whether this is an order we haven't previously tracked a creation event for.
-		if ( $order->get_meta( '_new_order_tracking_complete' ) !== 'yes' || is_null( $order->get_date_modified() ) ) {
+		if ( $order->get_meta( '_new_order_tracking_complete' ) !== 'yes' ) {
 			// Schedule the action to send this information to the payment server.
 			$this->action_scheduler_service->schedule_job(
 				strtotime( '+5 seconds' ),

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1682,10 +1682,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$this->action_scheduler_service->schedule_job(
 				strtotime( '+10 seconds' ),
 				'wcpay_track_update_order',
-				[
-					'order_id'      => $order_id,
-					'date_modified' => $order->get_date_modified(),
-				],
+				[ 'order_id' => $order_id ],
 				self::GATEWAY_ID
 			);
 		}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1661,8 +1661,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// Make sure that the order meta data key for payment_token is set to the most recent token.
 		$payment_token = $this->get_payment_token( $order );
-		if ( ! is_null( $payment_token ) && $order->get_meta( '_payment_method_token' ) !== $payment_token->get_token() ) {
-				$order->add_meta_data( '_payment_method_token', $payment_token->get_token(), true );
+		if ( ! is_null( $payment_token ) && $order->get_meta( '_payment_method_id' ) !== $payment_token->get_token() ) {
+				$order->add_meta_data( '_payment_method_id', $payment_token->get_token(), true );
 				$order->save_meta_data();
 		}
 

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -58,14 +58,20 @@ class WC_Payments_Action_Scheduler_Service {
 		}
 
 		// If we do not have a valid payment method for this order, don't send the request.
-		$payment_method = $order->get_meta( ( '_payment_method_id' ) );
+		$payment_method = $order->get_meta( ( '_payment_method_token' ) );
 		if ( empty( $payment_method ) ) {
 			return false;
 		}
 
 		// Send the order data to the Payments API to track it.
 		$result = $this->payments_api_client->track_order(
-			array_merge( $order->get_data(), [ '_payment_method_id' => $payment_method ] ),
+			array_merge( 
+				$order->get_data(),
+				[
+					'_payment_method_token' => $payment_method,
+					'_stripe_customer_id'   => $order->get_meta( '_stripe_customer_id' ),
+				]
+			),
 			false
 		);
 
@@ -88,14 +94,20 @@ class WC_Payments_Action_Scheduler_Service {
 		}
 
 		// If we do not have a valid payment method for this order, don't send the request.
-		$payment_method = $order->get_meta( ( '_payment_method_id' ) );
+		$payment_method = $order->get_meta( ( '_payment_method_token' ) );
 		if ( empty( $payment_method ) ) {
 			return false;
 		}
 
 		// Send the order data to the Payments API to track it.
 		$result = $this->payments_api_client->track_order(
-			array_merge( $order->get_data(), [ '_payment_method_id' => $payment_method ] ),
+			array_merge( 
+				$order->get_data(),
+				[
+					'_payment_method_token' => $payment_method,
+					'_stripe_customer_id'   => $order->get_meta( '_stripe_customer_id' ),
+				]
+			),
 			true
 		);
 

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -105,7 +105,7 @@ class WC_Payments_Action_Scheduler_Service {
 			$order->save_meta_data();
 		}
 
-		return $response;
+		return ( 'success' === ( $response['result'] ?? null ) );
 	}
 
 	/**

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -57,15 +57,15 @@ class WC_Payments_Action_Scheduler_Service {
 			return false;
 		}
 
-		// If we do not have a valid payment method token for this order, don't send the request.
-		$payment_method = $order->get_meta( ( '_payment_method_token' ) );
+		// If we do not have a valid payment method for this order, don't send the request.
+		$payment_method = $order->get_meta( ( '_payment_method_id' ) );
 		if ( empty( $payment_method ) ) {
 			return false;
 		}
 
 		// Send the order data to the Payments API to track it.
 		$result = $this->payments_api_client->track_order(
-			array_merge( $order->get_data(), [ '_payment_method_token' => $payment_method ] ),
+			array_merge( $order->get_data(), [ '_payment_method_id' => $payment_method ] ),
 			false
 		);
 
@@ -87,15 +87,15 @@ class WC_Payments_Action_Scheduler_Service {
 			return false;
 		}
 
-		// If we do not have a valid payment method token for this order, don't send the request.
-		$payment_method = $order->get_meta( ( '_payment_method_token' ) );
+		// If we do not have a valid payment method for this order, don't send the request.
+		$payment_method = $order->get_meta( ( '_payment_method_id' ) );
 		if ( empty( $payment_method ) ) {
 			return false;
 		}
 
 		// Send the order data to the Payments API to track it.
 		$result = $this->payments_api_client->track_order(
-			array_merge( $order->get_data(), [ '_payment_method_token' => $payment_method ] ),
+			array_merge( $order->get_data(), [ '_payment_method_id' => $payment_method ] ),
 			true
 		);
 

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -60,7 +60,7 @@ class WC_Payments_Action_Scheduler_Service {
 
 		// Send the order data to the Payments API to track it.
 		$result = $this->payments_api_client->track_order(
-			array_merge( $order->get_data(), [ '_intent_id' => $order->get_meta( '_intent_id' ) ] ),
+			array_merge( $order->get_data(), [ '_payment_method_token' => $order->get_meta( '_payment_method_token' ) ] ),
 			false
 		);
 
@@ -85,7 +85,7 @@ class WC_Payments_Action_Scheduler_Service {
 
 		// Send the order data to the Payments API to track it.
 		$result = $this->payments_api_client->track_order(
-			array_merge( $order->get_data(), [ '_intent_id' => $order->get_meta( '_intent_id' ) ] ),
+			array_merge( $order->get_data(), [ '_payment_method_token' => $order->get_meta( '_payment_method_token' ) ] ),
 			true
 		);
 

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -53,14 +53,19 @@ class WC_Payments_Action_Scheduler_Service {
 	public function track_new_order_action( $order_id ) {
 		// Get the order details.
 		$order = wc_get_order( $order_id );
-
 		if ( ! $order ) {
+			return false;
+		}
+
+		// If we do not have a valid payment method token for this order, don't send the request.
+		$payment_method = $order->get_meta( ( '_payment_method_token' ) );
+		if ( empty( $payment_method ) ) {
 			return false;
 		}
 
 		// Send the order data to the Payments API to track it.
 		$result = $this->payments_api_client->track_order(
-			array_merge( $order->get_data(), [ '_payment_method_token' => $order->get_meta( '_payment_method_token' ) ] ),
+			array_merge( $order->get_data(), [ '_payment_method_token' => $payment_method ] ),
 			false
 		);
 
@@ -78,14 +83,19 @@ class WC_Payments_Action_Scheduler_Service {
 	public function track_update_order_action( $order_id ) {
 		// Get the order details.
 		$order = wc_get_order( $order_id );
-
 		if ( ! $order ) {
+			return false;
+		}
+
+		// If we do not have a valid payment method token for this order, don't send the request.
+		$payment_method = $order->get_meta( ( '_payment_method_token' ) );
+		if ( empty( $payment_method ) ) {
 			return false;
 		}
 
 		// Send the order data to the Payments API to track it.
 		$result = $this->payments_api_client->track_order(
-			array_merge( $order->get_data(), [ '_payment_method_token' => $order->get_meta( '_payment_method_token' ) ] ),
+			array_merge( $order->get_data(), [ '_payment_method_token' => $payment_method ] ),
 			true
 		);
 

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -65,7 +65,7 @@ class WC_Payments_Action_Scheduler_Service {
 
 		// Send the order data to the Payments API to track it.
 		$result = $this->payments_api_client->track_order(
-			array_merge( 
+			array_merge(
 				$order->get_data(),
 				[
 					'_payment_method_token' => $payment_method,
@@ -101,7 +101,7 @@ class WC_Payments_Action_Scheduler_Service {
 
 		// Send the order data to the Payments API to track it.
 		$result = $this->payments_api_client->track_order(
-			array_merge( 
+			array_merge(
 				$order->get_data(),
 				[
 					'_payment_method_token' => $payment_method,

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -402,20 +402,20 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 		// If we can't get the payment token for this order, then we check if we already have a payment token
 		// set in the order metadata. If we don't, then we try and get the parent order's token from the metadata.
 		if ( is_null( $payment_token ) ) {
-			if ( empty( $order->get_meta( '_payment_method_token' ) ) ) {
+			if ( empty( $order->get_meta( '_payment_method_id' ) ) ) {
 				$parent_order = wc_get_order( $order->get_parent_id() );
 
 				// If there is no parent order, or the parent order doesn't have the metadata set, then we cannot track this order.
-				if ( empty( $parent_order ) || empty( $parent_order->get_meta( '_payment_method_token' ) ) ) {
+				if ( empty( $parent_order ) || empty( $parent_order->get_meta( '_payment_method_id' ) ) ) {
 					return;
 				}
 
-				$order->update_meta_data( '_payment_method_token', $parent_order->get_meta( '_payment_method_token' ) );
+				$order->update_meta_data( '_payment_method_id', $parent_order->get_meta( '_payment_method_id' ) );
 				$save_meta_data = true;
 			}
-		} elseif ( $order->get_meta( '_payment_method_token' ) !== $payment_token->get_token() ) {
+		} elseif ( $order->get_meta( '_payment_method_id' ) !== $payment_token->get_token() ) {
 			// If the payment token stored in the metadata already doesn't reflect the latest token, update it.
-			$order->update_meta_data( '_payment_method_token', $payment_token->get_token() );
+			$order->update_meta_data( '_payment_method_id', $payment_token->get_token() );
 			$save_meta_data = true;
 		}
 

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -400,7 +400,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 
 		// If this order doesn't have an _intent_id attached, try and get the parent ID instead.
 		if ( empty( $order->get_meta( '_intent_id' ) ) ) {
-			$order = wc_get_order( $order->get_parent_id() );
+			$order_id = $order->get_parent_id();
+			$order    = wc_get_order( $order_id );
 		}
 
 		parent::schedule_order_tracking( $order_id, $order );

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -382,28 +382,4 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 		}
 		echo '</select>';
 	}
-
-	/**
-	 * When an order is created, we want to add an ActionScheduler job to send this data to
-	 * the payment server. This logic requires a PaymentIntent or SetupIntent to function correctly,
-	 * so for child subscriptions we fetch the parent order.
-	 *
-	 * @param int                  $order_id  The ID of the order that has been created.
-	 * @param WC_Subscription|null $order     The order that has been created.
-	 *
-	 * @return void
-	 */
-	public function schedule_order_tracking( $order_id, $order = null ) {
-		if ( is_null( $order ) ) {
-			$order = wc_get_order( $order_id );
-		}
-
-		// If this order doesn't have an _intent_id attached, try and get the parent ID instead.
-		if ( empty( $order->get_meta( '_intent_id' ) ) ) {
-			$order_id = $order->get_parent_id();
-			$order    = wc_get_order( $order_id );
-		}
-
-		parent::schedule_order_tracking( $order_id, $order );
-	}
 }

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -382,4 +382,27 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 		}
 		echo '</select>';
 	}
+
+	/**
+	 * When an order is created, we want to add an ActionScheduler job to send this data to
+	 * the payment server. This logic requires a PaymentIntent or SetupIntent to function correctly,
+	 * so for child subscriptions we fetch the parent order.
+	 *
+	 * @param int                  $order_id  The ID of the order that has been created.
+	 * @param WC_Subscription|null $order     The order that has been created.
+	 *
+	 * @return void
+	 */
+	public function schedule_order_tracking( $order_id, $order = null ) {
+		if ( is_null( $order ) ) {
+			$order = wc_get_order( $order_id );
+		}
+
+		// If this order doesn't have an _intent_id attached, try and get the parent ID instead.
+		if ( empty( $order->get_meta( '_intent_id' ) ) ) {
+			$order = wc_get_order( $order->get_parent_id() );
+		}
+
+		parent::schedule_order_tracking( $order_id, $order );
+	}
 }

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -136,13 +136,13 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	 */
 	public function test_intent_status_success() {
 		// Arrange: Reusable data.
-		$intent_id         = 'pi_123';
-		$charge_id         = 'ch_123';
-		$customer_id       = 'cu_123';
-		$status            = 'succeeded';
-		$secret            = 'client_secret_123';
-		$order_id          = 123;
-		$total             = 12.23;
+		$intent_id   = 'pi_123';
+		$charge_id   = 'ch_123';
+		$customer_id = 'cu_123';
+		$status      = 'succeeded';
+		$secret      = 'client_secret_123';
+		$order_id    = 123;
+		$total       = 12.23;
 
 		// Arrange: Create an order to test with.
 		$mock_order = $this->createMock( 'WC_Order' );
@@ -310,13 +310,13 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	 */
 	public function test_intent_status_requires_capture() {
 		// Arrange: Reusable data.
-		$intent_id         = 'pi_123';
-		$charge_id         = 'ch_123';
-		$customer_id       = 'cu_123';
-		$status            = 'requires_capture';
-		$secret            = 'client_secret_123';
-		$order_id          = 123;
-		$total             = 12.23;
+		$intent_id   = 'pi_123';
+		$charge_id   = 'ch_123';
+		$customer_id = 'cu_123';
+		$status      = 'requires_capture';
+		$secret      = 'client_secret_123';
+		$order_id    = 123;
+		$total       = 12.23;
 
 		// Arrange: Create an order to test with.
 		$mock_order = $this->createMock( 'WC_Order' );
@@ -521,13 +521,13 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	 */
 	public function test_intent_status_requires_action() {
 		// Arrange: Reusable data.
-		$intent_id         = 'pi_123';
-		$charge_id         = 'ch_123';
-		$customer_id       = 'cu_123';
-		$status            = 'requires_action';
-		$secret            = 'client_secret_123';
-		$order_id          = 123;
-		$total             = 12.23;
+		$intent_id   = 'pi_123';
+		$charge_id   = 'ch_123';
+		$customer_id = 'cu_123';
+		$status      = 'requires_action';
+		$secret      = 'client_secret_123';
+		$order_id    = 123;
+		$total       = 12.23;
 
 		// Arrange: Create an order to test with.
 		$mock_order = $this->createMock( 'WC_Order' );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -194,7 +194,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->expects( $this->exactly( 6 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
-				[ '_payment_method_token', 'pm_mock' ],
+				[ '_payment_method_id', 'pm_mock' ],
 				[ '_stripe_customer_id', $customer_id ],
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', $charge_id ],
@@ -368,7 +368,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->expects( $this->exactly( 6 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
-				[ '_payment_method_token', 'pm_mock' ],
+				[ '_payment_method_id', 'pm_mock' ],
 				[ '_stripe_customer_id', $customer_id ],
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', $charge_id ],
@@ -579,7 +579,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->expects( $this->exactly( 6 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
-				[ '_payment_method_token', 'pm_mock' ],
+				[ '_payment_method_id', 'pm_mock' ],
 				[ '_stripe_customer_id', $customer_id ],
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', $charge_id ],

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -157,6 +157,11 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->method( 'get_total' )
 			->willReturn( $total );
 
+		// Arrange: Set a WP_User object as a return value of order's get_user.
+		$mock_order
+			->method( 'get_user' )
+			->willReturn( wp_get_current_user() );
+
 		// Arrange: Set a good return value for customer ID.
 		$this->mock_customer_service->expects( $this->once() )
 			->method( 'create_customer_for_user' )
@@ -330,6 +335,11 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$mock_order
 			->method( 'get_total' )
 			->willReturn( $total );
+
+		// Arrange: Set a WP_User object as a return value of order's get_user.
+		$mock_order
+			->method( 'get_user' )
+			->willReturn( wp_get_current_user() );
 
 		// Arrange: Set a good return value for customer ID.
 		$this->mock_customer_service->expects( $this->once() )
@@ -541,6 +551,11 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$mock_order
 			->method( 'get_total' )
 			->willReturn( $total );
+
+		// Arrange: Set a WP_User object as a return value of order's get_user.
+		$mock_order
+			->method( 'get_user' )
+			->willReturn( wp_get_current_user() );
 
 		// Arrange: Set a good return value for customer ID.
 		$this->mock_customer_service->expects( $this->once() )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -136,12 +136,13 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	 */
 	public function test_intent_status_success() {
 		// Arrange: Reusable data.
-		$intent_id = 'pi_123';
-		$charge_id = 'ch_123';
-		$status    = 'succeeded';
-		$secret    = 'client_secret_123';
-		$order_id  = 123;
-		$total     = 12.23;
+		$intent_id         = 'pi_123';
+		$charge_id         = 'ch_123';
+		$customer_id       = 'cu_123';
+		$status            = 'succeeded';
+		$secret            = 'client_secret_123';
+		$order_id          = 123;
+		$total             = 12.23;
 
 		// Arrange: Create an order to test with.
 		$mock_order = $this->createMock( 'WC_Order' );
@@ -156,10 +157,10 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->method( 'get_total' )
 			->willReturn( $total );
 
-		// Arrange: Set a WP_User object as a return value of order's get_user.
-		$mock_order
-			->method( 'get_user' )
-			->willReturn( wp_get_current_user() );
+		// Arrange: Set a good return value for customer ID.
+		$this->mock_customer_service->expects( $this->once() )
+			->method( 'create_customer_for_user' )
+			->willReturn( $customer_id );
 
 		// Arrange: Create a mock cart.
 		$mock_cart = $this->createMock( 'WC_Cart' );
@@ -190,9 +191,11 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		// There's an issue open for that here:
 		// https://github.com/sebastianbergmann/phpunit/issues/4026.
 		$mock_order
-			->expects( $this->exactly( 4 ) )
+			->expects( $this->exactly( 6 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
+				[ '_payment_method_token', 'pm_mock' ],
+				[ '_stripe_customer_id', $customer_id ],
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', $charge_id ],
 				[ '_intention_status', $status ],
@@ -307,12 +310,13 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	 */
 	public function test_intent_status_requires_capture() {
 		// Arrange: Reusable data.
-		$intent_id = 'pi_123';
-		$charge_id = 'ch_123';
-		$status    = 'requires_capture';
-		$secret    = 'client_secret_123';
-		$order_id  = 123;
-		$total     = 12.23;
+		$intent_id         = 'pi_123';
+		$charge_id         = 'ch_123';
+		$customer_id       = 'cu_123';
+		$status            = 'requires_capture';
+		$secret            = 'client_secret_123';
+		$order_id          = 123;
+		$total             = 12.23;
 
 		// Arrange: Create an order to test with.
 		$mock_order = $this->createMock( 'WC_Order' );
@@ -327,10 +331,10 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->method( 'get_total' )
 			->willReturn( $total );
 
-		// Arrange: Set a WP_User object as a return value of order's get_user.
-		$mock_order
-			->method( 'get_user' )
-			->willReturn( wp_get_current_user() );
+		// Arrange: Set a good return value for customer ID.
+		$this->mock_customer_service->expects( $this->once() )
+			->method( 'create_customer_for_user' )
+			->willReturn( $customer_id );
 
 		// Arrange: Create a mock cart.
 		$mock_cart = $this->createMock( 'WC_Cart' );
@@ -361,9 +365,11 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		// There's an issue open for that here:
 		// https://github.com/sebastianbergmann/phpunit/issues/4026.
 		$mock_order
-			->expects( $this->exactly( 4 ) )
+			->expects( $this->exactly( 6 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
+				[ '_payment_method_token', 'pm_mock' ],
+				[ '_stripe_customer_id', $customer_id ],
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', $charge_id ],
 				[ '_intention_status', $status ],
@@ -515,12 +521,13 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	 */
 	public function test_intent_status_requires_action() {
 		// Arrange: Reusable data.
-		$intent_id = 'pi_123';
-		$charge_id = 'ch_123';
-		$status    = 'requires_action';
-		$secret    = 'client_secret_123';
-		$order_id  = 123;
-		$total     = 12.23;
+		$intent_id         = 'pi_123';
+		$charge_id         = 'ch_123';
+		$customer_id       = 'cu_123';
+		$status            = 'requires_action';
+		$secret            = 'client_secret_123';
+		$order_id          = 123;
+		$total             = 12.23;
 
 		// Arrange: Create an order to test with.
 		$mock_order = $this->createMock( 'WC_Order' );
@@ -535,10 +542,10 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->method( 'get_total' )
 			->willReturn( $total );
 
-		// Arrange: Set a WP_User object as a return value of order's get_user.
-		$mock_order
-			->method( 'get_user' )
-			->willReturn( wp_get_current_user() );
+		// Arrange: Set a good return value for customer ID.
+		$this->mock_customer_service->expects( $this->once() )
+			->method( 'create_customer_for_user' )
+			->willReturn( $customer_id );
 
 		// Arrange: Create a mock cart.
 		$mock_cart = $this->createMock( 'WC_Cart' );
@@ -569,12 +576,14 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		// There's an issue open for that here:
 		// https://github.com/sebastianbergmann/phpunit/issues/4026.
 		$mock_order
-			->expects( $this->exactly( 4 ) )
+			->expects( $this->exactly( 6 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
+				[ '_payment_method_token', 'pm_mock' ],
+				[ '_stripe_customer_id', $customer_id ],
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', $charge_id ],
-				[ '_intention_status', 'requires_action' ],
+				[ '_intention_status', $status ],
 				[ WC_Payments_Utils::ORDER_INTENT_CURRENCY_META_KEY, 'USD' ]
 			);
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -1057,7 +1057,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->wcpay_gateway->schedule_order_tracking( $order->get_id(), $order );
 	}
 
-	public function test_schedule_order_tracking_with_no_payment_method_token() {
+	public function test_schedule_order_tracking_with_no_payment_method_id() {
 		$order = WC_Helper_Order::create_order();
 		$order->set_payment_method( 'woocommerce_payments' );
 		$order->delete_meta_data( '_new_order_tracking_complete' );
@@ -1082,7 +1082,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	public function test_schedule_order_tracking() {
 		$order = WC_Helper_Order::create_order();
 		$order->set_payment_method( 'woocommerce_payments' );
-		$order->update_meta_data( '_payment_method_token', 'pm_123' );
+		$order->update_meta_data( '_payment_method_id', 'pm_123' );
 		$order->delete_meta_data( '_new_order_tracking_complete' );
 
 		$this->mock_action_scheduler_service

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -1057,9 +1057,32 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->wcpay_gateway->schedule_order_tracking( $order->get_id(), $order );
 	}
 
+	public function test_schedule_order_tracking_with_no_payment_method_token() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( 'woocommerce_payments' );
+		$order->delete_meta_data( '_new_order_tracking_complete' );
+
+		$this->mock_action_scheduler_service
+			->expects( $this->never() )
+			->method( 'schedule_job' );
+
+		$this->mock_wcpay_account
+			->expects( $this->once() )
+			->method( 'get_fraud_services_config' )
+			->willReturn(
+				[
+					'stripe' => [],
+					'sift'   => [],
+				]
+			);
+
+		$this->wcpay_gateway->schedule_order_tracking( $order->get_id(), $order );
+	}
+
 	public function test_schedule_order_tracking() {
 		$order = WC_Helper_Order::create_order();
 		$order->set_payment_method( 'woocommerce_payments' );
+		$order->update_meta_data( '_payment_method_token', 'pm_123' );
 		$order->delete_meta_data( '_new_order_tracking_complete' );
 
 		$this->mock_action_scheduler_service

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -1038,28 +1038,6 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->wcpay_gateway->schedule_order_tracking( $order->get_id(), $order );
 	}
 
-	public function test_schedule_order_tracking_without_intent_id() {
-		$order = WC_Helper_Order::create_order();
-		$order->set_payment_method( 'woocommerce_payments' );
-		$order->delete_meta_data( '_intent_id' );
-
-		$this->mock_action_scheduler_service
-			->expects( $this->never() )
-			->method( 'schedule_job' );
-
-		$this->mock_wcpay_account
-			->expects( $this->once() )
-			->method( 'get_fraud_services_config' )
-			->willReturn(
-				[
-					'stripe' => [],
-					'sift'   => [],
-				]
-			);
-
-		$this->wcpay_gateway->schedule_order_tracking( $order->get_id(), $order );
-	}
-
 	public function test_schedule_order_tracking_with_sift_disabled() {
 		$order = WC_Helper_Order::create_order();
 
@@ -1082,7 +1060,6 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	public function test_schedule_order_tracking() {
 		$order = WC_Helper_Order::create_order();
 		$order->set_payment_method( 'woocommerce_payments' );
-		$order->add_meta_data( '_intent_id', 'pi_1325347347437' );
 		$order->delete_meta_data( '_new_order_tracking_complete' );
 
 		$this->mock_action_scheduler_service
@@ -1105,7 +1082,6 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	public function test_schedule_order_tracking_on_already_created_order() {
 		$order = WC_Helper_Order::create_order();
 		$order->set_payment_method( 'woocommerce_payments' );
-		$order->add_meta_data( '_intent_id', 'pi_1325347347437' );
 		$order->add_meta_data( '_new_order_tracking_complete', 'yes' );
 
 		$this->mock_action_scheduler_service

--- a/tests/unit/test-class-wc-payments-action-scheduler-service.php
+++ b/tests/unit/test-class-wc-payments-action-scheduler-service.php
@@ -78,7 +78,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 		$this->mock_api_client->expects( $this->once() )
 			->method( 'track_order' )
 			->with( $this->get_order_data_mock( $order->get_id() ), true )
-			->willReturn( [ 'result' => 'success'] );
+			->willReturn( [ 'result' => 'success' ] );
 
 		$this->assertTrue( $this->action_scheduler_service->track_update_order_action( $order->get_id() ) );
 	}

--- a/tests/unit/test-class-wc-payments-action-scheduler-service.php
+++ b/tests/unit/test-class-wc-payments-action-scheduler-service.php
@@ -39,6 +39,8 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 	public function test_track_new_order_action() {
 		$order = WC_Helper_Order::create_order();
+		$order->add_meta_data( '_payment_method_token', 'pm_131535132531', true );
+		$order->save_meta_data();
 
 		$this->mock_api_client->expects( $this->once() )
 			->method( 'track_order' )
@@ -46,6 +48,14 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 			->willReturn( true );
 
 		$this->assertTrue( $this->action_scheduler_service->track_new_order_action( $order->get_id() ) );
+	}
+
+	public function test_track_new_order_action_with_no_payment_method() {
+		$order = WC_Helper_Order::create_order();
+		$order->delete_meta_data( '_payment_method_token' );
+		$order->save_meta_data();
+
+		$this->assertFalse( $this->action_scheduler_service->track_new_order_action( $order ) );
 	}
 
 	public function test_track_new_order_action_with_invalid_order_id() {
@@ -60,6 +70,8 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 	public function test_track_update_order_action() {
 		$order = WC_Helper_Order::create_order();
+		$order->add_meta_data( '_payment_method_token', 'pm_131535132531', true );
+		$order->save_meta_data();
 
 		$this->mock_api_client->expects( $this->once() )
 			->method( 'track_order' )
@@ -67,6 +79,14 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 			->willReturn( true );
 
 		$this->assertTrue( $this->action_scheduler_service->track_update_order_action( $order->get_id() ) );
+	}
+
+	public function test_track_update_order_action_with_no_payment_method() {
+		$order = WC_Helper_Order::create_order();
+		$order->delete_meta_data( '_payment_method_token' );
+		$order->save_meta_data();
+
+		$this->assertFalse ( $this->action_scheduler_service->track_update_order_action( $order ) );
 	}
 
 	public function test_track_update_order_action_with_invalid_order_id() {
@@ -89,7 +109,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 		return array_merge(
 			$order->get_data(),
-			[ '_intent_id' => $order->get_meta( '_intent_id' ) ]
+			[ '_payment_method_token' => $order->get_meta( '_payment_method_token' ) ]
 		);
 	}
 }

--- a/tests/unit/test-class-wc-payments-action-scheduler-service.php
+++ b/tests/unit/test-class-wc-payments-action-scheduler-service.php
@@ -39,7 +39,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 	public function test_track_new_order_action() {
 		$order = WC_Helper_Order::create_order();
-		$order->add_meta_data( '_payment_method_token', 'pm_131535132531', true );
+		$order->add_meta_data( '_payment_method_id', 'pm_131535132531', true );
 		$order->add_meta_data( '_stripe_customer_id', 'cu_123', true );
 		$order->save_meta_data();
 
@@ -53,7 +53,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 	public function test_track_new_order_action_with_no_payment_method() {
 		$order = WC_Helper_Order::create_order();
-		$order->delete_meta_data( '_payment_method_token' );
+		$order->delete_meta_data( '_payment_method_id' );
 		$order->save_meta_data();
 
 		$this->assertFalse( $this->action_scheduler_service->track_new_order_action( $order ) );
@@ -71,7 +71,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 	public function test_track_update_order_action() {
 		$order = WC_Helper_Order::create_order();
-		$order->add_meta_data( '_payment_method_token', 'pm_131535132531', true );
+		$order->add_meta_data( '_payment_method_id', 'pm_131535132531', true );
 		$order->add_meta_data( '_stripe_customer_id', 'cu_123', true );
 		$order->save_meta_data();
 
@@ -85,7 +85,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 	public function test_track_update_order_action_with_no_payment_method() {
 		$order = WC_Helper_Order::create_order();
-		$order->delete_meta_data( '_payment_method_token' );
+		$order->delete_meta_data( '_payment_method_id' );
 		$order->save_meta_data();
 
 		$this->assertFalse( $this->action_scheduler_service->track_update_order_action( $order ) );
@@ -112,8 +112,8 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 		return array_merge(
 			$order->get_data(),
 			[
-				'_payment_method_token' => $order->get_meta( '_payment_method_token' ),
-				'_stripe_customer_id'   => $order->get_meta( '_stripe_customer_id' ),
+				'_payment_method_id'  => $order->get_meta( '_payment_method_id' ),
+				'_stripe_customer_id' => $order->get_meta( '_stripe_customer_id' ),
 			]
 		);
 	}

--- a/tests/unit/test-class-wc-payments-action-scheduler-service.php
+++ b/tests/unit/test-class-wc-payments-action-scheduler-service.php
@@ -39,7 +39,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 	public function test_track_new_order_action() {
 		$order = WC_Helper_Order::create_order();
-		$order->add_meta_data( '_payment_method_token', 'pm_131535132531', true );
+		$order->add_meta_data( '_payment_method_id', 'pm_131535132531', true );
 		$order->save_meta_data();
 
 		$this->mock_api_client->expects( $this->once() )
@@ -52,7 +52,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 	public function test_track_new_order_action_with_no_payment_method() {
 		$order = WC_Helper_Order::create_order();
-		$order->delete_meta_data( '_payment_method_token' );
+		$order->delete_meta_data( '_payment_method_id' );
 		$order->save_meta_data();
 
 		$this->assertFalse( $this->action_scheduler_service->track_new_order_action( $order ) );
@@ -70,7 +70,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 	public function test_track_update_order_action() {
 		$order = WC_Helper_Order::create_order();
-		$order->add_meta_data( '_payment_method_token', 'pm_131535132531', true );
+		$order->add_meta_data( '_payment_method_id', 'pm_131535132531', true );
 		$order->save_meta_data();
 
 		$this->mock_api_client->expects( $this->once() )
@@ -83,7 +83,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 	public function test_track_update_order_action_with_no_payment_method() {
 		$order = WC_Helper_Order::create_order();
-		$order->delete_meta_data( '_payment_method_token' );
+		$order->delete_meta_data( '_payment_method_id' );
 		$order->save_meta_data();
 
 		$this->assertFalse( $this->action_scheduler_service->track_update_order_action( $order ) );
@@ -109,7 +109,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 		return array_merge(
 			$order->get_data(),
-			[ '_payment_method_token' => $order->get_meta( '_payment_method_token' ) ]
+			[ '_payment_method_id' => $order->get_meta( '_payment_method_id' ) ]
 		);
 	}
 }

--- a/tests/unit/test-class-wc-payments-action-scheduler-service.php
+++ b/tests/unit/test-class-wc-payments-action-scheduler-service.php
@@ -46,7 +46,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 		$this->mock_api_client->expects( $this->once() )
 			->method( 'track_order' )
 			->with( $this->get_order_data_mock( $order->get_id() ), false )
-			->willReturn( true );
+			->willReturn( [ 'result' => 'success' ] );
 
 		$this->assertTrue( $this->action_scheduler_service->track_new_order_action( $order->get_id() ) );
 	}
@@ -78,7 +78,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 		$this->mock_api_client->expects( $this->once() )
 			->method( 'track_order' )
 			->with( $this->get_order_data_mock( $order->get_id() ), true )
-			->willReturn( true );
+			->willReturn( [ 'result' => 'success'] );
 
 		$this->assertTrue( $this->action_scheduler_service->track_update_order_action( $order->get_id() ) );
 	}

--- a/tests/unit/test-class-wc-payments-action-scheduler-service.php
+++ b/tests/unit/test-class-wc-payments-action-scheduler-service.php
@@ -39,7 +39,8 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 	public function test_track_new_order_action() {
 		$order = WC_Helper_Order::create_order();
-		$order->add_meta_data( '_payment_method_id', 'pm_131535132531', true );
+		$order->add_meta_data( '_payment_method_token', 'pm_131535132531', true );
+		$order->add_meta_data( '_stripe_customer_id', 'cu_123', true );
 		$order->save_meta_data();
 
 		$this->mock_api_client->expects( $this->once() )
@@ -52,7 +53,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 	public function test_track_new_order_action_with_no_payment_method() {
 		$order = WC_Helper_Order::create_order();
-		$order->delete_meta_data( '_payment_method_id' );
+		$order->delete_meta_data( '_payment_method_token' );
 		$order->save_meta_data();
 
 		$this->assertFalse( $this->action_scheduler_service->track_new_order_action( $order ) );
@@ -70,7 +71,8 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 	public function test_track_update_order_action() {
 		$order = WC_Helper_Order::create_order();
-		$order->add_meta_data( '_payment_method_id', 'pm_131535132531', true );
+		$order->add_meta_data( '_payment_method_token', 'pm_131535132531', true );
+		$order->add_meta_data( '_stripe_customer_id', 'cu_123', true );
 		$order->save_meta_data();
 
 		$this->mock_api_client->expects( $this->once() )
@@ -83,7 +85,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 	public function test_track_update_order_action_with_no_payment_method() {
 		$order = WC_Helper_Order::create_order();
-		$order->delete_meta_data( '_payment_method_id' );
+		$order->delete_meta_data( '_payment_method_token' );
 		$order->save_meta_data();
 
 		$this->assertFalse( $this->action_scheduler_service->track_update_order_action( $order ) );
@@ -109,7 +111,10 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 
 		return array_merge(
 			$order->get_data(),
-			[ '_payment_method_id' => $order->get_meta( '_payment_method_id' ) ]
+			[
+				'_payment_method_token' => $order->get_meta( '_payment_method_token' ),
+				'_stripe_customer_id'   => $order->get_meta( '_stripe_customer_id' ),
+			]
 		);
 	}
 }

--- a/tests/unit/test-class-wc-payments-action-scheduler-service.php
+++ b/tests/unit/test-class-wc-payments-action-scheduler-service.php
@@ -86,7 +86,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 		$order->delete_meta_data( '_payment_method_token' );
 		$order->save_meta_data();
 
-		$this->assertFalse ( $this->action_scheduler_service->track_update_order_action( $order ) );
+		$this->assertFalse( $this->action_scheduler_service->track_update_order_action( $order ) );
 	}
 
 	public function test_track_update_order_action_with_invalid_order_id() {


### PR DESCRIPTION
Fixes 585-gh-Automattic/woocommerce-payments-server 

Relies on #1295.

#### Changes proposed in this Pull Request

Adds Subscription Compatibility for Order Update Events

Some order updates were not getting tracked because the child-orders which are created for a Subscription do not have an `intent_id` attached. This adds logic to the Subscriptions compatibility WCPay gateway to get the details of the parent order when a subscription is updated.

#### Testing instructions

- Checkout this branch and server branch 590-gh-Automattic/woocommerce-payments-server (if not already merged).
- Make sure the async jobs watcher is running on your sandbox and that your client is pointed at your sandbox.
- Create a subscription order by purchasing it via the checkout. 
- Check **Tools -> ActionScheduler** and verify that `wcpay_create_order` and `wcpay_update_order` events are present for the newly created subscription order.
- Run these jobs and verify that the events appear in the async jobs watcher and in the [Sift Console](https://console.sift.com/developer/api-logs?abuse_type=account_abuse).
- Go to the account of the user who purchased the order (**My Account -> Subscriptions**) and make a change to the subscription (for example, cancelling it or changing the payment method)
- Verify that this created an update order event in the **Tools -> ActionScheduler** section (this should be visible in the 'Pending' jobs section). Run it and verify it appears in the async jobs watcher and in Sift console.

Note that there is still an issue when it comes to free trial subscriptions. Once the free trial is over, the renewal order event should send an event, however the free trial order creation currently does not send an event because there is no Payment Method attached to the order, which is a requirement for tracking. This PR however stops any errors/alerts from occurring because of this (previously, we were seeing some errors in Slack related to subscriptions).

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->