### PR TITLE
Disable Payment Request buttons when authentication is required

### DIFF
--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -129,7 +129,7 @@ class WC_Payments_Apple_Pay_Registration {
 	 * Vefifies if hosted domain association file is up to date
 	 * with the file from the plugin directory.
 	 *
-	 * @return bool Wether file is up to date or not.
+	 * @return bool Whether file is up to date or not.
 	 */
 	private function is_hosted_domain_association_file_up_to_date() {
 		// Contents of domain association file from plugin dir.

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -612,8 +612,13 @@ class WC_Payments_Payment_Request_Button_Handler {
 			return false;
 		}
 
-		// Composite products are not supported on product page.
+		// Composite products are not supported on the product page.
 		if ( class_exists( 'WC_Composite_Products' ) && function_exists( 'is_composite_product' ) && is_composite_product() ) {
+			return false;
+		}
+
+		// Mix and match products are not supported on the product page.
+		if ( class_exists( 'WC_Mix_and_Match' ) && $product->is_type( 'mix-and-match' ) ) {
 			return false;
 		}
 

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -391,7 +391,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 			}
 
 			// Trial subscriptions with shipping are not supported.
-			if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Product::is_subscription( $_product ) && $_product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $_product ) > 0 ) {
+			if ( class_exists( 'WC_Subscriptions_Product' ) && WC_Subscriptions_Product::is_subscription( $_product ) && $_product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $_product ) > 0 ) {
 				return false;
 			}
 
@@ -609,6 +609,11 @@ class WC_Payments_Payment_Request_Button_Handler {
 
 		// Pre Orders charge upon release not supported.
 		if ( class_exists( 'WC_Pre_Orders_Product' ) && WC_Pre_Orders_Product::product_is_charged_upon_release( $product ) ) {
+			return false;
+		}
+
+		// Composite products are not supported on product page.
+		if ( class_exists( 'WC_Composite_Products' ) && function_exists( 'is_composite_product' ) && is_composite_product() ) {
 			return false;
 		}
 

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -95,7 +95,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 	}
 
 	/**
-	 * Checks wether authentication is required for checkout.
+	 * Checks whether authentication is required for checkout.
 	 *
 	 * @return bool
 	 */
@@ -110,7 +110,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 	}
 
 	/**
-	 * Checks wether account creation is possible during checkout.
+	 * Checks whether account creation is possible during checkout.
 	 *
 	 * @return bool
 	 */
@@ -391,12 +391,12 @@ class WC_Payments_Payment_Request_Button_Handler {
 			}
 
 			// Trial subscriptions with shipping are not supported.
-			if ( class_exists( 'WC_Subscriptions_Order' ) && WC_Subscriptions_Cart::cart_contains_subscription() && $_product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $_product ) > 0 ) {
+			if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Product::is_subscription( $_product ) && $_product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $_product ) > 0 ) {
 				return false;
 			}
 
 			// Pre Orders compatbility where we don't support charge upon release.
-			if ( class_exists( 'WC_Pre_Orders_Order' ) && WC_Pre_Orders_Cart::cart_contains_pre_order() && WC_Pre_Orders_Product::product_is_charged_upon_release( WC_Pre_Orders_Cart::get_pre_order_product() ) ) {
+			if ( class_exists( 'WC_Pre_Orders_Cart' ) && WC_Pre_Orders_Cart::cart_contains_pre_order() && WC_Pre_Orders_Product::product_is_charged_upon_release( WC_Pre_Orders_Cart::get_pre_order_product() ) ) {
 				return false;
 			}
 		}
@@ -603,13 +603,12 @@ class WC_Payments_Payment_Request_Button_Handler {
 		}
 
 		// Trial subscriptions with shipping are not supported.
-		if ( class_exists( 'WC_Subscriptions_Order' ) && $product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $product ) > 0 ) {
+		if ( class_exists( 'WC_Subscriptions_Product' ) && $product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $product ) > 0 ) {
 			return false;
 		}
 
 		// Pre Orders charge upon release not supported.
-		if ( class_exists( 'WC_Pre_Orders_Order' ) && WC_Pre_Orders_Product::product_is_charged_upon_release( $product ) ) {
-			Logger::log( 'Pre Order charge upon release is not supported. ( Payment Request button disabled )' );
+		if ( class_exists( 'WC_Pre_Orders_Product' ) && WC_Pre_Orders_Product::product_is_charged_upon_release( $product ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #1388 

**Note: This should not be included in 2.1.0 and there's no need to review it before releasing.**

#### Changes proposed in this Pull Request

- Hide Payment Request button if authentication is required (if guest checkout and signup upon checkout are disabled).
- Hide Payment Request button for Subscription products when creating an account upon checkout isn't possible.
- Hide Payment Request button on the product page for "mix-and-match" and "composite" products, because of related issue in 829-gh-woocommerce/woocommerce-gateway-stripe. - In the cart page it works as expected.

#### Testing instructions
**Scenario: A**
- Disable `Allow customers to create an account during checkout` in WooCommerce > Settings > Accounts & Privacy.
- Make sure you're not authenticated and visit a subscription product page.
- Notice there's no Payment Request button.
- Enable `Allow customers to create an account during checkout` and notice the button is displayed.

**Scenario: B**
- Disable `Allow customers to create an account during checkout` and `Allow customers to place orders without an account`.
- Make sure you're not authenticated and visit a simple product page.
- Notice there's no Payment Request button.
- Enable either `Allow customers to create an account during checkout` or `Allow customers to place orders without an account` (if automatically generate an account username and password are enabled as well). - notice the button is displayed.

**Scenario: C**
- Disable `Allow customers to create an account during checkout` and `Allow customers to place orders without an account`.
- Authenticate.
- Notice the button is displayed for any supported product.

**Scenario: D**
- Visit any [Composite](https://woocommerce.com/products/composite-products/) or [Mix and Match](http://www.woocommerce.com/products/woocommerce-mix-and-match-products/) product page.
- Notice the button is not displayed.
- Visit the cart and notice the button is displayed and works as expected.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)