### PR TITLE
Fix the name of the API class filter

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -532,7 +532,7 @@ class WC_Payments {
 
 		$http_class = self::get_wc_payments_http();
 
-		$api_client_class = apply_filters( 'wc_api_client', 'WC_Payments_API_Client' );
+		$api_client_class = apply_filters( 'wc_payments_api_client', 'WC_Payments_API_Client' );
 
 		if ( ! is_subclass_of( $api_client_class, 'WC_Payments_API_Client' ) ) {
 			$api_client_class = 'WC_Payments_API_Client';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Rename `wc_api_client` to `wc_payments_api_client` for consistency with other parts of the plugin

cc @millerf - you will need to update your changes too after this ships

#### Testing instructions

* Tests should pass

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
