### PR TITLE
Remove feature flag and allow Payment Request feature for US merchants only

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 2.x.x - 2021-xx-xx =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.
+* Add - Payment Request Button support for US merchants (Apple Pay, Google Pay, Microsoft Pay, and the browser standard Payment Request API).
 
 = 2.1.1 - 2021-03-23 =
 * Fix - Fatal error when a subscription is processed with action scheduler hook.

--- a/client/settings.js
+++ b/client/settings.js
@@ -57,7 +57,7 @@ window.addEventListener( 'load', () => {
 	enqueueFraudScripts( wcpayAdminSettings.fraudServices );
 } );
 
-// TODO: Remove this `if` ahead of Apple Pay release.
+// TODO: Remove this `if` ahead of releasing Apple Pay for all merchants.
 if ( wcpayAdminSettings.paymentRequestEnabled ) {
 	// Payment Request button settings migrated and adapted from Stripe gateway extension.
 	const findParent = ( el, selector ) => {

--- a/client/settings.js
+++ b/client/settings.js
@@ -58,7 +58,7 @@ window.addEventListener( 'load', () => {
 } );
 
 // TODO: Remove this `if` ahead of releasing Apple Pay for all merchants.
-if ( wcpayAdminSettings.paymentRequestEnabled ) {
+if ( wcpayAdminSettings.paymentRequestAvailable ) {
 	// Payment Request button settings migrated and adapted from Stripe gateway extension.
 	const findParent = ( el, selector ) => {
 		while (

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -287,11 +287,11 @@ class WC_Payments_Admin {
 			'WCPAY_ADMIN_SETTINGS',
 			'wcpayAdminSettings',
 			[
-				'accountStatus'         => $this->account->get_account_status_data(),
-				'accountFees'           => $this->account->get_fees(),
-				'fraudServices'         => $this->account->get_fraud_services_config(),
+				'accountStatus'           => $this->account->get_account_status_data(),
+				'accountFees'             => $this->account->get_fees(),
+				'fraudServices'           => $this->account->get_fraud_services_config(),
 				// TODO: Remove this line ahead of releasing Apple Pay for all merchants.
-				'paymentRequestEnabled' => WC_Payments::should_payment_request_be_available(),
+				'paymentRequestAvailable' => WC_Payments::should_payment_request_be_available(),
 			]
 		);
 

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -290,8 +290,8 @@ class WC_Payments_Admin {
 				'accountStatus'         => $this->account->get_account_status_data(),
 				'accountFees'           => $this->account->get_fees(),
 				'fraudServices'         => $this->account->get_fraud_services_config(),
-				// TODO: Remove this line ahead of Apple Pay release.
-				'paymentRequestEnabled' => 'yes' === get_option( '_wcpay_feature_payment_request' ),
+				// TODO: Remove this line ahead of releasing Apple Pay for all merchants.
+				'paymentRequestEnabled' => 'US' === WC()->countries->get_base_country(),
 			]
 		);
 

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -291,7 +291,7 @@ class WC_Payments_Admin {
 				'accountFees'           => $this->account->get_fees(),
 				'fraudServices'         => $this->account->get_fraud_services_config(),
 				// TODO: Remove this line ahead of releasing Apple Pay for all merchants.
-				'paymentRequestEnabled' => 'US' === WC()->countries->get_base_country(),
+				'paymentRequestEnabled' => WC_Payments::should_payment_request_be_available(),
 			]
 		);
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -205,7 +205,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public function add_payment_request_form_fields() {
 		// TODO: Remove this check and inject contents of `$payment_request_fields` into `$this->form_fields`
 		// after `saved_cards` ahead of releasing Apple Pay for all merchants.
-		if ( 'US' === WC()->countries->get_base_country() ) {
+		if ( WC_Payments::should_payment_request_be_available() ) {
 			$payment_request_fields = [
 				'payment_request'                     => [
 					'title'       => __( 'Payment Request Button', 'woocommerce-payments' ),

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -167,10 +167,45 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			],
 		];
 
-		// Feature flag.
+		// Load the settings.
+		$this->init_settings();
+
+		// If the setting to enable saved cards is enabled, then we should support tokenization and adding payment methods.
+		if ( $this->is_saved_cards_enabled() ) {
+			$this->supports = array_merge( $this->supports, [ 'tokenization', 'add_payment_method' ] );
+		}
+
+		// Add Payment Request form fields after WC initialization.
+		add_filter( 'init', [ $this, 'add_payment_request_form_fields' ] );
+
+		add_filter( 'woocommerce_settings_api_sanitized_fields_' . $this->id, [ $this, 'sanitize_plugin_settings' ] );
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
+		add_action( 'admin_notices', [ $this, 'display_errors' ], 9999 );
+		add_action( 'woocommerce_woocommerce_payments_admin_notices', [ $this, 'display_test_mode_notice' ] );
+		add_action( 'woocommerce_order_actions', [ $this, 'add_order_actions' ] );
+		add_action( 'woocommerce_order_action_capture_charge', [ $this, 'capture_charge' ] );
+		add_action( 'woocommerce_order_action_cancel_authorization', [ $this, 'cancel_authorization' ] );
+
+		add_action( 'wp_ajax_update_order_status', [ $this, 'update_order_status' ] );
+		add_action( 'wp_ajax_nopriv_update_order_status', [ $this, 'update_order_status' ] );
+
+		add_action( 'wp_enqueue_scripts', [ $this, 'register_scripts' ] );
+		add_action( 'wp_ajax_create_setup_intent', [ $this, 'create_setup_intent_ajax' ] );
+		add_action( 'wp_ajax_nopriv_create_setup_intent', [ $this, 'create_setup_intent_ajax' ] );
+
+		add_action( 'woocommerce_update_order', [ $this, 'schedule_order_tracking' ], 10, 2 );
+
+		// Update the current request logged_in cookie after a guest user is created to avoid nonce inconsistencies.
+		add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
+	}
+
+	/**
+	 * Add Payment Request form fields.
+	 */
+	public function add_payment_request_form_fields() {
 		// TODO: Remove this check and inject contents of `$payment_request_fields` into `$this->form_fields`
-		// after `saved_cards` ahead of Apple Pay release.
-		if ( 'yes' === get_option( '_wcpay_feature_payment_request' ) ) {
+		// after `saved_cards` ahead of releasing Apple Pay for all merchants.
+		if ( 'US' === WC()->countries->get_base_country() ) {
 			$payment_request_fields = [
 				'payment_request'                     => [
 					'title'       => __( 'Payment Request Button', 'woocommerce-payments' ),
@@ -250,34 +285,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$payment_request_fields +
 				array_slice( $this->form_fields, $fields_index, count( $this->form_fields ) - 1 );
 		}
-
-		// Load the settings.
-		$this->init_settings();
-
-		// If the setting to enable saved cards is enabled, then we should support tokenization and adding payment methods.
-		if ( $this->is_saved_cards_enabled() ) {
-			$this->supports = array_merge( $this->supports, [ 'tokenization', 'add_payment_method' ] );
-		}
-
-		add_filter( 'woocommerce_settings_api_sanitized_fields_' . $this->id, [ $this, 'sanitize_plugin_settings' ] );
-		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
-		add_action( 'admin_notices', [ $this, 'display_errors' ], 9999 );
-		add_action( 'woocommerce_woocommerce_payments_admin_notices', [ $this, 'display_test_mode_notice' ] );
-		add_action( 'woocommerce_order_actions', [ $this, 'add_order_actions' ] );
-		add_action( 'woocommerce_order_action_capture_charge', [ $this, 'capture_charge' ] );
-		add_action( 'woocommerce_order_action_cancel_authorization', [ $this, 'cancel_authorization' ] );
-
-		add_action( 'wp_ajax_update_order_status', [ $this, 'update_order_status' ] );
-		add_action( 'wp_ajax_nopriv_update_order_status', [ $this, 'update_order_status' ] );
-
-		add_action( 'wp_enqueue_scripts', [ $this, 'register_scripts' ] );
-		add_action( 'wp_ajax_create_setup_intent', [ $this, 'create_setup_intent_ajax' ] );
-		add_action( 'wp_ajax_nopriv_create_setup_intent', [ $this, 'create_setup_intent_ajax' ] );
-
-		add_action( 'woocommerce_update_order', [ $this, 'schedule_order_tracking' ], 10, 2 );
-
-		// Update the current request logged_in cookie after a guest user is created to avoid nonce inconsistencies.
-		add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
 	}
 
 	/**

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -79,6 +79,11 @@ class WC_Payments_Apple_Pay_Registration {
 	 * @return  void
 	 */
 	public function init() {
+		// TODO: Remove this ahead releasing Apple Pay for all merchants.
+		if ( 'US' !== WC()->countries->get_base_country() ) {
+			return;
+		}
+
 		$this->gateway = WC_Payments::get_gateway();
 		$this->add_domain_association_rewrite_rule();
 

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -80,7 +80,7 @@ class WC_Payments_Apple_Pay_Registration {
 	 */
 	public function init() {
 		// TODO: Remove this ahead releasing Apple Pay for all merchants.
-		if ( 'US' !== WC()->countries->get_base_country() ) {
+		if ( ! WC_Payments::should_payment_request_be_available() ) {
 			return;
 		}
 

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -50,6 +50,11 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 * @return  void
 	 */
 	public function init() {
+		// TODO: Remove this ahead releasing Apple Pay for all merchants.
+		if ( 'US' !== WC()->countries->get_base_country() ) {
+			return;
+		}
+
 		$this->gateway = WC_Payments::get_gateway();
 
 		// Checks if WCPay is enabled.

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -51,7 +51,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 */
 	public function init() {
 		// TODO: Remove this ahead releasing Apple Pay for all merchants.
-		if ( 'US' !== WC()->countries->get_base_country() ) {
+		if ( ! WC_Payments::should_payment_request_be_available() ) {
 			return;
 		}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -167,12 +167,9 @@ class WC_Payments {
 
 		self::$gateway = new $gateway_class( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service );
 
-		// Feature flag.
-		// TODO: Remove this check ahead of Apple Pay release.
-		if ( 'yes' === get_option( '_wcpay_feature_payment_request' ) ) {
-			self::$payment_request_button_handler = new WC_Payments_Payment_Request_Button_Handler( self::$account );
-			self::$apple_pay_registration         = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$account );
-		}
+		// Payment Request and Apple Pay.
+		self::$payment_request_button_handler = new WC_Payments_Payment_Request_Button_Handler( self::$account );
+		self::$apple_pay_registration         = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$account );
 
 		add_filter( 'woocommerce_payment_gateways', [ __CLASS__, 'register_gateway' ] );
 		add_filter( 'option_woocommerce_gateway_order', [ __CLASS__, 'set_gateway_top_of_list' ], 2 );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -188,6 +188,14 @@ class WC_Payments {
 	}
 
 	/**
+	 * Checks whether Payment Request Button feature should be available.
+	 * TODO: Remove this ahead of releasing Apple Pay for all merchants.
+	 */
+	public static function should_payment_request_be_available() {
+		return 'US' === WC()->countries->get_base_country();
+	}
+
+	/**
 	 * Prints the given message in an "admin notice" wrapper with "error" class.
 	 *
 	 * @param string $message Message to print. Can contain HTML.

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,10 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 2.x.x - 2021-xx-xx =
+* Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.
+* Add - Payment Request Button support for US merchants (Apple Pay, Google Pay, Microsoft Pay, and the browser standard Payment Request API).
+
 = 2.1.1 - 2021-03-23 =
 * Fix - Fatal error when a subscription is processed with action scheduler hook.
 


### PR DESCRIPTION
Fixes #1414
Fixes #1415

#### Changes proposed in this Pull Request

In the next release, we want the Payment Request Button feature to be visible only to US merchants.

This PR removes the feature flag condition from 2.1.0 and replaces it with a country check. If the merchant is based on the 'US', then the feature should be visible.

#### Testing instructions

- Make sure the base country in WooCommerce > Settings is set to anything other than `United States (US) — *`.
- Go to Payments > Settings and notice there is no "Payment Request Button" setting.
- Change your base country to `US` and notice the "Payment Request Button" setting is visible.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
