### PR TITLE
feat: add grouped settings flag

### DIFF
--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -300,7 +300,10 @@ class WC_Payments_Admin {
 		wp_localize_script(
 			'WCPAY_ADMIN_SETTINGS',
 			'wcpaySettings',
-			[ 'zeroDecimalCurrencies' => WC_Payments_Utils::zero_decimal_currencies() ]
+			[
+				'zeroDecimalCurrencies' => WC_Payments_Utils::zero_decimal_currencies(),
+				'featureFlags'          => $this->get_frontend_feature_flags(),
+			]
 		);
 
 		wp_register_style(
@@ -383,6 +386,7 @@ class WC_Payments_Admin {
 			'paymentTimeline' => self::version_compare( WC_ADMIN_VERSION_NUMBER, '1.4.0', '>=' ),
 			'customSearch'    => self::version_compare( WC_ADMIN_VERSION_NUMBER, '1.3.0', '>=' ),
 			'accountOverview' => self::is_account_overview_page_enabled(),
+			'groupedSettings' => self::is_grouped_settings_enabled(),
 		];
 	}
 
@@ -437,5 +441,14 @@ class WC_Payments_Admin {
 	 */
 	private static function is_account_overview_page_enabled() {
 		return get_option( '_wcpay_feature_account_overview' );
+	}
+
+	/**
+	 * Checks whether the grouped settings feature is enabled
+	 *
+	 * @return bool
+	 */
+	private static function is_grouped_settings_enabled() {
+		return get_option( 'wcpaydev_grouped_settings', '0' ) === '1';
 	}
 }

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -449,6 +449,6 @@ class WC_Payments_Admin {
 	 * @return bool
 	 */
 	private static function is_grouped_settings_enabled() {
-		return get_option( 'wcpaydev_grouped_settings', '0' ) === '1';
+		return get_option( '_wcpay_feature_grouped_settings', '0' ) === '1';
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/1466

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

Adding a feature flag to group the changes needed to update the settings.
The feature flag will be used to enable the new designs, as well as enabling the new payment methods.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

Assuming you are using the dev version of the plugin:
```
cd docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools
git pull
git checkout frosso/add-grouped-settings-flag
```

Go to the WC Pay Dev Utils page, enable/disable the flag: https://d.pr/i/sfW0OX

The related PR will also need to be reviewed and merged: 8-gh-Automattic/woocommerce-payments-dev-tools

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [-] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->