### PR TITLE
Create a hook to allow custom api-client

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -514,11 +514,21 @@ class WC_Payments {
 
 		$http_class = self::get_wc_payments_http();
 
-		$payments_api_client = new WC_Payments_API_Client(
+		$api_client_class = apply_filters( 'wc_api_client', null );
+
+		$payments_api_client = new $api_client_class(
 			'WooCommerce Payments/' . WCPAY_VERSION_NUMBER,
 			$http_class,
 			self::$db_helper
 		);
+
+		if ( ! $payments_api_client instanceof WC_Payments_API_Client ) {
+			$payments_api_client = new WC_Payments_API_Client(
+				'WooCommerce Payments/' . WCPAY_VERSION_NUMBER,
+				$http_class,
+				self::$db_helper
+			);
+		}
 
 		return $payments_api_client;
 	}


### PR DESCRIPTION
In TumblrPay we're implementing an endpoint that doesn't really make sense for "vanilla" WCPay (it's related with IAP and payouts). We added an endpoint in /wpcom/v2/tumblrpay and now they're looking for a convenient way to call it.

Allowing to create a custom API client will allow to add new endpoints and/or modify some logic wihtout touching the "vanilla" cleint. 

@marcinbot Any other suggestion or objection to this? I

CC @DanReyLop 


