### PR TITLE
Configurable payment request button locations

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Add - Add a new admin note to collect qualitative feedback.
 * Add - Introduced deposit currency filter for deposits overview page.
 * Update - Make Payment Request Button available for all merchants.
+* Add - Configurable Payment Request Button locations.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.

--- a/client/settings/index.js
+++ b/client/settings/index.js
@@ -101,6 +101,7 @@ paymentRequest.addEventListener( 'change', () => {
 		'woocommerce_woocommerce_payments_payment_request_button_theme',
 		'woocommerce_woocommerce_payments_payment_request_button_type',
 		'woocommerce_woocommerce_payments_payment_request_button_height',
+		'woocommerce_woocommerce_payments_payment_request_button_locations',
 	];
 
 	if ( paymentRequest.checked ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -159,76 +159,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'default'     => 'yes',
 				'desc_tip'    => true,
 			],
-			'payment_request'                     => [
-				'title'       => __( 'Payment Request Button', 'woocommerce-payments' ),
-				'label'       => sprintf(
-					/* translators: 1) br tag 2) Stripe anchor tag 3) Apple anchor tag */
-					__( 'Enable Payment Request Button (Apple Pay, Google Pay, and more). %1$sBy using Apple Pay, you agree to %2$s and %3$s\'s terms of service.', 'woocommerce-payments' ),
-					'<br />',
-					'<a href="https://stripe.com/apple-pay/legal" target="_blank">Stripe</a>',
-					'<a href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/" target="_blank">Apple</a>'
-				),
-				'type'        => 'checkbox',
-				'description' => __( 'If enabled, users will be able to pay using Apple Pay or Chrome Payment Request if supported by the browser.', 'woocommerce-payments' ),
-				'default'     => empty( get_option( 'woocommerce_woocommerce_payments_settings' ) ) ? 'yes' : 'no', // Enable by default for new installations only.
-				'desc_tip'    => true,
-			],
-			'payment_request_button_type'         => [
-				'title'       => __( 'Payment Request Button Type', 'woocommerce-payments' ),
-				'label'       => __( 'Button Type', 'woocommerce-payments' ),
-				'type'        => 'select',
-				'description' => __( 'Select the button type you would like to show.', 'woocommerce-payments' ),
-				'default'     => 'buy',
-				'desc_tip'    => true,
-				'options'     => [
-					'default' => __( 'Default', 'woocommerce-payments' ),
-					'buy'     => __( 'Buy', 'woocommerce-payments' ),
-					'donate'  => __( 'Donate', 'woocommerce-payments' ),
-					'branded' => __( 'Branded', 'woocommerce-payments' ),
-					'custom'  => __( 'Custom', 'woocommerce-payments' ),
-				],
-			],
-			'payment_request_button_theme'        => [
-				'title'       => __( 'Payment Request Button Theme', 'woocommerce-payments' ),
-				'label'       => __( 'Button Theme', 'woocommerce-payments' ),
-				'type'        => 'select',
-				'description' => __( 'Select the button theme you would like to show.', 'woocommerce-payments' ),
-				'default'     => 'dark',
-				'desc_tip'    => true,
-				'options'     => [
-					'dark'          => __( 'Dark', 'woocommerce-payments' ),
-					'light'         => __( 'Light', 'woocommerce-payments' ),
-					'light-outline' => __( 'Light-Outline', 'woocommerce-payments' ),
-				],
-			],
-			'payment_request_button_height'       => [
-				'title'       => __( 'Payment Request Button Height', 'woocommerce-payments' ),
-				'label'       => __( 'Button Height', 'woocommerce-payments' ),
-				'type'        => 'text',
-				'description' => __( 'Enter the height you would like the button to be in pixels. Width will always be 100%.', 'woocommerce-payments' ),
-				'default'     => '44',
-				'desc_tip'    => true,
-			],
-			'payment_request_button_label'        => [
-				'title'       => __( 'Payment Request Button Label', 'woocommerce-payments' ),
-				'label'       => __( 'Button Label', 'woocommerce-payments' ),
-				'type'        => 'text',
-				'description' => __( 'Enter the custom text you would like the button to have.', 'woocommerce-payments' ),
-				'default'     => __( 'Buy now', 'woocommerce-payments' ),
-				'desc_tip'    => true,
-			],
-			'payment_request_button_branded_type' => [
-				'title'       => __( 'Payment Request Branded Button Label Format', 'woocommerce-payments' ),
-				'label'       => __( 'Branded Button Label Format', 'woocommerce-payments' ),
-				'type'        => 'select',
-				'description' => __( 'Select the branded button label format.', 'woocommerce-payments' ),
-				'default'     => 'long',
-				'desc_tip'    => true,
-				'options'     => [
-					'short' => __( 'Logo only', 'woocommerce-payments' ),
-					'long'  => __( 'Text and logo', 'woocommerce-payments' ),
-				],
-			],
 			'test_mode'                           => [
 				'title'       => __( 'Test mode', 'woocommerce-payments' ),
 				'label'       => __( 'Enable test mode', 'woocommerce-payments' ),
@@ -243,6 +173,95 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'type'        => 'checkbox',
 				'description' => '',
 				'default'     => 'no',
+			],
+			'payment_request_details'             => [
+				'title'       => __( 'Payment request buttons', 'woocommerce-payments' ),
+				'type'        => 'title',
+				'description' => '',
+			],
+			'payment_request'                     => [
+				'title'       => __( 'Enable/disable', 'woocommerce-payments' ),
+				'label'       => sprintf(
+					/* translators: 1) br tag 2) Stripe anchor tag 3) Apple anchor tag */
+					__( 'Enable payment request buttons (Apple Pay, Google Pay, and more). %1$sBy using Apple Pay, you agree to %2$s and %3$s\'s terms of service.', 'woocommerce-payments' ),
+					'<br />',
+					'<a href="https://stripe.com/apple-pay/legal" target="_blank">Stripe</a>',
+					'<a href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/" target="_blank">Apple</a>'
+				),
+				'type'        => 'checkbox',
+				'description' => __( 'If enabled, users will be able to pay using Apple Pay or Chrome Payment Request if supported by the browser.', 'woocommerce-payments' ),
+				'default'     => empty( get_option( 'woocommerce_woocommerce_payments_settings' ) ) ? 'yes' : 'no', // Enable by default for new installations only.
+				'desc_tip'    => true,
+			],
+			'payment_request_button_type'         => [
+				'title'       => __( 'Button type', 'woocommerce-payments' ),
+				'type'        => 'select',
+				'description' => __( 'Select the button type you would like to show.', 'woocommerce-payments' ),
+				'default'     => 'buy',
+				'desc_tip'    => true,
+				'options'     => [
+					'default' => __( 'Default', 'woocommerce-payments' ),
+					'buy'     => __( 'Buy', 'woocommerce-payments' ),
+					'donate'  => __( 'Donate', 'woocommerce-payments' ),
+					'branded' => __( 'Branded', 'woocommerce-payments' ),
+					'custom'  => __( 'Custom', 'woocommerce-payments' ),
+				],
+			],
+			'payment_request_button_theme'        => [
+				'title'       => __( 'Button theme', 'woocommerce-payments' ),
+				'type'        => 'select',
+				'description' => __( 'Select the button theme you would like to show.', 'woocommerce-payments' ),
+				'default'     => 'dark',
+				'desc_tip'    => true,
+				'options'     => [
+					'dark'          => __( 'Dark', 'woocommerce-payments' ),
+					'light'         => __( 'Light', 'woocommerce-payments' ),
+					'light-outline' => __( 'Light-Outline', 'woocommerce-payments' ),
+				],
+			],
+			'payment_request_button_height'       => [
+				'title'       => __( 'Button height', 'woocommerce-payments' ),
+				'type'        => 'text',
+				'description' => __( 'Enter the height you would like the button to be in pixels. Width will always be 100%.', 'woocommerce-payments' ),
+				'default'     => '44',
+				'desc_tip'    => true,
+			],
+			'payment_request_button_label'        => [
+				'title'       => __( 'Custom button label', 'woocommerce-payments' ),
+				'type'        => 'text',
+				'description' => __( 'Enter the custom text you would like the button to have.', 'woocommerce-payments' ),
+				'default'     => __( 'Buy now', 'woocommerce-payments' ),
+				'desc_tip'    => true,
+			],
+			'payment_request_button_branded_type' => [
+				'title'       => __( 'Branded button format', 'woocommerce-payments' ),
+				'type'        => 'select',
+				'description' => __( 'Select the branded button label format.', 'woocommerce-payments' ),
+				'default'     => 'long',
+				'desc_tip'    => true,
+				'options'     => [
+					'short' => __( 'Logo only', 'woocommerce-payments' ),
+					'long'  => __( 'Text and logo', 'woocommerce-payments' ),
+				],
+			],
+			'payment_request_button_locations'    => [
+				'title'             => __( 'Button locations', 'woocommerce-payments' ),
+				'type'              => 'multiselect',
+				'description'       => __( 'Select where you would like to display the button.', 'woocommerce-payments' ),
+				'default'           => [
+					'product',
+					'cart',
+				],
+				'class'             => 'wc-enhanced-select',
+				'desc_tip'          => true,
+				'options'           => [
+					'product'  => __( 'Product', 'woocommerce-payments' ),
+					'cart'     => __( 'Cart', 'woocommerce-payments' ),
+					'checkout' => __( 'Checkout', 'woocommerce-payments' ),
+				],
+				'custom_attributes' => [
+					'data-placeholder' => __( 'Select pages', 'woocommerce-payments' ),
+				],
 			],
 		];
 

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -491,10 +491,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 			return;
 		}
 
