### PR TITLE
Change the default track `recordEvent` to use @woocommerce/tracks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Add - Introduced deposit currency filter for transactions overview page.
 * Add - Download transactions report in CSV.
 * Update - Tweak the connection detection logic.
+* Update - Change the default track `recordEvent` to use @woocommerce/tracks.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.

--- a/client/data/disputes/actions.js
+++ b/client/data/disputes/actions.js
@@ -13,6 +13,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import { NAMESPACE, STORE_NAME } from '../constants';
 import TYPES from './action-types';
+import wcpayTracks from 'tracks';
 
 export function updateDispute( data ) {
 	return {
@@ -49,7 +50,7 @@ export function* acceptDispute( id ) {
 			} )
 		);
 
-		window.wcTracks.recordEvent( 'wcpay_dispute_accept_success' );
+		wcpayTracks.recordEvent( 'wcpay_dispute_accept_success' );
 		const message = dispute.order
 			? sprintf(
 					/* translators: #%s is an order number, e.g. 15 */
@@ -66,7 +67,7 @@ export function* acceptDispute( id ) {
 			'There has been an error accepting the dispute. Please try again later.',
 			'woocommerce-payments'
 		);
-		window.wcTracks.recordEvent( 'wcpay_dispute_accept_failed' );
+		wcpayTracks.recordEvent( 'wcpay_dispute_accept_failed' );
 		yield dispatch( 'core/notices', 'createErrorNotice', message );
 	}
 }

--- a/client/disputes/details/actions.js
+++ b/client/disputes/details/actions.js
@@ -8,6 +8,11 @@ import { addQueryArgs } from '@wordpress/url';
 import { Button } from '@wordpress/components';
 import { Link } from '@woocommerce/components';
 
