### PR TITLE
Fix undefined default currency notices in multi currency tests

### DIFF
--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -39,6 +39,14 @@ function _manually_load_plugin() {
 	// Load the WooCommerce plugin so we can use its classes in our WooCommerce Payments plugin.
 	require_once WP_PLUGIN_DIR . '/woocommerce/woocommerce.php';
 
+	// Set a default currency to be used for the multi-currency tests.
+	add_filter(
+		'woocommerce_currency',
+		function () {
+			return 'USD';
+		}
+	);
+
 	$_plugin_dir = dirname( __FILE__ ) . '/../../';
 
 	require $_plugin_dir . 'woocommerce-payments.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Define a default WooCommerce currency in the tests `bootstrap.php` using the `woocommerce_currency` filter to prevent notices caused by not having a default currency set in the test environment.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the unit tests and assert that no notices are thrown by the Multi-Currency code

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
