### PR TITLE
refactor: settings save button section

### DIFF
--- a/client/settings/payment-method-settings/digital-wallets-settings.js
+++ b/client/settings/payment-method-settings/digital-wallets-settings.js
@@ -11,11 +11,53 @@ import { Card, CardBody, RadioControl } from '@wordpress/components';
  */
 import './index.scss';
 
+const buttonSizeOptions = [
+	{
+		label: __( 'Default (40 px)', 'woocommerce-payments' ),
+		value: 'default',
+	},
+	{
+		label: __( 'Medium (48 px)', 'woocommerce-payments' ),
+		value: 'medium',
+	},
+	{
+		label: __( 'Large (56 px)', 'woocommerce-payments' ),
+		value: 'large',
+	},
+];
+const buttonActionOptions = [
+	{
+		label: __( 'Only icon', 'woocommerce-payments' ),
+		value: 'only-icon',
+	},
+	{
+		label: __( 'Buy', 'woocommerce-payments' ),
+		value: 'buy',
+	},
+	{
+		label: __( 'Donate', 'woocommerce-payments' ),
+		value: 'donate',
+	},
+	{
+		label: __( 'Book', 'woocommerce-payments' ),
+		value: 'book',
+	},
+];
+const buttonThemeOptions = [
+	{
+		label: __( 'Dark', 'woocommerce-payments' ),
+		value: 'dark',
+	},
+	{
+		label: __( 'Light', 'woocommerce-payments' ),
+		value: 'light',
+	},
+];
+
 const DigitalWalletsSettings = () => {
 	const [ cta, setCta ] = useState( 'buy' );
 	const [ size, setSize ] = useState( 'default' );
 	const [ theme, setTheme ] = useState( 'dark' );
-
 	return (
 		<Card>
 			<CardBody>
@@ -26,24 +68,7 @@ const DigitalWalletsSettings = () => {
 						'woocommerce-payments'
 					) }
 					selected={ cta }
-					options={ [
-						{
-							label: __( 'Only icon', 'woocommerce-payments' ),
-							value: 'only-icon',
-						},
-						{
-							label: __( 'Buy', 'woocommerce-payments' ),
-							value: 'buy',
-						},
-						{
-							label: __( 'Donate', 'woocommerce-payments' ),
-							value: 'donate',
-						},
-						{
-							label: __( 'Book', 'woocommerce-payments' ),
-							value: 'book',
-						},
-					] }
+					options={ buttonActionOptions }
 					onChange={ setCta }
 				/>
 				<h4>{ __( 'Appearance', 'woocommerce-payments' ) }</h4>
@@ -54,29 +79,7 @@ const DigitalWalletsSettings = () => {
 					) }
 					label={ __( 'Size', 'woocommerce-payments' ) }
 					selected={ size }
-					options={ [
-						{
-							label: __(
-								'Default (40 px)',
-								'woocommerce-payments'
-							),
-							value: 'default',
-						},
-						{
-							label: __(
-								'Medium (48 px)',
-								'woocommerce-payments'
-							),
-							value: 'medium',
-						},
-						{
-							label: __(
-								'Large (56 px)',
-								'woocommerce-payments'
-							),
-							value: 'large',
-						},
-					] }
+					options={ buttonSizeOptions }
 					onChange={ setSize }
 				/>
 				<RadioControl
@@ -87,16 +90,7 @@ const DigitalWalletsSettings = () => {
 					) }
 					label={ __( 'Theme', 'woocommerce-payments' ) }
 					selected={ theme }
-					options={ [
-						{
-							label: __( 'Dark', 'woocommerce-payments' ),
-							value: 'dark',
-						},
-						{
-							label: __( 'Light', 'woocommerce-payments' ),
-							value: 'light',
-						},
-					] }
+					options={ buttonThemeOptions }
 					onChange={ setTheme }
 				/>
 			</CardBody>

--- a/client/settings/payment-method-settings/digital-wallets-settings.js
+++ b/client/settings/payment-method-settings/digital-wallets-settings.js
@@ -4,7 +4,7 @@
  */
 import React, { useState } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button, Card, CardBody, RadioControl } from '@wordpress/components';
