### PR TITLE
feat: hide add payment method section when necessary

### DIFF
--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -42,6 +42,13 @@ export const useGeneralSettings = () => {
 	);
 };
 
+export const useGetAvailablePaymentMethodIds = () =>
+	useSelect( ( select ) => {
+		const { getAvailablePaymentMethodIds } = select( STORE_NAME );
+
+		return getAvailablePaymentMethodIds();
+	} );
+
 export const useSettings = () => {
 	const { saveSettings } = useDispatch( STORE_NAME );
 

--- a/client/data/settings/selectors.js
+++ b/client/data/settings/selectors.js
@@ -23,6 +23,10 @@ export const getEnabledPaymentMethodIds = ( state ) => {
 	return getSettings( state ).enabled_payment_method_ids || EMPTY_ARR;
 };
 
+export const getAvailablePaymentMethodIds = ( state ) => {
+	return getSettings( state ).available_payment_method_ids || EMPTY_ARR;
+};
+
 export const isSavingSettings = ( state ) => {
 	return getSettingsState( state ).isSaving || false;
 };

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -11,7 +11,10 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import './style.scss';
-import { useEnabledPaymentMethodIds } from 'data';
+import {
+	useEnabledPaymentMethodIds,
+	useGetAvailablePaymentMethodIds,
+} from 'data';
 import PaymentMethodsList from 'components/payment-methods-list';
 import PaymentMethod from 'components/payment-methods-list/payment-method';
 import PaymentMethodsSelector from 'settings/payment-methods-selector';
@@ -20,8 +23,9 @@ import GiropayIcon from '../gateway-icons/giropay';
 import SofortIcon from '../gateway-icons/sofort';
 import SepaIcon from '../gateway-icons/sepa';
 
-const availableMethods = [
-	{
+const methodsConfiguration = {
+	// eslint-disable-next-line camelcase
+	woocommerce_payments: {
 		id: 'woocommerce_payments',
 		label: __( 'Credit card / debit card', 'woocommerce-payments' ),
 		description: __(
@@ -30,7 +34,8 @@ const availableMethods = [
 		),
 		Icon: CreditCardIcon,
 	},
-	{
+	// eslint-disable-next-line camelcase
+	woocommerce_payments_giropay: {
 		id: 'woocommerce_payments_giropay',
 		label: __( 'giropay', 'woocommerce-payments' ),
 		description: __(
@@ -39,7 +44,8 @@ const availableMethods = [
 		),
 		Icon: GiropayIcon,
 	},
-	{
+	// eslint-disable-next-line camelcase
+	woocommerce_payments_sofort: {
 		id: 'woocommerce_payments_sofort',
 		label: __( 'Sofort', 'woocommerce-payments' ),
 		description: __(
@@ -48,7 +54,8 @@ const availableMethods = [
 		),
 		Icon: SofortIcon,
 	},
-	{
+	// eslint-disable-next-line camelcase
+	woocommerce_payments_sepa: {
 		id: 'woocommerce_payments_sepa',
 		label: __( 'Direct debit payment', 'woocommerce-payments' ),
 		description: __(
@@ -57,7 +64,7 @@ const availableMethods = [
 		),
 		Icon: SepaIcon,
 	},
-];
+};
 
 const PaymentMethods = () => {
 	const {
@@ -65,13 +72,15 @@ const PaymentMethods = () => {
 		updateEnabledPaymentMethodIds: updateEnabledMethodIds,
 	} = useEnabledPaymentMethodIds();
 
-	const enabledMethods = enabledMethodIds.map( ( methodId ) =>
-		availableMethods.find( ( method ) => method.id === methodId )
-	);
+	const availablePaymentMethodIds = useGetAvailablePaymentMethodIds();
 
-	const disabledMethods = availableMethods.filter(
-		( method ) => ! enabledMethodIds.includes( method.id )
-	);
+	const enabledMethods = availablePaymentMethodIds
+		.filter( ( method ) => enabledMethodIds.includes( method ) )
+		.map( ( methodId ) => methodsConfiguration[ methodId ] );
+
+	const disabledMethods = availablePaymentMethodIds
+		.filter( ( methodId ) => ! enabledMethodIds.includes( methodId ) )
+		.map( ( methodId ) => methodsConfiguration[ methodId ] );
 
 	const handleDeleteClick = ( itemId ) => {
 		updateEnabledMethodIds(
@@ -102,27 +111,34 @@ const PaymentMethods = () => {
 						) }
 					</PaymentMethodsList>
 				</CardBody>
-				<CardDivider />
-				<CardBody className="payment-methods__available-methods-container">
-					<PaymentMethodsSelector className="payment-methods__add-payment-method" />
-					<ul className="payment-methods__available-methods">
-						{ disabledMethods.map( ( { id, label, Icon } ) => (
-							<li
-								key={ id }
-								className={ classNames(
-									'payment-methods__available-method',
-									{
-										'has-icon-border':
-											'woocommerce_payments' !== id,
-									}
+				{ 1 < availablePaymentMethodIds.length ? (
+					<>
+						<CardDivider />
+						<CardBody className="payment-methods__available-methods-container">
+							<PaymentMethodsSelector className="payment-methods__add-payment-method" />
+							<ul className="payment-methods__available-methods">
+								{ disabledMethods.map(
+									( { id, label, Icon } ) => (
+										<li
+											key={ id }
+											className={ classNames(
+												'payment-methods__available-method',
+												{
+													'has-icon-border':
+														'woocommerce_payments' !==
+														id,
+												}
+											) }
+											aria-label={ label }
+										>
+											<Icon height="24" width="38" />
+										</li>
+									)
 								) }
-								aria-label={ label }
-							>
-								<Icon height="24" width="38" />
-							</li>
-						) ) }
-					</ul>
-				</CardBody>
+							</ul>
+						</CardBody>
+					</>
+				) : null }
 			</Card>
 		</>
 	);

--- a/client/payment-methods/test/index.js
+++ b/client/payment-methods/test/index.js
@@ -10,11 +10,15 @@ import user from '@testing-library/user-event';
 /**
  * Internal dependencies
  */
-import PaymentMethods from '../';
-import { useEnabledPaymentMethodIds } from 'data';
+import PaymentMethods from '..';
+import {
+	useEnabledPaymentMethodIds,
+	useGetAvailablePaymentMethodIds,
+} from 'data';
 
 jest.mock( '../../data', () => ( {
 	useEnabledPaymentMethodIds: jest.fn(),
+	useGetAvailablePaymentMethodIds: jest.fn(),
 } ) );
 
 describe( 'PaymentMethods', () => {
@@ -23,9 +27,29 @@ describe( 'PaymentMethods', () => {
 			enabledPaymentMethodIds: [],
 			updateEnabledPaymentMethodIds: jest.fn(),
 		} );
+		useGetAvailablePaymentMethodIds.mockReturnValue( [
+			'woocommerce_payments',
+			'woocommerce_payments_giropay',
+			'woocommerce_payments_sofort',
+			'woocommerce_payments_sepa',
+		] );
 	} );
 
-	test( 'renders the "Add payment method" button', () => {
+	test( 'does not render the "Add payment method" button when there is only one payment method available', () => {
+		useGetAvailablePaymentMethodIds.mockReturnValue( [
+			'woocommerce_payments',
+		] );
+
+		render( <PaymentMethods /> );
+
+		const addPaymentMethodButton = screen.queryByRole( 'button', {
+			name: 'Add payment method',
+		} );
+
+		expect( addPaymentMethodButton ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders the "Add payment method" button when there are at least 2 payment methods', () => {
 		render( <PaymentMethods /> );
 
 		const addPaymentMethodButton = screen.queryByRole( 'button', {
@@ -43,6 +67,7 @@ describe( 'PaymentMethods', () => {
 		} );
 
 		fireEvent.click( addPaymentMethodButton );
+
 		expect(
 			screen.queryByText( 'Add payment methods' )
 		).toBeInTheDocument();

--- a/client/settings/payment-method-icon/index.js
+++ b/client/settings/payment-method-icon/index.js
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import './style.scss';
+import CreditCardIcon from '../../gateway-icons/credit-card';
 import GiropayIcon from '../../gateway-icons/giropay';
 import SepaIcon from '../../gateway-icons/sepa';
 import SofortIcon from '../../gateway-icons/sofort';
@@ -16,6 +17,10 @@ import GooglePayIcon from '../../gateway-icons/google-pay';
 
 const paymentMethods = {
 	/* eslint-disable camelcase */
+	woocommerce_payments: {
+		label: __( 'Credit card / debit card', 'woocommerce-payments' ),
+		Icon: CreditCardIcon,
+	},
 	woocommerce_payments_giropay: {
 		label: __( 'GiroPay', 'woocommerce-payments' ),
 		Icon: GiropayIcon,

--- a/client/settings/payment-methods-selector/index.js
+++ b/client/settings/payment-methods-selector/index.js
@@ -10,18 +10,17 @@ import { HorizontalRule } from '@wordpress/primitives';
 /**
  * Internal dependencies
  */
-
-import { useEnabledPaymentMethodIds } from 'data';
+import {
+	useEnabledPaymentMethodIds,
+	useGetAvailablePaymentMethodIds,
+} from 'data';
 import PaymentMethodCheckboxes from '../../components/payment-methods-checkboxes';
 import PaymentMethodCheckbox from '../../components/payment-methods-checkboxes/payment-method-checkbox';
 import './style.scss';
 
-const availablePaymentMethods = [
-	'woocommerce_payments_giropay',
-	'woocommerce_payments_sofort',
-	'woocommerce_payments_sepa',
-];
 const PaymentMethodsSelector = ( { className } ) => {
+	const availablePaymentMethodIds = useGetAvailablePaymentMethodIds();
+
 	const {
 		enabledPaymentMethodIds: enabledMethodIds,
 		updateEnabledPaymentMethodIds: updateEnabledMethodIds,
@@ -36,7 +35,7 @@ const PaymentMethodsSelector = ( { className } ) => {
 
 	useEffect( () => {
 		setPaymentMethods(
-			availablePaymentMethods
+			availablePaymentMethodIds
 				.filter(
 					( methodId ) => ! enabledMethodIds.includes( methodId )
 				)
@@ -45,7 +44,7 @@ const PaymentMethodsSelector = ( { className } ) => {
 					return acc;
 				}, {} )
 		);
-	}, [ enabledMethodIds ] );
+	}, [ availablePaymentMethodIds, enabledMethodIds ] );
 
 	const addSelectedPaymentMethods = ( itemIds ) => {
 		updateEnabledMethodIds( [
@@ -122,6 +121,9 @@ const PaymentMethodsSelector = ( { className } ) => {
 				isSecondary
 				className={ className }
 				onClick={ handlePaymentMethodAddButtonClick }
+				disabled={
+					enabledMethodIds.length === availablePaymentMethodIds.length
+				}
 			>
 				{ __( 'Add payment method', 'woocommerce-payments' ) }
 			</Button>

--- a/client/settings/payment-methods-selector/test/index.js
+++ b/client/settings/payment-methods-selector/test/index.js
@@ -2,16 +2,23 @@
 /**
  * External dependencies
  */
-import { render, within } from '@testing-library/react';
+import { render, within, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
 
 /**
  * Internal dependencies
  */
 import PaymentMethodsSelector from '..';
-import { useEnabledPaymentMethodIds } from 'data';
 
-jest.mock( 'data', () => ( { useEnabledPaymentMethodIds: jest.fn() } ) );
+import {
+	useEnabledPaymentMethodIds,
+	useGetAvailablePaymentMethodIds,
+} from 'data';
+
+jest.mock( 'data', () => ( {
+	useEnabledPaymentMethodIds: jest.fn(),
+	useGetAvailablePaymentMethodIds: jest.fn(),
+} ) );
 
 describe( 'PaymentMethodsSelector', () => {
 	beforeEach( () => {
@@ -19,26 +26,30 @@ describe( 'PaymentMethodsSelector', () => {
 			enabledPaymentMethodIds: [],
 			updateEnabledPaymentMethodIds: jest.fn(),
 		} );
+		useGetAvailablePaymentMethodIds.mockReturnValue( [
+			'woocommerce_payments',
+			'woocommerce_payments_giropay',
+			'woocommerce_payments_sofort',
+			'woocommerce_payments_sepa',
+		] );
 	} );
 
 	test( 'Displays "Add payment Method" button, modal is not visible', () => {
-		const { getByRole, queryByText, queryByRole } = render(
-			<PaymentMethodsSelector />
-		);
+		render( <PaymentMethodsSelector /> );
 
-		const addPaymentMethodButton = getByRole( 'button', {
+		const addPaymentMethodButton = screen.queryByRole( 'button', {
 			name: 'Add payment method',
 		} );
 		expect( addPaymentMethodButton ).toBeInTheDocument();
 
 		expect(
-			queryByText(
+			screen.queryByText(
 				"Increase your store's conversion by offering your customers preferred and convenient payment methods."
 			)
 		).toBeNull();
 
 		expect(
-			queryByRole( 'button', {
+			screen.queryByRole( 'button', {
 				name: 'Add selected',
 			} )
 		).toBeNull();
@@ -50,53 +61,55 @@ describe( 'PaymentMethodsSelector', () => {
 			updateEnabledPaymentMethodIds: jest.fn( () => {} ),
 		} );
 
-		const { getByText, getByRole, getAllByRole } = render(
-			<PaymentMethodsSelector />
-		);
+		render( <PaymentMethodsSelector /> );
 
-		const addPaymentMethodButton = getByRole( 'button', {
+		const addPaymentMethodButton = screen.getByRole( 'button', {
 			name: 'Add payment method',
 		} );
 		user.click( addPaymentMethodButton );
 
 		expect(
-			getByText(
+			screen.getByText(
 				"Increase your store's conversion by offering your customers preferred and convenient payment methods."
 			)
 		).toBeInTheDocument();
 
-		const paymentMethods = getAllByRole( 'listitem' );
+		const paymentMethods = screen.getAllByRole( 'listitem' );
 		expect( paymentMethods ).toHaveLength( 3 );
 
-		const giroPayCheckbox = getByRole( 'checkbox', { name: 'GiroPay' } );
+		const giroPayCheckbox = screen.getByRole( 'checkbox', {
+			name: 'GiroPay',
+		} );
 		expect( giroPayCheckbox ).not.toBeChecked();
 
-		const sofortCheckbox = getByRole( 'checkbox', { name: 'Sofort' } );
+		const sofortCheckbox = screen.getByRole( 'checkbox', {
+			name: 'Sofort',
+		} );
 		expect( sofortCheckbox ).not.toBeChecked();
 
-		const sepaCheckbox = getByRole( 'checkbox', {
+		const sepaCheckbox = screen.getByRole( 'checkbox', {
 			name: 'Direct Debit Payments',
 		} );
 		expect( sepaCheckbox ).not.toBeChecked();
 
 		expect(
-			getByRole( 'button', {
+			screen.getByRole( 'button', {
 				name: 'Add selected',
 			} )
 		).toBeInTheDocument();
 	} );
 
 	test( 'Payment method selection can be dismissed', () => {
-		const { getByRole, queryByRole } = render( <PaymentMethodsSelector /> );
+		render( <PaymentMethodsSelector /> );
 
 		user.click(
-			getByRole( 'button', {
+			screen.getByRole( 'button', {
 				name: 'Add payment method',
 			} )
 		);
 
 		user.click(
-			getByRole( 'button', {
+			screen.getByRole( 'button', {
 				name: 'Cancel',
 			} )
 		);
@@ -106,7 +119,7 @@ describe( 'PaymentMethodsSelector', () => {
 		).not.toHaveBeenCalled();
 
 		expect(
-			queryByRole( 'button', {
+			screen.queryByRole( 'button', {
 				name: 'Cancel',
 			} )
 		).toBeNull();
@@ -121,18 +134,18 @@ describe( 'PaymentMethodsSelector', () => {
 			updateEnabledPaymentMethodIds: jest.fn( () => {} ),
 		} );
 
-		const { getByRole, getAllByRole, queryByRole } = render(
-			<PaymentMethodsSelector />
-		);
+		render( <PaymentMethodsSelector /> );
 
-		const addPaymentMethodButton = getByRole( 'button', {
+		const addPaymentMethodButton = screen.getByRole( 'button', {
 			name: 'Add payment method',
 		} );
 		user.click( addPaymentMethodButton );
 
-		const paymentMethods = getAllByRole( 'listitem' );
+		const paymentMethods = screen.getAllByRole( 'listitem' );
 		expect( paymentMethods ).toHaveLength( 2 );
-		expect( queryByRole( 'checkbox', { name: 'Sofort' } ) ).toBeNull();
+		expect(
+			screen.queryByRole( 'checkbox', { name: 'Sofort' } )
+		).toBeNull();
 	} );
 
 	test( 'Selecting payment methods does not update enabled payment methods', () => {
@@ -144,16 +157,14 @@ describe( 'PaymentMethodsSelector', () => {
 			updateEnabledPaymentMethodIds: jest.fn( () => {} ),
 		} );
 
-		const { getByRole, getAllByRole } = render(
-			<PaymentMethodsSelector />
-		);
+		render( <PaymentMethodsSelector /> );
 
-		const addPaymentMethodButton = getByRole( 'button', {
+		const addPaymentMethodButton = screen.getByRole( 'button', {
 			name: 'Add payment method',
 		} );
 		user.click( addPaymentMethodButton );
 
-		const paymentMethods = getAllByRole( 'listitem' );
+		const paymentMethods = screen.getAllByRole( 'listitem' );
 		const paymentMethodCheckbox = within( paymentMethods[ 0 ] ).getByRole(
 			'checkbox'
 		);
@@ -174,17 +185,19 @@ describe( 'PaymentMethodsSelector', () => {
 			updateEnabledPaymentMethodIds: jest.fn( () => {} ),
 		} );
 
-		const { getByRole, queryByRole } = render( <PaymentMethodsSelector /> );
+		render( <PaymentMethodsSelector /> );
 
-		const addPaymentMethodButton = getByRole( 'button', {
+		const addPaymentMethodButton = screen.getByRole( 'button', {
 			name: 'Add payment method',
 		} );
 		user.click( addPaymentMethodButton );
 
-		const giroPayCheckbox = getByRole( 'checkbox', { name: 'GiroPay' } );
+		const giroPayCheckbox = screen.getByRole( 'checkbox', {
+			name: 'GiroPay',
+		} );
 		user.click( giroPayCheckbox );
 
-		const addSelectedButton = getByRole( 'button', {
+		const addSelectedButton = screen.getByRole( 'button', {
 			name: 'Add selected',
 		} );
 		user.click( addSelectedButton );
@@ -196,7 +209,7 @@ describe( 'PaymentMethodsSelector', () => {
 			'woocommerce_payments_giropay',
 		] );
 		expect(
-			queryByRole( 'button', {
+			screen.queryByRole( 'button', {
 				name: 'Add selected',
 			} )
 		).toBeNull();


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/1832

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Hides the "Add payment methods" section when there is only one payment method available.
Disables the "Add payment methods" button when there are no payment methods that can be added.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have the latest version of the dev tools: `cd docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools && git checkout trunk && git pull`
- Ensure you have the "grouped settings" flag enabled in WCPay Dev Tools
- Visit http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout
- Only the "credit card" method should be visible
- Check the "Add UPE additional payment methods" flag in WCPay Dev Tools
- Now you can add/remove payment methods through the "Add payment method" button
- Once all the payment methods are added, the button appears disabled

Only one payment method available - section is hidden
![Screen Shot 2021-05-18 at 5 14 07 PM](https://user-images.githubusercontent.com/273592/118730072-9b4ba680-b7fc-11eb-9aa3-8ab91b6da58d.png)

At least one payment method available - section is displayed
![Screen Shot 2021-05-18 at 5 15 33 PM](https://user-images.githubusercontent.com/273592/118730120-b1f1fd80-b7fc-11eb-9c13-d1ae0a506124.png)


All payment methods have been added - button is disabled
![Screen Shot 2021-05-18 at 5 16 00 PM](https://user-images.githubusercontent.com/273592/118730147-c1714680-b7fc-11eb-9b8d-936d03f38d6f.png)



-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