-		if ( is_checkout() && ! apply_filters( 'wcpay_show_payment_request_on_checkout', false, $post ) ) {
-			return;
-		}
-
 		if ( is_product() && ! $this->should_show_payment_button_on_product_page() ) {
 			return;
 		} elseif ( ! $this->should_show_payment_button_on_cart() ) {
@@ -521,8 +517,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 * Display payment request button separator.
 	 */
 	public function display_payment_request_button_separator_html() {
-		global $post;
-
 		$gateways = WC()->payment_gateways->get_available_payment_gateways();
 
 		if ( ! isset( $gateways['woocommerce_payments'] ) ) {
@@ -530,10 +524,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 		}
 
 		if ( ! is_cart() && ! is_checkout() && ! is_product() && ! isset( $_GET['pay_for_order'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			return;
-		}
-
-		if ( is_checkout() && ! apply_filters( 'wcpay_show_payment_request_on_checkout', false, $post ) ) {
 			return;
 		}
 
@@ -558,7 +548,11 @@ class WC_Payments_Payment_Request_Button_Handler {
 			return false;
 		}
 
-		if ( ! apply_filters( 'wcpay_show_payment_request_on_cart', true ) ) {
+		if ( is_checkout() && ! in_array( 'checkout', $this->gateway->get_option( 'payment_request_button_locations' ), true ) ) {
+			return false;
+		}
+
+		if ( is_cart() && ! in_array( 'cart', $this->gateway->get_option( 'payment_request_button_locations' ), true ) ) {
 			return false;
 		}
 
@@ -579,7 +573,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 
 		$product = wc_get_product( $post->ID );
 
-		if ( apply_filters( 'wcpay_hide_payment_request_on_product_page', false, $post ) ) {
+		if ( ! in_array( 'product', $this->gateway->get_option( 'payment_request_button_locations' ), true ) ) {
 			return false;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Add a new admin note to collect qualitative feedback.
 * Add - Introduced deposit currency filter for deposits overview page.
 * Update - Make Payment Request Button available for all merchants.
+* Add - Configurable Payment Request Button locations.
 
 = 2.2.0 - 2021-03-31 =
 * Fix - Paying with a saved card for a subscription with a free trial will now correctly save the chosen payment method to the order for future renewals.


### PR DESCRIPTION
Fixes #1475

#### Changes proposed in this Pull Request

- Changed the way the PRB fields look in the settings page. Some fields were renamed, Slack convo: p1618434483291900-slack-CGGCLBN58
- Some fields had the label key removed, because that's only relevant for checkboxes ([Ref](https://docs.woocommerce.com/document/settings-api/)).
- Synced changes from 1530-gh-woocommerce/woocommerce-gateway-stripe, so this gets merged earlier and we avoid some conflicts changing the same lines in #1529. Please ignore the `is_block` check for now, we will be able test it on #1529 later.
- Removed these filters and replaced with the newly created setting.
  - `wcpay_show_payment_request_on_checkout`
  - `wcpay_show_payment_request_on_cart`
  - `wcpay_hide_payment_request_on_product_page`

Note: This is using the base branch from #1529.
Note[2]: There are many force-pushes here because I had branched from #1529, but later rebased #1529 and the diff wasn't working as expected. Now it's correct.

#### Testing instructions

- Make sure your website is served over HTTPS.
- Go to Payments > Settings and notice the `Button locations` field shows `Product` and `Cart` by default.
- Test if the button is displayed in the product, cart and checkout pages according to the locations setting.

#### Screenshot

![payment-request-button-locations](https://user-images.githubusercontent.com/5509901/114899210-23e3bb00-9de9-11eb-9e72-d0d6d553f6dd.png)


-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)