### PR TITLE
Add download transactions in CSV format

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 2.3.0 - 2021-xx-xx =
 * Add - Introduced deposit currency filter for transactions overview page.
+* Add - Download transactions report in CSV.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -301,6 +301,8 @@ export const TransactionsList = ( props ) => {
 		? __( 'Deposit transactions', 'woocommerce-payments' )
 		: __( 'Transactions', 'woocommerce-payments' );
 
+	const downloadable = !! rows.length;
+
 	const onDownload = () => {
 		const { page, path, ...params } = getQuery();
 
@@ -403,17 +405,19 @@ export const TransactionsList = ( props ) => {
 						}
 						autocompleter={ autocompleter }
 					/>,
-					<Button
-						key="download"
-						className="woocommerce-table__download-button"
-						disabled={ isLoading }
-						onClick={ onDownload }
-					>
-						<Gridicon icon={ 'cloud-download' } />
-						<span className="woocommerce-table__download-button__label">
-							{ __( 'Download', 'woocommerce-payments' ) }
-						</span>
-					</Button>,
+					downloadable && (
+						<Button
+							key="download"
+							className="woocommerce-table__download-button"
+							disabled={ isLoading }
+							onClick={ onDownload }
+						>
+							<Gridicon icon={ 'cloud-download' } />
+							<span className="woocommerce-table__download-button__label">
+								{ __( 'Download', 'woocommerce-payments' ) }
+							</span>
+						</Button>
+					),
 				] }
 			/>
 		</Page>

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -405,12 +405,12 @@ export const TransactionsList = ( props ) => {
 					/>,
 					<Button
 						key="download"
-						className="transactions-list__download-button"
+						className="woocommerce-table__download-button"
 						disabled={ isLoading }
 						onClick={ onDownload }
 					>
 						<Gridicon icon={ 'cloud-download' } />
-						<span>
+						<span className="woocommerce-table__download-button__label">
 							{ __( 'Download', 'woocommerce-payments' ) }
 						</span>
 					</Button>,

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -302,11 +302,16 @@ export const TransactionsList = ( props ) => {
 		: __( 'Transactions', 'woocommerce-payments' );
 
 	const onDownload = () => {
+		const { page, path, ...params } = getQuery();
+
 		downloadCSVFile(
-			generateCSVFileName( title, getQuery() ),
+			generateCSVFileName( title, params ),
 			generateCSVDataFromTable( columnsToDisplay, rows )
 		);
-		// TODO: Record event?
+
+		window.wcTracks.recordEvent( 'wcpay_transactions_download', {
+			rows: transactionsSummary.count,
+		} );
 	};
 
 	if ( ! wcpaySettings.featureFlags.customSearch ) {

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -9,11 +9,18 @@ import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import moment from 'moment';
 import { TableCard, Search } from '@woocommerce/components';
+import { Button } from '@wordpress/components';
 import {
 	onQueryChange,
 	getQuery,
 	updateQueryString,
 } from '@woocommerce/navigation';
+import {
+	downloadCSVFile,
+	generateCSVDataFromTable,
+	generateCSVFileName,
+} from '@woocommerce/csv-export';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -289,6 +296,19 @@ export const TransactionsList = ( props ) => {
 				'Search by order number, customer name, or billing email',
 				'woocommerce-payments'
 		  );
+
+	const title = props.depositId
+		? __( 'Deposit transactions', 'woocommerce-payments' )
+		: __( 'Transactions', 'woocommerce-payments' );
+
+	const onDownload = () => {
+		downloadCSVFile(
+			generateCSVFileName( title, getQuery() ),
+			generateCSVDataFromTable( columnsToDisplay, rows )
+		);
+		// TODO: Record event?
+	};
+
 	if ( ! wcpaySettings.featureFlags.customSearch ) {
 		searchPlaceholder = __(
 			'Search by customer name',
@@ -375,6 +395,17 @@ export const TransactionsList = ( props ) => {
 						}
 						autocompleter={ autocompleter }
 					/>,
+					<Button
+						key="download"
+						className="transactions-list__download-button"
+						disabled={ isLoading }
+						onClick={ onDownload }
+					>
+						<Gridicon icon={ 'cloud-download' } />
+						<span>
+							{ __( 'Download', 'woocommerce-payments' ) }
+						</span>
+					</Button>,
 				] }
 			/>
 		</Page>

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -310,7 +310,10 @@ export const TransactionsList = ( props ) => {
 		);
 
 		window.wcTracks.recordEvent( 'wcpay_transactions_download', {
-			rows: transactionsSummary.count,
+			// eslint-disable-next-line camelcase
+			exported_transactions: rows.length,
+			// eslint-disable-next-line camelcase
+			total_transactions: transactionsSummary.count,
 		} );
 	};
 

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -1,6 +1,5 @@
 @import 'node_modules/@wordpress/components/src/tooltip/style.scss';
 
-$gap-smaller: 8px; // From wc-admin, read last comment.
 .transactions-list {
 	.date-time {
 		min-width: 195px;
@@ -16,22 +15,6 @@ $gap-smaller: 8px; // From wc-admin, read last comment.
 			fill: $studio-gray-30;
 		}
 	}
-
-	.transactions-list__download-button {
-		svg {
-			margin-right: $gap-smaller;
-		}
-
-		@include breakpoint( '<660px' ) {
-			svg {
-				margin-right: 0;
-			}
-
-			span {
-				display: none;
-			}
-		}
-	}
 }
 
 /**
@@ -41,6 +24,7 @@ $gap-smaller: 8px; // From wc-admin, read last comment.
 */
 $gap: 16px;
 $gap-small: 12px;
+$gap-smaller: 8px;
 .woocommerce-report-table {
 	.woocommerce-search {
 		flex-grow: 1;
@@ -50,6 +34,7 @@ $gap-small: 12px;
 		position: relative;
 	}
 
+	&.has-compare,
 	&.has-search {
 		.woocommerce-card__action {
 			align-items: center;
@@ -77,6 +62,13 @@ $gap-small: 12px;
 					grid-area: 2 / 2 / 3 / 4;
 					margin-right: 0;
 				}
+
+				.woocommerce-table__download-button {
+					grid-area: 1 / 2 / 2 / 3;
+					justify-self: end;
+					margin: -6px 0;
+					position: absolute;
+				}
 			}
 		}
 
@@ -89,6 +81,12 @@ $gap-small: 12px;
 					grid-column-start: 1;
 					grid-column-end: 2;
 				}
