### PR TITLE
Allow users to clear the account cache

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Fix - Fixed broken search on transactions list page.
 * Add - More helpful message on checkout errors.
 * Update - Change the default track `recordEvent` to use @woocommerce/tracks.
+* Add - Allow users to clear the account cache.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -61,7 +61,7 @@ class WC_Payments_Account {
 		$tools['clear_wcpay_account_cache'] = [
 			'name'     => __( 'Clear WooCommerce Payments account cache', 'woocommerce-payments' ),
 			'button'   => __( 'Clear', 'woocommerce-payments' ),
-			'desc'     => __( 'This tool will empty the WooCommerce Payments account cache.', 'woocommerce-payments' ),
+			'desc'     => __( 'This tool will clear the account cached values used in WooCommerce Payments.', 'woocommerce-payments' ),
 			'callback' => [ $this, 'refresh_account_data' ],
 		];
 		return $tools;

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -42,6 +42,7 @@ class WC_Payments_Account {
 		add_action( 'admin_init', [ $this, 'maybe_redirect_to_onboarding' ], 11 ); // Run this after the WC setup wizard redirection logic.
 		add_filter( 'allowed_redirect_hosts', [ $this, 'allowed_redirect_hosts' ] );
 		add_action( 'jetpack_site_registered', [ $this, 'clear_cache' ] );
+		add_filter( 'woocommerce_debug_tools', [ $this, 'debug_tool' ] );
 	}
 
 	/**
@@ -49,6 +50,21 @@ class WC_Payments_Account {
 	 */
 	public function clear_cache() {
 		delete_transient( self::ACCOUNT_TRANSIENT );
+	}
+
+	/**
+	 * Add clear account cache tool to WooCommerce debug tools.
+	 *
+	 * @param array $tools List of current available tools.
+	 */
+	public function debug_tool( $tools ) {
+		$tools['clear_wcpay_account_cache'] = [
+			'name'     => __( 'Clear WooCommerce Payments account cache', 'woocommerce-payments' ),
+			'button'   => __( 'Clear', 'woocommerce-payments' ),
+			'desc'     => __( 'This tool will empty the WooCommerce Payments account cache.', 'woocommerce-payments' ),
+			'callback' => [ $this, 'refresh_account_data' ],
+		];
+		return $tools;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Fixed broken search on transactions list page.
 * Add - More helpful message on checkout errors.
 * Update - Change the default track `recordEvent` to use @woocommerce/tracks.
+* Add - Allow users to clear the account cache.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.


### PR DESCRIPTION
Fixes #537 

#### Changes proposed in this Pull Request

Used `woocommerce_debug_tools` hook to add a new tool to `WooCommerce > Status > Tools` that allow the users to clear the account cache.

Set `callback` to `refresh_account_data` instead of `clear_cache` to refetch the account after clearing cache, as commented in the issue.

<img width="740" src="https://user-images.githubusercontent.com/7670276/114363890-24761a80-9b79-11eb-909a-4fd5886e8c41.png" />


#### Testing instructions

- Access [`WooCommerce > Status > Tools`](http://localhost:8082/wp-admin/admin.php?page=wc-status&tab=tools).
- Scroll down and click **Clear**  button next to `Clear WooCommerce Payments account cache`.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)