### PR TITLE
Pass type card in checkout block payment element.

### DIFF
--- a/client/checkout/blocks/fields.js
+++ b/client/checkout/blocks/fields.js
@@ -46,6 +46,7 @@ const WCPayFields = ( {
 
 				const cardElement = elements.getElement( CardElement );
 				const paymentElements = {
+					type: 'card',
 					card: cardElement,
 				};
 


### PR DESCRIPTION
Fixes #1594

#### Changes proposed in this Pull Request

Pass `type: card` as payment element for checkout block.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

* Make sure purchasing with credit card using checkout block works.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

