### PR TITLE
Add WPCOM connection status to `wcpay_connect_account_clicked` track

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Add - Download transactions report in CSV.
 * Update - Tweak the connection detection logic.
 * Add - Notification badge next to payments menu.
+* Add - WPCOM connection status event prop to 'wcpay_connect_account_clicked' track.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.

--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Card } from '@woocommerce/components';
 import { Button, Notice } from '@wordpress/components';
 import { useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -41,10 +42,16 @@ const ConnectPageOnboardingDisabled = () => (
 
 const ConnectPageOnboarding = () => {
 	const [ isSubmitted, setSubmitted ] = useState( false );
+	const isJetpackConnected = useSelect( ( select ) =>
+		select( 'wc/admin/plugins' ).isJetpackConnected()
+	);
 
 	const handleSetup = () => {
 		setSubmitted( true );
-		wcpayTracks.recordEvent( wcpayTracks.events.CONNECT_ACCOUNT_CLICKED );
+		wcpayTracks.recordEvent( wcpayTracks.events.CONNECT_ACCOUNT_CLICKED, {
+			// eslint-disable-next-line camelcase
+			wpcom_connection: isJetpackConnected ? 'Yes' : 'No',
+		} );
 	};
 
 	return (

--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -6,7 +6,6 @@ import { __ } from '@wordpress/i18n';
 import { Card } from '@woocommerce/components';
 import { Button, Notice } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -42,15 +41,12 @@ const ConnectPageOnboardingDisabled = () => (
 
 const ConnectPageOnboarding = () => {
 	const [ isSubmitted, setSubmitted ] = useState( false );
-	const isJetpackConnected = useSelect( ( select ) =>
-		select( 'wc/admin/plugins' ).isJetpackConnected()
-	);
 
 	const handleSetup = () => {
 		setSubmitted( true );
 		wcpayTracks.recordEvent( wcpayTracks.events.CONNECT_ACCOUNT_CLICKED, {
 			// eslint-disable-next-line camelcase
-			wpcom_connection: isJetpackConnected ? 'Yes' : 'No',
+			wpcom_connection: wcpaySettings.isJetpackConnected ? 'Yes' : 'No',
 		} );
 	};
 

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -13,6 +13,13 @@ defined( 'ABSPATH' ) || exit;
 class WC_Payments_Admin {
 
 	/**
+	 * Client for making requests to the WooCommerce Payments API.
+	 *
+	 * @var WC_Payments_API_Client
+	 */
+	protected $payments_api_client;
+
+	/**
 	 * WCPay Gateway instance to get information regarding WooCommerce Payments setup.
 	 *
 	 * @var WC_Payment_Gateway_WCPay
@@ -29,15 +36,18 @@ class WC_Payments_Admin {
 	/**
 	 * Hook in admin menu items.
 	 *
-	 * @param WC_Payment_Gateway_WCPay $gateway WCPay Gateway instance to get information regarding WooCommerce Payments setup.
-	 * @param WC_Payments_Account      $account Account instance.
+	 * @param WC_Payments_API_Client   $payments_api_client WooCommerce Payments API client.
+	 * @param WC_Payment_Gateway_WCPay $gateway             WCPay Gateway instance to get information regarding WooCommerce Payments setup.
+	 * @param WC_Payments_Account      $account             Account instance.
 	 */
 	public function __construct(
+		WC_Payments_API_Client $payments_api_client,
 		WC_Payment_Gateway_WCPay $gateway,
 		WC_Payments_Account $account
 	) {
-		$this->wcpay_gateway = $gateway;
-		$this->account       = $account;
+		$this->payments_api_client = $payments_api_client;
+		$this->wcpay_gateway       = $gateway;
+		$this->account             = $account;
 
 		// Add menu items.
 		add_action( 'admin_menu', [ $this, 'add_payments_menu' ], 0 );
@@ -245,6 +255,7 @@ class WC_Payments_Admin {
 				'isSubscriptionsActive' => class_exists( 'WC_Payment_Gateway_WCPay_Subscriptions_Compat' ),
 				'zeroDecimalCurrencies' => WC_Payments_Utils::zero_decimal_currencies(),
 				'fraudServices'         => $this->account->get_fraud_services_config(),
+				'isJetpackConnected'    => $this->payments_api_client->is_server_connected(),
 			]
 		);
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -178,7 +178,7 @@ class WC_Payments {
 		// Add admin screens.
 		if ( is_admin() ) {
 			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin.php';
-			new WC_Payments_Admin( self::$gateway, self::$account );
+			new WC_Payments_Admin( self::$api_client, self::$gateway, self::$account );
 
 			// Use tracks loader only in admin screens because it relies on WC_Tracks loaded by WC_Admin.
 			include_once WCPAY_ABSPATH . 'includes/admin/tracks/tracks-loader.php';

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Download transactions report in CSV.
 * Update - Tweak the connection detection logic.
 * Add - Notification badge next to payments menu.
+* Add - WPCOM connection status event prop to 'wcpay_connect_account_clicked' track.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.


### PR DESCRIPTION
Fixes #1478

#### Changes proposed in this Pull Request

This PR adds event prop `wpcom_connection` to `wcadmin_wcpay_connect_account_clicked` which records initial state of WPCOM connection with value `Yes` or `No`.

Note: Previously, this PR uses the following method to determine WPCOM connection, however, I found out that the minimum supported version of WooCommerce (4.0) did not have this feature.

~~In order to determine the state of WPCOM connection, it uses `isJetpackConnected` selector from `wc/admin/plugins` store provided by WooCommerce Admin. I have tested and confirmed the selector's value is available by the time `ConnectPageOnboarding` is rendered, thus no resolving query check is required.~~

~~This PR also assumes to Jetpack plugin is installed (which AFAIK is a hard requirement for a user to connect their site with WPCOM).~~

#### Testing instructions

Note: You can install the plugin [woocommerce-admin-test-helper](https://github.com/woocommerce/woocommerce-admin-test-helper/archive/refs/tags/v0.1.0.zip) to be able to quickly delete options, or access the database directly if that's preferable.

* If you have WCPay connected, delete the `jetpack_options` option if it exists (This disconnects WPCOM connection).
* Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect` page.
* Open your browser console and navigate to the Network tab.
* Click on `Set up`.
* Filter network request for `t.gif` requests, and look at the query string parameters. It should contain `en: wcadmin_wcpay_connect_account_clicked` and `wpcom_connection` with a value `Yes` or `No`.

-------------------

- [x] Added changelog entry (or does not apply)

