### PR TITLE
feat: do not show delete when one payment method enabled

### DIFF
--- a/client/components/orderable-list/payment-method.js
+++ b/client/components/orderable-list/payment-method.js
@@ -41,14 +41,16 @@ const PaymentMethod = ( {
 				>
 					{ __( 'Manage', 'woocommerce-payments' ) }
 				</a>
-				<Button
-					isLink
-					aria-label={ __( 'Delete', 'woocommerce-payments' ) }
-					className="payment-method__action delete"
-					onClick={ onDeleteClick }
-				>
-					<IconComponent icon={ trash } size={ 24 } />
-				</Button>
+				{ onDeleteClick && (
+					<Button
+						isLink
+						aria-label={ __( 'Delete', 'woocommerce-payments' ) }
+						className="payment-method__action delete"
+						onClick={ onDeleteClick }
+					>
+						<IconComponent icon={ trash } size={ 24 } />
+					</Button>
+				) }
 			</div>
 		</>
 	);

--- a/client/components/orderable-list/test/payment-method.js
+++ b/client/components/orderable-list/test/payment-method.js
@@ -20,7 +20,7 @@ describe( 'PaymentMethod', () => {
 	} );
 
 	test( 'renders "Manage" and "Delete"', () => {
-		render( <PaymentMethod label="Foo" /> );
+		render( <PaymentMethod label="Foo" onDeleteClick={ jest.fn() } /> );
 
 		const manageLink = screen.queryByRole( 'link', {
 			name: 'Manage',
@@ -32,6 +32,21 @@ describe( 'PaymentMethod', () => {
 
 		expect( manageLink ).toBeInTheDocument();
 		expect( deleteButton ).toBeInTheDocument();
+	} );
+
+	test( 'does not render "Delete" when the handler is not provided', () => {
+		render( <PaymentMethod label="Foo" onDeleteClick={ undefined } /> );
+
+		const manageLink = screen.queryByRole( 'link', {
+			name: 'Manage',
+		} );
+
+		const deleteButton = screen.queryByRole( 'button', {
+			name: 'Delete',
+		} );
+
+		expect( manageLink ).toBeInTheDocument();
+		expect( deleteButton ).not.toBeInTheDocument();
 	} );
 
 	test( '"Manage" is a link to expected URL', () => {
@@ -46,14 +61,19 @@ describe( 'PaymentMethod', () => {
 	} );
 
 	test( 'clicking "Delete" button calls onDeleteClick()', () => {
-		const onDeleteClick = jest.fn();
-		render( <PaymentMethod label="Foo" onDeleteClick={ onDeleteClick } /> );
+		const handleDeleteClickMock = jest.fn();
+		render(
+			<PaymentMethod
+				label="Foo"
+				onDeleteClick={ handleDeleteClickMock }
+			/>
+		);
 
 		const deleteButton = screen.getByRole( 'button', {
 			name: 'Delete',
 		} );
 		user.click( deleteButton );
-		expect( onDeleteClick ).toHaveBeenCalled();
+		expect( handleDeleteClickMock ).toHaveBeenCalled();
 	} );
 
 	test( 'label is a link to expected URL', () => {

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -122,8 +122,10 @@ const PaymentMethods = ( { enabledMethodIds, onEnabledMethodIdsChange } ) => {
 									className={ classNames( 'payment-method', {
 										'has-icon-border': 'cc' !== id,
 									} ) }
-									onDeleteClick={ () =>
-										handleDeleteClick( id )
+									onDeleteClick={
+										1 < enabledMethods.length
+											? () => handleDeleteClick( id )
+											: undefined
 									}
 									id={ id }
 									label={ label }

--- a/client/payment-methods/test/index.js
+++ b/client/payment-methods/test/index.js
@@ -75,6 +75,27 @@ describe( 'PaymentMethods', () => {
 	} );
 
 	test( 'enabled methods are rendered with "Manage" and "Delete" buttons', () => {
+		const enabledMethodIds = [ 'cc', 'sepa' ];
+
+		render(
+			<PaymentMethods
+				enabledMethodIds={ enabledMethodIds }
+				onEnabledMethodIdsChange={ () => {} }
+			/>
+		);
+
+		const cc = screen.getByText( 'Credit card / debit card' );
+		const listItem = cc.closest( 'li' );
+
+		expect(
+			within( listItem ).queryByRole( 'link', { name: 'Manage' } )
+		).toBeInTheDocument();
+		expect(
+			within( listItem ).queryByRole( 'button', { name: 'Delete' } )
+		).toBeInTheDocument();
+	} );
+
+	test( 'when only one enabled method is rendered, the "Delete" button is not visible', () => {
 		const enabledMethodIds = [ 'cc' ];
 
 		render(
@@ -87,12 +108,12 @@ describe( 'PaymentMethods', () => {
 		const cc = screen.getByText( 'Credit card / debit card' );
 		const listItem = cc.closest( 'li' );
 
-		expect( listItem ).toContainElement(
-			within( listItem ).getByRole( 'link', { name: 'Manage' } )
-		);
-		expect( listItem ).toContainElement(
-			within( listItem ).getByRole( 'button', { name: 'Delete' } )
-		);
+		expect(
+			within( listItem ).queryByRole( 'link', { name: 'Manage' } )
+		).toBeInTheDocument();
+		expect(
+			within( listItem ).queryByRole( 'button', { name: 'Delete' } )
+		).not.toBeInTheDocument();
 	} );
 
 	test( 'clicking delete updates enabled method IDs', () => {


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When more than one payment method is enabled, show the "delete" button: https://d.pr/i/l4gDtS
When only one payment method is enabled, hide the "delete" button: https://d.pr/i/fowycM / https://d.pr/i/8yFzUJ

![2021-05-05 11 26 53](https://user-images.githubusercontent.com/273592/117175797-d5e12800-ad94-11eb-8544-4269bc2d18f0.gif)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have the "grouped settings" flag enabled in WCPay Dev Tools
- Visit http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout
- Clicking the "delete" button on one of the enabled payment methods will remove the "delete" button from the remaining one

-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
