### PR TITLE
Revert Connect Page Event Name

### DIFF
--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -20,7 +20,7 @@ function recordEvent( eventName, eventProperties ) {
 }
 
 const events = {
-	CONNECT_ACCOUNT_CLICKED: 'wcpay_welcome_finish_setup',
+	CONNECT_ACCOUNT_CLICKED: 'wcpay_connect_account_clicked',
 	CONNECT_ACCOUNT_VIEW: 'page_view',
 	CONNECT_ACCOUNT_LEARN_MORE: 'wcpay_welcome_learn_more',
 };


### PR DESCRIPTION
Fixes (partially) #1612

#### Changes proposed in this Pull Request

Reverts the Connect Page event name made in PR #1746. 
 
The new name would break existing dashboards, so it was decided to use the old event name for both pages in the experiment in #1612.

Tests not required since the snapshots for the page components are not affected by tracks events.

#### Testing instructions

Presently an A/B test is used to experiment with the old design vs the new. Both page designs will need to be tested.

First, open developer tools and open Network requests. Filter URLs by the string `wcpay_connect_account_clicked` so that tracks events are easily found.

___
#### Testing the old page
- Go to payments and click "Set up"
![image](https://user-images.githubusercontent.com/9312929/117817305-0b58aa80-b29a-11eb-8c9d-ddf68d3fd888.png)

- See that the tracks event was performed in the Network requests.
<img width="803" alt="Screen Shot 2021-05-11 at 8 45 54 pm" src="https://user-images.githubusercontent.com/9312929/117817747-7d30f400-b29a-11eb-96b0-176784bd6fa2.png">

___
#### Testing the new page

- Change the defaultExperience to `ConnectAccountPageVariant`.

 https://github.com/Automattic/woocommerce-payments/blob/54ef9057095d1d988db2d3f99da299273d1e5962/client/connect-account-page-experiment/index.js#L18

-  Go to payments and click "Finish Setup"
<img width="700" alt="Screen Shot 2021-05-11 at 8 43 47 pm" src="https://user-images.githubusercontent.com/9312929/117818491-3d1e4100-b29b-11eb-86d8-c891f9b48a3f.png">

- See that the tracks event was performed in the Network requests.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)


