### PR TITLE
fix: payment methods modal action order

### DIFF
--- a/client/settings/payment-methods-selector/index.js
+++ b/client/settings/payment-methods-selector/index.js
@@ -72,11 +72,11 @@ const PaymentMethodsSelector = ( { onClose, enabledPaymentMethods = [] } ) => {
 			</PaymentMethodCheckboxes>
 			<HorizontalRule className="woocommerce-payments__payment-method-selector__separator" />
 			<div className="woocommerce-payments__payment-method-selector__footer">
-				<Button isSecondary onClick={ onClose }>
-					{ __( 'Cancel', 'woocommerce-payments' ) }
-				</Button>
 				<Button isPrimary onClick={ handleAddSelected }>
 					{ __( 'Add selected', 'woocommerce-payments' ) }
+				</Button>
+				<Button isSecondary onClick={ onClose }>
+					{ __( 'Cancel', 'woocommerce-payments' ) }
 				</Button>
 			</div>
 		</Modal>

--- a/client/settings/payment-methods-selector/style.scss
+++ b/client/settings/payment-methods-selector/style.scss
@@ -4,6 +4,6 @@
 	}
 
 	&__footer {
-		@include modal-footer-buttons;
+		@include modal-footer-buttons-left;
 	}
 }

--- a/client/stylesheets/abstracts/_mixins.scss
+++ b/client/stylesheets/abstracts/_mixins.scss
@@ -28,3 +28,13 @@
 		margin-left: 16px;
 	}
 }
+
+@mixin modal-footer-buttons-left {
+	display: flex;
+
+	> * {
+		&:not( :last-child ) {
+			margin-right: 16px;
+		}
+	}
+}


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed that the order of the actions in the modal is inaccurate compared to the designs.
- They are right-aligned (the designs show them left-aligned)
- The "Confirmation" action is displayed on the right (in the design it is on the right)

Design:
<img width="564" alt="Screen Shot 2021-05-12 at 3 33 57 PM" src="https://user-images.githubusercontent.com/273592/118040690-7f955b80-b337-11eb-9675-bd8e6b748509.png">

Current:
![Screen Shot 2021-05-12 at 3 34 19 PM](https://user-images.githubusercontent.com/273592/118040717-8a4ff080-b337-11eb-8e59-accd734d767d.png)

With these changes:
![Screen Shot 2021-05-12 at 3 35 27 PM](https://user-images.githubusercontent.com/273592/118040858-b8353500-b337-11eb-84fb-9cff02d8e904.png)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have the "grouped settings" flag enabled in WCPay Dev Tools
- Visit http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout
- Click the "Add payment method" action to display the modal

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
