### PR TITLE
Use correct amount for Variable products if “Default form values” is set

### DIFF
--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -228,8 +228,12 @@ class WC_Payments_Payment_Request_Button_Handler {
 			$attributes           = [];
 
 			foreach ( $variation_attributes as $attribute_name => $attribute_values ) {
-				$attribute_key                = 'attribute_' . $attribute_name;
-				$attributes[ $attribute_key ] = isset( $_GET[ $attribute_key ] ) ? wc_clean( wp_unslash( $_GET[ $attribute_key ] ) ) : $product->get_variation_default_attribute( $attribute_name ); // phpcs:ignore WordPress.Security.NonceVerification
+				$attribute_key = 'attribute_' . sanitize_title( $attribute_name );
+
+				// Passed value via GET takes precedence. Otherwise get the default value for given attribute.
+				$attributes[ $attribute_key ] = isset( $_GET[ $attribute_key ] ) // phpcs:ignore WordPress.Security.NonceVerification
+					? wc_clean( wp_unslash( $_GET[ $attribute_key ] ) ) // phpcs:ignore WordPress.Security.NonceVerification
+					: $product->get_variation_default_attribute( $attribute_name );
 			}
 
 			$data_store   = WC_Data_Store::load( 'product' );

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -224,14 +224,12 @@ class WC_Payments_Payment_Request_Button_Handler {
 		$product = $this->get_product();
 
 		if ( 'variable' === $product->get_type() ) {
-			$attributes = wc_clean( wp_unslash( $_GET ) ); // phpcs:ignore WordPress.Security.NonceVerification
+			$variation_attributes = $product->get_variation_attributes();
+			$attributes           = [];
 
-			if ( empty( $attributes ) ) {
-				$get_default_attributes = $product->get_default_attributes();
-				$attributes             = [];
-				foreach ( $get_default_attributes as $key => $value ) {
-					$attributes[ 'attribute_' . $key ] = $value;
-				}
+			foreach ( $variation_attributes as $attribute_name => $attribute_values ) {
+				$attribute_key                = 'attribute_' . $attribute_name;
+				$attributes[ $attribute_key ] = isset( $_GET[ $attribute_key ] ) ? wc_clean( wp_unslash( $_GET[ $attribute_key ] ) ) : $product->get_variation_default_attribute( $attribute_name ); // phpcs:ignore WordPress.Security.NonceVerification
 			}
 
 			$data_store   = WC_Data_Store::load( 'product' );

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -226,6 +226,14 @@ class WC_Payments_Payment_Request_Button_Handler {
 		if ( 'variable' === $product->get_type() ) {
 			$attributes = wc_clean( wp_unslash( $_GET ) ); // phpcs:ignore WordPress.Security.NonceVerification
 
+			if ( empty( $attributes ) ) {
+				$get_default_attributes = $product->get_default_attributes();
+				$attributes             = [];
+				foreach ( $get_default_attributes as $key => $value ) {
+					$attributes[ 'attribute_' . $key ] = $value;
+				}
+			}
+
 			$data_store   = WC_Data_Store::load( 'product' );
 			$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
 


### PR DESCRIPTION
Fixes #1408 for Variable Products

This is a port from a fix done in `woocommerce-gateway-stripe` here https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1533

The bug is exactly the same and testing instructions are also the same. I've tested with Variable Products and with both Apple Pay and Google Pay
