### PR TITLE
Put SEPA gateway registration behind the feature flag

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -178,7 +178,9 @@ class WC_Payments {
 		}
 
 		self::$card_gateway = new $gateway_class( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service );
-		self::$sepa_gateway = new $sepa_class( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service );
+		if ( '1' === get_option( '_wcpay_feature_sepa' ) ) {
+			self::$sepa_gateway = new $sepa_class( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service );
+		}
 
 		// Payment Request and Apple Pay.
 		self::$payment_request_button_handler = new WC_Payments_Payment_Request_Button_Handler( self::$account );
@@ -410,7 +412,9 @@ class WC_Payments {
 	 */
 	public static function register_gateway( $gateways ) {
 		$gateways[] = self::$card_gateway;
-		$gateways[] = self::$sepa_gateway;
+		if ( '1' === get_option( '_wcpay_feature_sepa' ) ) {
+			$gateways[] = self::$sepa_gateway;
+		}
 
 		return $gateways;
 	}


### PR DESCRIPTION
Fixes #1604.

#### Changes proposed in this Pull Request

This functionality is already behind a feature flag, but the constructors on these gateways have side effects that we also need to isolate.

In this case the symptom was a double test mode notification, but it's likely other processes are unintentionally running twice as well.

**Note:** I think we're at a point were adding a little "is feature enabled" utility function would be nice. I'll handle this in a follow-up PR.

#### Testing instructions
We don't (and probably won't ever) have unit tests in this bootstrap code. So a quick manual test should do:

* Add the feature flag `_wcpay_feature_sepa` to your `wp_options` table.
* Check the "Enable WooCommerce SEPA Direct Debit" setting appears to prove the SEPA feature is enabled.
* Observe the double test mode notification described in #1604.
* Disable the feature flag (delete or set to 0).
* Check the test mode notification is only displayed only once.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
