### PR TITLE
Add customer default currency to account settings

### DIFF
--- a/includes/multi-currency/class-user-settings.php
+++ b/includes/multi-currency/class-user-settings.php
@@ -29,8 +29,8 @@ class User_Settings {
 	public function __construct( Multi_Currency $multi_currency ) {
 		$this->multi_currency = $multi_currency;
 
-		add_action( 'woocommerce_edit_account_form', [ $this, 'add_default_currency_switch' ] );
-		add_action( 'woocommerce_save_account_details', [ $this, 'save_default_currency' ] );
+		add_action( 'woocommerce_edit_account_form', [ $this, 'add_presentment_currency_switch' ] );
+		add_action( 'woocommerce_save_account_details', [ $this, 'save_presentment_currency' ] );
 	}
 
 	/**
@@ -38,7 +38,7 @@ class User_Settings {
 	 *
 	 * @return void
 	 */
-	public function add_default_currency_switch() {
+	public function add_presentment_currency_switch() {
 		?>
 		<p class="woocommerce-form-row woocommerce-form-row--first form-row form-row-first">
 			<label for="wcpay_selected_currency"><?php esc_html_e( 'Default currency', 'woocommerce-payments' ); ?></label>
@@ -67,7 +67,7 @@ class User_Settings {
 	 *
 	 * @return void
 	 */
-	public function save_default_currency() {
+	public function save_presentment_currency() {
 		if ( isset( $_POST['wcpay_selected_currency'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$currency_code = wc_clean( wp_unslash( $_POST['wcpay_selected_currency'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 			$this->multi_currency->update_selected_currency( $currency_code );

--- a/includes/multi-currency/class-user-settings.php
+++ b/includes/multi-currency/class-user-settings.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * WooCommerce Payments Multi Currency User Settings
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Multi_Currency;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class that add Multi Currency settings to user my account page.
+ */
+class User_Settings {
+
+	/**
+	 * Multi-Currency instance.
+	 *
+	 * @var Multi_Currency
+	 */
+	protected $multi_currency;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Multi_Currency $multi_currency The Multi_Currency instance.
+	 */
+	public function __construct( Multi_Currency $multi_currency ) {
+		$this->multi_currency = $multi_currency;
+
+		add_action( 'woocommerce_edit_account_form', [ $this, 'add_default_currency_switch' ] );
+		add_action( 'woocommerce_save_account_details', [ $this, 'save_default_currency' ] );
+	}
+
+	/**
+	 * Add a select to allow user choose default currency in `my account > account details`.
+	 *
+	 * @return void
+	 */
+	public function add_default_currency_switch() {
+		?>
+		<p class="woocommerce-form-row woocommerce-form-row--first form-row form-row-first">
+			<label for="wcpay_selected_currency"><?php esc_html_e( 'Default currency', 'woocommerce-payments' ); ?></label>
+			<select
+				name="wcpay_selected_currency"
+				id="wcpay_selected_currency"
+			>
+				<?php
+				foreach ( $this->multi_currency->get_enabled_currencies() as $currency ) {
+					$code     = $currency->get_code();
+					$symbol   = $currency->get_symbol();
+					$selected = $this->multi_currency->get_selected_currency()->code === $code ? ' selected' : '';
+
+					echo "<option value=\"$code\"$selected>$symbol $code</option>"; // phpcs:ignore WordPress.Security.EscapeOutput
+				}
+				?>
+			</select>
+			<span><em><?php esc_html_e( 'Select your prefered currency for shopping and payments.', 'woocommerce-payments' ); ?></em></span>
+		</p>
+		<div class="clear"></div>
+		<?php
+	}
+
+	/**
+	 * Hook into save account details to capture the new value `wcpay_selected_currency` and persist it.
+	 *
+	 * @return void
+	 */
+	public function save_default_currency() {
+		if ( isset( $_POST['wcpay_selected_currency'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$currency_code = wc_clean( wp_unslash( $_POST['wcpay_selected_currency'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+			$this->multi_currency->update_selected_currency( $currency_code );
+		}
+	}
+
+}

--- a/tests/unit/multi-currency/test-class-user-settings.php
+++ b/tests/unit/multi-currency/test-class-user-settings.php
@@ -45,8 +45,8 @@ class WCPay_Multi_Currency_User_Settings_Tests extends WP_UnitTestCase {
 		$this->user_settings = new WCPay\Multi_Currency\User_Settings( $this->mock_multi_currency );
 	}
 
-	public function test_add_default_currency_switch_renders_markup() {
-		$this->user_settings->add_default_currency_switch();
+	public function test_add_presentment_currency_switch_renders_markup() {
+		$this->user_settings->add_presentment_currency_switch();
 		$this->expectOutputRegex( '/<p class="woocommerce-form-row woocommerce-form-row--first form-row form-row-first">/' );
 		$this->expectOutputRegex( '/<label for="wcpay_selected_currency">Default currency<\/label>/' );
 		$this->expectOutputRegex( '/<select.+name="wcpay_selected_currency"/s' );
@@ -54,27 +54,27 @@ class WCPay_Multi_Currency_User_Settings_Tests extends WP_UnitTestCase {
 		$this->expectOutputRegex( '/<div class="clear"><\/div>/' );
 	}
 
-	public function test_add_default_currency_switch_renders_enabled_currencies() {
-		$this->user_settings->add_default_currency_switch();
+	public function test_add_presentment_currency_switch_renders_enabled_currencies() {
+		$this->user_settings->add_presentment_currency_switch();
 		$this->expectOutputRegex( '/<option value="USD">&#36; USD<\/option>/' );
 		$this->expectOutputRegex( '/<option value="GBP">&pound; GBP<\/option>/' );
 		$this->expectOutputRegex( '/<option value="EUR">&euro; EUR<\/option>/' );
 	}
 
-	public function test_add_default_currency_switch_selects_selected_currency() {
+	public function test_add_presentment_currency_switch_selects_selected_currency() {
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( 'EUR' ) );
-		$this->user_settings->add_default_currency_switch();
+		$this->user_settings->add_presentment_currency_switch();
 		$this->expectOutputRegex( '/<option value="USD">&#36; USD<\/option>/' );
 		$this->expectOutputRegex( '/<option value="GBP">&pound; GBP<\/option>/' );
 		$this->expectOutputRegex( '/<option value="EUR" selected>&euro; EUR<\/option>/' );
 	}
 
-	public function test_save_default_currency() {
+	public function test_save_presentment_currency() {
 		$_POST['wcpay_selected_currency'] = 'GBP';
 		$this->mock_multi_currency
 			->expects( $this->once() )
 			->method( 'update_selected_currency' )
 			->with( 'GBP' );
-		$this->user_settings->save_default_currency();
+		$this->user_settings->save_presentment_currency();
 	}
 }

--- a/tests/unit/multi-currency/test-class-user-settings.php
+++ b/tests/unit/multi-currency/test-class-user-settings.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Class WCPay_Multi_Currency_User_Settings_Tests
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\Multi_Currency\Currency;
+
+/**
+ * WCPay\Multi_Currency\User_Settings unit tests.
+ */
+class WCPay_Multi_Currency_User_Settings_Tests extends WP_UnitTestCase {
+	/**
+	 * Mock WCPay\Multi_Currency\Multi_Currency.
+	 *
+	 * @var WCPay\Multi_Currency\Multi_Currency|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_multi_currency;
+
+	/**
+	 * WCPay\Multi_Currency\User_Settings instance.
+	 *
+	 * @var WCPay\Multi_Currency\User_Settings
+	 */
+	private $user_settings;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->mock_multi_currency = $this->createMock( WCPay\Multi_Currency\Multi_Currency::class );
+		$this->mock_multi_currency
+			->method( 'get_enabled_currencies' )
+			->willReturn(
+				[
+					new Currency( 'USD' ),
+					new Currency( 'GBP' ),
+					new Currency( 'EUR' ),
+				]
+			);
+
+		$this->user_settings = new WCPay\Multi_Currency\User_Settings( $this->mock_multi_currency );
+	}
+
+	public function test_add_default_currency_switch_renders_markup() {
+		$this->user_settings->add_default_currency_switch();
+		$this->expectOutputRegex( '/<p class="woocommerce-form-row woocommerce-form-row--first form-row form-row-first">/' );
+		$this->expectOutputRegex( '/<label for="wcpay_selected_currency">Default currency<\/label>/' );
+		$this->expectOutputRegex( '/<select.+name="wcpay_selected_currency"/s' );
+		$this->expectOutputRegex( '/<span><em>Select your prefered currency for shopping and payments.<\/em><\/span>/' );
+		$this->expectOutputRegex( '/<div class="clear"><\/div>/' );
+	}
+
+	public function test_add_default_currency_switch_renders_enabled_currencies() {
+		$this->user_settings->add_default_currency_switch();
+		$this->expectOutputRegex( '/<option value="USD">&#36; USD<\/option>/' );
+		$this->expectOutputRegex( '/<option value="GBP">&pound; GBP<\/option>/' );
+		$this->expectOutputRegex( '/<option value="EUR">&euro; EUR<\/option>/' );
+	}
+
+	public function test_add_default_currency_switch_selects_selected_currency() {
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( 'EUR' ) );
+		$this->user_settings->add_default_currency_switch();
+		$this->expectOutputRegex( '/<option value="USD">&#36; USD<\/option>/' );
+		$this->expectOutputRegex( '/<option value="GBP">&pound; GBP<\/option>/' );
+		$this->expectOutputRegex( '/<option value="EUR" selected>&euro; EUR<\/option>/' );
+	}
+
+	public function test_save_default_currency() {
+		$_POST['wcpay_selected_currency'] = 'GBP';
+		$this->mock_multi_currency
+			->expects( $this->once() )
+			->method( 'update_selected_currency' )
+			->with( 'GBP' );
+		$this->user_settings->save_default_currency();
+	}
+}


### PR DESCRIPTION
Fixes #1770 

#### Changes proposed in this Pull Request

Following specs in paJDYF-1kA-p2. Added the option to allow a customer to select a default currency in account settings:
- Add new method `update_selected_currency` to `Multi_Currency` that allow update the selected currency directly without using URL param.
- Add `add_default_currency_switch` that hooks into `woocommerce_edit_account_form` to show a select to allow user choose default currency in **My Account > Account Details**.
- Add `save_default_currency` that hooks into `woocommerce_save_account_details` to capture the new value from `wcpay_selected_currency` and persists it using the new mentioned method.
- The select input uses the same markup that the current available form elements. Taking one of the two rows as in Figma design.

#### Testing instructions
- Go to **My Account > Account Details**
- Select a currency from the select
- Hit the **Save** button
- After refresh you should see the new currency selected in the select, updated in the session. And if you have the widget enabled, you can see the new currency selected there too.

#### Screenshots

<img width="809" alt="Screenshot 2021-05-26 at 11 32 45" src="https://user-images.githubusercontent.com/7670276/119637814-5637fd80-be16-11eb-91f9-63eb15431b3c.png">
