### PR TITLE
Send order key in the meta when creating intentions

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -547,6 +547,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'customer_email' => $email,
 			'site_url'       => esc_url( get_site_url() ),
 			'order_id'       => $order_id,
+			'order_key'      => $order->get_order_key(),
 			'payment_type'   => $payment_information->get_payment_type(),
 		];
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
@@ -160,8 +160,9 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WP_UnitTestCase {
 				$this->anything(),
 				// Metadata argument.
 				$this->callback(
-					function( $metadata ) {
+					function( $metadata ) use ( $order ) {
 						$this->assertEquals( $metadata['payment_type'], 'single' );
+						$this->assertEquals( $metadata['order_key'], $order->get_order_key() );
 						return is_array( $metadata );
 					}
 				)
@@ -188,8 +189,9 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WP_UnitTestCase {
 				$this->anything(),
 				// Metadata argument.
 				$this->callback(
-					function( $metadata ) {
+					function( $metadata ) use ( $order ) {
 						$this->assertEquals( $metadata['payment_type'], 'recurring' );
+						$this->assertEquals( $metadata['order_key'], $order->get_order_key() );
 						return is_array( $metadata );
 					}
 				)
@@ -222,8 +224,9 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WP_UnitTestCase {
 				$this->anything(),
 				// Metadata argument.
 				$this->callback(
-					function( $metadata ) {
+					function( $metadata ) use ( $order ) {
 						$this->assertEquals( $metadata['payment_type'], 'recurring' );
+						$this->assertEquals( $metadata['order_key'], $order->get_order_key() );
 						return is_array( $metadata );
 					}
 				)


### PR DESCRIPTION
Fixes 505-gh-Automattic/woocommerce-payments-server

#### Changes proposed in this Pull Request

- Add `order_key` field to the payment intention metadata

#### Testing instructions

* Make a payment
* View in the Stripe dashboard - the order key meta should be present

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->