### PR TITLE
Add/apple pay domain registration tracks event

### DIFF
--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -241,7 +241,7 @@ class WC_Payments_Apple_Pay_Registration {
 
 		Logger::log( 'Error registering domain with Apple: ' . $error );
 		Tracker::track_admin(
-			'wcpay_apple_pay_domain_registration_failed',
+			'wcpay_apple_pay_domain_registration_failure',
 			[
 				'domain' => $this->domain_name,
 				'reason' => $error,

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -31,18 +31,18 @@ class WC_Payments_Apple_Pay_Registration {
 	private $payments_api_client;
 
 	/**
-	 * Gateway settings.
-	 *
-	 * @var array
-	 */
-	private $gateway_settings;
-
-	/**
 	 * The WCPay gateway object.
 	 *
 	 * @var WC_Payment_Gateway_WCPay
 	 */
 	private $gateway;
+
+	/**
+	 * Gateway settings.
+	 *
+	 * @var array
+	 */
+	private $gateway_settings;
 
 	/**
 	 * Current domain name.

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use WCPay\Logger;
 use WCPay\Exceptions\API_Exception;
+use WCPay\Tracker;
 
 /**
  * WC_Payments_Apple_Pay_Registration class.
@@ -216,6 +217,12 @@ class WC_Payments_Apple_Pay_Registration {
 				update_option( 'woocommerce_woocommerce_payments_settings', $this->gateway_settings );
 
 				Logger::log( __( 'Your domain has been verified with Apple Pay!', 'woocommerce-payments' ) );
+				Tracker::track_admin(
+					'wcpay_apple_pay_domain_registration_success',
+					[
+						'domain' => $this->domain_name,
+					]
+				);
 
 				return;
 			} elseif ( isset( $registration_response['error']['message'] ) ) {
@@ -233,6 +240,13 @@ class WC_Payments_Apple_Pay_Registration {
 		update_option( 'woocommerce_woocommerce_payments_settings', $this->gateway_settings );
 
 		Logger::log( 'Error registering domain with Apple: ' . $error );
+		Tracker::track_admin(
+			'wcpay_apple_pay_domain_registration_failed',
+			[
+				'domain' => $this->domain_name,
+				'reason' => $error,
+			]
+		);
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -168,7 +168,7 @@ class WC_Payments {
 		self::$gateway = new $gateway_class( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service );
 
 		self::$payment_request_button_handler = new WC_Payments_Payment_Request_Button_Handler( self::$account );
-		self::$apple_pay_registration         = new WC_Payments_Apple_Pay_Registration( self::$api_client );
+		self::$apple_pay_registration         = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$gateway );
 
 		add_filter( 'woocommerce_payment_gateways', [ __CLASS__, 'register_gateway' ] );
 		add_filter( 'option_woocommerce_gateway_order', [ __CLASS__, 'set_gateway_top_of_list' ], 2 );

--- a/tests/unit/test-class-wc-payments-apple-pay-registration.php
+++ b/tests/unit/test-class-wc-payments-apple-pay-registration.php
@@ -25,6 +25,13 @@ class WC_Payments_Apple_Pay_Registration_Test extends WP_UnitTestCase {
 	private $mock_api_client;
 
 	/**
+	 * Mock WC_Payment_Gateway_WCPay.
+	 *
+	 * @var WC_Payment_Gateway_WCPay|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_gateway;
+
+	/**
 	 * Domain association file name.
 	 *
 	 * @var string
@@ -48,7 +55,11 @@ class WC_Payments_Apple_Pay_Registration_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->wc_apple_pay_registration = new WC_Payments_Apple_Pay_Registration( $this->mock_api_client );
+		$this->mock_gateway = $this->getMockBuilder( 'WC_Payment_Gateway_WCPay' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->wc_apple_pay_registration = new WC_Payments_Apple_Pay_Registration( $this->mock_api_client, $this->mock_gateway );
 
 		$this->file_name             = 'apple-developer-merchantid-domain-association';
 		$this->initial_file_contents = file_get_contents( WCPAY_ABSPATH . '/' . $this->file_name ); // @codingStandardsIgnoreLine


### PR DESCRIPTION
## Changes proposed in this Pull Request

- Add 2 Tracks events (note that the `wcadmin_` prefix is added by the Tracks code, which is why you don't see it in the diff):
    - `wcadmin_wcpay_apple_pay_domain_registration_success`
    - `wcadmin_wcpay_apple_pay_domain_registration_failure`

Both events include the domain name, the `_failure` event also includes the reason for why the domain registration failed.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

Follow testing instructions in #1239 for Apple Pay verification, and then search the Live Tracks view for events with `wcadmin_wcpay_apple_pay_%` and check for success and failure events.

If you're not sure how to find the Live Tracks view, look for the "Tool – Live View" page in the Field Guide.

More details:

### Setting up a live account

You can either create a live WCPay account, or link your site to an existing account through your sandbox with `wp wcpay link_account_to_blog --blog_id=<your_blog_id> --stripe_id=<live_stripe_id> --skip_sync=1 --mode=live`.

**Make sure to take note of your current Stripe ID so you can link back to your previous WCPay account**.

For example, when I linked my site back to my **test account** I used `wp wcpay link_account_to_blog --blog_id=<blog_id> --stripe_id=<test_stripe_id> --skip_sync=1 --mode=test`. Note the `--mode=test` flag here, as opposed to the `--mode=live` flag when linking to a live account.

### Testing the domain registration

Do one of 3 things to trigger the domain registration:

- Delete the option `woocommerce_woocommerce_payments_version` and visit any wp-admin page to simulate a plugin update.
- Disable the Payment Request button in Payments > Settings, save, enable it, then save again.
- Change your domain and visit any wp-admin page.

Any of these will work. Using `ngrok` or `pagekite` is a good way to try this with multiple domains.

**Testing domain registration failure**

Do any of the 3 things to trigger domain registration while using your dev account. You should see a notice in wp-admin informing you that domain registration failed, and you should be able to see a corresponding event in the Tracks Live view. Note that it can take ~5 minutes for the event to show up in the Tracks Live view.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
    - We don't test Tracks events in our test suite.
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
