### PR TITLE
Put passing sepa as payment method behind feature flag in create_and_confirm_setup_intent()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,8 @@
 = 2.4.0 - 2021-xx-xx =
 * Update - Improve the Connect Account page.
 * Update - Base UI components and their styling.
+
+= 2.3.2 - 2021-xx-xx =
 * Fix - Error when purchasing free trial subscriptions.
 
 = 2.3.1 - 2021-04-26 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 2.4.0 - 2021-xx-xx =
 * Update - Improve the Connect Account page.
 * Update - Base UI components and their styling.
+* Fix - Error when purchasing free trial subscriptions.
 
 = 2.3.1 - 2021-04-26 =
 * Fix - Various account connection cache tweaks

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -294,17 +294,15 @@ class WC_Payments_API_Client {
 	 * @throws API_Exception - Exception thrown on setup intent creation failure.
 	 */
 	public function create_and_confirm_setup_intent( $payment_method_id, $customer_id ) {
-		$payment_method_types = [ Payment_Method::CARD ];
-		if ( WC_Payments_Features::is_sepa_enabled() ) {
-			$payment_method_types[] = Payment_Method::SEPA;
-		}
-
 		$request = [
-			'payment_method'       => $payment_method_id,
-			'customer'             => $customer_id,
-			'confirm'              => 'true',
-			'payment_method_types' => $payment_method_types,
+			'payment_method' => $payment_method_id,
+			'customer'       => $customer_id,
+			'confirm'        => 'true',
 		];
+
+		if ( WC_Payments_Features::is_sepa_enabled() ) {
+			$request['payment_method_types'] = [ Payment_Method::CARD, Payment_Method::SEPA ];
+		}
 
 		return $this->request( $request, self::SETUP_INTENTS_API, self::POST );
 	}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -294,11 +294,16 @@ class WC_Payments_API_Client {
 	 * @throws API_Exception - Exception thrown on setup intent creation failure.
 	 */
 	public function create_and_confirm_setup_intent( $payment_method_id, $customer_id ) {
+		$payment_method_types = [ Payment_Method::CARD ];
+		if ( WC_Payments_Features::is_sepa_enabled() ) {
+			$payment_method_types[] = Payment_Method::SEPA;
+		}
+
 		$request = [
 			'payment_method'       => $payment_method_id,
 			'customer'             => $customer_id,
 			'confirm'              => 'true',
-			'payment_method_types' => [ Payment_Method::CARD, Payment_Method::SEPA ],
+			'payment_method_types' => $payment_method_types,
 		];
 
 		return $this->request( $request, self::SETUP_INTENTS_API, self::POST );

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,8 @@ Please note that our support for the checkout block is still experimental and th
 = 2.4.0 - 2021-xx-xx =
 * Update - Improve the Connect Account page.
 * Update - Base UI components and their styling.
+
+= 2.3.2 - 2021-xx-xx =
 * Fix - Error when purchasing free trial subscriptions.
 
 = 2.3.1 - 2021-04-26 =

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ Please note that our support for the checkout block is still experimental and th
 = 2.4.0 - 2021-xx-xx =
 * Update - Improve the Connect Account page.
 * Update - Base UI components and their styling.
+* Fix - Error when purchasing free trial subscriptions.
 
 = 2.3.1 - 2021-04-26 =
 * Fix - Various account connection cache tweaks


### PR DESCRIPTION
Fixes #1694

#### Changes proposed in this Pull Request

In `create_and_confirm_setup_intent()`, check feature flag before passing SEPA as one of the payment methods.

#### Testing instructions

* Purchase a free trial subscriptions in live mode. I found it reproducible only with in non-test mode, using real card. I expected that as long as it's in live mode, even in test mode (Admin > Payments > Settings > Enabled test mode), using test card, the error should be reproducible, but that's not the case. Any idea why?
* With base branch, there will be error like mentioned in issue 1694 https://user-images.githubusercontent.com/1867547/116157961-db1ae480-a6bb-11eb-91cc-4df7a35c435c.png, with PR branch, purchase should be successful. Don't forget to cancel the subscription afterward if you're using real card =)

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
