### PR TITLE
Payment Request Button: Handle Puerto Rico country as United States

### DIFF
--- a/client/payment-request/index.js
+++ b/client/payment-request/index.js
@@ -195,6 +195,18 @@ jQuery( ( $ ) => {
 					},
 					600
 				);
+			} else if ( wcpayPaymentRequestParams.is_checkout_page ) {
+				const element = $( '.entry-content .woocommerce' ).first();
+
+				element.before( message );
+
+				$( 'html, body' ).animate(
+					{
+						scrollTop: element.prev( '.woocommerce-error' ).offset()
+							.top,
+					},
+					600
+				);
 			} else {
 				const $form = $( '.shop_table.cart' ).closest( 'form' );
 

--- a/client/payment-request/index.js
+++ b/client/payment-request/index.js
@@ -183,7 +183,7 @@ jQuery( ( $ ) => {
 
 			$( '.woocommerce-error' ).remove();
 
-			const $container = $( '.woocommerce-notices-wrapper').first();
+			const $container = $( '.woocommerce-notices-wrapper' ).first();
 
 			$container.before( message );
 

--- a/client/payment-request/index.js
+++ b/client/payment-request/index.js
@@ -183,39 +183,24 @@ jQuery( ( $ ) => {
 
 			$( '.woocommerce-error' ).remove();
 
+			let $container = $( '.shop_table.cart' ).closest( 'form' ).first();
+
 			if ( wcpayPaymentRequestParams.is_product_page ) {
-				const element = $( '.product' ).first();
+				$container = $( '.product' ).first();
+			}
 
-				element.before( message );
+			if ( wcpayPaymentRequestParams.is_checkout_page ) {
+				$container = $( '.entry-content .woocommerce' ).first();
+			}
 
-				$( 'html, body' ).animate(
-					{
-						scrollTop: element.prev( '.woocommerce-error' ).offset()
-							.top,
-					},
-					600
-				);
-			} else if ( wcpayPaymentRequestParams.is_checkout_page ) {
-				const element = $( '.entry-content .woocommerce' ).first();
-
-				element.before( message );
+			if ( $container.length ) {
+				$container.before( message );
 
 				$( 'html, body' ).animate(
 					{
-						scrollTop: element.prev( '.woocommerce-error' ).offset()
-							.top,
-					},
-					600
-				);
-			} else {
-				const $form = $( '.shop_table.cart' ).closest( 'form' );
-
-				$form.before( message );
-
-				$( 'html, body' ).animate(
-					{
-						scrollTop: $form.prev( '.woocommerce-error' ).offset()
-							.top,
+						scrollTop: $container
+							.prev( '.woocommerce-error' )
+							.offset().top,
 					},
 					600
 				);

--- a/client/payment-request/index.js
+++ b/client/payment-request/index.js
@@ -402,6 +402,12 @@ jQuery( ( $ ) => {
 				paymentDetails = cart.order_data;
 			}
 
+			// Puerto Rico (PR) is the only US territory/possession that's supported by Stripe.
+			// Since it's considered a US state by Stripe, we need to do some special mapping.
+			if ( 'PR' === options.country ) {
+				options.country = 'US';
+			}
+
 			const paymentRequest = stripe.paymentRequest( options );
 
 			const elements = stripe.elements( {

--- a/client/payment-request/index.js
+++ b/client/payment-request/index.js
@@ -183,19 +183,11 @@ jQuery( ( $ ) => {
 
 			$( '.woocommerce-error' ).remove();
 
-			let $container = $( '.shop_table.cart' ).closest( 'form' ).first();
+			const $container = $( '.woocommerce-notices-wrapper').first();
 
-			if ( wcpayPaymentRequestParams.is_product_page ) {
-				$container = $( '.product' ).first();
-			}
-
-			if ( wcpayPaymentRequestParams.is_checkout_page ) {
-				$container = $( '.entry-content .woocommerce' ).first();
-			}
+			$container.before( message );
 
 			if ( $container.length ) {
-				$container.before( message );
-
 				$( 'html, body' ).animate(
 					{
 						scrollTop: $container

--- a/client/payment-request/index.js
+++ b/client/payment-request/index.js
@@ -185,13 +185,13 @@ jQuery( ( $ ) => {
 
 			const $container = $( '.woocommerce-notices-wrapper' ).first();
 
-			$container.before( message );
-
 			if ( $container.length ) {
+				$container.append( message );
+
 				$( 'html, body' ).animate(
 					{
 						scrollTop: $container
-							.prev( '.woocommerce-error' )
+							.find( '.woocommerce-error' )
 							.offset().top,
 					},
 					600

--- a/client/payment-request/index.js
+++ b/client/payment-request/index.js
@@ -184,7 +184,7 @@ jQuery( ( $ ) => {
 			$( '.woocommerce-error' ).remove();
 
 			if ( wcpayPaymentRequestParams.is_product_page ) {
-				const element = $( '.product' );
+				const element = $( '.product' ).first();
 
 				element.before( message );
 

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -469,6 +469,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 				'branded_type' => $this->gateway->get_option( 'payment_request_button_branded_type' ),
 			],
 			'is_product_page' => is_product(),
+			'is_checkout_page' => is_checkout(),
 			'product'         => $this->get_product_data(),
 		];
 

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -469,7 +469,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 				'branded_type' => $this->gateway->get_option( 'payment_request_button_branded_type' ),
 			],
 			'is_product_page' => is_product(),
-			'is_checkout_page' => is_checkout(),
 			'product'         => $this->get_product_data(),
 		];
 


### PR DESCRIPTION
Fixes #1395

#### Changes proposed in this Pull Request

This is a port from a fix done in woocommerce/woocommerce-gateway-stripe#1443

- Fixes a Javascript error from the Stripe JS SDK that occurs when merchants have their country set to Puerto Rico (`PR`).  The country is remapped to `US` when making the request to stripe (`stripe.paymentRequest()`) to create the PaymentRequest object.
- `wcpayPaymentRequest.abortPayment` is simplified to avoid some repeated code.
- Also, fixes an issue where multiple error messages were added to the Products page
- Error message's container is set to '.woocommerce-notices-wrapper' which assures us it will always be present when WooCommerce is installed and is not dependant of the theme.

#### Testing instructions

- [x] Tested with WooCommerce 4.0

### Puerto Rico mapping

1. Set merchant's country to Puerto Rico
2. Enable Payment Request buttons via Stripe payment gateway settings.
3. Use Safari/Chrome to load a Product page
4. Notice Payment Request button is displayed correctly

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/1025173/111721251-7dc68480-882d-11eb-9e66-2a87ebd41a0e.png" width="200" /> | <img src="https://user-images.githubusercontent.com/1025173/111721355-b36b6d80-882d-11eb-9c2e-71e14b069bfa.png" width="200" /> |

### Fix for multiple error message on Product page

1. Enable Payment Request buttons via Stripe payment gateway settings.
2. Use Safari/Chrome to load a Product page
3. Click "Buy Now" button
4. Pay with the following [testing credit card](https://stripe.com/docs/testing#cards) `4000000000000119`. Use a valid future date and any number as CVC. This card will generate an [error response from Stripe](https://stripe.com/docs/testing#cards-responses)
5. You should see only one error message at the top of the page

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/1025173/111720682-6a66e980-882c-11eb-83f6-954034b0ded6.png" width="200" /> | <img src="https://user-images.githubusercontent.com/1025173/111720228-7bfbc180-882b-11eb-8bec-2c5356c01f02.png" width="200" /> |