### PR TITLE
Display empty page for the new settings

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -18,11 +18,7 @@ redirect_output() {
 # https://hub.docker.com/_/wordpress#running-as-an-arbitrary-user
 cli()
 {
-	INTERACTIVE=''
-	if [ -t 1 ] ; then
-		INTERACTIVE='-it'
-	fi
-	redirect_output docker run $INTERACTIVE --env-file default.env --rm --user xfs --volumes-from $WP_CONTAINER --network container:$WP_CONTAINER wordpress:cli "$@"
+	redirect_output docker run -it --env-file default.env --rm --user xfs --volumes-from $WP_CONTAINER --network container:$WP_CONTAINER wordpress:cli "$@"
 }
 
 set +e

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -18,7 +18,11 @@ redirect_output() {
 # https://hub.docker.com/_/wordpress#running-as-an-arbitrary-user
 cli()
 {
-	redirect_output docker run -it --env-file default.env --rm --user xfs --volumes-from $WP_CONTAINER --network container:$WP_CONTAINER wordpress:cli "$@"
+	INTERACTIVE=''
+	if [ -t 1 ] ; then
+		INTERACTIVE='-it'
+	fi
+	redirect_output docker run $INTERACTIVE --env-file default.env --rm --user xfs --volumes-from $WP_CONTAINER --network container:$WP_CONTAINER wordpress:cli "$@"
 }
 
 set +e

--- a/client/settings/index.js
+++ b/client/settings/index.js
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 import AccountStatus from 'account-status';
 import AccountFees from 'account-fees';
 import enqueueFraudScripts from 'fraud-scripts';
+import SettingsManager from 'settings/settings-manager';
 
 const statusContainer = document.getElementById(
 	'wcpay-account-status-container'
@@ -56,6 +57,16 @@ authorization and order will be canceled. Are you sure you want to enable it?',
 window.addEventListener( 'load', () => {
 	enqueueFraudScripts( wcpayAdminSettings.fraudServices );
 } );
+
+const settingsContainer = document.getElementById(
+	'wcpay-account-settings-container'
+);
+if ( settingsContainer ) {
+	ReactDOM.render(
+		<SettingsManager { ...wcpayAdminSettings } />,
+		settingsContainer
+	);
+}
 
 // TODO: Remove this `if` ahead of releasing Apple Pay for all merchants.
 if ( wcpayAdminSettings.paymentRequestAvailable ) {

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -1,0 +1,5 @@
+const SettingsManager = () => {
+	return <div></div>;
+};
+
+export default SettingsManager;

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -454,7 +454,7 @@ class WC_Payments_Admin {
 	 *
 	 * @return bool
 	 */
-	private static function is_grouped_settings_enabled() {
+	public static function is_grouped_settings_enabled() {
 		return get_option( '_wcpay_feature_grouped_settings', '0' ) === '1';
 	}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -404,7 +404,29 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// Add notices to the WooCommerce Payments settings page.
 		do_action( 'woocommerce_woocommerce_payments_admin_notices' );
 
-		parent::admin_options();
+		if ( isset( $_GET['old_settings'] ) ) {
+			parent::admin_options();
+			return;
+		}
+
+		$this->output_payments_settings_screen();
+	}
+
+	/**
+	 * Generates markup for the settings screen.
+	 */
+	public function output_payments_settings_screen() {
+		// hiding the save button because the react container has its own.
+		global $hide_save_button;
+		$hide_save_button = true;
+
+		?>
+		<ul class="subsubsub">
+			<li><a href="<?php echo esc_html( self::get_settings_url() ); ?>" class="current"><?php echo esc_html( $this->get_method_title() ); ?></a></li>
+			<li>|</li>
+			<li><a href="<?php echo esc_html( admin_url( 'admin.php?page=wc-settings&tab=checkout' ) ); ?>"><?php echo esc_html( __( 'All payment methods', 'woocommerce-payments' ) ); ?></a></li>
+		</ul>
+		<?php
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -404,7 +404,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// Add notices to the WooCommerce Payments settings page.
 		do_action( 'woocommerce_woocommerce_payments_admin_notices' );
 
-		if ( isset( $_GET['old_settings'] ) ) {
+		if ( ! WC_Payments_Admin::is_grouped_settings_enabled() ) {
 			parent::admin_options();
 			return;
 		}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -426,6 +426,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			<li>|</li>
 			<li><a href="<?php echo esc_html( admin_url( 'admin.php?page=wc-settings&tab=checkout' ) ); ?>"><?php echo esc_html( __( 'All payment methods', 'woocommerce-payments' ) ); ?></a></li>
 		</ul>
+
+		<div id="wcpay-account-settings-container"></div>
 		<?php
 	}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ const webpackConfig = {
 	devtool: process.env.SOURCEMAP === 'none' ? undefined : 'source-map',
 	entry: {
 		index: './client/index.js',
-		settings: './client/settings.js',
+		settings: './client/settings/index.js',
 		'blocks-checkout': './client/checkout/blocks/index.js',
 		checkout: './client/checkout/classic/index.js',
 		'payment-request': './client/payment-request/index.js',


### PR DESCRIPTION
Fixes #1523 

#### Changes proposed in this Pull Request

##### Display the new settings screen.

After enabling the `_wcpay_feature_grouped_settings` feature flag, the (currently, empty) new grouped settings page is displayed instead of the old one. Also, adds an entry point for the new Javascript components that are being developed.

#### Testing instructions

1. Download the [dev tools](https://github.com/Automattic/woocommerce-payments-dev-tool). Follow the instructions in the readme to add it to your test site.
2. Enable the feature flag: `Enable grouped settings` and save the form.
3. The new settings screen should be displayed.
   ![shot-2021-04-12-18-24-41](https://user-images.githubusercontent.com/130142/114428362-63798f80-9bbc-11eb-9273-d7274b346441.png)
4. Disable the feature flag set in step 3.
5. The old settings screen should be displayed.
   ![shot-2021-04-12-18-23-37](https://user-images.githubusercontent.com/130142/114428272-43e26700-9bbc-11eb-9eba-0c859c7e8ae9.png)

*

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
