### PR TITLE
Tweak the onboarding redirection logic to fetch the account less often

### DIFF
--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -10,6 +10,7 @@ docker-compose exec -u www-data wordpress \
 echo "Running the tests..."
 
 docker-compose exec -u www-data wordpress \
+	php -d xdebug.remote_autostart=on \
 	/var/www/html/wp-content/plugins/woocommerce-payments/vendor/bin/phpunit \
 	--configuration /var/www/html/wp-content/plugins/woocommerce-payments/phpunit.xml.dist \
 	$*

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 2.3.0 - 2021-xx-xx =
 * Add - Introduced deposit currency filter for transactions overview page.
 * Add - Download transactions report in CSV.
+* Update - Tweak the connection detection logic.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1194,7 +1194,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$description .= wp_kses_post( '<p class="description">' . __( 'You will automatically be <em>signed in to Stripe</em> with your WooCommerce Payments account.', 'woocommerce-payments' ) . '</p>' );
 			} else {
 				// This should never happen, if the account is not connected the merchant should have been redirected to the onboarding screen.
-				// @see WC_Payments_Account::check_stripe_account_status.
+				// @see WC_Payments_Account::maybe_redirect_to_onboarding.
 				$description = esc_html__( 'Error determining the connection status.', 'woocommerce-payments' );
 			}
 		} catch ( Exception $e ) {

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -233,11 +233,11 @@ class WC_Payments_Account {
 	/**
 	 * Checks if Stripe account is connected and redirects to the onboarding page if it is not.
 	 *
-	 * @return bool True if the account is connected properly.
+	 * @return bool True if the redirection happened.
 	 */
 	public function maybe_redirect_to_onboarding() {
 		if ( wp_doing_ajax() ) {
-			return;
+			return false;
 		}
 
 		$is_on_settings_page           = WC_Payment_Gateway_WCPay::is_current_page_settings();

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -39,7 +39,7 @@ class WC_Payments_Account {
 		$this->payments_api_client = $payments_api_client;
 
 		add_action( 'admin_init', [ $this, 'maybe_handle_oauth' ] );
-		add_action( 'admin_init', [ $this, 'check_stripe_account_status' ], 11 ); // Run this after the WC setup wizard redirection logic.
+		add_action( 'admin_init', [ $this, 'maybe_redirect_to_onboarding' ], 11 ); // Run this after the WC setup wizard redirection logic.
 		add_filter( 'allowed_redirect_hosts', [ $this, 'allowed_redirect_hosts' ] );
 		add_action( 'jetpack_site_registered', [ $this, 'clear_cache' ] );
 	}
@@ -231,29 +231,26 @@ class WC_Payments_Account {
 	}
 
 	/**
-	 * Whether to do a full-page redirect to the WCPay onboarding page. It has several exceptions, to prevent
-	 * "hijacking" the multiple WC/WC-Admin onboarding flows.
-	 * This function assumes that the Stripe account hasn't been setup yet.
-	 *
-	 * @return bool True if the user should be redirected to the WCPay onboarding page, false otherwise.
-	 */
-	private function should_redirect_to_onboarding() {
-		// If the user is in the WCPay settings screen and hasn't onboarded yet, always redirect.
-		if ( WC_Payment_Gateway_WCPay::is_current_page_settings() ) {
-			return true;
-		}
-
-		return get_option( 'wcpay_should_redirect_to_onboarding', false );
-	}
-
-	/**
 	 * Checks if Stripe account is connected and redirects to the onboarding page if it is not.
 	 *
 	 * @return bool True if the account is connected properly.
 	 */
-	public function check_stripe_account_status() {
+	public function maybe_redirect_to_onboarding() {
 		if ( wp_doing_ajax() ) {
 			return;
+		}
+
+		$is_on_settings_page           = WC_Payment_Gateway_WCPay::is_current_page_settings();
+		$should_redirect_to_onboarding = get_option( 'wcpay_should_redirect_to_onboarding', false );
+
+		if (
+			// If not loading the settings page...
+			! $is_on_settings_page
+			// ...and we have redirected before.
+			&& ! $should_redirect_to_onboarding
+		) {
+			// Do not attempt to redirect again.
+			return false;
 		}
 
 		$account = $this->get_cached_account_data();
@@ -262,13 +259,19 @@ class WC_Payments_Account {
 			return false;
 		}
 
-		if ( empty( $account ) ) {
-			if ( $this->should_redirect_to_onboarding() ) {
-				update_option( 'wcpay_should_redirect_to_onboarding', false );
-				$this->redirect_to_onboarding_page();
-			}
+		if ( $should_redirect_to_onboarding ) {
+			// Update the option. If there's an account connected, we won't need to redirect in the future.
+			// If not, we will redirect once and will not want to redirect again.
+			update_option( 'wcpay_should_redirect_to_onboarding', false );
+		}
+
+		if ( ! empty( $account ) ) {
+			// Do not redirect if connected.
 			return false;
 		}
+
+		// Redirect if not connected.
+		$this->redirect_to_onboarding_page();
 		return true;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ Please note that our support for the checkout block is still experimental and th
 = 2.3.0 - 2021-xx-xx =
 * Add - Introduced deposit currency filter for transactions overview page.
 * Add - Download transactions report in CSV.
+* Update - Tweak the connection detection logic.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.


### PR DESCRIPTION
See paJDYF-16p-p2#comment-4828 for more details. Also related to #1372

#### Changes proposed in this Pull Request

- Rename `check_stripe_account_status` to `maybe_redirect_to_onboarding` since that's all that the function was doing.
- Reorder the logic a bit to check if the redirection is needed first, and only then check the account.
- Bonus: make `npm run test:php` trigger debug breakpoints

#### Testing instructions

* Using dev tools, make the plugin act as disconnected
* Update `wp_options`, set `wcpay_should_redirect_to_onboarding` to 1 (insert it if it doesn't exist)
* Open any admin page, you should be redirected to the onboarding screen
* Navigate away from the screen, you should not be redirected again

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
