### PR TITLE
Send more data when creating/updating customers

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -535,7 +535,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		$order_id = $order->get_id();
 		$amount   = $order->get_total();
-		$user     = $order->get_user() ?? wp_get_current_user();
+		$user     = $order->get_user();
+		if ( false === $user ) {
+			$user = wp_get_current_user();
+		}
 		$name     = sanitize_text_field( $order->get_billing_first_name() ) . ' ' . sanitize_text_field( $order->get_billing_last_name() );
 		$email    = sanitize_email( $order->get_billing_email() );
 		$metadata = [

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1670,11 +1670,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$payment_information = Payment_Information::from_payment_request( $_POST );
 
 		// Determine the customer adding the payment method, create one if we don't have one already.
-		$user          = wp_get_current_user();
-		$customer_id   = $this->customer_service->get_customer_id_by_user_id( $user->ID );
-		$customer_data = WC_Payments_Customer_Service::map_customer_data( null, new WC_Customer( $user->ID ) );
+		$user        = wp_get_current_user();
+		$customer_id = $this->customer_service->get_customer_id_by_user_id( $user->ID );
 		if ( null === $customer_id ) {
-			$customer_id = $this->customer_service->create_customer_for_user( $user, $customer_data );
+			$customer_data = WC_Payments_Customer_Service::map_customer_data( null, new WC_Customer( $user->ID ) );
+			$customer_id   = $this->customer_service->create_customer_for_user( $user, $customer_data );
 		}
 
 		return $this->payments_api_client->create_and_confirm_setup_intent(

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -547,15 +547,16 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		];
 
 		// Determine the customer making the payment, create one if we don't have one already.
-		$customer_id = $this->customer_service->get_customer_id_by_user_id( $user->ID );
+		$customer_id   = $this->customer_service->get_customer_id_by_user_id( $user->ID );
+		$customer_data = WC_Payments_Customer_Service::construct_customer_data( $order, new WC_Customer( $user->ID ) );
 
 		if ( null === $customer_id ) {
 			// Create a new customer.
-			$customer_id = $this->customer_service->create_customer_for_user( $user, $name, $email );
+			$customer_id = $this->customer_service->create_customer_for_user( $user, $customer_data );
 		} else {
 			// Update the existing customer with the current details. In the event the old customer can't be
 			// found a new one is created, so we update the customer ID here as well.
-			$customer_id = $this->customer_service->update_customer_for_user( $customer_id, $user, $name, $email );
+			$customer_id = $this->customer_service->update_customer_for_user( $customer_id, $user, $customer_data );
 		}
 
 		// Update saved payment method information with checkout values, as some saved methods might not have billing details.
@@ -1669,10 +1670,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$payment_information = Payment_Information::from_payment_request( $_POST );
 
 		// Determine the customer adding the payment method, create one if we don't have one already.
-		$user        = wp_get_current_user();
-		$customer_id = $this->customer_service->get_customer_id_by_user_id( $user->ID );
+		$user          = wp_get_current_user();
+		$customer_id   = $this->customer_service->get_customer_id_by_user_id( $user->ID );
+		$customer_data = WC_Payments_Customer_Service::construct_customer_data( null, new WC_Customer( $user->ID ) );
 		if ( null === $customer_id ) {
-			$customer_id = $this->customer_service->create_customer_for_user( $user, "{$user->first_name} {$user->last_name}", $user->user_email );
+			$customer_id = $this->customer_service->create_customer_for_user( $user, $customer_data );
 		}
 
 		return $this->payments_api_client->create_and_confirm_setup_intent(

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -548,7 +548,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// Determine the customer making the payment, create one if we don't have one already.
 		$customer_id   = $this->customer_service->get_customer_id_by_user_id( $user->ID );
-		$customer_data = WC_Payments_Customer_Service::construct_customer_data( $order, new WC_Customer( $user->ID ) );
+		$customer_data = WC_Payments_Customer_Service::map_customer_data( $order, new WC_Customer( $user->ID ) );
 
 		if ( null === $customer_id ) {
 			// Create a new customer.
@@ -1672,7 +1672,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// Determine the customer adding the payment method, create one if we don't have one already.
 		$user          = wp_get_current_user();
 		$customer_id   = $this->customer_service->get_customer_id_by_user_id( $user->ID );
-		$customer_data = WC_Payments_Customer_Service::construct_customer_data( null, new WC_Customer( $user->ID ) );
+		$customer_data = WC_Payments_Customer_Service::map_customer_data( null, new WC_Customer( $user->ID ) );
 		if ( null === $customer_id ) {
 			$customer_id = $this->customer_service->create_customer_for_user( $user, $customer_data );
 		}

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -246,7 +246,7 @@ class WC_Payments_Customer_Service {
 	 *
 	 * @return array Customer data.
 	 */
-	public static function construct_customer_data( $wc_order = null, $wc_customer = null ) {
+	public static function map_customer_data( $wc_order = null, $wc_customer = null ) {
 		if ( null === $wc_customer && null === $wc_order ) {
 			return [];
 		}

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -94,23 +94,20 @@ class WC_Payments_Customer_Service {
 	/**
 	 * Create a customer and associate it with a WordPress user.
 	 *
-	 * @param WP_User $user  User to create a customer for.
-	 * @param string  $name  Customer name.
-	 * @param string  $email Customer email.
+	 * @param WP_User $user          User to create a customer for.
+	 * @param array   $customer_data Customer data.
 	 *
 	 * @return string The created customer's ID
 	 *
 	 * @throws API_Exception Error creating customer.
 	 */
-	public function create_customer_for_user( $user, $name, $email ) {
-		$description = $this->build_description_string( $user, $name );
-
+	public function create_customer_for_user( $user, $customer_data ) {
 		// Include the session ID for the user.
-		$fraud_config = $this->account->get_fraud_services_config();
-		$session_id   = isset( $fraud_config['sift']['session_id'] ) ? $fraud_config['sift']['session_id'] : null;
+		$fraud_config                = $this->account->get_fraud_services_config();
+		$customer_data['session_id'] = $fraud_config['sift']['session_id'] ?? null;
 
 		// Create a customer on the WCPay server.
-		$customer_id = $this->payments_api_client->create_customer( $name, $email, $description, $session_id );
+		$customer_id = $this->payments_api_client->create_customer( $customer_data );
 
 		if ( $user->ID > 0 ) {
 			$result = update_user_option( $user->ID, $this->get_customer_id_option(), $customer_id );
@@ -128,25 +125,18 @@ class WC_Payments_Customer_Service {
 	 *
 	 * @param string  $customer_id WCPay customer ID.
 	 * @param WP_User $user        WordPress user.
-	 * @param string  $name        Customer's full name.
-	 * @param string  $email       Customer's email address.
+	 * @param array   $customer_data Customer data.
 	 *
 	 * @return string The updated customer's ID. Can be different to the ID parameter if the customer was re-created.
 	 *
 	 * @throws API_Exception Error updating the customer.
 	 */
-	public function update_customer_for_user( $customer_id, $user, $name, $email ) {
-		$description = $this->build_description_string( $user, $name );
-
+	public function update_customer_for_user( $customer_id, $user, $customer_data ) {
 		try {
 			// Update the customer on the WCPay server.
 			$this->payments_api_client->update_customer(
 				$customer_id,
-				[
-					'name'        => $name,
-					'email'       => $email,
-					'description' => $description,
-				]
+				$customer_data
 			);
 
 			// We successfully updated the existing customer, so return the passed in ID unchanged.
@@ -157,7 +147,7 @@ class WC_Payments_Customer_Service {
 			// account was changed, or if users were imported from another site.
 			if ( $e->get_error_code() === 'resource_missing' ) {
 				// Create a new customer to associate with this user. We'll return the new customer ID.
-				return $this->recreate_customer( $user, $name, $email );
+				return $this->recreate_customer( $user, $customer_data );
 			}
 
 			// For any other type of exception, just re-throw.
@@ -248,37 +238,76 @@ class WC_Payments_Customer_Service {
 	}
 
 	/**
-	 * Build the customer description string.
+	 * Given a WC_Order or WC_Customer, returns an array representing a Stripe customer object.
+	 * At least one parameter has to not be null.
 	 *
-	 * @param WP_User $user WordPress user.
-	 * @param string  $name Customer's full name.
+	 * @param WC_Order    $wc_order    The Woo order to parse.
+	 * @param WC_Customer $wc_customer The Woo customer to parse.
 	 *
-	 * @return string
+	 * @return array Customer data.
 	 */
-	private function build_description_string( $user, $name ) {
-		if ( $user->ID > 0 ) {
+	public static function construct_customer_data( $wc_order = null, $wc_customer = null ) {
+		if ( null === $wc_customer && null === $wc_order ) {
+			return [];
+		}
+
+		// Where available, the order data takes precedence over the customer.
+		$object_to_parse = $wc_order ?? $wc_customer;
+		$name            = $object_to_parse->get_billing_first_name() . ' ' . $object_to_parse->get_billing_last_name();
+		$description     = '';
+		if ( null !== $wc_customer ) {
 			// We have a logged in user, so add their username to the customer description.
 			// translators: %1$s Name, %2$s Username.
-			return sprintf( __( 'Name: %1$s, Username: %2$s', 'woocommerce-payments' ), $name, $user->user_login );
+			$description = sprintf( __( 'Name: %1$s, Username: %2$s', 'woocommerce-payments' ), $name, $wc_customer->get_username() );
 		} else {
 			// Current user is not logged in.
 			// translators: %1$s Name.
-			return sprintf( __( 'Name: %1$s, Guest', 'woocommerce-payments' ), $name );
+			$description = sprintf( __( 'Name: %1$s, Guest', 'woocommerce-payments' ), $name );
 		}
+
+		$data = [
+			'name'        => $name,
+			'description' => $description,
+			'email'       => $object_to_parse->get_billing_email(),
+			'phone'       => $object_to_parse->get_billing_phone(),
+			'address'     => [
+				'line1'       => $object_to_parse->get_billing_address_1(),
+				'line2'       => $object_to_parse->get_billing_address_2(),
+				'postal_code' => $object_to_parse->get_billing_postcode(),
+				'city'        => $object_to_parse->get_billing_city(),
+				'state'       => $object_to_parse->get_billing_state(),
+				'country'     => $object_to_parse->get_billing_country(),
+			],
+		];
+
+		if ( ! empty( $object_to_parse->get_shipping_postcode() ) ) {
+			$data['shipping'] = [
+				'name'    => $object_to_parse->get_shipping_first_name() . ' ' . $object_to_parse->get_shipping_last_name(),
+				'address' => [
+					'line1'       => $object_to_parse->get_shipping_address_1(),
+					'line2'       => $object_to_parse->get_shipping_address_2(),
+					'postal_code' => $object_to_parse->get_shipping_postcode(),
+					'city'        => $object_to_parse->get_shipping_city(),
+					'state'       => $object_to_parse->get_shipping_state(),
+					'country'     => $object_to_parse->get_shipping_country(),
+				],
+			];
+		}
+
+		return $data;
 	}
 
 	/**
 	 * Recreates the customer for this user.
 	 *
-	 * @param WP_User $user  User to recreate a customer for.
-	 * @param string  $name  Customer name.
-	 * @param string  $email Customer email.
+	 * @param WP_User $user          User to recreate a customer for.
+	 * @param array   $customer_data Customer data.
 	 *
 	 * @return string The newly created customer's ID
 	 *
 	 * @throws API_Exception Error creating customer.
 	 */
-	private function recreate_customer( $user, $name, $email ) {
+	private function recreate_customer( $user, $customer_data ) {
 		if ( $user->ID > 0 ) {
 			$result = delete_user_option( $user->ID, $this->get_customer_id_option() );
 			if ( ! $result ) {
@@ -287,7 +316,7 @@ class WC_Payments_Customer_Service {
 			}
 		}
 
-		return $this->create_customer_for_user( $user, $name, $email );
+		return $this->create_customer_for_user( $user, $customer_data );
 	}
 
 	/**

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -255,7 +255,7 @@ class WC_Payments_Customer_Service {
 		$object_to_parse = $wc_order ?? $wc_customer;
 		$name            = $object_to_parse->get_billing_first_name() . ' ' . $object_to_parse->get_billing_last_name();
 		$description     = '';
-		if ( null !== $wc_customer ) {
+		if ( null !== $wc_customer && ! empty( $wc_customer->get_username() ) ) {
 			// We have a logged in user, so add their username to the customer description.
 			// translators: %1$s Name, %2$s Username.
 			$description = sprintf( __( 'Name: %1$s, Username: %2$s', 'woocommerce-payments' ), $name, $wc_customer->get_username() );

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -101,7 +101,7 @@ class WC_Payments_Customer_Service {
 	 *
 	 * @throws API_Exception Error creating customer.
 	 */
-	public function create_customer_for_user( $user, $customer_data ) {
+	public function create_customer_for_user( WP_User $user, array $customer_data ): string {
 		// Include the session ID for the user.
 		$fraud_config                = $this->account->get_fraud_services_config();
 		$customer_data['session_id'] = $fraud_config['sift']['session_id'] ?? null;
@@ -131,7 +131,7 @@ class WC_Payments_Customer_Service {
 	 *
 	 * @throws API_Exception Error updating the customer.
 	 */
-	public function update_customer_for_user( $customer_id, $user, $customer_data ) {
+	public function update_customer_for_user( string $customer_id, WP_User $user, array $customer_data ): string {
 		try {
 			// Update the customer on the WCPay server.
 			$this->payments_api_client->update_customer(
@@ -246,7 +246,7 @@ class WC_Payments_Customer_Service {
 	 *
 	 * @return array Customer data.
 	 */
-	public static function map_customer_data( $wc_order = null, $wc_customer = null ) {
+	public static function map_customer_data( WC_Order $wc_order = null, WC_Customer $wc_customer = null ): array {
 		if ( null === $wc_customer && null === $wc_order ) {
 			return [];
 		}
@@ -307,7 +307,7 @@ class WC_Payments_Customer_Service {
 	 *
 	 * @throws API_Exception Error creating customer.
 	 */
-	private function recreate_customer( $user, $customer_data ) {
+	private function recreate_customer( WP_User $user, array $customer_data ): string {
 		if ( $user->ID > 0 ) {
 			$result = delete_user_option( $user->ID, $this->get_customer_id_option() );
 			if ( ! $result ) {

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -694,23 +694,15 @@ class WC_Payments_API_Client {
 	/**
 	 * Create a customer.
 	 *
-	 * @param string|null $name        Customer's full name.
-	 * @param string|null $email       Customer's email address.
-	 * @param string|null $description Description of customer.
-	 * @param string|null $session_id  Customer's session ID.
+	 * @param array $customer_data Customer data.
 	 *
 	 * @return string The created customer's ID
 	 *
 	 * @throws API_Exception Error creating customer.
 	 */
-	public function create_customer( $name = null, $email = null, $description = null, $session_id = null ) {
+	public function create_customer( $customer_data ) {
 		$customer_array = $this->request(
-			[
-				'name'        => $name,
-				'email'       => $email,
-				'description' => $description,
-				'session_id'  => $session_id,
-			],
+			$customer_data,
 			self::CUSTOMERS_API,
 			self::POST
 		);

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -700,7 +700,7 @@ class WC_Payments_API_Client {
 	 *
 	 * @throws API_Exception Error creating customer.
 	 */
-	public function create_customer( $customer_data ) {
+	public function create_customer( array $customer_data ): string {
 		$customer_array = $this->request(
 			$customer_data,
 			self::CUSTOMERS_API,

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -298,9 +298,11 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 	 * @throws API_Exception
 	 */
 	public function test_create_customer_success() {
-		$name        = 'Test Customer';
-		$email       = 'test.customer@example.com';
-		$description = 'Test Customer Description';
+		$customer_data = [
+			'name'        => 'Test Customer',
+			'email'       => 'test.customer@example.com',
+			'description' => 'Test Customer Description',
+		];
 
 		$this->set_http_mock_response(
 			200,
@@ -310,7 +312,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 			]
 		);
 
-		$customer_id = $this->payments_api_client->create_customer( $name, $email, $description );
+		$customer_id = $this->payments_api_client->create_customer( $customer_data );
 
 		$this->assertEquals( 'cus_test12345', $customer_id );
 	}


### PR DESCRIPTION
Fixes 506-gh-Automattic/woocommerce-payments-server

#### Changes proposed in this Pull Request

- Added `WC_Payments_Customer_Service::map_customer_data` to map Woo Orders and Woo Customers to Stripe-acceptable data
- Updated the gateway to use that method when creating or updating customers in the backend

#### Testing instructions

* Checkout the Server PR 592-gh-Automattic/woocommerce-payments-server
* Checkout as a logged-in user
* Checkout as a logged-out user
* Add a payment method as a brand new user on the site
* Check your Stripe dashboard - all of the customers should have extra data set on them, not just name/email

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->