### PR TITLE
Fix payment gateway filtering

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@
 * Update - Improve the Connect Account page.
 * Update - Base UI components and their styling.
 * Fix - Deposits overview details not displayed.
-* Fix - WooCommerce Payments dissapeard from WooCommerce Settings if WooCommerce Subscriptions is activated.
+* Fix - WooCommerce Payments disappeared from WooCommerce Settings if WooCommerce Subscriptions is activated.
 
 = 2.3.2 - 2021-04-27 =
 * Fix - Error when purchasing free trial subscriptions.

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Update - Improve the Connect Account page.
 * Update - Base UI components and their styling.
 * Fix - Deposits overview details not displayed.
+* Fix - WooCommerce Payments dissapeard from WooCommerce Settings if WooCommerce Subscriptions is activated.
 
 = 2.3.2 - 2021-04-27 =
 * Fix - Error when purchasing free trial subscriptions.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -464,11 +464,15 @@ class WC_Payments {
 
 	/**
 	 * Called on Payments setting page.
-	 * Remove all WCPay gateways except CC one.
+	 *
+	 * Remove all WCPay gateways except CC one. Comparison is done against
+	 * $self::card_gateway because it should be the same instance as
+	 * registered with WooCommerce and class can change depending on
+	 * environment (see `init` method where $card_gateway is set).
 	 */
 	public static function hide_gateways_on_settings_page() {
 		foreach ( WC()->payment_gateways->payment_gateways as $index => $payment_gateway ) {
-			if ( $payment_gateway instanceof WC_Payment_Gateway_WCPay && ! $payment_gateway instanceof CC_Payment_Gateway ) {
+			if ( $payment_gateway instanceof WC_Payment_Gateway_WCPay && $payment_gateway !== self::$card_gateway ) {
 				unset( WC()->payment_gateways->payment_gateways[ $index ] );
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Improve the Connect Account page.
 * Update - Base UI components and their styling.
 * Fix - Deposits overview details not displayed.
+* Fix - WooCommerce Payments dissapeard from WooCommerce Settings if WooCommerce Subscriptions is activated.
 
 = 2.3.2 - 2021-04-27 =
 * Fix - Error when purchasing free trial subscriptions.

--- a/readme.txt
+++ b/readme.txt
@@ -105,7 +105,7 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Improve the Connect Account page.
 * Update - Base UI components and their styling.
 * Fix - Deposits overview details not displayed.
-* Fix - WooCommerce Payments dissapeard from WooCommerce Settings if WooCommerce Subscriptions is activated.
+* Fix - WooCommerce Payments disappeared from WooCommerce Settings if WooCommerce Subscriptions is activated.
 
 = 2.3.2 - 2021-04-27 =
 * Fix - Error when purchasing free trial subscriptions.


### PR DESCRIPTION
Fixes #1717

#### Changes proposed in this Pull Request

When WCPay detects that WooCommerce Subscriptions is enabled it switches class for Credit Card gateway to one compatible with Subscriptions.

Since support for more payment gateways was introduced WCPay started filtering payment gateways from **WooCommerce > Payment > Settings** to avoid duplicated rows. But comparison had a flaw that didn't account that Credit Card gateway can be of one of the two classes.

By comparing class instances directly this issue can be avoided for any future modifications of `$card_gateway`.

#### Testing instructions

**To re-create the issue:**

1. Install and activate_WooCommerce Payments_ (from `develop` branch) and _WooCommerce Subscriptions_.
2. Go to **WooCommerce > Settings > Payments**. _WooCommerce Payments_ will be missing.
3. Deactivate _WooCommerce Subscriptions_.
4. Go to **WooCommerce > Settings > Payments**. _WooCommerce Payments_ is visible.

**After fix:**

1. Install and activate_WooCommerce Payments_ (from `develop` branch) and _WooCommerce Subscriptions_.
2. Go to **WooCommerce > Settings > Payments**. _WooCommerce Payments_ is visible.
3. Switch on other payment gateways in`WC_Payments_Features`.
4. Go to **WooCommerce > Settings > Payments**. _WooCommerce Payments_ is visible and is displayed only once.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
