### PR TITLE
If store's country is not US, return empty level3 data.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 2.x.x - 2021-xx-xx =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.
 * Add - Payment Request Button support for US merchants (Apple Pay, Google Pay, Microsoft Pay, and the browser standard Payment Request API).
+* Update - Not passing level3 data for non-US merchants.
 
 = 2.1.1 - 2021-03-23 =
 * Fix - Fatal error when a subscription is processed with action scheduler hook.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1403,6 +1403,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return array          The level 3 data to send to Stripe.
 	 */
 	public function get_level3_data_from_order( $order ) {
+		// non-US merchants no need to send level 3 data
+		if ( 'US' !== WC()->countries->get_base_country() ) {
+			return [];
+		}
+
 		// Get the order items. Don't need their keys, only their values.
 		// Order item IDs are used as keys in the original order items array.
 		$order_items = array_values( $order->get_items( [ 'line_item', 'fee' ] ) );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -718,7 +718,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$payment_information->is_using_manual_capture(),
 				$save_payment_method,
 				$metadata,
-				$this->get_level3_data_from_order( $order ),
+				$this->get_level3_data_from_order( $this->account->get_account_country(), $order ),
 				$payment_information->is_merchant_initiated()
 			);
 
@@ -1256,7 +1256,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$intent = $this->payments_api_client->capture_intention(
 				$order->get_transaction_id(),
 				WC_Payments_Utils::prepare_amount( $amount, $order->get_currency() ),
-				$this->get_level3_data_from_order( $order )
+				$this->get_level3_data_from_order( $this->account->get_account_country(), $order )
 			);
 
 			$status   = $intent->get_status();
@@ -1399,12 +1399,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	/**
 	 * Create the level 3 data array to send to Stripe when making a purchase.
 	 *
+	 * @param string   $merchant_country The merchant country.
 	 * @param WC_Order $order The order that is being paid for.
 	 * @return array          The level 3 data to send to Stripe.
 	 */
