### PR TITLE
Added doc url and updated content for instant deposits eligibility note

### DIFF
--- a/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
+++ b/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
@@ -29,13 +29,12 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 	 * Get the note.
 	 */
 	public static function get_note() {
-		$note_class = WC_Payment_Woo_Compat_Utils::get_note_class();
-		$note       = new $note_class();
-		$content    = __( 'You are now eligible for Instant Deposits! Skip the wait and get paid instantly.', 'woocommerce-payments' );
+		$note_class   = WC_Payment_Woo_Compat_Utils::get_note_class();
+		$note         = new $note_class();
+		$note_content = __( 'You are now eligible for Instant Deposits! Skip the wait and get paid instantly.', 'woocommerce-payments' );
 
-		// TODO: get the proper title and message.
 		$note->set_title( __( 'Instant deposits available', 'woocommerce-payments' ) );
-		$note->set_content( $content );
+		$note->set_content( $note_content );
 		$note->set_content_data( (object) [] );
 		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );

--- a/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
+++ b/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
@@ -31,10 +31,9 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 	public static function get_note() {
 		$note_class   = WC_Payment_Woo_Compat_Utils::get_note_class();
 		$note         = new $note_class();
-		$note_content = __( 'You are now eligible for Instant Deposits! Skip the wait and get paid instantly.', 'woocommerce-payments' );
 
 		$note->set_title( __( 'Instant deposits available', 'woocommerce-payments' ) );
-		$note->set_content( $note_content );
+		$note->set_content( __( 'You are now eligible for Instant Deposits! Skip the wait and get paid instantly.', 'woocommerce-payments' ) );
 		$note->set_content_data( (object) [] );
 		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );

--- a/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
+++ b/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
@@ -29,8 +29,8 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 	 * Get the note.
 	 */
 	public static function get_note() {
-		$note_class   = WC_Payment_Woo_Compat_Utils::get_note_class();
-		$note         = new $note_class();
+		$note_class = WC_Payment_Woo_Compat_Utils::get_note_class();
+		$note       = new $note_class();
 
 		$note->set_title( __( 'Instant deposits available', 'woocommerce-payments' ) );
 		$note->set_content( __( 'You are now eligible for Instant Deposits! Skip the wait and get paid instantly.', 'woocommerce-payments' ) );

--- a/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
+++ b/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
@@ -23,8 +23,7 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 	/**
 	 * Name of the note for use in the database.
 	 */
-	// TODO: Get the proper doc url.
-	const NOTE_DOCUMENTATION_URL = '';
+	const NOTE_DOCUMENTATION_URL = 'https://docs.woocommerce.com/document/payments/';
 
 	/**
 	 * Get the note.
@@ -32,10 +31,11 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 	public static function get_note() {
 		$note_class = WC_Payment_Woo_Compat_Utils::get_note_class();
 		$note       = new $note_class();
+		$content    = __( 'You are now eligible for Instant Deposits! Skip the wait and get paid instantly.', 'woocommerce-payments' );
 
 		// TODO: get the proper title and message.
 		$note->set_title( __( 'Instant deposits available', 'woocommerce-payments' ) );
-		$note->set_content( __( 'You are now eligible for Instant Deposits!', 'woocommerce-payments' ) );
+		$note->set_content( $content );
 		$note->set_content_data( (object) [] );
 		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );


### PR DESCRIPTION
Fixes #1142

#### Changes proposed in this Pull Request

* Just url and text content changes.

#### Testing instructions

1. You will need to use a server branch that has instant deposits available, the branch in 648-gh-Automattic/woocommerce-payments-server is the best to use, unless it has been merged.
2. All test accounts _should_ be instant deposit eligible.
3. You may need to _Delete all WCPay inbox notes_ and then _Account cache contents (clear)_ with WCPay Dev tools.
4. View any admin page that has the WC Admin bar at the top with the Inbox.
5. Open the inbox and view the notification.
6. Verify the _Read more_ button/link goes to https://docs.woocommerce.com/document/payments/
7. Verify there is a scheduled action created under WooCommerce > Status > Scheduled Actions > Pending with the hook `wcpay_instant_deposit_reminder` with a scheduled date 90 days into the future. 

![Screenshot on 2021-04-14 at 11-37-31](https://user-images.githubusercontent.com/4634416/114728861-dc402f00-9d15-11eb-9dc2-0e3f611c18a7.png)


-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
