### PR TITLE
Fix the order of arguments passed to attach_intent_info_to_order

### DIFF
--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -88,9 +88,9 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 				$order,
 				$intent->get_id(),
 				$intent->get_status(),
-				$intent->get_charge_id(),
-				$intent->get_customer_id(),
 				$intent->get_payment_method_id(),
+				$intent->get_customer_id(),
+				$intent->get_charge_id(),
 				$intent->get_currency()
 			);
 

--- a/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
@@ -62,6 +62,26 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 			->expects( $this->any() )
 			->method( 'get_status' )
 			->willReturn( 'requires_capture' );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_id' )
+			->willReturn( 'pi_mock' );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_payment_method_id' )
+			->willReturn( 'pm_mock' );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_customer_id' )
+			->willReturn( 'cus_mock' );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_charge_id' )
+			->willReturn( 'ch_mock' );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_currency' )
+			->willReturn( 'mok' );
 
 		$this->mock_api_client
 			->expects( $this->once() )
@@ -81,7 +101,16 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway
 			->expects( $this->once() )
-			->method( 'attach_intent_info_to_order' );
+			->method( 'attach_intent_info_to_order' )
+			->with(
+				$this->isInstanceOf( WC_Order::class ),
+				'pi_mock',
+				'requires_capture',
+				'pm_mock',
+				'cus_mock',
+				'ch_mock',
+				'mok'
+			);
 
 		$request = new WP_REST_Request( 'POST' );
 		$request->set_body_params(


### PR DESCRIPTION
Fixes #1812 

#### Changes proposed in this Pull Request

- Fix the order of arguments and add a unit test

#### Testing instructions

* Unit tests should pass

cc @allendav 

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
