### PR TITLE
Apply styles correctly to SEPA input

### DIFF
--- a/client/checkout/classic/style.scss
+++ b/client/checkout/classic/style.scss
@@ -19,12 +19,13 @@
 }
 
 #wcpay-card-element,
-#wcpay-sepa-card-element {
+#wcpay-sepa-element {
 	border: 1px solid #ddd;
 	padding: 5px 7px;
 	min-height: 29px;
 }
 
-.wcpay-card-mounted {
+.wcpay-card-mounted,
+.wcpay-sepa-mounted {
 	background-color: #fff;
 }


### PR DESCRIPTION
Fixes #1691 

#### Changes proposed in this Pull Request

Corrects styles to correctly apply background/border to SEPA input

![image](https://user-images.githubusercontent.com/6209518/116132329-48aa1f00-a682-11eb-8bf7-eedaf3238d53.png)

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- Enable SEPA in test environment
- Go through checkout flow and make sure credit card and SEPA input styles match

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
