### PR TITLE
Fix reference to phpcbf executable in `lint:php-fix` npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint:css": "stylelint 'client/**/*.scss' 'client/**/*.css' 'assets/**/*.scss' 'assets/**/*.css'",
     "lint:js": "tsc --noEmit && eslint . --ext=js,jsx,ts,tsx",
     "lint:php": "./vendor/bin/phpcs --standard=phpcs.xml.dist $(git ls-files | grep .php$)",
-    "lint:php-fix": "./vendor/bin/phpbf --standard=phpcs.xml.dist $(git ls-files | grep .php$)",
+    "lint:php-fix": "./vendor/bin/phpcbf --standard=phpcs.xml.dist $(git ls-files | grep .php$)",
     "format": "npm run format:js && npm run format:css",
     "format:js": "npm run format:provided '**/*.js' '**/*.ts' '**/*.tsx'",
     "format:css": "npm run format:provided '**/*.scss' '**/*.css'",


### PR DESCRIPTION
Fixes typo in reference to the PHP Code Beautifier and Fixer executable.


**Before**

```
$ npm run lint:php-fix

> woocommerce-payments@2.1.0 lint:php-fix /Users/asumaran/www/woocommerce-payments
> ./vendor/bin/phpbf --standard=phpcs.xml.dist $(git ls-files | grep .php$)

sh: ./vendor/bin/phpbf: No such file or directory
npm ERR! code ELIFECYCLE
npm ERR! syscall spawn
npm ERR! file sh
npm ERR! errno ENOENT
npm ERR! woocommerce-payments@2.1.0 lint:php-fix: `./vendor/bin/phpbf --standard=phpcs.xml.dist $(git ls-files | grep .php$)`
npm ERR! spawn ENOENT
npm ERR!
npm ERR! Failed at the woocommerce-payments@2.1.0 lint:php-fix script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/asumaran/.npm/_logs/2021-03-18T20_54_27_255Z-debug.log
```

**After**

```
$ npm run lint:php-fix

> woocommerce-payments@2.1.0 lint:php-fix /Users/asumaran/www/woocommerce-payments
> ./vendor/bin/phpcbf --standard=phpcs.xml.dist $(git ls-files | grep .php$)


No fixable errors were found

Time: 12.98 secs; Memory: 42MB
```


