### PR TITLE
Fix "Maximum update depth exceeded" error when filtering transactions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Add - Download transactions report in CSV.
 * Update - Tweak the connection detection logic.
 * Add - Notification badge next to payments menu.
+* Fix - Fixed broken search on transactions list page.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.

--- a/client/data/transactions/hooks.js
+++ b/client/data/transactions/hooks.js
@@ -71,12 +71,12 @@ export const useTransactions = (
 			match,
 			dateBefore,
 			dateAfter,
-			dateBetween,
+			JSON.stringify( dateBetween ),
 			typeIs,
 			typeIsNot,
 			storeCurrencyIs,
 			depositId,
-			search,
+			JSON.stringify( search ),
 		]
 	);
 
@@ -120,11 +120,11 @@ export const useTransactionsSummary = (
 			match,
 			dateBefore,
 			dateAfter,
-			dateBetween,
+			JSON.stringify( dateBetween ),
 			typeIs,
 			typeIsNot,
 			storeCurrencyIs,
 			depositId,
-			search,
+			JSON.stringify( search ),
 		]
 	);

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Download transactions report in CSV.
 * Update - Tweak the connection detection logic.
 * Add - Notification badge next to payments menu.
+* Fix - Fixed broken search on transactions list page.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.


### PR DESCRIPTION
Fixes #1480 and #1499

#### Changes proposed in this Pull Request

Using an array within a hook dependencies might cause an infinite loop because React does shallow equality check, this PR replaces the `array` in the hook dependencies with a `string` representation (using `JSON.stringify()`), as shallow comparing of strings will not cause an infinite loop as they are "shallow equal".

The actual error shown in the console is:
> Uncaught Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.

Other possible alternatives are: 
- use the spread operator to add each array element as a dependency
- join the array values
- instead of using arrays, use comma separated values

All the options end up using a primitive type for the dependency, and using `JSON.stringify()` is the simplest approach, using `join()` would require to check that the array is not undefined, and using comma separated values would require changes in the filters components as well.

#### Testing instructions

1. Use the develop branch: `git checkout develop`
2. Run `npm run start`
3. Go to WP-Admin > Payments->Transactions.
4. Now filter the transactions using between the dates filter (and/or search for an order number and a customer name)
5. Observe that blank screen is displayed (and the above error is displayed in the console)

Switch to this branch:

1. Use the develop branch: `git checkout fix/1499-black-screen-when-filtering-transactions`
2. Run `npm run start`
3. Go to WP-Admin > Payments->Transactions.
4. Now filter the transactions using between the dates filter (and/or search for an order number and a customer name)
5. Observe that the transactions are correctly displayed.


-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
