### PR TITLE
Fix typo in the timeline component

### DIFF
--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -249,7 +249,7 @@ const mapEventToTimelineItems = ( event ) => {
 					stringWithAmount(
 						/* translators: %s is a monetary amount */
 						__(
-							'A payment of %s was successfully authorized',
+							'A payment of %s was successfully authorized.',
 							'woocommerce-payments'
 						),
 						event.amount
@@ -269,7 +269,7 @@ const mapEventToTimelineItems = ( event ) => {
 					stringWithAmount(
 						__(
 							/* translators: %s is a monetary amount */
-							'Authorization for %s was voided',
+							'Authorization for %s was voided.',
 							'woocommerce-payments'
 						),
 						event.amount
@@ -289,7 +289,7 @@ const mapEventToTimelineItems = ( event ) => {
 					stringWithAmount(
 						__(
 							/* translators: %s is a monetary amount */
-							'Authorization for %s expired',
+							'Authorization for %s expired.',
 							'woocommerce-payments'
 						),
 						event.amount
@@ -312,7 +312,7 @@ const mapEventToTimelineItems = ( event ) => {
 					stringWithAmount(
 						__(
 							/* translators: %s is a monetary amount */
-							'A payment of %s was successfully charged',
+							'A payment of %s was successfully charged.',
 							'woocommerce-payments'
 						),
 						event.amount
@@ -355,7 +355,7 @@ const mapEventToTimelineItems = ( event ) => {
 					sprintf(
 						__(
 							/* translators: %s is a monetary amount */
-							'A payment of %s was successfully refunded',
+							'A payment of %s was successfully refunded.',
 							'woocommerce-payments'
 						),
 						formattedAmount
@@ -375,7 +375,7 @@ const mapEventToTimelineItems = ( event ) => {
 					event,
 					stringWithAmount(
 						/* translators: %s is a monetary amount */
-						__( 'A payment of %s failed', 'woocommerce-payments' ),
+						__( 'A payment of %s failed.', 'woocommerce-payments' ),
 						event.amount
 					),
 					'cross',
@@ -407,7 +407,7 @@ const mapEventToTimelineItems = ( event ) => {
 					date: new Date( event.datetime * 1000 ),
 					icon: getIcon( 'info-outline' ),
 					headline: __(
-						'No funds have been withdrawn yet',
+						'No funds have been withdrawn yet.',
 						'woocommerce-payments'
 					),
 					body: [
@@ -477,7 +477,7 @@ const mapEventToTimelineItems = ( event ) => {
 				getMainTimelineItem(
 					event,
 					__(
-						'Challenge evidence submitted',
+						'Challenge evidence submitted.',
 						'woocommerce-payments'
 					),
 					'checkmark',
@@ -509,7 +509,7 @@ const mapEventToTimelineItems = ( event ) => {
 				getMainTimelineItem(
 					event,
 					__(
-						'Dispute won! The bank ruled in your favor',
+						'Dispute won! The bank ruled in your favor.',
 						'woocommerce-payments'
 					),
 					'notice-outline',
@@ -525,7 +525,7 @@ const mapEventToTimelineItems = ( event ) => {
 				getMainTimelineItem(
 					event,
 					__(
-						'Dispute lost. The bank ruled favor of your customer',
+						'Dispute lost. The bank ruled in favor of your customer.',
 						'woocommerce-payments'
 					),
 					'cross',

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -43,7 +43,7 @@ const getStatusChangeTimelineItem = ( event, status ) => {
 		icon: getIcon( 'sync' ),
 		headline: sprintf(
 			// translators: %s new status, for example Authorized, Refunded, etc
-			__( 'Payment status changed to %s', 'woocommerce-payments' ),
+			__( 'Payment status changed to %s.', 'woocommerce-payments' ),
 			status
 		),
 		body: [],
@@ -72,12 +72,12 @@ const getDepositTimelineItem = (
 			isPositive
 				? // translators: %1$s - formatted amount, %2$s - deposit arrival date, <a> - link to the deposit
 				  __(
-						'%1$s was added to your <a>%2$s deposit</a>',
+						'%1$s was added to your <a>%2$s deposit</a>.',
 						'woocommerce-payments'
 				  )
 				: // translators: %1$s - formatted amount, %2$s - deposit arrival date, <a> - link to the deposit
 				  __(
-						'%1$s was deducted from your <a>%2$s deposit</a>',
+						'%1$s was deducted from your <a>%2$s deposit</a>.',
 						'woocommerce-payments'
 				  ),
 			formattedAmount,
@@ -102,12 +102,12 @@ const getDepositTimelineItem = (
 			isPositive
 				? // translators: %s - formatted amount
 				  __(
-						'%s will be added to a future deposit',
+						'%s will be added to a future deposit.',
 						'woocommerce-payments'
 				  )
 				: // translators: %s - formatted amount
 				  __(
-						'%s will be deducted from a future deposit',
+						'%s will be deducted from a future deposit.',
 						'woocommerce-payments'
 				  ),
 			formattedAmount
@@ -390,7 +390,7 @@ const mapEventToTimelineItems = ( event ) => {
 			if ( disputeReasons[ event.reason ] ) {
 				reasonHeadline = sprintf(
 					/* translators: %s is a monetary amount */
-					__( 'Payment disputed as %s', 'woocommerce-payments' ),
+					__( 'Payment disputed as %s.', 'woocommerce-payments' ),
 					disputeReasons[ event.reason ].display
 				);
 			}

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -214,7 +214,7 @@ Array [
     "body": Array [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $20.97 was added to your
+      $20.97 was added to your 
       <a
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
       >
@@ -261,7 +261,7 @@ Array [
     "body": Array [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $20.97 was added to your
+      $20.97 was added to your 
       <a
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
       >
@@ -356,7 +356,7 @@ Array [
     ],
     "date": 2020-04-04T16:20:50.000Z,
     "headline": <React.Fragment>
-      $44.99 was added to your
+      $44.99 was added to your 
       <a
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b2d3"
       >
@@ -473,7 +473,7 @@ Array [
     "body": Array [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $59.50 was added to your
+      $59.50 was added to your 
       <a
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
       >
@@ -520,7 +520,7 @@ Array [
     "body": Array [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $59.50 was added to your
+      $59.50 was added to your 
       <a
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
       >
@@ -640,7 +640,7 @@ Array [
     ],
     "date": 2020-04-04T16:20:50.000Z,
     "headline": <React.Fragment>
-      $115.00 was added to your
+      $115.00 was added to your 
       <a
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b2d3"
       >

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -15,7 +15,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-03-31T21:58:40.000Z,
-    "headline": "Authorization for $86.00 expired",
+    "headline": "Authorization for $86.00 expired.",
     "icon": <t
       className="is-error"
       icon="cross"
@@ -40,7 +40,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-03-31T10:57:59.000Z,
-    "headline": "Authorization for $59.00 was voided",
+    "headline": "Authorization for $59.00 was voided.",
     "icon": <t
       className="is-warning"
       icon="checkmark"
@@ -65,7 +65,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-03-30T17:33:16.000Z,
-    "headline": "A payment of $79.00 was successfully authorized",
+    "headline": "A payment of $79.00 was successfully authorized.",
     "icon": <t
       className="is-warning"
       icon="checkmark"
@@ -90,7 +90,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-01T03:35:13.000Z,
-    "headline": "A payment of $77.00 failed",
+    "headline": "A payment of $77.00 failed.",
     "icon": <t
       className="is-error"
       icon="cross"
@@ -130,7 +130,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-02T20:26:47.000Z,
-    "headline": "Challenge evidence submitted",
+    "headline": "Challenge evidence submitted.",
     "icon": <t
       className="is-success"
       icon="checkmark"
@@ -157,7 +157,7 @@ Array [
       "The cardholder's bank is requesting more information to decide whether to return these funds to the cardholder.",
     ],
     "date": 2020-04-02T02:06:14.000Z,
-    "headline": "No funds have been withdrawn yet",
+    "headline": "No funds have been withdrawn yet.",
     "icon": <t
       className=""
       icon="info-outline"
@@ -234,7 +234,7 @@ Array [
       "Net deposit: $20.97",
     ],
     "date": 2020-04-01T14:37:54.000Z,
-    "headline": "A payment of €18,00 was successfully charged",
+    "headline": "A payment of €18,00 was successfully charged.",
     "icon": <t
       className="is-success"
       icon="checkmark"
@@ -280,7 +280,7 @@ Array [
       "Net deposit: $20.97",
     ],
     "date": 2020-04-01T14:37:54.000Z,
-    "headline": "A payment of €18,00 was successfully charged",
+    "headline": "A payment of €18,00 was successfully charged.",
     "icon": <t
       className="is-success"
       icon="checkmark"
@@ -370,7 +370,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-04T16:20:50.000Z,
-    "headline": "Dispute won! The bank ruled in your favor",
+    "headline": "Dispute won! The bank ruled in your favor.",
     "icon": <t
       className="is-success"
       icon="notice-outline"
@@ -407,7 +407,7 @@ Array [
       "€1,00 → $1.20222: $21.64",
     ],
     "date": 2020-04-04T13:51:06.000Z,
-    "headline": "A payment of €18,00 was successfully refunded",
+    "headline": "A payment of €18,00 was successfully refunded.",
     "icon": <t
       className="is-success"
       icon="checkmark"
@@ -444,7 +444,7 @@ Array [
       "€1,00 → $1.2: $6.00",
     ],
     "date": 2020-04-03T18:58:01.000Z,
-    "headline": "A payment of €5,00 was successfully refunded",
+    "headline": "A payment of €5,00 was successfully refunded.",
     "icon": <t
       className="is-success"
       icon="checkmark"
@@ -490,7 +490,7 @@ Array [
       "Net deposit: $59.50",
     ],
     "date": 2020-04-01T14:37:54.000Z,
-    "headline": "A payment of $63.00 was successfully charged",
+    "headline": "A payment of $63.00 was successfully charged.",
     "icon": <t
       className="is-success"
       icon="checkmark"
@@ -536,7 +536,7 @@ Array [
       "Net deposit: $59.50",
     ],
     "date": 2020-04-01T14:37:54.000Z,
-    "headline": "A payment of $63.00 was successfully charged",
+    "headline": "A payment of $63.00 was successfully charged.",
     "icon": <t
       className="is-success"
       icon="checkmark"
@@ -561,7 +561,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-05T02:56:10.000Z,
-    "headline": "Dispute lost. The bank ruled favor of your customer",
+    "headline": "Dispute lost. The bank ruled in favor of your customer.",
     "icon": <t
       className="is-error"
       icon="cross"
@@ -651,7 +651,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-04T16:20:50.000Z,
-    "headline": "Dispute won! The bank ruled in your favor",
+    "headline": "Dispute won! The bank ruled in your favor.",
     "icon": <t
       className="is-success"
       icon="notice-outline"
@@ -688,7 +688,7 @@ Array [
       undefined,
     ],
     "date": 2020-04-04T13:51:06.000Z,
-    "headline": "A payment of $100.00 was successfully refunded",
+    "headline": "A payment of $100.00 was successfully refunded.",
     "icon": <t
       className="is-success"
       icon="checkmark"
@@ -725,7 +725,7 @@ Array [
       undefined,
     ],
     "date": 2020-04-03T18:58:01.000Z,
-    "headline": "A payment of $50.00 was successfully refunded",
+    "headline": "A payment of $50.00 was successfully refunded.",
     "icon": <t
       className="is-success"
       icon="checkmark"

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -5,7 +5,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-03-31T21:58:40.000Z,
-    "headline": "Payment status changed to Authorization Expired",
+    "headline": "Payment status changed to Authorization Expired.",
     "icon": <t
       className=""
       icon="sync"
@@ -30,7 +30,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-03-31T10:57:59.000Z,
-    "headline": "Payment status changed to Authorization Voided",
+    "headline": "Payment status changed to Authorization Voided.",
     "icon": <t
       className=""
       icon="sync"
@@ -55,7 +55,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-03-30T17:33:16.000Z,
-    "headline": "Payment status changed to Authorized",
+    "headline": "Payment status changed to Authorized.",
     "icon": <t
       className=""
       icon="sync"
@@ -80,7 +80,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-01T03:35:13.000Z,
-    "headline": "Payment status changed to Failed",
+    "headline": "Payment status changed to Failed.",
     "icon": <t
       className=""
       icon="sync"
@@ -120,7 +120,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-02T20:26:47.000Z,
-    "headline": "Payment status changed to Disputed: In Review",
+    "headline": "Payment status changed to Disputed: In Review.",
     "icon": <t
       className=""
       icon="sync"
@@ -145,7 +145,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-02T02:06:14.000Z,
-    "headline": "Payment status changed to Disputed: Needs Response",
+    "headline": "Payment status changed to Disputed: Needs Response.",
     "icon": <t
       className=""
       icon="sync"
@@ -173,7 +173,7 @@ Array [
       </a>,
     ],
     "date": 2020-04-02T02:06:14.000Z,
-    "headline": "Payment disputed as Fraudulent",
+    "headline": "Payment disputed as Fraudulent.",
     "icon": <t
       className="is-error"
       icon="cross"
@@ -203,7 +203,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-01T14:37:54.000Z,
-    "headline": "Payment status changed to Paid",
+    "headline": "Payment status changed to Paid.",
     "icon": <t
       className=""
       icon="sync"
@@ -214,12 +214,13 @@ Array [
     "body": Array [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $20.97 was added to your 
+      $20.97 was added to your
       <a
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
       >
         Apr 2, 2020 deposit
       </a>
+      .
     </React.Fragment>,
     "icon": <t
       className=""
@@ -249,7 +250,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-01T14:37:54.000Z,
-    "headline": "Payment status changed to Paid",
+    "headline": "Payment status changed to Paid.",
     "icon": <t
       className=""
       icon="sync"
@@ -260,12 +261,13 @@ Array [
     "body": Array [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $20.97 was added to your 
+      $20.97 was added to your
       <a
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
       >
         Apr 2, 2020 deposit
       </a>
+      .
     </React.Fragment>,
     "icon": <t
       className=""
@@ -295,7 +297,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-02T02:06:14.000Z,
-    "headline": "Payment status changed to Disputed: Needs Response",
+    "headline": "Payment status changed to Disputed: Needs Response.",
     "icon": <t
       className=""
       icon="sync"
@@ -309,7 +311,7 @@ Array [
       "Fee: $15.00",
     ],
     "date": 2020-04-02T02:06:14.000Z,
-    "headline": "$36.60 will be deducted from a future deposit",
+    "headline": "$36.60 will be deducted from a future deposit.",
     "icon": <t
       className=""
       icon="minus"
@@ -325,7 +327,7 @@ Array [
       </a>,
     ],
     "date": 2020-04-02T02:06:14.000Z,
-    "headline": "Payment disputed as Fraudulent",
+    "headline": "Payment disputed as Fraudulent.",
     "icon": <t
       className="is-error"
       icon="cross"
@@ -340,7 +342,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-04T16:20:50.000Z,
-    "headline": "Payment status changed to Disputed: Won",
+    "headline": "Payment status changed to Disputed: Won.",
     "icon": <t
       className=""
       icon="sync"
@@ -354,12 +356,13 @@ Array [
     ],
     "date": 2020-04-04T16:20:50.000Z,
     "headline": <React.Fragment>
-      $44.99 was added to your 
+      $44.99 was added to your
       <a
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b2d3"
       >
         Apr 5, 2020 deposit
       </a>
+      .
     </React.Fragment>,
     "icon": <t
       className=""
@@ -385,7 +388,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-04T13:51:06.000Z,
-    "headline": "Payment status changed to Refunded",
+    "headline": "Payment status changed to Refunded.",
     "icon": <t
       className=""
       icon="sync"
@@ -395,7 +398,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-04T13:51:06.000Z,
-    "headline": "$21.64 will be deducted from a future deposit",
+    "headline": "$21.64 will be deducted from a future deposit.",
     "icon": <t
       className=""
       icon="minus"
@@ -422,7 +425,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-03T18:58:01.000Z,
-    "headline": "Payment status changed to Partial Refund",
+    "headline": "Payment status changed to Partial Refund.",
     "icon": <t
       className=""
       icon="sync"
@@ -432,7 +435,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-03T18:58:01.000Z,
-    "headline": "$6.00 will be deducted from a future deposit",
+    "headline": "$6.00 will be deducted from a future deposit.",
     "icon": <t
       className=""
       icon="minus"
@@ -459,7 +462,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-01T14:37:54.000Z,
-    "headline": "Payment status changed to Paid",
+    "headline": "Payment status changed to Paid.",
     "icon": <t
       className=""
       icon="sync"
@@ -470,12 +473,13 @@ Array [
     "body": Array [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $59.50 was added to your 
+      $59.50 was added to your
       <a
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
       >
         Apr 2, 2020 deposit
       </a>
+      .
     </React.Fragment>,
     "icon": <t
       className=""
@@ -505,7 +509,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-01T14:37:54.000Z,
-    "headline": "Payment status changed to Paid",
+    "headline": "Payment status changed to Paid.",
     "icon": <t
       className=""
       icon="sync"
@@ -516,12 +520,13 @@ Array [
     "body": Array [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $59.50 was added to your 
+      $59.50 was added to your
       <a
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
       >
         Apr 2, 2020 deposit
       </a>
+      .
     </React.Fragment>,
     "icon": <t
       className=""
@@ -551,7 +556,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-05T02:56:10.000Z,
-    "headline": "Payment status changed to Disputed: Lost",
+    "headline": "Payment status changed to Disputed: Lost.",
     "icon": <t
       className=""
       icon="sync"
@@ -576,7 +581,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-02T02:06:14.000Z,
-    "headline": "Payment status changed to Disputed: Needs Response",
+    "headline": "Payment status changed to Disputed: Needs Response.",
     "icon": <t
       className=""
       icon="sync"
@@ -590,7 +595,7 @@ Array [
       "Fee: $15.00",
     ],
     "date": 2020-04-02T02:06:14.000Z,
-    "headline": "$110.00 will be deducted from a future deposit",
+    "headline": "$110.00 will be deducted from a future deposit.",
     "icon": <t
       className=""
       icon="minus"
@@ -606,7 +611,7 @@ Array [
       </a>,
     ],
     "date": 2020-04-02T02:06:14.000Z,
-    "headline": "Payment disputed as Fraudulent",
+    "headline": "Payment disputed as Fraudulent.",
     "icon": <t
       className="is-error"
       icon="cross"
@@ -621,7 +626,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-04T16:20:50.000Z,
-    "headline": "Payment status changed to Disputed: Won",
+    "headline": "Payment status changed to Disputed: Won.",
     "icon": <t
       className=""
       icon="sync"
@@ -635,12 +640,13 @@ Array [
     ],
     "date": 2020-04-04T16:20:50.000Z,
     "headline": <React.Fragment>
-      $115.00 was added to your 
+      $115.00 was added to your
       <a
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b2d3"
       >
         Apr 5, 2020 deposit
       </a>
+      .
     </React.Fragment>,
     "icon": <t
       className=""
@@ -666,7 +672,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-04T13:51:06.000Z,
-    "headline": "Payment status changed to Refunded",
+    "headline": "Payment status changed to Refunded.",
     "icon": <t
       className=""
       icon="sync"
@@ -676,7 +682,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-04T13:51:06.000Z,
-    "headline": "$100.00 will be deducted from a future deposit",
+    "headline": "$100.00 will be deducted from a future deposit.",
     "icon": <t
       className=""
       icon="minus"
@@ -703,7 +709,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-03T18:58:01.000Z,
-    "headline": "Payment status changed to Partial Refund",
+    "headline": "Payment status changed to Partial Refund.",
     "icon": <t
       className=""
       icon="sync"
@@ -713,7 +719,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-03T18:58:01.000Z,
-    "headline": "$50.00 will be deducted from a future deposit",
+    "headline": "$50.00 will be deducted from a future deposit.",
     "icon": <t
       className=""
       icon="minus"


### PR DESCRIPTION
Fixes #1381

#### Changes proposed in this Pull Request

- Add the `in` to `The bank ruled in favor...`
- Add period to the end of all of the headline sentences. Some headlines had it, some didn't. Now all should have it.

#### Testing instructions

* Open a lost dispute transaction and confirm the sentence is correct now.

<img width="1085" alt="Screenshot 2021-03-10 at 10 41 05" src="https://user-images.githubusercontent.com/800604/110617589-c3c87c00-818d-11eb-9e4d-969e7c5af463.png">


-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
