### PR TITLE
Bump minimum WP version to 5.4

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           # Edge case: oldest dependencies compatibility
           - woocommerce: '4.0.0'
-            wordpress:   '5.3'
+            wordpress:   '5.4'
             php:         '7.0'
     env:
       WP_VERSION: ${{ matrix.wordpress }}

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Update - Change the default track `recordEvent` to use @woocommerce/tracks.
 * Add - WPCOM connection status event prop to 'wcpay_connect_account_clicked' track.
 * Add - Allow users to clear the account cache.
+* Update - Bump minimum supported version of WordPress from 5.3 to 5.4.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,7 +11,7 @@
 	<exclude-pattern>*\.(?!php$)</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="5.3" />
+	<config name="minimum_supported_wp_version" value="5.4" />
 	<config name="testVersion" value="7.0-" />
 
 	<!-- Rules -->

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Payments ===
 Contributors: woocommerce, automattic
 Tags: woocommerce, payment, payment request, credit card, automattic
-Requires at least: 5.3
+Requires at least: 5.4
 Tested up to: 5.7
 Requires PHP: 7.0
 Stable tag: 2.2.0
@@ -39,7 +39,7 @@ Our global support team is available to answer questions you may have about WooC
 = Requirements =
 
 * United States-based business.
-* WordPress 5.3 or newer.
+* WordPress 5.4 or newer.
 * WooCommerce 4.0 or newer.
 * PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
 
@@ -111,6 +111,7 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Change the default track `recordEvent` to use @woocommerce/tracks.
 * Add - WPCOM connection status event prop to 'wcpay_connect_account_clicked' track.
 * Add - Allow users to clear the account cache.
+* Update - Bump minimum supported version of WordPress from 5.3 to 5.4.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -9,7 +9,7 @@
  * Domain Path: /languages
  * WC requires at least: 4.0
  * WC tested up to: 5.1
- * Requires WP: 5.3
+ * Requires WP: 5.4
  * Version: 2.2.0
  *
  * @package WooCommerce\Payments


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Bump the minimum supported version of WordPress to 5.4.

#### Testing instructions
The only "code" changes are around our e2e test version matrix. So we can check those run as expected.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
