### PR TITLE
Add TypeScript preset for babel to recognize TypeScript syntax

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,7 +2,10 @@
 // :exploding_head: same case here: https://github.com/facebook/jest/issues/9292#issuecomment-625750534
 module.exports = {
 	ignore: [],
-	presets: [ '@wordpress/babel-preset-default' ],
+	presets: [
+		'@wordpress/babel-preset-default',
+		[ '@babel/preset-typescript', { allowNamespaces: true } ],
+	],
 	plugins: [
 		[ '@babel/transform-runtime', { corejs: 3 } ],
 		'@babel/plugin-proposal-optional-chaining',

--- a/package-lock.json
+++ b/package-lock.json
@@ -782,6 +782,15 @@
         "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.13.tgz",
+      "integrity": "sha512-cHP3u1JiUiG2LFDKbXnwVad81GvfyIOmCD6HIEId6ojrY0Drfy2q1jw7BwN7dE84+kTnBjLkXoL3IEy/3JPu2w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      }
+    },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.13.0.tgz",
@@ -1147,6 +1156,17 @@
         "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.13.0.tgz",
+      "integrity": "sha512-elQEwluzaU8R8dbVuW2Q2Y8Nznf7hnjM7+DSCd14Lo5fF63C9qNLbwZYbmZrtV9/ySpSUpkRpQXvJb6xyu4hCQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.13.0",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-typescript": "^7.12.13"
+      }
+    },
     "@babel/plugin-transform-unicode-escapes": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.13.tgz",
@@ -1289,6 +1309,17 @@
         "@babel/plugin-transform-react-jsx": "^7.13.12",
         "@babel/plugin-transform-react-jsx-development": "^7.12.17",
         "@babel/plugin-transform-react-pure-annotations": "^7.12.1"
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.13.0.tgz",
+      "integrity": "sha512-LXJwxrHy0N3f6gIJlYbLta1D9BDtHpQeqwzM0LIfjDlr6UE/D5Mc7W4iDiQzaE+ks0sTjT26ArcHWnJVt0QiHw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-validator-option": "^7.12.17",
+        "@babel/plugin-transform-typescript": "^7.13.0"
       }
     },
     "@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@automattic/color-studio": "2.3.1",
     "@automattic/puppeteer-utils": "github:Automattic/puppeteer-utils",
     "@babel/plugin-proposal-object-rest-spread": "7.12.13",
+    "@babel/preset-typescript": "^7.13.0",
     "@testing-library/jest-dom": "5.11.9",
     "@testing-library/react": "11.2.5",
     "@testing-library/user-event": "10.4.1",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Make development environment TypeScript ready by adding a TypeScript preset to babel to properly recognize syntax.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
