### PR TITLE
feat: additional payment methods onboarding skeleton

### DIFF
--- a/client/additional-methods-setup/index.js
+++ b/client/additional-methods-setup/index.js
@@ -1,0 +1,43 @@
+/** @format **/
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import MethodSelector from './methods-selector';
+
+addFilter(
+	'woocommerce_admin_onboarding_task_list',
+	'woocommerce-payments',
+	( tasks ) => {
+		return [
+			...tasks,
+			{
+				key: 'woocommerce-payments--additional-payment-methods',
+				title: __(
+					'Set up additional payment methods',
+					'woocommerce-payments'
+				),
+				// it might be worth exploring how to use Suspense
+				// to lazily load the JS that might not be necessary if the action is not taken.
+				// TODO: error boundary to prevent the whole page to be blank
+				container: <MethodSelector />,
+				// please note: marking an item as "dismissed" does not mean it's "completed" - they are considered 2 different things
+				completed:
+					'yes' ===
+					window.wcpayAdditionalMethodsSetup.isSetupCompleted,
+				visible: true,
+				additionalInfo: __(
+					'Offer your customers preferred payment methods with WooCommerce Payments',
+					'woocommerce-payments'
+				),
+				isDismissable: true,
+			},
+		];
+	}
+);

--- a/client/additional-methods-setup/methods-selector/index.js
+++ b/client/additional-methods-setup/methods-selector/index.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Card, CardBody } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+
+const MethodsSelector = () => (
+	<Card className="methods-selector">
+		<CardBody>Placeholder content</CardBody>
+	</Card>
+);
+
+export default MethodsSelector;

--- a/includes/admin/class-wc-payments-admin-additional-methods-setup.php
+++ b/includes/admin/class-wc-payments-admin-additional-methods-setup.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Adds the onboarding steps to the WC home, when necessary.
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Payments_Admin_Additional_Methods_Setup Class.
+ */
+class WC_Payments_Admin_Additional_Methods_Setup {
+	/**
+	 * WC_Payments_Admin_Additional_Methods_Setup constructor.
+	 */
+	public function __construct() {
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
+	}
+
+	/**
+	 * Adds the scripts to the WC home, when necessary.
+	 */
+	public function enqueue_scripts() {
+		if ( ! wc_admin_is_registered_page() ) {
+			return;
+		}
+
+		// TODO: we also need to check whether giropay/etc are available and whether they have been set up before or not.
+		$script_src_url    = plugins_url( 'dist/additional-methods-setup.js', WCPAY_PLUGIN_FILE );
+		$script_asset_path = WCPAY_ABSPATH . 'dist/additional-methods-setup.asset.php';
+		$script_asset      = file_exists( $script_asset_path ) ? require_once $script_asset_path : [ 'dependencies' => [] ];
+		wp_register_script(
+			'WCPAY_ADDITIONAL_METHODS_SETUP',
+			$script_src_url,
+			$script_asset['dependencies'],
+			WC_Payments::get_file_version( 'dist/additional-methods-setup.js' ),
+			true
+		);
+		wp_localize_script(
+			'WCPAY_ADDITIONAL_METHODS_SETUP',
+			'wcpayAdditionalMethodsSetup',
+			[
+				'isSetupCompleted' => get_option( 'wcpay_additional_methods_setup_completed', 'no' ),
+			]
+		);
+
+		wp_register_style(
+			'WCPAY_ADDITIONAL_METHODS_SETUP',
+			plugins_url( 'dist/additional-methods-setup.css', WCPAY_PLUGIN_FILE ),
+			[ 'wc-components' ],
+			WC_Payments::get_file_version( 'dist/additional-methods-setup.css' )
+		);
+
+		wp_enqueue_script( 'WCPAY_ADDITIONAL_METHODS_SETUP' );
+		wp_enqueue_style( 'WCPAY_ADDITIONAL_METHODS_SETUP' );
+
+	}
+}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -236,6 +236,9 @@ class WC_Payments {
 			if ( WC_Payments_Features::is_grouped_settings_enabled() ) {
 				include_once __DIR__ . '/admin/class-wc-payments-admin-sections-overwrite.php';
 				new WC_Payments_Admin_Sections_Overwrite();
+
+				include_once __DIR__ . '/admin/class-wc-payments-admin-additional-methods-setup.php';
+				new WC_Payments_Admin_Additional_Methods_Setup();
 			}
 		}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,8 @@ const webpackConfig = {
 		'payment-request': './client/payment-request/index.js',
 		'subscription-edit-page': './client/subscription-edit-page.js',
 		tos: './client/tos/index.js',
+		'additional-methods-setup':
+			'./client/additional-methods-setup/index.js',
 	},
 	output: {
 		filename: '[name].js',


### PR DESCRIPTION
Helps with https://github.com/Automattic/woocommerce-payments/issues/1633

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Splitting up a bigger PR.

In order to display the onboarding steps for the additional payment methods, we need to add a task to WC admin.

This PR just adds the necessary skeleton to display some placeholder text.

![2021-05-05 12 07 36](https://user-images.githubusercontent.com/273592/117181335-b947ee80-ad9a-11eb-81f5-644e9372899d.gif)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have the "grouped settings" flag enabled in WCPay Dev Tools
- Visit http://localhost:8082/wp-admin/admin.php?page=wc-admin
- You should be able to see the task
- Clicking on the task will show some placeholder text

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