+
+				.woocommerce-table__download-button {
+					align-self: center;
+					grid-column-start: 2;
+					grid-column-end: 3;
+				}
 			}
 
 			@include breakpoint( '<960px' ) {
@@ -98,6 +96,10 @@ $gap-small: 12px;
 					.woocommerce-search {
 						grid-area: 2 / 1 / 3 / 4;
 						margin-left: 0;
+					}
+
+					.woocommerce-table__download-button {
+						grid-area: 1 / 2 / 2 / 3;
 					}
 				}
 			}
@@ -109,6 +111,34 @@ $gap-small: 12px;
 			.woocommerce-select-control__control {
 				height: 38px;
 			}
+		}
+
+		.woocommerce-compare-button {
+			padding: 3px $gap-small;
+			height: auto;
+		}
+	}
+}
+
+button.woocommerce-table__download-button {
+	padding: 6px $gap-small;
+	color: $studio-black;
+	text-decoration: none;
+	align-items: center;
+
+	svg {
+		margin-right: $gap-smaller;
+		height: 24px;
+		width: 24px;
+	}
+
+	@include breakpoint( '<960px' ) {
+		svg {
+			margin-right: 0;
+		}
+
+		.woocommerce-table__download-button__label {
+			display: none;
 		}
 	}
 }

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -1,5 +1,6 @@
 @import 'node_modules/@wordpress/components/src/tooltip/style.scss';
 
+$gap-smaller: 8px; // From wc-admin, read last comment.
 .transactions-list {
 	.date-time {
 		min-width: 195px;
@@ -13,6 +14,22 @@
 			margin-right: 6px;
 			height: 18px;
 			fill: $studio-gray-30;
+		}
+	}
+
+	.transactions-list__download-button {
+		svg {
+			margin-right: $gap-smaller;
+		}
+
+		@include breakpoint( '<660px' ) {
+			svg {
+				margin-right: 0;
+			}
+
+			span {
+				display: none;
+			}
 		}
 	}
 }

--- a/client/transactions/list/test/__snapshots__/index.js.snap
+++ b/client/transactions/list/test/__snapshots__/index.js.snap
@@ -136,7 +136,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
             </div>
           </div>
           <button
-            class="components-button transactions-list__download-button"
+            class="components-button woocommerce-table__download-button"
             type="button"
           >
             <svg
