### PR TITLE
Search functionality for customer multi currencies available modal

### DIFF
--- a/client/components/search/index.js
+++ b/client/components/search/index.js
@@ -1,0 +1,26 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Icon, search } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const Search = ( props ) => {
+	return (
+		<div className="search">
+			<Icon className="search__icon" icon={ search } />
+			<input
+				{ ...props }
+				type="text"
+				className="components-text-control__input"
+			/>
+		</div>
+	);
+};
+
+export default Search;

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -1,0 +1,14 @@
+.search {
+	position: relative;
+
+	&__icon {
+		position: absolute;
+		top: 50%;
+		left: 10px;
+		transform: translateY( -50% );
+	}
+
+	input.components-text-control__input {
+		padding-left: 8px + 24px + 8px;
+	}
+}

--- a/client/components/search/test/__snapshots__/index.js.snap
+++ b/client/components/search/test/__snapshots__/index.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Search renders a search input with placeholder 1`] = `
+<div>
+  <div
+    class="search"
+  >
+    <svg
+      aria-hidden="true"
+      class="search__icon"
+      focusable="false"
+      height="24"
+      role="img"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M13.5 6C10.5 6 8 8.5 8 11.5c0 1.1.3 2.1.9 3l-3.4 3 1 1.1 3.4-2.9c1 .9 2.2 1.4 3.6 1.4 3 0 5.5-2.5 5.5-5.5C19 8.5 16.5 6 13.5 6zm0 9.5c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z"
+      />
+    </svg>
+    <input
+      class="components-text-control__input"
+      placeholder="Placeholder text"
+      type="text"
+    />
+  </div>
+</div>
+`;

--- a/client/components/search/test/index.js
+++ b/client/components/search/test/index.js
@@ -1,0 +1,19 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Search from '../';
+
+describe( 'Search', () => {
+	test( 'renders a search input with placeholder', () => {
+		const { container } = render(
+			<Search placeholder="Placeholder text" />
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+} );

--- a/client/multi-currency/enabled-currencies-list/list-item.js
+++ b/client/multi-currency/enabled-currencies-list/list-item.js
@@ -5,7 +5,6 @@
 import classNames from 'classnames';
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Icon } from '@wordpress/components';
-import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -31,7 +30,7 @@ const EnabledCurrenciesListItem = ( {
 				<div className="enabled-currency__flag">{ flag }</div>
 				<div className="enabled-currency__label">{ name }</div>
 				<div className="enabled-currency__code">
-					({ decodeEntities( symbol ) } { currencyCode })
+					({ symbol } { currencyCode })
 				</div>
 			</div>
 			<div className="enabled-currency__actions">

--- a/client/multi-currency/enabled-currencies-list/modal-checkbox.js
+++ b/client/multi-currency/enabled-currencies-list/modal-checkbox.js
@@ -6,7 +6,6 @@ import React from 'react';
 import { CheckboxControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import interpolateComponents from 'interpolate-components';
-import { decodeEntities } from '@wordpress/html-entities';
 
 const EnabledCurrenciesModalCheckbox = ( {
 	onChange,
@@ -37,7 +36,7 @@ const EnabledCurrenciesModalCheckbox = ( {
 						name: <span>{ name }</span>,
 						code: (
 							<span className="enabled-currency-checkbox__code">
-								({ decodeEntities( symbol ) } { code })
+								({ symbol } { code })
 							</span>
 						),
 					},

--- a/client/multi-currency/enabled-currencies-list/modal.js
+++ b/client/multi-currency/enabled-currencies-list/modal.js
@@ -114,14 +114,16 @@ const EnabledCurrenciesModal = ( { className } ) => {
 					onRequestClose={ handleAddSelectedCancelClick }
 					className="add-enabled-currencies-modal"
 				>
-					<Search
-						value={ searchText }
-						placeholder={ __(
-							'Search currencies',
-							'woocommerce-payments'
-						) }
-						onChange={ handleSearchChange }
-					/>
+					<div className="add-enabled-currencies-modal__search">
+						<Search
+							value={ searchText }
+							placeholder={ __(
+								'Search currencies',
+								'woocommerce-payments'
+							) }
+							onChange={ handleSearchChange }
+						/>
+					</div>
 					<h3>
 						{ searchText
 							? /* translators: %1: filtered currencies count */

--- a/client/multi-currency/enabled-currencies-list/modal.js
+++ b/client/multi-currency/enabled-currencies-list/modal.js
@@ -129,7 +129,7 @@ const EnabledCurrenciesModal = ( { className } ) => {
 							? /* translators: %1: filtered currencies count */
 							  sprintf(
 									__(
-										'Search results ( %1$d currencies)',
+										'Search results (%1$d currencies)',
 										'woocommerce-payments'
 									),
 									filteredCurrencyCodes.length

--- a/client/multi-currency/enabled-currencies-list/modal.js
+++ b/client/multi-currency/enabled-currencies-list/modal.js
@@ -21,7 +21,6 @@ import './style.scss';
 
 // TODO: This works when saving, but list does not refresh.
 // TODO: Should we reset selected currencies on modal close?
-// TODO: Need to add a currency search. V2?
 const EnabledCurrenciesModal = ( { className } ) => {
 	const availableCurrencies = useAvailableCurrencies();
 	const availableCurrencyCodes = Object.keys( availableCurrencies );

--- a/client/multi-currency/enabled-currencies-list/modal.js
+++ b/client/multi-currency/enabled-currencies-list/modal.js
@@ -16,6 +16,7 @@ import {
 } from 'data';
 import EnabledCurrenciesModalCheckboxList from './modal-checkbox-list';
 import EnabledCurrenciesModalCheckbox from './modal-checkbox';
+import Search from 'components/search';
 import './style.scss';
 
 // TODO: This works when saving, but list does not refresh.
@@ -46,10 +47,10 @@ const EnabledCurrenciesModal = ( { className } ) => {
 	const filteredCurrencyCodes = ! searchText
 		? availableCurrencyCodes
 		: availableCurrencyCodes.filter( ( code ) => {
-				const currency = availableCurrencies[ code ];
+				const { symbol, name } = availableCurrencies[ code ];
 				return (
 					-1 <
-					`${ currency.symbol } ${ currency.code } ${ currency.name }`
+					`${ symbol } ${ code } ${ name }`
 						.toLocaleLowerCase()
 						.indexOf( searchText.toLocaleLowerCase() )
 				);
@@ -68,6 +69,10 @@ const EnabledCurrenciesModal = ( { className } ) => {
 		JSON.stringify( enabledCurrencyCodes ),
 	] );
 	/* eslint-enable react-hooks/exhaustive-deps */
+
+	const handleSearchChange = ( event ) => {
+		setSearchText( event.target.value );
+	};
 
 	const handleChange = ( currencyCode, enabled ) => {
 		setSelectedCurrencies( ( previouslyEnabled ) => ( {
@@ -109,12 +114,13 @@ const EnabledCurrenciesModal = ( { className } ) => {
 					onRequestClose={ handleAddSelectedCancelClick }
 					className="add-enabled-currencies-modal"
 				>
-					<input
-						type="text"
-						onChange={ ( { target } ) =>
-							setSearchText( target.value )
-						}
+					<Search
 						value={ searchText }
+						placeholder={ __(
+							'Search currencies',
+							'woocommerce-payments'
+						) }
+						onChange={ handleSearchChange }
 					/>
 					<h3>
 						{ searchText

--- a/client/multi-currency/enabled-currencies-list/modal.js
+++ b/client/multi-currency/enabled-currencies-list/modal.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Button, Modal } from '@wordpress/components';
 import { useState, useCallback, useEffect } from '@wordpress/element';
 
@@ -40,7 +40,20 @@ const EnabledCurrenciesModal = ( { className } ) => {
 		1
 	);
 
+	const [ searchText, setSearchText ] = useState( '' );
 	const [ selectedCurrencies, setSelectedCurrencies ] = useState( {} );
+
+	const filteredCurrencyCodes = ! searchText
+		? availableCurrencyCodes
+		: availableCurrencyCodes.filter( ( code ) => {
+				const currency = availableCurrencies[ code ];
+				return (
+					-1 <
+					`${ currency.symbol } ${ currency.code } ${ currency.name }`
+						.toLocaleLowerCase()
+						.indexOf( searchText.toLocaleLowerCase() )
+				);
+		  } );
 
 	useEffect( () => {
 		setSelectedCurrencies(
@@ -96,8 +109,27 @@ const EnabledCurrenciesModal = ( { className } ) => {
 					onRequestClose={ handleAddSelectedCancelClick }
 					className="add-enabled-currencies-modal"
 				>
+					<input
+						type="text"
+						onChange={ ( { target } ) =>
+							setSearchText( target.value )
+						}
+						value={ searchText }
+					/>
+					<h3>
+						{ searchText
+							? /* translators: %1: filtered currencies count */
+							  sprintf(
+									__(
+										'Search results ( %1$d currencies)',
+										'woocommerce-payments'
+									),
+									filteredCurrencyCodes.length
+							  )
+							: __( 'All currencies', 'woocommerce-payments' ) }
+					</h3>
 					<EnabledCurrenciesModalCheckboxList>
-						{ availableCurrencyCodes.map( ( code ) => (
+						{ filteredCurrencyCodes.map( ( code ) => (
 							<EnabledCurrenciesModalCheckbox
 								key={ availableCurrencies[ code ].id }
 								checked={ selectedCurrencies[ code ] }

--- a/client/multi-currency/enabled-currencies-list/style.scss
+++ b/client/multi-currency/enabled-currencies-list/style.scss
@@ -61,10 +61,17 @@
 		font-size: 15px;
 	}
 
+	&__search {
+		border-bottom: 1px solid $studio-gray-5;
+		margin: -24px -24px 0;
+		padding: 16px;
+	}
+
 	&__footer {
 		@include modal-footer-buttons;
 		border-top: 1px solid $studio-gray-5;
-		padding: 15px 0 0;
+		margin: 0 -24px -24px;
+		padding: 16px;
 	}
 }
 

--- a/includes/multi-currency/class-currency.php
+++ b/includes/multi-currency/class-currency.php
@@ -188,7 +188,7 @@ class Currency implements \JsonSerializable {
 			'id'         => $this->get_id(),
 			'is_default' => $this->get_is_default(),
 			'flag'       => $this->get_flag(),
-			'symbol'     => $this->get_symbol(),
+			'symbol'     => html_entity_decode( $this->get_symbol() ),
 		];
 	}
 }

--- a/tests/unit/multi-currency/test-class-currency.php
+++ b/tests/unit/multi-currency/test-class-currency.php
@@ -29,7 +29,7 @@ class WCPay_Multi_Currency_Currency_Tests extends WP_UnitTestCase {
 		$json = wp_json_encode( $this->currency );
 
 		$this->assertSame(
-			'{"code":"USD","rate":1,"name":"United States (US) dollar","id":"usd","is_default":true,"flag":"\ud83c\uddfa\ud83c\uddf8","symbol":"&#36;"}',
+			'{"code":"USD","rate":1,"name":"United States (US) dollar","id":"usd","is_default":true,"flag":"\ud83c\uddfa\ud83c\uddf8","symbol":"$"}',
 			$json
 		);
 	}


### PR DESCRIPTION
Fixes #1924

#### Changes proposed in this Pull Request
- Created new component `<Search/>` for a stylized input with the search icon. I didn't find any implemented solution in our repo, wc/components or WC Admin. I made it very simple just passing props to the input element and applying some custom style.
- Moved symbols entities decode from JS to PHP side, to allow the user to search by it without issues. Made some quick tests and doesn't seem to be any issue decoding any kind of symbol used in WC.
- Added the new search component to the modal and used to filter available currencies. Check for `searchText` before filtering to avoid unnecessary filtering.
- Added missing header with the text `All currencies` or `Search results ( # results )` when applicable.
- Custom style to ensure full width separator between search, footer and list sections. As expected in Figma design.

#### Screenshots
| Filtered by name and code | Filtered by symbol |
|-|-|
|<img width="368" alt="Screenshot 2021-06-01 at 16 09 40" src="https://user-images.githubusercontent.com/7670276/120337661-cd2c3500-c2f3-11eb-851e-fc24b957a902.png">|<img width="368" alt="Screenshot 2021-06-01 at 16 08 50" src="https://user-images.githubusercontent.com/7670276/120337651-cb627180-c2f3-11eb-8a02-c5b45a403847.png">|


#### Testing instructions
- Access **WooCommerce > Settings > Multi-currency**
- Click **Add currencies**
- Search should filter by currency name, symbol and code.