### PR TITLE
Set overview page as default page for WCPay.

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -11,7 +11,7 @@
 }
 /* stylelint-disable selector-id-pattern */
 #adminmenu
-	#toplevel_page_wc-admin-path--payments-deposits
+	#toplevel_page_wc-admin-path--payments-overview
 	.menu-icon-generic
 	div.wp-menu-image::before,
 #adminmenu

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Add - Redirect to WooCommerce home page after successful WooCommerce Payments KYC (Know Your Customer).
 * Fix - Added CSV column heading for transaction id column.
 * Add - Deposit overviews have been added to the overview page.
+* Update - Account overview page is now GA and default page for woocommerce payments.
 
 = 2.4.0 - 2021-05-12 =
 * Update - Improve the Connect Account page.

--- a/client/index.js
+++ b/client/index.js
@@ -46,20 +46,16 @@ addFilter(
 			},
 		} );
 
-		if ( wcpaySettings.featureFlags.accountOverview ) {
-			pages.push( {
-				container: OverviewPage,
-				path: '/payments/overview',
-				wpOpenMenu: menuID,
-				breadcrumbs: [
-					rootLink,
-					__( 'Overview', 'woocommerce-payments' ),
-				],
-				navArgs: {
-					id: 'wc-payments-overview',
-				},
-			} );
-		}
+		pages.push( {
+			container: OverviewPage,
+			path: '/payments/overview',
+			wpOpenMenu: menuID,
+			breadcrumbs: [ rootLink, __( 'Overview', 'woocommerce-payments' ) ],
+			navArgs: {
+				id: 'wc-payments-overview',
+			},
+		} );
+
 		pages.push( {
 			container: DepositsPage,
 			path: '/payments/deposits',
@@ -147,7 +143,7 @@ addFilter(
 );
 
 /**
- * Get menu settings based on the top level link being connect or deposits
+ * Get menu settings based on the top level link being connect or overview
  *
  * @return { { menuID, rootLink } }  Object containing menuID and rootLink
  */
@@ -155,7 +151,7 @@ function getMenuSettings() {
 	const connectPage = document.querySelector(
 		'#toplevel_page_wc-admin-path--payments-connect'
 	);
-	const topLevelPage = connectPage ? 'connect' : 'deposits';
+	const topLevelPage = connectPage ? 'connect' : 'overview';
 
 	return {
 		menuID: `toplevel_page_wc-admin-path--payments-${ topLevelPage }`,

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -16,7 +16,12 @@ import { getTasks } from './task-list/tasks';
 import './style.scss';
 
 const OverviewPage = () => {
-	const { accountStatus, showUpdateDetailsTask } = wcpaySettings;
+	const {
+		accountStatus,
+		showUpdateDetailsTask,
+		featureFlags: { accountOverviewTaskList },
+	} = wcpaySettings;
+
 	const tasks = getTasks( { accountStatus, showUpdateDetailsTask } );
 	return (
 		<Page className="wcpay-overview">
@@ -26,7 +31,9 @@ const OverviewPage = () => {
 				accountStatus={ wcpaySettings.accountStatus }
 				accountFees={ wcpaySettings.accountFees }
 			/>
-			{ 0 < tasks.length && <TaskList tasks={ tasks } /> }
+			{ !! accountOverviewTaskList && 0 < tasks.length && (
+				<TaskList tasks={ tasks } />
+			) }
 		</Page>
 	);
 };

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -4,6 +4,10 @@
  * External dependencies
  */
 
+import { Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { parse } from 'qs';
+
 /**
  * Internal dependencies.
  */
@@ -23,8 +27,20 @@ const OverviewPage = () => {
 	} = wcpaySettings;
 
 	const tasks = getTasks( { accountStatus, showUpdateDetailsTask } );
+	const searchQuery = parse( window?.location?.search );
+	const showKycSuccessNotice =
+		'1' === searchQuery[ 'wcpay-connection-success' ];
+
 	return (
 		<Page className="wcpay-overview">
+			{ showKycSuccessNotice && (
+				<Notice status="success">
+					{ __(
+						"Thanks for verifying your business details. You're ready to start taking payments!",
+						'woocommerce-payments'
+					) }
+				</Notice>
+			) }
 			<TestModeNotice topic={ topics.overview } />
 			<DepositsInformation />
 			<AccountStatus

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -5,8 +5,8 @@
  */
 
 import { Notice } from '@wordpress/components';
+import { getQuery } from '@woocommerce/navigation';
 import { __ } from '@wordpress/i18n';
-import { parse } from 'qs';
 
 /**
  * Internal dependencies.
@@ -17,6 +17,7 @@ import AccountStatus from 'components/account-status';
 import DepositsInformation from 'components/deposits-information';
 import TaskList from './task-list';
 import { getTasks } from './task-list/tasks';
+
 import './style.scss';
 
 const OverviewPage = () => {
@@ -27,9 +28,10 @@ const OverviewPage = () => {
 	} = wcpaySettings;
 
 	const tasks = getTasks( { accountStatus, showUpdateDetailsTask } );
-	const searchQuery = parse( window.location.search );
+	const queryParams = getQuery();
+
 	const showKycSuccessNotice =
-		'1' === searchQuery[ 'wcpay-connection-success' ];
+		'1' === queryParams[ 'wcpay-connection-success' ];
 
 	return (
 		<Page className="wcpay-overview">

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -27,7 +27,7 @@ const OverviewPage = () => {
 	} = wcpaySettings;
 
 	const tasks = getTasks( { accountStatus, showUpdateDetailsTask } );
-	const searchQuery = parse( window?.location?.search );
+	const searchQuery = parse( window.location.search );
 	const showKycSuccessNotice =
 		'1' === searchQuery[ 'wcpay-connection-success' ];
 

--- a/client/overview/style.scss
+++ b/client/overview/style.scss
@@ -37,3 +37,9 @@
 		}
 	}
 }
+
+.wcpay-overview {
+	.components-notice {
+		margin: 24px 0;
+	}
+}

--- a/client/overview/test/index.js
+++ b/client/overview/test/index.js
@@ -31,10 +31,27 @@ describe( 'Overview page', () => {
 				},
 				discount: [],
 			},
+			featureFlags: {
+				accountOverviewTaskList: true,
+			},
 		};
 	} );
 
 	it( 'Skips rendering task list when there are no tasks', () => {
+		getTasks.mockReturnValue( [] );
+		const { container } = render( <OverviewPage /> );
+
+		expect(
+			container.querySelector( '.woocommerce-experimental-list' )
+		).toBeNull();
+	} );
+
+	it( 'Skips rendering task list when accountOverviewTaskList feature flag is off', () => {
+		global.wcpaySettings = {
+			...global.wcpaySettings,
+			featureFlags: {},
+		};
+
 		getTasks.mockReturnValue( [] );
 		const { container } = render( <OverviewPage /> );
 

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -68,7 +68,7 @@ class WC_Payments_Admin {
 			$should_render_full_menu = true;
 		}
 
-		$top_level_link = $should_render_full_menu ? '/payments/deposits' : '/payments/connect';
+		$top_level_link = $should_render_full_menu ? '/payments/overview' : '/payments/connect';
 
 		wc_admin_register_page(
 			[
@@ -94,6 +94,19 @@ class WC_Payments_Admin {
 			 * wc_admin_register_page to duplicate "Payments" menu item as a
 			 * first item in the sub-menu.
 			 */
+			wc_admin_register_page(
+				[
+					'id'       => 'wc-payments-overview',
+					'title'    => __( 'Overview', 'woocommerce-payments' ),
+					'parent'   => 'wc-payments',
+					'path'     => '/payments/overview',
+					'nav_args' => [
+						'parent' => 'wc-payments',
+						'order'  => 5,
+					],
+				]
+			);
+
 			wc_admin_register_page(
 				[
 					'id'       => 'wc-payments-deposits',
@@ -132,26 +145,6 @@ class WC_Payments_Admin {
 					],
 				]
 			);
-
-			if ( self::is_account_overview_page_enabled() ) {
-				/**
-				 * Once page is fully implemented it should become the main
-				 * entry page and implement a proper adjustment of
-				 * $top_level_link if needed to avoid menu item duplication.
-				 */
-				wc_admin_register_page(
-					[
-						'id'       => 'wc-payments-overview',
-						'title'    => __( 'Overview', 'woocommerce-payments' ),
-						'parent'   => 'wc-payments',
-						'path'     => '/payments/overview',
-						'nav_args' => [
-							'parent' => 'wc-payments',
-							'order'  => 5,
-						],
-					]
-				);
-			}
 
 			wc_admin_connect_page(
 				[
@@ -418,10 +411,10 @@ class WC_Payments_Admin {
 	 */
 	private function get_frontend_feature_flags() {
 		return [
-			'paymentTimeline' => self::version_compare( WC_ADMIN_VERSION_NUMBER, '1.4.0', '>=' ),
-			'customSearch'    => self::version_compare( WC_ADMIN_VERSION_NUMBER, '1.3.0', '>=' ),
-			'accountOverview' => self::is_account_overview_page_enabled(),
-			'groupedSettings' => WC_Payments_Features::is_grouped_settings_enabled(),
+			'paymentTimeline'         => self::version_compare( WC_ADMIN_VERSION_NUMBER, '1.4.0', '>=' ),
+			'customSearch'            => self::version_compare( WC_ADMIN_VERSION_NUMBER, '1.3.0', '>=' ),
+			'accountOverviewTaskList' => self::is_account_overview_task_list_enabled(),
+			'groupedSettings'         => WC_Payments_Features::is_grouped_settings_enabled(),
 		];
 	}
 
@@ -474,8 +467,8 @@ class WC_Payments_Admin {
 	 *
 	 * @return bool
 	 */
-	private static function is_account_overview_page_enabled() {
-		return get_option( '_wcpay_feature_account_overview' );
+	private static function is_account_overview_task_list_enabled() {
+		return get_option( '_wcpay_feature_account_overview_task_list' );
 	}
 
 	/**

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -102,7 +102,7 @@ class WC_Payments_Admin {
 					'path'     => '/payments/overview',
 					'nav_args' => [
 						'parent' => 'wc-payments',
-						'order'  => 5,
+						'order'  => 10,
 					],
 				]
 			);
@@ -115,7 +115,7 @@ class WC_Payments_Admin {
 					'path'     => '/payments/deposits',
 					'nav_args' => [
 						'parent' => 'wc-payments',
-						'order'  => 10,
+						'order'  => 20,
 					],
 				]
 			);
@@ -128,7 +128,7 @@ class WC_Payments_Admin {
 					'path'     => '/payments/transactions',
 					'nav_args' => [
 						'parent' => 'wc-payments',
-						'order'  => 20,
+						'order'  => 30,
 					],
 				]
 			);
@@ -141,7 +141,7 @@ class WC_Payments_Admin {
 					'path'     => '/payments/disputes',
 					'nav_args' => [
 						'parent' => 'wc-payments',
-						'order'  => 30,
+						'order'  => 40,
 					],
 				]
 			);
@@ -156,7 +156,7 @@ class WC_Payments_Admin {
 						'parent' => 'wc-payments',
 						'title'  => __( 'Settings', 'woocommerce-payments' ),
 						'url'    => 'wc-settings&tab=checkout&section=woocommerce_payments',
-						'order'  => 40,
+						'order'  => 50,
 					],
 				]
 			);

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -340,18 +340,6 @@ class WC_Payments_Account {
 			return;
 		}
 
-		if ( isset( $_GET['wcpay-connection-success'] ) ) {
-			$account_status = $this->get_account_status_data();
-
-			if ( empty( $account_status['error'] ) && $account_status['paymentsEnabled'] ) {
-				$this->redirect_to_wc_admin_home();
-			} else {
-				$message = __( 'Thanks for verifying your business details!', 'woocommerce-payments' );
-				$this->add_notice_to_settings_page( $message, 'notice-success' );
-			}
-			return;
-		}
-
 		if ( isset( $_GET['wcpay-connect'] ) && check_admin_referer( 'wcpay-connect' ) ) {
 			$wcpay_connect_param = sanitize_text_field( wp_unslash( $_GET['wcpay-connect'] ) );
 
@@ -475,8 +463,8 @@ class WC_Payments_Account {
 	 * @return string
 	 */
 	private function get_oauth_return_url( $wcpay_connect_from ) {
-		// Usually the return URL is the WCPay plugin settings page.
-		// But if connection originated on the WCADMIN payment task page, return there.
+		// If connection originated on the WCADMIN payment task page, return there.
+		// else goto the overview page, since now it is GA (earlier it was redirected to plugin settings page).
 		return 'WCADMIN_PAYMENT_TASK' === $wcpay_connect_from
 			? add_query_arg(
 				[
@@ -486,7 +474,13 @@ class WC_Payments_Account {
 				],
 				admin_url( 'admin.php' )
 			)
-			: WC_Payment_Gateway_WCPay::get_settings_url();
+			: add_query_arg(
+				[
+					'page' => 'wc-admin',
+					'path' => '/payments/overview',
+				],
+				admin_url( 'admin.php' )
+			);
 	}
 
 	/**

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -252,18 +252,6 @@ class WC_Payments_Account {
 	}
 
 	/**
-	 * Immediately redirect to the WooCommerce Admin home page.
-	 */
-	private function redirect_to_wc_admin_home() {
-		$params = [
-			'page' => 'wc-admin',
-		];
-
-		wp_safe_redirect( admin_url( add_query_arg( $params, 'admin.php' ) ) );
-		exit();
-	}
-
-	/**
 	 * Checks if Stripe account is connected and redirects to the onboarding page if it is not.
 	 *
 	 * @return bool True if the redirection happened.
@@ -410,6 +398,37 @@ class WC_Payments_Account {
 	}
 
 	/**
+	 * Payments task page url
+	 *
+	 * @return string payments task page url
+	 */
+	public static function get_payments_task_page_url() {
+		return add_query_arg(
+			[
+				'page'   => 'wc-admin',
+				'task'   => 'payments',
+				'method' => 'wcpay',
+			],
+			admin_url( 'admin.php' )
+		);
+	}
+
+	/**
+	 * Get overview page url
+	 *
+	 * @return string overview page url
+	 */
+	public static function get_overview_url() {
+		return add_query_arg(
+			[
+				'page' => 'wc-admin',
+				'path' => '/payments/overview',
+			],
+			admin_url( 'admin.php' )
+		);
+	}
+
+	/**
 	 * Has on-boarding been disabled?
 	 *
 	 * @return boolean
@@ -466,21 +485,8 @@ class WC_Payments_Account {
 		// If connection originated on the WCADMIN payment task page, return there.
 		// else goto the overview page, since now it is GA (earlier it was redirected to plugin settings page).
 		return 'WCADMIN_PAYMENT_TASK' === $wcpay_connect_from
-			? add_query_arg(
-				[
-					'page'   => 'wc-admin',
-					'task'   => 'payments',
-					'method' => 'wcpay',
-				],
-				admin_url( 'admin.php' )
-			)
-			: add_query_arg(
-				[
-					'page' => 'wc-admin',
-					'path' => '/payments/overview',
-				],
-				admin_url( 'admin.php' )
-			);
+			? $this->get_payments_task_page_url()
+			: $this->get_overview_url();
 	}
 
 	/**

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -418,7 +418,7 @@ class WC_Payments_Account {
 	 *
 	 * @return string overview page url
 	 */
-	public static function get_overview_url() {
+	public static function get_overview_page_url() {
 		return add_query_arg(
 			[
 				'page' => 'wc-admin',
@@ -426,6 +426,15 @@ class WC_Payments_Account {
 			],
 			admin_url( 'admin.php' )
 		);
+	}
+
+	/**
+	 * Checks if the current page is overview page
+	 *
+	 * @return boolean
+	 */
+	public static function is_overview_page() {
+		return isset( $_GET['path'] ) && '/payments/overview' === $_GET['path'];
 	}
 
 	/**
@@ -469,8 +478,9 @@ class WC_Payments_Account {
 	private function redirect_to_login() {
 		// Clear account transient when generating Stripe dashboard's login link.
 		$this->clear_cache();
+		$redirect_url = $this->is_overview_page() ? $this->get_overview_page_url() : WC_Payment_Gateway_WCPay::get_settings_url();
 
-		$login_data = $this->payments_api_client->get_login_data( WC_Payment_Gateway_WCPay::get_settings_url() );
+		$login_data = $this->payments_api_client->get_login_data( $redirect_url );
 		wp_safe_redirect( $login_data['url'] );
 		exit;
 	}
@@ -486,7 +496,7 @@ class WC_Payments_Account {
 		// else goto the overview page, since now it is GA (earlier it was redirected to plugin settings page).
 		return 'WCADMIN_PAYMENT_TASK' === $wcpay_connect_from
 			? $this->get_payments_task_page_url()
-			: $this->get_overview_url();
+			: $this->get_overview_page_url();
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9508,7 +9508,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -13565,8 +13564,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "function.prototype.name": {
       "version": "1.1.4",
@@ -13670,7 +13668,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -13952,7 +13949,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -13989,8 +13985,7 @@
     "has-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-      "dev": true
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -18325,8 +18320,7 @@
     "object-inspect": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
-      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==",
-      "dev": true
+      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
     },
     "object-is": {
       "version": "1.1.5",
@@ -19598,10 +19592,12 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "query-string": {
       "version": "4.3.4",
@@ -20398,6 +20394,12 @@
             "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
           }
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
         }
       }
     },
@@ -20948,7 +20950,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9508,6 +9508,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -13564,7 +13565,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "function.prototype.name": {
       "version": "1.1.4",
@@ -13668,6 +13670,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -13949,6 +13952,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -13985,7 +13989,8 @@
     "has-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -18320,7 +18325,8 @@
     "object-inspect": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
-      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
+      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==",
+      "dev": true
     },
     "object-is": {
       "version": "1.1.5",
@@ -19595,6 +19601,7 @@
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
       "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
       }
@@ -20950,6 +20957,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "debug": "^4.1.1",
     "interpolate-components": "^1.1.1",
     "lodash": "^4.17.14",
+    "qs": "^6.10.1",
     "wordpress-element": "npm:@wordpress/element@2.11.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "debug": "^4.1.1",
     "interpolate-components": "^1.1.1",
     "lodash": "^4.17.14",
-    "qs": "^6.10.1",
     "wordpress-element": "npm:@wordpress/element@2.11.0"
   },
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Redirect to WooCommerce home page after successful WooCommerce Payments KYC (Know Your Customer).
 * Fix - Added CSV column heading for transaction id column.
 * Add - Deposit overviews have been added to the overview page.
+* Update - Account overview page is now GA and default page for woocommerce payments.
 
 = 2.4.0 - 2021-05-12 =
 * Update - Improve the Connect Account page.


### PR DESCRIPTION
Implements #1412 

This PR includes a couple of changes which are listed as follows.

#### Changes proposed in this Pull Request
- Make the overview page as default when you click on the payments tab.
- Push the overview page at the top of the navigation list.
- Removed feature flag for overview page.
- Added feature flag for overview tasklist component.
- Redirect user to overview page after successful auth. from stripe, ref. https://github.com/Automattic/woocommerce-payments/issues/1412#issuecomment-848025873
- Redirect user to overview page after they click on `edit details` link on the overview page.
- Show user a success note after successful kyc.


#### Testing instructions
Default WCPay page
- switch to `add/1412-enable-account-overview`.
- Click on the payments page, the overview page should be default now. (Feature flag is also removed for overview page)
- The overview menu item must be at the top now.

Redirect user to overview page after successful auth. from stripe
- switch to `add/1412-enable-account-overview`.
- Force onboard again (use WCPay dev plugin).
- Start onboarding from the connect page.
- After successful auth, you should be redirected to the new overview page.
- If you start onboarding journey from onboarding task list, then you should be redirected to the same after a successful auth. (ref. https://github.com/Automattic/woocommerce-payments/issues/1412#issuecomment-848025873)

Redirect user to overview page after clicking the edit details link on the overview page
- switch to `add/1412-enable-account-overview`.
- Goto overview page and click edit details.
- Now, click `Return to WooCommerce Payments` or Sign out while you are on the stripe page.
- You should be redirected to the new overview page.

##### A feature toggle for task list `is_account_overview_task_list_enabled` is added in `WC_Payments_Admin` class.


-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