-	public function get_level3_data_from_order( $order ) {
-		// Non-US merchants do not need to send level3 data.
-		if ( 'US' !== $this->account->get_account_country() ) {
+	public function get_level3_data_from_order( string $merchant_country, WC_Order $order ): array {
+		// We do not need to send level3 data if merchant account country is non-US.
+		if ( 'US' !== $merchant_country ) {
 			return [];
 		}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1403,8 +1403,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return array          The level 3 data to send to Stripe.
 	 */
 	public function get_level3_data_from_order( $order ) {
-		// non-US merchants no need to send level 3 data.
-		if ( 'US' !== WC()->countries->get_base_country() ) {
+		// Non-US merchants do not need to send level3 data.
+		if ( 'US' !== $this->account->get_account_country() ) {
 			return [];
 		}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1403,7 +1403,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return array          The level 3 data to send to Stripe.
 	 */
 	public function get_level3_data_from_order( $order ) {
-		// non-US merchants no need to send level 3 data
+		// non-US merchants no need to send level 3 data.
 		if ( 'US' !== WC()->countries->get_base_country() ) {
 			return [];
 		}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -756,4 +756,20 @@ class WC_Payments_Account {
 
 		return $wcpay_note_names;
 	}
+
+	/**
+	 * Gets the account country.
+	 *
+	 * @return string|null Country.
+	 */
+	public function get_account_country() {
+		$account = $this->get_cached_account_data();
+
+		// When there is an account connected, if 'country' is missing, default to US.
+		if ( $account ) {
+			return $account['country'] ?? 'US';
+		}
+
+		return null;
+	}
 }

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -760,16 +760,10 @@ class WC_Payments_Account {
 	/**
 	 * Gets the account country.
 	 *
-	 * @return string|null Country.
+	 * @return string Country.
 	 */
 	public function get_account_country() {
 		$account = $this->get_cached_account_data();
-
-		// When there is an account connected, if 'country' is missing, default to US.
-		if ( $account ) {
-			return $account['country'] ?? 'US';
-		}
-
-		return null;
+		return $account['country'] ?? 'US';
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ Please note that our support for the checkout block is still experimental and th
 = 2.x.x - 2021-xx-xx =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.
 * Add - Payment Request Button support for US merchants (Apple Pay, Google Pay, Microsoft Pay, and the browser standard Payment Request API).
+* Update - Not passing level3 data for non-US merchants.
 
 = 2.1.1 - 2021-03-23 =
 * Fix - Fatal error when a subscription is processed with action scheduler hook.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -450,13 +450,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 		update_option( 'woocommerce_store_postcode', '94110' );
 
-		$this->mock_wcpay_account
-			->expects( $this->once() )
-			->method( 'get_account_country' )
-			->willReturn( 'US' );
-
 		$mock_order   = $this->mock_level_3_order( '98012' );
-		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( $mock_order );
+		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( 'US', $mock_order );
 
 		$this->assertEquals( $expected_data, $level_3_data );
 	}
@@ -489,13 +484,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 		update_option( 'woocommerce_store_postcode', '94110' );
 
-		$this->mock_wcpay_account
-			->expects( $this->once() )
-			->method( 'get_account_country' )
-			->willReturn( 'US' );
-
 		$mock_order   = $this->mock_level_3_order( '98012', true );
-		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( $mock_order );
+		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( 'US', $mock_order );
 
 		$this->assertEquals( $expected_data, $level_3_data );
 	}
@@ -503,7 +493,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	public function test_us_store_level_3_data() {
 		// Use a non-us customer postcode to ensure it's not included in the level3 data.
 		$mock_order   = $this->mock_level_3_order( '9000' );
-		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( $mock_order );
+		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( 'US', $mock_order );
 
 		$this->assertArrayNotHasKey( 'shipping_address_zip', $level_3_data );
 	}
@@ -528,13 +518,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		// Use a non-US postcode.
 		update_option( 'woocommerce_store_postcode', '9000' );
 
-		$this->mock_wcpay_account
-			->expects( $this->once() )
-			->method( 'get_account_country' )
-			->willReturn( 'US' );
-
 		$mock_order   = $this->mock_level_3_order( '98012' );
-		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( $mock_order );
+		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( 'US', $mock_order );
 
 		$this->assertEquals( $expected_data, $level_3_data );
 	}
@@ -542,13 +527,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	public function test_non_us_customer_level_3_data() {
 		$expected_data = [];
 
-		$this->mock_wcpay_account
-			->expects( $this->once() )
-			->method( 'get_account_country' )
-			->willReturn( 'CA' );
-
 		$mock_order   = $this->mock_level_3_order( 'K0A' );
-		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( $mock_order );
+		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( 'CA', $mock_order );
 
 		$this->assertEquals( $expected_data, $level_3_data );
 	}
@@ -577,6 +557,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 				)
 			)
 		);
+
+		$this->mock_wcpay_account
+			->expects( $this->once() )
+			->method( 'get_account_country' )
+			->willReturn( 'US' );
 
 		$this->wcpay_gateway->capture_charge( $order );
 
@@ -619,6 +604,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			)
 		);
 
+		$this->mock_wcpay_account
+			->expects( $this->once() )
+			->method( 'get_account_country' )
+			->willReturn( 'US' );
+
 		$this->wcpay_gateway->capture_charge( $order );
 
 		$notes             = wc_get_order_notes(
@@ -660,6 +650,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			)
 		);
 
+		$this->mock_wcpay_account
+			->expects( $this->once() )
+			->method( 'get_account_country' )
+			->willReturn( 'US' );
+
 		$this->wcpay_gateway->capture_charge( $order );
 
 		$note = wc_get_order_notes(
@@ -699,6 +694,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 				)
 			)
 		);
+
+		$this->mock_wcpay_account
+			->expects( $this->once() )
+			->method( 'get_account_country' )
+			->willReturn( 'US' );
 
 		$this->wcpay_gateway->capture_charge( $order );
 
@@ -742,6 +742,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 				)
 			)
 		);
