### PR TITLE
Account Overview page: styling improvements

### DIFF
--- a/client/components/account-status/account-status-item.js
+++ b/client/components/account-status/account-status-item.js
@@ -18,8 +18,10 @@ const AccountStatusItem = ( { label, align, value, children } ) => {
 			gap={ 3 }
 			className={ 'woocommerce-account-status-item' }
 		>
-			<FlexItem>{ label }</FlexItem>
-			<FlexBlock>{ children || value || null }</FlexBlock>
+			<FlexItem className={ 'item-label' }>{ label }</FlexItem>
+			<FlexBlock className={ 'item-value' }>
+				{ children || value || null }
+			</FlexBlock>
 		</Flex>
 	);
 };

--- a/client/components/account-status/index.js
+++ b/client/components/account-status/index.js
@@ -60,13 +60,13 @@ const AccountStatusDetails = ( props ) => {
 
 	const cardTitle = (
 		<>
-			<FlexItem>
+			<FlexItem className={ 'account-details' }>
 				{ __( 'Account details', 'woocommerce-payments' ) }
 			</FlexItem>
-			<FlexBlock>
+			<FlexBlock className={ 'account-status' }>
 				<StatusChip accountStatus={ accountStatus.status } />
 			</FlexBlock>
-			<FlexItem className={ 'woocommerce-account-status__controls' }>
+			<FlexItem className={ 'edit-details' }>
 				<Button isLink href={ accountStatus.accountLink }>
 					{ __( 'Edit details', 'woocommerce-payments' ) }
 				</Button>

--- a/client/components/account-status/style.scss
+++ b/client/components/account-status/style.scss
@@ -1,31 +1,32 @@
 /** @format */
-.woocommerce-account-status__controls .components-button.is-link {
-	text-decoration: none;
-}
 .woocommerce-account-status__header {
 	flex-wrap: wrap;
 
-	div {
-		flex-shrink: 1;
+	.edit-details .components-button.is-link {
+		text-decoration: none;
+	}
+
+	.edit-details,
+	.account-details,
+	.account-status {
 		flex-basis: auto;
+		min-width: max-content;
 	}
 
 	// on a smaller viewports controls section should move in front of the
 	// status chip
 	@include breakpoint( '<480px' ) {
-		div:first-child {
-			flex-grow: 1;
-			order: -2;
-			margin-bottom: 8px;
-		}
-		div:last-child {
-			order: -1;
-			margin-bottom: 8px;
-		}
-	}
-	@include breakpoint( '<480px' ) {
-		div:last-child {
+		.account-details {
 			order: 1;
+			flex-grow: 1;
+			margin-bottom: 8px;
+		}
+		.edit-details {
+			order: 2;
+			margin-bottom: 8px;
+		}
+		.account-status {
+			order: 3;
 		}
 	}
 }
@@ -44,20 +45,26 @@
 		}
 	}
 
-	div {
+	.item-label,
+	.item-value {
 		flex-shrink: 1;
 		flex-basis: auto;
 		width: min-content;
 	}
 
-	// label
-	div:first-child {
+	.item-label {
 		color: $gray-900;
 		min-width: 130px;
+		white-space: nowrap;
 	}
 
-	// value
-	div:last-child {
+	@include breakpoint( '<480px' ) {
+		.item-label {
+			min-width: 80px;
+		}
+	}
+
+	.item-value {
 		color: $gray-700;
 
 		svg {
@@ -70,14 +77,6 @@
 			flex-direction: row;
 			align-items: center;
 			height: 24px;
-		}
-	}
-
-	@media only screen and ( max-width: 390px ) {
-		div:first-child {
-			overflow: visible;
-			white-space: nowrap;
-			min-width: 80px;
 		}
 	}
 }

--- a/client/components/account-status/test/__snapshots__/index.js.snap
+++ b/client/components/account-status/test/__snapshots__/index.js.snap
@@ -30,12 +30,12 @@ exports[`AccountStatus renders normal status 1`] = `
       direction="row"
     >
       <div
-        class="components-flex__item css-1s295sp-Item eboqfv51"
+        class="components-flex__item account-details css-1s295sp-Item eboqfv51"
       >
         Account details
       </div>
       <div
-        class="components-flex__block css-yr442k-Item-Block eboqfv52"
+        class="components-flex__block account-status css-yr442k-Item-Block eboqfv52"
       >
         <span
           class="chip chip-primary is-compact"
@@ -44,7 +44,7 @@ exports[`AccountStatus renders normal status 1`] = `
         </span>
       </div>
       <div
-        class="components-flex__item woocommerce-account-status__controls css-1s295sp-Item eboqfv51"
+        class="components-flex__item edit-details css-1s295sp-Item eboqfv51"
       >
         <button
           class="components-button is-link"
@@ -62,12 +62,12 @@ exports[`AccountStatus renders normal status 1`] = `
         direction="row"
       >
         <div
-          class="components-flex__item css-1s295sp-Item eboqfv51"
+          class="components-flex__item item-label css-1s295sp-Item eboqfv51"
         >
           Payments:
         </div>
         <div
-          class="components-flex__block css-yr442k-Item-Block eboqfv52"
+          class="components-flex__block item-value css-yr442k-Item-Block eboqfv52"
         >
           <span
             class="account-status__info__green"
@@ -94,12 +94,12 @@ exports[`AccountStatus renders normal status 1`] = `
         direction="row"
       >
         <div
-          class="components-flex__item css-1s295sp-Item eboqfv51"
+          class="components-flex__item item-label css-1s295sp-Item eboqfv51"
         >
           Deposits:
         </div>
         <div
-          class="components-flex__block css-yr442k-Item-Block eboqfv52"
+          class="components-flex__block item-value css-yr442k-Item-Block eboqfv52"
         >
           <span
             class="account-status__info__green"
@@ -126,12 +126,12 @@ exports[`AccountStatus renders normal status 1`] = `
         direction="row"
       >
         <div
-          class="components-flex__item css-1s295sp-Item eboqfv51"
+          class="components-flex__item item-label css-1s295sp-Item eboqfv51"
         >
           Base Fee:
         </div>
         <div
-          class="components-flex__block css-yr442k-Item-Block eboqfv52"
+          class="components-flex__block item-value css-yr442k-Item-Block eboqfv52"
         >
           Euro 
           (EUR) 


### PR DESCRIPTION
Fixes #1911

#### Changes proposed in this Pull Request

Cosmetic changes in styling. Replaced HTML elements with respective classes and made a few reliability fixes for component ordering on smaller screens.

Desktop rendering:
![image](https://user-images.githubusercontent.com/683297/120479018-c2ce7180-c3ad-11eb-9ec5-f1f9cf76ef63.png)

Expected rendering for a smaller screen:
![image](https://user-images.githubusercontent.com/683297/120478938-ab8f8400-c3ad-11eb-8923-dc47697c910c.png)


#### Testing instructions

 * Go to WooCommerce Payments entry (**Overview**) page
 * Check that "Account Details" block is rendered as expected

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
