### PR TITLE
Recalculate cart when changing currency

### DIFF
--- a/includes/multi-currency/class-frontend-currencies.php
+++ b/includes/multi-currency/class-frontend-currencies.php
@@ -46,6 +46,7 @@ class Frontend_Currencies {
 			add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 50 );
 			add_filter( 'wc_get_price_thousand_separator', [ $this, 'get_price_thousand_separator' ], 50 );
 			add_filter( 'woocommerce_price_format', [ $this, 'get_woocommerce_price_format' ], 50 );
+			add_filter( 'woocommerce_cart_hash', [ $this, 'add_currency_to_cart_hash' ], 50 );
 		}
 	}
 
@@ -109,6 +110,18 @@ class Frontend_Currencies {
 			default:
 				return '%1$s%2$s';
 		}
+	}
+
+	/**
+	 * Adds the currency and exchange rate to the cart hash so it's recalculated properly.
+	 *
+	 * @param string $hash The cart hash.
+	 *
+	 * @return string The adjusted cart hash.
+	 */
+	public function add_currency_to_cart_hash( $hash ) {
+		$currency = $this->multi_currency->get_selected_currency();
+		return md5( $hash . $currency->get_code() . $currency->get_rate() );
 	}
 
 	/**

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -288,6 +288,9 @@ class Multi_Currency {
 		}
 
 		$this->update_selected_currency( sanitize_text_field( wp_unslash( $_GET['currency'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
+
+		// Recalculate cart when currency changes.
+		add_action( 'wp_loaded', [ $this, 'recalculate_cart' ] );
 	}
 
 	/**
@@ -348,6 +351,13 @@ class Multi_Currency {
 			: in_array( $type, $charm_compatible_types, true );
 
 		return $this->get_adjusted_price( $converted_price, $apply_charm_pricing );
+	}
+
+	/**
+	 * Recalculates WooCommerce cart totals.
+	 */
+	public function recalculate_cart() {
+		WC()->cart->calculate_totals();
 	}
 
 	/**

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -55,6 +55,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 			[ 'wc_get_price_decimal_separator', 'get_price_decimal_separator' ],
 			[ 'wc_get_price_thousand_separator', 'get_price_thousand_separator' ],
 			[ 'woocommerce_price_format', 'get_woocommerce_price_format' ],
+			[ 'woocommerce_cart_hash', 'add_currency_to_cart_hash' ],
 		];
 	}
 
@@ -173,6 +174,16 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 			[ 'left_space', '%1$s&nbsp;%2$s' ],
 			[ 'right_space', '%2$s&nbsp;%1$s' ],
 		];
+	}
+
+	public function test_add_currency_to_cart_hash_adds_currency_and_rate() {
+		$current_currency = new WCPay\Multi_Currency\Currency( 'GBP', 0.71 );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+
+		$this->assertSame(
+			md5( 'cart_hashGBP0.71' ),
+			$this->frontend_currencies->add_currency_to_cart_hash( 'cart_hash' )
+		);
 	}
 
 	private function mock_currency_format( $currency_code, $currency_settings ) {

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -136,6 +136,19 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->assertSame( 'GBP', WC()->session->get( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY ) );
 	}
 
+	public function test_update_selected_currency_by_url_recalculates_cart() {
+		wp_set_current_user( self::LOGGED_IN_USER_ID );
+		$_GET['currency'] = 'GBP';
+
+		$this->assertContains( '&#36;', WC()->cart->get_total() );
+
+		$this->multi_currency->update_selected_currency_by_url();
+
+		$this->assertContains( '&pound;', WC()->cart->get_total() );
+		$this->assertNotContains( '&#36;', WC()->cart->get_total() );
+
+	}
+
 	public function test_get_price_returns_price_in_default_currency() {
 		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, get_woocommerce_currency() );
 


### PR DESCRIPTION
Fixes #2000 

#### Changes proposed in this Pull Request

When a currency is selected, the cart on the frontend header is not recalculated. This PR adds a call to force its recalculation so the currency change is reflected, and adds the exchange rate and currency code to the cart hash to refresh the cart when the total is 0.

![currency](https://user-images.githubusercontent.com/7714042/120507321-15ebf880-c39d-11eb-9f0b-1ed9e90c8959.gif)


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open up the Shop page and select a new currency
* Make sure that the cart in the header is updated with the selected currency
* Add a product to the cart and retest this

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
