### PR TITLE
Add a task to reconnect the WPCOM user if broken

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 2.6.0 - 2021-xx-xx =
+* Add - Notify the admin if WordPress.com user connection is broken.
+
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.
 * Update - Use Site Language when rendering Stripe elements.

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -24,10 +24,15 @@ const OverviewPage = () => {
 	const {
 		accountStatus,
 		showUpdateDetailsTask,
+		wpcomReconnectUrl,
 		featureFlags: { accountOverviewTaskList },
 	} = wcpaySettings;
 
-	const tasks = getTasks( { accountStatus, showUpdateDetailsTask } );
+	const tasks = getTasks( {
+		accountStatus,
+		showUpdateDetailsTask,
+		wpcomReconnectUrl,
+	} );
 	const queryParams = getQuery();
 
 	const showKycSuccessNotice =

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -7,7 +7,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 import moment from 'moment';
 
-export const getTasks = ( { accountStatus, showUpdateDetailsTask } ) => {
+export const getTasks = ( {
+	accountStatus,
+	showUpdateDetailsTask,
+	wpcomReconnectUrl,
+} ) => {
 	const { status, currentDeadline, pastDue, accountLink } = accountStatus;
 	const accountRestrictedSoon = 'restricted_soon' === status;
 	const accountDetailsPastDue = 'restricted' === status && pastDue;
@@ -49,6 +53,16 @@ export const getTasks = ( { accountStatus, showUpdateDetailsTask } ) => {
 					: () => {
 							window.open( accountLink, '_blank' );
 					  },
+		},
+		wpcomReconnectUrl && {
+			key: 'reconnect-wpcom-user',
+			level: 1,
+			title: __( 'Reconnect the WPCOM user', 'woocommerce-payments' ),
+			content: __( 'Or else.', 'woocommerce-payments' ),
+			completed: false,
+			onClick: () => {
+				window.location.href = wpcomReconnectUrl;
+			},
 		},
 	].filter( Boolean );
 };

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -57,8 +57,15 @@ export const getTasks = ( {
 		wpcomReconnectUrl && {
 			key: 'reconnect-wpcom-user',
 			level: 1,
-			title: __( 'Reconnect the WPCOM user', 'woocommerce-payments' ),
-			content: __( 'Or else.', 'woocommerce-payments' ),
+			title: __(
+				'Reconnect WooCommerce Payments',
+				'woocommerce-payments'
+			),
+			content: __(
+				'WooCommerce Payments is missing a connected WordPress.com account. ' +
+					'Some functionality will be limited without a connected account.',
+				'woocommerce-payments'
+			),
 			completed: false,
 			onClick: () => {
 				window.location.href = wpcomReconnectUrl;

--- a/client/overview/task-list/test/tasks.js
+++ b/client/overview/task-list/test/tasks.js
@@ -67,4 +67,39 @@ describe( 'getTasks()', () => {
 			] )
 		);
 	} );
+
+	it( 'adds WPCOM user reconnect task when the url is specified', () => {
+		const actual = getTasks( {
+			accountStatus: {
+				status: 'complete',
+			},
+			wpcomReconnectUrl: 'http://example.com',
+		} );
+
+		expect( actual ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					key: 'reconnect-wpcom-user',
+					completed: false,
+				} ),
+			] )
+		);
+	} );
+
+	it( 'should omit the WPCOM user reconnect task when the url is not specified', () => {
+		const actual = getTasks( {
+			accountStatus: {
+				status: 'complete',
+			},
+			wpcomReconnectUrl: null,
+		} );
+
+		expect( actual ).toEqual(
+			expect.not.arrayContaining( [
+				expect.objectContaining( {
+					key: 'reconnect-wpcom-user',
+				} ),
+			] )
+		);
+	} );
 } );

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -253,6 +253,7 @@ class WC_Payments_Admin {
 			'accountStatus'         => $this->account->get_account_status_data(),
 			'accountFees'           => $this->account->get_fees(),
 			'showUpdateDetailsTask' => get_option( 'wcpay_show_update_business_details_task', 'no' ),
+			'wpcomReconnectUrl'     => $this->payments_api_client->is_server_connected() && ! $this->payments_api_client->has_server_connection_owner() ? WC_Payments_Account::get_wpcom_reconnect_url() : null,
 		];
 
 		wp_localize_script(

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -328,6 +328,11 @@ class WC_Payments_Account {
 			return;
 		}
 
+		if ( isset( $_GET['wcpay-reconnect-wpcom'] ) && check_admin_referer( 'wcpay-reconnect-wpcom' ) ) {
+			$this->payments_api_client->start_server_connection( WC_Payment_Gateway_WCPay::get_settings_url() );
+			return;
+		}
+
 		if ( isset( $_GET['wcpay-connect'] ) && check_admin_referer( 'wcpay-connect' ) ) {
 			$wcpay_connect_param = sanitize_text_field( wp_unslash( $_GET['wcpay-connect'] ) );
 
@@ -438,6 +443,24 @@ class WC_Payments_Account {
 	}
 
 	/**
+	 * Get WPCOM/Jetpack reconnect url, for use in case of missing connection owner.
+	 *
+	 * @return string WPCOM/Jetpack reconnect url.
+	 */
+	public static function get_wpcom_reconnect_url() {
+		return admin_url(
+			add_query_arg(
+				[
+					'wcpay-reconnect-wpcom' => '1',
+					'_wpnonce'              => wp_create_nonce( 'wcpay-reconnect-wpcom' ),
+				],
+				'admin.php'
+			)
+		);
+	}
+
+
+	/**
 	 * Has on-boarding been disabled?
 	 *
 	 * @return boolean
@@ -456,7 +479,7 @@ class WC_Payments_Account {
 	 * @throws API_Exception If there was an error when registering the site on WP.com.
 	 */
 	private function maybe_init_jetpack_connection( $wcpay_connect_from ) {
-		$is_jetpack_fully_connected = $this->payments_api_client->is_server_connected();
+		$is_jetpack_fully_connected = $this->payments_api_client->is_server_connected() && $this->payments_api_client->has_server_connection_owner();
 		if ( $is_jetpack_fully_connected ) {
 			return;
 		}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -104,6 +104,15 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Checks if the site has an admin who is also a connection owner.
+	 *
+	 * @return bool True if Jetpack connection has an owner.
+	 */
+	public function has_server_connection_owner() {
+		return $this->http_client->has_connection_owner();
+	}
+
+	/**
 	 * Gets the current WP.com blog ID, if the Jetpack connection has been set up.
 	 *
 	 * @return integer|NULL Current WPCOM blog ID, or NULL if not connected yet.

--- a/includes/wc-payment-api/class-wc-payments-http-interface.php
+++ b/includes/wc-payment-api/class-wc-payments-http-interface.php
@@ -37,6 +37,13 @@ interface WC_Payments_Http_Interface {
 	public function is_connected();
 
 	/**
+	 * Checks if the site has an admin who is also a connection owner.
+	 *
+	 * @return bool True if Jetpack connection has an owner.
+	 */
+	public function has_connection_owner();
+
+	/**
 	 * Gets the current WP.com blog ID.
 	 *
 	 * @return integer Current WPCOM blog ID.

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -111,6 +111,15 @@ class WC_Payments_Http implements WC_Payments_Http_Interface {
 	}
 
 	/**
+	 * Checks if the site has an admin who is also a connection owner.
+	 *
+	 * @return bool True if Jetpack connection has an owner.
+	 */
+	public function has_connection_owner() {
+		return ! empty( $this->connection_manager->get_connection_owner_id() );
+	}
+
+	/**
 	 * Gets the current WP.com blog ID.
 	 *
 	 * @return integer Current WPCOM blog ID.

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 2.6.0 - 2021-xx-xx =
+* Add - Notify the admin if WordPress.com user connection is broken.
+
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.
 * Update - Use Site Language when rendering Stripe elements.


### PR DESCRIPTION
Fixes #1804

#### Changes proposed in this Pull Request

- When the connection owner user is missing, show a task in the Account Overview page
<img width="1146" alt="Screenshot 2021-05-27 at 13 46 13" src="https://user-images.githubusercontent.com/800604/119828633-4261c980-bef2-11eb-85ee-a240660214e7.png">

#### Testing instructions

- `update_option( '_wcpay_feature_account_overview', 1 );`
- Make sure Jetpack is installed and active
- Create a new admin user on the site
- Delete the original admin user that connected WCPay/Jetpack
- Run ngrok or other tunneling, open the admin panel via the tunnel
- Navigate to `Payments > Overview`
- The task to reconnect should be rendered in the list
- Click on the task, you should be taken to WPCOM to approve the connection
- Approve the connection, you should be taken back to the settings page and the task should not be rendered in the overview page anymore

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

cc @jeffstieler since this touches on the Task List work
