### PR TITLE
refactor: rename delete button from list

### DIFF
--- a/client/components/payment-methods-list/delete-button.js
+++ b/client/components/payment-methods-list/delete-button.js
@@ -112,7 +112,14 @@ const DeleteButton = ( { id, label, Icon, onClick, className } ) => {
 			) }
 			<Button
 				isLink
-				aria-label={ __( 'Delete', 'woocommerce-payments' ) }
+				aria-label={ sprintf(
+					__(
+						/* translators: %1: Name of the payment method being removed */
+						'Delete %1$s from checkout',
+						'woocommerce-payments'
+					),
+					label
+				) }
 				className={ className }
 				onClick={ handleDeleteIconClick }
 			>

--- a/client/components/payment-methods-list/test/payment-method.js
+++ b/client/components/payment-methods-list/test/payment-method.js
@@ -23,7 +23,7 @@ describe( 'PaymentMethod', () => {
 		render( <PaymentMethod label="Foo" onDeleteClick={ undefined } /> );
 
 		const deleteButton = screen.queryByRole( 'button', {
-			name: 'Delete',
+			name: 'Delete Foo from checkout',
 		} );
 
 		expect( deleteButton ).not.toBeInTheDocument();
@@ -41,7 +41,7 @@ describe( 'PaymentMethod', () => {
 
 		user.click(
 			screen.getByRole( 'button', {
-				name: 'Delete',
+				name: 'Delete Foo from checkout',
 			} )
 		);
 		user.click(
@@ -54,7 +54,7 @@ describe( 'PaymentMethod', () => {
 
 		user.click(
 			screen.getByRole( 'button', {
-				name: 'Delete',
+				name: 'Delete Foo from checkout',
 			} )
 		);
 		user.click(

--- a/client/payment-methods/test/index.js
+++ b/client/payment-methods/test/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
 
 /**
@@ -85,11 +85,10 @@ describe( 'PaymentMethods', () => {
 
 		render( <PaymentMethods /> );
 
-		const cc = screen.getByText( 'Credit card / debit card' );
-		const listItem = cc.closest( 'li' );
-
 		expect(
-			within( listItem ).queryByRole( 'button', { name: 'Delete' } )
+			screen.queryByRole( 'button', {
+				name: 'Delete Credit card / debit card from checkout',
+			} )
 		).toBeInTheDocument();
 	} );
 
@@ -100,11 +99,10 @@ describe( 'PaymentMethods', () => {
 
 		render( <PaymentMethods /> );
 
-		const cc = screen.getByText( 'Credit card / debit card' );
-		const listItem = cc.closest( 'li' );
-
 		expect(
-			within( listItem ).queryByRole( 'button', { name: 'Delete' } )
+			screen.queryByRole( 'button', {
+				name: 'Delete Credit card / debit card from checkout',
+			} )
 		).not.toBeInTheDocument();
 	} );
 
@@ -121,10 +119,8 @@ describe( 'PaymentMethods', () => {
 
 		render( <PaymentMethods /> );
 
-		const cc = screen.getByText( 'Credit card / debit card' );
-		const ccListItem = cc.closest( 'li' );
-		const ccDeleteButton = within( ccListItem ).getByRole( 'button', {
-			name: 'Delete',
+		const ccDeleteButton = screen.getByRole( 'button', {
+			name: 'Delete Credit card / debit card from checkout',
 		} );
 		user.click( ccDeleteButton );
 		user.click(


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When there's a list of elements and actions for the elements, it can be useful for screen readers to have some context on the action.
In this case we have a list of payment methods and a "Delete" action for the payment method. By changing the label on the action, we can help users using screen reader to know what the "delete" action is for.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have the "grouped settings" flag enabled in WCPay Dev Tools
- Visit http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout
- No functional change
- The `aria-label` on the "Delete" action has been updated with the payment method's name

Before:
![Markup 2021-05-14 at 12 17 10](https://user-images.githubusercontent.com/273592/118305987-5cd98300-b4ae-11eb-9332-fe83c98582c7.png)


After:
![Markup 2021-05-14 at 12 23 36](https://user-images.githubusercontent.com/273592/118306576-3e27bc00-b4af-11eb-9cef-2a5d6c55897c.png)


-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
