### PR TITLE
Fix Add Payment method for SEPA by sending mandate data on intent.

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -302,6 +302,15 @@ class WC_Payments_API_Client {
 
 		if ( WC_Payments_Features::is_sepa_enabled() ) {
 			$request['payment_method_types'] = [ Payment_Method::CARD, Payment_Method::SEPA ];
+			$request['mandate_data']         = [
+				'customer_acceptance' => [
+					'type'   => 'online',
+					'online' => [
+						'ip_address' => WC_Geolocation::get_ip_address(),
+						'user_agent' => $_SERVER['HTTP_USER_AGENT'] ?? $this->user_agent, //phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+					],
+				],
+			];
 		}
 
 		return $this->request( $request, self::SETUP_INTENTS_API, self::POST );


### PR DESCRIPTION
Fixes #1538 

#### Changes proposed in this Pull Request

This PR adds mandate data on setup intent so that we can save SEPA payment methods.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With the option _wcpay_feature_sepa = 1 and SEPA payment enabled
* Go to My Account > Add Payment method
* Click on SEPA Direct Debit and enter the test account
* Click on Add Payment Method. Check there is no error and the payment is saved.
* Place an order using the saved Payment Method.
* Check the payment information is correct in the order.
* Check out the payment details on Stripe dashboard. Verify the Payment method is SEPA and the owner data are the name and email of customer.
* Check Add CC Payment Method still works.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
