### PR TITLE
Tweak the "link_session" SIFT logic so it only fetches the WCPay account info when needed

### DIFF
--- a/includes/class-wc-payments-fraud-service.php
+++ b/includes/class-wc-payments-fraud-service.php
@@ -140,6 +140,9 @@ class WC_Payments_Fraud_Service {
 	 * @return boolean True if the user has just logged in, false in any other case.
 	 */
 	public function check_if_user_just_logged_in() {
+		if ( ! get_current_user_id() ) {
+			return false;
+		}
 		WC()->initialize_session();
 		$session_handler = WC()->session;
 		$cookie          = $session_handler->get_session_cookie();
@@ -161,13 +164,13 @@ class WC_Payments_Fraud_Service {
 			return;
 		}
 
-		$fraud_config = $this->account->get_fraud_services_config();
-		if ( ! isset( $fraud_config['sift'] ) ) {
-			// Only Sift needs to send data when the user logs in.
+		if ( ! $this->check_if_user_just_logged_in() ) {
 			return;
 		}
 
-		if ( ! $this->check_if_user_just_logged_in() ) {
+		$fraud_config = $this->account->get_fraud_services_config();
+		if ( ! isset( $fraud_config['sift'] ) ) {
+			// Only Sift needs to send data when the user logs in.
 			return;
 		}
 

--- a/includes/class-wc-payments-fraud-service.php
+++ b/includes/class-wc-payments-fraud-service.php
@@ -52,7 +52,6 @@ class WC_Payments_Fraud_Service {
 		$this->account             = $account;
 
 		add_filter( 'wcpay_prepare_fraud_config', [ $this, 'prepare_fraud_config' ], 10, 2 );
-		add_filter( 'wcpay_current_session_id', [ $this, 'get_session_id' ] );
 		add_action( 'woocommerce_init', [ $this, 'link_session_if_user_just_logged_in' ] );
 		add_action( 'admin_init', [ $this, 'send_forter_cookie_token' ] );
 	}


### PR DESCRIPTION
See paJDYF-16p-p2 for more details.

After releasing 1.9.0, we noticed an increase of calls to the server's `GET /accounts` endpoint. That may be caused by the new `link_session_if_user_just_logged_in` method. That method is run on every page load (admin or customer) to check if a user has just logged-in, and if it has, link their previously anonymous browsing session with that user. That logic ends up fetching the WCPay account info, because it only makes sense to link a session if SIFT is enabled.

We believe that there may be a handful of merchants with misconfigured or disabled transients (is that even possible?), so that would result on a HTTP request to our server on every page load. That's not great.

I've reordered the logic, so now basically it will check if the user has just logged in *before* fetching the WCPay account info.

cc/ @marcinbot 