### PR TITLE
Fix enabled currencies list so that it reloads on update.

### DIFF
--- a/client/data/multi-currency/actions.js
+++ b/client/data/multi-currency/actions.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
  * Internal Dependencies
  */
 import TYPES from './action-types';
-import { NAMESPACE } from '../constants';
+import { NAMESPACE, STORE_NAME } from '../constants';
 
 export function updateCurrencies( data ) {
 	return {
@@ -51,6 +51,11 @@ export function* submitEnabledCurrenciesUpdate( currencies ) {
 			},
 		} );
 		yield updateCurrencies( result );
+
+		// Need to invalidate the resolution so that the components will render again.
+		yield dispatch( STORE_NAME ).invalidateResolutionForStoreSelector(
+			'getCurrencies'
+		);
 
 		yield dispatch( 'core/notices' ).createSuccessNotice(
 			__( 'Enabled currencies updated.', 'woocommerce-payments' )


### PR DESCRIPTION
Fixes #1921

#### Changes proposed in this Pull Request

* Invalidate the resolution of the currencies so that the currency list will reload upon update.

#### Testing instructions

* Switch to the branch.
* Navigate to WooCommerce > Settings > Multi-Currency.
* Delete a currency from the list using the trash can.
* List should update.
* Use Add Currencies button, select/deselect currencies, click to save/update.
* List should update.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
