### PR TITLE
Add getters for the Frontend Currencies and Prices instances

### DIFF
--- a/includes/multi-currency/class-frontend-currencies.php
+++ b/includes/multi-currency/class-frontend-currencies.php
@@ -37,12 +37,16 @@ class Frontend_Currencies {
 
 		$this->load_locale_data();
 
-		// Currency hooks.
-		add_filter( 'woocommerce_currency', [ $this, 'get_woocommerce_currency' ], 50 );
-		add_filter( 'wc_get_price_decimals', [ $this, 'get_price_decimals' ], 50 );
-		add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 50 );
-		add_filter( 'wc_get_price_thousand_separator', [ $this, 'get_price_thousand_separator' ], 50 );
-		add_filter( 'woocommerce_price_format', [ $this, 'get_woocommerce_price_format' ], 50 );
+		$frontend_request = ! is_admin() && ! defined( 'DOING_CRON' ) && ! WC()->is_rest_api_request();
+
+		if ( $frontend_request ) {
+			// Currency hooks.
+			add_filter( 'woocommerce_currency', [ $this, 'get_woocommerce_currency' ], 50 );
+			add_filter( 'wc_get_price_decimals', [ $this, 'get_price_decimals' ], 50 );
+			add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 50 );
+			add_filter( 'wc_get_price_thousand_separator', [ $this, 'get_price_thousand_separator' ], 50 );
+			add_filter( 'woocommerce_price_format', [ $this, 'get_woocommerce_price_format' ], 50 );
+		}
 	}
 
 	/**

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -28,28 +28,32 @@ class Frontend_Prices {
 	public function __construct( Multi_Currency $multi_currency ) {
 		$this->multi_currency = $multi_currency;
 
-		// Simple product price hooks.
-		add_filter( 'woocommerce_product_get_price', [ $this, 'get_product_price' ], 50 );
-		add_filter( 'woocommerce_product_get_regular_price', [ $this, 'get_product_price' ], 50 );
-		add_filter( 'woocommerce_product_get_sale_price', [ $this, 'get_product_price' ], 50 );
+		$frontend_request = ! is_admin() && ! defined( 'DOING_CRON' ) && ! WC()->is_rest_api_request();
 
-		// Variation price hooks.
-		add_filter( 'woocommerce_product_variation_get_price', [ $this, 'get_product_price' ], 50 );
-		add_filter( 'woocommerce_product_variation_get_regular_price', [ $this, 'get_product_price' ], 50 );
-		add_filter( 'woocommerce_product_variation_get_sale_price', [ $this, 'get_product_price' ], 50 );
+		if ( $frontend_request ) {
+			// Simple product price hooks.
+			add_filter( 'woocommerce_product_get_price', [ $this, 'get_product_price' ], 50 );
+			add_filter( 'woocommerce_product_get_regular_price', [ $this, 'get_product_price' ], 50 );
+			add_filter( 'woocommerce_product_get_sale_price', [ $this, 'get_product_price' ], 50 );
 
-		// Variation price range hooks.
-		add_filter( 'woocommerce_variation_prices', [ $this, 'get_variation_price_range' ], 50 );
-		add_filter( 'woocommerce_get_variation_prices_hash', [ $this, 'add_exchange_rate_to_variation_prices_hash' ], 50 );
+			// Variation price hooks.
+			add_filter( 'woocommerce_product_variation_get_price', [ $this, 'get_product_price' ], 50 );
+			add_filter( 'woocommerce_product_variation_get_regular_price', [ $this, 'get_product_price' ], 50 );
+			add_filter( 'woocommerce_product_variation_get_sale_price', [ $this, 'get_product_price' ], 50 );
 
-		// Shipping methods hooks.
-		add_filter( 'woocommerce_package_rates', [ $this, 'convert_package_rates_prices' ], 50 );
-		add_action( 'init', [ $this, 'register_free_shipping_filters' ], 50 );
+			// Variation price range hooks.
+			add_filter( 'woocommerce_variation_prices', [ $this, 'get_variation_price_range' ], 50 );
+			add_filter( 'woocommerce_get_variation_prices_hash', [ $this, 'add_exchange_rate_to_variation_prices_hash' ], 50 );
 
-		// Coupon hooks.
-		add_filter( 'woocommerce_coupon_get_amount', [ $this, 'get_coupon_amount' ], 50, 2 );
-		add_filter( 'woocommerce_coupon_get_minimum_amount', [ $this, 'get_coupon_min_max_amount' ], 50 );
-		add_filter( 'woocommerce_coupon_get_maximum_amount', [ $this, 'get_coupon_min_max_amount' ], 50 );
+			// Shipping methods hooks.
+			add_filter( 'woocommerce_package_rates', [ $this, 'convert_package_rates_prices' ], 50 );
+			add_action( 'init', [ $this, 'register_free_shipping_filters' ], 50 );
+
+			// Coupon hooks.
+			add_filter( 'woocommerce_coupon_get_amount', [ $this, 'get_coupon_amount' ], 50, 2 );
+			add_filter( 'woocommerce_coupon_get_minimum_amount', [ $this, 'get_coupon_min_max_amount' ], 50 );
+			add_filter( 'woocommerce_coupon_get_maximum_amount', [ $this, 'get_coupon_min_max_amount' ], 50 );
+		}
 	}
 
 	/**

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -108,11 +108,11 @@ class Multi_Currency {
 
 		$is_frontend_request = ! is_admin() && ! defined( 'DOING_CRON' ) && ! WC()->is_rest_api_request();
 
+		$this->frontend_prices     = new Frontend_Prices( $this );
+		$this->frontend_currencies = new Frontend_Currencies( $this );
+
 		if ( $is_frontend_request ) {
 			add_action( 'init', [ $this, 'update_selected_currency_by_url' ] );
-
-			$this->frontend_prices     = new Frontend_Prices( $this );
-			$this->frontend_currencies = new Frontend_Currencies( $this );
 		}
 	}
 
@@ -142,6 +142,24 @@ class Multi_Currency {
 			[ 'BIF', '1974' ], // Zero dollar currency.
 			[ 'CLP', '706.8' ], // Zero dollar currency.
 		];
+	}
+
+	/**
+	 * Returns the Frontend_Prices instance.
+	 *
+	 * @return Frontend_Prices
+	 */
+	public function get_frontend_prices() {
+		return $this->frontend_prices;
+	}
+
+	/**
+	 * Returns the Frontend_Currencies instance.
+	 *
+	 * @return Frontend_Currencies
+	 */
+	public function get_frontend_currencies() {
+		return $this->frontend_currencies;
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're going to need to fetch some data from the conversion classes when previewing the currency conversion in the settings pages.

This commit adds the getters for them in the Multi_Currency class, along with changing it so they're always instantiated. The filters are still only registered with frontend requests.


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the changes make sense and that the currency conversion still works for frontend requests
* Make sure admin pages and quick edit prices are not converted

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
