### PR TITLE
Make Payment Request buttons available for merchants in all countries

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@
 * Update - Bump minimum supported version of WordPress from 5.3 to 5.4.
 * Add - Add a new admin note to collect qualitative feedback.
 * Add - Introduced deposit currency filter for deposits overview page.
+* Update - Make Payment Request Button available for all merchants.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.

--- a/client/settings/index.js
+++ b/client/settings/index.js
@@ -68,115 +68,112 @@ if ( settingsContainer ) {
 	);
 }
 
-// TODO: Remove this `if` ahead of releasing Apple Pay for all merchants.
-if ( wcpayAdminSettings.paymentRequestAvailable ) {
-	// Payment Request button settings migrated and adapted from Stripe gateway extension.
-	const findParent = ( el, selector ) => {
-		while (
-			( el = el.parentElement ) &&
-			! ( el.matches || el.matchesSelector ).call( el, selector )
-		);
-
-		return el;
-	};
-
-	const toggleDisplay = ( el, display ) => {
-		if ( el instanceof Element || el instanceof HTMLElement ) {
-			if ( display ) {
-				el.style.display = '';
-			} else {
-				el.style.display = 'none';
-			}
-		}
-	};
-
-	const paymentRequest = document.getElementById(
-		'woocommerce_woocommerce_payments_payment_request'
-	);
-	const paymentRequestButtonType = document.getElementById(
-		'woocommerce_woocommerce_payments_payment_request_button_type'
+// Payment Request button settings migrated and adapted from Stripe gateway extension.
+const findParent = ( el, selector ) => {
+	while (
+		( el = el.parentElement ) &&
+		! ( el.matches || el.matchesSelector ).call( el, selector )
 	);
 
-	// Payment Request button event listeners.
-	paymentRequest.addEventListener( 'change', () => {
-		const inputIds = [
-			'woocommerce_woocommerce_payments_payment_request_button_theme',
-			'woocommerce_woocommerce_payments_payment_request_button_type',
-			'woocommerce_woocommerce_payments_payment_request_button_height',
-		];
+	return el;
+};
 
-		if ( paymentRequest.checked ) {
-			inputIds.forEach( ( id ) => {
-				toggleDisplay(
-					findParent( document.getElementById( id ), 'tr' ),
-					true
-				);
-			} );
+const toggleDisplay = ( el, display ) => {
+	if ( el instanceof Element || el instanceof HTMLElement ) {
+		if ( display ) {
+			el.style.display = '';
 		} else {
-			inputIds.forEach( ( id ) => {
-				toggleDisplay(
-					findParent( document.getElementById( id ), 'tr' ),
-					false
-				);
-			} );
+			el.style.display = 'none';
 		}
+	}
+};
 
-		paymentRequestButtonType.dispatchEvent( new Event( 'change' ) );
-	} );
+const paymentRequest = document.getElementById(
+	'woocommerce_woocommerce_payments_payment_request'
+);
+const paymentRequestButtonType = document.getElementById(
+	'woocommerce_woocommerce_payments_payment_request_button_type'
+);
 
-	// Toggle Custom Payment Request configs.
-	paymentRequestButtonType.addEventListener( 'change', () => {
-		if (
-			'custom' === paymentRequestButtonType.value &&
-			paymentRequest.checked
-		) {
+// Payment Request button event listeners.
+paymentRequest.addEventListener( 'change', () => {
+	const inputIds = [
+		'woocommerce_woocommerce_payments_payment_request_button_theme',
+		'woocommerce_woocommerce_payments_payment_request_button_type',
+		'woocommerce_woocommerce_payments_payment_request_button_height',
+	];
+
+	if ( paymentRequest.checked ) {
+		inputIds.forEach( ( id ) => {
 			toggleDisplay(
-				findParent(
-					document.getElementById(
-						'woocommerce_woocommerce_payments_payment_request_button_label'
-					),
-					'tr'
-				),
+				findParent( document.getElementById( id ), 'tr' ),
 				true
 			);
-		} else {
+		} );
+	} else {
+		inputIds.forEach( ( id ) => {
 			toggleDisplay(
-				findParent(
-					document.getElementById(
-						'woocommerce_woocommerce_payments_payment_request_button_label'
-					),
-					'tr'
-				),
+				findParent( document.getElementById( id ), 'tr' ),
 				false
 			);
-		}
+		} );
+	}
 
-		if (
-			'branded' === paymentRequestButtonType.value &&
-			paymentRequest.checked
-		) {
-			toggleDisplay(
-				findParent(
-					document.getElementById(
-						'woocommerce_woocommerce_payments_payment_request_button_branded_type'
-					),
-					'tr'
-				),
-				true
-			);
-		} else {
-			toggleDisplay(
-				findParent(
-					document.getElementById(
-						'woocommerce_woocommerce_payments_payment_request_button_branded_type'
-					),
-					'tr'
-				),
-				false
-			);
-		}
-	} );
-
-	paymentRequest.dispatchEvent( new Event( 'change' ) );
 	paymentRequestButtonType.dispatchEvent( new Event( 'change' ) );
-}
+} );
+
+// Toggle Custom Payment Request configs.
+paymentRequestButtonType.addEventListener( 'change', () => {
+	if (
+		'custom' === paymentRequestButtonType.value &&
+		paymentRequest.checked
+	) {
+		toggleDisplay(
+			findParent(
+				document.getElementById(
+					'woocommerce_woocommerce_payments_payment_request_button_label'
+				),
+				'tr'
+			),
+			true
+		);
+	} else {
+		toggleDisplay(
+			findParent(
+				document.getElementById(
+					'woocommerce_woocommerce_payments_payment_request_button_label'
+				),
+				'tr'
+			),
+			false
+		);
+	}
+
+	if (
+		'branded' === paymentRequestButtonType.value &&
+		paymentRequest.checked
+	) {
+		toggleDisplay(
+			findParent(
+				document.getElementById(
+					'woocommerce_woocommerce_payments_payment_request_button_branded_type'
+				),
+				'tr'
+			),
+			true
+		);
+	} else {
+		toggleDisplay(
+			findParent(
+				document.getElementById(
+					'woocommerce_woocommerce_payments_payment_request_button_branded_type'
+				),
+				'tr'
+			),
+			false
+		);
+	}
+} );
+
+paymentRequest.dispatchEvent( new Event( 'change' ) );
+paymentRequestButtonType.dispatchEvent( new Event( 'change' ) );

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -303,11 +303,9 @@ class WC_Payments_Admin {
 			'WCPAY_ADMIN_SETTINGS',
 			'wcpayAdminSettings',
 			[
-				'accountStatus'           => $this->account->get_account_status_data(),
-				'accountFees'             => $this->account->get_fees(),
-				'fraudServices'           => $this->account->get_fraud_services_config(),
-				// TODO: Remove this line ahead of releasing Apple Pay for all merchants.
-				'paymentRequestAvailable' => WC_Payments::should_payment_request_be_available(),
+				'accountStatus' => $this->account->get_account_status_data(),
+				'accountFees'   => $this->account->get_fees(),
+				'fraudServices' => $this->account->get_fraud_services_config(),
 			]
 		);
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -120,23 +120,23 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// Define setting fields.
 		$this->form_fields = [
-			'enabled'                      => [
+			'enabled'                             => [
 				'title'       => __( 'Enable/disable', 'woocommerce-payments' ),
 				'label'       => __( 'Enable WooCommerce Payments', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
 				'description' => '',
 				'default'     => 'no',
 			],
-			'account_details'              => [
+			'account_details'                     => [
 				'type' => 'account_actions',
 			],
-			'account_status'               => [
+			'account_status'                      => [
 				'type' => 'account_status',
 			],
-			'account_fees'                 => [
+			'account_fees'                        => [
 				'type' => 'account_fees',
 			],
-			'account_statement_descriptor' => [
+			'account_statement_descriptor'        => [
 				'type'        => 'account_statement_descriptor',
 				'title'       => __( 'Customer bank statement', 'woocommerce-payments' ),
 				'description' => WC_Payments_Utils::esc_interpolated_html(
@@ -144,14 +144,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					[ 'a' => '<a href="https://docs.woocommerce.com/document/payments/bank-statement-descriptor/" target="_blank" rel="noopener noreferrer">' ]
 				),
 			],
-			'manual_capture'               => [
+			'manual_capture'                      => [
 				'title'       => __( 'Manual capture', 'woocommerce-payments' ),
 				'label'       => __( 'Issue an authorization on checkout, and capture later.', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
 				'description' => __( 'Charge must be captured within 7 days of authorization, otherwise the authorization and order will be canceled.', 'woocommerce-payments' ),
 				'default'     => 'no',
 			],
-			'saved_cards'                  => [
+			'saved_cards'                         => [
 				'title'       => __( 'Saved Cards', 'woocommerce-payments' ),
 				'label'       => __( 'Enable Payment via Saved Cards', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
@@ -159,7 +159,77 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'default'     => 'yes',
 				'desc_tip'    => true,
 			],
-			'test_mode'                    => [
+			'payment_request'                     => [
+				'title'       => __( 'Payment Request Button', 'woocommerce-payments' ),
+				'label'       => sprintf(
+					/* translators: 1) br tag 2) Stripe anchor tag 3) Apple anchor tag */
+					__( 'Enable Payment Request Button (Apple Pay, Google Pay, and more). %1$sBy using Apple Pay, you agree to %2$s and %3$s\'s terms of service.', 'woocommerce-payments' ),
+					'<br />',
+					'<a href="https://stripe.com/apple-pay/legal" target="_blank">Stripe</a>',
+					'<a href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/" target="_blank">Apple</a>'
+				),
+				'type'        => 'checkbox',
+				'description' => __( 'If enabled, users will be able to pay using Apple Pay or Chrome Payment Request if supported by the browser.', 'woocommerce-payments' ),
+				'default'     => empty( get_option( 'woocommerce_woocommerce_payments_settings' ) ) ? 'yes' : 'no', // Enable by default for new installations only.
+				'desc_tip'    => true,
+			],
+			'payment_request_button_type'         => [
+				'title'       => __( 'Payment Request Button Type', 'woocommerce-payments' ),
+				'label'       => __( 'Button Type', 'woocommerce-payments' ),
+				'type'        => 'select',
+				'description' => __( 'Select the button type you would like to show.', 'woocommerce-payments' ),
+				'default'     => 'buy',
+				'desc_tip'    => true,
+				'options'     => [
+					'default' => __( 'Default', 'woocommerce-payments' ),
+					'buy'     => __( 'Buy', 'woocommerce-payments' ),
+					'donate'  => __( 'Donate', 'woocommerce-payments' ),
+					'branded' => __( 'Branded', 'woocommerce-payments' ),
+					'custom'  => __( 'Custom', 'woocommerce-payments' ),
+				],
+			],
+			'payment_request_button_theme'        => [
+				'title'       => __( 'Payment Request Button Theme', 'woocommerce-payments' ),
+				'label'       => __( 'Button Theme', 'woocommerce-payments' ),
+				'type'        => 'select',
+				'description' => __( 'Select the button theme you would like to show.', 'woocommerce-payments' ),
+				'default'     => 'dark',
+				'desc_tip'    => true,
+				'options'     => [
+					'dark'          => __( 'Dark', 'woocommerce-payments' ),
+					'light'         => __( 'Light', 'woocommerce-payments' ),
+					'light-outline' => __( 'Light-Outline', 'woocommerce-payments' ),
+				],
+			],
+			'payment_request_button_height'       => [
+				'title'       => __( 'Payment Request Button Height', 'woocommerce-payments' ),
+				'label'       => __( 'Button Height', 'woocommerce-payments' ),
+				'type'        => 'text',
+				'description' => __( 'Enter the height you would like the button to be in pixels. Width will always be 100%.', 'woocommerce-payments' ),
+				'default'     => '44',
+				'desc_tip'    => true,
+			],
+			'payment_request_button_label'        => [
+				'title'       => __( 'Payment Request Button Label', 'woocommerce-payments' ),
+				'label'       => __( 'Button Label', 'woocommerce-payments' ),
+				'type'        => 'text',
+				'description' => __( 'Enter the custom text you would like the button to have.', 'woocommerce-payments' ),
+				'default'     => __( 'Buy now', 'woocommerce-payments' ),
+				'desc_tip'    => true,
+			],
+			'payment_request_button_branded_type' => [
+				'title'       => __( 'Payment Request Branded Button Label Format', 'woocommerce-payments' ),
+				'label'       => __( 'Branded Button Label Format', 'woocommerce-payments' ),
+				'type'        => 'select',
+				'description' => __( 'Select the branded button label format.', 'woocommerce-payments' ),
+				'default'     => 'long',
+				'desc_tip'    => true,
+				'options'     => [
+					'short' => __( 'Logo only', 'woocommerce-payments' ),
+					'long'  => __( 'Text and logo', 'woocommerce-payments' ),
+				],
+			],
+			'test_mode'                           => [
 				'title'       => __( 'Test mode', 'woocommerce-payments' ),
 				'label'       => __( 'Enable test mode', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
@@ -167,7 +237,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'default'     => 'no',
 				'desc_tip'    => true,
 			],
-			'enable_logging'               => [
+			'enable_logging'                      => [
 				'title'       => __( 'Debug log', 'woocommerce-payments' ),
 				'label'       => __( 'When enabled debug notes will be added to the log.', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
@@ -195,9 +265,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$this->supports = array_merge( $this->supports, [ 'tokenization', 'add_payment_method' ] );
 		}
 
-		// Add Payment Request form fields after WC initialization.
-		add_filter( 'init', [ $this, 'add_payment_request_form_fields' ] );
-
 		add_filter( 'woocommerce_settings_api_sanitized_fields_' . $this->id, [ $this, 'sanitize_plugin_settings' ] );
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
 		add_action( 'admin_notices', [ $this, 'display_errors' ], 9999 );
@@ -217,94 +284,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// Update the current request logged_in cookie after a guest user is created to avoid nonce inconsistencies.
 		add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
-	}
-
-	/**
-	 * Add Payment Request form fields.
-	 */
-	public function add_payment_request_form_fields() {
-		// TODO: Remove this check and inject contents of `$payment_request_fields` into `$this->form_fields`
-		// after `saved_cards` ahead of releasing Apple Pay for all merchants.
-		if ( WC_Payments::should_payment_request_be_available() ) {
-			$payment_request_fields = [
-				'payment_request'                     => [
-					'title'       => __( 'Payment Request Button', 'woocommerce-payments' ),
-					'label'       => sprintf(
-						/* translators: 1) br tag 2) Stripe anchor tag 3) Apple anchor tag */
-						__( 'Enable Payment Request Button (Apple Pay, Google Pay, and more). %1$sBy using Apple Pay, you agree to %2$s and %3$s\'s terms of service.', 'woocommerce-payments' ),
-						'<br />',
-						'<a href="https://stripe.com/apple-pay/legal" target="_blank">Stripe</a>',
-						'<a href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/" target="_blank">Apple</a>'
-					),
-					'type'        => 'checkbox',
-					'description' => __( 'If enabled, users will be able to pay using Apple Pay or Chrome Payment Request if supported by the browser.', 'woocommerce-payments' ),
-					'default'     => empty( get_option( 'woocommerce_woocommerce_payments_settings' ) ) ? 'yes' : 'no', // Enable by default for new installations only.
-					'desc_tip'    => true,
-				],
-				'payment_request_button_type'         => [
-					'title'       => __( 'Payment Request Button Type', 'woocommerce-payments' ),
-					'label'       => __( 'Button Type', 'woocommerce-payments' ),
-					'type'        => 'select',
-					'description' => __( 'Select the button type you would like to show.', 'woocommerce-payments' ),
-					'default'     => 'buy',
-					'desc_tip'    => true,
-					'options'     => [
-						'default' => __( 'Default', 'woocommerce-payments' ),
-						'buy'     => __( 'Buy', 'woocommerce-payments' ),
-						'donate'  => __( 'Donate', 'woocommerce-payments' ),
-						'branded' => __( 'Branded', 'woocommerce-payments' ),
-						'custom'  => __( 'Custom', 'woocommerce-payments' ),
-					],
-				],
-				'payment_request_button_theme'        => [
-					'title'       => __( 'Payment Request Button Theme', 'woocommerce-payments' ),
-					'label'       => __( 'Button Theme', 'woocommerce-payments' ),
-					'type'        => 'select',
-					'description' => __( 'Select the button theme you would like to show.', 'woocommerce-payments' ),
-					'default'     => 'dark',
-					'desc_tip'    => true,
-					'options'     => [
-						'dark'          => __( 'Dark', 'woocommerce-payments' ),
-						'light'         => __( 'Light', 'woocommerce-payments' ),
-						'light-outline' => __( 'Light-Outline', 'woocommerce-payments' ),
-					],
-				],
-				'payment_request_button_height'       => [
-					'title'       => __( 'Payment Request Button Height', 'woocommerce-payments' ),
-					'label'       => __( 'Button Height', 'woocommerce-payments' ),
-					'type'        => 'text',
-					'description' => __( 'Enter the height you would like the button to be in pixels. Width will always be 100%.', 'woocommerce-payments' ),
-					'default'     => '44',
-					'desc_tip'    => true,
-				],
-				'payment_request_button_label'        => [
-					'title'       => __( 'Payment Request Button Label', 'woocommerce-payments' ),
-					'label'       => __( 'Button Label', 'woocommerce-payments' ),
-					'type'        => 'text',
-					'description' => __( 'Enter the custom text you would like the button to have.', 'woocommerce-payments' ),
-					'default'     => __( 'Buy now', 'woocommerce-payments' ),
-					'desc_tip'    => true,
-				],
-				'payment_request_button_branded_type' => [
-					'title'       => __( 'Payment Request Branded Button Label Format', 'woocommerce-payments' ),
-					'label'       => __( 'Branded Button Label Format', 'woocommerce-payments' ),
-					'type'        => 'select',
-					'description' => __( 'Select the branded button label format.', 'woocommerce-payments' ),
-					'default'     => 'long',
-					'desc_tip'    => true,
-					'options'     => [
-						'short' => __( 'Logo only', 'woocommerce-payments' ),
-						'long'  => __( 'Text and logo', 'woocommerce-payments' ),
-					],
-				],
-			];
-			// Where to inject fields.
-			$fields_index = 7;
-			// Inject in the middle of `$this->form_fields`.
-			$this->form_fields = array_slice( $this->form_fields, 0, $fields_index ) +
-				$payment_request_fields +
-				array_slice( $this->form_fields, $fields_index, count( $this->form_fields ) - 1 );
-		}
 	}
 
 	/**

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -79,11 +79,6 @@ class WC_Payments_Apple_Pay_Registration {
 	 * @return  void
 	 */
 	public function init() {
-		// TODO: Remove this ahead releasing Apple Pay for all merchants.
-		if ( ! WC_Payments::should_payment_request_be_available() ) {
-			return;
-		}
-
 		$this->gateway = WC_Payments::get_gateway();
 		$this->add_domain_association_rewrite_rule();
 

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -50,11 +50,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 * @return  void
 	 */
 	public function init() {
-		// TODO: Remove this ahead releasing Apple Pay for all merchants.
-		if ( ! WC_Payments::should_payment_request_be_available() ) {
-			return;
-		}
-
 		$this->gateway = WC_Payments::get_gateway();
 
 		// Checks if WCPay is enabled.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -201,14 +201,6 @@ class WC_Payments {
 	}
 
 	/**
-	 * Checks whether Payment Request Button feature should be available.
-	 * TODO: Remove this ahead of releasing Apple Pay for all merchants.
-	 */
-	public static function should_payment_request_be_available() {
-		return 'US' === WC()->countries->get_base_country();
-	}
-
-	/**
 	 * Prints the given message in an "admin notice" wrapper with "error" class.
 	 *
 	 * @param string $message Message to print. Can contain HTML.

--- a/readme.txt
+++ b/readme.txt
@@ -114,6 +114,7 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Bump minimum supported version of WordPress from 5.3 to 5.4.
 * Add - Add a new admin note to collect qualitative feedback.
 * Add - Introduced deposit currency filter for deposits overview page.
+* Update - Make Payment Request Button available for all merchants.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.


### PR DESCRIPTION
Fixes #1562

#### Changes proposed in this Pull Request

- Remove feature flag for US based merchants.

#### Testing instructions

- Run `npm run build:client`.
- Change your country to anything other than United States in WooCommerce > Settings.
- Notice Payment Request Button settings are available in Payments > Settings.
- Enable it.
- Notice the Payment Request button is visible in a product page.

Note: Stripe has a limited list of supported countries, and might not work in certain countries. Right now it supports: "AE, AT, AU, BE, BG, BR, CA, CH, CI, CR, CY, CZ, DE, DK, DO, EE, ES, FI, FR, GB, GI, GR, GT, HK, HU, ID, IE, IN, IT, JP, LI, LT, LU, LV, MT, MX, MY, NL, NO, NZ, PE, PH, PL, PT, RO, SE, SG, SI, SK, SN, TH, TT, US, UY."

This list is not really controlled by us and it might change if Stripe adds support for a new country.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
