### PR TITLE
Implement empty "Digital wallets" edit screen

### DIFF
--- a/client/settings/digital-wallets/index.js
+++ b/client/settings/digital-wallets/index.js
@@ -13,6 +13,7 @@ import {
 	CheckboxControl,
 } from '@wordpress/components';
 import interpolateComponents from 'interpolate-components';
+import { getPaymentMethodSettingsUrl } from '../../utils';
 
 const DigitalWallets = () => {
 	const [ isEnabled, setIsEnabled ] = useState( false );
@@ -122,7 +123,10 @@ const DigitalWallets = () => {
 			</CardBody>
 			<CardDivider />
 			<CardBody>
-				<Button isSecondary href="/TODO">
+				<Button
+					isSecondary
+					href={ getPaymentMethodSettingsUrl( 'digital_wallets' ) }
+				>
 					{ __( 'Customize appearance', 'woocommerce-payments' ) }
 				</Button>
 			</CardBody>

--- a/client/settings/digital-wallets/test/index.test.js
+++ b/client/settings/digital-wallets/test/index.test.js
@@ -79,4 +79,16 @@ describe( 'DigitalWallets', () => {
 		expect( cartCheckbox ).not.toBeDisabled();
 		expect( cartCheckbox ).toBeChecked();
 	} );
+
+	it( 'has the correct href link to the digital wallets setting page', async () => {
+		render( <DigitalWallets /> );
+
+		const customizeAppearanceButton = screen.getByText(
+			'Customize appearance'
+		);
+		expect( customizeAppearanceButton ).toHaveAttribute(
+			'href',
+			'admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments_digital_wallets'
+		);
+	} );
 } );

--- a/client/settings/payment-method-settings/digital-wallets-settings.js
+++ b/client/settings/payment-method-settings/digital-wallets-settings.js
@@ -1,0 +1,15 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Card, CardBody } from '@wordpress/components';
+
+const DigitalWalletsSettings = () => {
+	return (
+		<Card>
+			<CardBody>Digital Wallets placeholder.</CardBody>
+		</Card>
+	);
+};
+
+export default DigitalWalletsSettings;

--- a/client/settings/payment-method-settings/index.js
+++ b/client/settings/payment-method-settings/index.js
@@ -8,6 +8,7 @@ import './index.scss';
 import SettingsSection from '../settings-section';
 import { getPaymentSettingsUrl } from '../../utils';
 import GiropaySettings from './giropay-settings';
+import DigitalWalletsSettings from './digital-wallets-settings';
 
 /* eslint-disable camelcase */
 const methods = {
@@ -21,6 +22,17 @@ const methods = {
 			</>
 		),
 		controls: () => <GiropaySettings />,
+	},
+	woocommerce_payments_digital_wallets: {
+		title: 'digital_wallets',
+		description: () => (
+			<>
+				{ /* Whoever picks this up will need to translate these strings */ }
+				<h2>digital wallets</h2>
+				<p>digital wallets description.</p>
+			</>
+		),
+		controls: () => <DigitalWalletsSettings />,
 	},
 };
 /* eslint-enable camelcase */

--- a/client/settings/payment-method-settings/index.js
+++ b/client/settings/payment-method-settings/index.js
@@ -9,6 +9,7 @@ import SettingsSection from '../settings-section';
 import { getPaymentSettingsUrl } from '../../utils';
 import GiropaySettings from './giropay-settings';
 import DigitalWalletsSettings from './digital-wallets-settings';
+import Banner from '../../banner';
 
 /* eslint-disable camelcase */
 const methods = {
@@ -55,6 +56,8 @@ const PaymentMethodSettings = ( { methodId } ) => {
 
 	return (
 		<div className="payment-method-settings">
+			<Banner />
+
 			<h2 className="payment-method-settings__breadcrumbs">
 				<a href={ getPaymentSettingsUrl() }>WooCommerce Payments</a>{ ' ' }
 				&gt; <span>{ title }</span>

--- a/client/settings/payment-method-settings/index.js
+++ b/client/settings/payment-method-settings/index.js
@@ -24,11 +24,11 @@ const methods = {
 		controls: () => <GiropaySettings />,
 	},
 	woocommerce_payments_digital_wallets: {
-		title: 'digital_wallets',
+		title: 'Digital wallets & express payment methods',
 		description: () => (
 			<>
 				{ /* Whoever picks this up will need to translate these strings */ }
-				<h2>digital wallets</h2>
+				<h2>Digital wallets &amp; saved cards</h2>
 				<p>digital wallets description.</p>
 			</>
 		),

--- a/client/settings/payment-method-settings/index.scss
+++ b/client/settings/payment-method-settings/index.scss
@@ -1,3 +1,7 @@
 .payment-method-settings__breadcrumbs {
 	margin-bottom: 40px;
 }
+
+#wcpay-payment-method-settings-container {
+	margin-top: 24px;
+}

--- a/client/settings/payment-method-settings/test/digital-wallets-settings.js
+++ b/client/settings/payment-method-settings/test/digital-wallets-settings.js
@@ -1,0 +1,21 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import DigitalWalletsSettings from '../digital-wallets-settings';
+
+describe( 'DigitalWalletsSettings', () => {
+	test( 'renders settings', () => {
+		render( <DigitalWalletsSettings /> );
+
+		expect(
+			screen.queryByText( 'Digital Wallets placeholder.' )
+		).toBeInTheDocument();
+	} );
+} );

--- a/client/settings/payment-method-settings/test/index.js
+++ b/client/settings/payment-method-settings/test/index.js
@@ -52,4 +52,15 @@ describe( 'PaymentMethodSettings', () => {
 		);
 		expect( errorMessage ).toBeInTheDocument();
 	} );
+
+	test( 'renders digital wallets settings and confirm its h2 copy', () => {
+		render(
+			<PaymentMethodSettings methodId="woocommerce_payments_digital_wallets" />
+		);
+
+		const heading = screen.queryByRole( 'heading', {
+			name: 'Digital wallets & saved cards',
+		} );
+		expect( heading ).toBeInTheDocument();
+	} );
 } );

