### PR TITLE
Fix: Columns are misaligned on Payments->Deposits

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.
 * Update - Use Site Language when rendering Stripe elements.
 * Update - Use blog ID for authenticating most of the requests.
+* Fix: Misaligned columns on Deposits page.
 
 = 2.4.0 - 2021-05-12 =
 * Update - Improve the Connect Account page.

--- a/client/deposits/list/index.js
+++ b/client/deposits/list/index.js
@@ -22,6 +22,8 @@ import ClickableCell from 'components/clickable-cell';
 import Page from '../../components/page';
 import DepositsFilters from '../filters';
 
+import './style.scss';
+
 const getColumns = ( sortByDate ) => [
 	{
 		key: 'details',
@@ -159,7 +161,7 @@ export const DepositsList = () => {
 		<Page>
 			<DepositsFilters storeCurrencies={ storeCurrencies } />
 			<TableCard
-				className="deposits-list woocommerce-report-table"
+				className="wcpay-deposits-list woocommerce-report-table"
 				title={ __( 'Deposit history', 'woocommerce-payments' ) }
 				isLoading={ isLoading }
 				rowsPerPage={ getQuery().per_page || 25 }

--- a/client/deposits/list/style.scss
+++ b/client/deposits/list/style.scss
@@ -1,0 +1,14 @@
+$space-header-item: 25px;
+
+.wcpay-deposits-list {
+	// alignment override for header items
+	.woocommerce-table__header:not( .is-left-aligned ),
+	.woocommerce-table__item:not( .is-left-aligned ) {
+		text-align: center;
+	}
+
+	// slight adjustment to align header items with sorting button to account for icon width
+	.woocommerce-table__header.is-numeric .components-button {
+		margin-right: $space-header-item;
+	}
+}

--- a/client/deposits/list/test/__snapshots__/index.js.snap
+++ b/client/deposits/list/test/__snapshots__/index.js.snap
@@ -46,7 +46,7 @@ exports[`Deposits list renders correctly with multiple currencies 1`] = `
       </div>
     </div>
     <div
-      class="woocommerce-card woocommerce-table woocommerce-analytics__card deposits-list woocommerce-report-table has-menu"
+      class="woocommerce-card woocommerce-table woocommerce-analytics__card wcpay-deposits-list woocommerce-report-table has-menu"
     >
       <div
         class="woocommerce-card__header"
@@ -478,7 +478,7 @@ exports[`Deposits list renders correctly with single currency 1`] = `
       />
     </div>
     <div
-      class="woocommerce-card woocommerce-table woocommerce-analytics__card deposits-list woocommerce-report-table has-menu"
+      class="woocommerce-card woocommerce-table woocommerce-analytics__card wcpay-deposits-list woocommerce-report-table has-menu"
     >
       <div
         class="woocommerce-card__header"

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -1,6 +1,6 @@
 @import 'node_modules/@wordpress/components/src/tooltip/style.scss';
 
-$space-header-item: 15px;
+$space-header-item: 25px;
 
 .transactions-list {
 	.date-time {

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -9,7 +9,7 @@ $space-header-item: 25px;
 
 	.converted-amount {
 		display: flex; // Necessary for conversion tooltip to show.
-		justify-content: flex-end;
+		justify-content: center;
 
 		.conversion-indicator {
 			margin-right: 6px;

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.
 * Update - Use Site Language when rendering Stripe elements.
 * Update - Use blog ID for authenticating most of the requests.
+* Fix: Misaligned columns on Deposits page.
 
 = 2.4.0 - 2021-05-12 =
 * Update - Improve the Connect Account page.


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/1719#issuecomment-838517662

I had to reopen #1719 as GlobalStep observed misalignment on the deposits page as per the above comment.

#### Changes proposed in this Pull Request
- Override alignment for table header on the deposits list page.
- Slight adjustment in the transactiond table header margin.

After fix:
![image](https://user-images.githubusercontent.com/15019298/118553684-449f8780-b77e-11eb-972a-bf7451744fa1.png)
![image](https://user-images.githubusercontent.com/15019298/118553713-4ec18600-b77e-11eb-9e7a-9538e511468d.png)


#### Testing instructions
- Checkout to `fix/1719-desposit-col-alignment`
- Visit deposits pages and transactions page
- Columns should be aligned now.


-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
