### PR TITLE
Specify wordpress docker image version to 5.6.2 because latest (5.7.0…

### DIFF
--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -120,7 +120,7 @@ cli wp core install \
 	--skip-email
 
 echo "Updating WordPress to the latest version..."
-cli wp core update --quiet
+cli wp core update --version=5.6.2 --quiet
 
 echo "Updating the WordPress database..."
 cli wp core update-db --quiet

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -120,7 +120,7 @@ cli wp core install \
 	--skip-email
 
 echo "Updating WordPress to the latest version..."
-cli wp core update --version=5.6.2 --quiet
+cli wp core update --quiet
 
 echo "Updating the WordPress database..."
 cli wp core update-db --quiet

--- a/tests/e2e/env/wordpress-xdebug/Dockerfile
+++ b/tests/e2e/env/wordpress-xdebug/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress
+FROM wordpress:5.6.2
 
 RUN pecl install xdebug \
 	&& echo 'xdebug.remote_enable=1' >> $PHP_INI_DIR/php.ini \


### PR DESCRIPTION
Fixes `Access denied for user 'username_here'@'172.19.0.3' (using password: YES) when trying to connect` error when e2e runs `npm run test:e2e-setup`.

This is because wordpress docker image's latest version is bumped to 5.7.0 from 5.6.2 and the change (not yet clear what) breaks e2e setup script.

#### Changes proposed in this Pull Request

Hardcode wordpress docker image to 5.6.2.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With trunk, e2e Github Actions check will stuck at step `npm run test:e2e-setup` showing this in the log:
```
===> Setting up CLIENT site
mysqlcheck: Got error: 2002: Can't connect to MySQL server on 'mysql' (115) when trying to connect
Waiting until the service is ready...
mysqlcheck: Got error: 2002: Can't connect to MySQL server on 'mysql' (115) when trying to connect
Waiting until the service is ready...
mysqlcheck: Got error: 1045: Access denied for user 'username_here'@'172.19.0.3' (using password: YES) when trying to connect
Waiting until the service is ready...
mysqlcheck: Got error: 1045: Access denied for user 'username_here'@'172.19.0.3' (using password: YES) when trying to connect
...
```

* With this branch, we are not stuck at that part of the e2e script that waits for database container finishes starting up, showing this in the log instead:
```
===> Setting up CLIENT site
mysqlcheck: Got error: 2002: Can't connect to MySQL server on 'db' (115) when trying to connect
Waiting until the service is ready...
mysqlcheck: Got error: 2002: Can't connect to MySQL server on 'db' (115) when trying to connect
Waiting until the service is ready...
Client DB is up and running...
```

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
