### PR TITLE
Fix: #1720 Risk level being displayed as a numeric value in CSV export file

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Add - Payment request button support for checkout and cart blocks.
 * Update - Implement expirement on Connect Page.
 * Fix - Columns are misaligned on Payments->Transactions/Disputes page.
+* Fix - Risk level is displayed as a "Numeric" value in transactions CSV #1720'
 
 = 2.3.3 - 2021-05-06 =
 * Update - Additional logic and styling for instant deposits.

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,7 +9,7 @@
 * Add - Payment request button support for checkout and cart blocks.
 * Update - Implement expirement on Connect Page.
 * Fix - Columns are misaligned on Payments->Transactions/Disputes page.
-* Fix - Risk level is displayed as a "Numeric" value in transactions CSV #1720'
+* Fix - Risk level is displayed as a "Numeric" value in transactions CSV.
 
 = 2.3.3 - 2021-05-06 =
 * Update - Additional logic and styling for instant deposits.

--- a/client/components/risk-level/index.js
+++ b/client/components/risk-level/index.js
@@ -13,12 +13,17 @@ const colorMappings = {
 	highest: 'red',
 };
 
+export function calculateRiskMapping( risk ) {
+	const riskLevel = riskOrder[ risk ];
+	return riskMappings[ riskLevel ];
+}
+
 const RiskLevel = ( { risk } ) => {
 	const riskLevel = riskOrder[ risk ];
 
 	return (
 		<span style={ { color: colorMappings[ riskLevel ] } }>
-			{ riskMappings[ riskLevel ] }
+			{ calculateRiskMapping( risk ) }
 		</span>
 	);
 };

--- a/client/components/risk-level/test/index.js
+++ b/client/components/risk-level/test/index.js
@@ -8,7 +8,7 @@ import { render } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import RiskLevel from '../';
+import RiskLevel, { calculateRiskMapping } from '../';
 
 describe( 'RiskLevel', () => {
 	test( 'Renders normal risk correctly.', () => {
@@ -29,4 +29,21 @@ describe( 'RiskLevel', () => {
 	function renderRisk( risk ) {
 		return render( <RiskLevel risk={ risk } /> ).container;
 	}
+} );
+
+describe( 'Test calculateRiskMapping', () => {
+	test( 'Returns correct risk mapping as Normal when value is 0', () => {
+		const riskMapping = calculateRiskMapping( 0 );
+		expect( riskMapping ).toEqual( 'Normal' );
+	} );
+
+	test( 'Returns correct risk mapping as Elevated when value is 1', () => {
+		const riskMapping = calculateRiskMapping( 1 );
+		expect( riskMapping ).toEqual( 'Elevated' );
+	} );
+
+	test( 'Returns correct risk mapping as Highest when value is 2', () => {
+		const riskMapping = calculateRiskMapping( 2 );
+		expect( riskMapping ).toEqual( 'Highest' );
+	} );
 } );

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -275,7 +275,6 @@ export const TransactionsList = ( props ) => {
 			// eslint-disable-next-line camelcase
 			risk_level: {
 				value: calculateRiskMapping( txn.risk_level ),
-				actualValue: txn.risk_level,
 				display: clickable( riskLevel ),
 			},
 			deposit: { value: txn.deposit_id, display: deposit },

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -27,7 +27,7 @@ import Gridicon from 'gridicons';
  */
 import { useTransactions, useTransactionsSummary } from 'data';
 import OrderLink from 'components/order-link';
-import RiskLevel from 'components/risk-level';
+import RiskLevel, { calculateRiskMapping } from 'components/risk-level';
 import ClickableCell from 'components/clickable-cell';
 import DetailsLink, { getDetailsURL } from 'components/details-link';
 import { displayType } from 'transactions/strings';
@@ -274,7 +274,8 @@ export const TransactionsList = ( props ) => {
 			},
 			// eslint-disable-next-line camelcase
 			risk_level: {
-				value: txn.risk_level,
+				value: calculateRiskMapping( txn.risk_level ),
+				actualValue: txn.risk_level,
 				display: clickable( riskLevel ),
 			},
 			deposit: { value: txn.deposit_id, display: deposit },

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Payment request button support for checkout and cart blocks.
 * Update - Implement expirement on Connect Page.
 * Fix - Columns are misaligned on Payments->Transactions/Disputes page.
+* Fix - Risk level is displayed as a "Numeric" value in transactions CSV.
 
 = 2.3.3 - 2021-05-06 =
 * Update - Additional logic and styling for instant deposits.


### PR DESCRIPTION
Fixes: #1720

 #### Summary
Presently if you export the data from the transaction table as a CSV, the risk level is displayed as a numeric value instead of a string representation. This is caused due to the value passed to the table row while exporting (`risk_level.value`) is numeric.

#### Changes proposed in this Pull Request
- created util in risk level component which calculates and maps the risk value to the appropriate risk level.
- wrote unit tests for the same.
- added mapped risk value for `risk_level.value` in the table row.
- ~~added `actualValue` as a key in case it is needed.~~

#### Testing instructions
- switch to `fix/1720-risk-level-zero-bug`
- Go to WP admin, Payments->Transactions.
- Click on the Download button present at the transaction table header.
- Note that CSV file gets downloaded, Open the CSV.
- Observe that Risk level is displayed as "Normal" for a risk level of Zero (0)

### screenshot after the fix
![image](https://user-images.githubusercontent.com/15019298/117339757-bbef3480-aebd-11eb-8332-3c27a644845e.png)

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
