### PR TITLE
Enable the Payment Request feature by default for new merchants only

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -171,9 +171,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// TODO: Remove this check and inject contents of `$payment_request_fields` into `$this->form_fields`
 		// after `saved_cards` ahead of Apple Pay release.
 		if ( 'yes' === get_option( '_wcpay_feature_payment_request' ) ) {
-			// Default values for Payment Request.
-			$payment_request_default_settings = WC_Payments_Payment_Request_Button_Handler::get_default_settings();
-			$payment_request_fields           = [
+			$payment_request_fields = [
 				'payment_request'                     => [
 					'title'       => __( 'Payment Request Button', 'woocommerce-payments' ),
 					'label'       => sprintf(
@@ -185,7 +183,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					),
 					'type'        => 'checkbox',
 					'description' => __( 'If enabled, users will be able to pay using Apple Pay or Chrome Payment Request if supported by the browser.', 'woocommerce-payments' ),
-					'default'     => $payment_request_default_settings['payment_request'],
+					'default'     => empty( get_option( 'woocommerce_woocommerce_payments_settings' ) ) ? 'yes' : 'no', // Enable by default for new installations only.
 					'desc_tip'    => true,
 				],
 				'payment_request_button_type'         => [
@@ -193,7 +191,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					'label'       => __( 'Button Type', 'woocommerce-payments' ),
 					'type'        => 'select',
 					'description' => __( 'Select the button type you would like to show.', 'woocommerce-payments' ),
-					'default'     => $payment_request_default_settings['payment_request_button_type'],
+					'default'     => 'buy',
 					'desc_tip'    => true,
 					'options'     => [
 						'default' => __( 'Default', 'woocommerce-payments' ),
@@ -208,7 +206,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					'label'       => __( 'Button Theme', 'woocommerce-payments' ),
 					'type'        => 'select',
 					'description' => __( 'Select the button theme you would like to show.', 'woocommerce-payments' ),
-					'default'     => $payment_request_default_settings['payment_request_button_theme'],
+					'default'     => 'dark',
 					'desc_tip'    => true,
 					'options'     => [
 						'dark'          => __( 'Dark', 'woocommerce-payments' ),
@@ -221,7 +219,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					'label'       => __( 'Button Height', 'woocommerce-payments' ),
 					'type'        => 'text',
 					'description' => __( 'Enter the height you would like the button to be in pixels. Width will always be 100%.', 'woocommerce-payments' ),
-					'default'     => $payment_request_default_settings['payment_request_button_height'],
+					'default'     => '44',
 					'desc_tip'    => true,
 				],
 				'payment_request_button_label'        => [
@@ -229,7 +227,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					'label'       => __( 'Button Label', 'woocommerce-payments' ),
 					'type'        => 'text',
 					'description' => __( 'Enter the custom text you would like the button to have.', 'woocommerce-payments' ),
-					'default'     => $payment_request_default_settings['payment_request_button_label'],
+					'default'     => __( 'Buy now', 'woocommerce-payments' ),
 					'desc_tip'    => true,
 				],
 				'payment_request_button_branded_type' => [
@@ -237,7 +235,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					'label'       => __( 'Branded Button Label Format', 'woocommerce-payments' ),
 					'type'        => 'select',
 					'description' => __( 'Select the branded button label format.', 'woocommerce-payments' ),
-					'default'     => $payment_request_default_settings['payment_request_button_branded_type'],
+					'default'     => 'long',
 					'desc_tip'    => true,
 					'options'     => [
 						'short' => __( 'Logo only', 'woocommerce-payments' ),

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -80,12 +80,6 @@ class WC_Payments_Apple_Pay_Registration {
 	 */
 	public function init() {
 		$this->gateway = WC_Payments::get_gateway();
-
-		// If the feature is disabled, don't proceed with the hooks.
-		if ( ! $this->is_enabled() ) {
-			return;
-		}
-
 		$this->add_domain_association_rewrite_rule();
 
 		add_action( 'admin_init', [ $this, 'verify_domain_on_domain_name_change' ] );
@@ -302,7 +296,7 @@ class WC_Payments_Apple_Pay_Registration {
 	public function verify_domain_if_configured() {
 		// If Payment Request Buttons are not enabled, or account is not live,
 		// do not attempt to register domain.
-		if ( ! $this->account->get_is_live() ) {
+		if ( ! $this->is_enabled() || ! $this->account->get_is_live() ) {
 			return;
 		}
 
@@ -344,7 +338,7 @@ class WC_Payments_Apple_Pay_Registration {
 	 * Display warning notice explaining that the domain can't be registered without a live account.
 	 */
 	public function display_live_account_notice() {
-		if ( $this->account->get_is_live() ) {
+		if ( ! $this->is_enabled() || $this->account->get_is_live() ) {
 			return;
 		}
 
@@ -362,7 +356,7 @@ class WC_Payments_Apple_Pay_Registration {
 	 * Display Apple Pay registration errors.
 	 */
 	public function display_error_notice() {
-		if ( ! $this->account->get_is_live() ) {
+		if ( ! $this->is_enabled() || ! $this->account->get_is_live() ) {
 			return;
 		}
 

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -80,6 +80,10 @@ class WC_Payments_Apple_Pay_Registration {
 	 */
 	public function init() {
 		$this->gateway_settings = array_merge( WC_Payments_Payment_Request_Button_Handler::get_default_settings(), WC_Payments::get_gateway()->settings );
+		// If the feature is disabled, don't proceed with the hooks.
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
 
 		$this->add_domain_association_rewrite_rule();
 
@@ -106,7 +110,7 @@ class WC_Payments_Apple_Pay_Registration {
 		$settings = $settings ?? $this->gateway_settings;
 
 		$gateway_enabled         = 'yes' === ( $settings['enabled'] ?? 'no' );
-		$payment_request_enabled = 'yes' === ( $settings['payment_request'] ?? 'yes' );
+		$payment_request_enabled = 'yes' === ( $settings['payment_request'] ?? 'no' );
 
 		return $gateway_enabled && $payment_request_enabled;
 	}

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -299,7 +299,7 @@ class WC_Payments_Apple_Pay_Registration {
 	public function verify_domain_if_configured() {
 		// If Payment Request Buttons are not enabled, or account is not live,
 		// do not attempt to register domain.
-		if ( ! $this->is_enabled() || ! $this->account->get_is_live() ) {
+		if ( ! $this->account->get_is_live() ) {
 			return;
 		}
 
@@ -343,7 +343,7 @@ class WC_Payments_Apple_Pay_Registration {
 	 * Display warning notice explaining that the domain can't be registered without a live account.
 	 */
 	public function display_live_account_notice() {
-		if ( ! $this->is_enabled() || $this->account->get_is_live() ) {
+		if ( $this->account->get_is_live() ) {
 			return;
 		}
 
@@ -361,7 +361,7 @@ class WC_Payments_Apple_Pay_Registration {
 	 * Display Apple Pay registration errors.
 	 */
 	public function display_error_notice() {
-		if ( ! $this->is_enabled() || ! $this->account->get_is_live() ) {
+		if ( ! $this->account->get_is_live() ) {
 			return;
 		}
 

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -31,13 +31,6 @@ class WC_Payments_Apple_Pay_Registration {
 	private $payments_api_client;
 
 	/**
-	 * The WCPay gateway object.
-	 *
-	 * @var WC_Payment_Gateway_WCPay
-	 */
-	private $gateway;
-
-	/**
 	 * The WCPay account object.
 	 *
 	 * @var WC_Payments_Account
@@ -68,12 +61,28 @@ class WC_Payments_Apple_Pay_Registration {
 	/**
 	 * Initialize class actions.
 	 *
-	 * @param WC_Payments_API_Client   $payments_api_client WooCommerce Payments API client.
-	 * @param WC_Payment_Gateway_WCPay $gateway WooCommerce Payments gateway.
-	 * @param WC_Payments_Account      $account WooCommerce Payments account.
+	 * @param WC_Payments_API_Client $payments_api_client WooCommerce Payments API client.
+	 * @param WC_Payments_Account    $account WooCommerce Payments account.
 	 */
-	public function __construct( WC_Payments_API_Client $payments_api_client, WC_Payment_Gateway_WCPay $gateway, WC_Payments_Account $account ) {
-		add_action( 'init', [ $this, 'add_domain_association_rewrite_rule' ] );
+	public function __construct( WC_Payments_API_Client $payments_api_client, WC_Payments_Account $account ) {
+		$this->domain_name             = $_SERVER['HTTP_HOST'] ?? str_replace( [ 'https://', 'http://' ], '', get_site_url() ); // @codingStandardsIgnoreLine
+		$this->apple_pay_verify_notice = '';
+		$this->payments_api_client     = $payments_api_client;
+		$this->account                 = $account;
+
+		add_action( 'init', [ $this, 'init' ] );
+	}
+
+	/**
+	 * Initialize hooks.
+	 *
+	 * @return  void
+	 */
+	public function init() {
+		$this->gateway_settings = array_merge( WC_Payments_Payment_Request_Button_Handler::get_default_settings(), WC_Payments::get_gateway()->settings );
+
+		$this->add_domain_association_rewrite_rule();
+
 		add_action( 'admin_init', [ $this, 'verify_domain_on_domain_name_change' ] );
 		add_filter( 'query_vars', [ $this, 'whitelist_domain_association_query_param' ], 10, 1 );
 		add_action( 'parse_request', [ $this, 'parse_domain_association_request' ], 10, 1 );
@@ -83,14 +92,6 @@ class WC_Payments_Apple_Pay_Registration {
 		add_action( 'woocommerce_woocommerce_payments_updated', [ $this, 'verify_domain_if_configured' ] );
 		add_action( 'add_option_woocommerce_woocommerce_payments_settings', [ $this, 'verify_domain_on_new_settings' ], 10, 2 );
 		add_action( 'update_option_woocommerce_woocommerce_payments_settings', [ $this, 'verify_domain_on_updated_settings' ], 10, 2 );
-
-		// Add default settings in case the payment request options are missing.
-		$this->gateway_settings        = array_merge( WC_Payments_Payment_Request_Button_Handler::get_default_settings(), get_option( 'woocommerce_woocommerce_payments_settings', [] ) );
-		$this->domain_name             = $_SERVER['HTTP_HOST'] ?? str_replace( [ 'https://', 'http://' ], '', get_site_url() ); // @codingStandardsIgnoreLine
-		$this->apple_pay_verify_notice = '';
-		$this->payments_api_client     = $payments_api_client;
-		$this->gateway                 = $gateway;
-		$this->account                 = $account;
 	}
 
 	/**
@@ -231,9 +232,10 @@ class WC_Payments_Apple_Pay_Registration {
 	 * @return string A string representation of the current mode.
 	 */
 	private function get_gateway_mode_string() {
-		if ( $this->gateway->is_in_dev_mode() ) {
+		$gateway = WC_Payments::get_gateway();
+		if ( $gateway->is_in_dev_mode() ) {
 			return 'dev';
-		} elseif ( $this->gateway->is_in_test_mode() ) {
+		} elseif ( $gateway->is_in_test_mode() ) {
 			return 'test';
 		}
 		return 'live';

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -355,7 +355,7 @@ class WC_Payments_Apple_Pay_Registration {
 	 * Display Apple Pay registration errors.
 	 */
 	public function display_error_notice() {
-		if ( ! $this->is_enabled() || ! current_user_can( 'manage_woocommerce' ) ) {
+		if ( ! $this->is_enabled() || ! current_user_can( 'manage_woocommerce' ) || ! $this->account->get_is_live() ) {
 			return;
 		}
 

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -355,7 +355,7 @@ class WC_Payments_Apple_Pay_Registration {
 	 * Display Apple Pay registration errors.
 	 */
 	public function display_error_notice() {
-		if ( ! $this->is_enabled() || ! current_user_can( 'manage_woocommerce' ) || ! $this->account->get_is_live() ) {
+		if ( ! $this->is_enabled() || ! $this->account->get_is_live() ) {
 			return;
 		}
 

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -120,7 +120,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 	}
 
 	/**
-	 * Get total label.
+	 * Gets total label.
 	 *
 	 * @return string
 	 */
@@ -145,30 +145,12 @@ class WC_Payments_Payment_Request_Button_Handler {
 	}
 
 	/**
-	 * Gets the button type.
-	 *
-	 * @return  string
-	 */
-	public function get_button_type() {
-		return isset( $this->gateway_settings['payment_request_button_type'] ) ? $this->gateway_settings['payment_request_button_type'] : 'default';
-	}
-
-	/**
-	 * Gets the button theme.
-	 *
-	 * @return  string
-	 */
-	public function get_button_theme() {
-		return isset( $this->gateway_settings['payment_request_button_theme'] ) ? $this->gateway_settings['payment_request_button_theme'] : 'dark';
-	}
-
-	/**
 	 * Gets the button height.
 	 *
-	 * @return  string
+	 * @return string
 	 */
 	public function get_button_height() {
-		return isset( $this->gateway_settings['payment_request_button_height'] ) ? str_replace( 'px', '', $this->gateway_settings['payment_request_button_height'] ) : '64';
+		return str_replace( 'px', '', $this->gateway_settings['payment_request_button_height'] );
 	}
 
 	/**
@@ -177,49 +159,31 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 * @return  boolean
 	 */
 	public function is_branded_button() {
-		return 'branded' === $this->get_button_type();
-	}
-
-	/**
-	 * Gets the branded button type.
-	 *
-	 * @return  string
-	 */
-	public function get_button_branded_type() {
-		return isset( $this->gateway_settings['payment_request_button_branded_type'] ) ? $this->gateway_settings['payment_request_button_branded_type'] : 'default';
+		return 'branded' === $this->gateway_settings['payment_request_button_type'];
 	}
 
 	/**
 	 * Checks if the button is custom.
 	 *
-	 * @return  boolean
+	 * @return boolean
 	 */
 	public function is_custom_button() {
-		return 'custom' === $this->get_button_type();
+		return 'custom' === $this->gateway_settings['payment_request_button_type'];
 	}
 
 	/**
 	 * Returns custom button css selector.
 	 *
-	 * @return  string
+	 * @return string
 	 */
 	public function custom_button_selector() {
 		return $this->is_custom_button() ? '#wcpay-custom-button' : '';
 	}
 
 	/**
-	 * Gets the custom button label.
-	 *
-	 * @return  string
-	 */
-	public function get_button_label() {
-		return isset( $this->gateway_settings['payment_request_button_label'] ) ? $this->gateway_settings['payment_request_button_label'] : 'Buy now';
-	}
-
-	/**
 	 * Gets the product data for the currently viewed page
 	 *
-	 * @return  mixed Returns false if not on a product page, the product information otherwise.
+	 * @return mixed Returns false if not on a product page, the product information otherwise.
 	 */
 	public function get_product_data() {
 		if ( ! is_product() ) {
@@ -479,14 +443,14 @@ class WC_Payments_Payment_Request_Button_Handler {
 				'needs_payer_phone' => 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' ),
 			],
 			'button'          => [
-				'type'         => $this->get_button_type(),
-				'theme'        => $this->get_button_theme(),
+				'type'         => $this->gateway_settings['payment_request_button_type'],
+				'theme'        => $this->gateway_settings['payment_request_button_theme'],
 				'height'       => $this->get_button_height(),
 				'locale'       => apply_filters( 'wcpay_payment_request_button_locale', substr( get_locale(), 0, 2 ) ), // Default format is en_US.
 				'is_custom'    => $this->is_custom_button(),
 				'is_branded'   => $this->is_branded_button(),
 				'css_selector' => $this->custom_button_selector(),
-				'branded_type' => $this->get_button_branded_type(),
+				'branded_type' => $this->gateway_settings['payment_request_button_branded_type'],
 			],
 			'is_product_page' => is_product(),
 			'product'         => $this->get_product_data(),
@@ -537,8 +501,8 @@ class WC_Payments_Payment_Request_Button_Handler {
 			<div id="wcpay-payment-request-button">
 				<?php
 				if ( $this->is_custom_button() ) {
-					$label      = esc_html( $this->get_button_label() );
-					$class_name = esc_attr( 'button ' . $this->get_button_theme() );
+					$label      = esc_html( $this->gateway_settings['payment_request_button_label'] );
+					$class_name = esc_attr( 'button ' . $this->gateway_settings['payment_request_button_theme'] );
 					$style      = esc_attr( 'height:' . $this->get_button_height() . 'px;' );
 					echo '<button id="wcpay-custom-button" class="' . esc_attr( $class_name ) . '" style="' . esc_attr( $style ) . '">' . esc_html( $label ) . '</button>';
 				}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -171,7 +171,7 @@ class WC_Payments {
 		// TODO: Remove this check ahead of Apple Pay release.
 		if ( 'yes' === get_option( '_wcpay_feature_payment_request' ) ) {
 			self::$payment_request_button_handler = new WC_Payments_Payment_Request_Button_Handler( self::$account );
-			self::$apple_pay_registration         = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$gateway, self::$account );
+			self::$apple_pay_registration         = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$account );
 		}
 
 		add_filter( 'woocommerce_payment_gateways', [ __CLASS__, 'register_gateway' ] );

--- a/tests/unit/test-class-wc-payments-apple-pay-registration.php
+++ b/tests/unit/test-class-wc-payments-apple-pay-registration.php
@@ -25,13 +25,6 @@ class WC_Payments_Apple_Pay_Registration_Test extends WP_UnitTestCase {
 	private $mock_api_client;
 
 	/**
-	 * Mock WC_Payment_Gateway_WCPay.
-	 *
-	 * @var WC_Payment_Gateway_WCPay|PHPUnit_Framework_MockObject_MockObject
-	 */
-	private $mock_gateway;
-
-	/**
 	 * Mock WC_Payments_Account.
 	 *
 	 * @var WC_Payments_Account|PHPUnit_Framework_MockObject_MockObject
@@ -62,15 +55,11 @@ class WC_Payments_Apple_Pay_Registration_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->mock_gateway = $this->getMockBuilder( 'WC_Payment_Gateway_WCPay' )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$this->mock_account = $this->getMockBuilder( 'WC_Payments_Account' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->wc_apple_pay_registration = new WC_Payments_Apple_Pay_Registration( $this->mock_api_client, $this->mock_gateway, $this->mock_account );
+		$this->wc_apple_pay_registration = new WC_Payments_Apple_Pay_Registration( $this->mock_api_client, $this->mock_account );
 
 		$this->file_name             = 'apple-developer-merchantid-domain-association';
 		$this->initial_file_contents = file_get_contents( WCPAY_ABSPATH . '/' . $this->file_name ); // @codingStandardsIgnoreLine


### PR DESCRIPTION
Fixes #1392 
Fixes #1394

#### Changes proposed in this Pull Request

Initially, the idea was to include only the #1392 issue in this PR, but in order to get the default values properly, I had to change the class implementation, so I ended up refactoring some code and fixing #1394 as well. - There might be other places that can be improved, but that's what was initially suggested and required for the main fix here.

- This enables Payment Request buttons for new merchants only (anyone who still doesn't have the `woocommerce_woocommerce_payments_settings` option set.
- Skip adding hooks for the Apple domain registration if the feature is disabled.
- Fixes some inconsistencies from the right default values for the payment request buttons.

#### Testing instructions

- Make sure you have the temporary `_wcpay_feature_payment_request` option set to `yes` so the feature is enabled.
- If you already had WCPay installed and enabled before, notice the Payment Request Button is disabled by default. - That's how it's supposed to work for existing merchants.
- Remove the `woocommerce_woocommerce_payments_settings` option to simulate a new installation and notice the Payment Request Button setting is enabled by default.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)