### PR TITLE
Fix order and subscription numbers on transaction list report

### DIFF
--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -223,7 +223,10 @@ export const TransactionsList = ( props ) => {
 					/>
 				),
 			},
-			order: { value: txn.order_id, display: orderUrl },
+			order: {
+				value: txn.order && txn.order.number,
+				display: orderUrl,
+			},
 			subscriptions: { value: txn.order_id, display: subscriptions },
 			// eslint-disable-next-line camelcase
 			customer_name: {

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -168,14 +168,20 @@ export const TransactionsList = ( props ) => {
 			<DetailsLink id={ txn.charge_id } parentSegment="transactions" />
 		);
 		const orderUrl = <OrderLink order={ txn.order } />;
+		const orderSubscriptions = txn.order && txn.order.subscriptions;
+		const subscriptionsValue =
+			wcpaySettings.isSubscriptionsActive && orderSubscriptions
+				? orderSubscriptions
+						.map( ( subscription ) => subscription.number )
+						.join( ', ' )
+				: '';
 		const subscriptions =
-			wcpaySettings.isSubscriptionsActive &&
-			txn.order &&
-			txn.order.subscriptions &&
-			txn.order.subscriptions.map( ( subscription, i, all ) => [
-				<OrderLink key={ i } order={ subscription } />,
-				i !== all.length - 1 && ', ',
-			] );
+			wcpaySettings.isSubscriptionsActive && orderSubscriptions
+				? orderSubscriptions.map( ( subscription, i, all ) => [
+						<OrderLink key={ i } order={ subscription } />,
+						i !== all.length - 1 && ', ',
+				  ] )
+				: [];
 		const riskLevel = <RiskLevel risk={ txn.risk_level } />;
 
 		const customerName = txn.order ? (
@@ -227,7 +233,10 @@ export const TransactionsList = ( props ) => {
 				value: txn.order && txn.order.number,
 				display: orderUrl,
 			},
-			subscriptions: { value: txn.order_id, display: subscriptions },
+			subscriptions: {
+				value: subscriptionsValue,
+				display: subscriptions,
+			},
 			// eslint-disable-next-line camelcase
 			customer_name: {
 				value: txn.customer_name,


### PR DESCRIPTION
Fixes #1548 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR fixes the order and subscription values when generating the transaction list, to fix the CSV download report.

I haven't added a changelog entry as this fix only impacts the transaction list download, which hasn't been shipped yet.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Submit 3 orders: one with a Simple product, one with a Subscriptions product, and another with two Subscription products that are charged on different days. Your transactions list should look like this:
![image](https://user-images.githubusercontent.com/7714042/114450858-e85cad00-9bac-11eb-8545-a2d7487eca33.png)
* Click on the "Download" button to export the data and assert that the order and subscription IDs have been exported correctly
* Disable the Subscriptions plugin and refresh the transactions list
    * Make sure the "Subscription #" column is not shown
    * Click on the "Download" button and assert that the order IDs have been exported correctly

Make sure the transaction list is rendered correctly and no console errors are thrown when rendering it.

*Missing order test:*

* Modify the `add_order_info_to_object` in `./includes/wc-payment-api/class-wc-payments-api-client.php:1119` to simulate an order not found response
* Reload the transactions list and assert that no errors show up in the console

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
