### PR TITLE
Add legacy widget for multi shopper currencies

### DIFF
--- a/includes/multi-currency/class-currency-switcher-widget.php
+++ b/includes/multi-currency/class-currency-switcher-widget.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * WooCommerce Payments Currency Switcher Widget
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Multi_Currency;
+
+use WP_Widget;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Currency Switcher Widget Class
+ */
+class Currency_Switcher_Widget extends WP_Widget {
+
+	const DEFAULT_SETTINGS = [
+		'title'  => '',
+		'symbol' => true,
+		'flag'   => false,
+	];
+
+	/**
+	 * Register widget with WordPress.
+	 */
+	public function __construct() {
+		parent::__construct(
+			'currency_switcher_widget',
+			__( 'Currency Switcher', 'woocommerce-payments' ),
+			[ 'description' => __( 'Let your customers switch between your enabled currencies', 'woocommerce-payments' ) ]
+		);
+	}
+
+	/**
+	 * Front-end display of widget.
+	 *
+	 * @param array $args     Widget arguments.
+	 * @param array $instance Saved values from database.
+	 */
+	public function widget( $args, $instance ) {
+		$instance = wp_parse_args(
+			$instance,
+			self::DEFAULT_SETTINGS
+		);
+
+		$title = apply_filters( 'widget_title', $instance['title'] );
+
+		echo $args['before_widget']; // phpcs:ignore WordPress.Security.EscapeOutput
+		if ( ! empty( $title ) ) {
+			echo $args['before_title'] . $title . $args['after_title']; // phpcs:ignore WordPress.Security.EscapeOutput
+		}
+
+		?>
+		<select>
+			<?php
+			foreach ( Multi_Currency::instance()->get_enabled_currencies() as $currency ) {
+				$this->display_currency_option( $currency, $instance['symbol'], $instance['flag'] );
+			}
+			?>
+		</select>
+		<?php
+
+		echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput
+	}
+
+	/**
+	 * Back-end widget form.
+	 *
+	 * @param array $instance Previously saved values from database.
+	 */
+	public function form( $instance ) {
+		$instance = wp_parse_args(
+			$instance,
+			self::DEFAULT_SETTINGS
+		);
+		?>
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>">
+				<?php esc_html_e( 'Title:', 'woocommerce-payments' ); ?>
+			</label>
+			<input
+				class="widefat"
+				id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"
+				name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
+				type="text"
+				value="<?php echo esc_attr( $instance['title'] ); ?>"
+			/>
+		</p>
+		<p>
+			<input
+				class="checkbox"
+				id="<?php echo esc_attr( $this->get_field_id( 'symbol' ) ); ?>"
+				name="<?php echo esc_attr( $this->get_field_name( 'symbol' ) ); ?>"
+				type="checkbox"<?php checked( $instance['symbol'] ); ?>
+			/>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'symbol' ) ); ?>">
+				<?php esc_html_e( 'Display curency symbols', 'woocommerce-payments' ); ?>
+			</label>
+			<br/>
+			<input
+				class="checkbox"
+				id="<?php echo esc_attr( $this->get_field_id( 'flag' ) ); ?>"
+				name="<?php echo esc_attr( $this->get_field_name( 'flag' ) ); ?>"
+				type="checkbox"<?php checked( $instance['flag'] ); ?>
+			/>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'flag' ) ); ?>">
+				<?php esc_html_e( 'Display flags', 'woocommerce-payments' ); ?>
+			</label>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Sanitize widget form values as they are saved.
+	 *
+	 * @param array $new_instance Values just sent to be saved.
+	 * @param array $old_instance Previously saved values from database.
+	 *
+	 * @return array Updated safe values to be saved.
+	 */
+	public function update( $new_instance, $old_instance ) {
+		$new_instance = wp_parse_args(
+			$new_instance,
+			self::DEFAULT_SETTINGS
+		);
+
+		$instance = [
+			'title'  => sanitize_text_field( $new_instance['title'] ),
+			'symbol' => $new_instance['symbol'] ? 1 : 0,
+			'flag'   => $new_instance['flag'] ? 1 : 0,
+		];
+
+		return $instance;
+	}
+
+	/**
+	 * Create an <option> element with provided currency. With symbol and flag if requested.
+	 *
+	 * @param Currency $currency    Currency to use for <option> element.
+	 * @param boolean  $with_symbol Whether to show the currency symbol.
+	 * @param boolean  $with_flag   Whether to show the currency flag.
+	 * @return void Displays HTML of currency <option>
+	 */
+	private function display_currency_option( Currency $currency, bool $with_symbol, bool $with_flag ) {
+		$text = $currency->get_code();
+		if ( $with_symbol ) {
+			$text = $currency->get_symbol() . ' ' . $text;
+		}
+		if ( $with_flag ) {
+			$text = $currency->get_flag() . ' ' . $text;
+		}
+		echo "<option>$text</option>"; // phpcs:ignore WordPress.Security.EscapeOutput
+	}
+}
+
+/**
+ * Widget registration
+ *
+ * @return void
+ */
+function currency_switcher_register_widget() {
+	register_widget( 'WCPay\Multi_Currency\Currency_Switcher_Widget' );
+}
+
+add_action( 'widgets_init', 'WCPay\Multi_Currency\currency_switcher_register_widget' );

