### PR TITLE
Rate limit failed account connection checks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,8 +2,9 @@
 
 = 2.1.0 - 2021-xx-xx =
 * Update - Show last 4 digit credit card number in order note when payment method is updated on failed renewal subscription order.
-* Update - Define constant for the group to be used for scheduled actions. 
+* Update - Define constant for the group to be used for scheduled actions.
 * Update - Enable multiple customer currencies support in live mode.
+* Add - Rate limit failed account connection checks.
 
 = 2.0.0 - 2021-02-22 =
 * Update - Render customer details in transactions list as text instead of link if order missing.
@@ -13,8 +14,8 @@
 * Fix - If account is set to manual payouts display 'Temporarily suspended' under Payments > Settings.
 * Add - Add file dropzones to dispute evidence upload fields
 * Add - Currency conversion indicator to Transactions list.
-* Add - Transaction timeline details for multi-currency transactions.  
-* Update - Link order note with transaction details page. 
+* Add - Transaction timeline details for multi-currency transactions.
+* Update - Link order note with transaction details page.
 * Fix - Updating payment method using saved payment for WC Subscriptions orders.
 
 = 1.9.2 - 2021-02-05 =

--- a/readme.txt
+++ b/readme.txt
@@ -105,12 +105,13 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Show last 4 digit credit card number in order note when payment method is updated on failed renewal subscription order.
 * Update - Define constant for the group to be used for scheduled actions.
 * Update - Enable multiple customer currencies support in live mode.
+* Add - Rate limit failed account connection checks.
 
 = 2.0.0 - 2021-02-22 =
 * Update - Render customer details in transactions list as text instead of link if order missing.
 * Update - Render transaction summary on details page for multi-currency transactions.
 * Update - Improvements to fraud prevention.
-* Fix - Added better notices for end users if there are connection errors when making payments. 
+* Fix - Added better notices for end users if there are connection errors when making payments.
 * Fix - If account is set to manual payouts display 'Temporarily suspended' under Payments > Settings.
 * Add - Add file dropzones to dispute evidence upload fields
 * Add - Currency conversion indicator to Transactions list.


### PR DESCRIPTION
Fixes #1164

#### Changes proposed in this Pull Request

- When an account fetch fails with an unexpected error, store a special value in the transient for 2 minutes
- If the transient is storing the error value, do not attempt to re-fetch the account, just act as if the error happened again

This should limit the number of failed API requests while not disrupting the site operation too much.

#### Testing instructions

* Stop the local server docker containers
* Using dev tools, empty the account cache (if the account has already been cached) - it should show an error value
* Open the latest client logs - only one error should be logged
* Bring the server back up and wait for 2 minutes
* Navigate around the client admin panel - everything should work again

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
