### PR TITLE
Fix changelog and readme in preparation for 2.5.0 release.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,8 @@
 * Update - Deposit overview details.
 * Add - Redirect to WooCommerce home page after successful WooCommerce Payments KYC (Know Your Customer).
 * Fix - Added CSV column heading for transaction id column.
+* Update - Bump minimum supported version of WordPress from 5.4 to 5.5.
+* Update - Bump minimum supported version of WooCommerce from 4.5 to 4.8.
 * Add - Deposit overviews have been added to the overview page.
 * Update - Account overview page is now GA and default page for woocommerce payments.
 * Update - Base fee and account status has been moved to overview page from WCPay settings.
@@ -28,7 +30,6 @@
 * Update - Implement expirement on Connect Page.
 * Fix - Columns are misaligned on Payments->Transactions/Disputes page.
 * Fix - Risk level is displayed as a "Numeric" value in transactions CSV.
-* Add - Redirect to WooCommerce home page after successful WooCommerce Payments KYC.
 
 = 2.3.3 - 2021-05-06 =
 * Update - Additional logic and styling for instant deposits.

--- a/readme.txt
+++ b/readme.txt
@@ -131,7 +131,6 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Implement expirement on Connect Page.
 * Fix - Columns are misaligned on Payments->Transactions/Disputes page.
 * Fix - Risk level is displayed as a "Numeric" value in transactions CSV.
-* Add - Redirect to WooCommerce home page after successful WooCommerce Payments KYC.
 
 = 2.3.3 - 2021-05-06 =
 * Update - Additional logic and styling for instant deposits.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Make changelog.txt and changelog in readme.txt identical.
- Remove '* Add - Redirect to WooCommerce home page after successful WooCommerce Payments KYC.' from 2.4.0 changelog because it's supposed to be under 2.5.0, not 2.4.0.

#### Testing instructions

* Make sure [PR 1759](https://github.com/Automattic/woocommerce-payments/pull/1759) that adds the 'Redirect to WooCommerce home page after successful WooCommerce Payments KYC' changelog entry is not part of 2.4.0. Hence, the move of changelog entry to 2.5.0.
* Make sure there is already 'Redirect to WooCommerce home page after successful WooCommerce Payments KYC' entry under 2.5.0 changelog [here](https://github.com/Automattic/woocommerce-payments/blob/develop/changelog.txt#L11) and [here](https://github.com/Automattic/woocommerce-payments/blob/develop/readme.txt#L112).
* Make sure changelog in changelog.txt and readme.txt are identical.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
