### PR TITLE
Add in WC Subscriptions for e2e tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -8,7 +8,7 @@ on:
       - release/*
 
 env:
-  E2E_GH_TOKEN:                                ${{ secrets.CI_USER_TOKEN }}
+  E2E_GH_TOKEN:                                ${{ secrets.E2E_GH_TOKEN }}
   CI_USER_TOKEN:                               ${{ secrets.CI_USER_TOKEN }}
   WCP_DEV_TOOLS_REPO:                          ${{ secrets.WCP_DEV_TOOLS_REPO }}
   WCP_SERVER_REPO:                             ${{ secrets.WCP_SERVER_REPO }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -8,9 +8,11 @@ on:
       - release/*
 
 env:
+  E2E_GH_TOKEN:                                ${{ secrets.E2E_GH_TOKEN }}
   CI_USER_TOKEN:                               ${{ secrets.CI_USER_TOKEN }}
   WCP_DEV_TOOLS_REPO:                          ${{ secrets.WCP_DEV_TOOLS_REPO }}
   WCP_SERVER_REPO:                             ${{ secrets.WCP_SERVER_REPO }}
+  WC_SUBSCRIPTIONS_REPO:                       ${{ secrets.WC_SUBSCRIPTIONS_REPO}}
   E2E_WCPAY_STRIPE_ACCOUNT_ID:                 ${{ secrets.E2E_WCPAY_STRIPE_ACCOUNT_ID }}
   E2E_WCPAY_STRIPE_TEST_CLIENT_ID:             ${{ secrets.E2E_WCPAY_STRIPE_TEST_CLIENT_ID }}
   E2E_WCPAY_STRIPE_TEST_PUBLIC_KEY:            ${{ secrets.E2E_WCPAY_STRIPE_TEST_PUBLIC_KEY }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -8,7 +8,7 @@ on:
       - release/*
 
 env:
-  E2E_GH_TOKEN:                                ${{ secrets.E2E_GH_TOKEN }}
+  E2E_GH_TOKEN:                                ${{ secrets.CI_USER_TOKEN }}
   CI_USER_TOKEN:                               ${{ secrets.CI_USER_TOKEN }}
   WCP_DEV_TOOLS_REPO:                          ${{ secrets.WCP_DEV_TOOLS_REPO }}
   WCP_SERVER_REPO:                             ${{ secrets.WCP_SERVER_REPO }}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -24,8 +24,8 @@ DEBUG=true
 For local setup:
 
 1. Create file `local.env` in the `tests/e2e/config` folder with required values.
-  * If you have access to the Subscriptions plugin, please follow the instructions from `tests/e2e/specs/subscriptions/README.md` before running the setup.
-  * If you don't, you may skip Subscriptions setup and tests by adding `SKIP_WC_SUBSCRIPTIONS_TESTS=1` to your `local.env` in the `tests/e2e/config` folder.
+    * If you have access to the Subscriptions plugin, please follow the instructions from `tests/e2e/specs/subscriptions/README.md` before running the setup.
+    * If you don't, you may skip Subscriptions setup and tests by adding `SKIP_WC_SUBSCRIPTIONS_TESTS=1` to your `local.env` in the `tests/e2e/config` folder.
 
 1. Make sure to run `npm install`,  `composer install` and `npm run build:client` before running setup script.
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -24,6 +24,8 @@ DEBUG=true
 For local setup:
 
 1. Create file `local.env` in the `tests/e2e/config` folder with required values.
+  * If you have access to the Subscriptions plugin, please follow the instructions from `tests/e2e/specs/subscriptions/README.md` before running the setup.
+  * If you don't, you may skip Subscriptions setup and tests by adding `SKIP_WC_SUBSCRIPTIONS_TESTS=1` to your `local.env` in the `tests/e2e/config` folder.
 
 1. Make sure to run `npm install`,  `composer install` and `npm run build:client` before running setup script.
 

--- a/tests/e2e/env/docker-compose.yml
+++ b/tests/e2e/env/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - ${E2E_ROOT}/docker/logs/apache2/:/var/log/apache2
       - ${WCP_ROOT}:/var/www/html/wp-content/plugins/woocommerce-payments
       - ${E2E_ROOT}/deps/${DEV_TOOLS_DIR}:/var/www/html/wp-content/plugins/${DEV_TOOLS_DIR}
+      - ${E2E_ROOT}/deps/woocommerce-subscriptions:/var/www/html/wp-content/plugins/woocommerce-subscriptions
   db:
     container_name: wcp_e2e_mysql
     image: mysql:5.7

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -176,6 +176,22 @@ cli wp plugin activate $DEV_TOOLS_DIR
 echo "Setting Jetpack blog_id"
 cli wp wcpay_dev set_blog_id $BLOG_ID
 
+if [[ ! ${SKIP_WC_SUBSCRIPTIONS_TESTS} ]]; then
+	echo "Install and activate the latest release of WooCommerce Subscriptions"
+	cd $E2E_ROOT/deps
+	LATEST_RELEASE=$(curl -H "Authorization: token $E2E_GH_TOKEN" -sL https://api.github.com/repos/$WC_SUBSCRIPTIONS_REPO/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
+	curl -LJO -H "Authorization: token $E2E_GH_TOKEN" "https://github.com/$WC_SUBSCRIPTIONS_REPO/archive/$LATEST_RELEASE.zip"
+
+	unzip -qq woocommerce-subscriptions-$LATEST_RELEASE.zip
+	mv woocommerce-subscriptions-$LATEST_RELEASE/* $E2E_ROOT/deps/woocommerce-subscriptions
+
+	cli wp plugin activate woocommerce-subscriptions
+
+	rm -rf woocommerce-subscriptions-$LATEST_RELEASE
+else
+	echo "Skipping install of WooCommerce Subscriptions"
+fi
+
 echo "Setting redirection to local server"
 
 # host.docker.internal is not available in linux. Use ip address for docker0 interface to redirect requests from container.
@@ -186,4 +202,3 @@ cli wp wcpay_dev redirect_to "http://${DOCKER_HOST-host.docker.internal}:8086/wp
 
 echo
 step "Client site is up and running at http://${WP_URL}/wp-admin/"
-

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -183,6 +183,8 @@ if [[ ! ${SKIP_WC_SUBSCRIPTIONS_TESTS} ]]; then
 	curl -LJO -H "Authorization: token $E2E_GH_TOKEN" "https://github.com/$WC_SUBSCRIPTIONS_REPO/archive/$LATEST_RELEASE.zip"
 
 	unzip -qq woocommerce-subscriptions-$LATEST_RELEASE.zip
+
+	echo "Moving the unzipped plugin files. This may require your admin password"
 	sudo mv woocommerce-subscriptions-$LATEST_RELEASE/* $E2E_ROOT/deps/woocommerce-subscriptions
 
 	cli wp plugin activate woocommerce-subscriptions

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -183,7 +183,7 @@ if [[ ! ${SKIP_WC_SUBSCRIPTIONS_TESTS} ]]; then
 	curl -LJO -H "Authorization: token $E2E_GH_TOKEN" "https://github.com/$WC_SUBSCRIPTIONS_REPO/archive/$LATEST_RELEASE.zip"
 
 	unzip -qq woocommerce-subscriptions-$LATEST_RELEASE.zip
-	mv woocommerce-subscriptions-$LATEST_RELEASE/* $E2E_ROOT/deps/woocommerce-subscriptions
+	sudo mv woocommerce-subscriptions-$LATEST_RELEASE/* $E2E_ROOT/deps/woocommerce-subscriptions
 
 	cli wp plugin activate woocommerce-subscriptions
 

--- a/tests/e2e/specs/subscriptions/README.md
+++ b/tests/e2e/specs/subscriptions/README.md
@@ -1,0 +1,21 @@
+# WooCommerce Payments e2e tests - WooCommerce Subscriptions
+
+The tests included here require the WooCommerce Subscriptions plugin to be installed.
+
+## Installing the plugin
+
+To install the plugin, make sure you have the following set in your `local.env` in the `tests/e2e/config` folder:
+
+```
+WC_SUBSCRIPTIONS_REPO='https://github.com/woocommerce-subscriptions or git@github.com:org/woocommerce-subscriptions.git
+```
+
+The setup script requires the above env variable to be configured in order to pull in the plugin.
+
+## Skipping tests
+
+Adding the following line to your `local.env` in the `tests/e2e/config` folder and set it to `1` to skip the tests that rely on the plugin:
+
+`SKIP_WC_SUBSCRIPTIONS_TESTS=1` 
+
+With this set, any tests that require the WooCommerce Subscriptions plugin will be skipped.

--- a/tests/e2e/specs/subscriptions/README.md
+++ b/tests/e2e/specs/subscriptions/README.md
@@ -11,7 +11,7 @@ E2E_GH_TOKEN='githubPersonalAccessToken'
 WC_SUBSCRIPTIONS_REPO='{owner}/{repo}'
 ```
 
-For the `E2E_GH_TOKEN`, follow [these instructions to generate a GitHub Personal Access Token](E2E_GH_TOKEN) and assign the `repo` scope to it.
+For the `E2E_GH_TOKEN`, follow [these instructions to generate a GitHub Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) and assign the `repo` scope to it.
 
 ## Skipping tests
 

--- a/tests/e2e/specs/subscriptions/README.md
+++ b/tests/e2e/specs/subscriptions/README.md
@@ -4,13 +4,14 @@ The tests included here require the WooCommerce Subscriptions plugin to be insta
 
 ## Installing the plugin
 
-To install the plugin, make sure you have the following set in your `local.env` in the `tests/e2e/config` folder:
+The setup script requires the below env variables to be configured. Make sure you have the following set in your `local.env` in the `tests/e2e/config` folder:
 
 ```
+E2E_GH_TOKEN='githubPersonalAccessToken'
 WC_SUBSCRIPTIONS_REPO='https://github.com/woocommerce-subscriptions or git@github.com:org/woocommerce-subscriptions.git
 ```
 
-The setup script requires the above env variable to be configured in order to pull in the plugin.
+For the `E2E_GH_TOKEN`, follow [these instructions to generate a GitHub Personal Access Token](E2E_GH_TOKEN) and assign the `repo` scope to it.
 
 ## Skipping tests
 

--- a/tests/e2e/specs/subscriptions/README.md
+++ b/tests/e2e/specs/subscriptions/README.md
@@ -8,7 +8,7 @@ The setup script requires the below env variables to be configured. Make sure yo
 
 ```
 E2E_GH_TOKEN='githubPersonalAccessToken'
-WC_SUBSCRIPTIONS_REPO='https://github.com/woocommerce-subscriptions or git@github.com:org/woocommerce-subscriptions.git
+WC_SUBSCRIPTIONS_REPO='{owner}/{repo}'
 ```
 
 For the `E2E_GH_TOKEN`, follow [these instructions to generate a GitHub Personal Access Token](E2E_GH_TOKEN) and assign the `repo` scope to it.

--- a/tests/e2e/specs/subscriptions/subscription-settings.spec.js
+++ b/tests/e2e/specs/subscriptions/subscription-settings.spec.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+
+const { merchant } = require( '@woocommerce/e2e-utils' );
+
+import { RUN_SUBSCRIPTIONS_TESTS } from '../../utils';
+
+const describeif = ( condition ) => ( condition ? describe : describe.skip );
+
+describeif( RUN_SUBSCRIPTIONS_TESTS )(
+	'WooCommerce > Settings > Subscriptions',
+	() => {
+		beforeAll( async () => {
+			await page.goto( config.get( 'url' ), {
+				waitUntil: 'networkidle0',
+			} );
+			await merchant.login();
+		} );
+
+		afterAll( async () => {
+			await merchant.logout();
+		} );
+
+		it( 'should be able to load WooCommerce Subscriptions Settings tab', async () => {
+			await merchant.openSettings( 'subscriptions' );
+			await expect( page ).toMatchElement( 'a.nav-tab-active', {
+				text: 'Subscriptions',
+			} );
+		} );
+	}
+);

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -11,6 +11,9 @@ const baseUrl = config.get( 'url' );
 const SHOP_MY_ACCOUNT_PAGE = baseUrl + 'my-account/';
 const MY_ACCOUNT_PAYMENT_METHODS = baseUrl + 'my-account/payment-methods';
 
+export const RUN_SUBSCRIPTIONS_TESTS =
+	'1' !== process.env.SKIP_WC_SUBSCRIPTIONS_TESTS;
+
 // The generic flows will be moved to their own package soon (more details in p7bje6-2gV-p2), so we're
 // keeping our customizations grouped here so it's easier to extend the flows once the move happens.
 export const paymentsShopper = {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/1702

#### Changes proposed in this Pull Request

This PR proposes pulling in the WooCommerce Subscriptions page as part of the environment setup to be used in the e2e tests. Additionally, an optional variable has been added that allows skipping the tests if the plugin is not available.

#### Testing instructions

To begin testing these changes, you'll need to make sure you have the following set in your `local.env` in the `tests/e2e/config` folder:

```
E2E_GH_TOKEN='githubPersonalAccessToken'
WC_SUBSCRIPTIONS_REPO='{owner}/{repo}'
```

To create the `E2E_GH_TOKEN`, follow [these instructions to generate a GitHub Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) and assign the `repo` scope to it.

**Test Steps - Subscriptions plugin properly installed**

* Spin up the Docker test environment with `npm run test:e2e-setup` and note in the terminal logs there's an entry for `Install and activate the latest release of WooCommerce Subscriptions`.
* Login to the test environment and navigate to `Plugins > Installed Plugins` and verify WooCommerce Subscriptions shows in the list and is activated.
* Make sure the new Subscription test runs and passes by running `npm run test:e2e tests/e2e/specs/subscriptions/subscription-settings.spec.js`.

**Test Steps - Verify environment variable is respected**

* Verify the environment flag is respected in the test environment by running `SKIP_WC_SUBSCRIPTIONS_TESTS=1 npm run test:e2e tests/e2e/specs/subscriptions/subscription-settings.spec.js`

Next, bring down your Docker environment with `npm run test:e2e-reset`. Add the following line to your `local.env` in the `tests/e2e/config` folder and set it to `1` to skip the tests that rely on the plugin:

```
SKIP_WC_SUBSCRIPTIONS_TESTS=1
```

* Verify the plugin install is skipped, noting that `Skipping install of WooCommerce Subscriptions` is output in the terminal as the environment is spinning up.
* Login to the test environment and navigate to `Plugins > Installed Plugins` and verify that WooCommerce Subscriptions is _not_ in the list of plugins.
* Run the Subscriptions tests with the following and verify they are skipped: `npm run test:e2e tests/e2e/specs/subscriptions/subscription-settings.spec.js`