### PR TITLE
`npm run up`: Provide default.env file to docker run command

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -18,7 +18,7 @@ redirect_output() {
 # https://hub.docker.com/_/wordpress#running-as-an-arbitrary-user
 cli()
 {
-	redirect_output docker run -it --rm --user xfs --volumes-from $WP_CONTAINER --network container:$WP_CONTAINER wordpress:cli "$@"
+	redirect_output docker run -it --env-file default.env --rm --user xfs --volumes-from $WP_CONTAINER --network container:$WP_CONTAINER wordpress:cli "$@"
 }
 
 set +e


### PR DESCRIPTION
### Description

This is a port from a fix done in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1506. Check it out for more details.

Fixes the exact same issue happening in `woocommerce-gateway-stripe` where `npm run up` doesn't finish on fresh installs. It gets stuck in `Waiting until the service is ready...` which is where the script is running `cli wp db check --path=/var/www/html --quiet > /dev/null` every 5 seconds.

After debugging I found out the `cli` function doesn't provide the env vars we need in order to complete the installation. Manually providing them via the `default.env` file adds the required env vars.

### Considerations

Although, I can reproduce the issue for both `woocommerce-payments` and `woocommerce-gateway-stripe` consistently,  this issue has happened only to me so far. So I'm not entirely sure if this PR is fixing the real issue.

Nevertheless, I see no harm on providing the .env file manually since env vars are appended to the existing ones.

### Testing

```
~/www/woocommerce-payments ‹fix/fix-docker-install› » npm run up

> woocommerce-payments@2.1.1 up /Users/asumaran/www/woocommerce-payments
> docker-compose up --build --force-recreate -d && ./bin/docker-setup.sh

Building wordpress
[+] Building 1.4s (9/9) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                   0.0s
 => => transferring dockerfile: 709B                                                                                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/wordpress:php7.3                                                                                                                                                                                                    1.3s
 => [1/5] FROM docker.io/library/wordpress:php7.3@sha256:f6945551c4a83ad02ab596828c3f7315f3613808304dd4ce86903277a65ea8a9                                                                                                                                              0.0s
 => CACHED [2/5] RUN pecl install xdebug-2.9.8  && echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini  && echo 'xdebug.remote_port=9000' >> /usr/local/etc/php/php.ini  && echo 'xdebug.remote_host=host.docker.internal' >> /usr/local/etc/php/php.ini  &&   0.0s
 => CACHED [3/5] RUN apt-get update  && apt-get install --assume-yes --quiet --no-install-recommends gnupg2 subversion mariadb-client less jq                                                                                                                          0.0s
 => CACHED [4/5] RUN apt-get install -y openssh-client                                                                                                                                                                                                                 0.0s
 => CACHED [5/5] RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar  && chmod +x wp-cli.phar  && mv wp-cli.phar /usr/local/bin/wp                                                                                                   0.0s
 => exporting to image                                                                                                                                                                                                                                                 0.0s
 => => exporting layers                                                                                                                                                                                                                                                0.0s
 => => writing image sha256:1185ee014c2f985d5b76fa9ff72af71f45affcc530033340ee14642e1408f1f7                                                                                                                                                                           0.0s
 => => naming to docker.io/library/woocommerce_payments_wordpress                                                                                                                                                                                                      0.0s
Successfully built 1185ee014c2f985d5b76fa9ff72af71f45affcc530033340ee14642e1408f1f7
Recreating woocommerce_payments_mysql      ... done
Recreating woocommerce_payments_phpmyadmin ... done
Recreating woocommerce_payments_wordpress  ... done
Waiting until the service is ready...
Waiting until the service is ready...
Waiting until the service is ready...

Setting up environment...

Pulling the WordPress CLI docker image...
Setting up WordPress...
Updating WordPress to the latest version...
Updating the WordPress database...
Configuring WordPress to work with ngrok (in order to allow creating a Jetpack-WPCOM connection)
Enabling WordPress debug flags
Enabling WordPress development environment (enforces Stripe testing mode)
Updating permalink structure
Installing and activating WooCommerce...
Installing and activating Storefront theme...
Adding basic WooCommerce settings...
Importing WooCommerce shop pages...
Installing and activating the WordPress Importer plugin...
Importing some sample data...
Activating the WooCommerce Payments plugin...
Setting up WooCommerce Payments...
Updating WooCommerce Payments settings
Installing dev tools plugin...
Cloning into 'docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools'...
remote: Enumerating objects: 107, done.
remote: Counting objects: 100% (107/107), done.
remote: Compressing objects: 100% (70/70), done.
remote: Total 107 (delta 54), reused 77 (delta 35), pack-reused 0
Receiving objects: 100% (107/107), 22.23 KiB | 11.12 MiB/s, done.
Resolving deltas: 100% (54/54), done.

SUCCESS! You should now be able to access http://localhost:8082/wp-admin/
You can login by using the username and password both as 'admin'
```