+/**
+ * Internal dependencies
+ */
+import wcpayTracks from 'tracks';
+
 const Actions = ( { id, needsResponse, isSubmitted, onAccept } ) => {
 	if ( ! needsResponse && ! isSubmitted ) {
 		return null;
@@ -30,7 +35,7 @@ const Actions = ( { id, needsResponse, isSubmitted, onAccept } ) => {
 				href={ challengeUrl }
 				className="components-button is-button is-primary is-large"
 				onClick={ () =>
-					window.wcTracks.recordEvent(
+					wcpayTracks.recordEvent(
 						needsResponse
 							? 'wcpay_dispute_challenge_clicked'
 							: 'wcpay_view_submitted_evidence_clicked'

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -33,6 +33,7 @@ import Page from 'components/page';
 import Loadable, { LoadableBlock } from 'components/loadable';
 import { TestModeNotice, topics } from 'components/test-mode-notice';
 import useConfirmNavigation from 'utils/use-confirm-navigation';
+import wcpayTracks from 'tracks';
 
 const PRODUCT_TYPE_META_KEY = '__product_type';
 
@@ -400,7 +401,7 @@ export default ( { query } ) => {
 			return;
 		}
 
-		window.wcTracks.recordEvent( 'wcpay_dispute_file_upload_started', {
+		wcpayTracks.recordEvent( 'wcpay_dispute_file_upload_started', {
 			type: key,
 		} );
 
@@ -431,11 +432,11 @@ export default ( { query } ) => {
 			} );
 			updateEvidence( key, uploadedFile.id );
 
-			window.wcTracks.recordEvent( 'wcpay_dispute_file_upload_success', {
+			wcpayTracks.recordEvent( 'wcpay_dispute_file_upload_success', {
 				type: key,
 			} );
 		} catch ( err ) {
-			window.wcTracks.recordEvent( 'wcpay_dispute_file_upload_failed', {
+			wcpayTracks.recordEvent( 'wcpay_dispute_file_upload_failed', {
 				message: err.message,
 			} );
 
@@ -459,7 +460,7 @@ export default ( { query } ) => {
 			path: '/payments/disputes',
 		} );
 
-		window.wcTracks.recordEvent(
+		wcpayTracks.recordEvent(
 			submit
 				? 'wcpay_dispute_submit_evidence_success'
 				: 'wcpay_dispute_save_evidence_success'
@@ -474,7 +475,7 @@ export default ( { query } ) => {
 	};
 
 	const handleSaveError = ( err, submit ) => {
-		window.wcTracks.recordEvent(
+		wcpayTracks.recordEvent(
 			submit
 				? 'wcpay_dispute_submit_evidence_failed'
 				: 'wcpay_dispute_save_evidence_failed'
@@ -501,7 +502,7 @@ export default ( { query } ) => {
 		setLoading( true );
 
 		try {
-			window.wcTracks.recordEvent(
+			wcpayTracks.recordEvent(
 				submit
 					? 'wcpay_dispute_submit_evidence_clicked'
 					: 'wcpay_dispute_save_evidence_clicked'
@@ -534,10 +535,7 @@ export default ( { query } ) => {
 		const properties = {
 			selection: newProductType,
 		};
-		window.wcTracks.recordEvent(
-			'wcpay_dispute_product_selected',
-			properties
-		);
+		wcpayTracks.recordEvent( 'wcpay_dispute_product_selected', properties );
 		updateDispute( {
 			metadata: { [ PRODUCT_TYPE_META_KEY ]: newProductType },
 		} );

--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -15,7 +15,7 @@ function isEnabled() {
  */
 function recordEvent( eventName, eventProperties ) {
 	const recordFunction =
-		window.wc.tracks.recordEvent ?? window.wcTracks.recordEvent;
+		window.wc?.tracks?.recordEvent ?? window.wcTracks.recordEvent;
 	recordFunction( eventName, eventProperties );
 }
 

--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -14,7 +14,9 @@ function isEnabled() {
  * @param {Object?} eventProperties Event properties.
  */
 function recordEvent( eventName, eventProperties ) {
-	window.wcTracks.recordEvent( eventName, eventProperties );
+	const recordFunction =
+		window.wc.tracks.recordEvent ?? window.wcTracks.recordEvent;
+	recordFunction( eventName, eventProperties );
 }
 
 const events = {

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -39,6 +39,7 @@ import autocompleter from 'transactions/autocompleter';
 import './style.scss';
 import TransactionsFilters from '../filters';
 import Page from '../../components/page';
+import wcpayTracks from 'tracks';
 
 const getColumns = ( includeDeposit, includeSubscription, sortByDate ) =>
 	[
@@ -311,7 +312,7 @@ export const TransactionsList = ( props ) => {
 			generateCSVDataFromTable( columnsToDisplay, rows )
 		);
 
-		window.wcTracks.recordEvent( 'wcpay_transactions_download', {
+		wcpayTracks.recordEvent( 'wcpay_transactions_download', {
 			// eslint-disable-next-line camelcase
 			exported_transactions: rows.length,
 			// eslint-disable-next-line camelcase

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Introduced deposit currency filter for transactions overview page.
 * Add - Download transactions report in CSV.
 * Update - Tweak the connection detection logic.
+* Update - Change the default track `recordEvent` to use @woocommerce/tracks.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR proposes to use [`@woocommerce/tracks`'s recordEvent ](https://github.com/woocommerce/woocommerce-admin/blob/4d00ed64740e9c68f282c0e05bd3e6a8d768650d/packages/tracks/src/index.js#L18-L37) as the preferred way to record track events in JavaScript, but defaults to the original `window.wcTracks.recordEvent` if the former is not available (which is highly unlikely unless WooCommerce plugin is not activated, which essentially disables WCPay anyway). 

The benefit of this is the ability to debug tracks without polluting live tracks data (track will not be sent if `process.env.NODE_ENV === 'development'`), and easier to inspect event props.

An example of the debug output:

![image](https://user-images.githubusercontent.com/3747241/113816938-1d7d8f80-97a8-11eb-871e-0c010c513ba7.png)


#### Testing instructions

* Disconnect from WCPay connection.
* Open browser console and run `localStorage.setItem( 'debug', 'wc-admin:tracks' );`
* Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect` page.
* Click on `Set up`.
* Verify in browser console that the following debug message exists: `wc-admin:tracks recordevent wcadmin_wcpay_connect_account_clicked` 

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
