### PR TITLE
fix: prevent JS error on settings page

### DIFF
--- a/client/settings/index.js
+++ b/client/settings/index.js
@@ -69,26 +69,6 @@ if ( settingsContainer ) {
 	);
 }
 
-// Payment Request button settings migrated and adapted from Stripe gateway extension.
-const findParent = ( el, selector ) => {
-	while (
-		( el = el.parentElement ) &&
-		! ( el.matches || el.matchesSelector ).call( el, selector )
-	);
-
-	return el;
-};
-
-const toggleDisplay = ( el, display ) => {
-	if ( el instanceof Element || el instanceof HTMLElement ) {
-		if ( display ) {
-			el.style.display = '';
-		} else {
-			el.style.display = 'none';
-		}
-	}
-};
-
 const paymentRequest = document.getElementById(
 	'woocommerce_woocommerce_payments_payment_request'
 );
@@ -96,86 +76,108 @@ const paymentRequestButtonType = document.getElementById(
 	'woocommerce_woocommerce_payments_payment_request_button_type'
 );
 
-// Payment Request button event listeners.
-paymentRequest.addEventListener( 'change', () => {
-	const inputIds = [
-		'woocommerce_woocommerce_payments_payment_request_button_theme',
-		'woocommerce_woocommerce_payments_payment_request_button_type',
-		'woocommerce_woocommerce_payments_payment_request_button_height',
-		'woocommerce_woocommerce_payments_payment_request_button_locations',
-	];
+if ( paymentRequest && paymentRequestButtonType ) {
+	// Payment Request button settings migrated and adapted from Stripe gateway extension.
+	const findParent = ( el, selector ) => {
+		while (
+			( el = el.parentElement ) &&
+			! ( el.matches || el.matchesSelector ).call( el, selector )
+		);
 
-	if ( paymentRequest.checked ) {
-		inputIds.forEach( ( id ) => {
+		return el;
+	};
+
+	const toggleDisplay = ( el, display ) => {
+		if ( el instanceof Element || el instanceof HTMLElement ) {
+			if ( display ) {
+				el.style.display = '';
+			} else {
+				el.style.display = 'none';
+			}
+		}
+	};
+
+	// Payment Request button event listeners.
+	paymentRequest.addEventListener( 'change', () => {
+		const inputIds = [
+			'woocommerce_woocommerce_payments_payment_request_button_theme',
+			'woocommerce_woocommerce_payments_payment_request_button_type',
+			'woocommerce_woocommerce_payments_payment_request_button_height',
+			'woocommerce_woocommerce_payments_payment_request_button_locations',
+		];
+
+		if ( paymentRequest.checked ) {
+			inputIds.forEach( ( id ) => {
+				toggleDisplay(
+					findParent( document.getElementById( id ), 'tr' ),
+					true
+				);
+			} );
+		} else {
+			inputIds.forEach( ( id ) => {
+				toggleDisplay(
+					findParent( document.getElementById( id ), 'tr' ),
+					false
+				);
+			} );
+		}
+
+		paymentRequestButtonType.dispatchEvent( new Event( 'change' ) );
+	} );
+
+	// Toggle Custom Payment Request configs.
+	paymentRequestButtonType.addEventListener( 'change', () => {
+		if (
+			'custom' === paymentRequestButtonType.value &&
+			paymentRequest.checked
+		) {
 			toggleDisplay(
-				findParent( document.getElementById( id ), 'tr' ),
+				findParent(
+					document.getElementById(
+						'woocommerce_woocommerce_payments_payment_request_button_label'
+					),
+					'tr'
+				),
 				true
 			);
-		} );
-	} else {
-		inputIds.forEach( ( id ) => {
+		} else {
 			toggleDisplay(
-				findParent( document.getElementById( id ), 'tr' ),
+				findParent(
+					document.getElementById(
+						'woocommerce_woocommerce_payments_payment_request_button_label'
+					),
+					'tr'
+				),
 				false
 			);
-		} );
-	}
+		}
 
+		if (
+			'branded' === paymentRequestButtonType.value &&
+			paymentRequest.checked
+		) {
+			toggleDisplay(
+				findParent(
+					document.getElementById(
+						'woocommerce_woocommerce_payments_payment_request_button_branded_type'
+					),
+					'tr'
+				),
+				true
+			);
+		} else {
+			toggleDisplay(
+				findParent(
+					document.getElementById(
+						'woocommerce_woocommerce_payments_payment_request_button_branded_type'
+					),
+					'tr'
+				),
+				false
+			);
+		}
+	} );
+
+	paymentRequest.dispatchEvent( new Event( 'change' ) );
 	paymentRequestButtonType.dispatchEvent( new Event( 'change' ) );
-} );
-
-// Toggle Custom Payment Request configs.
-paymentRequestButtonType.addEventListener( 'change', () => {
-	if (
-		'custom' === paymentRequestButtonType.value &&
-		paymentRequest.checked
-	) {
-		toggleDisplay(
-			findParent(
-				document.getElementById(
-					'woocommerce_woocommerce_payments_payment_request_button_label'
-				),
-				'tr'
-			),
-			true
-		);
-	} else {
-		toggleDisplay(
-			findParent(
-				document.getElementById(
-					'woocommerce_woocommerce_payments_payment_request_button_label'
-				),
-				'tr'
-			),
-			false
-		);
-	}
-
-	if (
-		'branded' === paymentRequestButtonType.value &&
-		paymentRequest.checked
-	) {
-		toggleDisplay(
-			findParent(
-				document.getElementById(
-					'woocommerce_woocommerce_payments_payment_request_button_branded_type'
-				),
-				'tr'
-			),
-			true
-		);
-	} else {
-		toggleDisplay(
-			findParent(
-				document.getElementById(
-					'woocommerce_woocommerce_payments_payment_request_button_branded_type'
-				),
-				'tr'
-			),
-			false
-		);
-	}
-} );
-
-paymentRequest.dispatchEvent( new Event( 'change' ) );
-paymentRequestButtonType.dispatchEvent( new Event( 'change' ) );
+}


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Fixes the JS error on the settings page when the grouped settings flag is enabled

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Recommend reviewing with this: https://d.pr/i/rQt4nB
- Prevents this error: https://d.pr/i/coFWEc
- Ensure you have the "grouped settings" flag enabled in WCPay Dev Tools
- Visit http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout
- No more error in the console

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
