### PR TITLE
Make WC_Payments_API_Client::request protected

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1011,7 +1011,7 @@ class WC_Payments_API_Client {
 	 * @return array
 	 * @throws API_Exception - If the account ID hasn't been set.
 	 */
-	private function request( $params, $api, $method, $is_site_specific = true ) {
+	protected function request( $params, $api, $method, $is_site_specific = true ) {
 		// Apply the default params that can be overridden by the calling method.
 		$params = wp_parse_args(
 			$params,


### PR DESCRIPTION
In TumblrPay they're implementing an endpoint that doesn't really make sense for "vanilla" WCPay (it's related with IAP and payouts). They added an endpoint in `/wpcom/v2/tumblrpay` and now they're looking for a convenient way to call it.

By making `WC_Payments_API_Client::request` public, they can extend `WC_Payments_API_Client` in their Tumblr-specific plugin and call `request` from there.

@marcinbot Any other suggestion or objection to this? I've thought that they can use this directly, but `request` has some significant boilerplate they would have to recreate: https://github.com/Automattic/multiwoo/blob/ceb657d7d8c5d0f179641d9df30067efd7997a69/sandbox/src/tumblrpay-plugin/class-wc-payments-http-wpcom.php#L45-L55

cc/ @millerf
