### PR TITLE
Fix console error on the settings screen.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,6 @@ const webpackConfig = {
 	output: {
 		filename: '[name].js',
 		path: path.resolve( 'dist' ),
-		libraryTarget: 'this',
 	},
 	module: {
 		rules: [


### PR DESCRIPTION
After making the Webpack-generated code be ES5 on #1384 , @ricardo noticed that an error is thrown in the settings screen: https://github.com/Automattic/woocommerce-payments/pull/1384#issuecomment-797762912

The error doesn't break anything, but it's annoying.

I tracked it down to the webpack config. We set `output.libraryTarget: this`, which roughly means that Webpack will run `this.exportedSymbol = exportedSymbol`. When using arrow functions (ES6-only), `this` was the `window` global. But now, `this` is `undefined`. `output.libraryTarget` doesn't really matter for our app, since our JS bundle doesn't export anything and it's not meant to be consumed by other JS. It was added during the initial scaffolding of WCPay, and it was probably just pasted from some tutorial without thinking twice.

To test:
- Go to the WCPay settings screen.
- See that there aren't any errors in the console.
