### PR TITLE
Add exchange rate to enabled currencies list

### DIFF
--- a/client/multi-currency/enabled-currencies-list/index.js
+++ b/client/multi-currency/enabled-currencies-list/index.js
@@ -46,6 +46,7 @@ const EnabledCurrencies = () => {
 					<div>
 						{ __( 'Enabled Currencies', 'woocommerce-payments' ) }
 					</div>
+					<div>{ __( 'Exchange rate', 'woocommerce-payments' ) }</div>
 				</CardBody>
 				<CardDivider />
 				<CardBody size={ null }>

--- a/client/multi-currency/enabled-currencies-list/index.js
+++ b/client/multi-currency/enabled-currencies-list/index.js
@@ -56,6 +56,9 @@ const EnabledCurrencies = () => {
 								<EnabledCurrenciesListItem
 									key={ enabledCurrencies[ code ].id }
 									currency={ enabledCurrencies[ code ] }
+									defaultCurrencyCode={
+										currencies.default.code
+									}
 									onDeleteClick={
 										enabledCurrencies[ code ].is_default
 											? undefined

--- a/client/multi-currency/enabled-currencies-list/list-item.js
+++ b/client/multi-currency/enabled-currencies-list/list-item.js
@@ -13,16 +13,15 @@ import DeleteButton from './delete-button';
 
 const EnabledCurrenciesListItem = ( {
 	// eslint-disable-next-line camelcase
-	currency: { code, flag, id, is_default, name, symbol },
+	currency: { code, flag, id, is_default, name, symbol, rate },
+	defaultCurrencyCode,
 	onDeleteClick,
 } ) => {
-	const defaultText = __( 'Default currency', 'woocommerce-payments' );
-	// eslint-disable-next-line camelcase
-	const currencyCode = is_default ? `${ code } - ${ defaultText }` : code;
-
 	const getEditUrl = ( currencyId ) => {
 		return `admin.php?page=wc-settings&tab=wcpay_multi_currency&section=${ currencyId.toLowerCase() }`;
 	};
+
+	const formattedRate = Number.parseFloat( rate ).toFixed( 2 );
 
 	return (
 		<li className={ classNames( 'enabled-currency', id ) }>
@@ -30,8 +29,16 @@ const EnabledCurrenciesListItem = ( {
 				<div className="enabled-currency__flag">{ flag }</div>
 				<div className="enabled-currency__label">{ name }</div>
 				<div className="enabled-currency__code">
-					({ symbol } { currencyCode })
+					({ symbol } { code })
 				</div>
+			</div>
+			<div className="enabled-currency__rate">
+				{
+					// eslint-disable-next-line camelcase
+					is_default
+						? __( 'Default currency', 'woocommerce-payments' )
+						: `1 ${ defaultCurrencyCode } → ${ formattedRate } ${ code }`
+				}
 			</div>
 			<div className="enabled-currency__actions">
 				<Button

--- a/client/multi-currency/enabled-currencies-list/style.scss
+++ b/client/multi-currency/enabled-currencies-list/style.scss
@@ -1,3 +1,12 @@
+.wcpay-multi-currency__enabled-currencies-header {
+	display: flex;
+	margin-right: 60px;
+
+	div {
+		flex: 1;
+	}
+}
+
 .enabled-currencies-list {
 	margin: 0;
 

--- a/client/multi-currency/enabled-currencies-list/style.scss
+++ b/client/multi-currency/enabled-currencies-list/style.scss
@@ -12,7 +12,6 @@
 
 	.enabled-currency {
 		display: flex;
-		justify-content: space-between;
 		padding: 7px 24px;
 		margin: 0;
 		border-top: 1px solid #e2e4e7;
@@ -21,6 +20,11 @@
 		&__container {
 			display: flex;
 			flex-wrap: wrap;
+		}
+
+		&__container,
+		&__rate {
+			flex: 1;
 		}
 
 		&__flag {
@@ -32,13 +36,16 @@
 			padding: 0 5px 0 0;
 		}
 
-		&__code {
+		&__code,
+		&__rate {
 			color: $studio-gray-30;
 		}
 
 		&__actions {
 			line-height: 35px;
 			padding: 10px 0 0;
+			width: 60px;
+			text-align: right;
 
 			.components-button {
 				text-decoration: none;


### PR DESCRIPTION
Fixes #1923 

### Changes proposed in this Pull Request

This PR adds an "Exchange rate" header and the exchange rate to the enabled currencies list. Based on the designs, the currency exchange rate was rounded to 2 decimal places.

![image](https://user-images.githubusercontent.com/7714042/120384406-7e36cd80-c2fc-11eb-82d7-62a580cda7db.png)


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Automated tests**

I could not find any existing tests for these components. Should I add some as part of this PR?

**Manual tests**

* Apply this PR and load up the enabled currencies list
* Check that the exchange rate is listed for every currency, except for the default one
* Check that the default currency has a "Default currency" text
* Check that the header and values are aligned and the action section is displayed correctly

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
