### PR TITLE
Fix Payment Request Google Pay method title

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -183,7 +183,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					'<a href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/" target="_blank">Apple</a>'
 				),
 				'type'        => 'checkbox',
-				'description' => __( 'If enabled, users will be able to pay using Apple Pay or Chrome Payment Request if supported by the browser.', 'woocommerce-payments' ),
+				'description' => __( 'If enabled, users will be able to pay using Apple Pay, Google Pay or the Payment Request API if supported by the browser.', 'woocommerce-payments' ),
 				'default'     => empty( get_option( 'woocommerce_woocommerce_payments_settings' ) ) ? 'yes' : 'no', // Enable by default for new installations only.
 				'desc_tip'    => true,
 			],

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -318,12 +318,14 @@ class WC_Payments_Payment_Request_Button_Handler {
 		$order        = wc_get_order( $post->ID );
 		$method_title = is_object( $order ) ? $order->get_payment_method_title() : '';
 
-		if ( 'woocommerce_payments' === $id && ! empty( $method_title ) && 'Apple Pay (WooCommerce Payments)' === $method_title ) {
-			return $method_title;
-		}
-
-		if ( 'woocommerce_payments' === $id && ! empty( $method_title ) && 'Payment Request (WooCommerce Payments)' === $method_title ) {
-			return $method_title;
+		if ( 'woocommerce_payments' === $id && ! empty( $method_title ) ) {
+			if (
+				'Apple Pay (WooCommerce Payments)' === $method_title
+				|| 'Google Pay (WooCommerce Payments)' === $method_title
+				|| 'Payment Request (WooCommerce Payments)' === $method_title
+			) {
+				return $method_title;
+			}
 		}
 
 		return $title;

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Class WC_Payments_Payment_Request_Button_Handler
- * Adds support for Apple Pay and Chrome Payment Request API buttons.
+ * Adds support for Apple Pay, Google Pay and Payment Request API buttons.
  * Utilizes the Stripe Payment Request Button to support checkout from the product detail and cart pages.
  *
  * Adapted from WooCommerce Stripe Gateway extension.


### PR DESCRIPTION
As [noticed in Stripe](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1545/commits/15076fa7fd31cc7a54addad0f9a14872ec2abb49), there's a missing method in `filter_gateway_title`.

#### Changes proposed in this Pull Request

- This is a small fix to add a missing "Google Pay" title to the order.

#### Testing instructions

Google Pay transactions only work in live mode for me, with my real card, so I guess you can test with a regular Chrome Payment Request API transaction and not lose any money.

1. Make a Payment Request purchase with Chrome using Stripe's test card `4242`.
2. Go to **WooCommerce > Orders > Edit order** and notice the title "Payment via Payment Request (WooCommerce Payments)"
3. Remove the line `|| 'Payment Request (WooCommerce Payments)' === $method_title` from the code and repeat steps 1 and 2. Notice the title now says "Payment via Credit card". - That's what happens for Google Pay before this fix.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)