### PR TITLE
Support multiple customer currencies in live mode

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
-= 2.x.x - 2021-xx-xx =
+= 2.1.0 - 2021-xx-xx =
 * Update - Show last 4 digit credit card number in order note when payment method is updated on failed renewal subscription order.
+* Update - Enable multiple customer currencies support in live mode.
 
 = 2.0.0 - 2021-02-22 =
 * Update - Render customer details in transactions list as text instead of link if order missing.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -277,10 +277,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return bool Whether the gateway is enabled and ready to accept payments.
 	 */
 	public function is_available() {
-		if ( ! $this->is_in_dev_mode() && 'USD' !== get_woocommerce_currency() ) {
-			return false;
-		}
-
 		return parent::is_available() && ! $this->needs_setup();
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -101,8 +101,10 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
-= 2.x.x - 2021-xx-xx =
+
+= 2.1.0 - 2021-xx-xx =
 * Update - Show last 4 digit credit card number in order note when payment method is updated on failed renewal subscription order.
+* Update - Enable multiple customer currencies support in live mode.
 
 = 2.0.0 - 2021-02-22 =
 * Update - Render customer details in transactions list as text instead of link if order missing.

--- a/readme.txt
+++ b/readme.txt
@@ -101,7 +101,6 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
-
 = 2.1.0 - 2021-xx-xx =
 * Update - Show last 4 digit credit card number in order note when payment method is updated on failed renewal subscription order.
 * Update - Enable multiple customer currencies support in live mode.


### PR DESCRIPTION
Fixes #777

#### Changes proposed in this Pull Request

* Remove USD only currency restriction for live mode (part of #1007)

#### Testing instructions

* Checks should be green.
* Purchases should work in USD and non-USD currencies (see testing instructions on https://github.com/Automattic/woocommerce-payments/pull/1007).

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
