### PR TITLE
Display a more helpful message on payment method missing errors

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Update - Tweak the connection detection logic.
 * Add - Notification badge next to payments menu.
 * Fix - Fixed broken search on transactions list page.
+* Add - More helpful message on checkout errors.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -566,6 +566,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$error_message = $e->getMessage();
 			if ( is_a( $e, Connection_Exception::class ) ) {
 				$error_message = __( 'There was an error while processing the payment. If you continue to see this notice, please contact the admin.', 'woocommerce-payments' );
+			} else if ( is_a( $e, API_Exception::class ) && 'wcpay_bad_request' === $e->get_error_code() ) {
+				$error_message = __( 'We\'re not able to process this payment. Please refresh the page and try again.', 'woocommerce-payments' );
 			}
 
 			wc_add_notice( $error_message, 'error' );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -566,7 +566,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$error_message = $e->getMessage();
 			if ( is_a( $e, Connection_Exception::class ) ) {
 				$error_message = __( 'There was an error while processing the payment. If you continue to see this notice, please contact the admin.', 'woocommerce-payments' );
-			} else if ( is_a( $e, API_Exception::class ) && 'wcpay_bad_request' === $e->get_error_code() ) {
+			} elseif ( is_a( $e, API_Exception::class ) && 'wcpay_bad_request' === $e->get_error_code() ) {
 				$error_message = __( 'We\'re not able to process this payment. Please refresh the page and try again.', 'woocommerce-payments' );
 			}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -564,9 +564,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		} catch ( Exception $e ) {
 			// TODO: Create more exceptions to handle merchant specific errors.
 			$error_message = $e->getMessage();
-			if ( is_a( $e, Connection_Exception::class ) ) {
+			if ( $e instanceof Connection_Exception ) {
 				$error_message = __( 'There was an error while processing the payment. If you continue to see this notice, please contact the admin.', 'woocommerce-payments' );
-			} elseif ( is_a( $e, API_Exception::class ) && 'wcpay_bad_request' === $e->get_error_code() ) {
+			} elseif ( $e instanceof API_Exception && 'wcpay_bad_request' === $e->get_error_code() ) {
 				$error_message = __( 'We\'re not able to process this payment. Please refresh the page and try again.', 'woocommerce-payments' );
 			}
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -175,7 +175,7 @@ class WC_Payments_API_Client {
 		$request['amount']         = $amount;
 		$request['currency']       = $currency_code;
 		$request['confirm']        = 'true';
-		$request['payment_method'] = 'pm_12345'; //$payment_method_id;
+		$request['payment_method'] = $payment_method_id;
 		$request['customer']       = $customer_id;
 		$request['capture_method'] = $manual_capture ? 'manual' : 'automatic';
 		$request['metadata']       = $metadata;

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -175,7 +175,7 @@ class WC_Payments_API_Client {
 		$request['amount']         = $amount;
 		$request['currency']       = $currency_code;
 		$request['confirm']        = 'true';
-		$request['payment_method'] = $payment_method_id;
+		$request['payment_method'] = 'pm_12345'; //$payment_method_id;
 		$request['customer']       = $customer_id;
 		$request['capture_method'] = $manual_capture ? 'manual' : 'automatic';
 		$request['metadata']       = $metadata;

--- a/readme.txt
+++ b/readme.txt
@@ -107,6 +107,7 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Tweak the connection detection logic.
 * Add - Notification badge next to payments menu.
 * Fix - Fixed broken search on transactions list page.
+* Add - More helpful message on checkout errors.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.


### PR DESCRIPTION
See 723-gh-Automattic/woocommerce-payments-server

#### Changes proposed in this Pull Request

- Catch bad request errors on checkout and advise the customer to refresh the page and try again
  - Refreshing should often help, not only with the test/live mode mismatch, but also with other errors

#### Testing instructions

* Checkout 723-gh-Automattic/woocommerce-payments-server
* Modify [line 178 in `class-wc-payments-api-client.php`](https://github.com/Automattic/woocommerce-payments/blob/7da72820c8517e290d3d9201800b537698d30b50/includes/wc-payment-api/class-wc-payments-api-client.php#L178) and hardcode the payment method to a non-existent ID, such as `pm_12345`
* Attempt to make a payment
* A friendly message should appear
* Open the failed order in wp-admin
* The note should contain the actual error message (missing payment method)

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->