### PR TITLE
Add "update business details" task

### DIFF
--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -18,7 +18,7 @@ const OverviewPage = () => {
 	return (
 		<Page className="overview">
 			<TestModeNotice topic={ topics.overview } />
-			{ tasks.length && <TaskList tasks={ tasks } /> }
+			{ 0 < tasks.length && <TaskList tasks={ tasks } /> }
 		</Page>
 	);
 };

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -12,13 +12,15 @@ import TaskList from './task-list';
 import { getTasks } from './task-list/tasks';
 import './style.scss';
 
-const { accountStatus } = wcpaySettings;
+const { accountStatus, showUpdateDetailsTask } = wcpaySettings;
 
 const OverviewPage = () => {
 	return (
 		<Page className="overview">
 			<TestModeNotice topic={ topics.overview } />
-			<TaskList tasks={ getTasks( { accountStatus } ) } />
+			<TaskList
+				tasks={ getTasks( { accountStatus, showUpdateDetailsTask } ) }
+			/>
 		</Page>
 	);
 };

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -9,12 +9,14 @@
 import Page from 'components/page';
 import { TestModeNotice, topics } from 'components/test-mode-notice';
 import TaskList from './task-list';
+import { tasks } from './task-list/tasks';
+import './style.scss';
 
 const OverviewPage = () => {
 	return (
 		<Page className="overview">
 			<TestModeNotice topic={ topics.overview } />
-			<TaskList />
+			<TaskList tasks={ tasks } />
 		</Page>
 	);
 };

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -12,15 +12,13 @@ import TaskList from './task-list';
 import { getTasks } from './task-list/tasks';
 import './style.scss';
 
-const { accountStatus, showUpdateDetailsTask } = wcpaySettings;
-
 const OverviewPage = () => {
+	const { accountStatus, showUpdateDetailsTask } = wcpaySettings;
+	const tasks = getTasks( { accountStatus, showUpdateDetailsTask } );
 	return (
 		<Page className="overview">
 			<TestModeNotice topic={ topics.overview } />
-			<TaskList
-				tasks={ getTasks( { accountStatus, showUpdateDetailsTask } ) }
-			/>
+			{ tasks.length && <TaskList tasks={ tasks } /> }
 		</Page>
 	);
 };

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -9,14 +9,16 @@
 import Page from 'components/page';
 import { TestModeNotice, topics } from 'components/test-mode-notice';
 import TaskList from './task-list';
-import { tasks } from './task-list/tasks';
+import { getTasks } from './task-list/tasks';
 import './style.scss';
