### PR TITLE
refactor: modal buttons alignment

### DIFF
--- a/client/settings/payment-methods-selector/index.js
+++ b/client/settings/payment-methods-selector/index.js
@@ -72,11 +72,11 @@ const PaymentMethodsSelector = ( { onClose, enabledPaymentMethods = [] } ) => {
 			</PaymentMethodCheckboxes>
 			<HorizontalRule className="woocommerce-payments__payment-method-selector__separator" />
 			<div className="woocommerce-payments__payment-method-selector__footer">
-				<Button isPrimary onClick={ handleAddSelected }>
-					{ __( 'Add selected', 'woocommerce-payments' ) }
-				</Button>
 				<Button isSecondary onClick={ onClose }>
 					{ __( 'Cancel', 'woocommerce-payments' ) }
+				</Button>
+				<Button isPrimary onClick={ handleAddSelected }>
+					{ __( 'Add selected', 'woocommerce-payments' ) }
 				</Button>
 			</div>
 		</Modal>

--- a/client/settings/payment-methods-selector/style.scss
+++ b/client/settings/payment-methods-selector/style.scss
@@ -4,6 +4,6 @@
 	}
 
 	&__footer {
-		@include modal-footer-buttons-left;
+		@include modal-footer-buttons;
 	}
 }

--- a/client/stylesheets/abstracts/_mixins.scss
+++ b/client/stylesheets/abstracts/_mixins.scss
@@ -24,17 +24,9 @@
 	display: flex;
 	justify-content: flex-end;
 
-	button.components-button {
-		margin-left: 16px;
-	}
-}
-
-@mixin modal-footer-buttons-left {
-	display: flex;
-
 	> * {
-		&:not( :last-child ) {
-			margin-right: 16px;
+		&:not( :first-child ) {
+			margin-left: 16px;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Modals have been updated in the designs to have the buttons aligned to the right (rather than the left).



#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have the "grouped settings" flag enabled in WCPay Dev Tools
- Visit http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout
- Click the "Add payment method" button

Before:
![Screen Shot 2021-05-18 at 8 07 04 AM](https://user-images.githubusercontent.com/273592/118656946-9f51d700-b7b0-11eb-9e90-5a2c3136b2b1.png)

After:
![Screen Shot 2021-05-18 at 8 09 56 AM](https://user-images.githubusercontent.com/273592/118656970-a4af2180-b7b0-11eb-9e7c-2ce8c543ce48.png)



-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
