### PR TITLE
Fix/issue 1732 add payment methods

### DIFF
--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -129,7 +129,7 @@ const PaymentMethods = () => {
 					</OrderableList>
 				</CardBody>
 				<CardBody className="payment-methods__available-methods-container">
-					<PaymentMethodsSelector className="payment-methods__add-payment-method"></PaymentMethodsSelector>
+					<PaymentMethodsSelector className="payment-methods__add-payment-method" />
 					<ul className="payment-methods__available-methods">
 						{ disabledMethods.map( ( { id, label, Icon } ) => (
 							<li

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -4,8 +4,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button, Card, CardBody } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { Card, CardBody } from '@wordpress/components';
 import classNames from 'classnames';
 
 /**
@@ -66,11 +65,6 @@ const PaymentMethods = () => {
 		updateEnabledPaymentMethodIds: updateEnabledMethodIds,
 	} = useEnabledPaymentMethodIds();
 
-	const [
-		isPaymentMethodsSelectorModalVisible,
-		setPaymentMethodsSelectorModalVisible,
-	] = useState( false );
-
 	const enabledMethods = enabledMethodIds.map( ( methodId ) =>
 		availableMethods.find( ( method ) => method.id === methodId )
 	);
@@ -107,14 +101,6 @@ const PaymentMethods = () => {
 
 	return (
 		<>
-			{ isPaymentMethodsSelectorModalVisible && (
-				<PaymentMethodsSelector
-					enabledPaymentMethods={ enabledMethodIds }
-					onClose={ () =>
-						setPaymentMethodsSelectorModalVisible( false )
-					}
-				/>
-			) }
 			<Card className="payment-methods">
 				<CardBody className="payment-methods__enabled-methods-container">
 					<OrderableList
@@ -143,15 +129,7 @@ const PaymentMethods = () => {
 					</OrderableList>
 				</CardBody>
 				<CardBody className="payment-methods__available-methods-container">
-					<Button
-						className="payment-methods__add-payment-method"
-						onClick={ () =>
-							setPaymentMethodsSelectorModalVisible( true )
-						}
-						isSecondary
-					>
-						{ __( 'Add payment method', 'woocommerce-payments' ) }
-					</Button>
+					<PaymentMethodsSelector className="payment-methods__add-payment-method"></PaymentMethodsSelector>
 					<ul className="payment-methods__available-methods">
 						{ disabledMethods.map( ( { id, label, Icon } ) => (
 							<li

--- a/client/settings/payment-methods-selector/index.js
+++ b/client/settings/payment-methods-selector/index.js
@@ -17,6 +17,11 @@ import PaymentMethodCheckbox from '../../components/payment-methods-checkboxes/p
 import './style.scss';
 
 const PaymentMethodsSelector = ( { className } ) => {
+	const availablePaymentMethods = [
+		'woocommerce_payments_giropay',
+		'woocommerce_payments_sofort',
+		'woocommerce_payments_sepa',
+	];
 	const {
 		enabledPaymentMethodIds: enabledMethodIds,
 		updateEnabledPaymentMethodIds: updateEnabledMethodIds,
@@ -31,10 +36,14 @@ const PaymentMethodsSelector = ( { className } ) => {
 
 	useEffect( () => {
 		setPaymentMethods(
-			enabledMethodIds.reduce( ( acc, value ) => {
-				acc[ value ] = true;
-				return acc;
-			}, {} )
+			availablePaymentMethods
+				.filter(
+					( methodId ) => ! enabledMethodIds.includes( methodId )
+				)
+				.reduce( ( acc, value ) => {
+					acc[ value ] = false;
+					return acc;
+				}, {} )
 		);
 	}, [ enabledMethodIds ] );
 
@@ -66,7 +75,6 @@ const PaymentMethodsSelector = ( { className } ) => {
 			.map( ( [ method ] ) => method );
 		addSelectedPaymentMethods( selectedPaymentMethods );
 	};
-
 	return (
 		<>
 			{ isPaymentMethodsSelectorModalOpen && (
@@ -84,28 +92,17 @@ const PaymentMethodsSelector = ( { className } ) => {
 						) }
 					</p>
 					<PaymentMethodCheckboxes>
-						<PaymentMethodCheckbox
-							checked={
-								paymentMethods.woocommerce_payments_giropay
-							}
-							onChange={ handleChange }
-							fees="missing fees"
-							name="woocommerce_payments_giropay"
-						/>
-						<PaymentMethodCheckbox
-							checked={
-								paymentMethods.woocommerce_payments_sofort
-							}
-							onChange={ handleChange }
-							fees="missing fees"
-							name="woocommerce_payments_sofort"
-						/>
-						<PaymentMethodCheckbox
-							checked={ paymentMethods.woocommerce_payments_sepa }
-							onChange={ handleChange }
-							fees="missing fees"
-							name="woocommerce_payments_sepa"
-						/>
+						{ Object.entries( paymentMethods ).map(
+							( [ key, enabled ] ) => (
+								<PaymentMethodCheckbox
+									key={ key }
+									checked={ enabled }
+									onChange={ handleChange }
+									fees="missing fees"
+									name={ key }
+								/>
+							)
+						) }
 					</PaymentMethodCheckboxes>
 					<HorizontalRule className="woocommerce-payments__payment-method-selector__separator" />
 					<div className="woocommerce-payments__payment-method-selector__footer">

--- a/client/settings/payment-methods-selector/index.js
+++ b/client/settings/payment-methods-selector/index.js
@@ -32,7 +32,7 @@ const PaymentMethodsSelector = ( { className } ) => {
 		setIsPaymentMethodsSelectorModalOpen,
 	] = useState( false );
 
-	const [ paymentMethods, setPaymentMethods ] = useState();
+	const [ paymentMethods, setPaymentMethods ] = useState( {} );
 
 	useEffect( () => {
 		setPaymentMethods(

--- a/client/settings/payment-methods-selector/index.js
+++ b/client/settings/payment-methods-selector/index.js
@@ -4,25 +4,45 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button, Modal } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useState, useCallback, useEffect } from '@wordpress/element';
 import { HorizontalRule } from '@wordpress/primitives';
 
 /**
  * Internal dependencies
  */
 
-import { addSelectedPaymentMethods } from 'data';
+import { useEnabledPaymentMethodIds } from 'data';
 import PaymentMethodCheckboxes from '../../components/payment-methods-checkboxes';
 import PaymentMethodCheckbox from '../../components/payment-methods-checkboxes/payment-method-checkbox';
 import './style.scss';
 
-const PaymentMethodsSelector = ( { onClose, enabledPaymentMethods = [] } ) => {
-	const [ paymentMethods, setPaymentMethods ] = useState(
-		enabledPaymentMethods.reduce( ( acc, value ) => {
-			acc[ value ] = true;
-			return acc;
-		}, {} )
-	);
+const PaymentMethodsSelector = ( { className } ) => {
+	const {
+		enabledPaymentMethodIds: enabledMethodIds,
+		updateEnabledPaymentMethodIds: updateEnabledMethodIds,
+	} = useEnabledPaymentMethodIds();
+
+	const [
+		isPaymentMethodsSelectorModalOpen,
+		setIsPaymentMethodsSelectorModalOpen,
+	] = useState( false );
+
+	const [ paymentMethods, setPaymentMethods ] = useState();
+
+	useEffect( () => {
+		setPaymentMethods(
+			enabledMethodIds.reduce( ( acc, value ) => {
+				acc[ value ] = true;
+				return acc;
+			}, {} )
+		);
+	}, [ enabledMethodIds ] );
+
+	const addSelectedPaymentMethods = ( itemIds ) => {
+		updateEnabledMethodIds( [
+			...new Set( [ ...enabledMethodIds, ...itemIds ] ),
+		] );
+	};
 
 	const handleChange = ( paymentMethod, enabled ) => {
 		setPaymentMethods( ( oldPaymentMethods ) => ( {
@@ -31,55 +51,84 @@ const PaymentMethodsSelector = ( { onClose, enabledPaymentMethods = [] } ) => {
 		} ) );
 	};
 
-	const handleAddSelected = () => {
+	const handlePaymentMethodAddButtonClick = useCallback( () => {
+		setIsPaymentMethodsSelectorModalOpen( true );
+	}, [ setIsPaymentMethodsSelectorModalOpen ] );
+
+	const handleAddSelectedCancelClick = useCallback( () => {
+		setIsPaymentMethodsSelectorModalOpen( false );
+	}, [ setIsPaymentMethodsSelectorModalOpen ] );
+
+	const handleAddSelectedClick = () => {
+		setIsPaymentMethodsSelectorModalOpen( false );
 		const selectedPaymentMethods = Object.entries( paymentMethods )
 			.filter( ( [ , enabled ] ) => enabled )
 			.map( ( [ method ] ) => method );
 		addSelectedPaymentMethods( selectedPaymentMethods );
-		onClose();
 	};
 
 	return (
-		<Modal
-			title={ __( 'Add payment methods', 'woocommerce-payments' ) }
-			onRequestClose={ onClose }
-		>
-			<p>
-				{ __(
-					"Increase your store's conversion by offering your customers preferred and convenient payment methods.",
-					'woocommerce-payments'
-				) }
-			</p>
-			<PaymentMethodCheckboxes>
-				<PaymentMethodCheckbox
-					checked={ paymentMethods.woocommerce_payments_giropay }
-					onChange={ handleChange }
-					fees="missing fees"
-					name="woocommerce_payments_giropay"
-				/>
-				<PaymentMethodCheckbox
-					checked={ paymentMethods.woocommerce_payments_sofort }
-					onChange={ handleChange }
-					fees="missing fees"
-					name="woocommerce_payments_sofort"
-				/>
-				<PaymentMethodCheckbox
-					checked={ paymentMethods.woocommerce_payments_sepa }
-					onChange={ handleChange }
-					fees="missing fees"
-					name="woocommerce_payments_sepa"
-				/>
-			</PaymentMethodCheckboxes>
-			<HorizontalRule className="woocommerce-payments__payment-method-selector__separator" />
-			<div className="woocommerce-payments__payment-method-selector__footer">
-				<Button isPrimary onClick={ handleAddSelected }>
-					{ __( 'Add selected', 'woocommerce-payments' ) }
-				</Button>
-				<Button isSecondary onClick={ onClose }>
-					{ __( 'Cancel', 'woocommerce-payments' ) }
-				</Button>
-			</div>
-		</Modal>
+		<>
+			{ isPaymentMethodsSelectorModalOpen && (
+				<Modal
+					title={ __(
+						'Add payment methods',
+						'woocommerce-payments'
+					) }
+					onRequestClose={ handleAddSelectedCancelClick }
+				>
+					<p>
+						{ __(
+							"Increase your store's conversion by offering your customers preferred and convenient payment methods.",
+							'woocommerce-payments'
+						) }
+					</p>
+					<PaymentMethodCheckboxes>
+						<PaymentMethodCheckbox
+							checked={
+								paymentMethods.woocommerce_payments_giropay
+							}
+							onChange={ handleChange }
+							fees="missing fees"
+							name="woocommerce_payments_giropay"
+						/>
+						<PaymentMethodCheckbox
+							checked={
+								paymentMethods.woocommerce_payments_sofort
+							}
+							onChange={ handleChange }
+							fees="missing fees"
+							name="woocommerce_payments_sofort"
+						/>
+						<PaymentMethodCheckbox
+							checked={ paymentMethods.woocommerce_payments_sepa }
+							onChange={ handleChange }
+							fees="missing fees"
+							name="woocommerce_payments_sepa"
+						/>
+					</PaymentMethodCheckboxes>
+					<HorizontalRule className="woocommerce-payments__payment-method-selector__separator" />
+					<div className="woocommerce-payments__payment-method-selector__footer">
+						<Button isPrimary onClick={ handleAddSelectedClick }>
+							{ __( 'Add selected', 'woocommerce-payments' ) }
+						</Button>
+						<Button
+							isSecondary
+							onClick={ handleAddSelectedCancelClick }
+						>
+							{ __( 'Cancel', 'woocommerce-payments' ) }
+						</Button>
+					</div>
+				</Modal>
+			) }
+			<Button
+				isSecondary
+				className={ className }
+				onClick={ handlePaymentMethodAddButtonClick }
+			>
+				{ __( 'Add payment method', 'woocommerce-payments' ) }
+			</Button>
+		</>
 	);
 };
 

--- a/client/settings/payment-methods-selector/test/index.js
+++ b/client/settings/payment-methods-selector/test/index.js
@@ -2,106 +2,185 @@
 /**
  * External dependencies
  */
-import { fireEvent, render, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, within } from '@testing-library/react';
+import user from '@testing-library/user-event';
 
 /**
  * Internal dependencies
  */
 import PaymentMethodsSelector from '..';
-import { addSelectedPaymentMethods } from 'data';
+import { useEnabledPaymentMethodIds } from 'data';
 
-jest.mock( 'data', () => ( { addSelectedPaymentMethods: jest.fn() } ) );
+jest.mock( 'data', () => ( { useEnabledPaymentMethodIds: jest.fn() } ) );
 
 describe( 'PaymentMethodsSelector', () => {
-	test( 'renders a modal window', () => {
-		const { getAllByRole, getByText } = render(
+	beforeEach( () => {
+		useEnabledPaymentMethodIds.mockReturnValue( {
+			enabledPaymentMethodIds: [],
+			updateEnabledPaymentMethodIds: jest.fn(),
+		} );
+	} );
+
+	test( 'Displays "Add payment Method" button, modal is not visible', () => {
+		const { getByRole, queryByText, queryByRole } = render(
 			<PaymentMethodsSelector />
 		);
 
-		expect( getByText( 'Add payment methods' ) ).toBeTruthy();
+		const addPaymentMethodButton = getByRole( 'button', {
+			name: 'Add payment method',
+		} );
+		expect( addPaymentMethodButton ).toBeInTheDocument();
+
+		expect(
+			queryByText(
+				"Increase your store's conversion by offering your customers preferred and convenient payment methods."
+			)
+		).toBeNull();
+
+		expect(
+			queryByRole( 'button', {
+				name: 'Add selected',
+			} )
+		).toBeNull();
+	} );
+
+	test( 'Clicking "Add Payment Method" opens the Payment method selection', () => {
+		useEnabledPaymentMethodIds.mockReturnValue( {
+			enabledPaymentMethodIds: [
+				'woocommerce_payments',
+				'woocommerce_payments_sepa',
+			],
+			updateEnabledPaymentMethodIds: jest.fn( () => {} ),
+		} );
+
+		const { getByText, getByRole, getAllByRole } = render(
+			<PaymentMethodsSelector />
+		);
+
+		const addPaymentMethodButton = getByRole( 'button', {
+			name: 'Add payment method',
+		} );
+		user.click( addPaymentMethodButton );
+
 		expect(
 			getByText(
 				"Increase your store's conversion by offering your customers preferred and convenient payment methods."
 			)
-		).toBeTruthy();
+		).toBeInTheDocument();
 
 		const paymentMethods = getAllByRole( 'listitem' );
 		expect( paymentMethods ).toHaveLength( 3 );
 
 		const giroPay = within( paymentMethods[ 0 ] );
-		expect( giroPay.getByRole( 'checkbox' ) ).toBeTruthy();
-		expect( giroPay.getByText( 'GiroPay' ) ).toBeTruthy();
-		expect( giroPay.getByText( 'missing fees' ) ).toBeTruthy();
+		expect( giroPay.getByRole( 'checkbox' ) ).not.toBeChecked();
 
 		const sofort = within( paymentMethods[ 1 ] );
-		expect( sofort.getByRole( 'checkbox' ) ).toBeTruthy();
-		expect( sofort.getByText( 'Sofort' ) ).toBeTruthy();
-		expect( sofort.getByText( 'missing fees' ) ).toBeTruthy();
+		expect( sofort.getByRole( 'checkbox' ) ).not.toBeChecked();
 
 		const sepa = within( paymentMethods[ 2 ] );
-		expect( sepa.getByRole( 'checkbox' ) ).toBeTruthy();
-		expect( sepa.getByText( 'Direct Debit Payments' ) ).toBeTruthy();
-		expect( sepa.getByText( 'missing fees' ) ).toBeTruthy();
+		expect( sepa.getByRole( 'checkbox' ) ).toBeChecked();
 
-		expect( getByText( 'Add selected' ) ).toBeTruthy();
-		expect( getByText( 'Cancel' ) ).toBeTruthy();
+		expect(
+			getByRole( 'button', {
+				name: 'Add selected',
+			} )
+		).toBeInTheDocument();
 	} );
 
-	test( 'can be dismissed', () => {
-		const handleClose = jest.fn();
+	test( 'Payment method selection can be dismissed', () => {
+		const { getByRole, queryByRole } = render( <PaymentMethodsSelector /> );
 
-		const { getByText } = render(
-			<PaymentMethodsSelector onClose={ handleClose } />
+		user.click(
+			getByRole( 'button', {
+				name: 'Add payment method',
+			} )
 		);
 
-		fireEvent.click( getByText( 'Cancel' ) );
+		user.click(
+			getByRole( 'button', {
+				name: 'Cancel',
+			} )
+		);
 
-		expect( handleClose ).toHaveBeenCalledTimes( 1 );
+		expect(
+			useEnabledPaymentMethodIds().updateEnabledPaymentMethodIds
+		).not.toHaveBeenCalled();
+
+		expect(
+			queryByRole( 'button', {
+				name: 'Cancel',
+			} )
+		).toBeNull();
 	} );
 
-	test( 'allows to add selected payment methods', () => {
-		const handleClose = jest.fn();
+	test( 'Selecting payment methods does not update enabled payment methods', () => {
+		useEnabledPaymentMethodIds.mockReturnValue( {
+			enabledPaymentMethodIds: [
+				'woocommerce_payments',
+				'woocommerce_payments_sepa',
+			],
+			updateEnabledPaymentMethodIds: jest.fn( () => {} ),
+		} );
 
-		const { getAllByRole, getByText } = render(
-			<PaymentMethodsSelector onClose={ handleClose } />
+		const { getByRole, getAllByRole } = render(
+			<PaymentMethodsSelector />
 		);
+
+		const addPaymentMethodButton = getByRole( 'button', {
+			name: 'Add payment method',
+		} );
+		user.click( addPaymentMethodButton );
 
 		const paymentMethods = getAllByRole( 'listitem' );
-		const giroPay = within( paymentMethods[ 0 ] );
-		const sofort = within( paymentMethods[ 1 ] );
+		const giroPayCheckbox = within( paymentMethods[ 0 ] ).getByRole(
+			'checkbox'
+		);
+		user.click( giroPayCheckbox );
 
-		userEvent.click( giroPay.getByRole( 'checkbox' ) );
-		userEvent.click( sofort.getByRole( 'checkbox' ) );
+		expect( giroPayCheckbox ).toBeChecked();
+		expect(
+			useEnabledPaymentMethodIds().updateEnabledPaymentMethodIds
+		).not.toHaveBeenCalled();
+	} );
+	test( 'Selecting a payment method and clicking "Add selected" adds the method and closes the modal', () => {
+		useEnabledPaymentMethodIds.mockReturnValue( {
+			enabledPaymentMethodIds: [
+				'woocommerce_payments',
+				'woocommerce_payments_sepa',
+			],
+			updateEnabledPaymentMethodIds: jest.fn( () => {} ),
+		} );
 
-		fireEvent.click( getByText( 'Add selected' ) );
+		const { getByRole, getAllByRole, queryByRole } = render(
+			<PaymentMethodsSelector />
+		);
 
-		expect( addSelectedPaymentMethods ).toHaveBeenCalledTimes( 1 );
-		expect( addSelectedPaymentMethods ).toHaveBeenCalledWith( [
+		const addPaymentMethodButton = getByRole( 'button', {
+			name: 'Add payment method',
+		} );
+		user.click( addPaymentMethodButton );
+
+		const paymentMethods = getAllByRole( 'listitem' );
+		const giroPayCheckbox = within( paymentMethods[ 0 ] ).getByRole(
+			'checkbox'
+		);
+		user.click( giroPayCheckbox );
+
+		const addSelectedButton = getByRole( 'button', {
+			name: 'Add selected',
+		} );
+		user.click( addSelectedButton );
+		expect(
+			useEnabledPaymentMethodIds().updateEnabledPaymentMethodIds
+		).toHaveBeenCalledWith( [
+			'woocommerce_payments',
+			'woocommerce_payments_sepa',
 			'woocommerce_payments_giropay',
-			'woocommerce_payments_sofort',
 		] );
-
-		expect( handleClose ).toHaveBeenCalledTimes( 1 );
-	} );
-
-	test( 'allows to preselect payment methods', () => {
-		const { getAllByRole } = render(
-			<PaymentMethodsSelector
-				enabledPaymentMethods={ [ 'woocommerce_payments_giropay' ] }
-			/>
-		);
-
-		const paymentMethods = getAllByRole( 'listitem' );
-		expect( paymentMethods ).toHaveLength( 3 );
-
-		const giroPay = within( paymentMethods[ 0 ] );
-		expect( giroPay.getByRole( 'checkbox' ).checked ).toBeTruthy();
-
-		const sofort = within( paymentMethods[ 1 ] );
-		expect( sofort.getByRole( 'checkbox' ).checked ).toBeFalsy();
-
-		const sepa = within( paymentMethods[ 2 ] );
-		expect( sepa.getByRole( 'checkbox' ).checked ).toBeFalsy();
+		expect(
+			queryByRole( 'button', {
+				name: 'Add selected',
+			} )
+		).toBeNull();
 	} );
 } );

--- a/client/settings/payment-methods-selector/test/index.js
+++ b/client/settings/payment-methods-selector/test/index.js
@@ -46,10 +46,7 @@ describe( 'PaymentMethodsSelector', () => {
 
 	test( 'Clicking "Add Payment Method" opens the Payment method selection', () => {
 		useEnabledPaymentMethodIds.mockReturnValue( {
-			enabledPaymentMethodIds: [
-				'woocommerce_payments',
-				'woocommerce_payments_sepa',
-			],
+			enabledPaymentMethodIds: [ 'woocommerce_payments' ],
 			updateEnabledPaymentMethodIds: jest.fn( () => {} ),
 		} );
 
@@ -71,14 +68,16 @@ describe( 'PaymentMethodsSelector', () => {
 		const paymentMethods = getAllByRole( 'listitem' );
 		expect( paymentMethods ).toHaveLength( 3 );
 
-		const giroPay = within( paymentMethods[ 0 ] );
-		expect( giroPay.getByRole( 'checkbox' ) ).not.toBeChecked();
+		const giroPayCheckbox = getByRole( 'checkbox', { name: 'GiroPay' } );
+		expect( giroPayCheckbox ).not.toBeChecked();
 
-		const sofort = within( paymentMethods[ 1 ] );
-		expect( sofort.getByRole( 'checkbox' ) ).not.toBeChecked();
+		const sofortCheckbox = getByRole( 'checkbox', { name: 'Sofort' } );
+		expect( sofortCheckbox ).not.toBeChecked();
 
-		const sepa = within( paymentMethods[ 2 ] );
-		expect( sepa.getByRole( 'checkbox' ) ).toBeChecked();
+		const sepaCheckbox = getByRole( 'checkbox', {
+			name: 'Direct Debit Payments',
+		} );
+		expect( sepaCheckbox ).not.toBeChecked();
 
 		expect(
 			getByRole( 'button', {
@@ -112,7 +111,28 @@ describe( 'PaymentMethodsSelector', () => {
 			} )
 		).toBeNull();
 	} );
+	test( 'Only payment methods that are not enabled are listed', () => {
+		useEnabledPaymentMethodIds.mockReturnValue( {
+			enabledPaymentMethodIds: [
+				'woocommerce_payments',
+				'woocommerce_payments_sofort',
+			],
+			updateEnabledPaymentMethodIds: jest.fn( () => {} ),
+		} );
 
+		const { getByRole, getAllByRole, queryByRole } = render(
+			<PaymentMethodsSelector />
+		);
+
+		const addPaymentMethodButton = getByRole( 'button', {
+			name: 'Add payment method',
+		} );
+		user.click( addPaymentMethodButton );
+
+		const paymentMethods = getAllByRole( 'listitem' );
+		expect( paymentMethods ).toHaveLength( 2 );
+		expect( queryByRole( 'checkbox', { name: 'Sofort' } ) ).toBeNull();
+	} );
 	test( 'Selecting payment methods does not update enabled payment methods', () => {
 		useEnabledPaymentMethodIds.mockReturnValue( {
 			enabledPaymentMethodIds: [
@@ -132,12 +152,12 @@ describe( 'PaymentMethodsSelector', () => {
 		user.click( addPaymentMethodButton );
 
 		const paymentMethods = getAllByRole( 'listitem' );
-		const giroPayCheckbox = within( paymentMethods[ 0 ] ).getByRole(
+		const paymentMethodCheckbox = within( paymentMethods[ 0 ] ).getByRole(
 			'checkbox'
 		);
-		user.click( giroPayCheckbox );
+		user.click( paymentMethodCheckbox );
 
-		expect( giroPayCheckbox ).toBeChecked();
+		expect( paymentMethodCheckbox ).toBeChecked();
 		expect(
 			useEnabledPaymentMethodIds().updateEnabledPaymentMethodIds
 		).not.toHaveBeenCalled();
@@ -151,19 +171,14 @@ describe( 'PaymentMethodsSelector', () => {
 			updateEnabledPaymentMethodIds: jest.fn( () => {} ),
 		} );
 
-		const { getByRole, getAllByRole, queryByRole } = render(
-			<PaymentMethodsSelector />
-		);
+		const { getByRole, queryByRole } = render( <PaymentMethodsSelector /> );
 
 		const addPaymentMethodButton = getByRole( 'button', {
 			name: 'Add payment method',
 		} );
 		user.click( addPaymentMethodButton );
 
-		const paymentMethods = getAllByRole( 'listitem' );
-		const giroPayCheckbox = within( paymentMethods[ 0 ] ).getByRole(
-			'checkbox'
-		);
+		const giroPayCheckbox = getByRole( 'checkbox', { name: 'GiroPay' } );
 		user.click( giroPayCheckbox );
 
 		const addSelectedButton = getByRole( 'button', {

--- a/client/settings/payment-methods-selector/test/index.js
+++ b/client/settings/payment-methods-selector/test/index.js
@@ -111,6 +111,7 @@ describe( 'PaymentMethodsSelector', () => {
 			} )
 		).toBeNull();
 	} );
+
 	test( 'Only payment methods that are not enabled are listed', () => {
 		useEnabledPaymentMethodIds.mockReturnValue( {
 			enabledPaymentMethodIds: [
@@ -133,6 +134,7 @@ describe( 'PaymentMethodsSelector', () => {
 		expect( paymentMethods ).toHaveLength( 2 );
 		expect( queryByRole( 'checkbox', { name: 'Sofort' } ) ).toBeNull();
 	} );
+
 	test( 'Selecting payment methods does not update enabled payment methods', () => {
 		useEnabledPaymentMethodIds.mockReturnValue( {
 			enabledPaymentMethodIds: [
@@ -162,6 +164,7 @@ describe( 'PaymentMethodsSelector', () => {
 			useEnabledPaymentMethodIds().updateEnabledPaymentMethodIds
 		).not.toHaveBeenCalled();
 	} );
+
 	test( 'Selecting a payment method and clicking "Add selected" adds the method and closes the modal', () => {
 		useEnabledPaymentMethodIds.mockReturnValue( {
 			enabledPaymentMethodIds: [


### PR DESCRIPTION
Fixes #1732

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- This PR updates the `PaymentMethodsSelector` component to use the hook `useEnabledPaymentMethodIds`. The list of enabled payment methods is updated when the button `Add selected` is clicked.

- It also moves the modal inside of the component, same as for the [`Delete `button](https://github.com/Automattic/woocommerce-payments/pull/1790/files).

- Tests have been updated/added.
#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have the "grouped settings" flag enabled in WCPay Dev Tools
- Visit http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout
- Click the "Add payment method" button
- The modal appears, currently enabled payment methods are checked.
- Cancelling the modal does not add new payment methods
- Selecting new methods and clicking on 'Add selected' adds the methods to the list.
- Remove a payment method by clicking on the trash icon.
- Click again on 'Add payment method' button
- Check the list is updated and the payment method removed is not checked.

There are [a couple of remaining questions ](https://github.com/Automattic/woocommerce-payments/issues/1732#issuecomment-842692186 ) that can be addressed on separate issues.

This issue does not cover clicking on 'Save settings' button on the settings screen.

-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
