### PR TITLE
Move changelog entry for #1148 to its proper place

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 2.x.x - 2021-xx-xx =
+* Update - Show last 4 digit credit card number in order note when payment method is updated on failed renewal subscription order.
+
 = 2.0.0 - 2021-02-22 =
 * Update - Render customer details in transactions list as text instead of link if order missing.
 * Update - Render transaction summary on details page for multi-currency transactions.
@@ -11,7 +14,6 @@
 * Add - Transaction timeline details for multi-currency transactions.  
 * Update - Link order note with transaction details page. 
 * Fix - Updating payment method using saved payment for WC Subscriptions orders.
-* Update - Show last 4 digit credit card number in order note when payment method is updated on failed renewal subscription order.
 
 = 1.9.2 - 2021-02-05 =
 * Fix - Checkout and cart blocks aren't usable in editor when WooCommerce Payments is enabled.

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 2.x.x - 2021-xx-xx =
+* Update - Show last 4 digit credit card number in order note when payment method is updated on failed renewal subscription order.
+
 = 2.0.0 - 2021-02-22 =
 * Update - Render customer details in transactions list as text instead of link if order missing.
 * Update - Render transaction summary on details page for multi-currency transactions.
@@ -112,7 +115,6 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Transaction timeline details for multi-currency transactions.
 * Update - Link order note with transaction details page.
 * Fix - Updating payment method using saved payment for WC Subscriptions orders.
-* Update - Show last 4 digit credit card number in order note when payment method is updated on failed renewal subscription order.
 
 = 1.9.2 - 2021-02-05 =
 * Fix - Checkout and cart blocks aren't usable in editor when WooCommerce Payments is enabled.


### PR DESCRIPTION
Fixes changelog entry for #1148

#### Changes proposed in this Pull Request

Only `changelog.txt` and `readme.txt` are changed to properly reflect where #1148 belongs.
- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
