### PR TITLE
CI: new build environment for E2E tests - lowest supported deps

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -27,6 +27,11 @@ jobs:
         woocommerce: [ '4.0.0', '4.5.0', 'beta' ]
         wordpress:   [ 'latest' ]
         php:         [ '7.4' ]
+        include:
+          # Edge case: oldest dependencies compatibility
+          - woocommerce: '4.0.0'
+            wordpress:   '5.4'
+            php:         '7.0'
     env:
       WP_VERSION: ${{ matrix.wordpress }}
       WC_VERSION: ${{ matrix.woocommerce }}


### PR DESCRIPTION
Fixes #1550

#### Changes proposed in this Pull Request

- Adds new build environment for E2E tests - lowest supported deps

#### Testing instructions

* All check should be green

PS: WP version is as per https://github.com/Automattic/woocommerce-payments/pull/1549

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in the description ☝️)
- [ ] Tested on mobile (or does not apply)


