### PR TITLE
Fix typo function call

### DIFF
--- a/client/tos/request.js
+++ b/client/tos/request.js
@@ -26,7 +26,7 @@ export const enableGatewayAfterTosDecline = async () =>
 export const maybeTrackStripeConnected = async () => {
 	// eslint-disable-next-line camelcase
 	const trackStripeConnected = wcpay_tos_settings.trackStripeConnected;
-	if ( ! wcpayTracks.isEnabled || ! trackStripeConnected ) {
+	if ( ! wcpayTracks.isEnabled() || ! trackStripeConnected ) {
 		return;
 	}
 


### PR DESCRIPTION
This PR is a follow-up fix for a typo in https://github.com/Automattic/woocommerce-payments/pull/1821. `wcpayTracks.isEnabled` is a function, but the previous implementation did not call it.

Please refer to the PR for testing instruction.