### PR TITLE
Construct table summary data only when transactions and deposits summary data has been loaded.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Update - Use blog ID for authenticating most of the requests.
 * Fix: Misaligned columns on Deposits page.
 * Add - Tracking for returning from OAuth connection.
+* Fix - Transactions and deposits counts on the table summary are rendered as "undefined".
 
 = 2.4.0 - 2021-05-12 =
 * Update - Improve the Connect Account page.

--- a/client/deposits/list/index.js
+++ b/client/deposits/list/index.js
@@ -72,7 +72,9 @@ const getColumns = ( sortByDate ) => [
 
 export const DepositsList = () => {
 	const { deposits, depositsCount, isLoading } = useDeposits( getQuery() );
-	const { depositsSummary } = useDepositsSummary( getQuery() );
+	const { depositsSummary, isLoading: isSummaryLoading } = useDepositsSummary(
+		getQuery()
+	);
 
 	const sortByDate = ! getQuery().orderby || 'date' === getQuery().orderby;
 	const columns = useMemo( () => getColumns( sortByDate ), [ sortByDate ] );
@@ -131,10 +133,12 @@ export const DepositsList = () => {
 	const isSingleCurrency =
 		2 > ( depositsSummary.store_currencies || [] ).length;
 
+	// initializing summary with undefined as we don't want to render the TableSummary component unless we have the data
 	let summary;
 	const isDespositsSummaryDataLoaded =
 		depositsSummary.count !== undefined &&
-		depositsSummary.total !== undefined;
+		depositsSummary.total !== undefined &&
+		false === isSummaryLoading;
 
 	// Generate summary only if the data has been loaded
 	if ( isDespositsSummaryDataLoaded ) {

--- a/client/deposits/list/index.js
+++ b/client/deposits/list/index.js
@@ -131,14 +131,19 @@ export const DepositsList = () => {
 	const isSingleCurrency =
 		2 > ( depositsSummary.store_currencies || [] ).length;
 
-	const summary = [];
+	let summary;
+	const isDespositsSummaryDataLoaded =
+		depositsSummary.count !== undefined &&
+		depositsSummary.total !== undefined;
 
-	// Generate summary if the data has been loaded and available currencies information
-	if ( depositsSummary.count !== undefined ) {
-		summary.push( {
-			label: __( 'deposits', 'woocommerce-payments' ),
-			value: `${ depositsSummary.count }`,
-		} );
+	// Generate summary only if the data has been loaded
+	if ( isDespositsSummaryDataLoaded ) {
+		summary = [
+			{
+				label: __( 'deposits', 'woocommerce-payments' ),
+				value: `${ depositsSummary.count }`,
+			},
+		];
 
 		if ( isSingleCurrency || isCurrencyFiltered ) {
 			summary.push( {

--- a/client/deposits/list/index.js
+++ b/client/deposits/list/index.js
@@ -72,9 +72,7 @@ const getColumns = ( sortByDate ) => [
 
 export const DepositsList = () => {
 	const { deposits, depositsCount, isLoading } = useDeposits( getQuery() );
-	const { depositsSummary, isLoading: isSummaryLoading } = useDepositsSummary(
-		getQuery()
-	);
+	const { depositsSummary } = useDepositsSummary( getQuery() );
 
 	const sortByDate = ! getQuery().orderby || 'date' === getQuery().orderby;
 	const columns = useMemo( () => getColumns( sortByDate ), [ sortByDate ] );
@@ -129,17 +127,19 @@ export const DepositsList = () => {
 		return columns.map( ( { key } ) => data[ key ] || { display: null } );
 	} );
 
-	const summary = [
-		{
+	const isCurrencyFiltered = 'string' === typeof getQuery().store_currency_is;
+	const isSingleCurrency =
+		2 > ( depositsSummary.store_currencies || [] ).length;
+
+	const summary = [];
+
+	// Generate summary if the data has been loaded and available currencies information
+	if ( depositsSummary.count !== undefined ) {
+		summary.push( {
 			label: __( 'deposits', 'woocommerce-payments' ),
 			value: `${ depositsSummary.count }`,
-		},
-	];
+		} );
 
-	const isCurrencyFiltered = 'string' === typeof getQuery().store_currency_is;
-	if ( ! isSummaryLoading ) {
-		const isSingleCurrency =
-			2 > ( depositsSummary.store_currencies || [] ).length;
 		if ( isSingleCurrency || isCurrencyFiltered ) {
 			summary.push( {
 				label: __( 'total', 'woocommerce-payments' ),

--- a/client/deposits/list/test/index.js
+++ b/client/deposits/list/test/index.js
@@ -87,4 +87,39 @@ describe( 'Deposits list', () => {
 		const { container } = render( <DepositsList /> );
 		expect( container ).toMatchSnapshot();
 	} );
+
+	test( 'renders table summary only when the deposits summary data is available', () => {
+		useDeposits.mockReturnValue( {
+			deposits: mockDeposits,
+			depositsCount: 2,
+			isLoading: false,
+		} );
+
+		useDepositsSummary.mockReturnValue( {
+			depositsSummary: {},
+			isLoading: true,
+		} );
+
+		let { container } = render( <DepositsList /> );
+		let tableSummary = container.querySelectorAll(
+			'.woocommerce-table__summary'
+		);
+
+		expect( tableSummary ).toHaveLength( 0 );
+
+		useDepositsSummary.mockReturnValue( {
+			depositsSummary: {
+				count: 2,
+				total: 100,
+			},
+			isLoading: false,
+		} );
+
+		( { container } = render( <DepositsList /> ) );
+		tableSummary = container.querySelectorAll(
+			'.woocommerce-table__summary'
+		);
+
+		expect( tableSummary ).toHaveLength( 1 );
+	} );
 } );

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -144,10 +144,10 @@ export const TransactionsList = ( props ) => {
 		getQuery(),
 		props.depositId
 	);
-	const {
-		transactionsSummary,
-		isLoading: isSummaryLoading,
-	} = useTransactionsSummary( getQuery(), props.depositId );
+	const { transactionsSummary } = useTransactionsSummary(
+		getQuery(),
+		props.depositId
+	);
 
 	const sortByDate = ! getQuery().orderby || 'date' === getQuery().orderby;
 	const columnsToDisplay = useMemo(
@@ -340,17 +340,20 @@ export const TransactionsList = ( props ) => {
 		);
 	}
 
-	// Generate summary based on loading state and available currencies information
-	const summary = [
-		{
+	const isCurrencyFiltered = 'string' === typeof getQuery().store_currency_is;
+
+	const isSingleCurrency =
+		2 > ( transactionsSummary.store_currencies || [] ).length;
+
+	const summary = [];
+
+	// Generate summary if the data has been loaded and available currencies information
+	if ( transactionsSummary.count !== undefined ) {
+		summary.push( {
 			label: __( 'transactions', 'woocommerce-payments' ),
 			value: `${ transactionsSummary.count }`,
-		},
-	];
-	const isCurrencyFiltered = 'string' === typeof getQuery().store_currency_is;
-	if ( ! isSummaryLoading ) {
-		const isSingleCurrency =
-			2 > ( transactionsSummary.store_currencies || [] ).length;
+		} );
+
 		if ( isSingleCurrency || isCurrencyFiltered ) {
 			summary.push(
 				{

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -345,14 +345,19 @@ export const TransactionsList = ( props ) => {
 	const isSingleCurrency =
 		2 > ( transactionsSummary.store_currencies || [] ).length;
 
-	const summary = [];
+	let summary;
+	const isTransactionsSummaryDataLoaded =
+		transactionsSummary.count !== undefined &&
+		transactionsSummary.total !== undefined;
 
-	// Generate summary if the data has been loaded and available currencies information
-	if ( transactionsSummary.count !== undefined ) {
-		summary.push( {
-			label: __( 'transactions', 'woocommerce-payments' ),
-			value: `${ transactionsSummary.count }`,
-		} );
+	// Generate summary only if the data has been loaded
+	if ( isTransactionsSummaryDataLoaded ) {
+		summary = [
+			{
+				label: __( 'transactions', 'woocommerce-payments' ),
+				value: `${ transactionsSummary.count }`,
+			},
+		];
 
 		if ( isSingleCurrency || isCurrencyFiltered ) {
 			summary.push(

--- a/client/transactions/list/index.js
+++ b/client/transactions/list/index.js
@@ -144,10 +144,10 @@ export const TransactionsList = ( props ) => {
 		getQuery(),
 		props.depositId
 	);
-	const { transactionsSummary } = useTransactionsSummary(
-		getQuery(),
-		props.depositId
-	);
+	const {
+		transactionsSummary,
+		isLoading: isSummaryLoading,
+	} = useTransactionsSummary( getQuery(), props.depositId );
 
 	const sortByDate = ! getQuery().orderby || 'date' === getQuery().orderby;
 	const columnsToDisplay = useMemo(
@@ -345,10 +345,12 @@ export const TransactionsList = ( props ) => {
 	const isSingleCurrency =
 		2 > ( transactionsSummary.store_currencies || [] ).length;
 
+	// initializing summary with undefined as we don't want to render the TableSummary component unless we have the data
 	let summary;
 	const isTransactionsSummaryDataLoaded =
 		transactionsSummary.count !== undefined &&
-		transactionsSummary.total !== undefined;
+		transactionsSummary.total !== undefined &&
+		false === isSummaryLoading;
 
 	// Generate summary only if the data has been loaded
 	if ( isTransactionsSummaryDataLoaded ) {

--- a/client/transactions/list/test/__snapshots__/index.js.snap
+++ b/client/transactions/list/test/__snapshots__/index.js.snap
@@ -108,7 +108,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   >
                     <label
                       class="components-base-control__label"
-                      for="woocommerce-select-control-7__control-input"
+                      for="woocommerce-select-control-10__control-input"
                     >
                       Search by order number, customer name, or billing email
                     </label>
@@ -118,7 +118,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                       aria-haspopup="true"
                       autocomplete="off"
                       class="woocommerce-select-control__control-input"
-                      id="woocommerce-select-control-7__control-input"
+                      id="woocommerce-select-control-10__control-input"
                       placeholder=""
                       role="combobox"
                       type="text"
@@ -126,7 +126,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                     />
                     <span
                       class="screen-reader-text"
-                      id="search-inline-input-7"
+                      id="search-inline-input-10"
                     >
                       Move backward for selected items
                     </span>
@@ -211,14 +211,14 @@ exports[`Transactions list renders correctly when can filter by several currenci
       >
         <div
           aria-hidden="false"
-          aria-labelledby="caption-7"
+          aria-labelledby="caption-10"
           class="woocommerce-table__table"
           role="group"
         >
           <table>
             <caption
               class="woocommerce-table__caption screen-reader-text"
-              id="caption-7"
+              id="caption-10"
             >
               Transactions
             </caption>
@@ -240,7 +240,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-7-1"
+                    aria-describedby="header-10-1"
                     class="components-button"
                     type="button"
                   >
@@ -270,7 +270,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-7-1"
+                    id="header-10-1"
                   >
                     Sort by Date and time in ascending order
                   </span>
@@ -298,7 +298,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-7-3"
+                    aria-describedby="header-10-3"
                     class="components-button"
                     type="button"
                   >
@@ -328,7 +328,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-7-3"
+                    id="header-10-3"
                   >
                     Sort by Amount in descending order
                   </span>
@@ -340,7 +340,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-7-4"
+                    aria-describedby="header-10-4"
                     class="components-button"
                     type="button"
                   >
@@ -370,7 +370,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-7-4"
+                    id="header-10-4"
                   >
                     Sort by Fees in descending order
                   </span>
@@ -382,7 +382,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-7-5"
+                    aria-describedby="header-10-5"
                     class="components-button"
                     type="button"
                   >
@@ -412,7 +412,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-7-5"
+                    id="header-10-5"
                   >
                     Sort by Net in descending order
                   </span>
@@ -886,7 +886,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   >
                     <label
                       class="components-base-control__label"
-                      for="woocommerce-select-control-8__control-input"
+                      for="woocommerce-select-control-11__control-input"
                     >
                       Search by order number, customer name, or billing email
                     </label>
@@ -896,7 +896,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                       aria-haspopup="true"
                       autocomplete="off"
                       class="woocommerce-select-control__control-input"
-                      id="woocommerce-select-control-8__control-input"
+                      id="woocommerce-select-control-11__control-input"
                       placeholder=""
                       role="combobox"
                       type="text"
@@ -904,7 +904,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                     />
                     <span
                       class="screen-reader-text"
-                      id="search-inline-input-8"
+                      id="search-inline-input-11"
                     >
                       Move backward for selected items
                     </span>
@@ -989,14 +989,14 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
       >
         <div
           aria-hidden="false"
-          aria-labelledby="caption-8"
+          aria-labelledby="caption-11"
           class="woocommerce-table__table"
           role="group"
         >
           <table>
             <caption
               class="woocommerce-table__caption screen-reader-text"
-              id="caption-8"
+              id="caption-11"
             >
               Transactions
             </caption>
@@ -1018,7 +1018,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-8-1"
+                    aria-describedby="header-11-1"
                     class="components-button"
                     type="button"
                   >
@@ -1048,7 +1048,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-8-1"
+                    id="header-11-1"
                   >
                     Sort by Date and time in ascending order
                   </span>
@@ -1076,7 +1076,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-8-3"
+                    aria-describedby="header-11-3"
                     class="components-button"
                     type="button"
                   >
@@ -1106,7 +1106,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-8-3"
+                    id="header-11-3"
                   >
                     Sort by Amount in descending order
                   </span>
@@ -1118,7 +1118,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-8-4"
+                    aria-describedby="header-11-4"
                     class="components-button"
                     type="button"
                   >
@@ -1148,7 +1148,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-8-4"
+                    id="header-11-4"
                   >
                     Sort by Fees in descending order
                   </span>
@@ -1160,7 +1160,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-8-5"
+                    aria-describedby="header-11-5"
                     class="components-button"
                     type="button"
                   >
@@ -1190,7 +1190,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-8-5"
+                    id="header-11-5"
                   >
                     Sort by Net in descending order
                   </span>
@@ -2285,7 +2285,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   >
                     <label
                       class="components-base-control__label"
-                      for="woocommerce-select-control-6__control-input"
+                      for="woocommerce-select-control-9__control-input"
                     >
                       Search by order number, subscription number, customer name, or billing email
                     </label>
@@ -2295,7 +2295,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                       aria-haspopup="true"
                       autocomplete="off"
                       class="woocommerce-select-control__control-input"
-                      id="woocommerce-select-control-6__control-input"
+                      id="woocommerce-select-control-9__control-input"
                       placeholder=""
                       role="combobox"
                       type="text"
@@ -2303,7 +2303,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                     />
                     <span
                       class="screen-reader-text"
-                      id="search-inline-input-6"
+                      id="search-inline-input-9"
                     >
                       Move backward for selected items
                     </span>
@@ -2388,14 +2388,14 @@ exports[`Transactions list subscription column renders correctly 1`] = `
       >
         <div
           aria-hidden="false"
-          aria-labelledby="caption-6"
+          aria-labelledby="caption-9"
           class="woocommerce-table__table"
           role="group"
         >
           <table>
             <caption
               class="woocommerce-table__caption screen-reader-text"
-              id="caption-6"
+              id="caption-9"
             >
               Transactions
             </caption>
@@ -2417,7 +2417,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-6-1"
+                    aria-describedby="header-9-1"
                     class="components-button"
                     type="button"
                   >
@@ -2447,7 +2447,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-6-1"
+                    id="header-9-1"
                   >
                     Sort by Date and time in ascending order
                   </span>
@@ -2475,7 +2475,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-6-3"
+                    aria-describedby="header-9-3"
                     class="components-button"
                     type="button"
                   >
@@ -2505,7 +2505,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-6-3"
+                    id="header-9-3"
                   >
                     Sort by Amount in descending order
                   </span>
@@ -2517,7 +2517,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-6-4"
+                    aria-describedby="header-9-4"
                     class="components-button"
                     type="button"
                   >
@@ -2547,7 +2547,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-6-4"
+                    id="header-9-4"
                   >
                     Sort by Fees in descending order
                   </span>
@@ -2559,7 +2559,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   scope="col"
                 >
                   <button
-                    aria-describedby="header-6-5"
+                    aria-describedby="header-9-5"
                     class="components-button"
                     type="button"
                   >
@@ -2589,7 +2589,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   </button>
                   <span
                     class="screen-reader-text"
-                    id="header-6-5"
+                    id="header-9-5"
                   >
                     Sort by Net in descending order
                   </span>

--- a/client/transactions/list/test/index.js
+++ b/client/transactions/list/test/index.js
@@ -189,6 +189,39 @@ describe( 'Transactions list', () => {
 			expectSortingToBe( 'net', 'asc' );
 		} );
 
+		test( 'renders table summary only when the transactions summary data is available', () => {
+			useTransactionsSummary.mockReturnValue( {
+				transactionsSummary: {},
+				isLoading: true,
+			} );
+
+			( { container } = render( <TransactionsList /> ) );
+			let tableSummary = container.querySelectorAll(
+				'.woocommerce-table__summary'
+			);
+			expect( tableSummary ).toHaveLength( 0 );
+
+			useTransactionsSummary.mockReturnValue( {
+				transactionsSummary: {
+					count: 10,
+					currency: 'usd',
+					// eslint-disable-next-line camelcase
+					store_currencies: [ 'usd' ],
+					fees: 100,
+					total: 1000,
+					net: 900,
+				},
+				isLoading: false,
+			} );
+
+			( { container } = render( <TransactionsList /> ) );
+			tableSummary = container.querySelectorAll(
+				'.woocommerce-table__summary'
+			);
+
+			expect( tableSummary ).toHaveLength( 1 );
+		} );
+
 		function sortBy( field ) {
 			user.click( screen.getByRole( 'button', { name: field } ) );
 			rerender( <TransactionsList /> );

--- a/readme.txt
+++ b/readme.txt
@@ -107,6 +107,7 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Use blog ID for authenticating most of the requests.
 * Fix: Misaligned columns on Deposits page.
 * Add - Tracking for returning from OAuth connection.
+* Fix - Transactions and deposits counts on the table summary are rendered as "undefined".
 
 = 2.4.0 - 2021-05-12 =
 * Update - Improve the Connect Account page.


### PR DESCRIPTION
Fixes #1639 

Presently we render the number of transactions and deposits in the summary section of the respective tables. While the data is being fetched from the server the count is rendered as `undefined`.

`isSummaryLoading` is set to false initially which leads to construction of an array with empty/falsy values.

#### Changes proposed in this Pull Request
- Construct table summary data only when transactions and deposits summary data has been loaded. This way table summary won't be rendered unless the summary data is loaded. As per comment https://github.com/Automattic/woocommerce-payments/issues/1639#issuecomment-837296088

#### Testing instructions
- switch to `fix/1639-transaction-deposit-count`
- goto deposits page, the table summary should appear after the data has been loaded.
- goto transactions page, the table summary should appear after the data has been loaded.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
