### PR TITLE
Fix subscription sign-up fees not showing up for Payment Request

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,18 +14,21 @@
 * Update - Account overview page is now GA and default page for woocommerce payments.
 * Update - Base fee and account status has been moved to overview page from WCPay settings.
 * Fix - Express payment method being displayed on blocks checkout when Payment Request is not supported.
+* Fix - Subscription sign-up fees not included in total for Payment Request Button.
 
 = 2.4.0 - 2021-05-12 =
 * Update - Improve the Connect Account page.
 * Update - Base UI components and their styling.
 * Fix - Deposits overview details not displayed.
 * Fix - WooCommerce Payments disappeared from WooCommerce Settings if WooCommerce Subscriptions is activated.
-* Add - REST endpoint to capture payments by order ID
+* Add - REST endpoint to capture payments by order ID.
+* Add - Explat package for A/B tests.
 * Add - Payment request button support for checkout and cart blocks.
 * Update - Bump minimum supported WooCommerce version from 4.0 to 4.5.
 * Update - Implement expirement on Connect Page.
 * Fix - Columns are misaligned on Payments->Transactions/Disputes page.
 * Fix - Risk level is displayed as a "Numeric" value in transactions CSV.
+* Add - Redirect to WooCommerce home page after successful WooCommerce Payments KYC.
 
 = 2.3.3 - 2021-05-06 =
 * Update - Additional logic and styling for instant deposits.

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -215,7 +215,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 * Gets the product total price.
 	 *
 	 * @param object $product WC_Product_* object.
-	 * @return integer Total price.
+	 * @return mixed Total price.
 	 */
 	public function get_product_price( $product ) {
 		$product_price = $product->get_price();

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -212,6 +212,22 @@ class WC_Payments_Payment_Request_Button_Handler {
 	}
 
 	/**
+	 * Gets the product total price.
+	 *
+	 * @param object $product WC_Product_* object.
+	 * @return integer Total price.
+	 */
+	public function get_product_price( $product ) {
+		$product_price = $product->get_price();
+		// Add subscription sign-up fees to product price.
+		if ( 'subscription' === $product->get_type() && class_exists( 'WC_Subscriptions_Product' ) ) {
+			$product_price = $product->get_price() + WC_Subscriptions_Product::get_sign_up_fee( $product );
+		}
+
+		return $product_price;
+	}
+
+	/**
 	 * Gets the product data for the currently viewed page.
 	 *
 	 * @return mixed Returns false if not on a product page, the product information otherwise.
@@ -249,7 +265,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 
 		$items[] = [
 			'label'  => $product->get_name(),
-			'amount' => WC_Payments_Utils::prepare_amount( $product->get_price() ),
+			'amount' => WC_Payments_Utils::prepare_amount( $this->get_product_price( $product ) ),
 		];
 
 		if ( wc_tax_enabled() ) {
@@ -278,7 +294,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 		$data['displayItems'] = $items;
 		$data['total']        = [
 			'label'   => apply_filters( 'wcpay_payment_request_total_label', $this->get_total_label() ),
-			'amount'  => WC_Payments_Utils::prepare_amount( $product->get_price() ),
+			'amount'  => WC_Payments_Utils::prepare_amount( $this->get_product_price( $product ) ),
 			'pending' => true,
 		];
 
@@ -909,7 +925,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 				throw new Exception( sprintf( __( 'You cannot add that amount of "%1$s"; to the cart because there is not enough stock (%2$s remaining).', 'woocommerce-payments' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity(), $product ) ) );
 			}
 
-			$total = $qty * $product->get_price() + $addon_value;
+			$total = $qty * $this->get_product_price( $product ) + $addon_value;
 
 			$quantity_label = 1 < $qty ? ' (x' . $qty . ')' : '';
 

--- a/readme.txt
+++ b/readme.txt
@@ -115,19 +115,21 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Account overview page is now GA and default page for woocommerce payments.
 * Update - Base fee and account status has been moved to overview page from WCPay settings.
 * Fix - Express payment method being displayed on blocks checkout when Payment Request is not supported.
+* Fix - Subscription sign-up fees not included in total for Payment Request Button.
 
 = 2.4.0 - 2021-05-12 =
 * Update - Improve the Connect Account page.
 * Update - Base UI components and their styling.
 * Fix - Deposits overview details not displayed.
 * Fix - WooCommerce Payments disappeared from WooCommerce Settings if WooCommerce Subscriptions is activated.
-* Add - REST endpoint to capture payments by order ID
+* Add - REST endpoint to capture payments by order ID.
 * Add - Explat package for A/B tests.
 * Add - Payment request button support for checkout and cart blocks.
 * Update - Bump minimum supported WooCommerce version from 4.0 to 4.5.
 * Update - Implement expirement on Connect Page.
 * Fix - Columns are misaligned on Payments->Transactions/Disputes page.
 * Fix - Risk level is displayed as a "Numeric" value in transactions CSV.
+* Add - Redirect to WooCommerce home page after successful WooCommerce Payments KYC.
 
 = 2.3.3 - 2021-05-06 =
 * Update - Additional logic and styling for instant deposits.


### PR DESCRIPTION
Fixes #1773

#### Changes proposed in this Pull Request

- Add get_product_price method to calculate product totals, considering sign-up fees, on the product page.

#### Testing instructions

- Ensure Payment Request Button is enabled under **WooCommerce > Payments > Settings**.
- Install WooCommerce Subscriptions.
- Create a subscription product similar to the one from [this screenshot](https://camo.githubusercontent.com/9f5809e1c37c126d15c3a006d43adf061a3ebf2e17b92674f8594f01209ab827/68747470733a2f2f642e70722f692f484439557a632b).
- Ensure you're signed in.
- Go to that subscription product page.
- Notice the total price is correct.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