+import { Card, CardBody, RadioControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -17,105 +17,90 @@ const DigitalWalletsSettings = () => {
 	const [ theme, setTheme ] = useState( 'dark' );
 
 	return (
-		<>
-			<Card>
-				<CardBody>
-					<h4>{ __( 'Call to action', 'woocommerce-payments' ) }</h4>
-					<RadioControl
-						help={ __(
-							'Select a button label that fits best with the flow of purchase or payment experience on your store.',
-							'woocommerce-payments'
-						) }
-						selected={ cta }
-						options={ [
-							{
-								label: __(
-									'Only icon',
-									'woocommerce-payments'
-								),
-								value: 'only-icon',
-							},
-							{
-								label: __( 'Buy', 'woocommerce-payments' ),
-								value: 'buy',
-							},
-							{
-								label: __( 'Donate', 'woocommerce-payments' ),
-								value: 'donate',
-							},
-							{
-								label: __( 'Book', 'woocommerce-payments' ),
-								value: 'book',
-							},
-						] }
-						onChange={ setCta }
-					/>
-					<h4>{ __( 'Appearance', 'woocommerce-payments' ) }</h4>
-					<RadioControl
-						help={ __(
-							'Note that larger buttons are more suitable for mobile use.',
-							'woocommerce-payments'
-						) }
-						label={ __( 'Size', 'woocommerce-payments' ) }
-						selected={ size }
-						options={ [
-							{
-								label: __(
-									'Default (40 px)',
-									'woocommerce-payments'
-								),
-								value: 'default',
-							},
-							{
-								label: __(
-									'Medium (48 px)',
-									'woocommerce-payments'
-								),
-								value: 'medium',
-							},
-							{
-								label: __(
-									'Large (56 px)',
-									'woocommerce-payments'
-								),
-								value: 'large',
-							},
-						] }
-						onChange={ setSize }
-					/>
-					<RadioControl
-						help={ __(
-							// eslint-disable-next-line max-len
-							'Dark is recommended for white or light-colored backgrounds and light is recommended for dark or colored backgrounds.',
-							'woocommerce-payments'
-						) }
-						label={ __( 'Theme', 'woocommerce-payments' ) }
-						selected={ theme }
-						options={ [
-							{
-								label: __( 'Dark', 'woocommerce-payments' ),
-								value: 'dark',
-							},
-							{
-								label: __( 'Light', 'woocommerce-payments' ),
-								value: 'light',
-							},
-						] }
-						onChange={ setTheme }
-					/>
-				</CardBody>
-			</Card>
-			<div className="woocommerce-payments_digital-wallets__action">
-				<Button
-					isPrimary
-					onClick={ () => {
-						return false;
-					} }
-				>
-					{ __( 'Save changes', 'woocommerce-payments' ) }
-				</Button>
-			</div>
-		</>
+		<Card>
+			<CardBody>
+				<h4>{ __( 'Call to action', 'woocommerce-payments' ) }</h4>
+				<RadioControl
+					help={ __(
+						'Select a button label that fits best with the flow of purchase or payment experience on your store.',
+						'woocommerce-payments'
+					) }
+					selected={ cta }
+					options={ [
+						{
+							label: __( 'Only icon', 'woocommerce-payments' ),
+							value: 'only-icon',
+						},
+						{
+							label: __( 'Buy', 'woocommerce-payments' ),
+							value: 'buy',
+						},
+						{
+							label: __( 'Donate', 'woocommerce-payments' ),
+							value: 'donate',
+						},
+						{
+							label: __( 'Book', 'woocommerce-payments' ),
+							value: 'book',
+						},
+					] }
+					onChange={ setCta }
+				/>
+				<h4>{ __( 'Appearance', 'woocommerce-payments' ) }</h4>
+				<RadioControl
+					help={ __(
+						'Note that larger buttons are more suitable for mobile use.',
+						'woocommerce-payments'
+					) }
+					label={ __( 'Size', 'woocommerce-payments' ) }
+					selected={ size }
+					options={ [
+						{
+							label: __(
+								'Default (40 px)',
+								'woocommerce-payments'
+							),
+							value: 'default',
+						},
+						{
+							label: __(
+								'Medium (48 px)',
+								'woocommerce-payments'
+							),
+							value: 'medium',
+						},
+						{
+							label: __(
+								'Large (56 px)',
+								'woocommerce-payments'
+							),
+							value: 'large',
+						},
+					] }
+					onChange={ setSize }
+				/>
+				<RadioControl
+					help={ __(
+						// eslint-disable-next-line max-len
+						'Dark is recommended for white or light-colored backgrounds and light is recommended for dark or colored backgrounds.',
+						'woocommerce-payments'
+					) }
+					label={ __( 'Theme', 'woocommerce-payments' ) }
+					selected={ theme }
+					options={ [
+						{
+							label: __( 'Dark', 'woocommerce-payments' ),
+							value: 'dark',
+						},
+						{
+							label: __( 'Light', 'woocommerce-payments' ),
+							value: 'light',
+						},
+					] }
+					onChange={ setTheme }
+				/>
+			</CardBody>
+		</Card>
 	);
 };
 

--- a/client/settings/payment-method-settings/index.js
+++ b/client/settings/payment-method-settings/index.js
@@ -13,6 +13,10 @@ import SettingsSection from '../settings-section';
 import { getPaymentSettingsUrl } from '../../utils';
 import DigitalWalletsSettings from './digital-wallets-settings';
 import Banner from '../../banner';
+import { useSettings } from '../../data';
+import { LoadableBlock } from '../../components/loadable';
+import React from 'react';
+import SaveSettingsSection from '../save-settings-section';
 
 /* eslint-disable camelcase */
 const methods = {
@@ -52,6 +56,7 @@ const methods = {
 
 const PaymentMethodSettings = ( { methodId } ) => {
 	const method = methods[ methodId ];
+	const { isLoading } = useSettings();
 
 	if ( ! method ) {
 		return (
@@ -71,13 +76,19 @@ const PaymentMethodSettings = ( { methodId } ) => {
 			<Banner />
 
 			<h2 className="payment-method-settings__breadcrumbs">
-				<a href={ getPaymentSettingsUrl() }>WooCommerce Payments</a>{ ' ' }
+				<a href={ getPaymentSettingsUrl() }>
+					{ __( 'WooCommerce Payments', 'woocommerce-payments' ) }
+				</a>{ ' ' }
 				&gt; <span>{ title }</span>
 			</h2>
 
 			<SettingsSection Description={ Description }>
-				<Controls />
+				<LoadableBlock isLoading={ isLoading } numLines={ 30 }>
+					<Controls />
+				</LoadableBlock>
 			</SettingsSection>
+
+			<SaveSettingsSection />
 		</div>
 	);
 };

--- a/client/settings/payment-method-settings/index.scss
+++ b/client/settings/payment-method-settings/index.scss
@@ -9,8 +9,3 @@
 .components-radio-control__input[type='radio']:checked::before {
 	box-sizing: border-box;
 }
-
-.woocommerce-payments_digital-wallets__action {
-	margin-top: 2em;
-	float: right;
-}

--- a/client/settings/payment-method-settings/test/index.js
+++ b/client/settings/payment-method-settings/test/index.js
@@ -10,6 +10,10 @@ import { render, screen, within } from '@testing-library/react';
  */
 import PaymentMethodSettings from '..';
 
+jest.mock( '../../../data', () => ( {
+	useSettings: jest.fn().mockReturnValue( {} ),
+} ) );
+
 describe( 'PaymentMethodSettings', () => {
 	test( 'renders title and description', () => {
 		render(

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -1,0 +1,33 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useSettings } from '../../data';
+import SettingsSection from '../settings-section';
+import './style.scss';
+
+const SaveSettingsSection = () => {
+	const { saveSettings, isSaving, isLoading } = useSettings();
+
+	return (
+		<SettingsSection className="save-settings-section">
+			<Button
+				isPrimary
+				isBusy={ isSaving }
+				disabled={ isSaving || isLoading }
+				onClick={ saveSettings }
+			>
+				{ __( 'Save changes', 'woocommerce-payments' ) }
+			</Button>
+		</SettingsSection>
+	);
+};
+
+export default SaveSettingsSection;

--- a/client/settings/save-settings-section/style.scss
+++ b/client/settings/save-settings-section/style.scss
@@ -1,0 +1,3 @@
+.save-settings-section {
+	text-align: right;
+}

--- a/client/settings/save-settings-section/test/index.test.js
+++ b/client/settings/save-settings-section/test/index.test.js
@@ -1,0 +1,59 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import SaveSettingsSection from '..';
+import { useSettings } from '../../../data';
+
+jest.mock( '../../../data', () => ( {
+	useSettings: jest.fn().mockReturnValue( {} ),
+} ) );
+
+describe( 'SaveSettingsSection', () => {
+	it( 'disables the button when loading data', () => {
+		useSettings.mockReturnValue( {
+			isLoading: true,
+		} );
+
+		render( <SaveSettingsSection /> );
+
+		expect( screen.getByText( 'Save changes' ) ).toBeDisabled();
+	} );
+
+	it( 'disables the button when saving data', () => {
+		useSettings.mockReturnValue( {
+			isSaving: true,
+		} );
+
+		render( <SaveSettingsSection /> );
+
+		expect( screen.getByText( 'Save changes' ) ).toBeDisabled();
+	} );
+
+	it( 'calls `saveSettings` when the button is clicked', () => {
+		const saveSettingsMock = jest.fn();
+		useSettings.mockReturnValue( {
+			isSaving: false,
+			isLoading: false,
+			saveSettings: saveSettingsMock,
+		} );
+
+		render( <SaveSettingsSection /> );
+
+		const saveChangesButton = screen.getByText( 'Save changes' );
+
+		expect( saveSettingsMock ).not.toHaveBeenCalled();
+		expect( saveChangesButton ).not.toBeDisabled();
+
+		userEvent.click( saveChangesButton );
+
+		expect( saveSettingsMock ).toHaveBeenCalled();
+	} );
+} );

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Button, ExternalLink } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -20,7 +20,7 @@ import GeneralSettings from '../general-settings';
 import TestModeSettings from '../test-mode-settings';
 import ApplePayIcon from '../../gateway-icons/apple-pay';
 import GooglePayIcon from '../../gateway-icons/google-pay';
-import './style.scss';
+import SaveSettingsSection from '../save-settings-section';
 
 const PaymentMethodsDescription = () => (
 	<>
@@ -78,7 +78,7 @@ const GeneralSettingsDescription = () => (
 );
 
 const SettingsManager = ( { accountStatus = {} } ) => {
-	const { saveSettings, isSaving, isLoading } = useSettings();
+	const { isLoading } = useSettings();
 
 	return (
 		<>
@@ -107,16 +107,7 @@ const SettingsManager = ( { accountStatus = {} } ) => {
 					</LoadableBlock>
 				</SettingsSection>
 				<AdvancedSettings />
-				<SettingsSection className="settings-manager__buttons">
-					<Button
-						isPrimary
-						isBusy={ isSaving }
-						disabled={ isSaving || isLoading }
-						onClick={ saveSettings }
-					>
-						{ __( 'Save changes', 'woocommerce-payments' ) }
-					</Button>
-				</SettingsSection>
+				<SaveSettingsSection />
 			</div>
 		</>
 	);

--- a/client/settings/settings-manager/style.scss
+++ b/client/settings/settings-manager/style.scss
@@ -1,3 +1,0 @@
-.settings-manager__buttons {
-	text-align: right;
-}


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

As part of working on https://github.com/Automattic/woocommerce-payments/issues/1905 , I noticed that the "save" button would have the same logic and styles as the main settings page.

I know this isn't super-reused, and it might be overly-abstracted, but I thought it would be nice to have a separate component so things are just a tiny bit more DRY - both in terms of functionality but also in terms of styling (which is the main benefit, IMO).

PLEASE NOTE: the "save changes" button won't work until https://github.com/Automattic/woocommerce-payments/pull/1904 is merged

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have the "grouped settings" flag enabled in WCPay Dev Tools
- Go to your WCPay Home: http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout
- You can still save the settings

PLEASE NOTE: the "save changes" button won't work until https://github.com/Automattic/woocommerce-payments/pull/1904 is merged

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
