### PR TITLE
Initialize WCPay multi currency, set mock currencies

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -179,6 +179,7 @@ class WC_Payments {
 		require_once __DIR__ . '/notes/class-wc-payments-remote-note-service.php';
 		include_once __DIR__ . '/class-wc-payments-action-scheduler-service.php';
 		include_once __DIR__ . '/class-wc-payments-fraud-service.php';
+		include_once __DIR__ . '/multi-currency/wc-payments-multi-currency.php';
 
 		// Always load tracker to avoid class not found errors.
 		include_once WCPAY_ABSPATH . 'includes/admin/tracks/class-tracker.php';

--- a/includes/multi-currency/class-wc-payments-multi-currency-currency.php
+++ b/includes/multi-currency/class-wc-payments-multi-currency-currency.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Class WC_Payments_Multi_Currency_Currency
+ *
+ * @package WooCommerce\Payments
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Multi Currency Currency object.
+ */
+class WC_Payments_Multi_Currency_Currency {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $code Three letter currency code.
+	 * @param float  $rate The conversion rate.
+	 * @param bool   $auto Whether to enable by default or not, for dev purposes.
+	 */
+	public function __construct( $code = '', $rate = '', $auto = false ) {
+		$this->id   = strtolower( $code );
+		$this->name = $this->get_currency_name_from_code( $code );
+		$this->code = $code;
+		$this->rate = $rate;
+		$this->img  = '';
+		$this->auto = $auto; // Auto enable for dev purposes.
+	}
+
+	/**
+	 * Don't lint me.
+	 *
+	 * @param string $code The currency code.
+	 */
+	public function get_currency_name_from_code( $code ) {
+		$wc_currencies = get_woocommerce_currencies();
+		return $wc_currencies[ $code ];
+	}
+}

--- a/includes/multi-currency/class-wc-payments-multi-currency-currency.php
+++ b/includes/multi-currency/class-wc-payments-multi-currency-currency.php
@@ -1,35 +1,70 @@
 <?php
 /**
- * Class WC_Payments_Multi_Currency_Currency
+ * Class Currency
  *
  * @package WooCommerce\Payments
  */
+
+namespace WCPay\Multi_Currency;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Multi Currency Currency object.
  */
-class WC_Payments_Multi_Currency_Currency {
+class Currency {
+
+	/**
+	 * Three letter currency code.
+	 *
+	 * @var string
+	 */
+	protected $code;
+
+	/**
+	 * Three letter currency code lowecased.
+	 *
+	 * @var string
+	 */
+	protected $id;
+
+	/**
+	 * Flag image for the currency.
+	 *
+	 * @var string
+	 */
+	protected $img;
+
+	/**
+	 * Currency name.
+	 *
+	 * @var string
+	 */
+	protected $name;
+
+	/**
+	 * Currency conversion rate.
+	 *
+	 * @var string
+	 */
+	protected $rate;
 
 	/**
 	 * Constructor.
 	 *
 	 * @param string $code Three letter currency code.
 	 * @param float  $rate The conversion rate.
-	 * @param bool   $auto Whether to enable by default or not, for dev purposes.
 	 */
-	public function __construct( $code = '', $rate = '', $auto = false ) {
-		$this->id   = strtolower( $code );
-		$this->name = $this->get_currency_name_from_code( $code );
+	public function __construct( $code = '', $rate = '' ) {
 		$this->code = $code;
-		$this->rate = $rate;
+		$this->id   = strtolower( $code );
 		$this->img  = '';
-		$this->auto = $auto; // Auto enable for dev purposes.
+		$this->name = $this->get_currency_name_from_code( $code );
+		$this->rate = $rate;
 	}
 
 	/**
-	 * Don't lint me.
+	 * Retrieves the currency's translated name from WooCommerce core.
 	 *
 	 * @param string $code The currency code.
 	 */

--- a/includes/multi-currency/class-wc-payments-multi-currency.php
+++ b/includes/multi-currency/class-wc-payments-multi-currency.php
@@ -1,21 +1,23 @@
 <?php
 /**
- * Class WC_Payments_Multi_Currency
+ * Class Multi_Currency
  *
  * @package WooCommerce\Payments
  */
+
+namespace WCPay\Multi_Currency;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Class that controls Multi Currency functionality.
  */
-class WC_Payments_Multi_Currency {
+class Multi_Currency {
 
 	/**
 	 * The single instance of the class.
 	 *
-	 * @var WC_Payments_Multi_Currency
+	 * @var Multi_Currency
 	 */
 	protected static $instance = null;
 
@@ -24,29 +26,29 @@ class WC_Payments_Multi_Currency {
 	 *
 	 * @var array
 	 */
-	public $available_currencies;
+	protected $available_currencies;
 
 	/**
 	 * The default currency.
 	 *
 	 * @var object
 	 */
-	public $default_currency;
+	protected $default_currency;
 
 	/**
 	 * The enabled currencies.
 	 *
 	 * @var array
 	 */
-	public $enabled_currencies;
+	protected $enabled_currencies;
 
 	/**
-	 * Main WC_Payments_Multi_Currency Instance.
+	 * Main Multi_Currency Instance.
 	 *
-	 * Ensures only one instance of WC_Payments_Multi_Currency is loaded or can be loaded.
+	 * Ensures only one instance of Multi_Currency is loaded or can be loaded.
 	 *
 	 * @static
-	 * @return WC_Payments_Multi_Currency - Main instance.
+	 * @return Multi_Currency - Main instance.
 	 */
 	public static function instance() {
 		if ( is_null( self::$instance ) ) {
@@ -75,43 +77,47 @@ class WC_Payments_Multi_Currency {
 	}
 
 	/**
+	 * Gets the mock available.
+	 *
+	 * @return array Array of currencies.
+	 */
+	public function get_mock_currencies() {
+		return [
+			[ 'USD', '1.00' ],
+			[ 'CAD', '1.206823' ],
+			[ 'GBP', '0.708099' ],
+			[ 'EUR', '0.826381' ],
+			[ 'AED', '3.6732' ],
+			[ 'CDF', '2000' ],
+			[ 'NZD', '1.387163' ],
+			[ 'DKK', '6.144615' ],
+			[ 'BIF', '1974' ], // Zero dollar currency.
+			[ 'CLP', '706.8' ], // Zero dollar currency.
+		];
+	}
+
+	/**
 	 * Gets the currencies available.
 	 *
-	 * @return array Array of WC_Payments_Multi_Currency_Currency objects.
+	 * @return array Array of Currency objects.
 	 */
 	public function get_available_currencies() {
 		if ( isset( $this->available_currencies ) ) {
 			return $this->available_currencies;
 		}
 
-		// TODO: Mock currencies to be replaced by stored values from API call.
-		// Third element in the array tells it to automatically set the currency as an enabled currency.
-		$mock_currencies = [
-			[ 'USD', '1.00', true ],
-			[ 'CAD', '1.206823', true ],
-			[ 'GBP', '0.708099', true ],
-			[ 'EUR', '0.826381', true ],
-			[ 'AED', '3.6732', false ],
-			[ 'CDF', '2000', false ],
-			[ 'NZD', '1.387163', false ],
-			[ 'DKK', '6.144615', false ],
-			[ 'BIF', '1974', false ], // Zero dollar currency.
-			[ 'CLP', '706.8', false ], // Zero dollar currency.
-		];
-
-		$available = [];
-		foreach ( $mock_currencies as $currency ) {
-			$c                     = new WC_Payments_Multi_Currency_Currency( $currency[0], $currency[1], $currency[2] );
-			$available[ $c->code ] = $c;
+		// TODO: This will need to get stored data, then build and return it accordingly.
+		$currencies = $this->get_mock_currencies();
+		foreach ( $currencies as $currency ) {
+			$this->available_currencies[ $currency[0] ] = new Currency( $currency[0], $currency[1] );
 		}
-		$this->available_currencies = $available;
 		return $this->available_currencies;
 	}
 
 	/**
 	 * Gets the store base currency.
 	 *
-	 * @return object WC_Payments_Multi_Currency_Currency object.
+	 * @return object Currency object.
 	 */
 	public function get_default_currency() {
 		if ( isset( $this->default_currency ) ) {
@@ -126,24 +132,30 @@ class WC_Payments_Multi_Currency {
 	/**
 	 * Gets the currently enabled currencies.
 	 *
-	 * @return array Array of WC_Payments_Multi_Currency_Currency objects.
+	 * @return array Array of Currency objects.
 	 */
 	public function get_enabled_currencies() {
 		if ( isset( $this->enabled_currencies ) ) {
 			return $this->enabled_currencies;
 		}
 
-		/*
-		This is how it should work.
-		// If there is no setting in the database, then use the store's default currency.
-		$this->enabled_currencies = get_option( $this->id . '_enabled_currencies', $this->get_default_currency() );
-		*/
-
-		// TODO: For dev purposes until settings are finished.
 		$this->enabled_currencies = get_option( $this->id . '_enabled_currencies', false );
-		foreach ( $this->available_currencies as $currency ) {
-			if ( $currency->auto ) {
-				$this->enabled_currencies[] = $currency;
+		if ( ! $this->enabled_currencies ) {
+
+			// TODO: Remove dev mode option here.
+			if ( get_option( 'wcpaydev_dev_mode', false ) ) {
+				$count = 0;
+				foreach ( $this->available_currencies as $currency ) {
+					$this->enabled_currencies[ $currency->code ] = $currency;
+					if ( $count >= 4 ) {
+						break;
+					}
+				}
+				$count++;
+			} else {
+				$default = $this->get_default_currency();
+				// Need to set the default as an array.
+				$this->enabled_currencies[ $default->code ] = $default;
 			}
 		}
 

--- a/includes/multi-currency/class-wc-payments-multi-currency.php
+++ b/includes/multi-currency/class-wc-payments-multi-currency.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Class WC_Payments_Multi_Currency
+ *
+ * @package WooCommerce\Payments
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class that controls Multi Currency functionality.
+ */
+class WC_Payments_Multi_Currency {
+
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var WC_Payments_Multi_Currency
+	 */
+	protected static $instance = null;
+
+	/**
+	 * The available currencies.
+	 *
+	 * @var array
+	 */
+	public $available_currencies;
+
+	/**
+	 * The default currency.
+	 *
+	 * @var object
+	 */
+	public $default_currency;
+
+	/**
+	 * The enabled currencies.
+	 *
+	 * @var array
+	 */
+	public $enabled_currencies;
+
+	/**
+	 * Main WC_Payments_Multi_Currency Instance.
+	 *
+	 * Ensures only one instance of WC_Payments_Multi_Currency is loaded or can be loaded.
+	 *
+	 * @static
+	 * @return WC_Payments_Multi_Currency - Main instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Init.
+	 */
+	public function init() {
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-wc-payments-multi-currency-currency.php';
+
+		$this->id = 'wcpay_multi_currency';
+		$this->get_available_currencies();
+		$this->get_default_currency();
+		$this->get_enabled_currencies();
+	}
+
+	/**
+	 * Gets the currencies available.
+	 *
+	 * @return array Array of WC_Payments_Multi_Currency_Currency objects.
+	 */
+	public function get_available_currencies() {
+		if ( isset( $this->available_currencies ) ) {
+			return $this->available_currencies;
+		}
+
+		// TODO: Mock currencies to be replaced by stored values from API call.
+		// Third element in the array tells it to automatically set the currency as an enabled currency.
+		$mock_currencies = [
+			[ 'USD', '1.00', true ],
+			[ 'CAD', '1.206823', true ],
+			[ 'GBP', '0.708099', true ],
+			[ 'EUR', '0.826381', true ],
+			[ 'AED', '3.6732', false ],
+			[ 'CDF', '2000', false ],
+			[ 'NZD', '1.387163', false ],
+			[ 'DKK', '6.144615', false ],
+			[ 'BIF', '1974', false ], // Zero dollar currency.
+			[ 'CLP', '706.8', false ], // Zero dollar currency.
+		];
+
+		$available = [];
+		foreach ( $mock_currencies as $currency ) {
+			$c                     = new WC_Payments_Multi_Currency_Currency( $currency[0], $currency[1], $currency[2] );
+			$available[ $c->code ] = $c;
+		}
+		$this->available_currencies = $available;
+		return $this->available_currencies;
+	}
+
+	/**
+	 * Gets the store base currency.
+	 *
+	 * @return object WC_Payments_Multi_Currency_Currency object.
+	 */
+	public function get_default_currency() {
+		if ( isset( $this->default_currency ) ) {
+			return $this->default_currency;
+		}
+
+		$this->default_currency = $this->available_currencies[ get_woocommerce_currency() ];
+
+		return $this->default_currency;
+	}
+
+	/**
+	 * Gets the currently enabled currencies.
+	 *
+	 * @return array Array of WC_Payments_Multi_Currency_Currency objects.
+	 */
+	public function get_enabled_currencies() {
+		if ( isset( $this->enabled_currencies ) ) {
+			return $this->enabled_currencies;
+		}
+
+		/*
+		This is how it should work.
+		// If there is no setting in the database, then use the store's default currency.
+		$this->enabled_currencies = get_option( $this->id . '_enabled_currencies', $this->get_default_currency() );
+		*/
+
+		// TODO: For dev purposes until settings are finished.
+		$this->enabled_currencies = get_option( $this->id . '_enabled_currencies', false );
+		foreach ( $this->available_currencies as $currency ) {
+			if ( $currency->auto ) {
+				$this->enabled_currencies[] = $currency;
+			}
+		}
+
+		return $this->enabled_currencies;
+	}
+}

--- a/includes/multi-currency/wc-payments-multi-currency.php
+++ b/includes/multi-currency/wc-payments-multi-currency.php
@@ -1,24 +1,24 @@
 <?php
 /**
- * Main functions to start WC_Payments_Multi_Currency class.
+ * Main functions to start Multi_Currency class.
  *
  * @package WooCommerce\Payments
  */
 
 defined( 'ABSPATH' ) || exit;
 
-// Include the main WC_Payments_Multi_Currency class.
-if ( ! class_exists( 'WC_Payments_Multi_Currency', false ) ) {
+// Include the main Multi_Currency class.
+if ( ! class_exists( 'WCPay\Multi_Currency\Multi_Currency', false ) ) {
 	include_once WCPAY_ABSPATH . 'includes/multi-currency/class-wc-payments-multi-currency.php';
 }
 
 /**
- * Returns the main instance of WC_Payments_Multi_Currency.
+ * Returns the main instance of Multi_Currency.
  *
- * @return WC_Payments_Multi_Currency
+ * @return Multi_Currency
  */
 function WC_Payments_Multi_Currency() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
-	return WC_Payments_Multi_Currency::instance();
+	return WCPay\Multi_Currency\Multi_Currency::instance();
 }
 
 add_action( 'plugins_loaded', 'WC_Payments_Multi_Currency', 12 );

--- a/includes/multi-currency/wc-payments-multi-currency.php
+++ b/includes/multi-currency/wc-payments-multi-currency.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Main functions to start WC_Payments_Multi_Currency class.
+ *
+ * @package WooCommerce\Payments
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+// Include the main WC_Payments_Multi_Currency class.
+if ( ! class_exists( 'WC_Payments_Multi_Currency', false ) ) {
+	include_once WCPAY_ABSPATH . 'includes/multi-currency/class-wc-payments-multi-currency.php';
+}
+
+/**
+ * Returns the main instance of WC_Payments_Multi_Currency.
+ *
+ * @return WC_Payments_Multi_Currency
+ */
+function WC_Payments_Multi_Currency() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+	return WC_Payments_Multi_Currency::instance();
+}
+
+add_action( 'plugins_loaded', 'WC_Payments_Multi_Currency', 12 );


### PR DESCRIPTION


#### Changes proposed in this Pull Request

Start of the Multi Currency project.
Create the main class and initialize it.
Set mock and default currencies.
Create currency object to be used for widgets, settings, etc.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
