### PR TITLE
Fix a critical error when a subscription renewal runs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 2.1.1 - 2021-xx-xx =
+* Fix - Fatal error when a subscription is processed with action scheduler hook.
+
 = 2.1.0 - 2021-03-16 =
 * Update - Show last 4 digit credit card number in order note when payment method is updated on failed renewal subscription order.
 * Update - Define constant for the group to be used for scheduled actions.

--- a/includes/class-wc-payments-fraud-service.php
+++ b/includes/class-wc-payments-fraud-service.php
@@ -110,7 +110,7 @@ class WC_Payments_Fraud_Service {
 		if ( $this->check_if_user_just_logged_in() ) {
 			$config['session_id'] = $this->get_cookie_session_id();
 		} else {
-			if ( is_a( WC()->session, 'WC_Session' ) && method_exists( WC()->session, 'get_customer_id' ) ) {
+			if ( is_a( WC()->session, 'WC_Session' ) ) {
 				$config['session_id'] = $wpcom_blog_id . '_' . WC()->session->get_customer_id();
 			} else {
 				return null; // we do not have a valid session for the current process.

--- a/includes/class-wc-payments-fraud-service.php
+++ b/includes/class-wc-payments-fraud-service.php
@@ -110,7 +110,11 @@ class WC_Payments_Fraud_Service {
 		if ( $this->check_if_user_just_logged_in() ) {
 			$config['session_id'] = $this->get_cookie_session_id();
 		} else {
-			$config['session_id'] = $wpcom_blog_id . '_' . WC()->session->get_customer_id();
+			if ( is_a( WC()->session, 'WC_Session') && method_exists( WC()->session, 'get_customer_id' ) ) {
+				$config['session_id'] = $wpcom_blog_id . '_' . WC()->session->get_customer_id();
+			} else {
+				return null; // we do not have a valid session for the current process.
+			}
 		}
 
 		return $config;

--- a/includes/class-wc-payments-fraud-service.php
+++ b/includes/class-wc-payments-fraud-service.php
@@ -110,7 +110,7 @@ class WC_Payments_Fraud_Service {
 		if ( $this->check_if_user_just_logged_in() ) {
 			$config['session_id'] = $this->get_cookie_session_id();
 		} else {
-			if ( is_a( WC()->session, 'WC_Session') && method_exists( WC()->session, 'get_customer_id' ) ) {
+			if ( is_a( WC()->session, 'WC_Session' ) && method_exists( WC()->session, 'get_customer_id' ) ) {
 				$config['session_id'] = $wpcom_blog_id . '_' . WC()->session->get_customer_id();
 			} else {
 				return null; // we do not have a valid session for the current process.

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 2.1.1 - 2021-xx-xx =
+* Fix - Fatal error when a subscription is processed with action scheduler hook.
+
 = 2.1.0 - 2021-03-16 =
 * Update - Show last 4 digit credit card number in order note when payment method is updated on failed renewal subscription order.
 * Update - Define constant for the group to be used for scheduled actions.


### PR DESCRIPTION
Fixes #1420 

#### Changes proposed in this Pull Request

- Check the session object before attempting to access the `get_customer_id` method.


The issue is caused by the fraud prevention scripts attempt to access the WooCommerce
session object user ID when we do not have a valid session.


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
