### PR TITLE
Add customer multi-currency feature flag

### DIFF
--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -48,4 +48,13 @@ class WC_Payments_Features {
 	public static function is_sofort_enabled() {
 		return '1' === get_option( '_wcpay_feature_sofort', '0' );
 	}
+
+	/**
+	 * Checks whether the customer multi-currency feature is enabled
+	 *
+	 * @return bool
+	 */
+	public static function is_customer_multi_currency_enabled() {
+		return '1' === get_option( '_wcpay_feature_customer_multi_currency', '0' );
+	}
 }

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -179,7 +179,11 @@ class WC_Payments {
 		require_once __DIR__ . '/notes/class-wc-payments-remote-note-service.php';
 		include_once __DIR__ . '/class-wc-payments-action-scheduler-service.php';
 		include_once __DIR__ . '/class-wc-payments-fraud-service.php';
-		include_once __DIR__ . '/multi-currency/wc-payments-multi-currency.php';
+
+		// Load customer multi-currency if feature is enabled.
+		if ( WC_Payments_Features::is_customer_multi_currency_enabled() ) {
+			include_once __DIR__ . '/multi-currency/wc-payments-multi-currency.php';
+		}
 
 		// Always load tracker to avoid class not found errors.
 		include_once WCPAY_ABSPATH . 'includes/admin/tracks/class-tracker.php';

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -39,13 +39,10 @@ function _manually_load_plugin() {
 	// Load the WooCommerce plugin so we can use its classes in our WooCommerce Payments plugin.
 	require_once WP_PLUGIN_DIR . '/woocommerce/woocommerce.php';
 
-	// Set a default currency to be used for the multi-currency tests.
-	add_filter(
-		'woocommerce_currency',
-		function () {
-			return 'USD';
-		}
-	);
+	// Enable and set a default currency to be used for the multi-currency tests because the default
+	// is not loaded even though it's set during the tests setup.
+	update_option( '_wcpay_feature_customer_multi_currency', '1' );
+	update_option( 'woocommerce_currency', 'USD' );
 
 	// Set the 'wcpaydev_dev_mode' option to enable more currencies for now.
 	// TODO: Remove dev mode option here.


### PR DESCRIPTION
Fixes #1793 

#### Changes proposed in this Pull Request


Add a feature flag under the `_wcpay_feature_customer_multi_currency` option to enable the customer multi-currency code.

11-gh-Automattic/woocommerce-payments-dev-tools introduces the checkbox to `woocommerce-payments-dev-tools` to easily enable it.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Before enabling the feature flag, make sure the multi-currency code is not loaded
* Enable the feature flag by setting the `_wcpay_feature_customer_multi_currency` option to `'1'` or using the dev tools checkbox
* Make sure the multi-currency code is loaded after the flag is enabled

*You may check whether the code is enabled by adding a breakpoint to `includes/multi-currency/wc-payments-multi-currency.php`* 

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->