### PR TITLE
Fix: #1721 Replaced column with info icon with transaction id column for CSV

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix - Transactions and deposits counts on the table summary are rendered as "undefined".
 * Update - Deposit overview details.
 * Add - Redirect to WooCommerce home page after successful WooCommerce Payments KYC (Know Your Customer).
+* Fix - Added CSV column heading for transaction id column.
 
 = 2.4.0 - 2021-05-12 =
 * Update - Improve the Connect Account page.

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -45,7 +45,7 @@ const getColumns = ( includeDeposit, includeSubscription ) =>
 	[
 		{
 			key: 'transaction_id',
-			label: 'Transaction Id',
+			label: __( 'Transaction Id', 'woocommerce-payments' ),
 			visible: false,
 		},
 		{

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -29,7 +29,7 @@ import { useTransactions, useTransactionsSummary } from 'data';
 import OrderLink from 'components/order-link';
 import RiskLevel, { calculateRiskMapping } from 'components/risk-level';
 import ClickableCell from 'components/clickable-cell';
-import DetailsLink, { getDetailsURL } from 'components/details-link';
+import { getDetailsURL } from 'components/details-link';
 import { displayType } from 'transactions/strings';
 import { formatStringValue } from 'utils';
 import { formatCurrency } from 'utils/currency';
@@ -41,14 +41,12 @@ import TransactionsFilters from '../filters';
 import Page from '../../components/page';
 import wcpayTracks from 'tracks';
 
-const getColumns = ( includeDeposit, includeSubscription, sortByDate ) =>
+const getColumns = ( includeDeposit, includeSubscription ) =>
 	[
 		{
-			key: 'details',
-			label: '',
-			required: true,
-			// Match background of details and date when sorting.
-			cellClassName: 'info-button ' + ( sortByDate ? 'is-sorted' : '' ),
+			key: 'transaction_id',
+			label: 'Transaction Id',
+			visible: false,
 		},
 		{
 			key: 'date',
@@ -165,9 +163,7 @@ export const TransactionsList = ( props ) => {
 		const clickable = ( children ) => (
 			<ClickableCell href={ detailsURL }>{ children }</ClickableCell>
 		);
-		const detailsLink = (
-			<DetailsLink id={ txn.charge_id } parentSegment="transactions" />
-		);
+
 		const orderUrl = <OrderLink order={ txn.order } />;
 		const orderSubscriptions = txn.order && txn.order.subscriptions;
 		const subscriptionsValue =
@@ -206,7 +202,8 @@ export const TransactionsList = ( props ) => {
 
 		// Map transaction into table row.
 		const data = {
-			details: { value: txn.transaction_id, display: detailsLink },
+			// eslint-disable-next-line camelcase
+			transaction_id: { value: txn.transaction_id },
 			date: {
 				value: txn.date,
 				display: clickable(

--- a/client/transactions/list/test/__snapshots__/index.js.snap
+++ b/client/transactions/list/test/__snapshots__/index.js.snap
@@ -225,15 +225,6 @@ exports[`Transactions list renders correctly when can filter by several currenci
             <tbody>
               <tr>
                 <th
-                  class="woocommerce-table__header info-button is-sorted"
-                  role="columnheader"
-                  scope="col"
-                >
-                  <span
-                    aria-hidden="false"
-                  />
-                </th>
-                <th
                   aria-sort="descending"
                   class="woocommerce-table__header date-time is-left-aligned is-sortable is-sorted"
                   role="columnheader"
@@ -484,30 +475,8 @@ exports[`Transactions list renders correctly when can filter by several currenci
               </tr>
               <tr>
                 <th
-                  class="woocommerce-table__item info-button is-sorted"
-                  scope="row"
-                >
-                  <a
-                    data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
-                  >
-                    <svg
-                      class="gridicon gridicons-info-outline needs-offset"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      width="18"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <g>
-                        <path
-                          d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.41 0-8 3.59-8 8s3.59 8 8 8 8-3.59 8-8-3.59-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z"
-                        />
-                      </g>
-                    </svg>
-                  </a>
-                </th>
-                <td
                   class="woocommerce-table__item date-time is-left-aligned is-sorted"
+                  scope="row"
                 >
                   <a
                     class="woocommerce-table__clickable-cell"
@@ -517,7 +486,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   >
                     Jan 2, 2020 / 12:46PM
                   </a>
-                </td>
+                </th>
                 <td
                   class="woocommerce-table__item"
                 >
@@ -605,30 +574,8 @@ exports[`Transactions list renders correctly when can filter by several currenci
               </tr>
               <tr>
                 <th
-                  class="woocommerce-table__item info-button is-sorted"
-                  scope="row"
-                >
-                  <a
-                    data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
-                  >
-                    <svg
-                      class="gridicon gridicons-info-outline needs-offset"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      width="18"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <g>
-                        <path
-                          d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.41 0-8 3.59-8 8s3.59 8 8 8 8-3.59 8-8-3.59-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z"
-                        />
-                      </g>
-                    </svg>
-                  </a>
-                </th>
-                <td
                   class="woocommerce-table__item date-time is-left-aligned is-sorted"
+                  scope="row"
                 >
                   <a
                     class="woocommerce-table__clickable-cell"
@@ -638,7 +585,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   >
                     Jan 4, 2020 / 11:22PM
                   </a>
-                </td>
+                </th>
                 <td
                   class="woocommerce-table__item"
                 >
@@ -1003,15 +950,6 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
             <tbody>
               <tr>
                 <th
-                  class="woocommerce-table__header info-button is-sorted"
-                  role="columnheader"
-                  scope="col"
-                >
-                  <span
-                    aria-hidden="false"
-                  />
-                </th>
-                <th
                   aria-sort="descending"
                   class="woocommerce-table__header date-time is-left-aligned is-sortable is-sorted"
                   role="columnheader"
@@ -1262,30 +1200,8 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
               </tr>
               <tr>
                 <th
-                  class="woocommerce-table__item info-button is-sorted"
-                  scope="row"
-                >
-                  <a
-                    data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
-                  >
-                    <svg
-                      class="gridicon gridicons-info-outline needs-offset"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      width="18"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <g>
-                        <path
-                          d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.41 0-8 3.59-8 8s3.59 8 8 8 8-3.59 8-8-3.59-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z"
-                        />
-                      </g>
-                    </svg>
-                  </a>
-                </th>
-                <td
                   class="woocommerce-table__item date-time is-left-aligned is-sorted"
+                  scope="row"
                 >
                   <a
                     class="woocommerce-table__clickable-cell"
@@ -1295,7 +1211,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   >
                     Jan 2, 2020 / 12:46PM
                   </a>
-                </td>
+                </th>
                 <td
                   class="woocommerce-table__item"
                 >
@@ -1383,30 +1299,8 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
               </tr>
               <tr>
                 <th
-                  class="woocommerce-table__item info-button is-sorted"
-                  scope="row"
-                >
-                  <a
-                    data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
-                  >
-                    <svg
-                      class="gridicon gridicons-info-outline needs-offset"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      width="18"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <g>
-                        <path
-                          d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.41 0-8 3.59-8 8s3.59 8 8 8 8-3.59 8-8-3.59-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z"
-                        />
-                      </g>
-                    </svg>
-                  </a>
-                </th>
-                <td
                   class="woocommerce-table__item date-time is-left-aligned is-sorted"
+                  scope="row"
                 >
                   <a
                     class="woocommerce-table__clickable-cell"
@@ -1416,7 +1310,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   >
                     Jan 4, 2020 / 11:22PM
                   </a>
-                </td>
+                </th>
                 <td
                   class="woocommerce-table__item"
                 >
@@ -1756,22 +1650,13 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
             <tbody>
               <tr>
                 <th
-                  class="woocommerce-table__header info-button is-sorted"
-                  role="columnheader"
-                  scope="col"
-                >
-                  <span
-                    aria-hidden="false"
-                  />
-                </th>
-                <th
                   aria-sort="descending"
                   class="woocommerce-table__header date-time is-left-aligned is-sortable is-sorted"
                   role="columnheader"
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-0-1"
+                    aria-describedby="header-0-0"
                     class="components-button"
                     type="button"
                   >
@@ -1801,7 +1686,7 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-0-1"
+                    id="header-0-0"
                   >
                     Sort by Date and time in ascending order
                   </span>
@@ -1820,6 +1705,48 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                     class="screen-reader-text"
                   >
                     Type
+                  </span>
+                </th>
+                <th
+                  aria-sort="none"
+                  class="woocommerce-table__header is-sortable is-numeric"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <button
+                    aria-describedby="header-0-2"
+                    class="components-button"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      focusable="false"
+                      height="24"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
+                      />
+                    </svg>
+                    <span
+                      aria-hidden="true"
+                    >
+                      Amount
+                    </span>
+                    <span
+                      class="screen-reader-text"
+                    >
+                      Amount
+                    </span>
+                  </button>
+                  <span
+                    class="screen-reader-text"
+                    id="header-0-2"
+                  >
+                    Sort by Amount in descending order
                   </span>
                 </th>
                 <th
@@ -1849,19 +1776,19 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                     <span
                       aria-hidden="true"
                     >
-                      Amount
+                      Fees
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Amount
+                      Fees
                     </span>
                   </button>
                   <span
                     class="screen-reader-text"
                     id="header-0-3"
                   >
-                    Sort by Amount in descending order
+                    Sort by Fees in descending order
                   </span>
                 </th>
                 <th
@@ -1891,59 +1818,17 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                     <span
                       aria-hidden="true"
                     >
-                      Fees
+                      Net
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Fees
+                      Net
                     </span>
                   </button>
                   <span
                     class="screen-reader-text"
                     id="header-0-4"
-                  >
-                    Sort by Fees in descending order
-                  </span>
-                </th>
-                <th
-                  aria-sort="none"
-                  class="woocommerce-table__header is-sortable is-numeric"
-                  role="columnheader"
-                  scope="col"
-                >
-                  <button
-                    aria-describedby="header-0-5"
-                    class="components-button"
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      focusable="false"
-                      height="24"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
-                      />
-                    </svg>
-                    <span
-                      aria-hidden="true"
-                    >
-                      Net
-                    </span>
-                    <span
-                      class="screen-reader-text"
-                    >
-                      Net
-                    </span>
-                  </button>
-                  <span
-                    class="screen-reader-text"
-                    id="header-0-5"
                   >
                     Sort by Net in descending order
                   </span>
@@ -1999,30 +1884,8 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
               </tr>
               <tr>
                 <th
-                  class="woocommerce-table__item info-button is-sorted"
-                  scope="row"
-                >
-                  <a
-                    data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
-                  >
-                    <svg
-                      class="gridicon gridicons-info-outline needs-offset"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      width="18"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <g>
-                        <path
-                          d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.41 0-8 3.59-8 8s3.59 8 8 8 8-3.59 8-8-3.59-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z"
-                        />
-                      </g>
-                    </svg>
-                  </a>
-                </th>
-                <td
                   class="woocommerce-table__item date-time is-left-aligned is-sorted"
+                  scope="row"
                 >
                   <a
                     class="woocommerce-table__clickable-cell"
@@ -2032,7 +1895,7 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                   >
                     Jan 4, 2020 / 11:22PM
                   </a>
-                </td>
+                </th>
                 <td
                   class="woocommerce-table__item"
                 >
@@ -2402,15 +2265,6 @@ exports[`Transactions list subscription column renders correctly 1`] = `
             <tbody>
               <tr>
                 <th
-                  class="woocommerce-table__header info-button is-sorted"
-                  role="columnheader"
-                  scope="col"
-                >
-                  <span
-                    aria-hidden="false"
-                  />
-                </th>
-                <th
                   aria-sort="descending"
                   class="woocommerce-table__header date-time is-left-aligned is-sortable is-sorted"
                   role="columnheader"
@@ -2677,30 +2531,8 @@ exports[`Transactions list subscription column renders correctly 1`] = `
               </tr>
               <tr>
                 <th
-                  class="woocommerce-table__item info-button is-sorted"
-                  scope="row"
-                >
-                  <a
-                    data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
-                  >
-                    <svg
-                      class="gridicon gridicons-info-outline needs-offset"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      width="18"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <g>
-                        <path
-                          d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.41 0-8 3.59-8 8s3.59 8 8 8 8-3.59 8-8-3.59-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z"
-                        />
-                      </g>
-                    </svg>
-                  </a>
-                </th>
-                <td
                   class="woocommerce-table__item date-time is-left-aligned is-sorted"
+                  scope="row"
                 >
                   <a
                     class="woocommerce-table__clickable-cell"
@@ -2710,7 +2542,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   >
                     Jan 2, 2020 / 12:46PM
                   </a>
-                </td>
+                </th>
                 <td
                   class="woocommerce-table__item"
                 >
@@ -2808,30 +2640,8 @@ exports[`Transactions list subscription column renders correctly 1`] = `
               </tr>
               <tr>
                 <th
-                  class="woocommerce-table__item info-button is-sorted"
-                  scope="row"
-                >
-                  <a
-                    data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
-                  >
-                    <svg
-                      class="gridicon gridicons-info-outline needs-offset"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      width="18"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <g>
-                        <path
-                          d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.41 0-8 3.59-8 8s3.59 8 8 8 8-3.59 8-8-3.59-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z"
-                        />
-                      </g>
-                    </svg>
-                  </a>
-                </th>
-                <td
                   class="woocommerce-table__item date-time is-left-aligned is-sorted"
+                  scope="row"
                 >
                   <a
                     class="woocommerce-table__clickable-cell"
@@ -2841,7 +2651,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   >
                     Jan 4, 2020 / 11:22PM
                   </a>
-                </td>
+                </th>
                 <td
                   class="woocommerce-table__item"
                 >
@@ -3224,22 +3034,13 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
             <tbody>
               <tr>
                 <th
-                  class="woocommerce-table__header info-button is-sorted"
-                  role="columnheader"
-                  scope="col"
-                >
-                  <span
-                    aria-hidden="false"
-                  />
-                </th>
-                <th
                   aria-sort="descending"
                   class="woocommerce-table__header date-time is-left-aligned is-sortable is-sorted"
                   role="columnheader"
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-1-1"
+                    aria-describedby="header-1-0"
                     class="components-button"
                     type="button"
                   >
@@ -3269,7 +3070,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-1-1"
+                    id="header-1-0"
                   >
                     Sort by Date and time in ascending order
                   </span>
@@ -3288,6 +3089,48 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                     class="screen-reader-text"
                   >
                     Type
+                  </span>
+                </th>
+                <th
+                  aria-sort="none"
+                  class="woocommerce-table__header is-sortable is-numeric"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <button
+                    aria-describedby="header-1-2"
+                    class="components-button"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      focusable="false"
+                      height="24"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
+                      />
+                    </svg>
+                    <span
+                      aria-hidden="true"
+                    >
+                      Amount
+                    </span>
+                    <span
+                      class="screen-reader-text"
+                    >
+                      Amount
+                    </span>
+                  </button>
+                  <span
+                    class="screen-reader-text"
+                    id="header-1-2"
+                  >
+                    Sort by Amount in descending order
                   </span>
                 </th>
                 <th
@@ -3317,19 +3160,19 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                     <span
                       aria-hidden="true"
                     >
-                      Amount
+                      Fees
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Amount
+                      Fees
                     </span>
                   </button>
                   <span
                     class="screen-reader-text"
                     id="header-1-3"
                   >
-                    Sort by Amount in descending order
+                    Sort by Fees in descending order
                   </span>
                 </th>
                 <th
@@ -3359,59 +3202,17 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                     <span
                       aria-hidden="true"
                     >
-                      Fees
+                      Net
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Fees
+                      Net
                     </span>
                   </button>
                   <span
                     class="screen-reader-text"
                     id="header-1-4"
-                  >
-                    Sort by Fees in descending order
-                  </span>
-                </th>
-                <th
-                  aria-sort="none"
-                  class="woocommerce-table__header is-sortable is-numeric"
-                  role="columnheader"
-                  scope="col"
-                >
-                  <button
-                    aria-describedby="header-1-5"
-                    class="components-button"
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      focusable="false"
-                      height="24"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
-                      />
-                    </svg>
-                    <span
-                      aria-hidden="true"
-                    >
-                      Net
-                    </span>
-                    <span
-                      class="screen-reader-text"
-                    >
-                      Net
-                    </span>
-                  </button>
-                  <span
-                    class="screen-reader-text"
-                    id="header-1-5"
                   >
                     Sort by Net in descending order
                   </span>
@@ -3483,30 +3284,8 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
               </tr>
               <tr>
                 <th
-                  class="woocommerce-table__item info-button is-sorted"
-                  scope="row"
-                >
-                  <a
-                    data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda"
-                  >
-                    <svg
-                      class="gridicon gridicons-info-outline needs-offset"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      width="18"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <g>
-                        <path
-                          d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.41 0-8 3.59-8 8s3.59 8 8 8 8-3.59 8-8-3.59-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z"
-                        />
-                      </g>
-                    </svg>
-                  </a>
-                </th>
-                <td
                   class="woocommerce-table__item date-time is-left-aligned is-sorted"
+                  scope="row"
                 >
                   <a
                     class="woocommerce-table__clickable-cell"
@@ -3516,7 +3295,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                   >
                     Jan 2, 2020 / 12:46PM
                   </a>
-                </td>
+                </th>
                 <td
                   class="woocommerce-table__item"
                 >
@@ -3604,30 +3383,8 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
               </tr>
               <tr>
                 <th
-                  class="woocommerce-table__item info-button is-sorted"
-                  scope="row"
-                >
-                  <a
-                    data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda"
-                  >
-                    <svg
-                      class="gridicon gridicons-info-outline needs-offset"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      width="18"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <g>
-                        <path
-                          d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.41 0-8 3.59-8 8s3.59 8 8 8 8-3.59 8-8-3.59-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z"
-                        />
-                      </g>
-                    </svg>
-                  </a>
-                </th>
-                <td
                   class="woocommerce-table__item date-time is-left-aligned is-sorted"
+                  scope="row"
                 >
                   <a
                     class="woocommerce-table__clickable-cell"
@@ -3637,7 +3394,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                   >
                     Jan 4, 2020 / 11:22PM
                   </a>
-                </td>
+                </th>
                 <td
                   class="woocommerce-table__item"
                 >

--- a/client/transactions/list/test/__snapshots__/index.js.snap
+++ b/client/transactions/list/test/__snapshots__/index.js.snap
@@ -231,7 +231,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-10-1"
+                    aria-describedby="header-10-0"
                     class="components-button"
                     type="button"
                   >
@@ -261,7 +261,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-10-1"
+                    id="header-10-0"
                   >
                     Sort by Date and time in ascending order
                   </span>
@@ -280,6 +280,48 @@ exports[`Transactions list renders correctly when can filter by several currenci
                     class="screen-reader-text"
                   >
                     Type
+                  </span>
+                </th>
+                <th
+                  aria-sort="none"
+                  class="woocommerce-table__header is-sortable is-numeric"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <button
+                    aria-describedby="header-10-2"
+                    class="components-button"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      focusable="false"
+                      height="24"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
+                      />
+                    </svg>
+                    <span
+                      aria-hidden="true"
+                    >
+                      Amount
+                    </span>
+                    <span
+                      class="screen-reader-text"
+                    >
+                      Amount
+                    </span>
+                  </button>
+                  <span
+                    class="screen-reader-text"
+                    id="header-10-2"
+                  >
+                    Sort by Amount in descending order
                   </span>
                 </th>
                 <th
@@ -309,19 +351,19 @@ exports[`Transactions list renders correctly when can filter by several currenci
                     <span
                       aria-hidden="true"
                     >
-                      Amount
+                      Fees
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Amount
+                      Fees
                     </span>
                   </button>
                   <span
                     class="screen-reader-text"
                     id="header-10-3"
                   >
-                    Sort by Amount in descending order
+                    Sort by Fees in descending order
                   </span>
                 </th>
                 <th
@@ -351,59 +393,17 @@ exports[`Transactions list renders correctly when can filter by several currenci
                     <span
                       aria-hidden="true"
                     >
-                      Fees
+                      Net
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Fees
+                      Net
                     </span>
                   </button>
                   <span
                     class="screen-reader-text"
                     id="header-10-4"
-                  >
-                    Sort by Fees in descending order
-                  </span>
-                </th>
-                <th
-                  aria-sort="none"
-                  class="woocommerce-table__header is-sortable is-numeric"
-                  role="columnheader"
-                  scope="col"
-                >
-                  <button
-                    aria-describedby="header-10-5"
-                    class="components-button"
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      focusable="false"
-                      height="24"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
-                      />
-                    </svg>
-                    <span
-                      aria-hidden="true"
-                    >
-                      Net
-                    </span>
-                    <span
-                      class="screen-reader-text"
-                    >
-                      Net
-                    </span>
-                  </button>
-                  <span
-                    class="screen-reader-text"
-                    id="header-10-5"
                   >
                     Sort by Net in descending order
                   </span>
@@ -956,7 +956,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-11-1"
+                    aria-describedby="header-11-0"
                     class="components-button"
                     type="button"
                   >
@@ -986,7 +986,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-11-1"
+                    id="header-11-0"
                   >
                     Sort by Date and time in ascending order
                   </span>
@@ -1005,6 +1005,48 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                     class="screen-reader-text"
                   >
                     Type
+                  </span>
+                </th>
+                <th
+                  aria-sort="none"
+                  class="woocommerce-table__header is-sortable is-numeric"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <button
+                    aria-describedby="header-11-2"
+                    class="components-button"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      focusable="false"
+                      height="24"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
+                      />
+                    </svg>
+                    <span
+                      aria-hidden="true"
+                    >
+                      Amount
+                    </span>
+                    <span
+                      class="screen-reader-text"
+                    >
+                      Amount
+                    </span>
+                  </button>
+                  <span
+                    class="screen-reader-text"
+                    id="header-11-2"
+                  >
+                    Sort by Amount in descending order
                   </span>
                 </th>
                 <th
@@ -1034,19 +1076,19 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                     <span
                       aria-hidden="true"
                     >
-                      Amount
+                      Fees
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Amount
+                      Fees
                     </span>
                   </button>
                   <span
                     class="screen-reader-text"
                     id="header-11-3"
                   >
-                    Sort by Amount in descending order
+                    Sort by Fees in descending order
                   </span>
                 </th>
                 <th
@@ -1076,59 +1118,17 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                     <span
                       aria-hidden="true"
                     >
-                      Fees
+                      Net
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Fees
+                      Net
                     </span>
                   </button>
                   <span
                     class="screen-reader-text"
                     id="header-11-4"
-                  >
-                    Sort by Fees in descending order
-                  </span>
-                </th>
-                <th
-                  aria-sort="none"
-                  class="woocommerce-table__header is-sortable is-numeric"
-                  role="columnheader"
-                  scope="col"
-                >
-                  <button
-                    aria-describedby="header-11-5"
-                    class="components-button"
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      focusable="false"
-                      height="24"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
-                      />
-                    </svg>
-                    <span
-                      aria-hidden="true"
-                    >
-                      Net
-                    </span>
-                    <span
-                      class="screen-reader-text"
-                    >
-                      Net
-                    </span>
-                  </button>
-                  <span
-                    class="screen-reader-text"
-                    id="header-11-5"
                   >
                     Sort by Net in descending order
                   </span>
@@ -2271,7 +2271,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-9-1"
+                    aria-describedby="header-9-0"
                     class="components-button"
                     type="button"
                   >
@@ -2301,7 +2301,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-9-1"
+                    id="header-9-0"
                   >
                     Sort by Date and time in ascending order
                   </span>
@@ -2320,6 +2320,48 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                     class="screen-reader-text"
                   >
                     Type
+                  </span>
+                </th>
+                <th
+                  aria-sort="none"
+                  class="woocommerce-table__header is-sortable is-numeric"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <button
+                    aria-describedby="header-9-2"
+                    class="components-button"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      focusable="false"
+                      height="24"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
+                      />
+                    </svg>
+                    <span
+                      aria-hidden="true"
+                    >
+                      Amount
+                    </span>
+                    <span
+                      class="screen-reader-text"
+                    >
+                      Amount
+                    </span>
+                  </button>
+                  <span
+                    class="screen-reader-text"
+                    id="header-9-2"
+                  >
+                    Sort by Amount in descending order
                   </span>
                 </th>
                 <th
@@ -2349,19 +2391,19 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                     <span
                       aria-hidden="true"
                     >
-                      Amount
+                      Fees
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Amount
+                      Fees
                     </span>
                   </button>
                   <span
                     class="screen-reader-text"
                     id="header-9-3"
                   >
-                    Sort by Amount in descending order
+                    Sort by Fees in descending order
                   </span>
                 </th>
                 <th
@@ -2391,59 +2433,17 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                     <span
                       aria-hidden="true"
                     >
-                      Fees
+                      Net
                     </span>
                     <span
                       class="screen-reader-text"
                     >
-                      Fees
+                      Net
                     </span>
                   </button>
                   <span
                     class="screen-reader-text"
                     id="header-9-4"
-                  >
-                    Sort by Fees in descending order
-                  </span>
-                </th>
-                <th
-                  aria-sort="none"
-                  class="woocommerce-table__header is-sortable is-numeric"
-                  role="columnheader"
-                  scope="col"
-                >
-                  <button
-                    aria-describedby="header-9-5"
-                    class="components-button"
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      focusable="false"
-                      height="24"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
-                      />
-                    </svg>
-                    <span
-                      aria-hidden="true"
-                    >
-                      Net
-                    </span>
-                    <span
-                      class="screen-reader-text"
-                    >
-                      Net
-                    </span>
-                  </button>
-                  <span
-                    class="screen-reader-text"
-                    id="header-9-5"
                   >
                     Sort by Net in descending order
                   </span>

--- a/client/transactions/list/test/index.js
+++ b/client/transactions/list/test/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
 
@@ -13,10 +13,21 @@ import { getQuery, updateQueryString } from '@woocommerce/navigation';
 import { TransactionsList } from '../';
 import { useTransactions, useTransactionsSummary } from 'data';
 
+import { downloadCSVFile } from '@woocommerce/csv-export';
+
 jest.mock( 'data', () => ( {
 	useTransactions: jest.fn(),
 	useTransactionsSummary: jest.fn(),
 } ) );
+
+jest.mock( '@woocommerce/csv-export', () => {
+	const actualModule = jest.requireActual( '@woocommerce/csv-export' );
+
+	return {
+		...actualModule,
+		downloadCSVFile: jest.fn(),
+	};
+} );
 
 const getMockTransactions = () => [
 	{
@@ -325,5 +336,52 @@ describe( 'Transactions list', () => {
 
 		const { container } = render( <TransactionsList /> );
 		expect( container ).toMatchSnapshot();
+	} );
+
+	describe( 'CSV download', () => {
+		beforeEach( () => {
+			useTransactions.mockReturnValue( {
+				transactions: getMockTransactions(),
+				isLoading: false,
+			} );
+
+			useTransactionsSummary.mockReturnValue( {
+				transactionsSummary: {
+					count: 10,
+					currency: 'usd',
+					// eslint-disable-next-line camelcase
+					store_currencies: [ 'eur', 'usd' ],
+					fees: 100,
+					total: 1000,
+					net: 900,
+				},
+				isLoading: false,
+			} );
+		} );
+
+		afterEach( () => {
+			jest.resetAllMocks();
+		} );
+
+		afterAll( () => {
+			jest.restoreAllMocks();
+		} );
+
+		test( 'should render expected columns in CSV when the download button is clicked', () => {
+			render( <TransactionsList /> );
+			const downloadButton = screen.getByRole( 'button', {
+				name: 'Download',
+			} );
+
+			// simulate click on the download CSV button
+			fireEvent.click( downloadButton );
+			const expected =
+				'Transaction Id","Date / Time",Type,Amount,Fees,Net,"Order #",Source,Customer,Email,Country,"Risk level",Deposit';
+
+			// checking if columns in CSV are rendered correctly
+			expect( downloadCSVFile.mock.calls[ 0 ][ 1 ] ).toContain(
+				expected
+			);
+		} );
 	} );
 } );

--- a/client/transactions/list/test/index.js
+++ b/client/transactions/list/test/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
 
@@ -368,20 +368,31 @@ describe( 'Transactions list', () => {
 		} );
 
 		test( 'should render expected columns in CSV when the download button is clicked', () => {
-			render( <TransactionsList /> );
-			const downloadButton = screen.getByRole( 'button', {
-				name: 'Download',
-			} );
+			const { getByRole } = render( <TransactionsList /> );
+			getByRole( 'button', { name: 'Download' } ).click();
 
-			// simulate click on the download CSV button
-			fireEvent.click( downloadButton );
-			const expected =
-				'Transaction Id","Date / Time",Type,Amount,Fees,Net,"Order #",Source,Customer,Email,Country,"Risk level",Deposit';
+			const expected = [
+				'"Transaction Id"',
+				'"Date / Time"',
+				'Type',
+				'Amount',
+				'Fees',
+				'Net',
+				'"Order #"',
+				'Source',
+				'Customer',
+				'Email',
+				'Country',
+				'"Risk level"',
+				'Deposit',
+			];
 
 			// checking if columns in CSV are rendered correctly
-			expect( downloadCSVFile.mock.calls[ 0 ][ 1 ] ).toContain(
-				expected
-			);
+			expect(
+				downloadCSVFile.mock.calls[ 0 ][ 1 ]
+					.split( '\n' )[ 0 ]
+					.split( ',' )
+			).toEqual( expected );
 		} );
 	} );
 } );

--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Transactions and deposits counts on the table summary are rendered as "undefined".
 * Update - Deposit overview details.
 * Add - Redirect to WooCommerce home page after successful WooCommerce Payments KYC (Know Your Customer).
+* Fix - Added CSV column heading for transaction id column.
 
 = 2.4.0 - 2021-05-12 =
 * Update - Improve the Connect Account page.


### PR DESCRIPTION
Fixes #1721 

#### Changes proposed in this Pull Request
- Replaced info icon which was at the start of the table as per https://github.com/Automattic/woocommerce-payments/issues/1721#issuecomment-837114313 with Transaction Id column.
- Added a Transaction Id column with key `transaction_id` only for the CSV file.
- Updated failing snapshots and added test for `getColumns` function.

#### After fix
![image](https://user-images.githubusercontent.com/15019298/117931662-1274cc80-b31d-11eb-9d8f-54c27c710ad0.png)
![image](https://user-images.githubusercontent.com/15019298/117932624-34228380-b31e-11eb-9d6b-2db7d959842a.png)

#### Testing instructions
- Switch to `fix/1721-extra-column-csv-bug`
- Goto transactions page
- Click on `Download`
- Now it should have a new column with a label as Transaction Id.

Not sure if we require unit tests for CSV export.
-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)