### PR TITLE
Add customer facing prices for customer multi-currency

### DIFF
--- a/includes/multi-currency/class-frontend-currencies.php
+++ b/includes/multi-currency/class-frontend-currencies.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * WooCommerce Payments Multi Currency Frontend Currencies
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Multi_Currency;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class that formats Multi Currency currencies on the frontend.
+ */
+class Frontend_Currencies {
+	/**
+	 * Multi-Currency instance.
+	 *
+	 * @var Multi_Currency
+	 */
+	protected $multi_currency;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Multi_Currency $multi_currency The Multi_Currency instance.
+	 */
+	public function __construct( Multi_Currency $multi_currency ) {
+		$this->multi_currency = $multi_currency;
+
+		// Currency hooks.
+		add_filter( 'woocommerce_currency', [ $this, 'get_current_currency_code' ] );
+	}
+
+	/**
+	 * Returns the currency code to be used by WooCommerce.
+	 *
+	 * @return string The code of the currency to be used.
+	 */
+	public function get_current_currency_code() {
+		return $this->multi_currency->get_selected_currency()->get_code();
+	}
+}

--- a/includes/multi-currency/class-frontend-currencies.php
+++ b/includes/multi-currency/class-frontend-currencies.php
@@ -21,6 +21,13 @@ class Frontend_Currencies {
 	protected $multi_currency;
 
 	/**
+	 * Multi-Currency currency formatting map.
+	 *
+	 * @var array
+	 */
+	protected $currency_settings = [];
+
+	/**
 	 * Constructor.
 	 *
 	 * @param Multi_Currency $multi_currency The Multi_Currency instance.
@@ -28,8 +35,14 @@ class Frontend_Currencies {
 	public function __construct( Multi_Currency $multi_currency ) {
 		$this->multi_currency = $multi_currency;
 
+		$this->load_locale_data();
+
 		// Currency hooks.
 		add_filter( 'woocommerce_currency', [ $this, 'get_current_currency_code' ] );
+		add_filter( 'wc_get_price_decimals', [ $this, 'get_current_currency_decimals' ] );
+		add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_current_currency_decimal_separator' ] );
+		add_filter( 'wc_get_price_thousand_separator', [ $this, 'get_current_currency_thousand_separator' ] );
+		add_filter( 'woocommerce_price_format', [ $this, 'get_current_currency_format' ] );
 	}
 
 	/**
@@ -39,5 +52,104 @@ class Frontend_Currencies {
 	 */
 	public function get_current_currency_code() {
 		return $this->multi_currency->get_selected_currency()->get_code();
+	}
+
+	/**
+	 * Returns the number of decimals to be used by WooCommerce.
+	 *
+	 * @return int The number of decimals.
+	 */
+	public function get_current_currency_decimals() {
+		$currency_code = $this->multi_currency->get_selected_currency()->get_code();
+		return $this->get_currency_settings( $currency_code )['num_decimals'];
+	}
+
+	/**
+	 * Returns the decimal separator to be used by WooCommerce.
+	 *
+	 * @return int The decimal separator.
+	 */
+	public function get_current_currency_decimal_separator() {
+		$currency_code = $this->multi_currency->get_selected_currency()->get_code();
+		return $this->get_currency_settings( $currency_code )['decimal_sep'];
+	}
+
+	/**
+	 * Returns the thousand separator to be used by WooCommerce.
+	 *
+	 * @return int The thousand separator.
+	 */
+	public function get_current_currency_thousand_separator() {
+		$currency_code = $this->multi_currency->get_selected_currency()->get_code();
+		return $this->get_currency_settings( $currency_code )['thousand_sep'];
+	}
+
+	/**
+	 * Returns the currency format to be used by WooCommerce.
+	 *
+	 * @return int The currency format.
+	 */
+	public function get_current_currency_format() {
+		$currency_code = $this->multi_currency->get_selected_currency()->get_code();
+		$currency_pos  = $this->get_currency_settings( $currency_code )['currency_pos'];
+
+		switch ( $currency_pos ) {
+			case 'left':
+				return '%1$s%2$s';
+			case 'right':
+				return '%2$s%1$s';
+			case 'left_space':
+				return '%1$s&nbsp;%2$s';
+			case 'right_space':
+				return '%2$s&nbsp;%1$s';
+			default:
+				return '%1$s%2$s';
+		}
+	}
+
+	/**
+	 * Retrieves the currency's settings from mapped data.
+	 *
+	 * @param string $currency_code The currency code.
+	 *
+	 * @return array The currency's settings.
+	 */
+	private function get_currency_settings( $currency_code ) {
+		// Default to USD settings if mapping not found.
+		$currency_settings = $this->currency_settings[ $currency_code ] ?? [
+			'currency_pos' => 'left',
+			'thousand_sep' => ',',
+			'decimal_sep'  => '.',
+			'num_decimals' => 2,
+		];
+
+		return apply_filters( 'wcpay_multi_currency_currency_settings', $currency_settings, $currency_code );
+	}
+
+	/**
+	 * Loads locale data from WooCommerce core (/i18n/locale-info.php) and maps it
+	 * to be used by currency.
+	 */
+	private function load_locale_data() {
+		$locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
+
+		// Extract the currency formatting options from the locale info.
+		foreach ( $locale_info as $locale ) {
+			$currency_code = $locale['currency_code'];
+
+			// Convert Norwegian Krone symbol to its ISO 4217 currency code.
+			if ( 'Kr' === $currency_code ) {
+				$currency_code = 'NOK';
+			}
+
+			if ( empty( $this->currency_settings[ $currency_code ] ) ) {
+				$this->currency_settings[ $currency_code ] = [
+					'currency_pos' => $locale['currency_pos'],
+					'thousand_sep' => $locale['thousand_sep'],
+					'decimal_sep'  => $locale['decimal_sep'],
+					'num_decimals' => $locale['num_decimals'],
+				];
+			}
+		}
 	}
 }

--- a/includes/multi-currency/class-frontend-currencies.php
+++ b/includes/multi-currency/class-frontend-currencies.php
@@ -38,11 +38,11 @@ class Frontend_Currencies {
 		$this->load_locale_data();
 
 		// Currency hooks.
-		add_filter( 'woocommerce_currency', [ $this, 'get_current_currency_code' ], 50 );
-		add_filter( 'wc_get_price_decimals', [ $this, 'get_current_currency_decimals' ], 50 );
-		add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_current_currency_decimal_separator' ], 50 );
-		add_filter( 'wc_get_price_thousand_separator', [ $this, 'get_current_currency_thousand_separator' ], 50 );
-		add_filter( 'woocommerce_price_format', [ $this, 'get_current_currency_format' ], 50 );
+		add_filter( 'woocommerce_currency', [ $this, 'get_woocommerce_currency' ], 50 );
+		add_filter( 'wc_get_price_decimals', [ $this, 'get_price_decimals' ], 50 );
+		add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 50 );
+		add_filter( 'wc_get_price_thousand_separator', [ $this, 'get_price_thousand_separator' ], 50 );
+		add_filter( 'woocommerce_price_format', [ $this, 'get_woocommerce_price_format' ], 50 );
 	}
 
 	/**
@@ -50,7 +50,7 @@ class Frontend_Currencies {
 	 *
 	 * @return string The code of the currency to be used.
 	 */
