### PR TITLE
Support non-USD base fee currency on settings screen

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Update - Define constant for the group to be used for scheduled actions.
 * Update - Enable multiple customer currencies support in live mode.
 * Add - Rate limit failed account connection checks.
+* Add - Support displaying non-USD base fees on settings page.
 
 = 2.0.0 - 2021-02-22 =
 * Update - Render customer details in transactions list as text instead of link if order missing.

--- a/client/account-fees/index.js
+++ b/client/account-fees/index.js
@@ -77,7 +77,7 @@ const AccountFees = ( { accountFees } ) => {
 		/* translators: %1: Percentage part of the fee. %2: Fixed part of the fee */
 		__( '%1$.1f%% + %2$s per transaction', 'woocommerce-payments' ),
 		currentFee.percentage_rate * 100,
-		formatCurrency( currentFee.fixed_rate )
+		formatCurrency( currentFee.fixed_rate, baseFee.currency )
 	);
 
 	if ( accountFees.discount.length ) {
@@ -103,7 +103,7 @@ const AccountFees = ( { accountFees } ) => {
 			),
 			feeDescription,
 			percentage * 100,
-			formatCurrency( fixed )
+			formatCurrency( fixed, baseFee.currency )
 		);
 
 		if ( currentFee.discount ) {

--- a/client/account-fees/test/__snapshots__/index.js.snap
+++ b/client/account-fees/test/__snapshots__/index.js.snap
@@ -186,6 +186,53 @@ exports[`AccountFees renders discounted fee without volume limit 1`] = `
 </div>
 `;
 
+exports[`AccountFees renders discounted non-USD base fee 1`] = `
+<div>
+  <p>
+    <s>
+      1.4% + £0.20 per transaction
+    </s>
+     0.7% + £0.10 per transaction
+  </p>
+  <div
+    class="progressbar"
+  >
+    <div
+      class="progressbar__container"
+    >
+      <div
+        class="progressbar__inner"
+        style="width: 1.234556%;"
+      />
+      <span
+        class="progressbar__outer-progress-label"
+      >
+        $12,345.56
+      </span>
+    </div>
+    <span
+      class="progressbar__total-label"
+    >
+      $1,000,000.00
+    </span>
+  </div>
+  <p
+    class="description"
+  >
+    Discounted base fee expires after the first $1,000,000.00 of total payment volume.
+  </p>
+  <p>
+    <a
+      href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Learn more
+    </a>
+  </p>
+</div>
+`;
+
 exports[`AccountFees renders first discounted fee ignoring the rest 1`] = `
 <div>
   <p>
@@ -197,6 +244,23 @@ exports[`AccountFees renders first discounted fee ignoring the rest 1`] = `
   <p>
     <a
       href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Learn more
+    </a>
+  </p>
+</div>
+`;
+
+exports[`AccountFees renders non-USD base fee 1`] = `
+<div>
+  <p>
+    2.9% + €0,25 per transaction
+  </p>
+  <p>
+    <a
+      href="https://docs.woocommerce.com/document/payments/faq/fees/"
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/client/account-fees/test/index.js
+++ b/client/account-fees/test/index.js
@@ -30,6 +30,18 @@ describe( 'AccountFees', () => {
 		expect( accountFees ).toMatchSnapshot();
 	} );
 
+	test( 'renders non-USD base fee', () => {
+		const { container: accountFees } = renderAccountFees( {
+			base: {
+				percentage_rate: 0.029,
+				fixed_rate: 25,
+				currency: 'eur',
+			},
+			discount: [],
+		} );
+		expect( accountFees ).toMatchSnapshot();
+	} );
+
 	test( 'renders discounted base fee', () => {
 		const { container: accountFees } = renderAccountFees( {
 			base: {
@@ -40,6 +52,25 @@ describe( 'AccountFees', () => {
 				{
 					percentage_rate: 0.02,
 					fixed_rate: 20,
+					volume_allowance: 100000000,
+					current_volume: 1234556,
+				},
+			],
+		} );
+		expect( accountFees ).toMatchSnapshot();
+	} );
+
+	test( 'renders discounted non-USD base fee', () => {
+		const { container: accountFees } = renderAccountFees( {
+			base: {
+				percentage_rate: 0.014,
+				fixed_rate: 20,
+				currency: 'gbp',
+			},
+			discount: [
+				{
+					percentage_rate: 0.007,
+					fixed_rate: 10,
 					volume_allowance: 100000000,
 					current_volume: 1234556,
 				},

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Define constant for the group to be used for scheduled actions.
 * Update - Enable multiple customer currencies support in live mode.
 * Add - Rate limit failed account connection checks.
+* Add - Support displaying non-USD base fees on settings page.
 
 = 2.0.0 - 2021-02-22 =
 * Update - Render customer details in transactions list as text instead of link if order missing.


### PR DESCRIPTION
Fixes #1257 

#### Changes proposed in this Pull Request

* Update rendering base fee for non US countries.

#### Testing instructions

* See in 624-gh-Automattic/woocommerce-payments-server

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->