### PR TITLE
Add `transform-runtime` plugin to babel.config.js

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,7 @@ module.exports = {
 	ignore: [],
 	presets: [ '@wordpress/babel-preset-default' ],
 	plugins: [
+		[ '@babel/transform-runtime', { corejs: 3 } ],
 		'@babel/plugin-proposal-optional-chaining',
 		'@babel/plugin-proposal-nullish-coalescing-operator',
 	],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

h/t to @diegocurbelo for the solution.

After the Webpack was changed to use `babel-loader`, it was not possible to transpile async functions without this plugin.

#### Testing instructions

- Create an async function in `client/payment-request/index.js` in develop, run `npm run build:client` and check the console error when you try to visit a product page.
- Checkout this branch and run `npm run build:client`. The error should no longer be there, and the function should work.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