@@ -152,7 +152,9 @@ exports[`Transactions list renders correctly when can filter by several currenci
                 />
               </g>
             </svg>
-            <span>
+            <span
+              class="woocommerce-table__download-button__label"
+            >
               Download
             </span>
           </button>
@@ -912,7 +914,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
             </div>
           </div>
           <button
-            class="components-button transactions-list__download-button"
+            class="components-button woocommerce-table__download-button"
             type="button"
           >
             <svg
@@ -928,7 +930,9 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                 />
               </g>
             </svg>
-            <span>
+            <span
+              class="woocommerce-table__download-button__label"
+            >
               Download
             </span>
           </button>
@@ -1663,7 +1667,7 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
             </div>
           </div>
           <button
-            class="components-button transactions-list__download-button"
+            class="components-button woocommerce-table__download-button"
             type="button"
           >
             <svg
@@ -1679,7 +1683,9 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                 />
               </g>
             </svg>
-            <span>
+            <span
+              class="woocommerce-table__download-button__label"
+            >
               Download
             </span>
           </button>
@@ -2307,7 +2313,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
             </div>
           </div>
           <button
-            class="components-button transactions-list__download-button"
+            class="components-button woocommerce-table__download-button"
             type="button"
           >
             <svg
@@ -2323,7 +2329,9 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                 />
               </g>
             </svg>
-            <span>
+            <span
+              class="woocommerce-table__download-button__label"
+            >
               Download
             </span>
           </button>
@@ -3127,7 +3135,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
             </div>
           </div>
           <button
-            class="components-button transactions-list__download-button"
+            class="components-button woocommerce-table__download-button"
             type="button"
           >
             <svg
@@ -3143,7 +3151,9 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                 />
               </g>
             </svg>
-            <span>
+            <span
+              class="woocommerce-table__download-button__label"
+            >
               Download
             </span>
           </button>

--- a/client/transactions/list/test/__snapshots__/index.js.snap
+++ b/client/transactions/list/test/__snapshots__/index.js.snap
@@ -135,6 +135,27 @@ exports[`Transactions list renders correctly when can filter by several currenci
               </div>
             </div>
           </div>
+          <button
+            class="components-button transactions-list__download-button"
+            type="button"
+          >
+            <svg
+              class="gridicon gridicons-cloud-download"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g>
+                <path
+                  d="M18 9c-.01 0-.017.002-.025.003C17.72 5.646 14.922 3 11.5 3 7.91 3 5 5.91 5 9.5c0 .524.07 1.03.186 1.52C5.123 11.015 5.064 11 5 11c-2.21 0-4 1.79-4 4 0 1.202.54 2.267 1.38 3h18.593C22.196 17.09 23 15.643 23 14c0-2.76-2.24-5-5-5zm-6 7l-4-5h3V8h2v3h3l-4 5z"
+                />
+              </g>
+            </svg>
+            <span>
+              Download
+            </span>
+          </button>
         </div>
         <div
           class="woocommerce-card__menu woocommerce-card__header-item"
@@ -890,6 +911,27 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
               </div>
             </div>
           </div>
+          <button
+            class="components-button transactions-list__download-button"
+            type="button"
+          >
+            <svg
+              class="gridicon gridicons-cloud-download"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g>
+                <path
+                  d="M18 9c-.01 0-.017.002-.025.003C17.72 5.646 14.922 3 11.5 3 7.91 3 5 5.91 5 9.5c0 .524.07 1.03.186 1.52C5.123 11.015 5.064 11 5 11c-2.21 0-4 1.79-4 4 0 1.202.54 2.267 1.38 3h18.593C22.196 17.09 23 15.643 23 14c0-2.76-2.24-5-5-5zm-6 7l-4-5h3V8h2v3h3l-4 5z"
+                />
+              </g>
+            </svg>
+            <span>
+              Download
+            </span>
+          </button>
         </div>
         <div
           class="woocommerce-card__menu woocommerce-card__header-item"
@@ -1620,6 +1662,27 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
               </div>
             </div>
           </div>
+          <button
+            class="components-button transactions-list__download-button"
+            type="button"
+          >
+            <svg
+              class="gridicon gridicons-cloud-download"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g>
+                <path
+                  d="M18 9c-.01 0-.017.002-.025.003C17.72 5.646 14.922 3 11.5 3 7.91 3 5 5.91 5 9.5c0 .524.07 1.03.186 1.52C5.123 11.015 5.064 11 5 11c-2.21 0-4 1.79-4 4 0 1.202.54 2.267 1.38 3h18.593C22.196 17.09 23 15.643 23 14c0-2.76-2.24-5-5-5zm-6 7l-4-5h3V8h2v3h3l-4 5z"
+                />
+              </g>
+            </svg>
+            <span>
+              Download
+            </span>
+          </button>
         </div>
         <div
           class="woocommerce-card__menu woocommerce-card__header-item"
@@ -2243,6 +2306,27 @@ exports[`Transactions list subscription column renders correctly 1`] = `
               </div>
             </div>
           </div>
+          <button
+            class="components-button transactions-list__download-button"
+            type="button"
+          >
+            <svg
+              class="gridicon gridicons-cloud-download"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g>
+                <path
+                  d="M18 9c-.01 0-.017.002-.025.003C17.72 5.646 14.922 3 11.5 3 7.91 3 5 5.91 5 9.5c0 .524.07 1.03.186 1.52C5.123 11.015 5.064 11 5 11c-2.21 0-4 1.79-4 4 0 1.202.54 2.267 1.38 3h18.593C22.196 17.09 23 15.643 23 14c0-2.76-2.24-5-5-5zm-6 7l-4-5h3V8h2v3h3l-4 5z"
+                />
+              </g>
+            </svg>
+            <span>
+              Download
+            </span>
+          </button>
         </div>
         <div
           class="woocommerce-card__menu woocommerce-card__header-item"
@@ -3042,6 +3126,27 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
               </div>
             </div>
           </div>
+          <button
+            class="components-button transactions-list__download-button"
+            type="button"
+          >
+            <svg
+              class="gridicon gridicons-cloud-download"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g>
+                <path
+                  d="M18 9c-.01 0-.017.002-.025.003C17.72 5.646 14.922 3 11.5 3 7.91 3 5 5.91 5 9.5c0 .524.07 1.03.186 1.52C5.123 11.015 5.064 11 5 11c-2.21 0-4 1.79-4 4 0 1.202.54 2.267 1.38 3h18.593C22.196 17.09 23 15.643 23 14c0-2.76-2.24-5-5-5zm-6 7l-4-5h3V8h2v3h3l-4 5z"
+                />
+              </g>
+            </svg>
+            <span>
+              Download
+            </span>
+          </button>
         </div>
         <div
           class="woocommerce-card__menu woocommerce-card__header-item"

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 2.3.0 - 2021-xx-xx =
 * Add - Introduced deposit currency filter for transactions overview page.
+* Add - Download transactions report in CSV.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.


### PR DESCRIPTION
Fixes #689 

#### Changes proposed in this Pull Request

After some digging around the issue. I choose to replicate the functionality of wc-admin reports. I think that is the best approach to maintain the same user experience across WooCommerce.

Jus added the Download button:

![image](https://user-images.githubusercontent.com/7670276/113272221-b1001d80-92db-11eb-83eb-56f360240f12.png)

The downloaded file has the name `transactions_2021-04-01_page-wc-admin_path--payments-transactions_per-page-25_paged-2.csv` and the following content:
```
,"Date / Time",Type,Amount,Fees,Net,"Order #",Source,Customer,Email,Country,"Risk level",Deposit
txn_1IbLC0R0Jb8RqtxUyQTfIgV5,"2021-04-01 07:43:51",charge,18,0.82,17.18,,visa,"First Nane",admin@example.com,US,0,wcpay_estimated_daily_1617580800
txn_1IbL9fR0Jb8RqtxUYg8izFzj,"2021-04-01 07:41:26",charge,45,1.61,43.39,,visa,"First Nane",admin@example.com,US,0,wcpay_estimated_daily_1617580800
txn_1IazcbR0Jb8RqtxU8DfwiOFR,"2021-03-31 08:41:52",charge,16,0.76,15.24,,visa,"First Nane",admin@example.com,US,0,wcpay_estimated_daily_1617321600
txn_1IaeZzR0Jb8RqtxUUseRcluM,"2021-03-30 10:13:47",charge,15,0.74,14.26,,visa,"First Nane",admin@example.com,US,0,wcpay_estimated_daily_1617235200
```
I now realise that it would be better to use a filename like `[$title][$date][$query without path]` to keep it short and clear.

This is an initial WIP version to discuss the following topics:

* I don't know if there is any plan for that, but have you considered using wc-admin report-table? Seems like we are replicating the same functionality, and we will replicate more in the future. Also, I saw a comment in the SCSS file about the need of copy&paste some styles until we switch.
*  Do you think this will be enough or there is a special need to download all transactions at once? With this approach there is no need to implement a custom endpoint to obtain all the transactions, we only need to call `downloadCSVFile` and related functions with the available rows. Otherwise we need to implement something similar to `startExport` available in wc-admin report-table to send the full report by email, right?
*  About the exported CSV, I think we could remove the first and last keys because they don't provide useful information to the customer. What do you tink?
*  I saw that you record some events using `window.wcTracks.recordEvent`. And I assume that an event would be used here. How this actually works? I need to declare a new event type somewhere?

#### Testing instructions

* Access **Payments > Transactions**
* Click download button in right upper corner of table

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)