### PR TITLE
Separate initialization and getting of currency arrays.

### DIFF
--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -257,7 +257,7 @@ class Multi_Currency {
 	 * Sets the default currency.
 	 */
 	private function set_default_currency() {
-		$this->default_currency = $this->available_currencies[ get_woocommerce_currency() ];
+		$this->default_currency = $this->available_currencies[ get_woocommerce_currency() ] ?? null;
 	}
 
 	/**

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -92,7 +92,7 @@ class Multi_Currency {
 		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-currencies.php';
 
 		$this->id = 'wcpay_multi_currency';
-		$this->get_available_currencies();
+		$this->initialize_available_currencies();
 		$this->get_default_currency();
 		$this->get_enabled_currencies();
 
@@ -195,6 +195,17 @@ class Multi_Currency {
 	}
 
 	/**
+	 * Sets up the available currencies.
+	 */
+	public function initialize_available_currencies() {
+		// TODO: This will need to get stored data, then build and return it accordingly.
+		$currencies = $this->get_mock_currencies();
+		foreach ( $currencies as $currency ) {
+			$this->available_currencies[ $currency[0] ] = new Currency( $currency[0], $currency[1] );
+		}
+	}
+
+	/**
 	 * Gets the currencies available.
 	 *
 	 * @return array Array of Currency objects.
@@ -204,11 +215,7 @@ class Multi_Currency {
 			return $this->available_currencies;
 		}
 
-		// TODO: This will need to get stored data, then build and return it accordingly.
-		$currencies = $this->get_mock_currencies();
-		foreach ( $currencies as $currency ) {
-			$this->available_currencies[ $currency[0] ] = new Currency( $currency[0], $currency[1] );
-		}
+		$this->initialize_available_currencies();
 		return $this->available_currencies;
 	}
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Separate initialization and getting of currency arrays per recommendation here: https://github.com/Automattic/woocommerce-payments/pull/1762#discussion_r643826466
* The available and enabled currency arrays are now initialized when the class is, and the getters only return the data that's initialized.
* The default currency is set, as well, and the getter only returns the data. 
* Refactor in initializing the enabled currencies by using getters rather than accessing properties directly. 
* Fixed fatal error if there was no default currency set during enabled currencies initialization. `$default` was set as an object, then later used as an array.

#### Testing instructions

* Mostly refactor, so just enable the branch and look for errors.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
