### PR TITLE
Add/1444 new inbox msg qualitative feedback

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Add - WPCOM connection status event prop to 'wcpay_connect_account_clicked' track.
 * Add - Allow users to clear the account cache.
 * Update - Bump minimum supported version of WordPress from 5.3 to 5.4.
+* Add - Add a new admin note to collect qualitative feedback.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -581,6 +581,8 @@ class WC_Payments {
 	public static function add_woo_admin_notes() {
 		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
+			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-qualitative-feedback.php';
+			WC_Payments_Notes_Qualitative_Feedback::possibly_add_note();
 			WC_Payments_Notes_Set_Up_Refund_Policy::possibly_add_note();
 
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-https-for-checkout.php';
@@ -596,6 +598,8 @@ class WC_Payments {
 
 		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
+			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-qualitative-feedback.php';
+			WC_Payments_Notes_Qualitative_Feedback::possibly_delete_note();
 			WC_Payments_Notes_Set_Up_Refund_Policy::possibly_delete_note();
 
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-https-for-checkout.php';

--- a/includes/notes/class-wc-payments-notes-qualitative-feedback.php
+++ b/includes/notes/class-wc-payments-notes-qualitative-feedback.php
@@ -31,14 +31,14 @@ class WC_Payments_Notes_Qualitative_Feedback {
 	public static function get_note() {
 		global $wpdb;
 
-		// Store must be at least 60 days old
-		if( !self::wc_admin_active_for(60 * DAY_IN_SECONDS)) {
+		// Store must be at least 60 days old.
+		if ( ! self::wc_admin_active_for( 60 * DAY_IN_SECONDS ) ) {
 			return;
 		}
 
-		// We should have at least one transaction
-		$token_count = $wpdb->get_var("select count(*) from {$wpdb->prefix}woocommerce_payment_tokens");
-		if ($token_count === 0) {
+		// We should have at least one transaction.
+		$token_count = $wpdb->get_var( "select count(*) from {$wpdb->prefix}woocommerce_payment_tokens" );
+		if ( 0 === $token_count ) {
 			return;
 		}
 

--- a/includes/notes/class-wc-payments-notes-qualitative-feedback.php
+++ b/includes/notes/class-wc-payments-notes-qualitative-feedback.php
@@ -38,7 +38,7 @@ class WC_Payments_Notes_Qualitative_Feedback {
 
 		// We should have at least one transaction.
 		$token_count = $wpdb->get_var( "select count(*) from {$wpdb->prefix}woocommerce_payment_tokens" );
-		if ( 0 === $token_count ) {
+		if ( 0 === (int) $token_count ) {
 			return;
 		}
 

--- a/includes/notes/class-wc-payments-notes-qualitative-feedback.php
+++ b/includes/notes/class-wc-payments-notes-qualitative-feedback.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Set up refund policy note for WooCommerce inbox.
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WC_Payments_Notes_Set_Up_Refund_Policy
+ */
+class WC_Payments_Notes_Qualitative_Feedback {
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-payments-notes-qualitative-feedback';
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_DOCUMENTATION_URL = 'http://automattic.survey.fm/wc-pay-existing';
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		global $wpdb;
+
+		// Store must be at least 60 days old
+		if( !self::wc_admin_active_for(60 * DAY_IN_SECONDS)) {
+			return;
+		}
+
+		// We should have at least one transaction
+		$token_count = $wpdb->get_var("select count(*) from {$wpdb->prefix}woocommerce_payment_tokens");
+		if ($token_count === 0) {
+			return;
+		}
+
+		$note_class = WC_Payment_Woo_Compat_Utils::get_note_class();
+		$note       = new $note_class();
+
+		$note->set_title( __( 'Help us make improvements to WooCommerce Payments', 'woocommerce-payments' ) );
+		$note->set_content( __( 'Share your feedback in this 2 minute survey about how we can make the process of accepting payments more useful for your store.', 'woocommerce-payments' ) );
+		$note->set_content_data( (object) [] );
+		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-payments' );
+		$note->add_action(
+			self::NOTE_NAME,
+			__( 'Share feedback', 'woocommerce-payments' ),
+			self::NOTE_DOCUMENTATION_URL,
+			'unactioned',
+			true
+		);
+
+		return $note;
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - WPCOM connection status event prop to 'wcpay_connect_account_clicked' track.
 * Add - Allow users to clear the account cache.
 * Update - Bump minimum supported version of WordPress from 5.3 to 5.4.
+* Add - Add a new admin note to collect qualitative feedback.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.


### PR DESCRIPTION
Fixes #1444 

#### Changes proposed in this Pull Request

This PR adds a new admin note with a link to WC Payments survey to collect feedback from users who has a store older than 60+ days.

#### Testing instructions

1. Make your store 60+ days old by updating `woocommerce_admin_install_timestamp` option.
```
UPDATE `wp_options` SET `option_value`=UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 61 day)) WHERE `option_name` = 'woocommerce_admin_install_timestamp';
```

2. Turn WC Payments into dev mode by following [this guide](https://docs.woocommerce.com/document/payments/testing/dev-mode/) and finish WC Payments setup.
3. Make a test order and choose WC Payments as your payment option. This will create a new WC Payments transaction.
4. Navigate to WooCommerce -> Home
5. You should see a new note with the title "Help us make improvements to WooCommerce Payments"

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)