### PR TITLE
Fix lint-staged eslint config to lint only staged files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged
+npx --no-install lint-staged

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "npm run format:provided",
-      "npm run lint:js"
+      "tsc --noEmit",
+      "eslint"
     ],
     "*.{scss,css}": [
       "npm run format:provided",

--- a/package.json
+++ b/package.json
@@ -58,8 +58,10 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "npm run format:provided",
-      "tsc --noEmit",
       "eslint"
+    ],
+    "*.{ts,tsx}": [
+      "tsc --noEmit"
     ],
     "*.{scss,css}": [
       "npm run format:provided",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `lint-staged` config to run `eslint` only on staged files.
* Update `pre-commit` hook to add flag `--no-install` to force to use the already installed version.

We are currently running eslint on every file instead of the staged ones. Because calling `npm run lint:js` in with lint-staged results in calling eslint with `.` AND staged files. So one simple solution is to rewrite the lint-staged config to call eslint directly instead.

#### Testing instructions

You can check what files eslint is linting adding the `--debug` flag. For now it lints all files, with this change it should only lints the stages ones.