### PR TITLE
Fix instant deposits modal not working after error

### DIFF
--- a/client/data/deposits/actions.js
+++ b/client/data/deposits/actions.js
@@ -76,9 +76,6 @@ export function* submitInstantDeposit( transactionIds ) {
 		} );
 
 		yield updateInstantDeposit( deposit );
-		yield dispatch( STORE_NAME, 'finishResolution', 'getInstantDeposit', [
-			transactionIds,
-		] );
 
 		// Need to invalidate the resolution so that the components will render again.
 		yield dispatch(
@@ -115,12 +112,15 @@ export function* submitInstantDeposit( transactionIds ) {
 				],
 			}
 		);
-	} catch ( e ) {
-		yield updateInstantDeposit( e );
+	} catch {
 		yield dispatch(
 			'core/notices',
 			'createErrorNotice',
 			__( 'Error creating instant deposit.', 'woocommerce-payments' )
 		);
+	} finally {
+		yield dispatch( STORE_NAME, 'finishResolution', 'getInstantDeposit', [
+			transactionIds,
+		] );
 	}
 }

--- a/client/deposits/instant-deposits/index.js
+++ b/client/deposits/instant-deposits/index.js
@@ -18,10 +18,13 @@ const InstantDepositButton = ( {
 	balance: { amount, fee, net, transaction_ids: transactionIds },
 } ) => {
 	const [ isModalOpen, setModalOpen ] = useState( false );
-	const { deposit, inProgress, submit } = useInstantDeposit( transactionIds );
-
+	const { inProgress, submit } = useInstantDeposit( transactionIds );
 	const onClose = () => {
 		setModalOpen( false );
+	};
+	const onSubmit = () => {
+		setModalOpen( false );
+		submit();
 	};
 	// TODO: Need to update isDefault to isSecondary once @wordpress/components is updated
 	// https://github.com/Automattic/woocommerce-payments/pull/1536
@@ -30,13 +33,13 @@ const InstantDepositButton = ( {
 			<Button isDefault onClick={ () => setModalOpen( true ) }>
 				{ __( 'Instant deposit', 'woocommerce-payments' ) }
 			</Button>
-			{ isModalOpen && ! deposit && (
+			{ ( isModalOpen || inProgress ) && (
 				<InstantDepositModal
 					amount={ amount }
 					fee={ fee }
 					net={ net }
 					inProgress={ inProgress }
-					onSubmit={ submit }
+					onSubmit={ onSubmit }
 					onClose={ onClose }
 				/>
 			) }

--- a/client/deposits/instant-deposits/modal.js
+++ b/client/deposits/instant-deposits/modal.js
@@ -66,7 +66,12 @@ const InstantDepositModal = ( {
 				</li>
 			</ul>
 
-			<Button isPrimary onClick={ onSubmit } isBusy={ inProgress }>
+			<Button
+				isPrimary
+				onClick={ onSubmit }
+				isBusy={ inProgress }
+				disabled={ inProgress }
+			>
 				{ sprintf(
 					/* translators: %s: Monetary amount to deposit */
 					__( 'Deposit %s now', 'woocommerce-payments' ),


### PR DESCRIPTION
Fixes #1596

#### Changes proposed in this Pull Request

- Moved `submitInstantDeposit` dispatch of `finishResolution` to finally instead of try to ensure it will be called on error.
- Toggle the modal visibility using `isModalOpen` and `inProgress`, instead of `deposit` content, that store the server response with deposit details or error.

#### Testing instructions

1. You will need to use a server branch that has instant deposits available, the branch `add/instant-deposits-eligibility` is the best to use, unless it has been merged.
2. Edit server `class-deposits-controller.php` and add `return [];` at the beginning of `get_instant_balance_available` function.
3. Go to Payments > Deposits in the admin, the Instant Deposit button should appear.
4. Click the button to open the modal, then the button to _Deposit $xx now_.
5. Modal should close and show a snackbar notifying you an error.
6. You should be able to open the modal again.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)