### PR TITLE
Refresh cached account properties on external account events

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Add - Tracking for returning from OAuth connection.
 * Fix - Transactions and deposits counts on the table summary are rendered as "undefined".
 * Update - Deposit overview details.
+* Add - Refresh cached account properties when Stripe external accounts are changing.
 
 = 2.4.0 - 2021-05-12 =
 * Update - Improve the Connect Account page.

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,7 +8,7 @@
 * Add - Tracking for returning from OAuth connection.
 * Fix - Transactions and deposits counts on the table summary are rendered as "undefined".
 * Update - Deposit overview details.
-* Add - Refresh cached account properties when Stripe external accounts are changing.
+* Add - Refresh cached account on deposit bank accounts changes.
 
 = 2.4.0 - 2021-05-12 =
 * Update - Improve the Connect Account page.

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -25,6 +25,14 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	const RESULT_ERROR       = 'error';
 
 	/**
+	 * Events, which triggers refreshing cached account properties.
+	 */
+	const EVENT_ACCOUNT_UPDATED                  = 'account.updated';
+	const EVENT_ACCOUNT_EXTERNAL_ACCOUNT_CREATED = 'account.external_account.created';
+	const EVENT_ACCOUNT_EXTERNAL_ACCOUNT_DELETED = 'account.external_account.deleted';
+	const EVENT_ACCOUNT_EXTERNAL_ACCOUNT_UPDATED = 'account.external_account.updated';
+
+	/**
 	 * Endpoint path.
 	 *
 	 * @var string
@@ -120,7 +128,10 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 				case 'charge.expired':
 					$this->process_webhook_expired_authorization( $body );
 					break;
-				case 'account.updated':
+				case self::EVENT_ACCOUNT_UPDATED:
+				case self::EVENT_ACCOUNT_EXTERNAL_ACCOUNT_CREATED:
+				case self::EVENT_ACCOUNT_EXTERNAL_ACCOUNT_DELETED:
+				case self::EVENT_ACCOUNT_EXTERNAL_ACCOUNT_UPDATED:
 					$this->account->refresh_account_data();
 					break;
 				case 'wcpay.notification':

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -25,7 +25,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	const RESULT_ERROR       = 'error';
 
 	/**
-	 * Events, which triggers refreshing cached account properties.
+	 * Events triggering account cache refresh.
 	 */
 	const EVENT_ACCOUNT_UPDATED                  = 'account.updated';
 	const EVENT_ACCOUNT_EXTERNAL_ACCOUNT_CREATED = 'account.external_account.created';

--- a/readme.txt
+++ b/readme.txt
@@ -109,7 +109,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Tracking for returning from OAuth connection.
 * Fix - Transactions and deposits counts on the table summary are rendered as "undefined".
 * Update - Deposit overview details.
-* Add - Refresh cached account properties when Stripe external accounts are changing.
+* Add - Refresh cached account on deposit bank accounts changes.
 
 = 2.4.0 - 2021-05-12 =
 * Update - Improve the Connect Account page.

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Tracking for returning from OAuth connection.
 * Fix - Transactions and deposits counts on the table summary are rendered as "undefined".
 * Update - Deposit overview details.
+* Add - Refresh cached account properties when Stripe external accounts are changing.
 
 = 2.4.0 - 2021-05-12 =
 * Update - Improve the Connect Account page.


### PR DESCRIPTION
Fixes 681-gh-Automattic/woocommerce-payments-server.

#### Changes proposed in this Pull Request

- Refresh the account cache when `account.external_account.*` are getting forwarded.

#### Testing instructions

* See 816-gh-Automattic/woocommerce-payments-server

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)