+
+		$this->mock_wcpay_account
+			->expects( $this->once() )
+			->method( 'get_account_country' )
+			->willReturn( 'US' );
 
 		$this->wcpay_gateway->capture_charge( $order );
 
@@ -788,6 +793,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			)
 		);
 
+		$this->mock_wcpay_account
+			->expects( $this->once() )
+			->method( 'get_account_country' )
+			->willReturn( 'US' );
+
 		$this->wcpay_gateway->capture_charge( $order );
 
 		$note = wc_get_order_notes(
@@ -831,6 +841,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 				)
 			)
 		);
+
+		$this->mock_wcpay_account
+			->expects( $this->once() )
+			->method( 'get_account_country' )
+			->willReturn( 'US' );
 
 		$this->wcpay_gateway->capture_charge( $order );
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -450,6 +450,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 		update_option( 'woocommerce_store_postcode', '94110' );
 
+		$this->mock_wcpay_account
+			->expects( $this->once() )
+			->method( 'get_account_country' )
+			->willReturn( 'US' );
+
 		$mock_order   = $this->mock_level_3_order( '98012' );
 		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( $mock_order );
 
@@ -483,6 +488,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		];
 
 		update_option( 'woocommerce_store_postcode', '94110' );
+
+		$this->mock_wcpay_account
+			->expects( $this->once() )
+			->method( 'get_account_country' )
+			->willReturn( 'US' );
 
 		$mock_order   = $this->mock_level_3_order( '98012', true );
 		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( $mock_order );
@@ -518,7 +528,26 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		// Use a non-US postcode.
 		update_option( 'woocommerce_store_postcode', '9000' );
 
+		$this->mock_wcpay_account
+			->expects( $this->once() )
+			->method( 'get_account_country' )
+			->willReturn( 'US' );
+
 		$mock_order   = $this->mock_level_3_order( '98012' );
+		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( $mock_order );
+
+		$this->assertEquals( $expected_data, $level_3_data );
+	}
+
+	public function test_non_us_customer_level_3_data() {
+		$expected_data = [];
+
+		$this->mock_wcpay_account
+			->expects( $this->once() )
+			->method( 'get_account_country' )
+			->willReturn( 'CA' );
+
+		$mock_order   = $this->mock_level_3_order( 'K0A' );
 		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( $mock_order );
 
 		$this->assertEquals( $expected_data, $level_3_data );


### PR DESCRIPTION
Fixes #1099

#### Changes proposed in this Pull Request

In `get_level3_data_from_order()`, if merchant's Stripe account country is not US, return empty array.

#### Testing instructions

1. This PR needs to be tested against local WCPay server mentioned in this PR 672-gh-Automattic/woocommerce-payments-server, so run a local server with that branch.
2. Make sure 'Enable API request redirection' is checked in 'WCPay Dev' plugin to tell client to hit local WCPay server.
3. If your store is not currently connected to a non-US Stripe account, with the help of 'WCPay Dev' plugin, force onboarding to create a new non-US Stripe account.
4. Test these 2 cases:

Case 1: capture payment right away on purchase
1. Buy a product.
2. Open the order from admin.
3. Note the payment id from the order note, eg:
```
A payment of ¥1,956 was successfully charged using WooCommerce Payments (pi_abc).
```
Payment id is the one that starts with `pi_`.
4. Get your account id (from dev tool or search on Stripe's dashboard). It should start with `acct_`.
5. Open the payment detail page on Stripe, example link: https://dashboard.stripe.com/acct_abc/test/payments/pi_abc.
6. Go to the 'Events and logs' section.
7. With base branch, `level3` will not be empty. With this branch, it should be empty.
<img width="388" alt="Screen Shot 2021-03-16 at 22 37 14" src="https://user-images.githubusercontent.com/73803630/111336947-3f538d00-86a8-11eb-917a-4eda15f1203b.png">

Case 2: manual payment capture
Similar to steps for case 1, but enable manual capture (wp-admin > Payments > Settings > check Manual capture).
Then, after purchasing a product, on order admin page, select Order actions: Capture charge at the top right.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->