### PR TITLE
fix: payment methods elements align on wrap

### DIFF
--- a/client/components/orderable-list/payment-method.scss
+++ b/client/components/orderable-list/payment-method.scss
@@ -1,6 +1,7 @@
 .payment-method {
 	flex-wrap: wrap;
 	justify-content: space-between;
+	align-items: center;
 
 	@include breakpoint( '>660px' ) {
 		flex-wrap: nowrap;


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Adjusts the vertical alignment of items in the payment methods section when the text is wrapping at different breakpoints.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have the "grouped settings" flag enabled in WCPay Dev Tools
- Visit http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout
- The elements in the list should maintain a centered vertical alignment at different breakpoints

Before:
![Markup 2021-04-22 at 12 10 19](https://user-images.githubusercontent.com/273592/115757894-28b5eb00-a364-11eb-8d89-0b98ab437ef7.png)

After:
![Markup 2021-04-22 at 12 10 45](https://user-images.githubusercontent.com/273592/115757917-30758f80-a364-11eb-9be6-c36c330336ac.png)



-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
