### PR TITLE
Apple Pay / Payment Request Buttons Integration - Disable feature

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,6 @@
 * Update - Enable multiple customer currencies support in live mode.
 * Add - Rate limit failed account connection checks.
 * Add - Support displaying non-USD base fees on settings page.
-* Add - Payment Request Button support (Apple Pay, Google Pay, Microsoft Pay, and the browser standard Payment Request API).
 
 = 2.0.0 - 2021-02-22 =
 * Update - Render customer details in transactions list as text instead of link if order missing.

--- a/client/settings.js
+++ b/client/settings.js
@@ -84,7 +84,7 @@ const paymentRequestButtonType = document.getElementById(
 	'woocommerce_woocommerce_payments_payment_request_button_type'
 );
 
-// TODO: Remove this if after WCPay 2.2.0 gets released
+// TODO: Remove this `if` after WCPay 2.2.0 gets released.
 if ( paymentRequest ) {
 	// Payment Request button event listeners.
 	paymentRequest.addEventListener( 'change', () => {

--- a/client/settings.js
+++ b/client/settings.js
@@ -84,7 +84,7 @@ const paymentRequestButtonType = document.getElementById(
 	'woocommerce_woocommerce_payments_payment_request_button_type'
 );
 
-// TODO: Remove this `if` after WCPay 2.2.0 gets released.
+// TODO: Remove this `if` after Apple Pay gets released.
 if ( paymentRequest ) {
 	// Payment Request button event listeners.
 	paymentRequest.addEventListener( 'change', () => {

--- a/client/settings.js
+++ b/client/settings.js
@@ -57,35 +57,35 @@ window.addEventListener( 'load', () => {
 	enqueueFraudScripts( wcpayAdminSettings.fraudServices );
 } );
 
-// Payment Request button settings migrated and adapted from Stripe gateway extension.
-const findParent = ( el, selector ) => {
-	while (
-		( el = el.parentElement ) &&
-		! ( el.matches || el.matchesSelector ).call( el, selector )
+// TODO: Remove this `if` ahead of Apple Pay release.
+if ( wcpayAdminSettings.paymentRequestEnabled ) {
+	// Payment Request button settings migrated and adapted from Stripe gateway extension.
+	const findParent = ( el, selector ) => {
+		while (
+			( el = el.parentElement ) &&
+			! ( el.matches || el.matchesSelector ).call( el, selector )
+		);
+
+		return el;
+	};
+
+	const toggleDisplay = ( el, display ) => {
+		if ( el instanceof Element || el instanceof HTMLElement ) {
+			if ( display ) {
+				el.style.display = '';
+			} else {
+				el.style.display = 'none';
+			}
+		}
+	};
+
+	const paymentRequest = document.getElementById(
+		'woocommerce_woocommerce_payments_payment_request'
+	);
+	const paymentRequestButtonType = document.getElementById(
+		'woocommerce_woocommerce_payments_payment_request_button_type'
 	);
 
-	return el;
-};
-
-const toggleDisplay = ( el, display ) => {
-	if ( el instanceof Element || el instanceof HTMLElement ) {
-		if ( display ) {
-			el.style.display = '';
-		} else {
-			el.style.display = 'none';
-		}
-	}
-};
-
-const paymentRequest = document.getElementById(
-	'woocommerce_woocommerce_payments_payment_request'
-);
-const paymentRequestButtonType = document.getElementById(
-	'woocommerce_woocommerce_payments_payment_request_button_type'
-);
-
-// TODO: Remove this `if` after Apple Pay gets released.
-if ( paymentRequest ) {
 	// Payment Request button event listeners.
 	paymentRequest.addEventListener( 'change', () => {
 		const inputIds = [

--- a/client/settings.js
+++ b/client/settings.js
@@ -84,85 +84,88 @@ const paymentRequestButtonType = document.getElementById(
 	'woocommerce_woocommerce_payments_payment_request_button_type'
 );
 
-// Payment Request button event listeners.
-paymentRequest.addEventListener( 'change', () => {
-	const inputIds = [
-		'woocommerce_woocommerce_payments_payment_request_button_theme',
-		'woocommerce_woocommerce_payments_payment_request_button_type',
-		'woocommerce_woocommerce_payments_payment_request_button_height',
-	];
+// TODO: Remove this if after WCPay 2.2.0 gets released
+if ( paymentRequest ) {
+	// Payment Request button event listeners.
+	paymentRequest.addEventListener( 'change', () => {
+		const inputIds = [
+			'woocommerce_woocommerce_payments_payment_request_button_theme',
+			'woocommerce_woocommerce_payments_payment_request_button_type',
+			'woocommerce_woocommerce_payments_payment_request_button_height',
+		];
 
-	if ( paymentRequest.checked ) {
-		inputIds.forEach( ( id ) => {
+		if ( paymentRequest.checked ) {
+			inputIds.forEach( ( id ) => {
+				toggleDisplay(
+					findParent( document.getElementById( id ), 'tr' ),
+					true
+				);
+			} );
+		} else {
+			inputIds.forEach( ( id ) => {
+				toggleDisplay(
+					findParent( document.getElementById( id ), 'tr' ),
+					false
+				);
+			} );
+		}
+
+		paymentRequestButtonType.dispatchEvent( new Event( 'change' ) );
+	} );
+
+	// Toggle Custom Payment Request configs.
+	paymentRequestButtonType.addEventListener( 'change', () => {
+		if (
+			'custom' === paymentRequestButtonType.value &&
+			paymentRequest.checked
+		) {
 			toggleDisplay(
-				findParent( document.getElementById( id ), 'tr' ),
+				findParent(
+					document.getElementById(
+						'woocommerce_woocommerce_payments_payment_request_button_label'
+					),
+					'tr'
+				),
 				true
 			);
-		} );
-	} else {
-		inputIds.forEach( ( id ) => {
+		} else {
 			toggleDisplay(
-				findParent( document.getElementById( id ), 'tr' ),
+				findParent(
+					document.getElementById(
+						'woocommerce_woocommerce_payments_payment_request_button_label'
+					),
+					'tr'
+				),
 				false
 			);
-		} );
-	}
+		}
 
+		if (
+			'branded' === paymentRequestButtonType.value &&
+			paymentRequest.checked
+		) {
+			toggleDisplay(
+				findParent(
+					document.getElementById(
+						'woocommerce_woocommerce_payments_payment_request_button_branded_type'
+					),
+					'tr'
+				),
+				true
+			);
+		} else {
+			toggleDisplay(
+				findParent(
+					document.getElementById(
+						'woocommerce_woocommerce_payments_payment_request_button_branded_type'
+					),
+					'tr'
+				),
+				false
+			);
+		}
+	} );
+
+	paymentRequest.dispatchEvent( new Event( 'change' ) );
 	paymentRequestButtonType.dispatchEvent( new Event( 'change' ) );
-} );
-
-// Toggle Custom Payment Request configs.
-paymentRequestButtonType.addEventListener( 'change', () => {
-	if (
-		'custom' === paymentRequestButtonType.value &&
-		paymentRequest.checked
-	) {
-		toggleDisplay(
-			findParent(
-				document.getElementById(
-					'woocommerce_woocommerce_payments_payment_request_button_label'
-				),
-				'tr'
-			),
-			true
-		);
-	} else {
-		toggleDisplay(
-			findParent(
-				document.getElementById(
-					'woocommerce_woocommerce_payments_payment_request_button_label'
-				),
-				'tr'
-			),
-			false
-		);
-	}
-
-	if (
-		'branded' === paymentRequestButtonType.value &&
-		paymentRequest.checked
-	) {
-		toggleDisplay(
-			findParent(
-				document.getElementById(
-					'woocommerce_woocommerce_payments_payment_request_button_branded_type'
-				),
-				'tr'
-			),
-			true
-		);
-	} else {
-		toggleDisplay(
-			findParent(
-				document.getElementById(
-					'woocommerce_woocommerce_payments_payment_request_button_branded_type'
-				),
-				'tr'
-			),
-			false
-		);
-	}
-} );
-
-paymentRequest.dispatchEvent( new Event( 'change' ) );
-paymentRequestButtonType.dispatchEvent( new Event( 'change' ) );
+}

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -260,9 +260,11 @@ class WC_Payments_Admin {
 			'WCPAY_ADMIN_SETTINGS',
 			'wcpayAdminSettings',
 			[
-				'accountStatus' => $this->account->get_account_status_data(),
-				'accountFees'   => $this->account->get_fees(),
-				'fraudServices' => $this->account->get_fraud_services_config(),
+				'accountStatus'         => $this->account->get_account_status_data(),
+				'accountFees'           => $this->account->get_fees(),
+				'fraudServices'         => $this->account->get_fraud_services_config(),
+				// TODO: Remove this line ahead of Apple Pay release.
+				'paymentRequestEnabled' => 'yes' === get_option( '_wcpay_feature_payment_request' ),
 			]
 		);
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -169,8 +169,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// Feature flag.
 		// TODO: Remove this check and inject contents of `$payment_request_fields` into `$this->form_fields`
-		// after `saved_cards` when WCPay 2.2.0 gets released.
-		if ( version_compare( get_option( 'woocommerce_woocommerce_payments_version', WCPAY_VERSION_NUMBER ), '2.2.0', '>=' ) ) {
+		// after `saved_cards` when Apple Pay gets released.
+		if ( version_compare( get_option( 'woocommerce_woocommerce_payments_version', WCPAY_VERSION_NUMBER ), '3.0.0', '>=' ) ) {
 			// Default values for Payment Request.
 			$payment_request_default_settings = WC_Payments_Payment_Request_Button_Handler::get_default_settings();
 			$payment_request_fields           = [

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -251,6 +251,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		add_filter( 'woocommerce_settings_api_sanitized_fields_' . $this->id, [ $this, 'sanitize_plugin_settings' ] );
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
 		add_action( 'admin_notices', [ $this, 'display_errors' ], 9999 );
+		add_action( 'woocommerce_payments_admin_notices', [ $this, 'display_test_mode_notice' ] );
 		add_action( 'woocommerce_order_actions', [ $this, 'add_order_actions' ] );
 		add_action( 'woocommerce_order_action_capture_charge', [ $this, 'capture_charge' ] );
 		add_action( 'woocommerce_order_action_cancel_authorization', [ $this, 'cancel_authorization' ] );
@@ -363,9 +364,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Add notice to WooCommerce Payments settings page explaining test mode when it's enabled.
+	 * Add notice explaining test mode when it's enabled.
 	 */
-	public function admin_options() {
+	public function display_test_mode_notice() {
 		if ( $this->is_in_test_mode() ) {
 			?>
 			<div id="wcpay-test-mode-notice" class="notice notice-warning">
@@ -376,6 +377,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			</div>
 			<?php
 		}
+	}
+
+	/**
+	 * Admin Panel Options.
+	 */
+	public function admin_options() {
+		// Add notices to the WooCommerce Payments settings page.
+		do_action( 'woocommerce_payments_admin_notices' );
 
 		parent::admin_options();
 	}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -251,7 +251,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		add_filter( 'woocommerce_settings_api_sanitized_fields_' . $this->id, [ $this, 'sanitize_plugin_settings' ] );
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
 		add_action( 'admin_notices', [ $this, 'display_errors' ], 9999 );
-		add_action( 'woocommerce_payments_admin_notices', [ $this, 'display_test_mode_notice' ] );
+		add_action( 'woocommerce_woocommerce_payments_admin_notices', [ $this, 'display_test_mode_notice' ] );
 		add_action( 'woocommerce_order_actions', [ $this, 'add_order_actions' ] );
 		add_action( 'woocommerce_order_action_capture_charge', [ $this, 'capture_charge' ] );
 		add_action( 'woocommerce_order_action_cancel_authorization', [ $this, 'cancel_authorization' ] );
@@ -384,7 +384,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	public function admin_options() {
 		// Add notices to the WooCommerce Payments settings page.
-		do_action( 'woocommerce_payments_admin_notices' );
+		do_action( 'woocommerce_woocommerce_payments_admin_notices' );
 
 		parent::admin_options();
 	}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -169,8 +169,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// Feature flag.
 		// TODO: Remove this check and inject contents of `$payment_request_fields` into `$this->form_fields`
-		// after `saved_cards` when Apple Pay gets released.
-		if ( version_compare( get_option( 'woocommerce_woocommerce_payments_version', WCPAY_VERSION_NUMBER ), '3.0.0', '>=' ) ) {
+		// after `saved_cards` ahead of Apple Pay release.
+		if ( 'yes' === get_option( '_wcpay_feature_payment_request' ) ) {
 			// Default values for Payment Request.
 			$payment_request_default_settings = WC_Payments_Payment_Request_Button_Handler::get_default_settings();
 			$payment_request_fields           = [

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -109,28 +109,25 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'refunds',
 		];
 
-		// Default values for Payment Request.
-		$payment_request_default_settings = WC_Payments_Payment_Request_Button_Handler::get_default_settings();
-
 		// Define setting fields.
 		$this->form_fields = [
-			'enabled'                             => [
+			'enabled'                      => [
 				'title'       => __( 'Enable/disable', 'woocommerce-payments' ),
 				'label'       => __( 'Enable WooCommerce Payments', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
 				'description' => '',
 				'default'     => 'no',
 			],
-			'account_details'                     => [
+			'account_details'              => [
 				'type' => 'account_actions',
 			],
-			'account_status'                      => [
+			'account_status'               => [
 				'type' => 'account_status',
 			],
-			'account_fees'                        => [
+			'account_fees'                 => [
 				'type' => 'account_fees',
 			],
-			'account_statement_descriptor'        => [
+			'account_statement_descriptor' => [
 				'type'        => 'account_statement_descriptor',
 				'title'       => __( 'Customer bank statement', 'woocommerce-payments' ),
 				'description' => WC_Payments_Utils::esc_interpolated_html(
@@ -138,14 +135,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					[ 'a' => '<a href="https://docs.woocommerce.com/document/payments/bank-statement-descriptor/" target="_blank" rel="noopener noreferrer">' ]
 				),
 			],
-			'manual_capture'                      => [
+			'manual_capture'               => [
 				'title'       => __( 'Manual capture', 'woocommerce-payments' ),
 				'label'       => __( 'Issue an authorization on checkout, and capture later.', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
 				'description' => __( 'Charge must be captured within 7 days of authorization, otherwise the authorization and order will be canceled.', 'woocommerce-payments' ),
 				'default'     => 'no',
 			],
-			'saved_cards'                         => [
+			'saved_cards'                  => [
 				'title'       => __( 'Saved Cards', 'woocommerce-payments' ),
 				'label'       => __( 'Enable Payment via Saved Cards', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
@@ -153,77 +150,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'default'     => 'yes',
 				'desc_tip'    => true,
 			],
-			'payment_request'                     => [
-				'title'       => __( 'Payment Request Button', 'woocommerce-payments' ),
-				'label'       => sprintf(
-					/* translators: 1) br tag 2) Stripe anchor tag 3) Apple anchor tag */
-					__( 'Enable Payment Request Button (Apple Pay, Google Pay, and more). %1$sBy using Apple Pay, you agree to %2$s and %3$s\'s terms of service.', 'woocommerce-payments' ),
-					'<br />',
-					'<a href="https://stripe.com/apple-pay/legal" target="_blank">Stripe</a>',
-					'<a href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/" target="_blank">Apple</a>'
-				),
-				'type'        => 'checkbox',
-				'description' => __( 'If enabled, users will be able to pay using Apple Pay or Chrome Payment Request if supported by the browser.', 'woocommerce-payments' ),
-				'default'     => $payment_request_default_settings['payment_request'],
-				'desc_tip'    => true,
-			],
-			'payment_request_button_type'         => [
-				'title'       => __( 'Payment Request Button Type', 'woocommerce-payments' ),
-				'label'       => __( 'Button Type', 'woocommerce-payments' ),
-				'type'        => 'select',
-				'description' => __( 'Select the button type you would like to show.', 'woocommerce-payments' ),
-				'default'     => $payment_request_default_settings['payment_request_button_type'],
-				'desc_tip'    => true,
-				'options'     => [
-					'default' => __( 'Default', 'woocommerce-payments' ),
-					'buy'     => __( 'Buy', 'woocommerce-payments' ),
-					'donate'  => __( 'Donate', 'woocommerce-payments' ),
-					'branded' => __( 'Branded', 'woocommerce-payments' ),
-					'custom'  => __( 'Custom', 'woocommerce-payments' ),
-				],
-			],
-			'payment_request_button_theme'        => [
-				'title'       => __( 'Payment Request Button Theme', 'woocommerce-payments' ),
-				'label'       => __( 'Button Theme', 'woocommerce-payments' ),
-				'type'        => 'select',
-				'description' => __( 'Select the button theme you would like to show.', 'woocommerce-payments' ),
-				'default'     => $payment_request_default_settings['payment_request_button_theme'],
-				'desc_tip'    => true,
-				'options'     => [
-					'dark'          => __( 'Dark', 'woocommerce-payments' ),
-					'light'         => __( 'Light', 'woocommerce-payments' ),
-					'light-outline' => __( 'Light-Outline', 'woocommerce-payments' ),
-				],
-			],
-			'payment_request_button_height'       => [
-				'title'       => __( 'Payment Request Button Height', 'woocommerce-payments' ),
-				'label'       => __( 'Button Height', 'woocommerce-payments' ),
-				'type'        => 'text',
-				'description' => __( 'Enter the height you would like the button to be in pixels. Width will always be 100%.', 'woocommerce-payments' ),
-				'default'     => $payment_request_default_settings['payment_request_button_height'],
-				'desc_tip'    => true,
-			],
-			'payment_request_button_label'        => [
-				'title'       => __( 'Payment Request Button Label', 'woocommerce-payments' ),
-				'label'       => __( 'Button Label', 'woocommerce-payments' ),
-				'type'        => 'text',
-				'description' => __( 'Enter the custom text you would like the button to have.', 'woocommerce-payments' ),
-				'default'     => $payment_request_default_settings['payment_request_button_label'],
-				'desc_tip'    => true,
-			],
-			'payment_request_button_branded_type' => [
-				'title'       => __( 'Payment Request Branded Button Label Format', 'woocommerce-payments' ),
-				'label'       => __( 'Branded Button Label Format', 'woocommerce-payments' ),
-				'type'        => 'select',
-				'description' => __( 'Select the branded button label format.', 'woocommerce-payments' ),
-				'default'     => $payment_request_default_settings['payment_request_button_branded_type'],
-				'desc_tip'    => true,
-				'options'     => [
-					'short' => __( 'Logo only', 'woocommerce-payments' ),
-					'long'  => __( 'Text and logo', 'woocommerce-payments' ),
-				],
-			],
-			'test_mode'                           => [
+			'test_mode'                    => [
 				'title'       => __( 'Test mode', 'woocommerce-payments' ),
 				'label'       => __( 'Enable test mode', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
@@ -231,7 +158,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'default'     => 'no',
 				'desc_tip'    => true,
 			],
-			'enable_logging'                      => [
+			'enable_logging'               => [
 				'title'       => __( 'Debug log', 'woocommerce-payments' ),
 				'label'       => __( 'When enabled debug notes will be added to the log.', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
@@ -239,6 +166,92 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'default'     => 'no',
 			],
 		];
+
+		// Feature flag
+		// TODO: Remove this check and inject contents of `$payment_request_fields` into `$this->form_fields`
+		// after `saved_cards` when WCPay 2.2.0 gets released.
+		if ( version_compare( get_option( 'woocommerce_woocommerce_payments_version', WCPAY_VERSION_NUMBER ), '2.2.0', '>=' ) ) {
+			// Default values for Payment Request.
+			$payment_request_default_settings = WC_Payments_Payment_Request_Button_Handler::get_default_settings();
+			$payment_request_fields           = [
+				'payment_request'                     => [
+					'title'       => __( 'Payment Request Button', 'woocommerce-payments' ),
+					'label'       => sprintf(
+						/* translators: 1) br tag 2) Stripe anchor tag 3) Apple anchor tag */
+						__( 'Enable Payment Request Button (Apple Pay, Google Pay, and more). %1$sBy using Apple Pay, you agree to %2$s and %3$s\'s terms of service.', 'woocommerce-payments' ),
+						'<br />',
+						'<a href="https://stripe.com/apple-pay/legal" target="_blank">Stripe</a>',
+						'<a href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/" target="_blank">Apple</a>'
+					),
+					'type'        => 'checkbox',
+					'description' => __( 'If enabled, users will be able to pay using Apple Pay or Chrome Payment Request if supported by the browser.', 'woocommerce-payments' ),
+					'default'     => $payment_request_default_settings['payment_request'],
+					'desc_tip'    => true,
+				],
+				'payment_request_button_type'         => [
+					'title'       => __( 'Payment Request Button Type', 'woocommerce-payments' ),
+					'label'       => __( 'Button Type', 'woocommerce-payments' ),
+					'type'        => 'select',
+					'description' => __( 'Select the button type you would like to show.', 'woocommerce-payments' ),
+					'default'     => $payment_request_default_settings['payment_request_button_type'],
+					'desc_tip'    => true,
+					'options'     => [
+						'default' => __( 'Default', 'woocommerce-payments' ),
+						'buy'     => __( 'Buy', 'woocommerce-payments' ),
+						'donate'  => __( 'Donate', 'woocommerce-payments' ),
+						'branded' => __( 'Branded', 'woocommerce-payments' ),
+						'custom'  => __( 'Custom', 'woocommerce-payments' ),
+					],
+				],
+				'payment_request_button_theme'        => [
+					'title'       => __( 'Payment Request Button Theme', 'woocommerce-payments' ),
+					'label'       => __( 'Button Theme', 'woocommerce-payments' ),
+					'type'        => 'select',
+					'description' => __( 'Select the button theme you would like to show.', 'woocommerce-payments' ),
+					'default'     => $payment_request_default_settings['payment_request_button_theme'],
+					'desc_tip'    => true,
+					'options'     => [
+						'dark'          => __( 'Dark', 'woocommerce-payments' ),
+						'light'         => __( 'Light', 'woocommerce-payments' ),
+						'light-outline' => __( 'Light-Outline', 'woocommerce-payments' ),
+					],
+				],
+				'payment_request_button_height'       => [
+					'title'       => __( 'Payment Request Button Height', 'woocommerce-payments' ),
+					'label'       => __( 'Button Height', 'woocommerce-payments' ),
+					'type'        => 'text',
+					'description' => __( 'Enter the height you would like the button to be in pixels. Width will always be 100%.', 'woocommerce-payments' ),
+					'default'     => $payment_request_default_settings['payment_request_button_height'],
+					'desc_tip'    => true,
+				],
+				'payment_request_button_label'        => [
+					'title'       => __( 'Payment Request Button Label', 'woocommerce-payments' ),
+					'label'       => __( 'Button Label', 'woocommerce-payments' ),
+					'type'        => 'text',
+					'description' => __( 'Enter the custom text you would like the button to have.', 'woocommerce-payments' ),
+					'default'     => $payment_request_default_settings['payment_request_button_label'],
+					'desc_tip'    => true,
+				],
+				'payment_request_button_branded_type' => [
+					'title'       => __( 'Payment Request Branded Button Label Format', 'woocommerce-payments' ),
+					'label'       => __( 'Branded Button Label Format', 'woocommerce-payments' ),
+					'type'        => 'select',
+					'description' => __( 'Select the branded button label format.', 'woocommerce-payments' ),
+					'default'     => $payment_request_default_settings['payment_request_button_branded_type'],
+					'desc_tip'    => true,
+					'options'     => [
+						'short' => __( 'Logo only', 'woocommerce-payments' ),
+						'long'  => __( 'Text and logo', 'woocommerce-payments' ),
+					],
+				],
+			];
+			// Where to inject fields.
+			$fields_index = 7;
+			// Inject in the middle of `$this->form_fields`.
+			$this->form_fields = array_slice( $this->form_fields, 0, $fields_index ) +
+				$payment_request_fields +
+				array_slice( $this->form_fields, $fields_index, count( $this->form_fields ) - 1 );
+		}
 
 		// Load the settings.
 		$this->init_settings();

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -167,7 +167,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			],
 		];
 
-		// Feature flag
+		// Feature flag.
 		// TODO: Remove this check and inject contents of `$payment_request_fields` into `$this->form_fields`
 		// after `saved_cards` when WCPay 2.2.0 gets released.
 		if ( version_compare( get_option( 'woocommerce_woocommerce_payments_version', WCPAY_VERSION_NUMBER ), '2.2.0', '>=' ) ) {

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -78,9 +78,9 @@ class WC_Payments_Apple_Pay_Registration {
 		add_filter( 'query_vars', [ $this, 'whitelist_domain_association_query_param' ], 10, 1 );
 		add_action( 'parse_request', [ $this, 'parse_domain_association_request' ], 10, 1 );
 
-		add_action( 'woocommerce_payments_admin_notices', [ $this, 'display_error_notice' ] );
-		add_action( 'woocommerce_payments_admin_notices', [ $this, 'display_live_account_notice' ] );
-		add_action( 'woocommerce_payments_updated', [ $this, 'verify_domain_if_configured' ] );
+		add_action( 'woocommerce_woocommerce_payments_admin_notices', [ $this, 'display_error_notice' ] );
+		add_action( 'woocommerce_woocommerce_payments_admin_notices', [ $this, 'display_live_account_notice' ] );
+		add_action( 'woocommerce_woocommerce_payments_updated', [ $this, 'verify_domain_if_configured' ] );
 		add_action( 'add_option_woocommerce_woocommerce_payments_settings', [ $this, 'verify_domain_on_new_settings' ], 10, 2 );
 		add_action( 'update_option_woocommerce_woocommerce_payments_settings', [ $this, 'verify_domain_on_updated_settings' ], 10, 2 );
 

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -80,6 +80,7 @@ class WC_Payments_Apple_Pay_Registration {
 
 		add_action( 'woocommerce_payments_admin_notices', [ $this, 'display_error_notice' ] );
 		add_action( 'woocommerce_payments_admin_notices', [ $this, 'display_live_account_notice' ] );
+		add_action( 'woocommerce_payments_updated', [ $this, 'verify_domain_if_configured' ] );
 		add_action( 'add_option_woocommerce_woocommerce_payments_settings', [ $this, 'verify_domain_on_new_settings' ], 10, 2 );
 		add_action( 'update_option_woocommerce_woocommerce_payments_settings', [ $this, 'verify_domain_on_updated_settings' ], 10, 2 );
 
@@ -333,22 +334,10 @@ class WC_Payments_Apple_Pay_Registration {
 	}
 
 	/**
-	 * Checks wether this is a WooCommerce page or not.
-	 */
-	public function is_wc_page() {
-		$current_screen = get_current_screen();
-		return property_exists( $current_screen, 'parent_base' ) && 'woocommerce' === $current_screen->parent_base;
-	}
-
-	/**
 	 * Display warning notice explaining that the domain can't be registered without a live account.
 	 */
 	public function display_live_account_notice() {
-		if (
-			! $this->is_wc_page() ||
-			! $this->is_enabled() ||
-			$this->account->get_is_live()
-		) {
+		if ( ! $this->is_enabled() || $this->account->get_is_live() ) {
 			return;
 		}
 
@@ -366,11 +355,7 @@ class WC_Payments_Apple_Pay_Registration {
 	 * Display Apple Pay registration errors.
 	 */
 	public function display_error_notice() {
-		if (
-			! $this->is_wc_page() ||
-			! $this->is_enabled() ||
-			! current_user_can( 'manage_woocommerce' )
-		) {
+		if ( ! $this->is_enabled() || ! current_user_can( 'manage_woocommerce' ) ) {
 			return;
 		}
 

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -75,12 +75,11 @@ class WC_Payments_Apple_Pay_Registration {
 	public function __construct( WC_Payments_API_Client $payments_api_client, WC_Payment_Gateway_WCPay $gateway, WC_Payments_Account $account ) {
 		add_action( 'init', [ $this, 'add_domain_association_rewrite_rule' ] );
 		add_action( 'admin_init', [ $this, 'verify_domain_on_domain_name_change' ] );
-		add_action( 'admin_notices', [ $this, 'display_error_notice' ] );
-		add_action( 'admin_notices', [ $this, 'display_live_account_notice' ] );
 		add_filter( 'query_vars', [ $this, 'whitelist_domain_association_query_param' ], 10, 1 );
 		add_action( 'parse_request', [ $this, 'parse_domain_association_request' ], 10, 1 );
 
-		add_action( 'woocommerce_woocommerce_payments_updated', [ $this, 'verify_domain_if_configured' ] );
+		add_action( 'woocommerce_payments_admin_notices', [ $this, 'display_error_notice' ] );
+		add_action( 'woocommerce_payments_admin_notices', [ $this, 'display_live_account_notice' ] );
 		add_action( 'add_option_woocommerce_woocommerce_payments_settings', [ $this, 'verify_domain_on_new_settings' ], 10, 2 );
 		add_action( 'update_option_woocommerce_woocommerce_payments_settings', [ $this, 'verify_domain_on_updated_settings' ], 10, 2 );
 

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -86,7 +86,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 */
 	public static function get_default_settings() {
 		return [
-			'payment_request'                     => 'yes',
+			'payment_request'                     => 'no',
 			'payment_request_button_type'         => 'buy',
 			'payment_request_button_theme'        => 'dark',
 			'payment_request_button_height'       => '44',

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -168,8 +168,8 @@ class WC_Payments {
 		self::$gateway = new $gateway_class( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service );
 
 		// Feature flag.
-		// TODO: Remove this check when WCPay 2.2.0 gets released.
-		if ( version_compare( get_option( 'woocommerce_woocommerce_payments_version', WCPAY_VERSION_NUMBER ), '2.2.0', '>=' ) ) {
+		// TODO: Remove this check when Apple Pay gets released.
+		if ( version_compare( get_option( 'woocommerce_woocommerce_payments_version', WCPAY_VERSION_NUMBER ), '3.0.0', '>=' ) ) {
 			self::$payment_request_button_handler = new WC_Payments_Payment_Request_Button_Handler( self::$account );
 			self::$apple_pay_registration         = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$gateway, self::$account );
 		}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -168,8 +168,8 @@ class WC_Payments {
 		self::$gateway = new $gateway_class( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service );
 
 		// Feature flag.
-		// TODO: Remove this check when Apple Pay gets released.
-		if ( version_compare( get_option( 'woocommerce_woocommerce_payments_version', WCPAY_VERSION_NUMBER ), '3.0.0', '>=' ) ) {
+		// TODO: Remove this check ahead of Apple Pay release.
+		if ( 'yes' === get_option( '_wcpay_feature_payment_request' ) ) {
 			self::$payment_request_button_handler = new WC_Payments_Payment_Request_Button_Handler( self::$account );
 			self::$apple_pay_registration         = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$gateway, self::$account );
 		}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -536,7 +536,7 @@ class WC_Payments {
 	 */
 	public static function install_actions() {
 		if ( version_compare( WCPAY_VERSION_NUMBER, get_option( 'woocommerce_woocommerce_payments_version' ), '>' ) ) {
-			do_action( 'woocommerce_payments_updated' );
+			do_action( 'woocommerce_woocommerce_payments_updated' );
 			self::update_plugin_version();
 		}
 	}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -167,8 +167,12 @@ class WC_Payments {
 
 		self::$gateway = new $gateway_class( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service );
 
-		self::$payment_request_button_handler = new WC_Payments_Payment_Request_Button_Handler( self::$account );
-		self::$apple_pay_registration         = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$gateway, self::$account );
+		// Feature flag
+		// TODO: Remove this check when WCPay 2.2.0 gets released.
+		if ( version_compare( get_option( 'woocommerce_woocommerce_payments_version', WCPAY_VERSION_NUMBER ), '2.2.0', '>=' ) ) {
+			self::$payment_request_button_handler = new WC_Payments_Payment_Request_Button_Handler( self::$account );
+			self::$apple_pay_registration         = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$gateway, self::$account );
+		}
 
 		add_filter( 'woocommerce_payment_gateways', [ __CLASS__, 'register_gateway' ] );
 		add_filter( 'option_woocommerce_gateway_order', [ __CLASS__, 'set_gateway_top_of_list' ], 2 );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -536,7 +536,7 @@ class WC_Payments {
 	 */
 	public static function install_actions() {
 		if ( version_compare( WCPAY_VERSION_NUMBER, get_option( 'woocommerce_woocommerce_payments_version' ), '>' ) ) {
-			do_action( 'woocommerce_woocommerce_payments_updated' );
+			do_action( 'woocommerce_payments_updated' );
 			self::update_plugin_version();
 		}
 	}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -167,7 +167,7 @@ class WC_Payments {
 
 		self::$gateway = new $gateway_class( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service );
 
-		// Feature flag
+		// Feature flag.
 		// TODO: Remove this check when WCPay 2.2.0 gets released.
 		if ( version_compare( get_option( 'woocommerce_woocommerce_payments_version', WCPAY_VERSION_NUMBER ), '2.2.0', '>=' ) ) {
 			self::$payment_request_button_handler = new WC_Payments_Payment_Request_Button_Handler( self::$account );

--- a/readme.txt
+++ b/readme.txt
@@ -107,7 +107,6 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Enable multiple customer currencies support in live mode.
 * Add - Rate limit failed account connection checks.
 * Add - Support displaying non-USD base fees on settings page.
-* Add - Payment Request Button support (Apple Pay, Google Pay, Microsoft Pay, and the browser standard Payment Request API).
 
 = 2.0.0 - 2021-02-22 =
 * Update - Render customer details in transactions list as text instead of link if order missing.


### PR DESCRIPTION
Fixes #1386

#### Changes proposed in this Pull Request

- Display Apple Pay admin notices only in the WCPay settings page.
- Hide Apple Pay and other Payment Request buttons behind a feature flag - I just didn't skip importing class files because of unit tests.

#### Testing instructions

- Notice there's no Payment Request feature in settings.
- Manually create the `_wcpay_feature_payment_request ` option with a `yes` value and notice Payment Request Button is visible in settings.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)