### PR TITLE
Add Tracks event for Payment Request Button activation/deactivation

### DIFF
--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use WCPay\Logger;
+use WCPay\Tracker;
 
 /**
  * WC_Payments_Payment_Request_Button_Handler class.
@@ -51,6 +52,9 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 */
 	public function init() {
 		$this->gateway = WC_Payments::get_gateway();
+
+		// Add Track event on settings change.
+		add_action( 'update_option_woocommerce_woocommerce_payments_settings', [ $this, 'track_payment_request_settings_change' ], 10, 2 );
 
 		// Checks if WCPay is enabled.
 		if ( ! $this->gateway->is_enabled() ) {
@@ -96,6 +100,35 @@ class WC_Payments_Payment_Request_Button_Handler {
 		// will be used to calculate it whenever the option value is retrieved instead.
 		// It's used for displaying inbox notifications.
 		add_filter( 'pre_option_wcpay_is_apple_pay_enabled', [ $this, 'get_option_is_apple_pay_enabled' ], 10, 1 );
+	}
+
+	/**
+	 * Track Payment Request settings activation/deactivation.
+	 *
+	 * @param array $prev_settings Settings before update.
+	 * @param array $settings      Settings after update.
+	 */
+	public function track_payment_request_settings_change( $prev_settings, $settings ) {
+		$prev_payment_request_enabled = 'yes' === ( $prev_settings['payment_request'] ?? 'no' );
+		$payment_request_enabled      = 'yes' === ( $settings['payment_request'] ?? 'no' );
+
+		if ( ! $prev_payment_request_enabled && $payment_request_enabled ) {
+			// Payment Request Button was enabled.
+			Tracker::track_admin(
+				'wcpay_payment_request_settings_change',
+				[
+					'enabled' => true,
+				]
+			);
+		} elseif ( $prev_payment_request_enabled && ! $payment_request_enabled ) {
+			// Payment Request Button was disabled.
+			Tracker::track_admin(
+				'wcpay_payment_request_settings_change',
+				[
+					'enabled' => false,
+				]
+			);
+		}
 	}
 
 	/**

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -112,20 +112,11 @@ class WC_Payments_Payment_Request_Button_Handler {
 		$prev_payment_request_enabled = 'yes' === ( $prev_settings['payment_request'] ?? 'no' );
 		$payment_request_enabled      = 'yes' === ( $settings['payment_request'] ?? 'no' );
 
-		if ( ! $prev_payment_request_enabled && $payment_request_enabled ) {
-			// Payment Request Button was enabled.
+		if ( $prev_payment_request_enabled !== $payment_request_enabled ) {
 			Tracker::track_admin(
 				'wcpay_payment_request_settings_change',
 				[
-					'enabled' => true,
-				]
-			);
-		} elseif ( $prev_payment_request_enabled && ! $payment_request_enabled ) {
-			// Payment Request Button was disabled.
-			Tracker::track_admin(
-				'wcpay_payment_request_settings_change',
-				[
-					'enabled' => false,
+					'enabled' => $payment_request_enabled,
 				]
 			);
 		}


### PR DESCRIPTION
Fixes #1589

#### Changes proposed in this Pull Request

- Add a Tracks event for when the PRB gets enabled or disabled: `wcadmin_wcpay_payment_request_settings_change`.

Note: The prefix `wcadmin_` is added by the Tracks code automatically.

#### Testing instructions

- Make sure "Enable tracking" is checked under WooCommerce > Settings > Advanced > WooCommerce.com. Or the `woocommerce_allow_tracking` option is set to `yes`.
- Disable or enable the "Payment request button" setting under Payments > Settings, and notice the event is added to tracks. Note: It can take ~5 minutes for the event to show up in the Tracks Live view.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
