### PR TITLE
Payment Request: Fix shipping calculation for UK and CA postal codes with Apple Pay

### DIFF
--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -299,7 +299,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 */
 	public function get_normalized_postal_code( $postcode, $country ) {
 		/**
-		 * Currently Apple Pay truncates postal codes from UK and Canada to first 3-4 characters
+		 * Currently, Apple Pay truncates the UK and Canadian postal codes to the first 4 and 3 characters respectively
 		 * when passing it back from the shippingcontactselected object. This causes WC to invalidate
 		 * the postal code and not calculate shipping zones correctly.
 		 */

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -94,8 +94,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 		add_action( 'wc_ajax_wcpay_log_errors', [ $this, 'ajax_log_errors' ] );
 
 		add_filter( 'woocommerce_gateway_title', [ $this, 'filter_gateway_title' ], 10, 2 );
-		add_filter( 'woocommerce_validate_postcode', [ $this, 'postal_code_validation' ], 10, 3 );
-
 		add_action( 'woocommerce_checkout_order_processed', [ $this, 'add_order_meta' ], 10, 2 );
 
 		// Add a filter for the value of `wcpay_is_apple_pay_enabled`.
@@ -291,40 +289,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 		}
 
 		return $title;
-	}
-
-	/**
-	 * Removes postal code validation from WC.
-	 *
-	 * @param bool   $valid Whether postal code is valid.
-	 * @param string $postcode Postal code.
-	 * @param string $country Country.
-	 * @return bool Whether postal code is valid.
-	 */
-	public function postal_code_validation( $valid, $postcode, $country ) {
-		$gateways = WC()->payment_gateways->get_available_payment_gateways();
-
-		if ( ! isset( $gateways['woocommerce_payments'] ) ) {
-			return $valid;
-		}
-
-		$payment_request_type = isset( $_POST['payment_request_type'] ) ? wc_clean( wp_unslash( $_POST['payment_request_type'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
-
-		if ( 'apple_pay' !== $payment_request_type ) {
-			return $valid;
-		}
-
-		/**
-		 * Currently Apple Pay truncates postal codes from UK and Canada to first 3 characters
-		 * when passing it back from the shippingcontactselected object. This causes WC to invalidate
-		 * the order and not let it go through. The remedy for now is just to remove this validation.
-		 * Note that this only works with shipping providers that don't validate full postal codes.
-		 */
-		if ( 'GB' === $country || 'CA' === $country ) {
-			return true;
-		}
-
-		return $valid;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1525

For privacy reasons, Apple Pay redacts the postal code when calculating shipping options and displays only the first 3 characters for Canada and the first 4 characters for UK postal codes. The full postal code is submitted once the order is placed.

There was a bug with UK postal codes specifically, due to the [way WC validates UK postal codes](https://github.com/woocommerce/woocommerce/blob/ec77c3bcc985f26c97b962e53d8f9fb9d355c3cf/includes/class-wc-validation.php#L132), that was preventing it to display wildcard shipping zones when the postal code was redacted from Apple Pay.

#### Changes proposed in this Pull Request

- Fix the UK issue by filling the redacted postal code with `*`, so WC can calculate the shipping options based on up to 4 characters shipping zones.
- Remove the `woocommerce_validate_postcode` filter, which was used when calculating shipping options.

#### Testing instructions

- Ensure you have `Payment Request Button` enabled in Payments > Settings, and your base country is `US`.
- Ensure your site is served over HTTPS and is publicly accessible.
- Ensure you have a real card added to your Apple Wallet.
- Add a wildcard shipping zone with the following postal code in the UK: `LN10*`. Add a flat rate of $1 to it.
- Go to a product page with shipping in Safari and click the "Buy with Apple Pay" button.
- Add a new shipping address in the United Kingdom with a random city, state and street number, add `LN10 6SH` as the postal code.
- Notice the flat rate of $1 gets added.
- If you try with a postal code of `LN11 6SH`, it should not work.
- For shipping zones in Canada, the same behavior should apply, but you can add only up to 3 characters shipping zones, e.g: `T5T*`. - This is due to the Apple Pay privacy limitation.

-------------------

- [ ] Added changelog entry - does not apply, the feature was not released in the UK and CA yet.
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
