### PR TITLE
Use an option instead of a transient for caching account details

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 
 = 2.3.1 - 2021-xx-xx =
 * Fix - Various account connection cache tweaks
+* Update - Use option instead of transient for caching account data
 
 = 2.3.0 - 2021-04-21 =
 * Add - Introduced deposit currency filter for transactions overview page.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -692,6 +692,8 @@ class WC_Payments_API_Client {
 	 * Get current account data
 	 *
 	 * @return array An array describing an account object.
+	 *
+	 * @throws API_Exception - Error contacting the API.
 	 */
 	public function get_account_data() {
 		return $this->request(

--- a/readme.txt
+++ b/readme.txt
@@ -107,6 +107,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 2.3.1 - 2021-xx-xx =
 * Fix - Various account connection cache tweaks
+* Update - Use option instead of transient for caching account data
 
 = 2.3.0 - 2021-04-21 =
 * Add - Introduced deposit currency filter for transactions overview page.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -104,7 +104,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	 */
 	public function tearDown() {
 		delete_option( 'woocommerce_woocommerce_payments_settings' );
-		delete_transient( WC_Payments_Account::ACCOUNT_TRANSIENT );
+		delete_option( WC_Payments_Account::ACCOUNT_OPTION );
 
 		// Fall back to an US store.
 		update_option( 'woocommerce_store_postcode', '94110' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The account details we're storing in a transient aren't loading correctly in all environments. This PR swaps out the transient for an option with the expiry handled manually.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the logs after some general usage on your site. The account endpoint should only have been called once and you should see an option in the DB with timestamp 2 hours into the feature inside the value somewhere.
* Clear the WCPay cache through the WooCommerce debug menu, ensure the timestamp on your cache option is updated.
* Update your statement descriptor and ensure it is persisted correctly.
* Extra credit:
   * Run a build of this branch on a JN site where we've been able to replicate this issue before. Check logs for account endpoint usage.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