--- a/includes/multi-currency/class-currency-switcher-widget.php
+++ b/includes/multi-currency/class-currency-switcher-widget.php
@@ -54,7 +54,11 @@ class Currency_Switcher_Widget extends WP_Widget {
 
 		?>
 		<form>
-			<select name="currency" onchange="this.form.submit()">
+			<select
+				name="currency"
+				aria-label="<?php echo esc_attr( $title ); ?>"
+				onchange="this.form.submit()"
+			>
 				<?php
 				foreach ( Multi_Currency::instance()->get_enabled_currencies() as $currency ) {
 					$this->display_currency_option( $currency, $instance['symbol'], $instance['flag'] );

--- a/includes/multi-currency/class-currency-switcher-widget.php
+++ b/includes/multi-currency/class-currency-switcher-widget.php
@@ -53,13 +53,15 @@ class Currency_Switcher_Widget extends WP_Widget {
 		}
 
 		?>
-		<select>
-			<?php
-			foreach ( Multi_Currency::instance()->get_enabled_currencies() as $currency ) {
-				$this->display_currency_option( $currency, $instance['symbol'], $instance['flag'] );
-			}
-			?>
-		</select>
+		<form>
+			<select name="currency" onchange="this.form.submit()">
+				<?php
+				foreach ( Multi_Currency::instance()->get_enabled_currencies() as $currency ) {
+					$this->display_currency_option( $currency, $instance['symbol'], $instance['flag'] );
+				}
+				?>
+			</select>
+		</form>
 		<?php
 
 		echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput
@@ -144,14 +146,18 @@ class Currency_Switcher_Widget extends WP_Widget {
 	 * @return void Displays HTML of currency <option>
 	 */
 	private function display_currency_option( Currency $currency, bool $with_symbol, bool $with_flag ) {
-		$text = $currency->get_code();
+		$code     = $currency->get_code();
+		$text     = $code;
+		$selected = Multi_Currency::instance()->get_selected_currency()->code === $code ? 'selected' : '';
+
 		if ( $with_symbol ) {
 			$text = $currency->get_symbol() . ' ' . $text;
 		}
 		if ( $with_flag ) {
 			$text = $currency->get_flag() . ' ' . $text;
 		}
-		echo "<option>$text</option>"; // phpcs:ignore WordPress.Security.EscapeOutput
+
+		echo "<option value='$code' $selected>$text</option>"; // phpcs:ignore WordPress.Security.EscapeOutput
 	}
 }
 

--- a/includes/multi-currency/class-currency-switcher-widget.php
+++ b/includes/multi-currency/class-currency-switcher-widget.php
@@ -113,7 +113,7 @@ class Currency_Switcher_Widget extends WP_Widget {
 				type="checkbox"<?php checked( $instance['symbol'] ); ?>
 			/>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'symbol' ) ); ?>">
-				<?php esc_html_e( 'Display curency symbols', 'woocommerce-payments' ); ?>
+				<?php esc_html_e( 'Display currency symbols', 'woocommerce-payments' ); ?>
 			</label>
 			<br/>
 			<input

--- a/includes/multi-currency/class-currency-switcher-widget.php
+++ b/includes/multi-currency/class-currency-switcher-widget.php
@@ -127,11 +127,6 @@ class Currency_Switcher_Widget extends WP_Widget {
 	 * @return array Updated safe values to be saved.
 	 */
 	public function update( $new_instance, $old_instance ) {
-		$new_instance = wp_parse_args(
-			$new_instance,
-			self::DEFAULT_SETTINGS
-		);
-
 		$instance = [
 			'title'  => sanitize_text_field( $new_instance['title'] ),
 			'symbol' => $new_instance['symbol'] ? 1 : 0,

--- a/includes/multi-currency/class-currency-switcher-widget.php
+++ b/includes/multi-currency/class-currency-switcher-widget.php
@@ -140,8 +140,8 @@ class Currency_Switcher_Widget extends WP_Widget {
 	public function update( $new_instance, $old_instance ) {
 		$instance = [
 			'title'  => sanitize_text_field( $new_instance['title'] ),
-			'symbol' => $new_instance['symbol'] ? 1 : 0,
-			'flag'   => $new_instance['flag'] ? 1 : 0,
+			'symbol' => ( $new_instance['symbol'] ?? null ) ? 1 : 0,
+			'flag'   => ( $new_instance['flag'] ?? null ) ? 1 : 0,
 		];
 
 		return $instance;
@@ -158,7 +158,7 @@ class Currency_Switcher_Widget extends WP_Widget {
 	private function display_currency_option( Currency $currency, bool $with_symbol, bool $with_flag ) {
 		$code     = $currency->get_code();
 		$text     = $code;
-		$selected = $this->multi_currency->get_selected_currency()->code === $code ? 'selected' : '';
+		$selected = $this->multi_currency->get_selected_currency()->code === $code ? ' selected' : '';
 
 		if ( $with_symbol ) {
 			$text = $currency->get_symbol() . ' ' . $text;
@@ -167,6 +167,6 @@ class Currency_Switcher_Widget extends WP_Widget {
 			$text = $currency->get_flag() . ' ' . $text;
 		}
 
-		echo "<option value='$code' $selected>$text</option>"; // phpcs:ignore WordPress.Security.EscapeOutput
+		echo "<option value=\"$code\"$selected>$text</option>"; // phpcs:ignore WordPress.Security.EscapeOutput
 	}
 }

--- a/includes/multi-currency/class-currency-switcher-widget.php
+++ b/includes/multi-currency/class-currency-switcher-widget.php
@@ -56,7 +56,7 @@ class Currency_Switcher_Widget extends WP_Widget {
 			self::DEFAULT_SETTINGS
 		);
 
-		$title = apply_filters( 'widget_title', $instance['title'] );
+		$title = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
 
 		echo $args['before_widget']; // phpcs:ignore WordPress.Security.EscapeOutput
 		if ( ! empty( $title ) ) {

--- a/includes/multi-currency/class-currency-switcher-widget.php
+++ b/includes/multi-currency/class-currency-switcher-widget.php
@@ -23,9 +23,20 @@ class Currency_Switcher_Widget extends WP_Widget {
 	];
 
 	/**
-	 * Register widget with WordPress.
+	 * Multi-Currency instance.
+	 *
+	 * @var Multi_Currency
 	 */
-	public function __construct() {
+	protected $multi_currency;
+
+	/**
+	 * Register widget with WordPress.
+	 *
+	 * @param Multi_Currency $multi_currency The Multi_Currency instance.
+	 */
+	public function __construct( Multi_Currency $multi_currency ) {
+		$this->multi_currency = $multi_currency;
+
 		parent::__construct(
 			'currency_switcher_widget',
 			__( 'Currency Switcher', 'woocommerce-payments' ),
@@ -60,7 +71,7 @@ class Currency_Switcher_Widget extends WP_Widget {
 				onchange="this.form.submit()"
 			>
 				<?php
-				foreach ( Multi_Currency::instance()->get_enabled_currencies() as $currency ) {
+				foreach ( $this->multi_currency->get_enabled_currencies() as $currency ) {
 					$this->display_currency_option( $currency, $instance['symbol'], $instance['flag'] );
 				}
 				?>
@@ -147,7 +158,7 @@ class Currency_Switcher_Widget extends WP_Widget {
 	private function display_currency_option( Currency $currency, bool $with_symbol, bool $with_flag ) {
 		$code     = $currency->get_code();
 		$text     = $code;
-		$selected = Multi_Currency::instance()->get_selected_currency()->code === $code ? 'selected' : '';
+		$selected = $this->multi_currency->get_selected_currency()->code === $code ? 'selected' : '';
 
 		if ( $with_symbol ) {
 			$text = $currency->get_symbol() . ' ' . $text;
@@ -159,14 +170,3 @@ class Currency_Switcher_Widget extends WP_Widget {
 		echo "<option value='$code' $selected>$text</option>"; // phpcs:ignore WordPress.Security.EscapeOutput
 	}
 }
-
-/**
- * Widget registration
- *
- * @return void
- */
-function currency_switcher_register_widget() {
-	register_widget( 'WCPay\Multi_Currency\Currency_Switcher_Widget' );
-}
-
-add_action( 'widgets_init', 'WCPay\Multi_Currency\currency_switcher_register_widget' );

--- a/includes/multi-currency/class-currency-switcher-widget.php
+++ b/includes/multi-currency/class-currency-switcher-widget.php
@@ -140,8 +140,8 @@ class Currency_Switcher_Widget extends WP_Widget {
 	public function update( $new_instance, $old_instance ) {
 		$instance = [
 			'title'  => sanitize_text_field( $new_instance['title'] ),
-			'symbol' => ( $new_instance['symbol'] ?? null ) ? 1 : 0,
-			'flag'   => ( $new_instance['flag'] ?? null ) ? 1 : 0,
+			'symbol' => isset( $new_instance['symbol'] ) ? 1 : 0,
+			'flag'   => isset( $new_instance['flag'] ) ? 1 : 0,
 		];
 
 		return $instance;

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -72,6 +72,7 @@ class Multi_Currency {
 	public function init() {
 		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-currency.php';
 		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-country-flags.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-currency-switcher-widget.php';
 
 		$this->id = 'wcpay_multi_currency';
 		$this->get_available_currencies();

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -81,6 +81,12 @@ class Multi_Currency {
 
 		add_action( 'init', [ $this, 'update_selected_currency_by_url' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );
+		add_action(
+			'widgets_init',
+			function() {
+				register_widget( new Currency_Switcher_Widget( $this ) );
+			}
+		);
 	}
 
 	/**

--- a/includes/multi-currency/wc-payments-multi-currency.php
+++ b/includes/multi-currency/wc-payments-multi-currency.php
@@ -12,11 +12,6 @@ if ( ! class_exists( 'WCPay\Multi_Currency\Multi_Currency', false ) ) {
 	include_once WCPAY_ABSPATH . 'includes/multi-currency/class-multi-currency.php';
 }
 
-// Include widget.
-if ( ! class_exists( 'WCPay\Multi_Currency\Currency_Switcher_Widget', false ) ) {
-	include_once __DIR__ . '/class-currency-switcher-widget.php';
-}
-
 /**
  * Returns the main instance of Multi_Currency.
  *

--- a/includes/multi-currency/wc-payments-multi-currency.php
+++ b/includes/multi-currency/wc-payments-multi-currency.php
@@ -12,6 +12,11 @@ if ( ! class_exists( 'WCPay\Multi_Currency\Multi_Currency', false ) ) {
 	include_once WCPAY_ABSPATH . 'includes/multi-currency/class-multi-currency.php';
 }
 
+// Include widget.
+if ( ! class_exists( 'WCPay\Multi_Currency\Currency_Switcher_Widget', false ) ) {
+	include_once __DIR__ . '/class-currency-switcher-widget.php';
+}
+
 /**
  * Returns the main instance of Multi_Currency.
  *

--- a/tests/unit/multi-currency/test-class-currency-switcher-widget.php
+++ b/tests/unit/multi-currency/test-class-currency-switcher-widget.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\Multi_Currency\Currency;
+
+/**
+ * WCPay\Multi_Currency\Currency_Switcher_Widget unit tests.
+ */
+class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WP_UnitTestCase {
+	/**
+	 * Mock WCPay\Multi_Currency\Multi_Currency.
+	 *
+	 * @var WCPay\Multi_Currency\Multi_Currency|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_multi_currency;
+
+	/**
+	 * WCPay\Multi_Currency\Currency_Switcher_Widget instance.
+	 *
+	 * @var WCPay\Multi_Currency\Currency_Switcher_Widget
+	 */
+	private $currency_switcher_widget;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->mock_multi_currency = $this->createMock( WCPay\Multi_Currency\Multi_Currency::class );
+		$this->mock_multi_currency
+			->method( 'get_enabled_currencies' )
+			->willReturn(
+				[
+					new Currency( 'USD' ),
+					new Currency( 'CAD', 1.2 ),
+					new Currency( 'EUR', 0.8 ),
+				]
+			);
+
+		$this->currency_switcher_widget = new WCPay\Multi_Currency\Currency_Switcher_Widget( $this->mock_multi_currency );
+	}
+
+	public function test_widget_output() {
+		$args = [
+			'before_title'  => '<h2>',
+			'after_title'   => "</h2>\n",
+			'before_widget' => '<section>',
+			'after_widget'  => "</section>\n",
+		];
+
+		$instance = [
+			'title' => 'Test Title',
+		];
+
+		ob_start();
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( 'CAD' ) );
+		$this->currency_switcher_widget->widget( $args, $instance );
+		$output = ob_get_clean();
+		$this->assertContains( '<h2>Test Title</h2>', $output );
+		$this->assertContains( '<section>', $output );
+		$this->assertContains( '</section>', $output );
+		$this->assertContains( 'aria-label="Test Title"', $output );
+		$this->assertContains( 'onchange="this.form.submit()"', $output );
+		$this->assertContains( '<option value="USD">&#36; USD</option>', $output );
+		$this->assertContains( '<option value="CAD" selected>&#36; CAD</option>', $output );
+		$this->assertContains( '<option value="EUR">&euro; EUR</option>', $output );
+
+		// Show flag and hide symbol.
+		ob_start();
+		$instance['flag']   = true;
+		$instance['symbol'] = false;
+		$this->currency_switcher_widget->widget( $args, $instance );
+		$output = ob_get_clean();
+		$this->assertContains( '<option value="USD">🇺🇸 USD</option>', $output );
+	}
+
+	public function test_update_method() {
+		$old_instance = [];
+		$new_instance = [
+			'title'  => "Title <br/> \n",
+			'symbol' => 'on',
+		];
+
+		$result = $this->currency_switcher_widget->update( $new_instance, $old_instance );
+		$this->assertEquals(
+			[
+				'title'  => 'Title',
+				'symbol' => 1,
+				'flag'   => 0,
+			],
+			$result
+		);
+	}
+
+	public function test_form_output() {
+		$instance = [
+			'title'  => 'Custom title',
+			'symbol' => 0,
+			'flag'   => 0,
+		];
+
+		ob_start();
+		$this->currency_switcher_widget->form( $instance );
+		$output = ob_get_clean();
+
+		$this->assertContains( 'name="widget-currency_switcher_widget[][title]"', $output );
+		$this->assertContains( 'value="Custom title"', $output );
+		$this->assertContains( 'name="widget-currency_switcher_widget[][symbol]"', $output );
+		$this->assertContains( 'name="widget-currency_switcher_widget[][flag]"', $output );
+		$this->assertNotContains( 'checked=\'checked\'', $output );
+	}
+}


### PR DESCRIPTION
Fixes #1766 

#### Changes proposed in this Pull Request

Following specs in paJDYF-1kA-p2. Add a legacy widget with:
- Customizable title
- Optionally show currency symbol. Defaults to true.
- Optionally show currency flag. Defaults to false.

Used a form that submits on select change with the selected `currency` value.

#### Screenshots
| backend | fronted closed | fronted opened | with flags |
|-|-|-|-|
|<img width="310" alt="Screenshot 2021-05-19 at 12 32 45" src="https://user-images.githubusercontent.com/7670276/118798930-7ad42880-b89e-11eb-8b11-0ee39c270525.png">|<img width="217" alt="Screenshot 2021-05-19 at 12 33 02" src="https://user-images.githubusercontent.com/7670276/118798937-7c055580-b89e-11eb-8b0f-bbea58746242.png">|<img width="210" alt="Screenshot 2021-05-19 at 12 33 26" src="https://user-images.githubusercontent.com/7670276/118798940-7c055580-b89e-11eb-806b-2da0b355d1fb.png">|<img width="173" alt="Screenshot 2021-05-21 at 11 59 24" src="https://user-images.githubusercontent.com/7670276/119120009-134be380-ba2c-11eb-82ff-d303b92477b1.png">|

#### Testing instructions

* Go to **Appearance > Widgets** and add the new **Currency Switcher** widget to the sidebar (for example).
* You should be able to modify the title and show/hide the symbol and flag.
* Selecting a currency should redirect to the same page with the URL param `currency=[selected currency code]`.