### PR TITLE
Update dockerfile for client container in E2E environment

### DIFF
--- a/tests/e2e/env/wordpress-xdebug/Dockerfile
+++ b/tests/e2e/env/wordpress-xdebug/Dockerfile
@@ -1,8 +1,13 @@
-FROM wordpress:5.6.2
-
-RUN pecl install xdebug \
+FROM wordpress:php7.3
+RUN pecl install xdebug-2.9.8 \
 	&& echo 'xdebug.remote_enable=1' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.remote_port=9000' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.remote_host=host.docker.internal' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.remote_autostart=0' >> $PHP_INI_DIR/php.ini \
 	&& docker-php-ext-enable xdebug > /dev/null
+RUN apt-get update \
+	&& apt-get install --assume-yes --quiet --no-install-recommends gnupg2 subversion mariadb-client less jq
+RUN apt-get install -y openssh-client
+RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+	&& chmod +x wp-cli.phar \
+	&& mv wp-cli.phar /usr/local/bin/wp

--- a/tests/e2e/env/wordpress-xdebug/Dockerfile
+++ b/tests/e2e/env/wordpress-xdebug/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:php7.3
+FROM wordpress:5.6.2-php7.3
 RUN pecl install xdebug-2.9.8 \
 	&& echo 'xdebug.remote_enable=1' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.remote_port=9000' >> $PHP_INI_DIR/php.ini \


### PR DESCRIPTION
Dockerfile used for client container in e2e environment differs from dev container. It does not allow debugging e2e tests easily (at least in PHP Storm).

#### Changes proposed in this Pull Request

* Update docker file for client container in E2E environment to match dev environment.

#### Testing instructions

* All checks should be green.
* Launch e2e containers locally with `npm run test:e2e-setup`.
* Try to debug php code while running site in E2E docker container (localhost:8084).

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
