### PR TITLE
Package.json: add script to start and stop jurassic tube

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,6 @@ You will need a externally accessible URL to set up the plugin. You can use ngro
 
 ```ngrok http 8082```
 
-Alternatively you can use [Jurassic-tube](https://fieldguide.automattic.com/jurassic-tube/) developed internally for a permanent url. (works with only docker setup)
-
-```npm run setup:jurassic-tube```
-
-```npm run start:jurassic-tube```
-
-To stop
-
-```npm run stop:jurassic-tube```
-
 See: https://github.com/Automattic/woocommerce-payments/blob/trunk/CONTRIBUTING.md (possibly move contents here for visibility sake)
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -21,10 +21,23 @@ https://github.com/Automattic/woocommerce-payments/blob/trunk/docker/README.md
 
 Install the following plugins:
 - WooCommerce
+## Test account setup
 
 For setting up a test account follow [these instructions](https://docs.woocommerce.com/document/payments/testing/dev-mode/).
 
 You will need a externally accessible URL to set up the plugin. You can use ngrok for this.
+
+```ngrok http 8082```
+
+Alternatively you can use [Jurassic-tube](https://fieldguide.automattic.com/jurassic-tube/) developed internally for a permanent url. (works with only docker setup)
+
+```npm run setup:jurassic-tube```
+
+```npm run start:jurassic-tube```
+
+To stop
+
+```npm run stop:jurassic-tube```
 
 See: https://github.com/Automattic/woocommerce-payments/blob/trunk/CONTRIBUTING.md (possibly move contents here for visibility sake)
 

--- a/bin/jurassic-tube-setup.sh
+++ b/bin/jurassic-tube-setup.sh
@@ -43,8 +43,8 @@ echo
 ${PWD}/docker/bin/jt/config.sh username ${username}
 ${PWD}/docker/bin/jt/config.sh subdomain ${subdomain}
 
-echo "Setup complete!" 
-echo "Use the command: docker/bin/jt/tunnel.sh from the root directory of your WC Payments project to start running Jurassic Tube."
+echo "Setup complete!"
+echo "Use the command: npm run start:jurassic-tube from the root directory of your WC Payments project to start running Jurassic Tube."
 echo 
 
 

--- a/bin/jurassic-tube-setup.sh
+++ b/bin/jurassic-tube-setup.sh
@@ -44,7 +44,5 @@ ${PWD}/docker/bin/jt/config.sh username ${username}
 ${PWD}/docker/bin/jt/config.sh subdomain ${subdomain}
 
 echo "Setup complete!"
-echo "Use the command: npm run start:jurassic-tube from the root directory of your WC Payments project to start running Jurassic Tube."
+echo "Use the command: npm run tube:start from the root directory of your WC Payments project to start running Jurassic Tube."
 echo 
-
-

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "format:js": "npm run format:provided '**/*.js' '**/*.ts' '**/*.tsx'",
     "format:css": "npm run format:provided '**/*.scss' '**/*.css'",
     "format:provided": "prettier --write",
-    "setup:jurassic-tube": "./bin/jurassic-tube-setup.sh",
-    "start:jurassic-tube": "./docker/bin/jt/tunnel.sh",
-    "stop:jurassic-tube": "./docker/bin/jt/tunnel.sh break"
+    "tube:setup": "./bin/jurassic-tube-setup.sh",
+    "tube:start": "./docker/bin/jt/tunnel.sh",
+    "tube:stop": "./docker/bin/jt/tunnel.sh break"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "format:js": "npm run format:provided '**/*.js' '**/*.ts' '**/*.tsx'",
     "format:css": "npm run format:provided '**/*.scss' '**/*.css'",
     "format:provided": "prettier --write",
-    "setup:jurassic-tube": "./bin/jurassic-tube-setup.sh"
+    "setup:jurassic-tube": "./bin/jurassic-tube-setup.sh",
+    "start:jurassic-tube": "./docker/bin/jt/tunnel.sh",
+    "stop:jurassic-tube": "./docker/bin/jt/tunnel.sh break"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Fixes #1221 

#### Changes proposed in this Pull Request
- Added script to start and stop jurassic tube in Package.json
- Made changes in the readme file on how to setup and start jurassic tube.

#### Testing instructions

* `git checkout add/jurassic-start-stop`
* Run the commands `npm run tube:start` && `npm run tube:stop`
* Commands should start and stop the tunnel connection.