### PR TITLE
Use dispatch from wordpress/data instead of from wordpress/data-controls

### DIFF
--- a/client/data/deposits/actions.js
+++ b/client/data/deposits/actions.js
@@ -3,7 +3,8 @@
 /**
  * External dependencies
  */
-import { apiFetch, dispatch } from '@wordpress/data-controls';
+import { apiFetch } from '@wordpress/data-controls';
+import { dispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { formatCurrency } from 'utils/currency';
 import { addQueryArgs } from '@wordpress/url';
@@ -85,7 +86,7 @@ export function updateInstantDeposit( data ) {
 
 export function* submitInstantDeposit( transactionIds ) {
 	try {
-		yield dispatch( STORE_NAME, 'startResolution', 'getInstantDeposit', [
+		yield dispatch( STORE_NAME ).startResolution( 'getInstantDeposit', [
 			transactionIds,
 		] );
 
@@ -99,23 +100,17 @@ export function* submitInstantDeposit( transactionIds ) {
 			},
 		} );
 
-		yield updateInstantDeposit( deposit );
+		updateInstantDeposit( deposit );
 
 		// Need to invalidate the resolution so that the components will render again.
-		yield dispatch(
-			STORE_NAME,
-			'invalidateResolutionForStoreSelector',
+		dispatch( STORE_NAME ).invalidateResolutionForStoreSelector(
 			'getDeposits'
 		);
-		yield dispatch(
-			STORE_NAME,
-			'invalidateResolutionForStoreSelector',
+		dispatch( STORE_NAME ).invalidateResolutionForStoreSelector(
 			'getDepositsOverview'
 		);
 
-		yield dispatch(
-			'core/notices',
-			'createSuccessNotice',
+		dispatch( 'core/notices' ).createSuccessNotice(
 			sprintf(
 				__(
 					'Instant deposit for %s in transit.',
@@ -137,13 +132,11 @@ export function* submitInstantDeposit( transactionIds ) {
 			}
 		);
 	} catch {
-		yield dispatch(
-			'core/notices',
-			'createErrorNotice',
+		yield dispatch( 'core/notices' ).createErrorNotice(
 			__( 'Error creating instant deposit.', 'woocommerce-payments' )
 		);
 	} finally {
-		yield dispatch( STORE_NAME, 'finishResolution', 'getInstantDeposit', [
+		yield dispatch( STORE_NAME ).finishResolution( 'getInstantDeposit', [
 			transactionIds,
 		] );
 	}

--- a/client/data/deposits/actions.js
+++ b/client/data/deposits/actions.js
@@ -100,17 +100,17 @@ export function* submitInstantDeposit( transactionIds ) {
 			},
 		} );
 
-		updateInstantDeposit( deposit );
+		yield updateInstantDeposit( deposit );
 
 		// Need to invalidate the resolution so that the components will render again.
-		dispatch( STORE_NAME ).invalidateResolutionForStoreSelector(
+		yield dispatch( STORE_NAME ).invalidateResolutionForStoreSelector(
 			'getDeposits'
 		);
-		dispatch( STORE_NAME ).invalidateResolutionForStoreSelector(
+		yield dispatch( STORE_NAME ).invalidateResolutionForStoreSelector(
 			'getDepositsOverview'
 		);
 
-		dispatch( 'core/notices' ).createSuccessNotice(
+		yield dispatch( 'core/notices' ).createSuccessNotice(
 			sprintf(
 				__(
 					'Instant deposit for %s in transit.',


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Refactor of `dispatch` method used for new instant deposits feature. Currently `dispatch` through `@wordpress/data-controls` is deprecated and is replaced by `dispatch` in `@wordpress/data`. 

This can be the start of the work mentioned in #1574

#### Notes

@ismaeldcom Can you take a look at this when you get a chance? 
I was able to get `dispatch` updated after searching and finding this:
https://github.com/WordPress/gutenberg/blob/trunk/packages/data/src/store/index.js

I was able to determine that `startResolution` and the like were all built in to each store when created, so that helped.

What I cannot get working is the proper `apiFetch`. You said you had worked with it, so if you can take a look when you get a chance, that would be awesome. If we can get this working with the proper components, we can use this as a guide to correct the rest of the app.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
