### PR TITLE
Updated dispatch to be used from wordpress/data

### DIFF
--- a/client/data/deposits/resolvers.js
+++ b/client/data/deposits/resolvers.js
@@ -3,7 +3,8 @@
 /**
  * External dependencies
  */
-import { apiFetch, dispatch } from '@wordpress/data-controls';
+import { apiFetch } from '@wordpress/data-controls';
+import { dispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
@@ -34,9 +35,7 @@ export function* getDeposit( id ) {
 		const result = yield apiFetch( { path } );
 		yield updateDeposit( result );
 	} catch ( e ) {
-		yield dispatch(
-			'core/notices',
-			'createErrorNotice',
+		yield dispatch( 'core/notices' ).createErrorNotice(
 			__( 'Error retrieving deposit.', 'woocommerce-payments' )
 		);
 	}
@@ -52,9 +51,7 @@ export function* getDepositsOverview() {
 		const result = yield apiFetch( { path } );
 		yield updateDepositsOverview( result );
 	} catch ( e ) {
-		yield dispatch(
-			'core/notices',
-			'createErrorNotice',
+		yield dispatch( 'core/notices' ).createErrorNotice(
 			__( 'Error retrieving deposits overview.', 'woocommerce-payments' )
 		);
 		yield updateErrorForDepositsOverview( e );
@@ -90,14 +87,12 @@ export function* getDeposits( query ) {
 
 		// Update resolution state on getDeposit selector for each result.
 		for ( const i in results.data ) {
-			yield dispatch( STORE_NAME, 'finishResolution', 'getDeposit', [
+			yield dispatch( STORE_NAME ).finishResolution( 'getDeposit', [
 				results.data[ i ].id,
 			] );
 		}
 	} catch ( e ) {
-		yield dispatch(
-			'core/notices',
-			'createErrorNotice',
+		yield dispatch( 'core/notices' ).createErrorNotice(
 			__( 'Error retrieving deposits.', 'woocommerce-payments' )
 		);
 		yield updateErrorForDepositQuery( query, null, e );

--- a/client/data/deposits/test/resolvers.js
+++ b/client/data/deposits/test/resolvers.js
@@ -4,7 +4,8 @@
 /**
  * External dependencies
  */
-import { apiFetch, dispatch } from '@wordpress/data-controls';
+import { apiFetch } from '@wordpress/data-controls';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -74,9 +75,7 @@ describe( 'getDepositsOverview resolver', () => {
 	describe( 'on error', () => {
 		test( 'should update state with error on error', () => {
 			expect( generator.throw( errorResponse ).value ).toEqual(
-				dispatch(
-					'core/notices',
-					'createErrorNotice',
+				dispatch( 'core/notices' ).createErrorNotice(
 					expect.any( String )
 				)
 			);
@@ -112,9 +111,7 @@ describe( 'getDeposit resolver', () => {
 	describe( 'on error', () => {
 		test( 'should update state with error on error', () => {
 			expect( generator.throw( errorResponse ).value ).toEqual(
-				dispatch(
-					'core/notices',
-					'createErrorNotice',
+				dispatch( 'core/notices' ).createErrorNotice(
 					expect.any( String )
 				)
 			);
@@ -149,7 +146,7 @@ describe( 'getDeposits resolver', () => {
 
 			depositsResponse.data.forEach( ( payout ) => {
 				expect( generator.next().value ).toEqual(
-					dispatch( 'wc/payments', 'finishResolution', 'getDeposit', [
+					dispatch( 'wc/payments' ).finishResolution( 'getDeposit', [
 						payout.id,
 					] )
 				);
@@ -160,9 +157,7 @@ describe( 'getDeposits resolver', () => {
 	describe( 'on error', () => {
 		test( 'should update state with error on error', () => {
 			expect( generator.throw( errorResponse ).value ).toEqual(
-				dispatch(
-					'core/notices',
-					'createErrorNotice',
+				dispatch( 'core/notices' ).createErrorNotice(
 					expect.any( String )
 				)
 			);

--- a/client/data/disputes/actions.js
+++ b/client/data/disputes/actions.js
@@ -3,7 +3,8 @@
 /**
  * External dependencies
  */
-import { apiFetch, dispatch } from '@wordpress/data-controls';
+import { apiFetch } from '@wordpress/data-controls';
+import { dispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { getHistory } from '@woocommerce/navigation';
 import { __, sprintf } from '@wordpress/i18n';
@@ -32,7 +33,7 @@ export function updateDisputes( query, data ) {
 
 export function* acceptDispute( id ) {
 	try {
-		yield dispatch( STORE_NAME, 'startResolution', 'getDispute', [ id ] );
+		yield dispatch( STORE_NAME ).startResolution( 'getDispute', [ id ] );
 
 		const dispute = yield apiFetch( {
 			path: `${ NAMESPACE }/disputes/${ id }/close`,
@@ -40,7 +41,7 @@ export function* acceptDispute( id ) {
 		} );
 
 		yield updateDispute( dispute );
-		yield dispatch( STORE_NAME, 'finishResolution', 'getDispute', [ id ] );
+		yield dispatch( STORE_NAME ).finishResolution( 'getDispute', [ id ] );
 
 		// Redirect to Disputes list.
 		getHistory().push(
@@ -61,13 +62,13 @@ export function* acceptDispute( id ) {
 					dispute.order.number
 			  )
 			: __( 'You have accepted the dispute.', 'woocommerce-payments' );
-		yield dispatch( 'core/notices', 'createSuccessNotice', message );
+		yield dispatch( 'core/notices' ).createSuccessNotice( message );
 	} catch ( e ) {
 		const message = __(
 			'There has been an error accepting the dispute. Please try again later.',
 			'woocommerce-payments'
 		);
 		wcpayTracks.recordEvent( 'wcpay_dispute_accept_failed' );
-		yield dispatch( 'core/notices', 'createErrorNotice', message );
+		yield dispatch( 'core/notices' ).createErrorNotice( message );
 	}
 }

--- a/client/data/disputes/resolvers.js
+++ b/client/data/disputes/resolvers.js
@@ -3,7 +3,8 @@
 /**
  * External dependencies
  */
-import { apiFetch, dispatch } from '@wordpress/data-controls';
+import { apiFetch } from '@wordpress/data-controls';
+import { dispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
@@ -25,9 +26,7 @@ export function* getDispute( id ) {
 		const result = yield apiFetch( { path } );
 		yield updateDispute( result );
 	} catch ( e ) {
-		yield dispatch(
-			'core/notices',
-			'createErrorNotice',
+		yield dispatch( 'core/notices' ).createErrorNotice(
 			__( 'Error retrieving dispute.', 'woocommerce-payments' )
 		);
 	}
@@ -50,14 +49,12 @@ export function* getDisputes( query ) {
 
 		// Update resolution state on getDispute selector for each result.
 		for ( const i in results.data ) {
-			yield dispatch( STORE_NAME, 'finishResolution', 'getDispute', [
+			yield dispatch( STORE_NAME ).finishResolution( 'getDispute', [
 				results.data[ i ].id,
 			] );
 		}
 	} catch ( e ) {
-		yield dispatch(
-			'core/notices',
-			'createErrorNotice',
+		yield dispatch( 'core/notices' ).createErrorNotice(
 			__( 'Error retrieving disputes.', 'woocommerce-payments' )
 		);
 	}

--- a/client/data/disputes/test/actions.js
+++ b/client/data/disputes/test/actions.js
@@ -4,7 +4,8 @@
 /**
  * External dependencies
  */
-import { apiFetch, dispatch } from '@wordpress/data-controls';
+import { apiFetch } from '@wordpress/data-controls';
+import { dispatch } from '@wordpress/data';
 import { getHistory } from '@woocommerce/navigation';
 
 /**
@@ -27,7 +28,7 @@ describe( 'acceptDispute action', () => {
 		const generator = acceptDispute( 'dp_mock1' );
 
 		expect( generator.next().value ).toEqual(
-			dispatch( 'wc/payments', 'startResolution', 'getDispute', [
+			dispatch( 'wc/payments' ).startResolution( 'getDispute', [
 				'dp_mock1',
 			] )
 		);
@@ -41,7 +42,7 @@ describe( 'acceptDispute action', () => {
 			updateDispute( mockDispute )
 		);
 		expect( generator.next().value ).toEqual(
-			dispatch( 'wc/payments', 'finishResolution', 'getDispute', [
+			dispatch( 'wc/payments' ).finishResolution( 'getDispute', [
 				'dp_mock1',
 			] )
 		);
@@ -49,9 +50,7 @@ describe( 'acceptDispute action', () => {
 		const noticeAction = generator.next().value;
 		expect( getHistory.mock.calls.length ).toEqual( 1 );
 		expect( noticeAction ).toEqual(
-			dispatch(
-				'core/notices',
-				'createSuccessNotice',
+			dispatch( 'core/notices' ).createSuccessNotice(
 				expect.any( String )
 			)
 		);
@@ -63,11 +62,7 @@ describe( 'acceptDispute action', () => {
 
 		generator.next();
 		expect( generator.throw( { code: 'error' } ).value ).toEqual(
-			dispatch(
-				'core/notices',
-				'createErrorNotice',
-				expect.any( String )
-			)
+			dispatch( 'core/notices' ).createErrorNotice( expect.any( String ) )
 		);
 	} );
 } );

--- a/client/data/disputes/test/resolvers.js
+++ b/client/data/disputes/test/resolvers.js
@@ -4,7 +4,8 @@
 /**
  * External dependencies
  */
-import { apiFetch, dispatch } from '@wordpress/data-controls';
+import { apiFetch } from '@wordpress/data-controls';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -49,9 +50,7 @@ describe( 'getDispute resolver', () => {
 	describe( 'on error', () => {
 		test( 'should update state with error on error', () => {
 			expect( generator.throw( errorResponse ).value ).toEqual(
-				dispatch(
-					'core/notices',
-					'createErrorNotice',
+				dispatch( 'core/notices' ).createErrorNotice(
 					expect.any( String )
 				)
 			);
@@ -81,7 +80,7 @@ describe( 'getDisputes resolver', () => {
 			);
 			mockDisputes.forEach( ( dispute ) => {
 				expect( generator.next().value ).toEqual(
-					dispatch( 'wc/payments', 'finishResolution', 'getDispute', [
+					dispatch( 'wc/payments' ).finishResolution( 'getDispute', [
 						dispute.id,
 					] )
 				);
@@ -92,9 +91,7 @@ describe( 'getDisputes resolver', () => {
 	describe( 'on error', () => {
 		test( 'should update state with error on error', () => {
 			expect( generator.throw( errorResponse ).value ).toEqual(
-				dispatch(
-					'core/notices',
-					'createErrorNotice',
+				dispatch( 'core/notices' ).createErrorNotice(
 					expect.any( String )
 				)
 			);


### PR DESCRIPTION
Fixes #1574 

#### Changes proposed in this Pull Request
Updated `dispatch` to come from `@wordpress/data` instead of `@wordpress/data-controls`.
This fixes deprecation warnings in the console.

#### Testing instructions

*

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
