### PR TITLE
Save selected customer currency in user settings

### DIFF
--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
 class Multi_Currency {
 
 	const CURRENCY_SESSION_KEY = 'wcpay_currency';
+	const CURRENCY_META_KEY    = 'wcpay_currency';
 
 	/**
 	 * The single instance of the class.
@@ -220,12 +221,16 @@ class Multi_Currency {
 	 * @return Currency
 	 */
 	public function get_selected_currency(): Currency {
-		if ( WC()->session ) {
+		$user_id = get_current_user_id();
+		$code    = null;
+
+		if ( 0 === $user_id && WC()->session ) {
 			$code = WC()->session->get( self::CURRENCY_SESSION_KEY );
-			return $this->get_enabled_currencies()[ $code ] ?? $this->default_currency;
+		} elseif ( $user_id ) {
+			$code = get_user_meta( $user_id, self::CURRENCY_META_KEY, true );
 		}
 
-		return $this->default_currency;
+		return $this->get_enabled_currencies()[ $code ] ?? $this->default_currency;
 	}
 
 	/**

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -241,10 +241,17 @@ class Multi_Currency {
 	 */
 	public function update_selected_currency( string $currency_code ) {
 		$code     = strtoupper( $currency_code );
+		$user_id  = get_current_user_id();
 		$currency = $this->get_enabled_currencies()[ $code ] ?? null;
 
-		if ( $currency && WC()->session ) {
-			WC()->session->set( self::CURRENCY_SESSION_KEY, $currency->code );
+		if ( null === $currency ) {
+			return;
+		}
+
+		if ( 0 === $user_id && WC()->session ) {
+			WC()->session->set( self::CURRENCY_SESSION_KEY, $currency->get_code() );
+		} elseif ( $user_id ) {
+			update_user_meta( $user_id, self::CURRENCY_META_KEY, $currency->get_code() );
 		}
 	}
 

--- a/includes/multi-currency/class-user-settings.php
+++ b/includes/multi-currency/class-user-settings.php
@@ -56,7 +56,7 @@ class User_Settings {
 				}
 				?>
 			</select>
-			<span><em><?php esc_html_e( 'Select your prefered currency for shopping and payments.', 'woocommerce-payments' ); ?></em></span>
+			<span><em><?php esc_html_e( 'Select your preferred currency for shopping and payments.', 'woocommerce-payments' ); ?></em></span>
 		</p>
 		<div class="clear"></div>
 		<?php

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -86,6 +86,34 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->assertSame( 'GBP', $this->multi_currency->get_selected_currency()->get_code() );
 	}
 
+	public function test_update_selected_currency_does_not_set_invalid_session_currency() {
+		$this->multi_currency->update_selected_currency( 'UNSUPPORTED_CURRENCY' );
+
+		$this->assertNull( WC()->session->get( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY ) );
+	}
+
+	public function test_update_selected_currency_does_not_set_invalid_user_currency() {
+		wp_set_current_user( self::LOGGED_IN_USER_ID );
+
+		$this->multi_currency->update_selected_currency( 'UNSUPPORTED_CURRENCY' );
+
+		$this->assertEmpty( get_user_meta( self::LOGGED_IN_USER_ID, WCPay\Multi_Currency\Multi_Currency::CURRENCY_META_KEY, true ) );
+	}
+
+	public function test_update_selected_currency_sets_session_currency() {
+		$this->multi_currency->update_selected_currency( 'GBP' );
+
+		$this->assertSame( 'GBP', WC()->session->get( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY ) );
+	}
+
+	public function test_update_selected_currency_sets_user_currency() {
+		wp_set_current_user( self::LOGGED_IN_USER_ID );
+
+		$this->multi_currency->update_selected_currency( 'GBP' );
+
+		$this->assertSame( 'GBP', get_user_meta( self::LOGGED_IN_USER_ID, WCPay\Multi_Currency\Multi_Currency::CURRENCY_META_KEY, true ) );
+	}
+
 	public function test_update_selected_currency_by_url_does_not_set_session_when_parameter_not_set() {
 		$this->multi_currency->update_selected_currency_by_url();
 

--- a/tests/unit/multi-currency/test-class-user-settings.php
+++ b/tests/unit/multi-currency/test-class-user-settings.php
@@ -50,7 +50,7 @@ class WCPay_Multi_Currency_User_Settings_Tests extends WP_UnitTestCase {
 		$this->expectOutputRegex( '/<p class="woocommerce-form-row woocommerce-form-row--first form-row form-row-first">/' );
 		$this->expectOutputRegex( '/<label for="wcpay_selected_currency">Default currency<\/label>/' );
 		$this->expectOutputRegex( '/<select.+name="wcpay_selected_currency"/s' );
-		$this->expectOutputRegex( '/<span><em>Select your prefered currency for shopping and payments.<\/em><\/span>/' );
+		$this->expectOutputRegex( '/<span><em>Select your preferred currency for shopping and payments.<\/em><\/span>/' );
 		$this->expectOutputRegex( '/<div class="clear"><\/div>/' );
 	}
 


### PR DESCRIPTION
Fixes #1980 

#### Changes proposed in this Pull Request

When users are logged in, save and fetch the selected currency from the user meta.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* When logged out
    * Select a different currency using the widget
    * Navigate to another shop page and make sure the selected currency is used
    * Using another browser or incognito, load up a shop page and make sure the default store currency is used
* When logged in
    * Select a different currency using the widget
    * Navigate to another shop page and make sure the selected currency is used 
    * Using another browser or incognito, load up a shop page and make sure selected currency is used
    * In this new session, change the currency using the My account > Account details page
    * Refresh the original session and make sure the new currency is used
 
-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
