### PR TITLE
Define constant for the group to be used for scheduled actions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 2.x.x - 2021-xx-xx =
 * Update - Show last 4 digit credit card number in order note when payment method is updated on failed renewal subscription order.
+* Update - Define constant for the group to be used for scheduled actions. 
 
 = 2.0.0 - 2021-02-22 =
 * Update - Render customer details in transactions list as text instead of link if order missing.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1671,16 +1671,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$this->action_scheduler_service->schedule_job(
 				strtotime( '+5 seconds' ),
 				'wcpay_track_new_order',
-				[ 'order_id' => $order_id ],
-				self::GATEWAY_ID
+				[ 'order_id' => $order_id ]
 			);
 		} else {
 			// Schedule an update action to send this information to the payment server.
 			$this->action_scheduler_service->schedule_job(
 				strtotime( '+5 seconds' ),
 				'wcpay_track_update_order',
-				[ 'order_id' => $order_id ],
-				self::GATEWAY_ID
+				[ 'order_id' => $order_id ]
 			);
 		}
 	}

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -11,6 +11,9 @@ defined( 'ABSPATH' ) || exit;
  * Class which handles setting up all ActionScheduler hooks.
  */
 class WC_Payments_Action_Scheduler_Service {
+
+	const GROUP_ID = 'woocommerce_payments';
+
 	/**
 	 * Client for making requests to the WooCommerce Payments API
 	 *
@@ -116,15 +119,14 @@ class WC_Payments_Action_Scheduler_Service {
 	 * @param int    $timestamp - When the job will run.
 	 * @param string $hook      - The hook to trigger.
 	 * @param array  $args      - An array containing the arguments to be passed to the hook.
-	 * @param string $group     - The group to assign this job to.
 	 *
 	 * @return void
 	 */
-	public function schedule_job( $timestamp, $hook, $args = [], $group = '' ) {
+	public function schedule_job( $timestamp, $hook, $args = [] ) {
 		// Unschedule any previously scheduled instances of this particular job.
-		as_unschedule_action( $hook, $args, $group );
+		as_unschedule_action( $hook, $args, self::GROUP_ID );
 
 		// Schedule the job.
-		as_schedule_single_action( $timestamp, $hook, $args, $group );
+		as_schedule_single_action( $timestamp, $hook, $args, self::GROUP_ID );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 2.x.x - 2021-xx-xx =
 * Update - Show last 4 digit credit card number in order note when payment method is updated on failed renewal subscription order.
+* Update - Define constant for the group to be used for scheduled actions.
 
 = 2.0.0 - 2021-02-22 =
 * Update - Render customer details in transactions list as text instead of link if order missing.


### PR DESCRIPTION

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Defined a constant to be used for scheduled actions within the `WC_Payments_Action_Scheduler_Service`. This will make it so that a group doesn't need to be passed when working with scheduled actions and everything will remain consistent.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Presently the only code that is using the `schedule_job` is related to Sift. This means you either need to have Sift set up, or you need to comment out the Sift check in `schedule_order_tracking` in `includes/class-wc-payment-gateway-wcpay.php`.
* From there, place an order and a `wcpay_track_new_order` action will be created with the `woocommerce_payments` group just as it was previously.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
