### PR TITLE
Fix missing payment token for free trial paid for with a previously saved card

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 2.x.x - 2021-xx-xx =
+* Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.
+
 = 2.1.1 - 2021-03-23 =
 * Fix - Fatal error when a subscription is processed with action scheduler hook.
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -690,6 +690,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					$token->get_last4()
 				);
 				$order->add_order_note( $note );
+			} elseif ( $payment_information->is_using_saved_payment_method() ) {
+				// We need to make sure the saved payment method is saved to the order so we can
+				// charge the payment method for a future payment.
+				$this->add_token_to_order( $order, $payment_information->get_payment_token() );
 			}
 
 			return [

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -675,10 +675,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if ( ! $payment_needed && ! $save_payment_method ) {
 			$order->payment_complete();
 
-			if ( $is_changing_payment_method_for_subscription && $payment_information->is_using_saved_payment_method() ) {
-				$token = $payment_information->get_payment_token();
-				$this->add_token_to_order( $order, $token );
+			if ( $payment_information->is_using_saved_payment_method() ) {
+				// We need to make sure the saved payment method is saved to the order so we can
+				// charge the payment method for a future payment.
+				$this->add_token_to_order( $order, $payment_information->get_payment_token() );
+			}
 
+			if ( $is_changing_payment_method_for_subscription && $payment_information->is_using_saved_payment_method() ) {
 				$note = sprintf(
 					WC_Payments_Utils::esc_interpolated_html(
 						/* translators: %1: the last 4 digit of the credit card */
@@ -687,13 +690,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 							'strong' => '<strong>',
 						]
 					),
-					$token->get_last4()
+					$payment_information->get_payment_token()->get_last4()
 				);
 				$order->add_order_note( $note );
-			} elseif ( $payment_information->is_using_saved_payment_method() ) {
-				// We need to make sure the saved payment method is saved to the order so we can
-				// charge the payment method for a future payment.
-				$this->add_token_to_order( $order, $payment_information->get_payment_token() );
 			}
 
 			return [

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -298,12 +298,16 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 			->expects( $this->never() )
 			->method( 'create_and_confirm_setup_intent' );
 
+		// We're not saving a new payment method, so we don't need to add the payment method to
+		// a user account.
 		$this->mock_token_service
 			->expects( $this->never() )
 			->method( 'add_payment_method_to_user' );
 
+		// We do need to add the payment method to the order so we can charge it when it's time to
+		// renew the order or when the free trial is over.
 		$this->mock_wcpay_gateway
-			->expects( $this->never() )
+			->expects( $this->once() )
 			->method( 'add_token_to_order' );
 
 		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );


### PR DESCRIPTION
Fixes #1417 

#### Changes proposed in this Pull Request

- Save payment tokens to a subscription when the initial payment is free.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

Follow the testing instructions from #1417:

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before applying the changes in this PR:

1. Add a card to the customer using the My Account page, or saving it during a regular purchase
1. Create a Subscription with a free trial, which is processed as a $0 order, and use the saved card to pay for it
1. Using the My subscriptions page or the admin subscription view, process an early renewal of that subscription
1. The renewal should fail with a `There is no saved payment token for order` error as the token was not added to the subscription order during checkout


After applying the changes in this PR the renewal should work.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
