### PR TITLE
Set manual exchange rate field to hide if automatic rate is chosen.

### DIFF
--- a/client/multi-currency/index.js
+++ b/client/multi-currency/index.js
@@ -16,3 +16,28 @@ const currencyContainer = document.getElementById(
 if ( currencyContainer ) {
 	ReactDOM.render( <EnabledCurrencies />, currencyContainer );
 }
+
+const hideShowManualField = ( show ) => {
+	const manualRateField = document
+		.querySelector( '[id^=wcpay_multi_currency_manual_rate_]' )
+		.closest( 'tr' );
+	manualRateField.style.display = show ? 'table-row' : 'none';
+};
+
+const triggerHideShow = ( value, checked ) => {
+	hideShowManualField( 'manual' === value && true === checked );
+};
+
+window.onload = () => {
+	const exchangeRadio = document.querySelectorAll(
+		'.exchange-rate-selector'
+	);
+	for ( let i = 0; i < exchangeRadio.length; i++ ) {
+		const element = exchangeRadio[ i ];
+		triggerHideShow( element.value, element.checked );
+
+		element.addEventListener( 'change', ( event ) => {
+			triggerHideShow( event.target.value, event.target.checked );
+		} );
+	}
+};

--- a/client/multi-currency/index.js
+++ b/client/multi-currency/index.js
@@ -28,16 +28,10 @@ const triggerHideShow = ( value, checked ) => {
 	hideShowManualField( 'manual' === value && true === checked );
 };
 
-window.onload = () => {
-	const exchangeRadio = document.querySelectorAll(
-		'.exchange-rate-selector'
-	);
-	for ( let i = 0; i < exchangeRadio.length; i++ ) {
-		const element = exchangeRadio[ i ];
-		triggerHideShow( element.value, element.checked );
+document.querySelectorAll( '.exchange-rate-selector' ).forEach( ( radio ) => {
+	triggerHideShow( radio.value, radio.checked );
 
-		element.addEventListener( 'change', ( event ) => {
-			triggerHideShow( event.target.value, event.target.checked );
-		} );
-	}
-};
+	radio.addEventListener( 'change', ( event ) => {
+		triggerHideShow( event.target.value, event.target.checked );
+	} );
+} );

--- a/includes/multi-currency/class-settings.php
+++ b/includes/multi-currency/class-settings.php
@@ -240,11 +240,12 @@ class Settings extends \WC_Settings_Page {
 				[
 					'title'   => __( 'Exchange rate', 'woocommerce-payments' ),
 					'id'      => $this->id . '_exchange_rate_' . $currency->get_id(),
+					'class'   => 'exchange-rate-selector',
 					'default' => 'automatic',
 					'type'    => 'radio',
 					'options' => $exchange_rate_options,
 				],
-				// TODO: Manual rate field needs to hide if manual isn't selected.
+
 				[
 					'title'    => __( 'Manual rate', 'woocommerce-payments' ),
 					'type'     => 'text',


### PR DESCRIPTION
Fixes #1925

#### Changes proposed in this Pull Request

* Add JS to hide/show manual rate field based on radio selection. 
* Unsure if the location of the code is okay, wasn't sure if it needed to be in a separate file.

#### Testing instructions

* Switch to branch.
* Navigate to WooCommerce > Settings > Multi-Currency
* Click to edit an enabled currency.
* By default the automatic rate should be selected, and the Manual Rate field should be hidden.
* Select Manual Rate, and the Manual Rate field should then show.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
