### PR TITLE
Fix a typo and update settings link in setup wizard

### DIFF
--- a/client/additional-methods-setup/methods-selector/add-payment-methods-task.js
+++ b/client/additional-methods-setup/methods-selector/add-payment-methods-task.js
@@ -163,7 +163,7 @@ const AddPaymentMethodsTask = () => {
 					),
 					components: {
 						settingsLink: (
-							<a href="admin.php?page=wc-settings">
+							<a href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments">
 								{ __( 'settings', 'woocommerce-payments' ) }
 							</a>
 						),

--- a/client/additional-methods-setup/methods-selector/setup-complete-task.js
+++ b/client/additional-methods-setup/methods-selector/setup-complete-task.js
@@ -50,7 +50,7 @@ const SetupComplete = () => {
 			<CollapsibleBody>
 				<p className="wcpay-wizard-task__description-element is-muted-color">
 					{ __(
-						"You're ready to begin accepting payments with the new methods!.",
+						"You're ready to begin accepting payments with the new methods!",
 						'woocommerce-payments'
 					) }
 				</p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request



<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the "UPE additional payment methods" feature flag is enabled so you can see the setup task: `_wcpay_feature_upe_additional_payment_methods`
* Go to `WooCommerce > Settings > Home`.
* Click the `Set up additional payment methods` task.
* Verify that the `settings` link in "You can manage them later in settings." leads to WCPay settings, and that there is no dot after the `!` in "You're ready to begin accepting payments with the new methods!".

![Markup on 2021-06-02 at 20:39:10](https://user-images.githubusercontent.com/1759681/120534900-a862bb00-c3e2-11eb-9096-75ce2b1c906d.png)


-------------------

- [x] Added changelog entry (or does not apply)
    - No entry - unreleased feature.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