+
+const { accountStatus } = wcpaySettings;
 
 const OverviewPage = () => {
 	return (
 		<Page className="overview">
 			<TestModeNotice topic={ topics.overview } />
-			<TaskList tasks={ tasks } />
+			<TaskList tasks={ getTasks( { accountStatus } ) } />
 		</Page>
 	);
 };

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -12,7 +12,7 @@ import TaskList from './task-list';
 
 const OverviewPage = () => {
 	return (
-		<Page>
+		<Page className="overview">
 			<TestModeNotice topic={ topics.overview } />
 			<TaskList />
 		</Page>

--- a/client/overview/style.scss
+++ b/client/overview/style.scss
@@ -1,1 +1,34 @@
 @import 'node_modules/@woocommerce/experimental/src/style.scss';
+
+// Adapted from woocommerce-admin:client/homescreen/style.scss
+.woocommerce-payments-page.overview {
+	.components-card__header.is-size-large,
+	.components-card__header.is-size-medium {
+		min-height: 63px;
+		min-height: unset;
+		display: grid;
+		grid-template-columns: auto 24px;
+
+		// IE doesn't support `align-items` on grid container
+
+		& > * {
+			align-self: center;
+		}
+	}
+
+	.components-card__body.is-size-large {
+		padding: 0;
+	}
+
+	.components-card__footer.is-size-large {
+		padding: 0 $gap-smaller;
+	}
+
+	.wooocommerce-task-card__header {
+		display: flex;
+
+		.woocommerce-badge {
+			margin-left: 16px;
+		}
+	}
+}

--- a/client/overview/task-list.js
+++ b/client/overview/task-list.js
@@ -4,20 +4,39 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { CollapsibleList } from '@woocommerce/experimental';
+import { Card, CardBody, CardHeader } from '@wordpress/components';
+import { Badge } from '@woocommerce/components';
+import { CollapsibleList, Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies.
  */
 import './style.scss';
 
+const tasks = [];
+
 const TaskList = () => {
 	return (
-		<CollapsibleList
-			collapsed={ false }
-			collapseLabel={ __( 'Hide tasks', 'woocommerce-payments' ) }
-			expandLabel={ __( 'Show tasks', 'woocommerce-payments' ) }
-		/>
+		<Card
+			size="large"
+			className="woocommerce-task-card woocommerce-homescreen-card"
+		>
+			<CardHeader size="medium">
+				<div className="wooocommerce-task-card__header">
+					<Text variant="title.small">
+						{ __( 'Things to do', 'woocommerce-payments' ) }
+					</Text>
+					<Badge count={ tasks.length } />
+				</div>
+			</CardHeader>
+			<CardBody>
+				<CollapsibleList
+					collapsed={ false }
+					collapseLabel={ __( 'Hide tasks', 'woocommerce-payments' ) }
+					expandLabel={ __( 'Show tasks', 'woocommerce-payments' ) }
+				/>
+			</CardBody>
+		</Card>
 	);
 };
 

--- a/client/overview/task-list/index.js
+++ b/client/overview/task-list/index.js
@@ -13,6 +13,8 @@ import { CollapsibleList, TaskItem, Text } from '@woocommerce/experimental';
  */
 
 const TaskList = ( { tasks } ) => {
+	const pendingTaskCount = tasks.filter( ( task ) => ! task.completed )
+		.length;
 	return (
 		<Card
 			size="large"
@@ -23,7 +25,9 @@ const TaskList = ( { tasks } ) => {
 					<Text variant="title.small">
 						{ __( 'Things to do', 'woocommerce-payments' ) }
 					</Text>
-					<Badge count={ tasks.length } />
+					{ 0 < pendingTaskCount && (
+						<Badge count={ pendingTaskCount } />
+					) }
 				</div>
 			</CardHeader>
 			<CardBody>

--- a/client/overview/task-list/index.js
+++ b/client/overview/task-list/index.js
@@ -6,16 +6,13 @@
 import { __ } from '@wordpress/i18n';
 import { Card, CardBody, CardHeader } from '@wordpress/components';
 import { Badge } from '@woocommerce/components';
-import { CollapsibleList, Text } from '@woocommerce/experimental';
+import { CollapsibleList, TaskItem, Text } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies.
  */
-import './style.scss';
 
-const tasks = [];
-
-const TaskList = () => {
+const TaskList = ( { tasks } ) => {
 	return (
 		<Card
 			size="large"
@@ -34,7 +31,20 @@ const TaskList = () => {
 					collapsed={ false }
 					collapseLabel={ __( 'Hide tasks', 'woocommerce-payments' ) }
 					expandLabel={ __( 'Show tasks', 'woocommerce-payments' ) }
-				/>
+				>
+					{ tasks.map( ( task ) => (
+						<TaskItem
+							key={ task.key }
+							title={ task.title }
+							completed={ task.completed }
+							content={ task.content }
+							expanded
+							onClick={ task.onClick }
+							time={ task.time }
+							level={ task.level }
+						/>
+					) ) }
+				</CollapsibleList>
 			</CardBody>
 		</Card>
 	);

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -7,7 +7,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 import moment from 'moment';
 
-export const getTasks = ( { accountStatus } ) => {
+export const getTasks = ( { accountStatus, showUpdateDetailsTask } ) => {
 	const { status, currentDeadline, pastDue, accountLink } = accountStatus;
 	const accountRestrictedSoon = 'restricted_soon' === status;
 	const accountDetailsPastDue = 'restricted' === status && pastDue;
@@ -34,7 +34,7 @@ export const getTasks = ( { accountStatus } ) => {
 			);
 	}
 	return [
-		( accountRestrictedSoon || accountDetailsPastDue ) && {
+		'yes' === showUpdateDetailsTask && {
 			key: 'update-business-details',
 			level: 1,
 			title: __(
@@ -42,10 +42,13 @@ export const getTasks = ( { accountStatus } ) => {
 				'woocommerce-payments'
 			),
 			content: accountDetailsTaskDescription,
-			completed: false,
-			onClick: () => {
-				window.open( accountLink, '_blank' );
-			},
+			completed: 'complete' === status,
+			onClick:
+				'complete' === status
+					? undefined
+					: () => {
+							window.open( accountLink, '_blank' );
+					  },
 		},
 	].filter( Boolean );
 };

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -1,0 +1,47 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { dateI18n } from '@wordpress/date';
+import moment from 'moment';
+
+const { accountStatus } = wcpaySettings;
+const { status, currentDeadline, pastDue, accountLink } = accountStatus;
+const accountRestrictedSoon = 'restricted_soon' === status;
+const accountDetailsPastDue = 'restricted' === status && pastDue;
+let accountDetailsTaskDescription;
+
+if ( accountRestrictedSoon ) {
+	accountDetailsTaskDescription = sprintf(
+		/* translators: %s - formatted requirements current deadline (date) */
+		__(
+			'Update by %s to avoid a disruption in deposits.',
+			'woocommerce-payments'
+		),
+		dateI18n( 'ga M j, Y', moment( currentDeadline * 1000 ).toISOString() )
+	);
+} else if ( accountDetailsPastDue ) {
+	accountDetailsTaskDescription =
+		/* translators: <a> - dashboard login URL */
+		__(
+			'Payments and deposits are disabled for this account until missing business information is updated.',
+			'woocommerce-payments'
+		);
+}
+export const tasks = [
+	( accountRestrictedSoon || accountDetailsPastDue ) && {
+		key: 'update-business-details',
+		level: 1,
+		title: __(
+			'Update WooCommerce Payments business details',
+			'woocommerce-payments'
+		),
+		content: accountDetailsTaskDescription,
+		completed: false,
+		onClick: () => {
+			window.open( accountLink, '_blank' );
+		},
+	},
+].filter( Boolean );

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -7,41 +7,45 @@ import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 import moment from 'moment';
 
-const { accountStatus } = wcpaySettings;
-const { status, currentDeadline, pastDue, accountLink } = accountStatus;
-const accountRestrictedSoon = 'restricted_soon' === status;
-const accountDetailsPastDue = 'restricted' === status && pastDue;
-let accountDetailsTaskDescription;
+export const getTasks = ( { accountStatus } ) => {
+	const { status, currentDeadline, pastDue, accountLink } = accountStatus;
+	const accountRestrictedSoon = 'restricted_soon' === status;
+	const accountDetailsPastDue = 'restricted' === status && pastDue;
+	let accountDetailsTaskDescription;
 
-if ( accountRestrictedSoon ) {
-	accountDetailsTaskDescription = sprintf(
-		/* translators: %s - formatted requirements current deadline (date) */
-		__(
-			'Update by %s to avoid a disruption in deposits.',
-			'woocommerce-payments'
-		),
-		dateI18n( 'ga M j, Y', moment( currentDeadline * 1000 ).toISOString() )
-	);
-} else if ( accountDetailsPastDue ) {
-	accountDetailsTaskDescription =
-		/* translators: <a> - dashboard login URL */
-		__(
-			'Payments and deposits are disabled for this account until missing business information is updated.',
-			'woocommerce-payments'
+	if ( accountRestrictedSoon ) {
+		accountDetailsTaskDescription = sprintf(
+			/* translators: %s - formatted requirements current deadline (date) */
+			__(
+				'Update by %s to avoid a disruption in deposits.',
+				'woocommerce-payments'
+			),
+			dateI18n(
+				'ga M j, Y',
+				moment( currentDeadline * 1000 ).toISOString()
+			)
 		);
-}
-export const tasks = [
-	( accountRestrictedSoon || accountDetailsPastDue ) && {
-		key: 'update-business-details',
-		level: 1,
-		title: __(
-			'Update WooCommerce Payments business details',
-			'woocommerce-payments'
-		),
-		content: accountDetailsTaskDescription,
-		completed: false,
-		onClick: () => {
-			window.open( accountLink, '_blank' );
+	} else if ( accountDetailsPastDue ) {
+		accountDetailsTaskDescription =
+			/* translators: <a> - dashboard login URL */
+			__(
+				'Payments and deposits are disabled for this account until missing business information is updated.',
+				'woocommerce-payments'
+			);
+	}
+	return [
+		( accountRestrictedSoon || accountDetailsPastDue ) && {
+			key: 'update-business-details',
+			level: 1,
+			title: __(
+				'Update WooCommerce Payments business details',
+				'woocommerce-payments'
+			),
+			content: accountDetailsTaskDescription,
+			completed: false,
+			onClick: () => {
+				window.open( accountLink, '_blank' );
+			},
 		},
-	},
-].filter( Boolean );
+	].filter( Boolean );
+};

--- a/client/overview/task-list/test/tasks.js
+++ b/client/overview/task-list/test/tasks.js
@@ -1,0 +1,59 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getTasks } from '../tasks';
+
+describe( 'getTasks()', () => {
+	it( 'should include business details when account will be restricted', () => {
+		const actual = getTasks( {
+			accountStatus: {
+				status: 'restricted_soon',
+				currentDeadline: 1620857083,
+				pastDue: false,
+				accountLink: 'http://example.com',
+			},
+		} );
+
+		expect( actual ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( { key: 'update-business-details' } ),
+			] )
+		);
+	} );
+
+	it( 'should include business details when account is restricted', () => {
+		const actual = getTasks( {
+			accountStatus: {
+				status: 'restricted',
+				currentDeadline: 1620857083,
+				pastDue: true,
+				accountLink: 'http://example.com',
+			},
+		} );
+
+		expect( actual ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( { key: 'update-business-details' } ),
+			] )
+		);
+	} );
+
+	it( 'should not include business details when account is complete', () => {
+		const actual = getTasks( {
+			accountStatus: {
+				status: 'complete',
+				currentDeadline: 0,
+				pastDue: false,
+				accountLink: 'http://example.com',
+			},
+		} );
+
+		expect( actual ).toEqual(
+			expect.not.arrayContaining( [
+				expect.objectContaining( { key: 'update-business-details' } ),
+			] )
+		);
+	} );
+} );

--- a/client/overview/task-list/test/tasks.js
+++ b/client/overview/task-list/test/tasks.js
@@ -6,7 +6,7 @@
 import { getTasks } from '../tasks';
 
 describe( 'getTasks()', () => {
-	it( 'should include business details when account will be restricted', () => {
+	it( 'should include business details when flag is set', () => {
 		const actual = getTasks( {
 			accountStatus: {
 				status: 'restricted_soon',
@@ -14,16 +14,20 @@ describe( 'getTasks()', () => {
 				pastDue: false,
 				accountLink: 'http://example.com',
 			},
+			showUpdateDetailsTask: 'yes',
 		} );
 
 		expect( actual ).toEqual(
 			expect.arrayContaining( [
-				expect.objectContaining( { key: 'update-business-details' } ),
+				expect.objectContaining( {
+					key: 'update-business-details',
+					completed: false,
+				} ),
 			] )
 		);
 	} );
 
-	it( 'should include business details when account is restricted', () => {
+	it( 'should omit business details when flag is not set', () => {
 		const actual = getTasks( {
 			accountStatus: {
 				status: 'restricted',
@@ -31,16 +35,20 @@ describe( 'getTasks()', () => {
 				pastDue: true,
 				accountLink: 'http://example.com',
 			},
+			showUpdateDetailsTask: 'no',
 		} );
 
 		expect( actual ).toEqual(
 			expect.arrayContaining( [
-				expect.objectContaining( { key: 'update-business-details' } ),
+				expect.objectContaining( {
+					key: 'update-business-details',
+					completed: false,
+				} ),
 			] )
 		);
 	} );
 
-	it( 'should not include business details when account is complete', () => {
+	it( 'handles when account is complete', () => {
 		const actual = getTasks( {
 			accountStatus: {
 				status: 'complete',
@@ -48,11 +56,15 @@ describe( 'getTasks()', () => {
 				pastDue: false,
 				accountLink: 'http://example.com',
 			},
+			showUpdateDetailsTask: 'yes',
 		} );
 
 		expect( actual ).toEqual(
 			expect.not.arrayContaining( [
-				expect.objectContaining( { key: 'update-business-details' } ),
+				expect.objectContaining( {
+					key: 'update-business-details',
+					completed: true,
+				} ),
 			] )
 		);
 	} );

--- a/client/overview/task-list/test/tasks.js
+++ b/client/overview/task-list/test/tasks.js
@@ -39,10 +39,9 @@ describe( 'getTasks()', () => {
 		} );
 
 		expect( actual ).toEqual(
-			expect.arrayContaining( [
+			expect.not.arrayContaining( [
 				expect.objectContaining( {
 					key: 'update-business-details',
-					completed: false,
 				} ),
 			] )
 		);
@@ -60,7 +59,7 @@ describe( 'getTasks()', () => {
 		} );
 
 		expect( actual ).toEqual(
-			expect.not.arrayContaining( [
+			expect.arrayContaining( [
 				expect.objectContaining( {
 					key: 'update-business-details',
 					completed: true,

--- a/client/overview/test/index.js
+++ b/client/overview/test/index.js
@@ -9,13 +9,18 @@ import { render } from '@testing-library/react';
  * Internal dependencies
  */
 import OverviewPage from '../';
+import { getTasks } from '../task-list/tasks';
+
+jest.mock( '../task-list/tasks', () => ( { getTasks: jest.fn() } ) );
 
 describe( 'Overview page', () => {
-	it( 'Renders the task list', () => {
+	it( 'Skips rendering task list when there are no tasks', () => {
+		global.wcpaySettings = {};
+		getTasks.mockReturnValue( [] );
 		const { container } = render( <OverviewPage /> );
 
 		expect(
 			container.querySelector( '.woocommerce-experimental-list' )
-		).not.toBeNull();
+		).toBeNull();
 	} );
 } );

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -219,6 +219,7 @@ class WC_Payments_Admin {
 		);
 
 		$this->add_menu_notification_badge();
+		$this->add_update_business_details_task();
 	}
 
 	/**
@@ -257,6 +258,7 @@ class WC_Payments_Admin {
 				'fraudServices'         => $this->account->get_fraud_services_config(),
 				'isJetpackConnected'    => $this->payments_api_client->is_server_connected(),
 				'accountStatus'         => $this->account->get_account_status_data(),
+				'showUpdateDetailsTask' => get_option( 'wcpay_show_update_business_details_task', 'no' ),
 			]
 		);
 
@@ -473,6 +475,24 @@ class WC_Payments_Admin {
 				$menu[ $index ][0] .= ' <span class="wcpay-menu-badge awaiting-mod count-1">1</span>'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 				break;
 			}
+		}
+	}
+
+	/**
+	 * Attempts to add a setup task to remind the user to update
+	 * their business details when the account is facing restriction.
+	 */
+	public function add_update_business_details_task() {
+		if ( 'yes' === get_option( 'wcpay_show_update_business_details_task', 'no' ) ) {
+			return;
+		}
+
+		$account  = $this->account->get_account_status_data();
+		$status   = $account['status'];
+		$past_due = isset( $account['has_overdue_requirements'] ) ? $account['has_overdue_requirements'] : false;
+
+		if ( 'restricted_soon' === $status || ( 'restricted' === $status && $past_due ) ) {
+			update_option( 'wcpay_show_update_business_details_task', 'yes' );
 		}
 	}
 }

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -256,6 +256,7 @@ class WC_Payments_Admin {
 				'zeroDecimalCurrencies' => WC_Payments_Utils::zero_decimal_currencies(),
 				'fraudServices'         => $this->account->get_fraud_services_config(),
 				'isJetpackConnected'    => $this->payments_api_client->is_server_connected(),
+				'accountStatus'         => $this->account->get_account_status_data(),
 			]
 		);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4111,16 +4111,20 @@
       }
     },
     "@woocommerce/experimental": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@woocommerce/experimental/-/experimental-1.1.0.tgz",
-      "integrity": "sha512-ICDHwpuuVWlBbAiKWlk1ktx5l4GBEllBKVF6GPMI7OQQq12i56CcnUUbzY27Dp4nZmFQdtrtfyqEQAzcEZnJeQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/experimental/-/experimental-1.2.0.tgz",
+      "integrity": "sha512-QyqxpHGBDMvG3jHfrXUDjFwD3s9QGZMNAPvjQ+8AqDtgvOsrp+7tMWV70r0sFj9WbkYUW5wKG703yoXOttg5cw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "7.14.0",
         "@wordpress/components": "10.2.0",
         "@wordpress/element": "2.19.0",
+        "@wordpress/i18n": "3.17.0",
+        "@wordpress/icons": "2.9.0",
         "@wordpress/keycodes": "2.18.0",
         "classnames": "^2.3.1",
+        "dompurify": "2.2.7",
+        "gridicons": "3.3.1",
         "react-transition-group": "4.4.1"
       },
       "dependencies": {
@@ -4232,6 +4236,21 @@
                 "@babel/runtime": "^7.13.10"
               }
             },
+            "@wordpress/i18n": {
+              "version": "3.20.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.20.0.tgz",
+              "integrity": "sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@wordpress/hooks": "^2.12.3",
+                "gettext-parser": "^1.3.1",
+                "lodash": "^4.17.19",
+                "memize": "^1.1.0",
+                "sprintf-js": "^1.1.1",
+                "tannin": "^1.2.0"
+              }
+            },
             "@wordpress/is-shallow-equal": {
               "version": "3.1.3",
               "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-3.1.3.tgz",
@@ -4291,29 +4310,28 @@
           }
         },
         "@wordpress/i18n": {
-          "version": "3.20.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.20.0.tgz",
-          "integrity": "sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==",
+          "version": "3.17.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.17.0.tgz",
+          "integrity": "sha512-CTZ0oezI6BT5GlmiE4X0fzRY6i7bNsX6hxiROkGlpREY6q4s1pnwhM8ggLIaP18Bvkb/HDkUEENDrv3iwM/LIQ==",
           "dev": true,
           "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@wordpress/hooks": "^2.12.3",
+            "@babel/runtime": "^7.12.5",
             "gettext-parser": "^1.3.1",
             "lodash": "^4.17.19",
             "memize": "^1.1.0",
             "sprintf-js": "^1.1.1",
             "tannin": "^1.2.0"
-          },
-          "dependencies": {
-            "@wordpress/hooks": {
-              "version": "2.12.3",
-              "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.12.3.tgz",
-              "integrity": "sha512-LmKiwKldZt6UYqOxV/a6+eUFXdvALFnB/pQx3RmrMvO64sgFhfR6dhrlv+uVbuuezSuv8dce1jx8lUWAT0krMA==",
-              "dev": true,
-              "requires": {
-                "@babel/runtime": "^7.13.10"
-              }
-            }
+          }
+        },
+        "@wordpress/icons": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.9.0.tgz",
+          "integrity": "sha512-eQJQIaCLdmdo8iTjequNkB14Fzx3qLRbjzZTk26fnggG41L+uGRblIeheZDcHY/jPKDd2H4+v9c9/0LqfjuPCA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@wordpress/element": "^2.19.0",
+            "@wordpress/primitives": "^1.11.0"
           }
         },
         "@wordpress/keycodes": {
@@ -11155,6 +11173,12 @@
       "requires": {
         "domelementtype": "^2.2.0"
       }
+    },
+    "dompurify": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.7.tgz",
+      "integrity": "sha512-jdtDffdGNY+C76jvodNTu9jt5yYj59vuTUyx+wXdzcSwAGTYZDAQkQ7Iwx9zcGrA4ixC1syU4H3RZROqRxokxg==",
+      "dev": true
     },
     "domutils": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@woocommerce/date": "2.1.0",
     "@woocommerce/e2e-utils": "^0.1.4",
     "@woocommerce/eslint-plugin": "1.1.0",
-    "@woocommerce/experimental": "1.1.0",
+    "@woocommerce/experimental": "1.2.0",
     "@wordpress/api-fetch": "3.3.0",
     "@wordpress/babel-plugin-makepot": "2.1.3",
     "@wordpress/babel-preset-default": "4.3.0",


### PR DESCRIPTION
Fixes #1657.

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

Add a task to "update business details" for stores that are pending restriction.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Add a task linking users to their account page if the account status is `restricted_soon` or `restricted` with a `pastDue` flag. The descriptive text of the task differs based on the scenario:

<img width="732" alt="Screen Shot 2021-05-12 at 3 51 48 PM" src="https://user-images.githubusercontent.com/63922/118186319-d6b03480-b3fa-11eb-8802-7934c8509297.png">

<img width="733" alt="Screen Shot 2021-05-12 at 3 48 26 PM" src="https://user-images.githubusercontent.com/63922/118187478-378c3c80-b3fc-11eb-8038-e41b4e5485fb.png">

<img width="734" alt="Screen Shot 2021-05-13 at 4 35 49 PM" src="https://user-images.githubusercontent.com/63922/118186340-dd3eac00-b3fa-11eb-92c5-c207cda93ef7.png">

In order to keep the task visible even after completion, a new `wcpay_show_update_business_details_task` database flag was added.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Full disclosure: I don't know how to simulate an account in different states other than manipulating the value of `accountStatus` here: https://github.com/Automattic/woocommerce-payments/compare/add/1657-update-business-details-task?expand=1#diff-a70fc7fd837200557381243b7777d7df8134f8c183630fae8d73cf221a83f511R15 or the return of `WC_Payments_Account::get_cached_account_data()`.

* Enable the overview page (`_wcpay_feature_account_overview` option)
* With a `restricted_soon` account, verify the task is shown in the task list and has a due date (you might need to clear the `wcpay_show_update_business_details_task` option after modifying the account data)
* Verify clicking the task takes you to the account login URL
* With a `restricted` + `pastDue` account, verify the task is shown and says the account is restricted
* With a `complete` account, verify the task is not shown
* With a `complete` account, force the `wcpay_show_update_business_details_task` option to be `yes`, verify the task is shown as complete and has no click action

-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
