### PR TITLE
Add the store's currency to the list of available currencies

### DIFF
--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -153,15 +153,15 @@ class Multi_Currency {
 			return $this->available_currencies;
 		}
 
+		// Add default store currency with a rate of 1.0.
+		$woocommerce_currency                                = get_woocommerce_currency();
+		$this->available_currencies[ $woocommerce_currency ] = new Currency( $woocommerce_currency, 1.0 );
+
 		// TODO: This will need to get stored data, then build and return it accordingly.
 		$currencies = $this->get_mock_currencies();
 		foreach ( $currencies as $currency ) {
 			$this->available_currencies[ $currency[0] ] = new Currency( $currency[0], $currency[1] );
 		}
-
-		// Add default store currency with a rate of 1.0.
-		$woocommerce_currency                                = get_woocommerce_currency();
-		$this->available_currencies[ $woocommerce_currency ] = new Currency( $woocommerce_currency, 1.0 );
 
 		return $this->available_currencies;
 	}

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -159,6 +159,11 @@ class Multi_Currency {
 		foreach ( $currencies as $currency ) {
 			$this->available_currencies[ $currency[0] ] = new Currency( $currency[0], $currency[1] );
 		}
+
+		// Add default store currency with a rate of 1.0.
+		$woocommerce_currency                                = get_woocommerce_currency();
+		$this->available_currencies[ $woocommerce_currency ] = new Currency( $woocommerce_currency, 1.0 );
+
 		return $this->available_currencies;
 	}
 

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -131,7 +131,6 @@ class Multi_Currency {
 	 */
 	public function get_mock_currencies() {
 		return [
-			[ 'USD', '1.00' ],
 			[ 'CAD', '1.206823' ],
 			[ 'GBP', '0.708099' ],
 			[ 'EUR', '0.826381' ],

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -26,9 +26,29 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		WC()->session->__unset( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY );
 		remove_all_filters( 'wcpay_multi_currency_apply_charm_only_to_products' );
 		remove_all_filters( 'wcpay_multi_currency_round_precision' );
+		remove_all_filters( 'woocommerce_currency' );
 		$this->reset_multi_currency_instance();
 
 		parent::tearDown();
+	}
+
+	public function test_get_available_currencies_adds_store_currency() {
+		add_filter(
+			'woocommerce_currency',
+			function () {
+				return 'DEFAULT';
+			},
+			100
+		);
+
+		// Recreate Multi_Currency instance to use the recently set DEFAULT currency.
+		$this->reset_multi_currency_instance();
+		$this->multi_currency = WCPay\Multi_Currency\Multi_Currency::instance();
+
+		$default_currency = $this->multi_currency->get_available_currencies()['DEFAULT'];
+
+		$this->assertSame( 'DEFAULT', $default_currency->get_code() );
+		$this->assertSame( 1.0, $default_currency->get_rate() );
 	}
 
 	public function test_get_selected_currency_returns_default_currency_for_empty_session() {

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -26,6 +26,7 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		WC()->session->__unset( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY );
 		remove_all_filters( 'wcpay_multi_currency_apply_charm_only_to_products' );
 		remove_all_filters( 'wcpay_multi_currency_round_precision' );
+		$this->reset_multi_currency_instance();
 
 		parent::tearDown();
 	}
@@ -146,5 +147,13 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 			[ '141.0', -2, 100.0 ], // 99.841 after conversion
 			[ '142.0', -2, 200.0 ], // 100.550 after conversion
 		];
+	}
+
+	private function reset_multi_currency_instance() {
+		$multi_currency_reflection = new ReflectionClass( $this->multi_currency );
+		$instance_property         = $multi_currency_reflection->getProperty( 'instance' );
+		$instance_property->setAccessible( true );
+		$instance_property->setValue( null, null );
+		$instance_property->setAccessible( false );
 	}
 }


### PR DESCRIPTION
Fixes #1909 

#### Changes proposed in this Pull Request

The store currency is the currency in which merchants specify all prices. This means that its exchange rate should be `1.0`. E.g. the conversion from USD to USD should use a rate of 1 since they're the same currency. Because of that, we can prevent the `Undefined index` error that happens when the store currency is not part of the `available_currencies` array by manually injecting it there.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch your store to a currency that's not defined in [`Multi_Currency::get_mock_currencies`](https://github.com/Automattic/woocommerce-payments/blob/feature/multi-currency/includes/multi-currency/class-multi-currency.php#L132)
* Make sure no errors and notices are thrown
* Check the frontend widget and ensure the currency is listed and can be converted to other currencies

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
