### PR TITLE
Allow to run `docker-setup.sh` in non-tty envs

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -18,7 +18,11 @@ redirect_output() {
 # https://hub.docker.com/_/wordpress#running-as-an-arbitrary-user
 cli()
 {
-	redirect_output docker run -it --env-file default.env --rm --user xfs --volumes-from $WP_CONTAINER --network container:$WP_CONTAINER wordpress:cli "$@"
+	INTERACTIVE=''
+	if [ -t 1 ] ; then
+		INTERACTIVE='-it'
+	fi
+	redirect_output docker run $INTERACTIVE --env-file default.env --rm --user xfs --volumes-from $WP_CONTAINER --network container:$WP_CONTAINER wordpress:cli "$@"
 }
 
 set +e


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `docker-setup.sh` script assumes is always run in an interactive
shell, so it's impossible to launch it from a daemon manager like systemd.

This PR just checks if the script is running in an interactive shell, and if it does, it adds the `-it` arguments to the `docker run` command.

#### Testing instructions

Just run the command `npm run up` in both an interactive and a non-interactive shell. When running it in a non-interactive shell, you shouldn't get the error:

``` shell
...
the input device is not a TTY
Waiting until the service is ready...
...
```

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)