### PR TITLE
Added inbox notification for when instant deposits are eligible

### DIFF
--- a/client/deposits/overview/test/__snapshots__/index.js.snap
+++ b/client/deposits/overview/test/__snapshots__/index.js.snap
@@ -5,34 +5,38 @@ exports[`Deposits overview renders correctly 1`] = `
   <div
     class="wcpay-deposits-overview"
   >
-    <p
-      class="wcpay-deposits-overview__schedule"
+    <div
+      class="wcpay-deposits-overview__header"
     >
-      <svg
-        class="gridicon gridicons-calendar wcpay-deposits-overview__schedule-icon"
-        height="24"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
+      <p
+        class="wcpay-deposits-overview__schedule"
       >
-        <g>
-          <path
-            d="M19 4h-1V2h-2v2H8V2H6v2H5c-1.105 0-2 .896-2 2v13c0 1.104.895 2 2 2h14c1.104 0 2-.896 2-2V6c0-1.104-.896-2-2-2zm0 15H5V8h14v11z"
-          />
-        </g>
-      </svg>
-      <span
-        class="wcpay-deposits-overview__schedule-label"
-      >
-        Deposit schedule:
-      </span>
-       
-      <span
-        class="wcpay-deposits-overview__schedule-value"
-      >
-        Automatic, every business day
-      </span>
-    </p>
+        <svg
+          class="gridicon gridicons-calendar wcpay-deposits-overview__schedule-icon"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g>
+            <path
+              d="M19 4h-1V2h-2v2H8V2H6v2H5c-1.105 0-2 .896-2 2v13c0 1.104.895 2 2 2h14c1.104 0 2-.896 2-2V6c0-1.104-.896-2-2-2zm0 15H5V8h14v11z"
+            />
+          </g>
+        </svg>
+        <span
+          class="wcpay-deposits-overview__schedule-label"
+        >
+          Deposit schedule:
+        </span>
+         
+        <span
+          class="wcpay-deposits-overview__schedule-value"
+        >
+          Automatic, every business day
+        </span>
+      </p>
+    </div>
     <div
       aria-describedby="woocommerce-summary-helptext-1"
       aria-label="Deposits overview"

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -783,10 +783,9 @@ class WC_Payments_Account {
 	 * @return void
 	 */
 	public function handle_instant_deposits_inbox_reminder(): void {
-		$account = $this->get_cached_account_data();
 		require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-instant-deposits-eligible.php';
 		WC_Payments_Notes_Instant_Deposits_Eligible::possibly_delete_note();
-		$this->handle_instant_deposits_inbox_note( $account );
+		$this->handle_instant_deposits_inbox_note();
 	}
 
 	/**
@@ -802,7 +801,7 @@ class WC_Payments_Account {
 			return;
 		}
 
-		$reminder_time = time() + 30; //( 90 * DAY_IN_SECONDS );
+		$reminder_time = time() + ( 90 * DAY_IN_SECONDS );
 		$action_scheduler_service->schedule_job( $reminder_time, $action_hook );
 	}
 }

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -35,7 +35,7 @@ class WC_Payments_Account {
 	 * @param WC_Payments_API_Client $payments_api_client Payments API client.
 	 */
 	public function __construct( WC_Payments_API_Client $payments_api_client ) {
-		$this->payments_api_client      = $payments_api_client;
+		$this->payments_api_client = $payments_api_client;
 
 		add_action( 'admin_init', [ $this, 'maybe_handle_oauth' ] );
 		add_action( 'admin_init', [ $this, 'check_stripe_account_status' ], 11 ); // Run this after the WC setup wizard redirection logic.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -766,7 +766,7 @@ class WC_Payments_Account {
 	 *
 	 * @return void
 	 */
-	public function handle_instant_deposits_inbox_note(): void {
+	public function handle_instant_deposits_inbox_note() {
 		if ( ! $this->is_instant_deposits_eligible() ) {
 			return;
 		}
@@ -782,7 +782,7 @@ class WC_Payments_Account {
 	 *
 	 * @return void
 	 */
-	public function handle_instant_deposits_inbox_reminder(): void {
+	public function handle_instant_deposits_inbox_reminder() {
 		require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-instant-deposits-eligible.php';
 		WC_Payments_Notes_Instant_Deposits_Eligible::possibly_delete_note();
 		$this->handle_instant_deposits_inbox_note();
@@ -793,7 +793,7 @@ class WC_Payments_Account {
 	 *
 	 * @return void
 	 */
-	public function maybe_add_instant_deposit_note_reminder(): void {
+	public function maybe_add_instant_deposit_note_reminder() {
 		$action_scheduler_service = new WC_Payments_Action_Scheduler_Service( $this->payments_api_client );
 		$action_hook              = 'wcpay_instant_deposit_reminder';
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -749,14 +749,25 @@ class WC_Payments_Account {
 	}
 
 	/**
-	 * Handles adding a note if the merchant is eligible for Instant Deposits.
+	 * Checks to see if the account is eligible for Instant Deposits.
 	 *
-	 * @param array|null $account The merchant account data.
+	 * @return bool
+	 */
+	public function is_instant_deposits_eligible(): bool {
+		$account = $this->get_cached_account_data();
+		if ( ! isset( $account['instant_deposits_eligible'] ) || ! $account['instant_deposits_eligible'] ) {
+			return false;
+		}
+
+		return true;
+	}
+	/**
+	 * Handles adding a note if the merchant is eligible for Instant Deposits.
 	 *
 	 * @return void
 	 */
-	public function handle_instant_deposits_inbox_note( $account = null ): void {
-		if ( ! isset( $account['instant_deposits_eligible'] ) || ! $account['instant_deposits_eligible'] ) {
+	public function handle_instant_deposits_inbox_note(): void {
+		if ( ! $this->is_instant_deposits_eligible() ) {
 			return;
 		}
 
@@ -791,7 +802,7 @@ class WC_Payments_Account {
 			return;
 		}
 
-		$reminder_time = time() + ( 90 * DAY_IN_SECONDS );
+		$reminder_time = time() + 30; //( 90 * DAY_IN_SECONDS );
 		$action_scheduler_service->schedule_job( $reminder_time, $action_hook );
 	}
 }

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -121,7 +121,7 @@ class WC_Payments_Action_Scheduler_Service {
 	 *
 	 * @return bool
 	 */
-	public function pending_action_exists( $hook ) {
+	public function pending_action_exists( $hook ): bool {
 		$actions = as_get_scheduled_actions( [
 			'hook'   => $hook,
 			'status' => ActionScheduler_Store::STATUS_PENDING,

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -11,6 +11,8 @@ defined( 'ABSPATH' ) || exit;
  * Class which handles setting up all ActionScheduler hooks.
  */
 class WC_Payments_Action_Scheduler_Service {
+
+	const GROUP_ID = 'woocommerce_payments';
 	/**
 	 * Client for making requests to the WooCommerce Payments API
 	 *
@@ -104,11 +106,28 @@ class WC_Payments_Action_Scheduler_Service {
 	 *
 	 * @return void
 	 */
-	public function schedule_job( $timestamp, $hook, $args = [], $group = '' ) {
+	public function schedule_job( $timestamp, $hook, $args = [], $group = self::GROUP_ID ) {
 		// Unschedule any previously scheduled instances of this particular job.
 		as_unschedule_action( $hook, $args, $group );
 
 		// Schedule the job.
 		as_schedule_single_action( $timestamp, $hook, $args, $group );
+	}
+
+	/**
+	 * Checks to see if there is a Pending action with the same hook already.
+	 *
+	 * @param $hook
+	 *
+	 * @return bool
+	 */
+	public function pending_action_exists( $hook ) {
+		$actions = as_get_scheduled_actions( [
+			'hook'   => $hook,
+			'status' => ActionScheduler_Store::STATUS_PENDING,
+			'group'  => self::GROUP_ID,
+		] );
+
+		return count( $actions ) > 0;
 	}
 }

--- a/includes/class-wc-payments-fraud-service.php
+++ b/includes/class-wc-payments-fraud-service.php
@@ -53,7 +53,7 @@ class WC_Payments_Fraud_Service {
 
 		add_filter( 'wcpay_prepare_fraud_config', [ $this, 'prepare_fraud_config' ], 10, 2 );
 		add_filter( 'wcpay_current_session_id', [ $this, 'get_session_id' ] );
-		add_action( 'woocommerce_init', [ $this, 'link_session_if_user_just_logged_in' ] );
+		add_action( 'init', [ $this, 'link_session_if_user_just_logged_in' ] );
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -521,9 +521,6 @@ class WC_Payments {
 
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-https-for-checkout.php';
 			WC_Payments_Notes_Set_Https_For_Checkout::possibly_add_note();
-
-			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-instant-deposits-eligible.php';
-			WC_Payments_Notes_Instant_Deposits_Eligible::possibly_add_note();
 		}
 	}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -521,6 +521,9 @@ class WC_Payments {
 
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-https-for-checkout.php';
 			WC_Payments_Notes_Set_Https_For_Checkout::possibly_add_note();
+
+			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-instant-deposits-eligible.php';
+			WC_Payments_Notes_Instant_Deposits_Eligible::possibly_add_note();
 		}
 	}
 
@@ -536,6 +539,9 @@ class WC_Payments {
 
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-https-for-checkout.php';
 			WC_Payments_Notes_Set_Https_For_Checkout::possibly_delete_note();
+
+			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-instant-deposits-eligible.php';
+			WC_Payments_Notes_Instant_Deposits_Eligible::possibly_delete_note();
 		}
 	}
 }

--- a/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
+++ b/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
@@ -13,14 +13,7 @@ defined( 'ABSPATH' ) || exit;
  * Class WC_Payments_Notes_Set_Https_For_Checkout
  */
 class WC_Payments_Notes_Instant_Deposits_Eligible {
-	use NoteTraits {
-		can_be_added as protected trait_can_be_added;
-	}
-
-	/**
-	 * The transient that the account data is stored in.
-	 */
-	const ACCOUNT_TRANSIENT = 'wcpay_account_data';
+	use NoteTraits;
 
 	/**
 	 * Name of the note for use in the database.
@@ -32,20 +25,6 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 	 */
 	// TODO: Get the proper doc url.
 	const NOTE_DOCUMENTATION_URL = '';
-
-	/**
-	 * Checks if a note can and should be added.
-	 *
-	 * @return bool
-	 */
-	public static function can_be_added() {
-		$account = get_transient( self::ACCOUNT_TRANSIENT );
-
-		// If the flag exists and is true, we return that the note should be added.
-		if ( isset( $account['instant_deposits_eligible'] ) && $account['instant_deposits_eligible'] ) {
-			return self::trait_can_be_added();
-		}
-	}
 
 	/**
 	 * Get the note.

--- a/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
+++ b/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Notify merchant that they are eligible for Instant Deposits.
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WC_Payments_Notes_Set_Https_For_Checkout
+ */
+class WC_Payments_Notes_Instant_Deposits_Eligible {
+	use NoteTraits {
+		can_be_added as protected trait_can_be_added;
+	}
+
+	/**
+	 * The transient that the account data is stored in.
+	 */
+	const ACCOUNT_TRANSIENT = 'wcpay_account_data';
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-payments-notes-instant-deposits-eligible';
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	// TODO: Get the proper doc url.
+	const NOTE_DOCUMENTATION_URL = '';
+
+	/**
+	 * Checks if a note can and should be added.
+	 *
+	 * @return bool
+	 */
+	public static function can_be_added() {
+		$account = get_transient( self::ACCOUNT_TRANSIENT );
+
+		// If the flag exists and is true, we return that the note should be added.
+		if ( isset( $account['instant_deposits_eligible'] ) && $account['instant_deposits_eligible'] ) {
+			return self::trait_can_be_added();
+		}
+	}
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		$note_class = WC_Payment_Woo_Compat_Utils::get_note_class();
+		$note       = new $note_class();
+
+		// TODO: get the proper title and message.
+		$note->set_title( __( 'Instant deposits available', 'woocommerce-payments' ) );
+		$note->set_content( __( 'You are now eligible for Instant Deposits!', 'woocommerce-payments' ) );
+		$note->set_content_data( (object) [] );
+		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-payments' );
+		$note->add_action(
+			self::NOTE_NAME,
+			__( 'Read more', 'woocommerce-payments' ),
+			self::NOTE_DOCUMENTATION_URL,
+			'unactioned',
+			true
+		);
+
+		return $note;
+	}
+}

--- a/tests/unit/notes/test-class-wc-payments-notes-instant-deposits-eligible.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-instant-deposits-eligible.php
@@ -14,25 +14,8 @@ class WC_Payments_Notes_Instant_Deposits_Eligible_Test extends WP_UnitTestCase {
 			// Trigger WCPay extension deactivation callback.
 			wcpay_deactivated();
 
-			$note_id = WC_Payments_Notes_Set_Https_For_Checkout::NOTE_NAME;
-			$this->assertSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
-		} else {
-			$this->markTestSkipped( 'The used WC components are not backward compatible' );
-		}
-	}
-
-	// TODO: fix this test so it's actually testing.
-	public function test_adds_note_in_hook() {
-		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
-			// Trigger WCPay extension woo notes hook.
-			WC_Payments::add_woo_admin_notes();
-
 			$note_id = WC_Payments_Notes_Instant_Deposits_Eligible::NOTE_NAME;
-			if ( true ) {
-				$this->assertSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
-			} else {
-				$this->assertNotSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
-			}
+			$this->assertSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
 		} else {
 			$this->markTestSkipped( 'The used WC components are not backward compatible' );
 		}

--- a/tests/unit/notes/test-class-wc-payments-notes-instant-deposits-eligible.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-instant-deposits-eligible.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Class WC_Payments_Notes_Instant_Deposits_Eligible_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * Class WC_Payments_Notes_Instant_Deposits_Eligible tests.
+ */
+class WC_Payments_Notes_Instant_Deposits_Eligible_Test extends WP_UnitTestCase {
+	public function test_removes_note_on_extension_deactivation() {
+		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+			// Trigger WCPay extension deactivation callback.
+			wcpay_deactivated();
+
+			$note_id = WC_Payments_Notes_Set_Https_For_Checkout::NOTE_NAME;
+			$this->assertSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
+		} else {
+			$this->markTestSkipped( 'The used WC components are not backward compatible' );
+		}
+	}
+
+	// TODO: fix this test so it's actually testing.
+	public function test_adds_note_in_hook() {
+		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+			// Trigger WCPay extension woo notes hook.
+			WC_Payments::add_woo_admin_notes();
+
+			$note_id = WC_Payments_Notes_Instant_Deposits_Eligible::NOTE_NAME;
+			if ( true ) {
+				$this->assertSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
+			} else {
+				$this->assertNotSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
+			}
+		} else {
+			$this->markTestSkipped( 'The used WC components are not backward compatible' );
+		}
+	}
+}

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -151,6 +151,7 @@ class WC_Payments_Account_Test extends WP_UnitTestCase {
 						'test_publishable_key'     => 'pk_live_',
 						'has_pending_requirements' => true,
 						'current_deadline'         => 12345,
+						'is_live'                  => true,
 					];
 				}
 			);


### PR DESCRIPTION
Fixes #1142

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Adds an inbox notification once the account has the `instant_deposits_eligible` flag set to `true`. 

There are still a few TODOs at this point:
* Proper notice title and message are needed.
* ~Code to bring the notification back after X amount of time.~ Added code for 90 day reminder.
* Proper doc link for notice.
* ~Finish unit test.~ Tests added.
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* At present, you will either need to use your local server with the `/feature/instant-deposits` checked out and modify the account data sent back from `compose_basic_account_info` to include `'instant_deposits_eligible' => true,`, or modify the transient in the database to include this same flag.
* Once that's done, you view any page that has the WC Admin bar on the top and the notification will be there.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
