### PR TITLE
refactor: remove gateway classes from UPE settings

### DIFF
--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -127,7 +127,8 @@ const PaymentMethods = () => {
 									key={ id }
 									Icon={ Icon }
 									className={ classNames( 'payment-method', {
-										'has-icon-border': 'cc' !== id,
+										'has-icon-border':
+											'woocommerce_payments' !== id,
 									} ) }
 									onDeleteClick={
 										1 < enabledMethods.length
@@ -159,7 +160,8 @@ const PaymentMethods = () => {
 								className={ classNames(
 									'payment-methods__available-method',
 									{
-										'has-icon-border': 'cc' !== id,
+										'has-icon-border':
+											'woocommerce_payments' !== id,
 									}
 								) }
 								aria-label={ label }

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -27,23 +27,15 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	private $wcpay_gateway;
 
 	/**
-	 * Payment gateways.
-	 *
-	 * @var WC_Payment_Gateways
-	 */
-	private $payment_gateways;
-
-	/**
 	 * WC_REST_Payments_Settings_Controller constructor.
 	 *
 	 * @param WC_Payments_API_Client   $api_client WC_Payments_API_Client instance.
 	 * @param WC_Payment_Gateway_WCPay $wcpay_gateway WC_Payment_Gateway_WCPay instance.
-	 * @param WC_Payment_Gateways      $payment_gateways WC_Payment_Gateways instance.
 	 */
-	public function __construct( WC_Payments_API_Client $api_client, WC_Payment_Gateway_WCPay $wcpay_gateway, WC_Payment_Gateways $payment_gateways ) {
+	public function __construct( WC_Payments_API_Client $api_client, WC_Payment_Gateway_WCPay $wcpay_gateway ) {
 		parent::__construct( $api_client );
-		$this->wcpay_gateway    = $wcpay_gateway;
-		$this->payment_gateways = $payment_gateways;
+
+		$this->wcpay_gateway = $wcpay_gateway;
 	}
 
 	/**
@@ -73,11 +65,11 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 						'validate_callback' => 'rest_validate_request_arg',
 					],
 					'enabled_payment_method_ids' => [
-						'description'       => __( 'Payment method IDs that should be enabled, in the order they should appear in during checkout. Other methods will be disabled.', 'woocommerce-payments' ),
+						'description'       => __( 'Payment method IDs that should be enabled. Other methods will be disabled.', 'woocommerce-payments' ),
 						'type'              => 'array',
 						'items'             => [
 							'type' => 'string',
-							'enum' => wp_list_pluck( $this->get_available_wcpay_payment_methods(), 'id' ),
+							'enum' => $this->wcpay_gateway->get_upe_available_payment_methods(),
 						],
 						'validate_callback' => 'rest_validate_request_arg',
 					],
@@ -92,19 +84,11 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_settings(): WP_REST_Response {
-		$enabled_payment_methods = array_filter(
-			$this->get_available_wcpay_payment_methods(),
-			function ( WC_Payment_Gateway_WCPay $gateway ) {
-				return $gateway->is_enabled();
-			}
-		);
-
-		$enabled_payment_method_ids = wp_list_pluck( $enabled_payment_methods, 'id' );
-
 		return new WP_REST_Response(
 			[
-				'enabled_payment_method_ids' => array_values( $enabled_payment_method_ids ),
-				'is_wcpay_enabled'           => $this->wcpay_gateway->is_enabled(),
+				'enabled_payment_method_ids'   => $this->wcpay_gateway->get_upe_enabled_payment_method_ids(),
+				'available_payment_method_ids' => $this->wcpay_gateway->get_upe_available_payment_methods(),
+				'is_wcpay_enabled'             => $this->wcpay_gateway->is_enabled(),
 			]
 		);
 	}
@@ -119,20 +103,6 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		$this->update_enabled_payment_methods( $request );
 
 		return new WP_REST_Response( [], 200 );
-	}
-
-	/**
-	 * Get available payment methods.
-	 *
-	 * @return WC_Payment_Gateway_WCPay[]
-	 */
-	private function get_available_wcpay_payment_methods(): array {
-		return array_filter(
-			$this->payment_gateways->payment_gateways(),
-			function ( $gateway ) {
-				return is_subclass_of( $gateway, WC_Payment_Gateway_WCPay::class );
-			}
-		);
 	}
 
 	/**
@@ -165,18 +135,18 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		}
 
 		$payment_method_ids_to_enable = $request->get_param( 'enabled_payment_method_ids' );
+		$available_payment_methods    = $this->wcpay_gateway->get_upe_available_payment_methods();
 
-		foreach ( $this->get_available_wcpay_payment_methods() as $payment_method ) {
-			$should_be_enabled = in_array( $payment_method->id, $payment_method_ids_to_enable, true );
+		$payment_method_ids_to_enable = array_values(
+			array_filter(
+				$payment_method_ids_to_enable,
+				function ( $payment_method ) use ( $available_payment_methods ) {
+					return in_array( $payment_method, $available_payment_methods, true );
+				}
+			)
+		);
 
-			if ( $should_be_enabled ) {
-				$payment_method->enable();
-			} else {
-				$payment_method->disable();
-			}
-		}
-
-		$this->wcpay_gateway->update_option( 'payment_method_order', $payment_method_ids_to_enable );
+		$this->wcpay_gateway->update_option( 'enabled_payment_method_ids', $payment_method_ids_to_enable );
 	}
 
 }

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -265,6 +265,15 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			],
 		];
 
+		if ( WC_Payments_Features::is_grouped_settings_enabled() ) {
+			$this->form_fields['enabled_payment_method_ids'] = [
+				'title'   => __( 'Payments accepted on checkout', 'woocommerce-payments' ),
+				'type'    => 'multiselect',
+				'default' => [ 'woocommerce_payments' ],
+				'options' => [],
+			];
+		}
+
 		// Giropay option hidden behind feature flag.
 		if ( WC_Payments_Features::is_giropay_enabled() ) {
 			$this->form_fields['giropay_enabled'] = [
@@ -1224,7 +1233,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 *
 	 * @param  string $key Option key.
 	 * @param  mixed  $empty_value Value when empty.
-	 * @return string The value specified for the option or a default value for the option.
+	 * @return mixed The value specified for the option or a default value for the option.
 	 */
 	public function get_option( $key, $empty_value = null ) {
 		switch ( $key ) {
@@ -2126,5 +2135,30 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	public function enable() {
 		$this->update_option( 'enabled', 'yes' );
+	}
+
+	/**
+	 * Returns the list of enabled payment method types for UPE.
+	 *
+	 * @return string[]
+	 */
+	public function get_upe_enabled_payment_method_ids() {
+		return $this->get_option( 'enabled_payment_method_ids', [] );
+	}
+
+	/**
+	 * Returns the list of available payment method types for UPE.
+	 * See https://stripe.com/docs/stripe-js/payment-element#web-create-payment-intent for a complete list.
+	 *
+	 * @return string[]
+	 */
+	public function get_upe_available_payment_methods() {
+		return apply_filters(
+			'wcpay_upe_available_payment_methods',
+			[
+				// TODO: at this point, with UPE, we could just get rid of the prefixes on the payment method names.
+				'woocommerce_payments',
+			]
+		);
 	}
 }

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -646,7 +646,7 @@ class WC_Payments {
 		$tos_controller->register_routes();
 
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-settings-controller.php';
-		$settings_controller = new WC_REST_Payments_Settings_Controller( self::$api_client, self::$card_gateway, WC()->payment_gateways() );
+		$settings_controller = new WC_REST_Payments_Settings_Controller( self::$api_client, self::$card_gateway );
 		$settings_controller->register_routes();
 	}
 

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -34,11 +34,6 @@ class WC_REST_Payments_Settings_Controller_Test extends WP_UnitTestCase {
 	private $gateway;
 
 	/**
-	 * @var MockObject|WC_Payment_Gateways
-	 */
-	private $payment_gateways_mock;
-
-	/**
 	 * Pre-test setup
 	 */
 	public function setUp() {
@@ -48,6 +43,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WP_UnitTestCase {
 
 		// Set the user so that we can pass the authentication.
 		wp_set_current_user( 1 );
+		update_option( '_wcpay_feature_grouped_settings', '1' );
 
 		/** @var WC_Payments_API_Client|MockObject $mock_api_client */
 		$mock_api_client = $this->getMockBuilder( WC_Payments_API_Client::class )
@@ -59,11 +55,9 @@ class WC_REST_Payments_Settings_Controller_Test extends WP_UnitTestCase {
 		$token_service            = new WC_Payments_Token_Service( $mock_api_client, $customer_service );
 		$action_scheduler_service = new WC_Payments_Action_Scheduler_Service( $mock_api_client );
 
-		$this->gateway               = new WC_Payment_Gateway_WCPay( $mock_api_client, $account, $customer_service, $token_service, $action_scheduler_service );
-		$this->payment_gateways_mock = $this->getMockBuilder( WC_Payment_Gateways::class )
-			->disableOriginalConstructor()
-			->getMock();
-		$this->controller            = new WC_REST_Payments_Settings_Controller( $mock_api_client, $this->gateway, $this->payment_gateways_mock );
+		$this->gateway    = new WC_Payment_Gateway_WCPay( $mock_api_client, $account, $customer_service, $token_service, $action_scheduler_service );
+		$this->controller = new WC_REST_Payments_Settings_Controller( $mock_api_client, $this->gateway );
+		$this->set_available_gateways( [ 'woocommerce_payments' ] );
 	}
 
 	public function test_get_settings_request_returns_status_code_200() {
@@ -75,49 +69,27 @@ class WC_REST_Payments_Settings_Controller_Test extends WP_UnitTestCase {
 	}
 
 	public function test_get_settings_returns_enabled_payment_method_ids() {
-		$enabled_gateway_mock_one = $this->create_wcpay_gateway_mock( 'enabled 1' );
-		$enabled_gateway_mock_one->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
-
-		$enabled_gateway_mock_two = $this->create_wcpay_gateway_mock( 'enabled 2' );
-		$enabled_gateway_mock_two->expects( $this->once() )->method( 'is_enabled' )->willReturn( true );
-
-		$disabled_gateway_mock = $this->create_wcpay_gateway_mock( 'disabled' );
-		$disabled_gateway_mock->expects( $this->once() )->method( 'is_enabled' )->willReturn( false );
-
-		$this->payment_gateways_mock
-			->expects( $this->once() )
-			->method( 'payment_gateways' )
-			->willReturn( [ $enabled_gateway_mock_one, $enabled_gateway_mock_two, $disabled_gateway_mock ] );
-
 		$response           = $this->controller->get_settings();
 		$enabled_method_ids = $response->get_data()['enabled_payment_method_ids'];
 
 		$this->assertEquals(
-			[ 'enabled 1', 'enabled 2' ],
+			[ 'woocommerce_payments' ],
 			$enabled_method_ids
 		);
 	}
 
-	public function test_enabled_methods_include_only_subclasses_of_wcpay() {
-		$wcpay_subclass_gateway_mock = $this->create_wcpay_gateway_mock( 'foo' );
-		$wcpay_subclass_gateway_mock->method( 'is_enabled' )->willReturn( true );
-
-		$non_wcpay_subclass_gateway_mock = $this->create_non_wcpay_gateway_mock( 'bar' );
-
-		$this->set_available_gateways( [ $wcpay_subclass_gateway_mock, $non_wcpay_subclass_gateway_mock ] );
-
+	public function test_get_settings_returns_available_payment_method_ids() {
+		$this->set_available_gateways( [ 'foo', 'bar' ] );
 		$response           = $this->controller->get_settings();
-		$enabled_method_ids = $response->get_data()['enabled_payment_method_ids'];
+		$enabled_method_ids = $response->get_data()['available_payment_method_ids'];
 
 		$this->assertEquals(
-			[ 'foo' ],
+			[ 'foo', 'bar' ],
 			$enabled_method_ids
 		);
 	}
 
 	public function test_get_settings_returns_if_wcpay_is_enabled() {
-		$this->set_available_gateways( [] );
-
 		$this->gateway->enable();
 		$response = $this->controller->get_settings();
 		$this->assertTrue( $response->get_data()['is_wcpay_enabled'] );
@@ -191,55 +163,21 @@ class WC_REST_Payments_Settings_Controller_Test extends WP_UnitTestCase {
 	}
 
 	public function test_update_settings_saves_enabled_payment_methods() {
-		$foo_gateway = $this->create_wcpay_gateway_mock( 'foo' );
-		$bar_gateway = $this->create_wcpay_gateway_mock( 'bar' );
-
-		$this->set_available_gateways( [ $foo_gateway, $bar_gateway ] );
+		$this->set_available_gateways( [ 'foo', 'bar' ] );
 
 		$request = new WP_REST_Request();
-		$request->set_param( 'enabled_payment_method_ids', [ $bar_gateway->id ] );
-
-		$foo_gateway->expects( $this->once() )->method( 'disable' );
-		$bar_gateway->expects( $this->once() )->method( 'enable' );
+		$request->set_param( 'enabled_payment_method_ids', [ 'bar' ] );
 
 		$this->controller->update_settings( $request );
-	}
 
-	public function test_update_settings_saves_enabled_payment_method_order() {
-		$this->gateway->update_option( 'payment_method_order', [] );
-		$this->assertEmpty( $this->gateway->get_option( 'payment_method_order' ) );
-
-		$foo_gateway = $this->create_wcpay_gateway_mock( 'foo' );
-		$bar_gateway = $this->create_wcpay_gateway_mock( 'bar' );
-		$this->set_available_gateways( [ $foo_gateway, $bar_gateway ] );
-
-		$request = new WP_REST_Request();
-		$request->set_param( 'enabled_payment_method_ids', [ $foo_gateway->id, $bar_gateway->id ] );
-
-		$this->controller->update_settings( $request );
-		$this->assertEquals( [ 'foo', 'bar' ], $this->gateway->get_option( 'payment_method_order' ) );
+		$this->assertEquals( [ 'bar' ], $this->gateway->get_option( 'enabled_payment_method_ids' ) );
 	}
 
 	public function test_update_settings_validation_fails_if_invalid_gateway_id_supplied() {
-		$foo_gateway = $this->create_wcpay_gateway_mock( 'foo' );
-
-		$this->set_available_gateways( [ $foo_gateway ] );
+		$this->set_available_gateways( [ 'foo', 'bar' ] );
 
 		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
-		$request->set_param( 'enabled_payment_method_ids', [ 'bar' ] );
-
-		$response = rest_do_request( $request );
-		$this->assertEquals( 400, $response->get_status() );
-	}
-
-	public function test_update_settings_validation_fails_if_non_wcpay_gateway_id_supplied() {
-		$foo_gateway = $this->create_wcpay_gateway_mock( 'foo' );
-		$bar_gateway = $this->create_non_wcpay_gateway_mock( 'bar' );
-
-		$this->set_available_gateways( [ $foo_gateway, $bar_gateway ] );
-
-		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
-		$request->set_param( 'enabled_payment_method_ids', [ 'bar' ] );
+		$request->set_param( 'enabled_payment_method_ids', [ 'foo', 'baz' ] );
 
 		$response = rest_do_request( $request );
 		$this->assertEquals( 400, $response->get_status() );
@@ -260,30 +198,6 @@ class WC_REST_Payments_Settings_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @return MockObject|WC_Payment_Gateway_WCPay
-	 */
-	private function create_wcpay_gateway_mock( string $id ) {
-		$gateway_mock     = $this->getMockBuilder( WC_Payment_Gateway_WCPay::class )
-			->disableOriginalConstructor()
-			->getMock();
-		$gateway_mock->id = $id;
-
-		return $gateway_mock;
-	}
-
-	/**
-	 * @return MockObject|WC_Payment_Gateway
-	 */
-	private function create_non_wcpay_gateway_mock( string $id ) {
-		$gateway_mock     = $this->getMockBuilder( WC_Payment_Gateway::class )
-			->disableOriginalConstructor()
-			->getMock();
-		$gateway_mock->id = $id;
-
-		return $gateway_mock;
-	}
-
-	/**
 	 * @param bool $can_manage_woocommerce
 	 *
 	 * @return Closure
@@ -297,12 +211,15 @@ class WC_REST_Payments_Settings_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @param WC_Payment_Gateway[] $gateways Available gateways.
+	 * @param string[] $gateways Available gateways.
 	 */
 	private function set_available_gateways( array $gateways ) {
-		$this->payment_gateways_mock
-			->method( 'payment_gateways' )
-			->willReturn( $gateways );
+		add_filter(
+			'wcpay_upe_available_payment_methods',
+			function () use ( $gateways ) {
+				return $gateways;
+			}
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/1833

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The Sofort/giropay/SEPA gateway classes have been created before we could switch to UPE.
We don't need them. We can just save the list of enabled payment methods as string on the main WCPay gateway class.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
