### PR TITLE
Initialize WC()->session is initialized before calling get_customer_id()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 2.2.0 - 2021-xx-xx =
+* Fix - Failing subscriptions renewal due to fatal error.
+
 = 2.1.0 - 2021-03-16 =
 * Update - Show last 4 digit credit card number in order note when payment method is updated on failed renewal subscription order.
 * Update - Define constant for the group to be used for scheduled actions.

--- a/includes/class-wc-payments-fraud-service.php
+++ b/includes/class-wc-payments-fraud-service.php
@@ -110,6 +110,9 @@ class WC_Payments_Fraud_Service {
 		if ( $this->check_if_user_just_logged_in() ) {
 			$config['session_id'] = $this->get_cookie_session_id();
 		} else {
+			if ( ! isset( WC()->session ) ) {
+				WC()->initialize_session();
+			}
 			$config['session_id'] = $wpcom_blog_id . '_' . WC()->session->get_customer_id();
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 2.2.0 - 2021-xx-xx =
+* Fix - Failing subscriptions renewal due to fatal error.
+
 = 2.1.0 - 2021-03-16 =
 * Update - Show last 4 digit credit card number in order note when payment method is updated on failed renewal subscription order.
 * Update - Define constant for the group to be used for scheduled actions.


### PR DESCRIPTION
Fixes #1420

#### Changes proposed in this Pull Request

Call `WC()->initialize_session()` before `WC()->session->get_customer_id()` in case `WC()->session` is not yet set.

#### Testing instructions

*

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