-	public function get_current_currency_code() {
+	public function get_woocommerce_currency() {
 		return $this->multi_currency->get_selected_currency()->get_code();
 	}
 
@@ -59,7 +59,7 @@ class Frontend_Currencies {
 	 *
 	 * @return int The number of decimals.
 	 */
-	public function get_current_currency_decimals() {
+	public function get_price_decimals() {
 		$currency_code = $this->multi_currency->get_selected_currency()->get_code();
 		return $this->get_currency_settings( $currency_code )['num_decimals'];
 	}
@@ -69,7 +69,7 @@ class Frontend_Currencies {
 	 *
 	 * @return int The decimal separator.
 	 */
-	public function get_current_currency_decimal_separator() {
+	public function get_price_decimal_separator() {
 		$currency_code = $this->multi_currency->get_selected_currency()->get_code();
 		return $this->get_currency_settings( $currency_code )['decimal_sep'];
 	}
@@ -79,7 +79,7 @@ class Frontend_Currencies {
 	 *
 	 * @return int The thousand separator.
 	 */
-	public function get_current_currency_thousand_separator() {
+	public function get_price_thousand_separator() {
 		$currency_code = $this->multi_currency->get_selected_currency()->get_code();
 		return $this->get_currency_settings( $currency_code )['thousand_sep'];
 	}
@@ -89,7 +89,7 @@ class Frontend_Currencies {
 	 *
 	 * @return int The currency format.
 	 */
-	public function get_current_currency_format() {
+	public function get_woocommerce_price_format() {
 		$currency_code = $this->multi_currency->get_selected_currency()->get_code();
 		$currency_pos  = $this->get_currency_settings( $currency_code )['currency_pos'];
 

--- a/includes/multi-currency/class-frontend-currencies.php
+++ b/includes/multi-currency/class-frontend-currencies.php
@@ -123,7 +123,7 @@ class Frontend_Currencies {
 			'num_decimals' => 2,
 		];
 
-		return apply_filters( 'wcpay_multi_currency_currency_settings', $currency_settings, $currency_code );
+		return apply_filters( 'wcpay_multi_currency_' . strtolower( $currency_code ) . '_settings', $currency_settings );
 	}
 
 	/**

--- a/includes/multi-currency/class-frontend-currencies.php
+++ b/includes/multi-currency/class-frontend-currencies.php
@@ -38,11 +38,11 @@ class Frontend_Currencies {
 		$this->load_locale_data();
 
 		// Currency hooks.
-		add_filter( 'woocommerce_currency', [ $this, 'get_current_currency_code' ] );
-		add_filter( 'wc_get_price_decimals', [ $this, 'get_current_currency_decimals' ] );
-		add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_current_currency_decimal_separator' ] );
-		add_filter( 'wc_get_price_thousand_separator', [ $this, 'get_current_currency_thousand_separator' ] );
-		add_filter( 'woocommerce_price_format', [ $this, 'get_current_currency_format' ] );
+		add_filter( 'woocommerce_currency', [ $this, 'get_current_currency_code' ], 50 );
+		add_filter( 'wc_get_price_decimals', [ $this, 'get_current_currency_decimals' ], 50 );
+		add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_current_currency_decimal_separator' ], 50 );
+		add_filter( 'wc_get_price_thousand_separator', [ $this, 'get_current_currency_thousand_separator' ], 50 );
+		add_filter( 'woocommerce_price_format', [ $this, 'get_current_currency_format' ], 50 );
 	}
 
 	/**

--- a/includes/multi-currency/class-frontend-currencies.php
+++ b/includes/multi-currency/class-frontend-currencies.php
@@ -25,7 +25,7 @@ class Frontend_Currencies {
 	 *
 	 * @var array
 	 */
-	protected $currency_settings = [];
+	protected $currency_format = [];
 
 	/**
 	 * Constructor.
@@ -61,7 +61,7 @@ class Frontend_Currencies {
 	 */
 	public function get_price_decimals() {
 		$currency_code = $this->multi_currency->get_selected_currency()->get_code();
-		return $this->get_currency_settings( $currency_code )['num_decimals'];
+		return $this->get_currency_format( $currency_code )['num_decimals'];
 	}
 
 	/**
@@ -71,7 +71,7 @@ class Frontend_Currencies {
 	 */
 	public function get_price_decimal_separator() {
 		$currency_code = $this->multi_currency->get_selected_currency()->get_code();
-		return $this->get_currency_settings( $currency_code )['decimal_sep'];
+		return $this->get_currency_format( $currency_code )['decimal_sep'];
 	}
 
 	/**
@@ -81,7 +81,7 @@ class Frontend_Currencies {
 	 */
 	public function get_price_thousand_separator() {
 		$currency_code = $this->multi_currency->get_selected_currency()->get_code();
-		return $this->get_currency_settings( $currency_code )['thousand_sep'];
+		return $this->get_currency_format( $currency_code )['thousand_sep'];
 	}
 
 	/**
@@ -91,7 +91,7 @@ class Frontend_Currencies {
 	 */
 	public function get_woocommerce_price_format() {
 		$currency_code = $this->multi_currency->get_selected_currency()->get_code();
-		$currency_pos  = $this->get_currency_settings( $currency_code )['currency_pos'];
+		$currency_pos  = $this->get_currency_format( $currency_code )['currency_pos'];
 
 		switch ( $currency_pos ) {
 			case 'left':
@@ -108,22 +108,22 @@ class Frontend_Currencies {
 	}
 
 	/**
-	 * Retrieves the currency's settings from mapped data.
+	 * Retrieves the currency's format from mapped data.
 	 *
 	 * @param string $currency_code The currency code.
 	 *
-	 * @return array The currency's settings.
+	 * @return array The currency's format.
 	 */
-	private function get_currency_settings( $currency_code ) {
+	private function get_currency_format( $currency_code ) {
 		// Default to USD settings if mapping not found.
-		$currency_settings = $this->currency_settings[ $currency_code ] ?? [
+		$currency_format = $this->currency_format[ $currency_code ] ?? [
 			'currency_pos' => 'left',
 			'thousand_sep' => ',',
 			'decimal_sep'  => '.',
 			'num_decimals' => 2,
 		];
 
-		return apply_filters( 'wcpay_multi_currency_' . strtolower( $currency_code ) . '_settings', $currency_settings );
+		return apply_filters( 'wcpay_multi_currency_' . strtolower( $currency_code ) . '_format', $currency_format );
 	}
 
 	/**
@@ -142,8 +142,8 @@ class Frontend_Currencies {
 				$currency_code = 'NOK';
 			}
 
-			if ( empty( $this->currency_settings[ $currency_code ] ) ) {
-				$this->currency_settings[ $currency_code ] = [
+			if ( empty( $this->currency_format[ $currency_code ] ) ) {
+				$this->currency_format[ $currency_code ] = [
 					'currency_pos' => $locale['currency_pos'],
 					'thousand_sep' => $locale['thousand_sep'],
 					'decimal_sep'  => $locale['decimal_sep'],

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -105,9 +105,17 @@ class Frontend_Prices {
 	 * @return array Shipping rates with converted costs.
 	 */
 	public function get_shipping_rates_prices( $rates ) {
-		foreach ( $rates as $key => $rate ) {
+		foreach ( $rates as $rate ) {
 			if ( $rate->cost ) {
-				$rates[ $key ]->cost = $this->multi_currency->get_price( $rate->cost, false );
+				$rate->cost = $this->multi_currency->get_price( $rate->cost, false );
+			}
+			if ( $rate->taxes ) {
+				$rate->taxes = array_map(
+					function ( $tax ) {
+						return $this->multi_currency->get_price( $tax, false );
+					},
+					$rate->taxes
+				);
 			}
 		}
 		return $rates;

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -152,7 +152,9 @@ class Frontend_Prices {
 			return $amount;
 		}
 
-		return $this->multi_currency->get_price( $amount, 'coupon_min_max' );
+		// Coupon mix/max prices are treated as products to avoid inconsistencies with charm pricing
+		// making a coupon invalid when the coupon min/max amount is the same as the product's price.
+		return $this->multi_currency->get_price( $amount, 'product' );
 	}
 
 	/**

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -29,26 +29,26 @@ class Frontend_Prices {
 		$this->multi_currency = $multi_currency;
 
 		// Simple product price hooks.
-		add_filter( 'woocommerce_product_get_price', [ $this, 'get_product_price' ] );
-		add_filter( 'woocommerce_product_get_regular_price', [ $this, 'get_product_price' ] );
-		add_filter( 'woocommerce_product_get_sale_price', [ $this, 'get_product_price' ] );
+		add_filter( 'woocommerce_product_get_price', [ $this, 'get_product_price' ], 50 );
+		add_filter( 'woocommerce_product_get_regular_price', [ $this, 'get_product_price' ], 50 );
+		add_filter( 'woocommerce_product_get_sale_price', [ $this, 'get_product_price' ], 50 );
 
 		// Variation price hooks.
-		add_filter( 'woocommerce_product_variation_get_price', [ $this, 'get_product_price' ] );
-		add_filter( 'woocommerce_product_variation_get_regular_price', [ $this, 'get_product_price' ] );
-		add_filter( 'woocommerce_product_variation_get_sale_price', [ $this, 'get_product_price' ] );
+		add_filter( 'woocommerce_product_variation_get_price', [ $this, 'get_product_price' ], 50 );
+		add_filter( 'woocommerce_product_variation_get_regular_price', [ $this, 'get_product_price' ], 50 );
+		add_filter( 'woocommerce_product_variation_get_sale_price', [ $this, 'get_product_price' ], 50 );
 
 		// Variation price range hooks.
-		add_filter( 'woocommerce_variation_prices', [ $this, 'get_variation_price_range' ] );
-		add_filter( 'woocommerce_get_variation_prices_hash', [ $this, 'add_exchange_rate_to_variation_prices_hash' ] );
+		add_filter( 'woocommerce_variation_prices', [ $this, 'get_variation_price_range' ], 50 );
+		add_filter( 'woocommerce_get_variation_prices_hash', [ $this, 'add_exchange_rate_to_variation_prices_hash' ], 50 );
 
 		// Shipping methods hooks.
-		add_filter( 'woocommerce_package_rates', [ $this, 'get_shipping_rates_prices' ] );
+		add_filter( 'woocommerce_package_rates', [ $this, 'get_shipping_rates_prices' ], 50 );
 
 		// Coupon hooks.
-		add_filter( 'woocommerce_coupon_get_amount', [ $this, 'get_coupon_amount' ], 20, 2 );
-		add_filter( 'woocommerce_coupon_get_minimum_amount', [ $this, 'get_coupon_min_max_amount' ] );
-		add_filter( 'woocommerce_coupon_get_maximum_amount', [ $this, 'get_coupon_min_max_amount' ] );
+		add_filter( 'woocommerce_coupon_get_amount', [ $this, 'get_coupon_amount' ], 50, 2 );
+		add_filter( 'woocommerce_coupon_get_minimum_amount', [ $this, 'get_coupon_min_max_amount' ], 50 );
+		add_filter( 'woocommerce_coupon_get_maximum_amount', [ $this, 'get_coupon_min_max_amount' ], 50 );
 	}
 
 	/**

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -43,7 +43,7 @@ class Frontend_Prices {
 		add_filter( 'woocommerce_get_variation_prices_hash', [ $this, 'add_exchange_rate_to_variation_prices_hash' ], 50 );
 
 		// Shipping methods hooks.
-		add_filter( 'woocommerce_package_rates', [ $this, 'get_shipping_rates_prices' ], 50 );
+		add_filter( 'woocommerce_package_rates', [ $this, 'convert_package_rates_prices' ], 50 );
 		add_filter( 'init', [ $this, 'register_free_shipping_filters' ], 50 );
 
 		// Coupon hooks.
@@ -105,7 +105,7 @@ class Frontend_Prices {
 	 *
 	 * @return array Shipping rates with converted costs.
 	 */
-	public function get_shipping_rates_prices( $rates ) {
+	public function convert_package_rates_prices( $rates ) {
 		foreach ( $rates as $rate ) {
 			if ( $rate->cost ) {
 				$rate->cost = $this->multi_currency->get_price( $rate->cost, 'shipping' );

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -63,7 +63,7 @@ class Frontend_Prices {
 	 *
 	 * @param mixed $price The product's price.
 	 *
-	 * @return float The converted product's price.
+	 * @return mixed The converted product's price.
 	 */
 	public function get_product_price( $price ) {
 		if ( ! $price ) {

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -44,7 +44,7 @@ class Frontend_Prices {
 
 		// Shipping methods hooks.
 		add_filter( 'woocommerce_package_rates', [ $this, 'get_shipping_rates_prices' ], 50 );
-		$this->register_free_shipping_filters();
+		add_filter( 'init', [ $this, 'register_free_shipping_filters' ], 50 );
 
 		// Coupon hooks.
 		add_filter( 'woocommerce_coupon_get_amount', [ $this, 'get_coupon_amount' ], 50, 2 );
@@ -178,7 +178,7 @@ class Frontend_Prices {
 	/**
 	 * Register the hooks to set the min amount for free shipping methods.
 	 */
-	private function register_free_shipping_filters() {
+	public function register_free_shipping_filters() {
 		$shipping_zones = \WC_Shipping_Zones::get_zones();
 
 		$default_zone = \WC_Shipping_Zones::get_zone( 0 );

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -47,6 +47,11 @@ class Frontend_Prices {
 
 		// Shipping methods hooks.
 		add_filter( 'woocommerce_package_rates', [ $this, 'get_shipping_rates_prices' ] );
+
+		// Coupon hooks.
+		add_filter( 'woocommerce_coupon_get_amount', [ $this, 'get_coupon_amount' ], 20, 2 );
+		add_filter( 'woocommerce_coupon_get_minimum_amount', [ $this, 'get_coupon_min_max_amount' ] );
+		add_filter( 'woocommerce_coupon_get_maximum_amount', [ $this, 'get_coupon_min_max_amount' ] );
 	}
 
 	/**
@@ -120,5 +125,38 @@ class Frontend_Prices {
 			}
 		}
 		return $rates;
+	}
+
+	/**
+	 * Returns the amount for a coupon.
+	 *
+	 * @param mixed  $amount The coupon's amount.
+	 * @param object $coupon The coupon object.
+	 *
+	 * @return mixed The converted coupon's amount.
+	 */
+	public function get_coupon_amount( $amount, $coupon ) {
+		$percent_coupon_types = [ 'percent' ];
+
+		if ( ! $amount || $coupon->is_type( $percent_coupon_types ) ) {
+			return $amount;
+		}
+
+		return $this->multi_currency->get_price( $amount );
+	}
+
+	/**
+	 * Returns the min or max amount for a coupon.
+	 *
+	 * @param mixed $amount The coupon's min or max amount.
+	 *
+	 * @return mixed The converted coupon's min or max amount.
+	 */
+	public function get_coupon_min_max_amount( $amount ) {
+		if ( ! $amount ) {
+			return $amount;
+		}
+
+		return $this->multi_currency->get_price( $amount );
 	}
 }

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -88,9 +88,7 @@ class Frontend_Prices {
 	public function get_variation_price_range( $variation_prices ) {
 		foreach ( $variation_prices as $price_type => $prices ) {
 			foreach ( $prices as $variation_id => $price ) {
-				if ( $price ) {
-					$variation_prices[ $price_type ][ $variation_id ] = $this->multi_currency->get_price( $price );
-				}
+				$variation_prices[ $price_type ][ $variation_id ] = $this->get_product_price( $price );
 			}
 		}
 

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -44,7 +44,7 @@ class Frontend_Prices {
 
 		// Shipping methods hooks.
 		add_filter( 'woocommerce_package_rates', [ $this, 'convert_package_rates_prices' ], 50 );
-		add_filter( 'init', [ $this, 'register_free_shipping_filters' ], 50 );
+		add_action( 'init', [ $this, 'register_free_shipping_filters' ], 50 );
 
 		// Coupon hooks.
 		add_filter( 'woocommerce_coupon_get_amount', [ $this, 'get_coupon_amount' ], 50, 2 );

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -28,9 +28,6 @@ class Frontend_Prices {
 	public function __construct( Multi_Currency $multi_currency ) {
 		$this->multi_currency = $multi_currency;
 
-		// Currency hooks.
-		add_filter( 'woocommerce_currency', [ $this, 'get_current_currency_code' ] );
-
 		// Simple product price hooks.
 		add_filter( 'woocommerce_product_get_price', [ $this, 'get_product_price' ] );
 		add_filter( 'woocommerce_product_get_regular_price', [ $this, 'get_product_price' ] );
@@ -52,15 +49,6 @@ class Frontend_Prices {
 		add_filter( 'woocommerce_coupon_get_amount', [ $this, 'get_coupon_amount' ], 20, 2 );
 		add_filter( 'woocommerce_coupon_get_minimum_amount', [ $this, 'get_coupon_min_max_amount' ] );
 		add_filter( 'woocommerce_coupon_get_maximum_amount', [ $this, 'get_coupon_min_max_amount' ] );
-	}
-
-	/**
-	 * Returns the currency code to be used by WooCommerce.
-	 *
-	 * @return string The code of the currency to be used.
-	 */
-	public function get_current_currency_code() {
-		return $this->multi_currency->get_selected_currency()->get_code();
 	}
 
 	/**

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -44,6 +44,7 @@ class Frontend_Prices {
 
 		// Shipping methods hooks.
 		add_filter( 'woocommerce_package_rates', [ $this, 'get_shipping_rates_prices' ], 50 );
+		$this->register_free_shipping_filters();
 
 		// Coupon hooks.
 		add_filter( 'woocommerce_coupon_get_amount', [ $this, 'get_coupon_amount' ], 50, 2 );
@@ -152,5 +153,44 @@ class Frontend_Prices {
 		}
 
 		return $this->multi_currency->get_price( $amount, 'coupon_min_max' );
+	}
+
+	/**
+	 * Returns the free shipping zone settings with converted min_amount.
+	 *
+	 * @param array $data The shipping zone settings.
+	 *
+	 * @return array The shipping zone settings with converted min_amount.
+	 */
+	public function get_free_shipping_min_amount( $data ) {
+		if ( ! isset( $data['min_amount'] ) || ! $data['min_amount'] ) {
+			return $data;
+		}
+
+		// Free shipping min amount is treated as products to avoid inconsistencies with charm pricing
+		// making a method invalid when its min amount is the same as the product's price.
+		$data['min_amount'] = $this->multi_currency->get_price( $data['min_amount'], 'product' );
+		return $data;
+	}
+
+	/**
+	 * Register the hooks to set the min amount for free shipping methods.
+	 */
+	private function register_free_shipping_filters() {
+		$shipping_zones = \WC_Shipping_Zones::get_zones();
+
+		$default_zone = \WC_Shipping_Zones::get_zone( 0 );
+		if ( $default_zone ) {
+			$shipping_zones[] = [ 'shipping_methods' => $default_zone->get_shipping_methods() ];
+		}
+
+		foreach ( $shipping_zones as $shipping_zone ) {
+			foreach ( $shipping_zone['shipping_methods'] as $shipping_method ) {
+				if ( 'free_shipping' === $shipping_method->id ) {
+					$option_name = 'option_woocommerce_' . trim( $shipping_method->id ) . '_' . intval( $shipping_method->instance_id ) . '_settings';
+					add_filter( $option_name, [ $this, 'get_free_shipping_min_amount' ], 50 );
+				}
+			}
+		}
 	}
 }

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -63,7 +63,7 @@ class Frontend_Prices {
 			return $price;
 		}
 
-		return $this->multi_currency->get_price( $price );
+		return $this->multi_currency->get_price( $price, 'product' );
 	}
 
 	/**
@@ -107,12 +107,12 @@ class Frontend_Prices {
 	public function get_shipping_rates_prices( $rates ) {
 		foreach ( $rates as $rate ) {
 			if ( $rate->cost ) {
-				$rate->cost = $this->multi_currency->get_price( $rate->cost, false );
+				$rate->cost = $this->multi_currency->get_price( $rate->cost, 'shipping' );
 			}
 			if ( $rate->taxes ) {
 				$rate->taxes = array_map(
 					function ( $tax ) {
-						return $this->multi_currency->get_price( $tax, false );
+						return $this->multi_currency->get_price( $tax, 'tax' );
 					},
 					$rate->taxes
 				);
@@ -136,7 +136,7 @@ class Frontend_Prices {
 			return $amount;
 		}
 
-		return $this->multi_currency->get_price( $amount, false );
+		return $this->multi_currency->get_price( $amount, 'coupon' );
 	}
 
 	/**
@@ -151,6 +151,6 @@ class Frontend_Prices {
 			return $amount;
 		}
 
-		return $this->multi_currency->get_price( $amount, false );
+		return $this->multi_currency->get_price( $amount, 'coupon' );
 	}
 }

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -151,6 +151,6 @@ class Frontend_Prices {
 			return $amount;
 		}
 
-		return $this->multi_currency->get_price( $amount, 'coupon' );
+		return $this->multi_currency->get_price( $amount, 'coupon_min_max' );
 	}
 }

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * WooCommerce Payments Multi Currency Frontend Prices
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Multi_Currency;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class that applies Multi Currency prices on the frontend.
+ */
+class Frontend_Prices {
+	/**
+	 * Multi-Currency instance.
+	 *
+	 * @var Multi_Currency
+	 */
+	protected $multi_currency;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Multi_Currency $multi_currency The Multi_Currency instance.
+	 */
+	public function __construct( Multi_Currency $multi_currency ) {
+		$this->multi_currency = $multi_currency;
+
+		// Currency hooks.
+		add_filter( 'woocommerce_currency', [ $this, 'get_current_currency_code' ] );
+
+		// Simple product price hooks.
+		add_filter( 'woocommerce_product_get_price', [ $this, 'get_product_price' ] );
+		add_filter( 'woocommerce_product_get_regular_price', [ $this, 'get_product_price' ] );
+		add_filter( 'woocommerce_product_get_sale_price', [ $this, 'get_product_price' ] );
+
+		// Variation price hooks.
+		add_filter( 'woocommerce_product_variation_get_price', [ $this, 'get_product_price' ] );
+		add_filter( 'woocommerce_product_variation_get_regular_price', [ $this, 'get_product_price' ] );
+		add_filter( 'woocommerce_product_variation_get_sale_price', [ $this, 'get_product_price' ] );
+
+		// Variation price range hooks.
+		add_filter( 'woocommerce_variation_prices', [ $this, 'get_variation_price_range' ] );
+		add_filter( 'woocommerce_get_variation_prices_hash', [ $this, 'add_exchange_rate_to_variation_prices_hash' ] );
+	}
+
+	/**
+	 * Returns the currency code to be used by WooCommerce.
+	 *
+	 * @return string The code of the currency to be used.
+	 */
+	public function get_current_currency_code() {
+		return $this->multi_currency->get_selected_currency()->get_code();
+	}
+
+	/**
+	 * Returns the price for a product.
+	 *
+	 * @param mixed $price The product's price.
+	 *
+	 * @return float The converted product's price.
+	 */
+	public function get_product_price( $price ) {
+		return $this->multi_currency->get_price( $price );
+	}
+
+	/**
+	 * Returns the price range for a variation.
+	 *
+	 * @param array $variation_prices The variation's prices.
+	 *
+	 * @return array The converted variation's prices.
+	 */
+	public function get_variation_price_range( $variation_prices ) {
+		foreach ( $variation_prices as $price_type => $prices ) {
+			foreach ( $prices as $variation_id => $price ) {
+				$variation_prices[ $price_type ][ $variation_id ] = $this->multi_currency->get_price( $price );
+			}
+		}
+
+		return $variation_prices;
+	}
+
+	/**
+	 * Add the exchange rate into account for the variation prices hash.
+	 * This is used to recalculate the variation price range when the exchange
+	 * rate changes, otherwise the old prices will be cached.
+	 *
+	 * @param array $prices_hash The variation prices hash.
+	 *
+	 * @return array The variation prices hash with the current exchange rate.
+	 */
+	public function add_exchange_rate_to_variation_prices_hash( $prices_hash ) {
+		$prices_hash[] = $this->get_product_price( 1 );
+		return $prices_hash;
+	}
+}

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -44,6 +44,9 @@ class Frontend_Prices {
 		// Variation price range hooks.
 		add_filter( 'woocommerce_variation_prices', [ $this, 'get_variation_price_range' ] );
 		add_filter( 'woocommerce_get_variation_prices_hash', [ $this, 'add_exchange_rate_to_variation_prices_hash' ] );
+
+		// Shipping methods hooks.
+		add_filter( 'woocommerce_package_rates', [ $this, 'get_shipping_rates_prices' ] );
 	}
 
 	/**
@@ -101,5 +104,21 @@ class Frontend_Prices {
 	public function add_exchange_rate_to_variation_prices_hash( $prices_hash ) {
 		$prices_hash[] = $this->get_product_price( 1 );
 		return $prices_hash;
+	}
+
+	/**
+	 * Returns the shipping rates with their prices converted.
+	 *
+	 * @param array $rates Shipping rates.
+	 *
+	 * @return array Shipping rates with converted costs.
+	 */
+	public function get_shipping_rates_prices( $rates ) {
+		foreach ( $rates as $key => $rate ) {
+			if ( $rate->cost ) {
+				$rates[ $key ]->cost = $this->multi_currency->get_price( $rate->cost );
+			}
+		}
+		return $rates;
 	}
 }

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -121,7 +121,7 @@ class Frontend_Prices {
 	public function get_shipping_rates_prices( $rates ) {
 		foreach ( $rates as $key => $rate ) {
 			if ( $rate->cost ) {
-				$rates[ $key ]->cost = $this->multi_currency->get_price( $rate->cost );
+				$rates[ $key ]->cost = $this->multi_currency->get_price( $rate->cost, false );
 			}
 		}
 		return $rates;
@@ -142,7 +142,7 @@ class Frontend_Prices {
 			return $amount;
 		}
 
-		return $this->multi_currency->get_price( $amount );
+		return $this->multi_currency->get_price( $amount, false );
 	}
 
 	/**
@@ -157,6 +157,6 @@ class Frontend_Prices {
 			return $amount;
 		}
 
-		return $this->multi_currency->get_price( $amount );
+		return $this->multi_currency->get_price( $amount, false );
 	}
 }

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -63,6 +63,10 @@ class Frontend_Prices {
 	 * @return float The converted product's price.
 	 */
 	public function get_product_price( $price ) {
+		if ( ! $price ) {
+			return $price;
+		}
+
 		return $this->multi_currency->get_price( $price );
 	}
 
@@ -76,7 +80,9 @@ class Frontend_Prices {
 	public function get_variation_price_range( $variation_prices ) {
 		foreach ( $variation_prices as $price_type => $prices ) {
 			foreach ( $prices as $variation_id => $price ) {
-				$variation_prices[ $price_type ][ $variation_id ] = $this->multi_currency->get_price( $price );
+				if ( $price ) {
+					$variation_prices[ $price_type ][ $variation_id ] = $this->multi_currency->get_price( $price );
+				}
 			}
 		}
 

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -24,6 +24,13 @@ class Multi_Currency {
 	protected static $instance = null;
 
 	/**
+	 * Frontend_Prices instance.
+	 *
+	 * @var Frontend_Prices
+	 */
+	protected $frontend_prices;
+
+	/**
 	 * The available currencies.
 	 *
 	 * @var array
@@ -78,8 +85,13 @@ class Multi_Currency {
 		$this->get_default_currency();
 		$this->get_enabled_currencies();
 
-		add_action( 'init', [ $this, 'update_selected_currency_by_url' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );
+
+		$is_frontend_request = ( ! is_admin() || defined( 'DOING_AJAX' ) ) && ! defined( 'DOING_CRON' ) && ! WC()->is_rest_api_request();
+		if ( $is_frontend_request ) {
+			add_action( 'init', [ $this, 'update_selected_currency_by_url' ] );
+			$this->frontend_prices = new Frontend_Prices( $this );
+		}
 	}
 
 	/**

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -132,9 +132,9 @@ class Multi_Currency {
 	/**
 	 * Gets the store base currency.
 	 *
-	 * @return object Currency object.
+	 * @return Currency The store base currency.
 	 */
-	public function get_default_currency() {
+	public function get_default_currency(): Currency {
 		if ( isset( $this->default_currency ) ) {
 			return $this->default_currency;
 		}

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -264,12 +264,12 @@ class Multi_Currency {
 	 * Gets the converted price using the current currency with the rounding and charm pricing settings.
 	 *
 	 * @param mixed $price The price to be converted.
-	 * @param bool  $type  The type of price being converted. One of 'product', 'shipping', 'tax', or 'coupon'.
+	 * @param bool  $type  The type of price being converted. One of 'product', 'shipping', 'tax', 'coupon', or 'coupon_min_max'.
 	 *
 	 * @return float The converted price.
 	 */
 	public function get_price( $price, $type ): float {
-		$supported_types  = [ 'product', 'shipping', 'tax', 'coupon' ];
+		$supported_types  = [ 'product', 'shipping', 'tax', 'coupon', 'coupon_min_max' ];
 		$current_currency = $this->get_selected_currency();
 
 		if (
@@ -285,9 +285,11 @@ class Multi_Currency {
 			return $converted_price;
 		}
 
-		$charm_compatible_types = [ 'product', 'shipping' ];
+		$charm_compatible_types = [ 'product', 'shipping', 'coupon_min_max' ];
 		$apply_charm_pricing    = $this->get_apply_charm_only_to_products()
-			? 'product' === $type
+			// Coupon mix/max prices are treated as products to avoid inconsistencies with charm pricing
+			// making a coupon invalid when the coupon min/max amount is the same as the product's price.
+			? 'product' === $type || 'coupon_min_max' === $type
 			: in_array( $type, $charm_compatible_types, true );
 
 		return $this->get_adjusted_price( $converted_price, $apply_charm_pricing );

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -281,7 +281,7 @@ class Multi_Currency {
 
 		$converted_price = ( (float) $price ) * $current_currency->get_rate();
 
-		if ( 'tax' === $type ) {
+		if ( 'tax' === $type || 'coupon' === $type ) {
 			return $converted_price;
 		}
 

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -79,6 +79,7 @@ class Multi_Currency {
 	public function init() {
 		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-currency.php';
 		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-country-flags.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-prices.php';
 
 		$this->id = 'wcpay_multi_currency';
 		$this->get_available_currencies();

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -285,7 +285,10 @@ class Multi_Currency {
 			return $converted_price;
 		}
 
-		$apply_charm_pricing = $this->get_apply_charm_only_to_products() ? 'product' === $type : true;
+		$charm_compatible_types = [ 'product', 'shipping' ];
+		$apply_charm_pricing    = $this->get_apply_charm_only_to_products()
+			? 'product' === $type
+			: in_array( $type, $charm_compatible_types, true );
 
 		return $this->get_adjusted_price( $converted_price, $apply_charm_pricing );
 	}

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -245,29 +245,6 @@ class Multi_Currency {
 	}
 
 	/**
-	 * Gets the price after adjusting it with the rounding and charm settings.
-	 *
-	 * @param float $price               The price to be adjusted.
-	 * @param bool  $apply_charm_pricing Whether charm pricing should be applied.
-	 *
-	 * @return float The adjusted price.
-	 */
-	public function get_adjusted_price( $price, $apply_charm_pricing ): float {
-		$precision = $this->get_round_precision();
-		$charm     = $this->get_charm_pricing();
-
-		// TODO: round up.
-		$adjusted_price = round( $price, $precision );
-
-		if ( $apply_charm_pricing ) {
-			$adjusted_price += $charm;
-		}
-
-		// Do not return negative prices (possible because of $charm).
-		return max( 0, $adjusted_price );
-	}
-
-	/**
 	 * Gets the converted price using the current currency with the rounding and charm pricing settings.
 	 *
 	 * @param mixed $price      The price to be converted.
@@ -286,5 +263,28 @@ class Multi_Currency {
 		$apply_charm_pricing = $this->get_apply_charm_only_to_products() ? $is_product : true;
 
 		return $this->get_adjusted_price( $converted_price, $apply_charm_pricing );
+	}
+
+	/**
+	 * Gets the price after adjusting it with the rounding and charm settings.
+	 *
+	 * @param float $price               The price to be adjusted.
+	 * @param bool  $apply_charm_pricing Whether charm pricing should be applied.
+	 *
+	 * @return float The adjusted price.
+	 */
+	protected function get_adjusted_price( $price, $apply_charm_pricing ): float {
+		$precision = $this->get_round_precision();
+		$charm     = $this->get_charm_pricing();
+
+		// TODO: round up.
+		$adjusted_price = round( $price, $precision );
+
+		if ( $apply_charm_pricing ) {
+			$adjusted_price += $charm;
+		}
+
+		// Do not return negative prices (possible because of $charm).
+		return max( 0, $adjusted_price );
 	}
 }

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -96,7 +96,7 @@ class Multi_Currency {
 
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );
 
-		$is_frontend_request = ( ! is_admin() || defined( 'DOING_AJAX' ) ) && ! defined( 'DOING_CRON' ) && ! WC()->is_rest_api_request();
+		$is_frontend_request = ! is_admin() && ! defined( 'DOING_CRON' ) && ! WC()->is_rest_api_request();
 
 		if ( $is_frontend_request ) {
 			add_action( 'init', [ $this, 'update_selected_currency_by_url' ] );

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -31,6 +31,13 @@ class Multi_Currency {
 	protected $frontend_prices;
 
 	/**
+	 * Frontend_Currencies instance.
+	 *
+	 * @var Frontend_Currencies
+	 */
+	protected $frontend_currencies;
+
+	/**
 	 * The available currencies.
 	 *
 	 * @var array
@@ -80,6 +87,7 @@ class Multi_Currency {
 		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-currency.php';
 		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-country-flags.php';
 		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-prices.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-currencies.php';
 
 		$this->id = 'wcpay_multi_currency';
 		$this->get_available_currencies();
@@ -89,9 +97,12 @@ class Multi_Currency {
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );
 
 		$is_frontend_request = ( ! is_admin() || defined( 'DOING_AJAX' ) ) && ! defined( 'DOING_CRON' ) && ! WC()->is_rest_api_request();
+
 		if ( $is_frontend_request ) {
 			add_action( 'init', [ $this, 'update_selected_currency_by_url' ] );
-			$this->frontend_prices = new Frontend_Prices( $this );
+
+			$this->frontend_prices     = new Frontend_Prices( $this );
+			$this->frontend_currencies = new Frontend_Currencies( $this );
 		}
 	}
 

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -205,4 +205,53 @@ class Multi_Currency {
 		}
 	}
 
+	/**
+	 * Gets the rounding precision in the format used by round().
+	 *
+	 * @return int The rounding precision.
+	 */
+	public function get_round_precision(): float {
+		return 0;
+	}
+
+	/**
+	 * Gets the charm pricing to be added to the converted price after rounding.
+	 *
+	 * @return float The charm pricing.
+	 */
+	public function get_charm_pricing(): float {
+		return -0.1;
+	}
+
+	/**
+	 * Gets the price after adjusting it with the rounding and charm settings.
+	 *
+	 * @param float $price The price to be adjusted.
+	 *
+	 * @return float The adjusted price.
+	 */
+	public function get_adjusted_price( $price ): float {
+		$precision = $this->get_round_precision();
+		$charm     = $this->get_charm_pricing();
+
+		// TODO: round up.
+		return round( $price, $precision ) + $charm;
+	}
+
+	/**
+	 * Gets the converted price using the current currency with the rounding and charm pricing settings.
+	 *
+	 * @param mixed $price The price to be converted.
+	 *
+	 * @return float The converted price.
+	 */
+	public function get_price( $price ): float {
+		$current_currency = $this->get_selected_currency();
+
+		if ( $current_currency->get_code() === $this->get_default_currency()->get_code() ) {
+			return (float) $price;
+		}
+
+		return $this->get_adjusted_price( ( (float) $price ) * $current_currency->get_rate() );
+	}
 }

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -282,8 +282,7 @@ class Multi_Currency {
 		$precision = $this->get_round_precision();
 		$charm     = $this->get_charm_pricing();
 
-		// TODO: round up.
-		$adjusted_price = round( $price, $precision );
+		$adjusted_price = $this->ceil_price( $price, $precision );
 
 		if ( $apply_charm_pricing ) {
 			$adjusted_price += $charm;
@@ -291,5 +290,18 @@ class Multi_Currency {
 
 		// Do not return negative prices (possible because of $charm).
 		return max( 0, $adjusted_price );
+	}
+
+	/**
+	 * Ceils the price to the next number based on the precision.
+	 *
+	 * @param float $price     The price to be ceiled.
+	 * @param int   $precision The precision to be used.
+	 *
+	 * @return float The ceiled price.
+	 */
+	protected function ceil_price( $price, $precision ) {
+		$precision_modifier = pow( 10, $precision );
+		return ceil( $price * $precision_modifier ) / $precision_modifier;
 	}
 }

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -263,20 +263,29 @@ class Multi_Currency {
 	/**
 	 * Gets the converted price using the current currency with the rounding and charm pricing settings.
 	 *
-	 * @param mixed $price      The price to be converted.
-	 * @param bool  $is_product True if converting the price for a product.
+	 * @param mixed $price The price to be converted.
+	 * @param bool  $type  The type of price being converted. One of 'product', 'shipping', 'tax', or 'coupon'.
 	 *
 	 * @return float The converted price.
 	 */
-	public function get_price( $price, $is_product = true ): float {
+	public function get_price( $price, $type ): float {
+		$supported_types  = [ 'product', 'shipping', 'tax', 'coupon' ];
 		$current_currency = $this->get_selected_currency();
 
-		if ( $current_currency->get_code() === $this->get_default_currency()->get_code() ) {
+		if (
+			! in_array( $type, $supported_types, true ) ||
+			$current_currency->get_code() === $this->get_default_currency()->get_code()
+		) {
 			return (float) $price;
 		}
 
-		$converted_price     = ( (float) $price ) * $current_currency->get_rate();
-		$apply_charm_pricing = $this->get_apply_charm_only_to_products() ? $is_product : true;
+		$converted_price = ( (float) $price ) * $current_currency->get_rate();
+
+		if ( 'tax' === $type ) {
+			return $converted_price;
+		}
+
+		$apply_charm_pricing = $this->get_apply_charm_only_to_products() ? 'product' === $type : true;
 
 		return $this->get_adjusted_price( $converted_price, $apply_charm_pricing );
 	}

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -264,12 +264,12 @@ class Multi_Currency {
 	 * Gets the converted price using the current currency with the rounding and charm pricing settings.
 	 *
 	 * @param mixed $price The price to be converted.
-	 * @param bool  $type  The type of price being converted. One of 'product', 'shipping', 'tax', 'coupon', or 'coupon_min_max'.
+	 * @param bool  $type  The type of price being converted. One of 'product', 'shipping', 'tax', or 'coupon'.
 	 *
 	 * @return float The converted price.
 	 */
 	public function get_price( $price, $type ): float {
-		$supported_types  = [ 'product', 'shipping', 'tax', 'coupon', 'coupon_min_max' ];
+		$supported_types  = [ 'product', 'shipping', 'tax', 'coupon' ];
 		$current_currency = $this->get_selected_currency();
 
 		if (
@@ -285,11 +285,9 @@ class Multi_Currency {
 			return $converted_price;
 		}
 
-		$charm_compatible_types = [ 'product', 'shipping', 'coupon_min_max' ];
+		$charm_compatible_types = [ 'product', 'shipping' ];
 		$apply_charm_pricing    = $this->get_apply_charm_only_to_products()
-			// Coupon mix/max prices are treated as products to avoid inconsistencies with charm pricing
-			// making a coupon invalid when the coupon min/max amount is the same as the product's price.
-			? 'product' === $type || 'coupon_min_max' === $type
+			? 'product' === $type
 			: in_array( $type, $charm_compatible_types, true );
 
 		return $this->get_adjusted_price( $converted_price, $apply_charm_pricing );

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -223,7 +223,7 @@ class Multi_Currency {
 	 * @return int The rounding precision.
 	 */
 	public function get_round_precision(): float {
-		return 0;
+		return apply_filters( 'wcpay_multi_currency_round_precision', 0 );
 	}
 
 	/**
@@ -232,7 +232,7 @@ class Multi_Currency {
 	 * @return float The charm pricing.
 	 */
 	public function get_charm_pricing(): float {
-		return -0.1;
+		return apply_filters( 'wcpay_multi_currency_charm_pricing', -0.1 );
 	}
 
 	/**

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -196,8 +196,12 @@ class Multi_Currency {
 	 * @return Currency
 	 */
 	public function get_selected_currency(): Currency {
-		$code = WC()->session->get( self::CURRENCY_SESSION_KEY );
-		return $this->get_enabled_currencies()[ $code ] ?? $this->default_currency;
+		if ( WC()->session ) {
+			$code = WC()->session->get( self::CURRENCY_SESSION_KEY );
+			return $this->get_enabled_currencies()[ $code ] ?? $this->default_currency;
+		}
+
+		return $this->default_currency;
 	}
 
 	/**
@@ -213,7 +217,7 @@ class Multi_Currency {
 		$code     = strtoupper( sanitize_text_field( wp_unslash( $_GET['currency'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
 		$currency = $this->get_enabled_currencies()[ $code ] ?? null;
 
-		if ( $currency ) {
+		if ( $currency && WC()->session ) {
 			WC()->session->set( self::CURRENCY_SESSION_KEY, $currency->code );
 		}
 	}

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -247,7 +247,10 @@ class Multi_Currency {
 		$charm     = $this->get_charm_pricing();
 
 		// TODO: round up.
-		return round( $price, $precision ) + $charm;
+		$adjusted_price = round( $price, $precision ) + $charm;
+
+		// Do not return negative prices (possible because of $charm).
+		return max( 0, $adjusted_price );
 	}
 
 	/**

--- a/includes/multi-currency/wc-payments-multi-currency.php
+++ b/includes/multi-currency/wc-payments-multi-currency.php
@@ -13,7 +13,7 @@ if ( ! class_exists( 'WCPay\Multi_Currency\Multi_Currency', false ) ) {
 }
 
 // Include the Frontend_Prices class.
-if ( ! class_exists( 'WCPay\Multi_Currency\Prices', false ) ) {
+if ( ! class_exists( 'WCPay\Multi_Currency\Frontend_Prices', false ) ) {
 	include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-prices.php';
 }
 

--- a/includes/multi-currency/wc-payments-multi-currency.php
+++ b/includes/multi-currency/wc-payments-multi-currency.php
@@ -12,11 +12,6 @@ if ( ! class_exists( 'WCPay\Multi_Currency\Multi_Currency', false ) ) {
 	include_once WCPAY_ABSPATH . 'includes/multi-currency/class-multi-currency.php';
 }
 
-// Include the Frontend_Prices class.
-if ( ! class_exists( 'WCPay\Multi_Currency\Frontend_Prices', false ) ) {
-	include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-prices.php';
-}
-
 /**
  * Returns the main instance of Multi_Currency.
  *

--- a/includes/multi-currency/wc-payments-multi-currency.php
+++ b/includes/multi-currency/wc-payments-multi-currency.php
@@ -12,6 +12,11 @@ if ( ! class_exists( 'WCPay\Multi_Currency\Multi_Currency', false ) ) {
 	include_once WCPAY_ABSPATH . 'includes/multi-currency/class-multi-currency.php';
 }
 
+// Include the Frontend_Prices class.
+if ( ! class_exists( 'WCPay\Multi_Currency\Prices', false ) ) {
+	include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-prices.php';
+}
+
 /**
  * Returns the main instance of Multi_Currency.
  *

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -37,6 +37,26 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 		parent::tearDown();
 	}
 
+	/**
+	 * @dataProvider woocommerce_filter_provider
+	 */
+	public function test_registers_woocommerce_filter( $filter, $function_name ) {
+		$this->assertNotFalse(
+			has_filter( $filter, [ $this->frontend_currencies, $function_name ] ),
+			"Filter '$filter' was not registered with '$function_name'"
+		);
+	}
+
+	public function woocommerce_filter_provider() {
+		return [
+			[ 'woocommerce_currency', 'get_current_currency_code' ],
+			[ 'wc_get_price_decimals', 'get_current_currency_decimals' ],
+			[ 'wc_get_price_decimal_separator', 'get_current_currency_decimal_separator' ],
+			[ 'wc_get_price_thousand_separator', 'get_current_currency_thousand_separator' ],
+			[ 'woocommerce_price_format', 'get_current_currency_format' ],
+		];
+	}
+
 	public function test_get_currency_code() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'USD' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -74,14 +74,14 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_get_current_currency_decimal_separator_returns_currency_settings() {
-		$current_currency = new WCPay\Multi_Currency\Currency( 'EUR' );
+		$current_currency = new WCPay\Multi_Currency\Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 
 		$this->assertEquals( ',', $this->frontend_currencies->get_current_currency_decimal_separator() );
 	}
 
 	public function test_get_current_currency_decimal_separator_returns_filtered_settings() {
-		$current_currency = new WCPay\Multi_Currency\Currency( 'EUR' );
+		$current_currency = new WCPay\Multi_Currency\Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 		$this->mock_currency_settings( [ 'decimal_sep' => '/' ] );
 
@@ -96,14 +96,14 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_get_current_currency_thousand_separator_returns_currency_settings() {
-		$current_currency = new WCPay\Multi_Currency\Currency( 'EUR' );
+		$current_currency = new WCPay\Multi_Currency\Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 
 		$this->assertEquals( '.', $this->frontend_currencies->get_current_currency_thousand_separator() );
 	}
 
 	public function test_get_current_currency_thousand_separator_returns_filtered_settings() {
-		$current_currency = new WCPay\Multi_Currency\Currency( 'EUR' );
+		$current_currency = new WCPay\Multi_Currency\Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 		$this->mock_currency_settings( [ 'thousand_sep' => '/' ] );
 

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Class WCPay_Multi_Currency_Frontend_Currencies_Tests
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * WCPay\Multi_Currency\Frontend_Currencies unit tests.
+ */
+class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
+	/**
+	 * Mock WCPay\Multi_Currency\Multi_Currency.
+	 *
+	 * @var WCPay\Multi_Currency\Multi_Currency|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_multi_currency;
+
+	/**
+	 * WCPay\Multi_Currency\Frontend_Currencies instance.
+	 *
+	 * @var WCPay\Multi_Currency\Frontend_Currencies
+	 */
+	private $frontend_currencies;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->mock_multi_currency = $this->createMock( WCPay\Multi_Currency\Multi_Currency::class );
+
+		$this->frontend_currencies = new WCPay\Multi_Currency\Frontend_Currencies( $this->mock_multi_currency );
+	}
+
+	public function test_get_currency_code() {
+		$current_currency = new WCPay\Multi_Currency\Currency( 'USD' );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+
+		$this->assertSame( 'USD', $this->frontend_currencies->get_current_currency_code() );
+	}
+}

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -23,9 +23,6 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	 */
 	private $frontend_currencies;
 
-	/**
-	 * Pre-test setup
-	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -34,10 +31,132 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 		$this->frontend_currencies = new WCPay\Multi_Currency\Frontend_Currencies( $this->mock_multi_currency );
 	}
 
+	public function tearDown() {
+		remove_all_filters( 'wcpay_multi_currency_currency_settings' );
+
+		parent::tearDown();
+	}
+
 	public function test_get_currency_code() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'USD' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 
 		$this->assertSame( 'USD', $this->frontend_currencies->get_current_currency_code() );
+	}
+
+	public function test_get_current_currency_decimals_returns_default_settings() {
+		$current_currency = new WCPay\Multi_Currency\Currency( 'RANDOM_CODE' );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+
+		$this->assertEquals( 2, $this->frontend_currencies->get_current_currency_decimals() );
+	}
+
+	public function test_get_current_currency_decimals_returns_currency_settings() {
+		$current_currency = new WCPay\Multi_Currency\Currency( 'JPY' );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+
+		$this->assertEquals( 0, $this->frontend_currencies->get_current_currency_decimals() );
+	}
+
+	public function test_get_current_currency_decimals_returns_filtered_settings() {
+		$current_currency = new WCPay\Multi_Currency\Currency( 'JPY' );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_currency_settings( [ 'num_decimals' => 1 ] );
+
+		$this->assertEquals( 1, $this->frontend_currencies->get_current_currency_decimals() );
+	}
+
+	public function test_get_current_currency_decimal_separator_returns_default_settings() {
+		$current_currency = new WCPay\Multi_Currency\Currency( 'RANDOM_CODE' );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+
+		$this->assertEquals( '.', $this->frontend_currencies->get_current_currency_decimal_separator() );
+	}
+
+	public function test_get_current_currency_decimal_separator_returns_currency_settings() {
+		$current_currency = new WCPay\Multi_Currency\Currency( 'EUR' );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+
+		$this->assertEquals( ',', $this->frontend_currencies->get_current_currency_decimal_separator() );
+	}
+
+	public function test_get_current_currency_decimal_separator_returns_filtered_settings() {
+		$current_currency = new WCPay\Multi_Currency\Currency( 'EUR' );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_currency_settings( [ 'decimal_sep' => '/' ] );
+
+		$this->assertEquals( '/', $this->frontend_currencies->get_current_currency_decimal_separator() );
+	}
+
+	public function test_get_current_currency_thousand_separator_returns_default_settings() {
+		$current_currency = new WCPay\Multi_Currency\Currency( 'RANDOM_CODE' );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+
+		$this->assertEquals( ',', $this->frontend_currencies->get_current_currency_thousand_separator() );
+	}
+
+	public function test_get_current_currency_thousand_separator_returns_currency_settings() {
+		$current_currency = new WCPay\Multi_Currency\Currency( 'EUR' );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+
+		$this->assertEquals( '.', $this->frontend_currencies->get_current_currency_thousand_separator() );
+	}
+
+	public function test_get_current_currency_thousand_separator_returns_filtered_settings() {
+		$current_currency = new WCPay\Multi_Currency\Currency( 'EUR' );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_currency_settings( [ 'thousand_sep' => '/' ] );
+
+		$this->assertEquals( '/', $this->frontend_currencies->get_current_currency_thousand_separator() );
+	}
+
+	public function test_get_current_currency_format_returns_default_settings() {
+		$current_currency = new WCPay\Multi_Currency\Currency( 'RANDOM_CODE' );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+
+		$this->assertEquals( '%1$s%2$s', $this->frontend_currencies->get_current_currency_format() );
+	}
+
+	public function test_get_current_currency_format_returns_currency_settings() {
+		$current_currency = new WCPay\Multi_Currency\Currency( 'HUF' );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+
+		$this->assertEquals( '%2$s&nbsp;%1$s', $this->frontend_currencies->get_current_currency_format() );
+	}
+
+	public function test_get_current_currency_format_returns_filtered_settings() {
+		$current_currency = new WCPay\Multi_Currency\Currency( 'HUF' );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_currency_settings( [ 'currency_pos' => 'left_space' ] );
+
+		$this->assertEquals( '%1$s&nbsp;%2$s', $this->frontend_currencies->get_current_currency_format() );
+	}
+
+	/**
+	 * @dataProvider currency_format_provider
+	 */
+	public function test_get_current_currency_format_outputs_right_format( $currency_pos, $expected_format ) {
+		$this->mock_currency_settings( [ 'currency_pos' => $currency_pos ] );
+		$this->assertEquals( $expected_format, $this->frontend_currencies->get_current_currency_format() );
+	}
+
+	public function currency_format_provider() {
+		return [
+			[ '', '%1$s%2$s' ],
+			[ 'random_value', '%1$s%2$s' ],
+			[ 'left', '%1$s%2$s' ],
+			[ 'right', '%2$s%1$s' ],
+			[ 'left_space', '%1$s&nbsp;%2$s' ],
+			[ 'right_space', '%2$s&nbsp;%1$s' ],
+		];
+	}
+
+	private function mock_currency_settings( $currency_settings ) {
+		add_filter(
+			'wcpay_multi_currency_currency_settings',
+			function () use ( $currency_settings ) {
+				return $currency_settings;
+			}
+		);
 	}
 }

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -50,118 +50,118 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 
 	public function woocommerce_filter_provider() {
 		return [
-			[ 'woocommerce_currency', 'get_current_currency_code' ],
-			[ 'wc_get_price_decimals', 'get_current_currency_decimals' ],
-			[ 'wc_get_price_decimal_separator', 'get_current_currency_decimal_separator' ],
-			[ 'wc_get_price_thousand_separator', 'get_current_currency_thousand_separator' ],
-			[ 'woocommerce_price_format', 'get_current_currency_format' ],
+			[ 'woocommerce_currency', 'get_woocommerce_currency' ],
+			[ 'wc_get_price_decimals', 'get_price_decimals' ],
+			[ 'wc_get_price_decimal_separator', 'get_price_decimal_separator' ],
+			[ 'wc_get_price_thousand_separator', 'get_price_thousand_separator' ],
+			[ 'woocommerce_price_format', 'get_woocommerce_price_format' ],
 		];
 	}
 
-	public function test_get_currency_code() {
+	public function test_get_woocommerce_currency() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'USD' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 
-		$this->assertSame( 'USD', $this->frontend_currencies->get_current_currency_code() );
+		$this->assertSame( 'USD', $this->frontend_currencies->get_woocommerce_currency() );
 	}
 
-	public function test_get_current_currency_decimals_returns_default_settings() {
+	public function test_get_price_decimals_returns_default_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'RANDOM_CODE' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 
-		$this->assertEquals( 2, $this->frontend_currencies->get_current_currency_decimals() );
+		$this->assertEquals( 2, $this->frontend_currencies->get_price_decimals() );
 	}
 
-	public function test_get_current_currency_decimals_returns_currency_settings() {
+	public function test_get_price_decimals_returns_currency_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'JPY' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 
-		$this->assertEquals( 0, $this->frontend_currencies->get_current_currency_decimals() );
+		$this->assertEquals( 0, $this->frontend_currencies->get_price_decimals() );
 	}
 
-	public function test_get_current_currency_decimals_returns_filtered_settings() {
+	public function test_get_price_decimals_returns_filtered_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'JPY' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 		$this->mock_currency_settings( 'jpy', [ 'num_decimals' => 1 ] );
 
-		$this->assertEquals( 1, $this->frontend_currencies->get_current_currency_decimals() );
+		$this->assertEquals( 1, $this->frontend_currencies->get_price_decimals() );
 	}
 
-	public function test_get_current_currency_decimal_separator_returns_default_settings() {
+	public function test_get_price_decimal_separator_returns_default_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'RANDOM_CODE' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 
-		$this->assertEquals( '.', $this->frontend_currencies->get_current_currency_decimal_separator() );
+		$this->assertEquals( '.', $this->frontend_currencies->get_price_decimal_separator() );
 	}
 
-	public function test_get_current_currency_decimal_separator_returns_currency_settings() {
+	public function test_get_price_decimal_separator_returns_currency_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 
-		$this->assertEquals( ',', $this->frontend_currencies->get_current_currency_decimal_separator() );
+		$this->assertEquals( ',', $this->frontend_currencies->get_price_decimal_separator() );
 	}
 
-	public function test_get_current_currency_decimal_separator_returns_filtered_settings() {
+	public function test_get_price_decimal_separator_returns_filtered_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 		$this->mock_currency_settings( 'brl', [ 'decimal_sep' => '/' ] );
 
-		$this->assertEquals( '/', $this->frontend_currencies->get_current_currency_decimal_separator() );
+		$this->assertEquals( '/', $this->frontend_currencies->get_price_decimal_separator() );
 	}
 
-	public function test_get_current_currency_thousand_separator_returns_default_settings() {
+	public function test_get_price_thousand_separator_returns_default_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'RANDOM_CODE' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 
-		$this->assertEquals( ',', $this->frontend_currencies->get_current_currency_thousand_separator() );
+		$this->assertEquals( ',', $this->frontend_currencies->get_price_thousand_separator() );
 	}
 
-	public function test_get_current_currency_thousand_separator_returns_currency_settings() {
+	public function test_get_price_thousand_separator_returns_currency_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 
-		$this->assertEquals( '.', $this->frontend_currencies->get_current_currency_thousand_separator() );
+		$this->assertEquals( '.', $this->frontend_currencies->get_price_thousand_separator() );
 	}
 
-	public function test_get_current_currency_thousand_separator_returns_filtered_settings() {
+	public function test_get_price_thousand_separator_returns_filtered_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 		$this->mock_currency_settings( 'brl', [ 'thousand_sep' => '/' ] );
 
-		$this->assertEquals( '/', $this->frontend_currencies->get_current_currency_thousand_separator() );
+		$this->assertEquals( '/', $this->frontend_currencies->get_price_thousand_separator() );
 	}
 
-	public function test_get_current_currency_format_returns_default_settings() {
+	public function test_get_woocommerce_price_format_returns_default_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'RANDOM_CODE' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 
-		$this->assertEquals( '%1$s%2$s', $this->frontend_currencies->get_current_currency_format() );
+		$this->assertEquals( '%1$s%2$s', $this->frontend_currencies->get_woocommerce_price_format() );
 	}
 
-	public function test_get_current_currency_format_returns_currency_settings() {
+	public function test_get_woocommerce_price_format_returns_currency_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'HUF' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 
-		$this->assertEquals( '%2$s&nbsp;%1$s', $this->frontend_currencies->get_current_currency_format() );
+		$this->assertEquals( '%2$s&nbsp;%1$s', $this->frontend_currencies->get_woocommerce_price_format() );
 	}
 
-	public function test_get_current_currency_format_returns_filtered_settings() {
+	public function test_get_woocommerce_price_format_returns_filtered_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'HUF' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 		$this->mock_currency_settings( 'huf', [ 'currency_pos' => 'left_space' ] );
 
-		$this->assertEquals( '%1$s&nbsp;%2$s', $this->frontend_currencies->get_current_currency_format() );
+		$this->assertEquals( '%1$s&nbsp;%2$s', $this->frontend_currencies->get_woocommerce_price_format() );
 	}
 
 	/**
 	 * @dataProvider currency_format_provider
 	 */
-	public function test_get_current_currency_format_outputs_right_format( $currency_pos, $expected_format ) {
+	public function test_get_woocommerce_price_format_outputs_right_format( $currency_pos, $expected_format ) {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'USD' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 
 		$this->mock_currency_settings( 'usd', [ 'currency_pos' => $currency_pos ] );
-		$this->assertEquals( $expected_format, $this->frontend_currencies->get_current_currency_format() );
+		$this->assertEquals( $expected_format, $this->frontend_currencies->get_woocommerce_price_format() );
 	}
 
 	public function currency_format_provider() {

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -82,7 +82,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_current_currency_decimals_returns_filtered_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'JPY' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_currency_settings( [ 'num_decimals' => 1 ] );
+		$this->mock_currency_settings( 'jpy', [ 'num_decimals' => 1 ] );
 
 		$this->assertEquals( 1, $this->frontend_currencies->get_current_currency_decimals() );
 	}
@@ -104,7 +104,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_current_currency_decimal_separator_returns_filtered_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_currency_settings( [ 'decimal_sep' => '/' ] );
+		$this->mock_currency_settings( 'brl', [ 'decimal_sep' => '/' ] );
 
 		$this->assertEquals( '/', $this->frontend_currencies->get_current_currency_decimal_separator() );
 	}
@@ -126,7 +126,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_current_currency_thousand_separator_returns_filtered_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_currency_settings( [ 'thousand_sep' => '/' ] );
+		$this->mock_currency_settings( 'brl', [ 'thousand_sep' => '/' ] );
 
 		$this->assertEquals( '/', $this->frontend_currencies->get_current_currency_thousand_separator() );
 	}
@@ -148,7 +148,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_current_currency_format_returns_filtered_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'HUF' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_currency_settings( [ 'currency_pos' => 'left_space' ] );
+		$this->mock_currency_settings( 'huf', [ 'currency_pos' => 'left_space' ] );
 
 		$this->assertEquals( '%1$s&nbsp;%2$s', $this->frontend_currencies->get_current_currency_format() );
 	}
@@ -157,7 +157,10 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	 * @dataProvider currency_format_provider
 	 */
 	public function test_get_current_currency_format_outputs_right_format( $currency_pos, $expected_format ) {
-		$this->mock_currency_settings( [ 'currency_pos' => $currency_pos ] );
+		$current_currency = new WCPay\Multi_Currency\Currency( 'USD' );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+
+		$this->mock_currency_settings( 'usd', [ 'currency_pos' => $currency_pos ] );
 		$this->assertEquals( $expected_format, $this->frontend_currencies->get_current_currency_format() );
 	}
 
@@ -172,9 +175,9 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 		];
 	}
 
-	private function mock_currency_settings( $currency_settings ) {
+	private function mock_currency_settings( $currency_code, $currency_settings ) {
 		add_filter(
-			'wcpay_multi_currency_currency_settings',
+			'wcpay_multi_currency_' . $currency_code . '_settings',
 			function () use ( $currency_settings ) {
 				return $currency_settings;
 			}

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -41,9 +41,10 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	 * @dataProvider woocommerce_filter_provider
 	 */
 	public function test_registers_woocommerce_filter( $filter, $function_name ) {
-		$this->assertNotFalse(
+		$this->assertGreaterThan(
+			10,
 			has_filter( $filter, [ $this->frontend_currencies, $function_name ] ),
-			"Filter '$filter' was not registered with '$function_name'"
+			"Filter '$filter' was not registered with '$function_name' with a priority higher than the default"
 		);
 	}
 

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -82,7 +82,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_price_decimals_returns_filtered_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'JPY' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_currency_settings( 'jpy', [ 'num_decimals' => 1 ] );
+		$this->mock_currency_format( 'jpy', [ 'num_decimals' => 1 ] );
 
 		$this->assertEquals( 1, $this->frontend_currencies->get_price_decimals() );
 	}
@@ -104,7 +104,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_price_decimal_separator_returns_filtered_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_currency_settings( 'brl', [ 'decimal_sep' => '/' ] );
+		$this->mock_currency_format( 'brl', [ 'decimal_sep' => '/' ] );
 
 		$this->assertEquals( '/', $this->frontend_currencies->get_price_decimal_separator() );
 	}
@@ -126,7 +126,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_price_thousand_separator_returns_filtered_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_currency_settings( 'brl', [ 'thousand_sep' => '/' ] );
+		$this->mock_currency_format( 'brl', [ 'thousand_sep' => '/' ] );
 
 		$this->assertEquals( '/', $this->frontend_currencies->get_price_thousand_separator() );
 	}
@@ -148,7 +148,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_woocommerce_price_format_returns_filtered_settings() {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'HUF' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_currency_settings( 'huf', [ 'currency_pos' => 'left_space' ] );
+		$this->mock_currency_format( 'huf', [ 'currency_pos' => 'left_space' ] );
 
 		$this->assertEquals( '%1$s&nbsp;%2$s', $this->frontend_currencies->get_woocommerce_price_format() );
 	}
@@ -160,7 +160,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 		$current_currency = new WCPay\Multi_Currency\Currency( 'USD' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 
-		$this->mock_currency_settings( 'usd', [ 'currency_pos' => $currency_pos ] );
+		$this->mock_currency_format( 'usd', [ 'currency_pos' => $currency_pos ] );
 		$this->assertEquals( $expected_format, $this->frontend_currencies->get_woocommerce_price_format() );
 	}
 
@@ -175,9 +175,9 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 		];
 	}
 
-	private function mock_currency_settings( $currency_code, $currency_settings ) {
+	private function mock_currency_format( $currency_code, $currency_settings ) {
 		add_filter(
-			'wcpay_multi_currency_' . $currency_code . '_settings',
+			'wcpay_multi_currency_' . $currency_code . '_format',
 			function () use ( $currency_settings ) {
 				return $currency_settings;
 			}

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -30,11 +30,125 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WP_UnitTestCase {
 		parent::setUp();
 
 		$this->mock_multi_currency = $this->createMock( WCPay\Multi_Currency\Multi_Currency::class );
+		$this->mock_multi_currency
+			->method( 'get_price' )
+			->willReturnCallback(
+				function ( $price ) {
+					return (float) $price * 2.5;
+				}
+			);
 
 		$this->frontend_prices = new WCPay\Multi_Currency\Frontend_Prices( $this->mock_multi_currency );
 	}
 
-	public function test_placeholder() {
-		$this->assertTrue( true );
+	public function test_get_currency_code() {
+		$current_currency = new WCPay\Multi_Currency\Currency( 'USD' );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+
+		$this->assertSame( 'USD', $this->frontend_prices->get_current_currency_code() );
+	}
+
+	public function test_get_product_price_returns_empty_price() {
+		$this->assertSame( '', $this->frontend_prices->get_product_price( '' ) );
+	}
+
+	public function test_get_product_price_converts_prices() {
+		$this->assertSame( 25.0, $this->frontend_prices->get_product_price( 10.0 ) );
+	}
+
+	public function test_get_variation_price_range_converts_non_empty_prices() {
+		$base_variation_prices = [
+			'price'      => [
+				1 => '10.0',
+				2 => '12.0',
+			],
+			'sale_price' => [
+				1 => '6.0',
+				2 => '8.0',
+			],
+		];
+
+		$this->assertSame(
+			[
+				'price'      => [
+					1 => 25.0,
+					2 => 30.0,
+				],
+				'sale_price' => [
+					1 => 15.0,
+					2 => 20.0,
+				],
+			],
+			$this->frontend_prices->get_variation_price_range( $base_variation_prices )
+		);
+	}
+
+	public function test_get_variation_price_range_skips_empty_prices() {
+		$base_variation_prices = [
+			'sale_price' => [
+				1 => '',
+				2 => '',
+			],
+		];
+
+		$this->assertSame(
+			[
+				'sale_price' => [
+					1 => '',
+					2 => '',
+				],
+			],
+			$this->frontend_prices->get_variation_price_range( $base_variation_prices )
+		);
+	}
+
+	public function test_exchange_rate_is_added_to_prices_hash() {
+		$this->assertSame(
+			[ 'existing_item', 2.5 ],
+			$this->frontend_prices->add_exchange_rate_to_variation_prices_hash( [ 'existing_item' ] )
+		);
+	}
+
+	public function test_get_shipping_rates_prices_converts_rates() {
+		$shipping_zone_1       = new WC_Shipping_Zone();
+		$shipping_zone_2       = new WC_Shipping_Zone();
+		$shipping_zone_1->cost = '10.0';
+		$shipping_zone_2->cost = '0.0';
+
+		$base_shipping_rates = [
+			'shipping_rate_1' => $shipping_zone_1,
+			'shipping_rate_2' => $shipping_zone_2,
+		];
+
+		$shipping_rates = $this->frontend_prices->get_shipping_rates_prices( $base_shipping_rates );
+
+		$this->assertSame( 25.0, $shipping_rates['shipping_rate_1']->cost );
+		$this->assertSame( 0.0, $shipping_rates['shipping_rate_2']->cost );
+	}
+
+	public function test_get_coupon_amount_returns_empty_amount() {
+		$this->assertSame( '', $this->frontend_prices->get_coupon_amount( '', null ) );
+	}
+
+	public function test_get_coupon_amount_returns_percent_coupon_amount() {
+		$percent_coupon = new WC_Coupon();
+		$percent_coupon->set_discount_type( 'percent' );
+
+		$this->assertSame( '10', $this->frontend_prices->get_coupon_amount( '10', $percent_coupon ) );
+	}
+
+	public function test_get_coupon_amount_converts_fixed_cart_amount() {
+		$fixed_cart_coupon = new WC_Coupon();
+		$fixed_cart_coupon->set_discount_type( 'fixed_cart' );
+
+		$this->assertSame( 25.0, $this->frontend_prices->get_coupon_amount( '10', $fixed_cart_coupon ) );
+	}
+
+	public function test_get_coupon_mix_max_amount_returns_empty_amount() {
+		$this->assertSame( '', $this->frontend_prices->get_coupon_min_max_amount( '' ) );
+	}
+
+	public function test_get_coupon_mix_max_amount_converts_amount() {
+		$this->assertSame( 12.5, $this->frontend_prices->get_coupon_min_max_amount( '5.0' ) );
 	}
 }

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -41,13 +41,6 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WP_UnitTestCase {
 		$this->frontend_prices = new WCPay\Multi_Currency\Frontend_Prices( $this->mock_multi_currency );
 	}
 
-	public function test_get_currency_code() {
-		$current_currency = new WCPay\Multi_Currency\Currency( 'USD' );
-		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-
-		$this->assertSame( 'USD', $this->frontend_prices->get_current_currency_code() );
-	}
-
 	public function test_get_product_price_returns_empty_price() {
 		$this->assertSame( '', $this->frontend_prices->get_product_price( '' ) );
 	}

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -56,6 +56,7 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WP_UnitTestCase {
 			[ 'woocommerce_variation_prices', 'get_variation_price_range' ],
 			[ 'woocommerce_get_variation_prices_hash', 'add_exchange_rate_to_variation_prices_hash' ],
 			[ 'woocommerce_package_rates', 'get_shipping_rates_prices' ],
+			[ 'init', 'register_free_shipping_filters' ],
 			[ 'woocommerce_coupon_get_amount', 'get_coupon_amount' ],
 			[ 'woocommerce_coupon_get_minimum_amount', 'get_coupon_min_max_amount' ],
 			[ 'woocommerce_coupon_get_maximum_amount', 'get_coupon_min_max_amount' ],
@@ -70,11 +71,10 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WP_UnitTestCase {
 		$new_zone             = new WC_Shipping_Zone();
 		$new_zone_free_method = $new_zone->add_shipping_method( 'free_shipping' );
 
-		// Instantiate a new WCPay\Multi_Currency\Frontend_Prices to read the new zones.
-		$frontend_prices = new WCPay\Multi_Currency\Frontend_Prices( $this->mock_multi_currency );
+		$this->frontend_prices->register_free_shipping_filters();
 
-		$this->assertGreaterThan( 10, has_filter( 'option_woocommerce_free_shipping_' . $default_zone_free_method . '_settings', [ $frontend_prices, 'get_free_shipping_min_amount' ] ) );
-		$this->assertGreaterThan( 10, has_filter( 'option_woocommerce_free_shipping_' . $new_zone_free_method . '_settings', [ $frontend_prices, 'get_free_shipping_min_amount' ] ) );
+		$this->assertGreaterThan( 10, has_filter( 'option_woocommerce_free_shipping_' . $default_zone_free_method . '_settings', [ $this->frontend_prices, 'get_free_shipping_min_amount' ] ) );
+		$this->assertGreaterThan( 10, has_filter( 'option_woocommerce_free_shipping_' . $new_zone_free_method . '_settings', [ $this->frontend_prices, 'get_free_shipping_min_amount' ] ) );
 	}
 
 	public function test_get_product_price_returns_empty_price() {

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -192,7 +192,7 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_get_coupon_min_max_amount_converts_amount() {
-		$this->mock_multi_currency->method( 'get_price' )->with( 5.0, 'coupon' )->willReturn( 12.5 );
+		$this->mock_multi_currency->method( 'get_price' )->with( 5.0, 'coupon_min_max' )->willReturn( 12.5 );
 
 		$this->assertSame( 12.5, $this->frontend_prices->get_coupon_min_max_amount( '5.0' ) );
 	}

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -55,7 +55,7 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WP_UnitTestCase {
 			[ 'woocommerce_product_variation_get_sale_price', 'get_product_price' ],
 			[ 'woocommerce_variation_prices', 'get_variation_price_range' ],
 			[ 'woocommerce_get_variation_prices_hash', 'add_exchange_rate_to_variation_prices_hash' ],
-			[ 'woocommerce_package_rates', 'get_shipping_rates_prices' ],
+			[ 'woocommerce_package_rates', 'convert_package_rates_prices' ],
 			[ 'init', 'register_free_shipping_filters' ],
 			[ 'woocommerce_coupon_get_amount', 'get_coupon_amount' ],
 			[ 'woocommerce_coupon_get_minimum_amount', 'get_coupon_min_max_amount' ],
@@ -146,7 +146,7 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_get_shipping_rates_prices_converts_rates() {
+	public function test_convert_package_rates_prices_converts_rates() {
 		$this->mock_multi_currency
 			->method( 'get_price' )
 			->withConsecutive( [ 10.0, 'shipping' ], [ 0.0, 'shipping' ] )
@@ -162,13 +162,13 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WP_UnitTestCase {
 			'shipping_rate_2' => $free_method,
 		];
 
-		$shipping_rates = $this->frontend_prices->get_shipping_rates_prices( $base_shipping_rates );
+		$shipping_rates = $this->frontend_prices->convert_package_rates_prices( $base_shipping_rates );
 
 		$this->assertSame( 25.0, $shipping_rates['shipping_rate_1']->cost );
 		$this->assertSame( 0.0, $shipping_rates['shipping_rate_2']->cost );
 	}
 
-	public function test_get_shipping_rates_prices_converts_taxes() {
+	public function test_convert_package_rates_prices_converts_taxes() {
 		$this->mock_multi_currency
 			->method( 'get_price' )
 			->withConsecutive( [ 1.0, 'tax' ], [ 2.0, 'tax' ] )
@@ -177,7 +177,7 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WP_UnitTestCase {
 		$flat_rate_method        = new WC_Shipping_Rate();
 		$flat_rate_method->taxes = [ '1.0', '2.0' ];
 
-		$shipping_rates = $this->frontend_prices->get_shipping_rates_prices( [ 'shipping_rate_1' => $flat_rate_method ] );
+		$shipping_rates = $this->frontend_prices->convert_package_rates_prices( [ 'shipping_rate_1' => $flat_rate_method ] );
 
 		$this->assertSame( [ 2.5, 5.0 ], $shipping_rates['shipping_rate_1']->taxes );
 	}

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -206,8 +206,8 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WP_UnitTestCase {
 		$this->assertSame( '', $this->frontend_prices->get_coupon_min_max_amount( '' ) );
 	}
 
-	public function test_get_coupon_min_max_amount_converts_amount() {
-		$this->mock_multi_currency->method( 'get_price' )->with( 5.0, 'coupon_min_max' )->willReturn( 12.5 );
+	public function test_get_coupon_min_max_amount_converts_amount_as_product() {
+		$this->mock_multi_currency->method( 'get_price' )->with( 5.0, 'product' )->willReturn( 12.5 );
 
 		$this->assertSame( 12.5, $this->frontend_prices->get_coupon_min_max_amount( '5.0' ) );
 	}

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -41,6 +41,33 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WP_UnitTestCase {
 		$this->frontend_prices = new WCPay\Multi_Currency\Frontend_Prices( $this->mock_multi_currency );
 	}
 
+	/**
+	 * @dataProvider woocommerce_filter_provider
+	 */
+	public function test_registers_woocommerce_filter( $filter, $function_name ) {
+		$this->assertNotFalse(
+			has_filter( $filter, [ $this->frontend_prices, $function_name ] ),
+			"Filter '$filter' was not registered with '$function_name'"
+		);
+	}
+
+	public function woocommerce_filter_provider() {
+		return [
+			[ 'woocommerce_product_get_price', 'get_product_price' ],
+			[ 'woocommerce_product_get_regular_price', 'get_product_price' ],
+			[ 'woocommerce_product_get_sale_price', 'get_product_price' ],
+			[ 'woocommerce_product_variation_get_price', 'get_product_price' ],
+			[ 'woocommerce_product_variation_get_regular_price', 'get_product_price' ],
+			[ 'woocommerce_product_variation_get_sale_price', 'get_product_price' ],
+			[ 'woocommerce_variation_prices', 'get_variation_price_range' ],
+			[ 'woocommerce_get_variation_prices_hash', 'add_exchange_rate_to_variation_prices_hash' ],
+			[ 'woocommerce_package_rates', 'get_shipping_rates_prices' ],
+			[ 'woocommerce_coupon_get_amount', 'get_coupon_amount' ],
+			[ 'woocommerce_coupon_get_minimum_amount', 'get_coupon_min_max_amount' ],
+			[ 'woocommerce_coupon_get_maximum_amount', 'get_coupon_min_max_amount' ],
+		];
+	}
+
 	public function test_get_product_price_returns_empty_price() {
 		$this->assertSame( '', $this->frontend_prices->get_product_price( '' ) );
 	}

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -45,9 +45,10 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WP_UnitTestCase {
 	 * @dataProvider woocommerce_filter_provider
 	 */
 	public function test_registers_woocommerce_filter( $filter, $function_name ) {
-		$this->assertNotFalse(
+		$this->assertGreaterThan(
+			10,
 			has_filter( $filter, [ $this->frontend_prices, $function_name ] ),
-			"Filter '$filter' was not registered with '$function_name'"
+			"Filter '$filter' was not registered with '$function_name' with a priority higher than the default"
 		);
 	}
 

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Class WCPay_Multi_Currency_Frontend_Prices_Tests
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * WCPay\Multi_Currency\Frontend_Prices unit tests.
+ */
+class WCPay_Multi_Currency_Frontend_Prices_Tests extends WP_UnitTestCase {
+	/**
+	 * Mock WCPay\Multi_Currency\Multi_Currency.
+	 *
+	 * @var WCPay\Multi_Currency\Multi_Currency|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_multi_currency;
+
+	/**
+	 * WCPay\Multi_Currency\Frontend_Prices instance.
+	 *
+	 * @var WCPay\Multi_Currency\Frontend_Prices
+	 */
+	private $frontend_prices;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->mock_multi_currency = $this->createMock( WCPay\Multi_Currency\Multi_Currency::class );
+
+		$this->frontend_prices = new WCPay\Multi_Currency\Frontend_Prices( $this->mock_multi_currency );
+	}
+
+	public function test_placeholder() {
+		$this->assertTrue( true );
+	}
+}

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -103,20 +103,30 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_get_shipping_rates_prices_converts_rates() {
-		$shipping_zone_1       = new WC_Shipping_Zone();
-		$shipping_zone_2       = new WC_Shipping_Zone();
-		$shipping_zone_1->cost = '10.0';
-		$shipping_zone_2->cost = '0.0';
+		$flat_rate_method       = new WC_Shipping_Rate();
+		$free_method            = new WC_Shipping_Rate();
+		$flat_rate_method->cost = '10.0';
+		$free_method->cost      = '0.0';
 
 		$base_shipping_rates = [
-			'shipping_rate_1' => $shipping_zone_1,
-			'shipping_rate_2' => $shipping_zone_2,
+			'shipping_rate_1' => $flat_rate_method,
+			'shipping_rate_2' => $free_method,
 		];
 
 		$shipping_rates = $this->frontend_prices->get_shipping_rates_prices( $base_shipping_rates );
 
 		$this->assertSame( 25.0, $shipping_rates['shipping_rate_1']->cost );
 		$this->assertSame( 0.0, $shipping_rates['shipping_rate_2']->cost );
+	}
+
+	public function test_get_shipping_rates_prices_converts_taxes() {
+		$flat_rate_method        = new WC_Shipping_Rate();
+		$flat_rate_method->cost  = '10.0';
+		$flat_rate_method->taxes = [ '1.0', '2.0' ];
+
+		$shipping_rates = $this->frontend_prices->get_shipping_rates_prices( [ 'shipping_rate_1' => $flat_rate_method ] );
+
+		$this->assertSame( [ 2.5, 5.0 ], $shipping_rates['shipping_rate_1']->taxes );
 	}
 
 	public function test_get_coupon_amount_returns_empty_amount() {

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -106,6 +106,15 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->assertSame( 8.0, $this->multi_currency->get_price( '10.0', 'coupon' ) );
 	}
 
+
+	public function test_get_price_returns_converted_coupon_min_max_price_with_charm() {
+		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, 'GBP' );
+		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_true' );
+
+		// 0.708099 * 10 = 7,08099 -> ceiled to 8 -> 8 - 0.1 = 7.9
+		$this->assertSame( 7.9, $this->multi_currency->get_price( '10.0', 'coupon_min_max' ) );
+	}
+
 	public function test_get_price_returns_converted_tax_price() {
 		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, 'GBP' );
 		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_false' );

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -98,17 +98,9 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->assertSame( 8.0, $this->multi_currency->get_price( '10.0', 'shipping' ) );
 	}
 
-	public function test_get_price_returns_converted_coupon_price_with_charm() {
-		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, 'GBP' );
-		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_false' );
-
-		// 0.708099 * 10 = 7,08099 -> ceiled to 8 -> 8 - 0.1 = 7.9
-		$this->assertSame( 7.9, $this->multi_currency->get_price( '10.0', 'coupon' ) );
-	}
-
 	public function test_get_price_returns_converted_coupon_price_without_charm() {
 		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, 'GBP' );
-		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_true' );
+		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_false' );
 
 		// 0.708099 * 10 = 7,08099 -> ceiled to 8 -> 8 + 0.0 = 8.0
 		$this->assertSame( 8.0, $this->multi_currency->get_price( '10.0', 'coupon' ) );

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -98,12 +98,12 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->assertSame( 8.0, $this->multi_currency->get_price( '10.0', 'shipping' ) );
 	}
 
-	public function test_get_price_returns_converted_coupon_price_without_charm() {
+	public function test_get_price_returns_converted_coupon_price_without_adjustments() {
 		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, 'GBP' );
 		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_false' );
 
-		// 0.708099 * 10 = 7,08099 -> ceiled to 8 -> 8 + 0.0 = 8.0
-		$this->assertSame( 8.0, $this->multi_currency->get_price( '10.0', 'coupon' ) );
+		// 0.708099 * 10 = 7,08099
+		$this->assertSame( 7.08099, $this->multi_currency->get_price( '10.0', 'coupon' ) );
 	}
 
 

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -65,7 +65,13 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 	public function test_get_price_returns_price_in_default_currency() {
 		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, get_woocommerce_currency() );
 
-		$this->assertSame( 5.0, $this->multi_currency->get_price( '5.0' ) );
+		$this->assertSame( 5.0, $this->multi_currency->get_price( '5.0', 'product' ) );
+	}
+
+	public function test_get_price_returns_price_if_unsupported_type() {
+		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, get_woocommerce_currency() );
+
+		$this->assertSame( 5.0, $this->multi_currency->get_price( '5.0', 'unsupported_type' ) );
 	}
 
 	public function test_get_price_returns_converted_product_price_with_charm() {
@@ -73,23 +79,47 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_true' );
 
 		// 0.708099 * 10 = 7,08099 -> ceiled to 8 -> 8 - 0.1 = 7.9
-		$this->assertSame( 7.9, $this->multi_currency->get_price( '10.0' ) );
+		$this->assertSame( 7.9, $this->multi_currency->get_price( '10.0', 'product' ) );
 	}
 
-	public function test_get_price_returns_converted_non_product_price_with_charm() {
+	public function test_get_price_returns_converted_shipping_price_with_charm() {
 		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, 'GBP' );
 		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_false' );
 
 		// 0.708099 * 10 = 7,08099 -> ceiled to 8 -> 8 - 0.1 = 7.9
-		$this->assertSame( 7.9, $this->multi_currency->get_price( '10.0', false ) );
+		$this->assertSame( 7.9, $this->multi_currency->get_price( '10.0', 'shipping' ) );
 	}
 
-	public function test_get_price_returns_converted_non_product_price_without_charm() {
+	public function test_get_price_returns_converted_shipping_price_without_charm() {
 		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, 'GBP' );
 		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_true' );
 
 		// 0.708099 * 10 = 7,08099 -> ceiled to 8 -> 8 + 0.0 = 8.0
-		$this->assertSame( 8.0, $this->multi_currency->get_price( '10.0', false ) );
+		$this->assertSame( 8.0, $this->multi_currency->get_price( '10.0', 'shipping' ) );
+	}
+
+	public function test_get_price_returns_converted_coupon_price_with_charm() {
+		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, 'GBP' );
+		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_false' );
+
+		// 0.708099 * 10 = 7,08099 -> ceiled to 8 -> 8 - 0.1 = 7.9
+		$this->assertSame( 7.9, $this->multi_currency->get_price( '10.0', 'coupon' ) );
+	}
+
+	public function test_get_price_returns_converted_coupon_price_without_charm() {
+		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, 'GBP' );
+		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_true' );
+
+		// 0.708099 * 10 = 7,08099 -> ceiled to 8 -> 8 + 0.0 = 8.0
+		$this->assertSame( 8.0, $this->multi_currency->get_price( '10.0', 'coupon' ) );
+	}
+
+	public function test_get_price_returns_converted_tax_price() {
+		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, 'GBP' );
+		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_false' );
+
+		// 0.708099 * 10 = 7,08099
+		$this->assertSame( 7.08099, $this->multi_currency->get_price( '10.0', 'tax' ) );
 	}
 
 	/**
@@ -105,7 +135,7 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 			}
 		);
 
-		$this->assertSame( $expected, $this->multi_currency->get_price( $price, false ) );
+		$this->assertSame( $expected, $this->multi_currency->get_price( $price, 'shipping' ) );
 	}
 
 	public function get_price_provider() {

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -106,15 +106,6 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->assertSame( 7.08099, $this->multi_currency->get_price( '10.0', 'coupon' ) );
 	}
 
-
-	public function test_get_price_returns_converted_coupon_min_max_price_with_charm() {
-		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, 'GBP' );
-		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_true' );
-
-		// 0.708099 * 10 = 7,08099 -> ceiled to 8 -> 8 - 0.1 = 7.9
-		$this->assertSame( 7.9, $this->multi_currency->get_price( '10.0', 'coupon_min_max' ) );
-	}
-
 	public function test_get_price_returns_converted_tax_price() {
 		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, 'GBP' );
 		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_false' );

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -72,7 +72,7 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, 'GBP' );
 		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_true' );
 
-		// 0.708099 * 10 = 7,08099 -> rounded to 7 -> 7 - 0.1 = 6.9
+		// 0.708099 * 10 = 7,08099 -> ceiled to 8 -> 8 - 0.1 = 7.9
 		$this->assertSame( 7.9, $this->multi_currency->get_price( '10.0' ) );
 	}
 
@@ -80,7 +80,7 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, 'GBP' );
 		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_false' );
 
-		// 0.708099 * 10 = 7,08099 -> rounded to 7 -> 7 - 0.1 = 6.9
+		// 0.708099 * 10 = 7,08099 -> ceiled to 8 -> 8 - 0.1 = 7.9
 		$this->assertSame( 7.9, $this->multi_currency->get_price( '10.0', false ) );
 	}
 
@@ -88,7 +88,7 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, 'GBP' );
 		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_true' );
 
-		// 0.708099 * 10 = 7,08099 -> rounded to 7 -> 7 - 0.1 = 6.9
+		// 0.708099 * 10 = 7,08099 -> ceiled to 8 -> 8 + 0.0 = 8.0
 		$this->assertSame( 8.0, $this->multi_currency->get_price( '10.0', false ) );
 	}
 


### PR DESCRIPTION
Fixes #1769 

## Changes proposed in this Pull Request

This PR converts frontend prices to the selected currency, maintaining compatibility with WooCommerce's native features. Compatibility with other extensions will be addressed as part of another issue. But this work *should* also be compatible with WooCommerce Subscriptions, barring a few edge cases like Subscriptions-specific coupons.

The way prices are converted and formatted is by using some WooCommerce's hooks. Two classes were created to handle them: [Frontend_Prices](https://github.com/Automattic/woocommerce-payments/pull/1860/files#diff-5e2b0c63cb5e2acb8f645e5505db93b758eb74c36703584c42367c726bb2ed0bR15) and [Frontend_Currencies](https://github.com/Automattic/woocommerce-payments/pull/1860/files#diff-c67278bce0bbc54e546375c4d665efd19475a58c00f2586e6cc0f01cb981064aR15). As their names might indicate, they are only loaded in the frontend, by using the [same check as WC](https://github.com/woocommerce/woocommerce/blob/6667233eb11b3d925f5df502e4090742bf1b0c0f/includes/class-woocommerce.php#L359). Using that loading check means that, for now, the multi-currency prices won't work for the checkout blocks. Since we're only building support for blocks in the future, I think it'd be best to address this as part of another issue. Is that okay?

The Frontend_Prices class is responsible for the price conversion for products, shipping rates, and coupons. The Frontend_Currencies one is responsible for using the right symbol, formatting, separators, and decimal places when rendering currencies, and uses locale data from [woocommerce/i18n/locale-info.php](https://github.com/woocommerce/woocommerce/blob/b19500728b4b292562afb65eb3a0c0f50d5859de/i18n/locale-info.php). The data in the locale file can be filtered using [`wcpay_multi_currency_<currency_code>_format`](https://github.com/Automattic/woocommerce-payments/pull/1860/files#diff-c67278bce0bbc54e546375c4d665efd19475a58c00f2586e6cc0f01cb981064aR126).

I made a few assumptions when calculating and adjusting the prices, such as we'd always want to round up the converted amount, we wouldn't want to apply charm pricing to coupons, and we wouldn't want to ceil and apply charm pricing to taxes. Do they seem right?

The price calculation and adjustment can be found [here](https://github.com/Automattic/woocommerce-payments/pull/1860/files#diff-b17bf67925ece08a12ad748cd870705e5d668d3fa19214040f4841daaf712cdcR263-R326). When adjusting the price, we always round up. However, PHP doesn't provide a `ceil` method that accepts the number of decimal places and I had to write [`ceil_price`](https://github.com/Automattic/woocommerce-payments/pull/1860/files#diff-b17bf67925ece08a12ad748cd870705e5d668d3fa19214040f4841daaf712cdcR323). Is that solution robust and reliable enough for our use case?

A few settings are being mocked currently, and can be changed by using filters:
- `wcpay_multi_currency_round_precision`: The number of decimal places to use when rounding, can be negative.
- `wcpay_multi_currency_charm_pricing`: The charm pricing modifier that is added when adjusting the price.
- `wcpay_multi_currency_apply_charm_only_to_products`: Setting this to false indicates that shipping rates should have a charm modifier as well.

A few of the tests introduced in this PR rely on the mocked currencies setup and will have to be modified when we start fetching currencies for real.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You can select a different currency by using the `?currency=<code>` URL param when visiting a frontend page.

To be able to test different currency formatting and zero-currencies, I've modified `get_mock_currencies` to include:

```
return [
	[ 'USD', '1.00' ],
	[ 'CHF', '0.89873' ],
	[ 'HUF', '286.33421' ], // Zero decimal currency.
	[ 'KRW', '1127.7053' ], // Zero decimal currency.
	...
```

We need to make sure that the select currency is working with the following WooCommerce's features:

- Price formatting and conversion
    - Load up the Shop page with the default store currency and check that all prices look right
    - Select a different currency and ensure that the prices have been converted and formatted accordingly:
        - `USD` should look like `$x'xxx.xx`
        - `CHF` should look like `CHF x,xxx.xx`
        - `HUF` should look like `x xxx Ft`
        - `KRW` should look like `xx,xxx₩`
    - Make sure that discounted products and variation price ranges are rendered correctly
- Simple products
    - Make sure their price is converted in the Shop, Product, Cart, and Checkout pages
    - Purchase the product and check that the order has the right currency and price
    - Navigate to the transactions page and ensure that the currency used was the selected one
- Variable products
    - Make sure their price is converted in the Shop, Product, Cart, and Checkout pages
    - Modify the selected currency and ensure the price range was updated. It is cached by WC by default but should be refreshed when the exchange rate changes
    - Purchase the product and check that the order has the right currency and price
    - Navigate to the transactions page and ensure that the currency used was the selected one
- Coupons
    - Enable coupon codes in the General WooCommerce settings
    - Create three coupons, one for each type
    - Ensure that the fixed cart discount and fixed product discount amounts are converted when using them
    - Ensure that the percentage discount works correctly, without having its amount converted
    - Add a minimum and maximum spend usage restriction to a coupon, and check that those values are converted and matched against the cart subtotal
- Shipping
    - Add a free and a flat rate shipping method to your shipping zone
    - Make sure that they work correctly on the checkout page
        - If `apply_charm_only_to_products` is enabled, the shipping rate should only be ceiled after conversion
        - If it's not, the shipping rate should also have the charm pricing added to it
- Taxes
    - Enable taxes in the General WooCommerce settings and create a standard tax rate
    - Ensure that taxes are correctly applied and converted when using both "Prices inclusive of tax" and "Prices exclusive of tax"
    - Ensure that the shipping methods' taxes are also converted properly under both configurations


-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
