### PR TITLE
Fix the build for IE11

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,1 @@
+extends @wordpress/browserslist-config

--- a/package-lock.json
+++ b/package-lock.json
@@ -9544,6 +9544,14 @@
         "@babel/runtime": "^7.4.4",
         "@wordpress/babel-plugin-import-jsx-pragma": "^2.2.0",
         "@wordpress/browserslist-config": "^2.5.0"
+      },
+      "dependencies": {
+        "@wordpress/browserslist-config": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.7.0.tgz",
+          "integrity": "sha512-pB45JlfmHuEigNFZ1X+CTgIsOT3/TTb9iZxw1DHXge/7ytY8FNhtcNwTfF9IgnS6/xaFRZBqzw4DyH4sP1Lyxg==",
+          "dev": true
+        }
       }
     },
     "@wordpress/base-styles": {
@@ -9553,9 +9561,9 @@
       "dev": true
     },
     "@wordpress/browserslist-config": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.5.0.tgz",
-      "integrity": "sha512-cspE4iJ87YjweKAtnIsCxm7ZJQ/ved3TdRJWS0DX/0AOukoRhOMYh7CP1aVc0M3J1kB4LtTY7u3HOcqF2Yf2VA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-3.0.1.tgz",
+      "integrity": "sha512-l0c/X8w2v+NBShzEoykLuaLQNo1qiAONnPKXfIeiI145zAdjA5e8zMR0sUTDVsCxVfqfd2tH+D4wuhf68T3+Aw==",
       "dev": true
     },
     "@wordpress/components": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@wordpress/api-fetch": "3.3.0",
     "@wordpress/babel-preset-default": "4.3.0",
     "@wordpress/base-styles": "1.0.0",
+    "@wordpress/browserslist-config": "^3.0.1",
     "@wordpress/components": "8.5.0",
     "@wordpress/data": "4.22.1",
     "@wordpress/data-controls": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@wordpress/api-fetch": "3.3.0",
     "@wordpress/babel-preset-default": "4.3.0",
     "@wordpress/base-styles": "1.0.0",
-    "@wordpress/browserslist-config": "^3.0.1",
+    "@wordpress/browserslist-config": "3.0.1",
     "@wordpress/components": "8.5.0",
     "@wordpress/data": "4.22.1",
     "@wordpress/data-controls": "1.6.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -104,7 +104,6 @@ const webpackConfig = {
 			},
 		} ),
 	],
-	devtool: 'source-map',
 };
 
 module.exports = webpackConfig;


### PR DESCRIPTION
A few days ago, @reykjalin thought that maybe the switch to TypeScript had broken the build for older browsers. That fear wasn't entirely unfounded. The switch from Babel to TypeScript didn't break anything, but the upgrade from Webpack 4 to Webpack 5 (done months ago) did. WCPay hasn't been useable in IE11 all this time.

The problem is that Webpack 5 now can output its runtime using ES6, and that's the default option ([docs](https://webpack.js.org/migrate/5/#need-to-support-an-older-browser-like-ie-11)). To force it to use ES5, we must specify a `BROWSERSLIST` config. There are many ways to do so, I just mirrored exactly [what WC-Admin does](https://github.com/woocommerce/woocommerce-admin/blob/main/.browserslistrc) (which includes [Gutenberg's config](https://github.com/WordPress/gutenberg/blob/trunk/packages/browserslist-config/index.js)).

Just for good measure, I also fixed [a IE11 error in WC Core](https://github.com/woocommerce/woocommerce/pull/29322) :)

Note that the IE11 experience in WC-Admin and WCPay is still incredibly broken. See a couple of examples:
<img width="745" alt="Screenshot 2021-03-09 at 23 21 34" src="https://user-images.githubusercontent.com/1715800/110627007-5b7f9780-8199-11eb-9ce0-681a98879d8a.png">
<img width="539" alt="Screenshot 2021-03-09 at 22 51 04" src="https://user-images.githubusercontent.com/1715800/110627013-5d495b00-8199-11eb-8c3a-a7f35f960cde.png">