--- a/client/settings/payment-method-settings/test/index.js
+++ b/client/settings/payment-method-settings/test/index.js
@@ -63,4 +63,13 @@ describe( 'PaymentMethodSettings', () => {
 		} );
 		expect( heading ).toBeInTheDocument();
 	} );
+
+	test( 'renders banner at the top', () => {
+		render(
+			<PaymentMethodSettings methodId="woocommerce_payments_digital_wallets" />
+		);
+
+		const banner = screen.queryByTitle( 'WooCommerce Payments' );
+		expect( banner ).toBeInTheDocument();
+	} );
 } );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -14,6 +14,7 @@ use WCPay\Payment_Methods\CC_Payment_Gateway;
 use WCPay\Payment_Methods\Giropay_Payment_Gateway;
 use WCPay\Payment_Methods\Sepa_Payment_Gateway;
 use WCPay\Payment_Methods\Sofort_Payment_Gateway;
+use WCPay\Payment_Methods\Digital_Wallets_Payment_Gateway;
 
 /**
  * Main class for the WooCommerce Payments extension. Its responsibility is to initialize the extension.
@@ -47,6 +48,13 @@ class WC_Payments {
 	 * @var Sofort_Payment_Gateway
 	 */
 	private static $sofort_gateway;
+
+	/**
+	 * Instance of Digital Wallets payment gateway, created in init function.
+	 *
+	 * @var Digital_Wallets_Payment_Gateway
+	 */
+	private static $digital_wallets_gateway;
 
 	/**
 	 * Instance of WC_Payments_API_Client, created in init function.
@@ -162,6 +170,7 @@ class WC_Payments {
 		include_once __DIR__ . '/payment-methods/class-giropay-payment-gateway.php';
 		include_once __DIR__ . '/payment-methods/class-sepa-payment-gateway.php';
 		include_once __DIR__ . '/payment-methods/class-sofort-payment-gateway.php';
+		include_once __DIR__ . '/payment-methods/class-digital-wallets-payment-gateway.php';
 		include_once __DIR__ . '/class-wc-payment-token-wcpay-sepa.php';
 		include_once __DIR__ . '/class-wc-payments-token-service.php';
 		include_once __DIR__ . '/class-wc-payments-payment-request-button-handler.php';
@@ -190,10 +199,12 @@ class WC_Payments {
 		self::$action_scheduler_service = new WC_Payments_Action_Scheduler_Service( self::$api_client );
 		self::$fraud_service            = new WC_Payments_Fraud_Service( self::$api_client, self::$customer_service, self::$account );
 
-		$gateway_class = CC_Payment_Gateway::class;
-		$giropay_class = Giropay_Payment_Gateway::class;
-		$sepa_class    = Sepa_Payment_Gateway::class;
-		$sofort_class  = Sofort_Payment_Gateway::class;
+		$gateway_class         = CC_Payment_Gateway::class;
+		$giropay_class         = Giropay_Payment_Gateway::class;
+		$sepa_class            = Sepa_Payment_Gateway::class;
+		$sofort_class          = Sofort_Payment_Gateway::class;
+		$digital_wallets_class = Digital_Wallets_Payment_Gateway::class;
+
 		// TODO: Remove admin payment method JS hack for Subscriptions <= 3.0.7 when we drop support for those versions.
 		if ( class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '2.2.0', '>=' ) ) {
 			include_once __DIR__ . '/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php';
@@ -209,6 +220,9 @@ class WC_Payments {
 		}
 		if ( WC_Payments_Features::is_sofort_enabled() ) {
 			self::$sofort_gateway = new $sofort_class( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service );
+		}
+		if ( WC_Payments_Features::is_grouped_settings_enabled() ) {
+			self::$digital_wallets_gateway = new $digital_wallets_class( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service );
 		}
 
 		// Payment Request and Apple Pay.
@@ -455,6 +469,7 @@ class WC_Payments {
 	 */
 	public static function register_gateway( $gateways ) {
 		$gateways[] = self::$card_gateway;
+
 		if ( WC_Payments_Features::is_giropay_enabled() ) {
 			$gateways[] = self::$giropay_gateway;
 		}
@@ -463,6 +478,9 @@ class WC_Payments {
 		}
 		if ( WC_Payments_Features::is_sofort_enabled() ) {
 			$gateways[] = self::$sofort_gateway;
+		}
+		if ( WC_Payments_Features::is_grouped_settings_enabled() ) {
+			$gateways[] = self::$digital_wallets_gateway;
 		}
 
 		return $gateways;

--- a/includes/payment-methods/class-digital-wallets-payment-gateway.php
+++ b/includes/payment-methods/class-digital-wallets-payment-gateway.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Class CC_Payment_Gateway
+ *
+ * @package WCPay\Payment_Methods
+ */
+
+namespace WCPay\Payment_Methods;
+
+use WC_Payment_Gateway_WCPay;
+use WC_Payments_Account;
+use WC_Payments_Action_Scheduler_Service;
+use WC_Payments_API_Client;
+use WC_Payments_Customer_Service;
+use WC_Payments_Token_Service;
+
+/**
+ * Digital Wallets
+ */
+class Digital_Wallets_Payment_Gateway extends WC_Payment_Gateway_WCPay {
+	/**
+	 * Internal ID of the payment gateway.
+	 *
+	 * @type string
+	 */
+	const GATEWAY_ID = 'woocommerce_payments_digital_wallets';
+
+	const METHOD_ENABLED_KEY = 'digital_wallets_enabled';
+
+	/**
+	 * Sepa Constrictor same parameters as WC_Payment_Gateway_WCPay constructor.
+	 *
+	 * @param WC_Payments_API_Client               $payments_api_client      - WooCommerce Payments API client.
+	 * @param WC_Payments_Account                  $account                  - Account class instance.
+	 * @param WC_Payments_Customer_Service         $customer_service         - Customer class instance.
+	 * @param WC_Payments_Token_Service            $token_service            - Token class instance.
+	 * @param WC_Payments_Action_Scheduler_Service $action_scheduler_service - Action Scheduler service instance.
+	 */
+	public function __construct( WC_Payments_API_Client $payments_api_client, WC_Payments_Account $account, WC_Payments_Customer_Service $customer_service, WC_Payments_Token_Service $token_service, WC_Payments_Action_Scheduler_Service $action_scheduler_service ) {
+		parent::__construct( $payments_api_client, $account, $customer_service, $token_service, $action_scheduler_service );
+		$this->method_title       = __( 'WooCommerce Payments - Digital Wallets', 'woocommerce-payments' );
+		$this->method_description = __( 'Accept payments via Digital Wallets.', 'woocommerce-payments' );
+		$this->title              = __( 'Digital Wallets', 'woocommerce-payments' );
+		$this->description        = __( 'Mandate Information.', 'woocommerce-payments' );
+	}
+}

--- a/includes/payment-methods/class-digital-wallets-payment-gateway.php
+++ b/includes/payment-methods/class-digital-wallets-payment-gateway.php
@@ -28,7 +28,7 @@ class Digital_Wallets_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	const METHOD_ENABLED_KEY = 'digital_wallets_enabled';
 
 	/**
-	 * Sepa Constrictor same parameters as WC_Payment_Gateway_WCPay constructor.
+	 * Digital Wallets Constructor same parameters as WC_Payment_Gateway_WCPay constructor.
 	 *
 	 * @param WC_Payments_API_Client               $payments_api_client      - WooCommerce Payments API client.
 	 * @param WC_Payments_Account                  $account                  - Account class instance.

--- a/includes/payment-methods/class-digital-wallets-payment-gateway.php
+++ b/includes/payment-methods/class-digital-wallets-payment-gateway.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class CC_Payment_Gateway
+ * Class Digital_Wallets_Payment_Gateway
  *
  * @package WCPay\Payment_Methods
  */


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/1508

#### Changes proposed in this Pull Request
Create a new Payment Gateway for "Digital Wallets". This allows us to use existing codes to render "Digital Wallets" settings page similar to https://github.com/Automattic/woocommerce-payments/pull/1690. 

#### Testing instructions
1. Make sure [group settings feature flag](https://github.com/Automattic/woocommerce-payments/blob/54ef9057095d1d988db2d3f99da299273d1e5962/includes/class-wc-payments-features.php#L22) is enabled. 
2. Go to "wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments" and click "Customize appearance".
![image](https://user-images.githubusercontent.com/572862/117734140-10412f80-b1b0-11eb-8e9a-c71d9b63b2b7.png)
3 You should see a new page with URL "wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments_digital_wallets"
4. Confirm banner is at the top; header title is `Digital wallets & saved cards`; breadcrumb is `Digital wallets & express payment methods`
![image](https://user-images.githubusercontent.com/572862/117859989-face1300-b24c-11eb-8a7a-de2b00f7e586.png)


-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
