### PR TITLE
Fix the name of the hook for the api client

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -532,7 +532,7 @@ class WC_Payments {
 
 		$http_class = self::get_wc_payments_http();
 
-		$api_client_class = apply_filters( 'wc_api_client', 'WC_Payments_API_Client' );
+		$api_client_class = apply_filters( 'wc_payments_api_client', 'WC_Payments_API_Client' );
 
 		if ( ! is_subclass_of( $api_client_class, 'WC_Payments_API_Client' ) ) {
 			$api_client_class = 'WC_Payments_API_Client';


### PR DESCRIPTION
Hook name didn't match the plugin name:

See this discussion:
https://a8c.slack.com/archives/C01BPL3ALGP/p1620827144382200?thread_ts=1620824790.377200&cid=C01BPL3ALGP

CC @marcinbot 