### PR TITLE
Set script translations so js files can be translated

### DIFF
--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -246,6 +246,8 @@ class WC_Payments_Admin {
 			]
 		);
 
+		wp_set_script_translations( 'WCPAY_DASH_APP', 'woocommerce-payments' );
+
 		wp_register_style(
 			'WCPAY_DASH_APP',
 			plugins_url( 'dist/index.css', WCPAY_PLUGIN_FILE ),
@@ -264,6 +266,7 @@ class WC_Payments_Admin {
 			WC_Payments::get_file_version( 'dist/tos.js' ),
 			true
 		);
+		wp_set_script_translations( 'WCPAY_TOS', 'woocommerce-payments' );
 
 		wp_register_style(
 			'WCPAY_TOS',
@@ -302,6 +305,7 @@ class WC_Payments_Admin {
 			'wcpaySettings',
 			[ 'zeroDecimalCurrencies' => WC_Payments_Utils::zero_decimal_currencies() ]
 		);
+		wp_set_script_translations( 'WCPAY_ADMIN_SETTINGS', 'woocommerce-payments' );
 
 		wp_register_style(
 			'WCPAY_ADMIN_SETTINGS',

--- a/includes/class-wc-payments-blocks-payment-method.php
+++ b/includes/class-wc-payments-blocks-payment-method.php
@@ -49,6 +49,7 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 			'1.0.1',
 			true
 		);
+		wp_set_script_translations( 'wc-payment-method-wcpay', 'woocommerce-payments' );
 
 		return [ 'wc-payment-method-wcpay' ];
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Allows `__()` from `@wordpress/i18n` to actually work. See https://developer.wordpress.org/block-editor/how-to-guides/internationalization/ for more details. With this change the strings from the js files should be set to the translation project at https://translate.wordpress.org/projects/wp-plugins/woocommerce-payments/. Merchants switching their locale will be able to automatically download the translations in .po and json format.
Related to #1429

#### Testing instructions

* checkout branch `fix/js-translations`
* Download 
[woocommerce-payments-es_ES.zip](https://github.com/Automattic/woocommerce-payments/files/6207883/woocommerce-payments-es_ES.zip) and unzip into `wordpress/wp-content/languages/plugins/` a language pack I modified for testing purposes. 
* Switch language to spanish in general settings.
* Visit `/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits` 
* See some js strings translated like:
![image](https://user-images.githubusercontent.com/1534605/112543978-16a05700-8d7c-11eb-93eb-dec23eb85720.png)
Of course not all strings are translated yet but "Depósitos historias" (an imperfect translation) is coming from the json translation files.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
