### PR TITLE
Ensure SEPA can work without CC payment method

### DIFF
--- a/client/checkout/classic/index.js
+++ b/client/checkout/classic/index.js
@@ -127,16 +127,20 @@ jQuery( function ( $ ) {
 		// If the card element selector doesn't exist, then do nothing (for example, when a 100% discount coupon is applied).
 		// We also don't re-mount if already mounted in DOM.
 		if (
-			! $( '#wcpay-card-element' ).length ||
+			( ! $( '#wcpay-sepa-element' ).length &&
+				! $( '#wcpay-card-element' ).length ) ||
 			$( '#wcpay-card-element' ).children().length
 		) {
 			return;
 		}
 
-		cardElement.unmount();
-		cardElement.mount( '#wcpay-card-element' );
+		if ( $( '#wcpay-card-element' ).length ) {
+			cardElement.unmount();
+			cardElement.mount( '#wcpay-card-element' );
+		}
 
 		if ( $( '#wcpay-sepa-element' ).length ) {
+			sepaElement.unmount();
 			sepaElement.mount( '#wcpay-sepa-element' );
 		}
 	} );
@@ -145,7 +149,9 @@ jQuery( function ( $ ) {
 		$( 'form#add_payment_method' ).length ||
 		$( 'form#order_review' ).length
 	) {
-		cardElement.mount( '#wcpay-card-element' );
+		if ( $( '#wcpay-card-element' ).length ) {
+			cardElement.mount( '#wcpay-card-element' );
+		}
 
 		if ( $( '#wcpay-sepa-element' ).length ) {
 			sepaElement.mount( '#wcpay-sepa-element' );

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -81,7 +81,7 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 			}
 
 			// Set the payment method on the order.
-			$order->set_payment_method( WC_Payment_Gateway_WCPay::GATEWAY_ID );
+			$order->set_payment_method( $this->gateway::GATEWAY_ID );
 
 			// Mark the order as paid for with WCPay and the intent.
 			$this->gateway->attach_intent_info_to_order(

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -332,6 +332,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// Update the current request logged_in cookie after a guest user is created to avoid nonce inconsistencies.
 		add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
+
+		if ( WC_Payments_Features::is_giropay_enabled() || WC_Payments_Features::is_sofort_enabled() || WC_Payments_Features::is_sepa_enabled() ) {
+			add_action( 'woocommerce_admin_field_payment_gateways', [ $this, 'set_enabled_based_on_wrapper_only' ] );
+		}
 	}
 
 	/**
@@ -2047,5 +2051,17 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	public function enable() {
 		$this->update_option( static::METHOD_ENABLED_KEY, 'yes' );
+	}
+
+	/**
+	 * $this->enabled is set to yes ($this->init_settings()) if both this wrapper and the underlying payment methods are
+	 * both enabled (sepa/giropay/etc). This allows the checkout page to hide all payment methods if the wrapper is
+	 * turned off.
+	 *
+	 * This method handles a special case under the payment methods' settings page. We want to make sure that the
+	 * toggle button reflects the status of "enabled" for this wrapper class only.
+	 */
+	public function set_enabled_based_on_wrapper_only() {
+		$this->enabled = ! empty( $this->settings[ self::METHOD_ENABLED_KEY ] ) && 'yes' === $this->settings[ self::METHOD_ENABLED_KEY ] ? 'yes' : 'no';
 	}
 }

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -128,7 +128,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'label'       => __( 'Enable WooCommerce Payments Credit Card', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
 				'description' => '',
-				'default'     => 'no',
+				'default'     => 'yes',
 			],
 			'account_details'                     => [
 				'type' => 'account_actions',
@@ -1163,8 +1163,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * Overrides parent method so the option key is the same as the parent class.
 	 */
 	public function get_option_key() {
-		// Intentionally using self instead of static so options are loaded from main gateway settings.
-		return $this->plugin_id . self::GATEWAY_ID . '_settings';
+		// Intentionally using 'woocommerce_payments_settings' instead of CC_Payment_Gateway::GATEWAY_ID to avoid circular dependency.
+		return $this->plugin_id . 'woocommerce_payments_settings';
 	}
 
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -20,7 +20,7 @@ use WCPay\Tracker;
 /**
  * Gateway class for WooCommerce Payments
  */
-class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
+abstract class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 	/**
 	 * Internal ID of the payment gateway.
@@ -1165,22 +1165,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public function get_option_key() {
 		// Intentionally using 'woocommerce_payments_settings' instead of CC_Payment_Gateway::GATEWAY_ID to avoid circular dependency.
 		return $this->plugin_id . 'woocommerce_payments_settings';
-	}
-
-
-	/**
-	 * Update a single option.
-	 * Overrides parent method to use different key for `enabled`.
-	 *
-	 * @param string $key Option key.
-	 * @param mixed  $value Value to set.
-	 * @return bool was anything saved?
-	 */
-	public function update_option( $key, $value = '' ) {
-		if ( 'enabled' === $key ) {
-			$key = static::METHOD_ENABLED_KEY;
-		}
-		return parent::update_option( $key, $value );
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -20,7 +20,7 @@ use WCPay\Tracker;
 /**
  * Gateway class for WooCommerce Payments
  */
-abstract class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
+class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 	/**
 	 * Internal ID of the payment gateway.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -259,14 +259,18 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					'data-placeholder' => __( 'Select pages', 'woocommerce-payments' ),
 				],
 			],
-			'cc_enabled'                          => [
+		];
+
+		// Show Credit Card enable/disable option only if the other payment methods are enabled.
+		if ( WC_Payments_Features::is_giropay_enabled() || WC_Payments_Features::is_sofort_enabled() || WC_Payments_Features::is_sepa_enabled() ) {
+			$this->form_fields['cc_enabled'] = [
 				'title'       => __( 'Enable/disable Credit Card', 'woocommerce-payments' ),
 				'label'       => __( 'Enable WooCommerce Payments Credit Card', 'woocommerce-payments' ),
 				'type'        => 'checkbox',
 				'description' => '',
 				'default'     => 'yes',
-			],
-		];
+			];
+		}
 
 		// Giropay option hidden behind feature flag.
 		if ( WC_Payments_Features::is_giropay_enabled() ) {
@@ -1172,11 +1176,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	public function init_settings() {
 		parent::init_settings();
-		// The initialized settings need to be both WCPay Gateway wrapper and the actual Payment Method gateway.
-		if ( 'yes' === $this->settings[ self::METHOD_ENABLED_KEY ] ) {
-			$this->enabled = ! empty( $this->settings[ static::METHOD_ENABLED_KEY ] ) && 'yes' === $this->settings[ static::METHOD_ENABLED_KEY ] ? 'yes' : 'no';
-		} else {
-			$this->enabled = 'no';
+
+		if ( WC_Payments_Features::is_giropay_enabled() || WC_Payments_Features::is_sofort_enabled() || WC_Payments_Features::is_sepa_enabled() ) {
+			// The initialized settings need to be both WCPay Gateway wrapper and the actual Payment Method gateway.
+			if ( 'yes' === $this->settings[ self::METHOD_ENABLED_KEY ] ) {
+				$this->enabled = ! empty( $this->settings[ static::METHOD_ENABLED_KEY ] ) && 'yes' === $this->settings[ static::METHOD_ENABLED_KEY ] ? 'yes' : 'no';
+			} else {
+				$this->enabled = 'no';
+			}
 		}
 	}
 
@@ -2021,7 +2028,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return bool The result.
 	 */
 	public function is_enabled() {
-		return 'yes' === $this->get_option( static::METHOD_ENABLED_KEY );
+		if ( WC_Payments_Features::is_giropay_enabled() || WC_Payments_Features::is_sofort_enabled() || WC_Payments_Features::is_sepa_enabled() ) {
+			return 'yes' === $this->get_option( static::METHOD_ENABLED_KEY );
+		} else {
+			return 'yes' === $this->get_option( self::METHOD_ENABLED_KEY );
+		}
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1184,6 +1184,19 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Init settings for gateways.
+	 */
+	public function init_settings() {
+		parent::init_settings();
+		// The initialized settings need to be both WCPay Gateway wrapper and the actual Payment Method gateway.
+		if ( 'yes' === $this->settings[ self::METHOD_ENABLED_KEY ] ) {
+			$this->enabled = ! empty( $this->settings[ static::METHOD_ENABLED_KEY ] ) && 'yes' === $this->settings[ static::METHOD_ENABLED_KEY ] ? 'yes' : 'no';
+		} else {
+			$this->enabled = 'no';
+		}
+	}
+
+	/**
 	 * Get payment capture type from WCPay settings.
 	 *
 	 * @return Payment_Capture_Type MANUAL or AUTOMATIC depending on the settings.
@@ -2016,19 +2029,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			},
 			array_values( $tokens )
 		);
-	}
-
-	/**
-	 * Init settings for gateways.
-	 */
-	public function init_settings() {
-		parent::init_settings();
-		// The initialized settings need to be both WCPay Gateway wrapper and the actual Payment Method gateway.
-		if ( 'yes' === $this->settings[ self::METHOD_ENABLED_KEY ] ) {
-			$this->enabled = ! empty( $this->settings[ static::METHOD_ENABLED_KEY ] ) && 'yes' === $this->settings[ static::METHOD_ENABLED_KEY ] ? 'yes' : 'no';
-		} else {
-			$this->enabled = 'no';
-		}
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -123,13 +123,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'description' => '',
 				'default'     => 'no',
 			],
-			'cc_enabled'                          => [
-				'title'       => __( 'Enable/disable Credit Card', 'woocommerce-payments' ),
-				'label'       => __( 'Enable WooCommerce Payments Credit Card', 'woocommerce-payments' ),
-				'type'        => 'checkbox',
-				'description' => '',
-				'default'     => 'yes',
-			],
 			'account_details'                     => [
 				'type' => 'account_actions',
 			],
@@ -265,6 +258,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'custom_attributes' => [
 					'data-placeholder' => __( 'Select pages', 'woocommerce-payments' ),
 				],
+			],
+			'cc_enabled'                          => [
+				'title'       => __( 'Enable/disable Credit Card', 'woocommerce-payments' ),
+				'label'       => __( 'Enable WooCommerce Payments Credit Card', 'woocommerce-payments' ),
+				'type'        => 'checkbox',
+				'description' => '',
+				'default'     => 'yes',
 			],
 		];
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1171,7 +1171,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * Overrides parent method so the option key is the same as the parent class.
 	 */
 	public function get_option_key() {
-		// Intentionally using 'woocommerce_payments_settings' instead of CC_Payment_Gateway::GATEWAY_ID to avoid circular dependency.
+		// Intentionally using 'woocommerce_payments_settings' instead of self::GATEWAY_ID so that Credit Card, SEPA, Sofort, etc, all
+		// saves the settings under the same option_name.
 		return $this->plugin_id . 'woocommerce_payments_settings';
 	}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -262,7 +262,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		];
 
 		// Show Credit Card enable/disable option only if the other payment methods are enabled.
-		if ( WC_Payments_Features::is_giropay_enabled() || WC_Payments_Features::is_sofort_enabled() || WC_Payments_Features::is_sepa_enabled() ) {
+		if ( WC_Payments_Features::is_any_euro_debit_enabled() ) {
 			$this->form_fields['cc_enabled'] = [
 				'title'       => __( 'Enable/disable Credit Card', 'woocommerce-payments' ),
 				'label'       => __( 'Enable WooCommerce Payments Credit Card', 'woocommerce-payments' ),
@@ -333,7 +333,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// Update the current request logged_in cookie after a guest user is created to avoid nonce inconsistencies.
 		add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
 
-		if ( WC_Payments_Features::is_giropay_enabled() || WC_Payments_Features::is_sofort_enabled() || WC_Payments_Features::is_sepa_enabled() ) {
+		if ( WC_Payments_Features::is_any_euro_debit_enabled() ) {
 			add_action( 'woocommerce_admin_field_payment_gateways', [ $this, 'set_enabled_based_on_wrapper_only' ] );
 		}
 	}
@@ -1181,7 +1181,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public function init_settings() {
 		parent::init_settings();
 
-		if ( WC_Payments_Features::is_giropay_enabled() || WC_Payments_Features::is_sofort_enabled() || WC_Payments_Features::is_sepa_enabled() ) {
+		if ( WC_Payments_Features::is_any_euro_debit_enabled() ) {
 			// The initialized settings need to be both WCPay Gateway wrapper and the actual Payment Method gateway.
 			if ( 'yes' === $this->settings[ self::METHOD_ENABLED_KEY ] ) {
 				$this->enabled = ! empty( $this->settings[ static::METHOD_ENABLED_KEY ] ) && 'yes' === $this->settings[ static::METHOD_ENABLED_KEY ] ? 'yes' : 'no';
@@ -2032,7 +2032,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return bool The result.
 	 */
 	public function is_enabled() {
-		if ( WC_Payments_Features::is_giropay_enabled() || WC_Payments_Features::is_sofort_enabled() || WC_Payments_Features::is_sepa_enabled() ) {
+		if ( WC_Payments_Features::is_any_euro_debit_enabled() ) {
 			return 'yes' === $this->get_option( static::METHOD_ENABLED_KEY );
 		} else {
 			return 'yes' === $this->get_option( self::METHOD_ENABLED_KEY );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -123,6 +123,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'description' => '',
 				'default'     => 'no',
 			],
+			'cc_enabled'                          => [
+				'title'       => __( 'Enable/disable Credit Card', 'woocommerce-payments' ),
+				'label'       => __( 'Enable WooCommerce Payments Credit Card', 'woocommerce-payments' ),
+				'type'        => 'checkbox',
+				'description' => '',
+				'default'     => 'no',
+			],
 			'account_details'                     => [
 				'type' => 'account_actions',
 			],
@@ -1144,8 +1151,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	public function get_option( $key, $empty_value = null ) {
 		switch ( $key ) {
-			case 'enabled':
-				return parent::get_option( static::METHOD_ENABLED_KEY, $empty_value );
 			case 'account_statement_descriptor':
 				return $this->get_account_statement_descriptor();
 			default:
@@ -1176,14 +1181,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$key = static::METHOD_ENABLED_KEY;
 		}
 		return parent::update_option( $key, $value );
-	}
-
-	/**
-	 * Init settings for gateways.
-	 */
-	public function init_settings() {
-		parent::init_settings();
-		$this->enabled = ! empty( $this->settings[ static::METHOD_ENABLED_KEY ] ) && 'yes' === $this->settings[ static::METHOD_ENABLED_KEY ] ? 'yes' : 'no';
 	}
 
 	/**
@@ -1883,7 +1880,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		// We only want to track orders created by our payment gateway, and orders with a payment method set.
-		if ( $order->get_payment_method() !== self::GATEWAY_ID || empty( $order->get_meta_data( '_payment_method_id' ) ) ) {
+		if ( $order->get_payment_method() !== static::GATEWAY_ID || empty( $order->get_meta_data( '_payment_method_id' ) ) ) {
 			return;
 		}
 
@@ -2001,7 +1998,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$tokens = WC_Payment_Tokens::get_tokens(
 			[
 				'user_id'    => $user_id,
-				'gateway_id' => self::GATEWAY_ID,
+				'gateway_id' => static::GATEWAY_ID,
 			]
 		);
 		return array_map(

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2019,25 +2019,38 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Init settings for gateways.
+	 */
+	public function init_settings() {
+		parent::init_settings();
+		// The initialized settings need to be both WCPay Gateway wrapper and the actual Payment Method gateway.
+		if ( 'yes' === $this->settings[ self::METHOD_ENABLED_KEY ] ) {
+			$this->enabled = ! empty( $this->settings[ static::METHOD_ENABLED_KEY ] ) && 'yes' === $this->settings[ static::METHOD_ENABLED_KEY ] ? 'yes' : 'no';
+		} else {
+			$this->enabled = 'no';
+		}
+	}
+
+	/**
 	 * Checks whether the gateway is enabled.
 	 *
 	 * @return bool The result.
 	 */
 	public function is_enabled() {
-		return 'yes' === $this->get_option( 'enabled' );
+		return 'yes' === $this->get_option( static::METHOD_ENABLED_KEY );
 	}
 
 	/**
 	 * Disables gateway.
 	 */
 	public function disable() {
-		$this->update_option( 'enabled', 'no' );
+		$this->update_option( static::METHOD_ENABLED_KEY, 'no' );
 	}
 
 	/**
 	 * Enables gateway.
 	 */
 	public function enable() {
-		$this->update_option( 'enabled', 'yes' );
+		$this->update_option( static::METHOD_ENABLED_KEY, 'yes' );
 	}
 }

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -462,7 +462,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// hiding the save button because the react container has its own.
 		global $hide_save_button;
 		$hide_save_button                  = true;
-		$is_payment_method_settings_screen = self::GATEWAY_ID !== $this->id;
+		$is_payment_method_settings_screen = static::GATEWAY_ID !== $this->id;
 
 		if ( $is_payment_method_settings_screen ) :
 			?>

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -27,7 +27,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 *
 	 * @type string
 	 */
-	const GATEWAY_ID = 'woocommerce_payments';
+	const GATEWAY_ID = 'woocommerce_payments_wrapper';
 
 	const METHOD_ENABLED_KEY = 'enabled';
 
@@ -106,14 +106,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$this->token_service            = $token_service;
 		$this->action_scheduler_service = $action_scheduler_service;
 
-		$this->id                 = static::GATEWAY_ID;
-		$this->icon               = ''; // TODO: icon.
-		$this->has_fields         = true;
-		$this->method_title       = __( 'WooCommerce Payments', 'woocommerce-payments' );
-		$this->method_description = __( 'Accept payments via credit card.', 'woocommerce-payments' );
-		$this->title              = __( 'Credit card', 'woocommerce-payments' );
-		$this->description        = __( 'Enter your card details', 'woocommerce-payments' );
-		$this->supports           = [
+		$this->id         = static::GATEWAY_ID;
+		$this->icon       = ''; // TODO: icon.
+		$this->has_fields = true;
+		$this->supports   = [
 			'products',
 			'refunds',
 		];
@@ -585,83 +581,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		];
 
 		return $prepared_customer_data;
-	}
-	/**
-	 * Renders the Credit Card input fields needed to get the user's payment information on the checkout page.
-	 *
-	 * We also add the JavaScript which drives the UI.
-	 */
-	public function payment_fields() {
-		try {
-			$display_tokenization = $this->supports( 'tokenization' ) && is_checkout();
-
-			wp_localize_script( 'wcpay-checkout', 'wcpay_config', $this->get_payment_fields_js_config() );
-			wp_enqueue_script( 'wcpay-checkout' );
-
-			$prepared_customer_data = $this->get_prepared_customer_data();
-			if ( ! empty( $prepared_customer_data ) ) {
-				wp_localize_script( 'wcpay-checkout', 'wcpayCustomerData', $prepared_customer_data );
-			}
-
-			wp_enqueue_style(
-				'wcpay-checkout',
-				plugins_url( 'dist/checkout.css', WCPAY_PLUGIN_FILE ),
-				[],
-				WC_Payments::get_file_version( 'dist/checkout.css' )
-			);
-
-			// Output the form HTML.
-			?>
-			<?php if ( ! empty( $this->get_description() ) ) : ?>
-				<p><?php echo wp_kses_post( $this->get_description() ); ?></p>
-			<?php endif; ?>
-
-			<?php if ( $this->is_in_test_mode() ) : ?>
-				<p class="testmode-info">
-				<?php
-					echo WC_Payments_Utils::esc_interpolated_html(
-						/* translators: link to Stripe testing page */
-						__( '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC, or any test card numbers listed <a>here</a>.', 'woocommerce-payments' ),
-						[
-							'strong' => '<strong>',
-							'a'      => '<a href="https://docs.woocommerce.com/document/payments/testing/#test-cards" target="_blank">',
-						]
-					);
-				?>
-				</p>
-			<?php endif; ?>
-
-			<?php
-			if ( $display_tokenization ) {
-				$this->tokenization_script();
-				echo $this->saved_payment_methods(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			}
-			?>
-
-			<fieldset id="wc-<?php echo esc_attr( $this->id ); ?>-cc-form" class="wc-credit-card-form wc-payment-form">
-				<div id="wcpay-card-element"></div>
-				<div id="wcpay-errors" role="alert"></div>
-				<input id="wcpay-payment-method" type="hidden" name="wcpay-payment-method" />
-
-			<?php
-			if ( $this->is_saved_cards_enabled() ) {
-				$force_save_payment = ( $display_tokenization && ! apply_filters( 'wc_payments_display_save_payment_method_checkbox', $display_tokenization ) ) || is_add_payment_method_page();
-				$this->save_payment_method_checkbox( $force_save_payment );
-			}
-			?>
-
-			</fieldset>
-			<?php
-		} catch ( Exception $e ) {
-			// Output the error message.
-			?>
-			<div>
-				<?php
-				echo esc_html__( 'An error was encountered when preparing the payment form. Please try again later.', 'woocommerce-payments' );
-				?>
-			</div>
-			<?php
-		}
 	}
 
 	/**

--- a/includes/class-wc-payments-blocks-payment-method.php
+++ b/includes/class-wc-payments-blocks-payment-method.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+use WCPay\Payment_Methods\CC_Payment_Gateway;
 
 /**
  * The payment method, which allows the gateway to work with WooCommerce Blocks.
@@ -15,7 +16,7 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 	 * Initializes the class.
 	 */
 	public function initialize() {
-		$this->name    = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+		$this->name    = CC_Payment_Gateway::GATEWAY_ID;
 		$this->gateway = WC_Payments::get_gateway();
 	}
 

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -48,4 +48,13 @@ class WC_Payments_Features {
 	public static function is_sofort_enabled() {
 		return '1' === get_option( '_wcpay_feature_sofort', '0' );
 	}
+
+	/**
+	 * Checks whether any of our Euro debit payment gateway feature is enabled
+	 *
+	 * @return bool
+	 */
+	public static function is_any_euro_debit_enabled() {
+		return self::is_giropay_enabled() || self::is_sofort_enabled() || self::is_sepa_enabled();
+	}
 }

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -101,7 +101,7 @@ class WC_Payments_Token_Service {
 	 * @return array
 	 */
 	public function woocommerce_get_customer_payment_tokens( $tokens, $user_id, $gateway_id ) {
-		if ( ( ! empty( $gateway_id ) && WC_Payment_Gateway_WCPay::GATEWAY_ID !== $gateway_id ) || ! is_user_logged_in() ) {
+		if ( ( ! empty( $gateway_id ) && CC_Payment_Gateway::GATEWAY_ID !== $gateway_id ) || ! is_user_logged_in() ) {
 			return $tokens;
 		}
 
@@ -120,7 +120,7 @@ class WC_Payments_Token_Service {
 		$stored_tokens = [];
 
 		foreach ( $tokens as $token ) {
-			if ( WC_Payment_Gateway_WCPay::GATEWAY_ID === $token->get_gateway_id() ) {
+			if ( CC_Payment_Gateway::GATEWAY_ID === $token->get_gateway_id() ) {
 				$stored_tokens[ $token->get_token() ] = $token;
 			}
 		}
@@ -159,7 +159,7 @@ class WC_Payments_Token_Service {
 	 * @param WC_Payment_Token $token    Token object.
 	 */
 	public function woocommerce_payment_token_deleted( $token_id, $token ) {
-		if ( WC_Payment_Gateway_WCPay::GATEWAY_ID === $token->get_gateway_id() ) {
+		if ( CC_Payment_Gateway::GATEWAY_ID === $token->get_gateway_id() ) {
 			try {
 				$this->payments_api_client->detach_payment_method( $token->get_token() );
 				// Clear cached payment methods.
@@ -177,7 +177,7 @@ class WC_Payments_Token_Service {
 	 * @param WC_Payment_Token $token    Token object.
 	 */
 	public function woocommerce_payment_token_set_default( $token_id, $token ) {
-		if ( WC_Payment_Gateway_WCPay::GATEWAY_ID === $token->get_gateway_id() ) {
+		if ( CC_Payment_Gateway::GATEWAY_ID === $token->get_gateway_id() ) {
 			$customer_id = $this->customer_service->get_customer_id_by_user_id( $token->get_user_id() );
 			if ( $customer_id ) {
 				$this->customer_service->set_default_payment_method_for_customer( $customer_id, $token->get_token() );

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -20,7 +20,7 @@ use WCPay\Payment_Methods\CC_Payment_Gateway;
 /**
  * Gateway class for WooCommerce Payments, with added compatibility with WooCommerce Subscriptions.
  */
-class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_WCPay {
+class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends CC_Payment_Gateway {
 
 	const PAYMENT_METHOD_META_TABLE = 'wc_order_tokens';
 	const PAYMENT_METHOD_META_KEY   = 'token';

--- a/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
+++ b/includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php
@@ -15,6 +15,7 @@ use WCPay\Logger;
 use WCPay\Payment_Information;
 use WCPay\Constants\Payment_Type;
 use WCPay\Constants\Payment_Initiated_By;
+use WCPay\Payment_Methods\CC_Payment_Gateway;
 
 /**
  * Gateway class for WooCommerce Payments, with added compatibility with WooCommerce Subscriptions.
@@ -208,7 +209,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 		add_action(
 			sprintf(
 				'woocommerce_subscription_payment_meta_input_%s_%s_%s',
-				WC_Payment_Gateway_WCPay::GATEWAY_ID,
+				CC_Payment_Gateway::GATEWAY_ID,
 				self::PAYMENT_METHOD_META_TABLE,
 				self::PAYMENT_METHOD_META_KEY
 			),
@@ -400,7 +401,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 	 */
 	public function get_specific_old_payment_method_title( $old_payment_method_title, $old_payment_method, $subscription ) {
 		// make sure payment method is wcpay's.
-		if ( WC_Payment_Gateway_WCPay::GATEWAY_ID !== $old_payment_method ) {
+		if ( CC_Payment_Gateway::GATEWAY_ID !== $old_payment_method ) {
 			return $old_payment_method_title;
 		}
 
@@ -451,7 +452,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Compat extends WC_Payment_Gateway_W
 	 */
 	public function get_specific_new_payment_method_title( $new_payment_method_title, $new_payment_method, $subscription ) {
 		// make sure payment method is wcpay's.
-		if ( WC_Payment_Gateway_WCPay::GATEWAY_ID !== $new_payment_method ) {
+		if ( CC_Payment_Gateway::GATEWAY_ID !== $new_payment_method ) {
 			return $new_payment_method_title;
 		}
 

--- a/includes/payment-methods/class-cc-payment-gateway.php
+++ b/includes/payment-methods/class-cc-payment-gateway.php
@@ -8,11 +8,128 @@
 namespace WCPay\Payment_Methods;
 
 use WC_Payment_Gateway_WCPay;
+use WC_Payments_Account;
+use WC_Payments_Action_Scheduler_Service;
+use WC_Payments_API_Client;
+use WC_Payments_Customer_Service;
+use WC_Payments_Token_Service;
+use WC_Payments;
+use WC_Payments_Utils;
+use WCPay\Exceptions\{ Add_Payment_Method_Exception, Process_Payment_Exception, Intent_Authentication_Exception, API_Exception, Connection_Exception };
+use WCPay\Logger;
+use WCPay\Payment_Information;
+use WCPay\Constants\Payment_Type;
+use WCPay\Constants\Payment_Initiated_By;
+use WCPay\Constants\Payment_Capture_Type;
+use WCPay\Tracker;
 
 /**
  * Credit Card Payment method.
  * Right now behaves exactly like WC_Payment_Gateway_WCPay for max compatibility.
  */
 class CC_Payment_Gateway extends WC_Payment_Gateway_WCPay {
+	/**
+	 * Internal ID of the payment gateway.
+	 *
+	 * @type string
+	 */
+	const GATEWAY_ID = 'woocommerce_payments'; // Keeping it the same?
+
+	const METHOD_ENABLED_KEY = 'cc_enabled';
+
+	/**
+	 * CC_Payment_Gateway constructor.
+	 *
+	 * @param WC_Payments_API_Client               $payments_api_client      - WooCommerce Payments API client.
+	 * @param WC_Payments_Account                  $account                  - Account class instance.
+	 * @param WC_Payments_Customer_Service         $customer_service         - Customer class instance.
+	 * @param WC_Payments_Token_Service            $token_service            - Token class instance.
+	 * @param WC_Payments_Action_Scheduler_Service $action_scheduler_service - Action Scheduler service instance.
+	 */
+	public function __construct( WC_Payments_API_Client $payments_api_client, WC_Payments_Account $account, WC_Payments_Customer_Service $customer_service, WC_Payments_Token_Service $token_service, WC_Payments_Action_Scheduler_Service $action_scheduler_service ) {
+		parent::__construct( $payments_api_client, $account, $customer_service, $token_service, $action_scheduler_service );
+		$this->method_title       = __( 'WooCommerce Payments', 'woocommerce-payments' );
+		$this->method_description = __( 'Accept payments via credit card.', 'woocommerce-payments' );
+		$this->title              = __( 'Credit card', 'woocommerce-payments' );
+		$this->description        = __( 'Enter your card details', 'woocommerce-payments' );
+	}
+
+	/**
+	 * Renders the Credit Card input fields needed to get the user's payment information on the checkout page.
+	 *
+	 * We also add the JavaScript which drives the UI.
+	 */
+	public function payment_fields() {
+		try {
+			$display_tokenization = $this->supports( 'tokenization' ) && is_checkout();
+
+			wp_localize_script( 'wcpay-checkout', 'wcpay_config', $this->get_payment_fields_js_config() );
+			wp_enqueue_script( 'wcpay-checkout' );
+
+			$prepared_customer_data = $this->get_prepared_customer_data();
+			if ( ! empty( $prepared_customer_data ) ) {
+				wp_localize_script( 'wcpay-checkout', 'wcpayCustomerData', $prepared_customer_data );
+			}
+
+			wp_enqueue_style(
+				'wcpay-checkout',
+				plugins_url( 'dist/checkout.css', WCPAY_PLUGIN_FILE ),
+				[],
+				WC_Payments::get_file_version( 'dist/checkout.css' )
+			);
+
+			// Output the form HTML.
+			?>
+			<?php if ( ! empty( $this->get_description() ) ) : ?>
+				<p><?php echo wp_kses_post( $this->get_description() ); ?></p>
+			<?php endif; ?>
+
+			<?php if ( $this->is_in_test_mode() ) : ?>
+				<p class="testmode-info">
+				<?php
+					echo WC_Payments_Utils::esc_interpolated_html(
+						/* translators: link to Stripe testing page */
+						__( '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC, or any test card numbers listed <a>here</a>.', 'woocommerce-payments' ),
+						[
+							'strong' => '<strong>',
+							'a'      => '<a href="https://docs.woocommerce.com/document/payments/testing/#test-cards" target="_blank">',
+						]
+					);
+				?>
+				</p>
+			<?php endif; ?>
+
+			<?php
+			if ( $display_tokenization ) {
+				$this->tokenization_script();
+				echo $this->saved_payment_methods(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
+			?>
+
+			<fieldset id="wc-<?php echo esc_attr( $this->id ); ?>-cc-form" class="wc-credit-card-form wc-payment-form">
+				<div id="wcpay-card-element"></div>
+				<div id="wcpay-errors" role="alert"></div>
+				<input id="wcpay-payment-method" type="hidden" name="wcpay-payment-method" />
+
+			<?php
+			if ( $this->is_saved_cards_enabled() ) {
+				$force_save_payment = ( $display_tokenization && ! apply_filters( 'wc_payments_display_save_payment_method_checkbox', $display_tokenization ) ) || is_add_payment_method_page();
+				$this->save_payment_method_checkbox( $force_save_payment );
+			}
+			?>
+
+			</fieldset>
+			<?php
+		} catch ( Exception $e ) {
+			// Output the error message.
+			?>
+			<div>
+				<?php
+				echo esc_html__( 'An error was encountered when preparing the payment form. Please try again later.', 'woocommerce-payments' );
+				?>
+			</div>
+			<?php
+		}
+	}
 
 }

--- a/includes/payment-methods/class-cc-payment-gateway.php
+++ b/includes/payment-methods/class-cc-payment-gateway.php
@@ -131,41 +131,4 @@ class CC_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			<?php
 		}
 	}
-
-	/**
-	 * Init settings for gateways.
-	 */
-	public function init_settings() {
-		parent::init_settings();
-		// The initialized settings need to be both WCPay Gateway wrapper and the actual Payment Method gateway.
-		if ( 'yes' === $this->settings[ parent::METHOD_ENABLED_KEY ] ) {
-			$this->enabled = ! empty( $this->settings[ self::METHOD_ENABLED_KEY ] ) && 'yes' === $this->settings[ self::METHOD_ENABLED_KEY ] ? 'yes' : 'no';
-		} else {
-			$this->enabled = 'no';
-		}
-	}
-
-	/**
-	 * Checks whether the gateway is enabled.
-	 *
-	 * @return bool The result.
-	 */
-	public function is_enabled() {
-		return 'yes' === $this->get_option( 'cc_enabled' );
-	}
-
-	/**
-	 * Disables gateway.
-	 */
-	public function disable() {
-		$this->update_option( 'cc_enabled', 'no' );
-	}
-
-	/**
-	 * Enables gateway.
-	 */
-	public function enable() {
-		$this->update_option( 'cc_enabled', 'yes' );
-	}
-
 }

--- a/includes/payment-methods/class-cc-payment-gateway.php
+++ b/includes/payment-methods/class-cc-payment-gateway.php
@@ -15,13 +15,7 @@ use WC_Payments_Customer_Service;
 use WC_Payments_Token_Service;
 use WC_Payments;
 use WC_Payments_Utils;
-use WCPay\Exceptions\{ Add_Payment_Method_Exception, Process_Payment_Exception, Intent_Authentication_Exception, API_Exception, Connection_Exception };
-use WCPay\Logger;
-use WCPay\Payment_Information;
-use WCPay\Constants\Payment_Type;
-use WCPay\Constants\Payment_Initiated_By;
-use WCPay\Constants\Payment_Capture_Type;
-use WCPay\Tracker;
+use Exception;
 
 /**
  * Credit Card Payment method.

--- a/includes/payment-methods/class-cc-payment-gateway.php
+++ b/includes/payment-methods/class-cc-payment-gateway.php
@@ -132,4 +132,40 @@ class CC_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		}
 	}
 
+	/**
+	 * Init settings for gateways.
+	 */
+	public function init_settings() {
+		parent::init_settings();
+		// The initialized settings need to be both WCPay Gateway wrapper and the actual Payment Method gateway.
+		if ( 'yes' === $this->settings[ parent::METHOD_ENABLED_KEY ] ) {
+			$this->enabled = ! empty( $this->settings[ self::METHOD_ENABLED_KEY ] ) && 'yes' === $this->settings[ self::METHOD_ENABLED_KEY ] ? 'yes' : 'no';
+		} else {
+			$this->enabled = 'no';
+		}
+	}
+
+	/**
+	 * Checks whether the gateway is enabled.
+	 *
+	 * @return bool The result.
+	 */
+	public function is_enabled() {
+		return 'yes' === $this->get_option( 'cc_enabled' );
+	}
+
+	/**
+	 * Disables gateway.
+	 */
+	public function disable() {
+		$this->update_option( 'cc_enabled', 'no' );
+	}
+
+	/**
+	 * Enables gateway.
+	 */
+	public function enable() {
+		$this->update_option( 'cc_enabled', 'yes' );
+	}
+
 }

--- a/includes/payment-methods/class-sepa-payment-gateway.php
+++ b/includes/payment-methods/class-sepa-payment-gateway.php
@@ -56,16 +56,16 @@ class Sepa_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		try {
 			$display_tokenization = $this->supports( 'tokenization' ) && is_checkout();
 
-			wp_localize_script( 'wcpay-sepa-checkout', 'wcpay_config', $this->get_payment_fields_js_config() );
-			wp_enqueue_script( 'wcpay-sepa-checkout' );
+			wp_localize_script( 'wcpay-checkout', 'wcpay_config', $this->get_payment_fields_js_config() );
+			wp_enqueue_script( 'wcpay-checkout' );
 
 			$prepared_customer_data = $this->get_prepared_customer_data();
 			if ( ! empty( $prepared_customer_data ) ) {
-				wp_localize_script( 'wcpay-sepa-checkout', 'wcpayCustomerData', $prepared_customer_data );
+				wp_localize_script( 'wcpay-checkout', 'wcpayCustomerData', $prepared_customer_data );
 			}
 
 			wp_enqueue_style(
-				'wcpay-sepa-checkout',
+				'wcpay-checkout',
 				plugins_url( 'dist/checkout.css', WCPAY_PLUGIN_FILE ),
 				[],
 				WC_Payments::get_file_version( 'dist/checkout.css' )

--- a/includes/payment-methods/class-sepa-payment-gateway.php
+++ b/includes/payment-methods/class-sepa-payment-gateway.php
@@ -15,6 +15,7 @@ use WC_Payments_Customer_Service;
 use WC_Payments_Token_Service;
 use WC_Payments;
 use WC_Payments_Utils;
+use Exception;
 
 /**
  * SEPA Payment method extended from cart payment method.
@@ -118,7 +119,7 @@ class Sepa_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 			</fieldset>
 			<?php
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			// Output the error message.
 			?>
 			<div>

--- a/includes/payment-methods/class-sepa-payment-gateway.php
+++ b/includes/payment-methods/class-sepa-payment-gateway.php
@@ -129,40 +129,4 @@ class Sepa_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			<?php
 		}
 	}
-
-	/**
-	 * Init settings for gateways.
-	 */
-	public function init_settings() {
-		parent::init_settings();
-		// The initialized settings need to be both WCPay Gateway wrapper and the actual Payment Method gateway.
-		if ( 'yes' === $this->settings[ parent::METHOD_ENABLED_KEY ] ) {
-			$this->enabled = ! empty( $this->settings[ self::METHOD_ENABLED_KEY ] ) && 'yes' === $this->settings[ self::METHOD_ENABLED_KEY ] ? 'yes' : 'no';
-		} else {
-			$this->enabled = 'no';
-		}
-	}
-
-	/**
-	 * Checks whether the gateway is enabled.
-	 *
-	 * @return bool The result.
-	 */
-	public function is_enabled() {
-		return 'yes' === $this->get_option( self::METHOD_ENABLED_KEY );
-	}
-
-	/**
-	 * Disables gateway.
-	 */
-	public function disable() {
-		$this->update_option( self::METHOD_ENABLED_KEY, 'no' );
-	}
-
-	/**
-	 * Enables gateway.
-	 */
-	public function enable() {
-		$this->update_option( self::METHOD_ENABLED_KEY, 'yes' );
-	}
 }

--- a/includes/payment-methods/class-sepa-payment-gateway.php
+++ b/includes/payment-methods/class-sepa-payment-gateway.php
@@ -129,4 +129,40 @@ class Sepa_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			<?php
 		}
 	}
+
+	/**
+	 * Init settings for gateways.
+	 */
+	public function init_settings() {
+		parent::init_settings();
+		// The initialized settings need to be both WCPay Gateway wrapper and the actual Payment Method gateway.
+		if ( 'yes' === $this->settings[ parent::METHOD_ENABLED_KEY ] ) {
+			$this->enabled = ! empty( $this->settings[ self::METHOD_ENABLED_KEY ] ) && 'yes' === $this->settings[ self::METHOD_ENABLED_KEY ] ? 'yes' : 'no';
+		} else {
+			$this->enabled = 'no';
+		}
+	}
+
+	/**
+	 * Checks whether the gateway is enabled.
+	 *
+	 * @return bool The result.
+	 */
+	public function is_enabled() {
+		return 'yes' === $this->get_option( self::METHOD_ENABLED_KEY );
+	}
+
+	/**
+	 * Disables gateway.
+	 */
+	public function disable() {
+		$this->update_option( self::METHOD_ENABLED_KEY, 'no' );
+	}
+
+	/**
+	 * Enables gateway.
+	 */
+	public function enable() {
+		$this->update_option( self::METHOD_ENABLED_KEY, 'yes' );
+	}
 }

--- a/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
@@ -7,6 +7,7 @@
 
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Exceptions\Rest_Request_Exception;
+use WCPay\Payment_Methods\CC_Payment_Gateway;
 
 /**
  * WC_REST_Payments_Orders_Controller unit tests.
@@ -25,7 +26,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 	private $mock_api_client;
 
 	/**
-	 * @var WC_Payment_Gateway_WCPay|MockObject
+	 * @var CC_Payment_Gateway|MockObject
 	 */
 	private $mock_gateway;
 
@@ -46,7 +47,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 		wp_set_current_user( 1 );
 
 		$this->mock_api_client = $this->createMock( WC_Payments_API_Client::class );
-		$this->mock_gateway    = $this->createMock( WC_Payment_Gateway_WCPay::class );
+		$this->mock_gateway    = $this->createMock( CC_Payment_Gateway::class );
 
 		$this->controller = new WC_REST_Payments_Orders_Controller(
 			$this->mock_api_client,

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -52,6 +52,7 @@ function _manually_load_plugin() {
 
 	// Load the gateway files, so subscriptions can be tested.
 	require_once $_plugin_dir . 'includes/class-wc-payment-gateway-wcpay.php';
+	require_once $_plugin_dir . 'includes/payment-methods/class-cc-payment-gateway.php';
 	require_once $_plugin_dir . 'includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php';
 
 	require_once $_plugin_dir . 'includes/exceptions/class-rest-request-exception.php';

--- a/tests/unit/helpers/class-wc-helper-token.php
+++ b/tests/unit/helpers/class-wc-helper-token.php
@@ -6,6 +6,7 @@
  */
 
 use WCPay\Payment_Methods\Sepa_Payment_Gateway;
+use WCPay\Payment_Methods\CC_Payment_Gateway;
 
 /**
  * Class WC_Helper_Token.
@@ -21,7 +22,7 @@ class WC_Helper_Token {
 	 * @param int    $user_id        ID of the token's user, defaults to get_current_user_id().
 	 * @param string $gateway        Token's Gateway ID, default to WC_Payment_Gateway_WCPay::GATEWAY_ID
 	 */
-	public static function create_token( $payment_method, $user_id = null, $gateway = WC_Payment_Gateway_WCPay::GATEWAY_ID ) {
+	public static function create_token( $payment_method, $user_id = null, $gateway = CC_Payment_Gateway::GATEWAY_ID ) {
 		$token = new WC_Payment_Token_CC();
 		$token->set_token( $payment_method );
 		$token->set_gateway_id( $gateway );

--- a/tests/unit/helpers/class-wc-helper-token.php
+++ b/tests/unit/helpers/class-wc-helper-token.php
@@ -20,7 +20,7 @@ class WC_Helper_Token {
 	 *
 	 * @param string $payment_method Token payment method.
 	 * @param int    $user_id        ID of the token's user, defaults to get_current_user_id().
-	 * @param string $gateway        Token's Gateway ID, default to WC_Payment_Gateway_WCPay::GATEWAY_ID
+	 * @param string $gateway        Token's Gateway ID, default to CC_Payment_Gateway::GATEWAY_ID
 	 */
 	public static function create_token( $payment_method, $user_id = null, $gateway = CC_Payment_Gateway::GATEWAY_ID ) {
 		$token = new WC_Payment_Token_CC();

--- a/tests/unit/payment-methods/test-class-cc-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-cc-payment-gateway.php
@@ -1,17 +1,18 @@
 <?php
 /**
- * Class WC_Payment_Gateway_WCPay_Test
+ * Class CC_Payment_Gateway_Test
  *
  * @package WooCommerce\Payments\Tests
  */
 
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Exceptions\API_Exception;
+use WCPay\Payment_Methods\CC_Payment_Gateway;
 
 /**
- * WC_Payment_Gateway_WCPay unit tests.
+ * CC_Payment_Gateway unit tests.
  */
-class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
+class CC_Payment_Gateway_Test extends WP_UnitTestCase {
 
 	const NO_REQUIREMENTS      = false;
 	const PENDING_REQUIREMENTS = true;
@@ -19,7 +20,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	/**
 	 * System under test.
 	 *
-	 * @var WC_Payment_Gateway_WCPay
+	 * @var CC_Payment_Gateway
 	 */
 	private $wcpay_gateway;
 
@@ -90,7 +91,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 		$this->mock_action_scheduler_service = $this->createMock( WC_Payments_Action_Scheduler_Service::class );
 
-		$this->wcpay_gateway = new WC_Payment_Gateway_WCPay(
+		$this->wcpay_gateway = new CC_Payment_Gateway(
 			$this->mock_api_client,
 			$this->mock_wcpay_account,
 			$this->mock_customer_service,
@@ -1255,7 +1256,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_outputs_payment_method_settings_screen() {
-		$gateway     = $this->getMockBuilder( WC_Payment_Gateway_WCPay::class )
+		$gateway     = $this->getMockBuilder( CC_Payment_Gateway::class )
 			->disableOriginalConstructor()
 			->setMethods( null )
 			->getMock();

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -7,6 +7,7 @@
 
 use WCPay\Exceptions\API_Exception;
 use WCPay\Exceptions\Connection_Exception;
+use WCPay\Payment_Methods\CC_Payment_Gateway;
 
 /**
  * WC_Payment_Gateway_WCPay unit tests.
@@ -15,7 +16,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	/**
 	 * System under test.
 	 *
-	 * @var WC_Payment_Gateway_WCPay
+	 * @var CC_Payment_Gateway
 	 */
 	private $mock_wcpay_gateway;
 
@@ -95,9 +96,9 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		// Arrange: Mock WC_Payment_Gateway_WCPay so that some of its methods can be
+		// Arrange: Mock CC_Payment_Gateway so that some of its methods can be
 		// mocked, and their return values can be used for testing.
-		$this->mock_wcpay_gateway = $this->getMockBuilder( 'WC_Payment_Gateway_WCPay' )
+		$this->mock_wcpay_gateway = $this->getMockBuilder( CC_Payment_Gateway::class )
 			->setConstructorArgs(
 				[
 					$this->mock_api_client,
@@ -790,8 +791,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$token = WC_Helper_Token::create_token( 'pm_mock' );
 
 		return [
-			'payment_method' => WC_Payment_Gateway_WCPay::GATEWAY_ID,
-			'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' => (string) $token->get_id(),
+			'payment_method' => CC_Payment_Gateway::GATEWAY_ID,
+			'wc-' . CC_Payment_Gateway::GATEWAY_ID . '-payment-token' => (string) $token->get_id(),
 		];
 	}
 }

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-payment-method-order-note.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-payment-method-order-note.php
@@ -155,7 +155,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Payment_Method_Order_Note_Test exte
 		$this->renewal_order->set_payment_method( $new_payment_method );
 		$this->renewal_order->set_payment_method_title( $new_payment_method_title );
 
-		$_POST['payment_method']                      = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+		$_POST['payment_method']                      = CC_Payment_Gateway::GATEWAY_ID;
 		$_POST[ $this->post_payment_token_parameter ] = $this->token2->get_id();
 
 		$old_payment_method_title_modified = (string) apply_filters( 'woocommerce_subscription_note_old_payment_method_title', $old_payment_method_title, $old_payment_method, $this->subscription );
@@ -205,7 +205,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Payment_Method_Order_Note_Test exte
 		$this->subscription->set_payment_method( $new_payment_method );
 		$this->subscription->set_payment_method_title( $new_payment_method_title );
 
-		$_POST['payment_method']                      = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+		$_POST['payment_method']                      = CC_Payment_Gateway::GATEWAY_ID;
 		$_POST[ $this->post_payment_token_parameter ] = $this->token2->get_id();
 
 		$old_payment_method_title_modified = (string) apply_filters( 'woocommerce_subscription_note_old_payment_method_title', $old_payment_method_title, $old_payment_method, $this->subscription );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-payment-method-order-note.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-payment-method-order-note.php
@@ -6,6 +6,7 @@
  */
 
 use WCPay\Exceptions\API_Exception;
+use WCPay\Payment_Methods\CC_Payment_Gateway;
 
 /**
  * WC_Payment_Gateway_WCPay unit tests.
@@ -118,7 +119,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Payment_Method_Order_Note_Test exte
 		$this->token3->set_last4( $this->last4digits[3] );
 		$this->token3->save();
 
-		$this->post_payment_token_parameter  = 'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token';
+		$this->post_payment_token_parameter  = 'wc-' . CC_Payment_Gateway::GATEWAY_ID . '-payment-token';
 		$this->post_payment_method_parameter = 'wcpay-payment-method';
 
 		// add token to renewal order.
@@ -144,8 +145,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Payment_Method_Order_Note_Test exte
 	 * expect old and new title to be modified. Renewal order is updated.
 	 */
 	public function test_failed_renewal_using_saved_payment() {
-		$old_payment_method       = WC_Payment_Gateway_WCPay::GATEWAY_ID;
-		$new_payment_method       = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+		$old_payment_method       = CC_Payment_Gateway::GATEWAY_ID;
+		$new_payment_method       = CC_Payment_Gateway::GATEWAY_ID;
 		$old_payment_method_title = 'cc';
 		$new_payment_method_title = 'cc';
 
@@ -164,8 +165,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Payment_Method_Order_Note_Test exte
 	}
 
 	public function test_failed_renewal_using_new_payment_method() {
-		$old_payment_method       = WC_Payment_Gateway_WCPay::GATEWAY_ID;
-		$new_payment_method       = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+		$old_payment_method       = CC_Payment_Gateway::GATEWAY_ID;
+		$new_payment_method       = CC_Payment_Gateway::GATEWAY_ID;
 		$old_payment_method_title = 'cc';
 		$new_payment_method_title = 'cc';
 
@@ -194,8 +195,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Payment_Method_Order_Note_Test exte
 	 * expect old and new title to be modified. Subscription order is updated.
 	 */
 	public function test_subscriptions_order_using_saved_payment() {
-		$old_payment_method       = WC_Payment_Gateway_WCPay::GATEWAY_ID;
-		$new_payment_method       = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+		$old_payment_method       = CC_Payment_Gateway::GATEWAY_ID;
+		$new_payment_method       = CC_Payment_Gateway::GATEWAY_ID;
 		$old_payment_method_title = 'cc';
 		$new_payment_method_title = 'cc';
 
@@ -219,8 +220,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Payment_Method_Order_Note_Test exte
 	 * modified. Subscription order is updated.
 	 */
 	public function test_subscriptions_order_using_new_payment_method() {
-		$old_payment_method       = WC_Payment_Gateway_WCPay::GATEWAY_ID;
-		$new_payment_method       = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+		$old_payment_method       = CC_Payment_Gateway::GATEWAY_ID;
+		$new_payment_method       = CC_Payment_Gateway::GATEWAY_ID;
 		$old_payment_method_title = 'cc';
 		$new_payment_method_title = 'cc';
 
@@ -251,8 +252,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Payment_Method_Order_Note_Test exte
 	 * be changed.
 	 */
 	public function test_subscriptions_order_using_new_payment_method_flagged_as_change() {
-		$old_payment_method       = WC_Payment_Gateway_WCPay::GATEWAY_ID;
-		$new_payment_method       = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+		$old_payment_method       = CC_Payment_Gateway::GATEWAY_ID;
+		$new_payment_method       = CC_Payment_Gateway::GATEWAY_ID;
 		$old_payment_method_title = 'cc';
 		$new_payment_method_title = 'cc';
 
@@ -310,12 +311,12 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Payment_Method_Order_Note_Test exte
 	 * modified.
 	 */
 	public function test_new_payment_method_non_wc_pay() {
-		$old_payment_method       = WC_Payment_Gateway_WCPay::GATEWAY_ID;
-		$new_payment_method       = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+		$old_payment_method       = CC_Payment_Gateway::GATEWAY_ID;
+		$new_payment_method       = CC_Payment_Gateway::GATEWAY_ID;
 		$old_payment_method_title = 'cc';
 		$new_payment_method_title = 'cc';
 
-		$old_payment_method = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+		$old_payment_method = CC_Payment_Gateway::GATEWAY_ID;
 		$new_payment_method = 'non-wc-pay';
 		$this->subscription->update_meta_data( '_old_payment_method', $old_payment_method );
 		$this->subscription->set_payment_method( $new_payment_method );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -261,7 +261,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 		$order = WC_Helper_Order::create_order( self::USER_ID );
 
 		$_POST = [
-			'payment_method'        => WC_Payment_Gateway_WCPay::GATEWAY_ID,
+			'payment_method'        => CC_Payment_Gateway::GATEWAY_ID,
 			self::TOKEN_REQUEST_KEY => $this->token->get_id(),
 		];
 
@@ -297,7 +297,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 		$order = WC_Helper_Order::create_order( self::USER_ID, 0 );
 
 		$_POST = [
-			'payment_method'        => WC_Payment_Gateway_WCPay::GATEWAY_ID,
+			'payment_method'        => CC_Payment_Gateway::GATEWAY_ID,
 			self::TOKEN_REQUEST_KEY => $this->token->get_id(),
 		];
 
@@ -372,7 +372,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 		$order = WC_Helper_Order::create_order( self::USER_ID, 0 );
 
 		$_POST = [
-			'payment_method'        => WC_Payment_Gateway_WCPay::GATEWAY_ID,
+			'payment_method'        => CC_Payment_Gateway::GATEWAY_ID,
 			self::TOKEN_REQUEST_KEY => $this->token->get_id(),
 		];
 		$_GET  = [ 'change_payment_method' => 10 ];

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Payments\Tests
  */
 
+use WCPay\Payment_Methods\CC_Payment_Gateway;
+
 /**
  * WC_Payment_Gateway_WCPay unit tests.
  */
@@ -15,7 +17,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 	const CHARGE_ID         = 'ch_mock';
 	const SETUP_INTENT_ID   = 'si_mock';
 	const PAYMENT_INTENT_ID = 'pi_mock';
-	const TOKEN_REQUEST_KEY = 'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token';
+	const TOKEN_REQUEST_KEY = 'wc-' . CC_Payment_Gateway::GATEWAY_ID . '-payment-token';
 
 	/**
 	 * System under test.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -6,6 +6,7 @@
  */
 
 use WCPay\Exceptions\API_Exception;
+use WCPay\Payment_Methods\CC_Payment_Gateway;
 
 /**
  * WC_Payment_Gateway_WCPay unit tests.
@@ -527,7 +528,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 		$subscription->add_payment_token( WC_Helper_Token::create_token( self::PAYMENT_METHOD_ID, self::USER_ID ) );
 
 		$this->wcpay_gateway->add_subscription_payment_meta( [], $subscription );
-		$this->assertTrue( has_action( 'woocommerce_subscription_payment_meta_input_' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '_wc_order_tokens_token' ) );
+		$this->assertTrue( has_action( 'woocommerce_subscription_payment_meta_input_' . CC_Payment_Gateway::GATEWAY_ID . '_wc_order_tokens_token' ) );
 	}
 
 	public function test_adds_custom_payment_meta_input_fallback_until_subs_3_0_7() {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/1615

#### Changes proposed in this Pull Request
This PR attempts to decouple "woocommerce_payments" from credit card so that "WooCommerce Payments" and "WooCommerce Payments - Credit Card" can be enabled/disabled separately. As well, SEPA, Sofort, Giropay can be enabled on its own. For example,

| WooCommerce Payments | Credit Card | SEPA | Result|
|-|-|-|-|
|:white_check_mark: | :x: | :x: | No payment methods| 
|:white_check_mark: | :white_check_mark: | :x: | Credit card available| 
|:white_check_mark: | :x: | :white_check_mark: | SEPA available| 
|:white_check_mark: | :white_check_mark: | :white_check_mark: | Credit Card + SEPA available| 
|:x: | :white_check_mark:  / :x: | :white_check_mark:  / :x:  | No payment methods| 

This PR will make changes to the existing hierarchy as follow:
```
WC_Settings_API [wc core]
  - WC_Payment_Gateway [wc core]
  	- WC_Payment_Gateway_CC  [wc core, credit card]
  		- WC_Payment_Gateway_WCPay [Gateway class for WooCommerce Payments] 
  			- WC_Payment_Gateway_WCPay_Subscriptions_Compat
  			- CC_Payment_Gateway [blank]
  			- Giropay_Payment_Gateway
  			- Sepa_Payment_Gateway
  			- Sofort_Payment_Gateway
```
to 
```
WC_Settings_API [wc core]
  - WC_Payment_Gateway [wc core]
  	- WC_Payment_Gateway_CC  [wc core, credit card]
  		- WC_Payment_Gateway_WCPay [Wrapper Gateway class for WooCommerce Payments] 
  			- CC_Payment_Gateway [Credit card payment method]
  				- WC_Payment_Gateway_WCPay_Subscriptions_Compat
  			- Giropay_Payment_Gateway
  			- Sepa_Payment_Gateway
  			- Sofort_Payment_Gateway
```

This PR proposes the following changes:
- Refactored `WC_Payment_Gateway_WCPay` class and pull out Credit Card's function into `CC_Payment_Gateway`.
- Update `WC_Payment_Gateway_WCPay`'s `GATEWAY_ID` from `woocommerce_payments` to a new ID, `woocommerce_payments_wrapper`. This aims to make `WC_Payment_Gateway_WCPay` behaves almost like an abstract class.
- Update `WC_Payment_Gateway_WCPay_Subscriptions_Compat` to extend from `CC_Payment_Gateway` instead of `WC_Payment_Gateway_WCPay`.
- Replace all `WC_Payment_Gateway_WCPay::GATEWAY_ID` to `CC_Payment_Gateway::GATEWAY_ID`
- Make sure Credit Card is still enabled by default when none of the euro debit payment methods is enabled (backward compatible).
- Renamed `tests/unit/payment-methods/test-class-wc-payment-gateway-wcpay.php` to `tests/unit/payment-methods/test-class-cc-payment-gateway.php`. This continue to test Credit Card payments.

#### Testing instructions
Test backward compatibility. 
1. Pull this branch
2. Check out an item. Credit Card should show by default. Same behaviour as `develop`.
3. WooCommerce Payment Methods settings (wp-admin/admin.php?page=wc-settings&tab=checkout) should continue to work
4. WooCommerce Payment setting should behaves the same (wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments)

Test with SEPA feature flag enabled
1. With the option _wcpay_feature_sepa = 1 
2. Go to WooCommerce Payment Methods settings (wp-admin/admin.php?page=wc-settings&tab=checkout), you should see just "WooCommerce Payments" method
![image](https://user-images.githubusercontent.com/572862/117212348-75afad80-adb7-11eb-89df-26fba042c269.png)
3. Click "Manage", you should see 2 more Payment Method checkboxes at the bottom; Credit Card and SEPA. 
![image](https://user-images.githubusercontent.com/572862/117212645-d6d78100-adb7-11eb-9c40-0cf95ca7e12c.png)
4. Uncheck credit card's and check SEPA's.
5. Check out an item, and only SEPA should show as payment method.

-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
