### PR TITLE
Update deposit overview to reflect that is no longer loading

### DIFF
--- a/client/deposits/overview/index.js
+++ b/client/deposits/overview/index.js
@@ -170,7 +170,7 @@ const DepositsOverview = () => {
 				</span>{ ' ' }
 				<span className="wcpay-deposits-overview__schedule-value">
 					<Loadable
-						isLoading={ isLoading || ! overview }
+						isLoading={ isLoading }
 						display="inline"
 						placeholder="Deposit schedule placeholder"
 					>


### PR DESCRIPTION
Fixes #607 

#### Changes proposed in this Pull Request

As mentioned in https://github.com/Automattic/woocommerce-payments/issues/607#issuecomment-626589108, the new scope of the issue is `Updating the app state to reflect that it's no longer loading`.

Right now deposit overview keeps showing loading state the request fails:

![image](https://user-images.githubusercontent.com/7670276/113010135-e50efd80-9178-11eb-9682-ffb0ed7d4c5b.png)

The first commit just remove  `! overview` from isLoading prop of Loadable, to show an empty string instead of the placeholder. The existence of `overview` is already checked in the children.

The missing part is to replace `SummaryListPlaceholder`. I have searched the project but have not seen any examples to rely on. I think the most appropriate solution to keep the formatting after loading and a similar result to the table would be to use the same `SummaryNumber` but without values, like this:

![image](https://user-images.githubusercontent.com/7670276/113011395-0d4b2c00-917a-11eb-8b05-8aaad330bd2c.png)

The problem is that it implies repeating a certain part of the code, and that doesn't convince me. I thought some alternatives such as simply using a `<SummaryNumber/>` but the result does not seem aesthetic to me, or displaying the loading error but it seems out of place since it is already being displayed using a notice.

What do you think?

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

* Add `throw new Error();` after this:
https://github.com/Automattic/woocommerce-payments/blob/346924c422d2a4bf12405e6b639e89535a1a3fc3/client/data/deposits/resolvers.js#L50
* Access **Payments > Deposits** to check the result.
-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)