### PR TITLE
Fix: 1719 Columns are misaligned on Payments->Transactions/Disputes page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,7 +8,7 @@
 * Add - REST endpoint to capture payments by order ID
 * Add - Payment request button support for checkout and cart blocks.
 * Update - Implement expirement on Connect Page.
-* Fix - #1719 Columns are misaligned on Payments->Transactions/Disputes page
+* Fix - Columns are misaligned on Payments->Transactions/Disputes page.
 
 = 2.3.3 - 2021-05-06 =
 * Update - Additional logic and styling for instant deposits.

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Add - REST endpoint to capture payments by order ID
 * Add - Payment request button support for checkout and cart blocks.
 * Update - Implement expirement on Connect Page.
+* Fix - #1719 Columns are misaligned on Payments->Transactions/Disputes page
 
 = 2.3.3 - 2021-05-06 =
 * Update - Additional logic and styling for instant deposits.

--- a/client/disputes/index.js
+++ b/client/disputes/index.js
@@ -23,6 +23,8 @@ import { reasons } from './strings';
 import { formatStringValue } from 'utils';
 import { formatCurrency } from 'utils/currency';
 
+import './style.scss';
+
 const headers = [
 	{ key: 'details', label: '', required: true, cellClassName: 'info-button' },
 	{
@@ -175,6 +177,7 @@ export const DisputesList = () => {
 		<Page>
 			<TestModeNotice topic={ topics.disputes } />
 			<TableCard
+				className="disputes-list"
 				title={ __( 'Disputes', 'woocommerce-payments' ) }
 				isLoading={ isLoading }
 				rowsPerPage={ 10 }

--- a/client/disputes/index.js
+++ b/client/disputes/index.js
@@ -177,7 +177,7 @@ export const DisputesList = () => {
 		<Page>
 			<TestModeNotice topic={ topics.disputes } />
 			<TableCard
-				className="disputes-list"
+				className="wcpay-disputes-list"
 				title={ __( 'Disputes', 'woocommerce-payments' ) }
 				isLoading={ isLoading }
 				rowsPerPage={ 10 }

--- a/client/disputes/style.scss
+++ b/client/disputes/style.scss
@@ -1,5 +1,5 @@
 // dispute list table css override
-.disputes-list {
+.wcpay-disputes-list {
 	.woocommerce-table__header:not( .is-left-aligned ),
 	.woocommerce-table__item:not( .is-left-aligned ) {
 		text-align: center;

--- a/client/disputes/style.scss
+++ b/client/disputes/style.scss
@@ -1,3 +1,11 @@
+// dispute list table css override
+.disputes-list {
+	.woocommerce-table__header:not( .is-left-aligned ),
+	.woocommerce-table__item:not( .is-left-aligned ) {
+		text-align: center;
+	}
+}
+
 // TODO generalize most of these styles to other WCPay views, if not WooCommerce Admin in general.
 .wcpay-dispute-details,
 .wcpay-dispute-evidence {

--- a/client/disputes/test/__snapshots__/index.js.snap
+++ b/client/disputes/test/__snapshots__/index.js.snap
@@ -6,7 +6,7 @@ exports[`Disputes list renders correctly 1`] = `
     class=" woocommerce-payments-page"
   >
     <div
-      class="woocommerce-card woocommerce-table woocommerce-analytics__card has-menu"
+      class="woocommerce-card woocommerce-table woocommerce-analytics__card disputes-list has-menu"
     >
       <div
         class="woocommerce-card__header"

--- a/client/disputes/test/__snapshots__/index.js.snap
+++ b/client/disputes/test/__snapshots__/index.js.snap
@@ -6,7 +6,7 @@ exports[`Disputes list renders correctly 1`] = `
     class=" woocommerce-payments-page"
   >
     <div
-      class="woocommerce-card woocommerce-table woocommerce-analytics__card disputes-list has-menu"
+      class="woocommerce-card woocommerce-table woocommerce-analytics__card wcpay-disputes-list has-menu"
     >
       <div
         class="woocommerce-card__header"

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -15,6 +15,12 @@
 			fill: $studio-gray-30;
 		}
 	}
+
+	// alignment override
+	.woocommerce-table__header:not( .is-left-aligned ),
+	.woocommerce-table__item:not( .is-left-aligned ) {
+		text-align: center;
+	}
 }
 
 /**

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -1,5 +1,7 @@
 @import 'node_modules/@wordpress/components/src/tooltip/style.scss';
 
+$space-header-item: 15px;
+
 .transactions-list {
 	.date-time {
 		min-width: 195px;
@@ -16,10 +18,15 @@
 		}
 	}
 
-	// alignment override
+	// alignment override for header items
 	.woocommerce-table__header:not( .is-left-aligned ),
 	.woocommerce-table__item:not( .is-left-aligned ) {
 		text-align: center;
+	}
+
+	// slight adjustment to align header items with sorting button to account for icon width
+	.woocommerce-table__header.is-numeric .components-button {
+		margin-right: $space-header-item;
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Explat package for A/B tests.
 * Add - Payment request button support for checkout and cart blocks.
 * Update - Implement expirement on Connect Page.
+* Fix - Columns are misaligned on Payments->Transactions/Disputes page.
 
 = 2.3.3 - 2021-05-06 =
 * Update - Additional logic and styling for instant deposits.


### PR DESCRIPTION
Fixes #1719 

#### Changes proposed in this Pull Request
As the issue reported indicates that the table header items are right-aligned which was due to the default alignment of the table component. To fix this, I overrode the default CSS with a scoped CSS for transactions and dispute tables to make them center-aligned. A scoped alignment won't affect the alignment of the component used at other places.
- override alignment for transactions list page
- override alignment for disputes list page
- slight adjustment for table header items with arrow icon

#### After fix
![image](https://user-images.githubusercontent.com/15019298/117404261-4029d200-af27-11eb-8cbb-03757ab4133f.png)

![image](https://user-images.githubusercontent.com/15019298/117368061-a7706380-aee0-11eb-8f96-cc50c914d41b.png)


#### Testing instructions
- checkout to `fix/1719-columns-misaligned`
- visit transactions and dispute pages
- Items should be aligned now.
-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in the description ☝️)
- [ ] Tested on mobile (or does not apply)


