### PR TITLE
Set customer session cookie manually after select currency

### DIFF
--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -250,6 +250,7 @@ class Multi_Currency {
 
 		if ( 0 === $user_id && WC()->session ) {
 			WC()->session->set( self::CURRENCY_SESSION_KEY, $currency->get_code() );
+			WC()->session->set_customer_session_cookie( true );
 		} elseif ( $user_id ) {
 			update_user_meta( $user_id, self::CURRENCY_META_KEY, $currency->get_code() );
 		}

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -250,7 +250,10 @@ class Multi_Currency {
 
 		if ( 0 === $user_id && WC()->session ) {
 			WC()->session->set( self::CURRENCY_SESSION_KEY, $currency->get_code() );
-			WC()->session->set_customer_session_cookie( true );
+			// Set the session cookie if is not yet to persist the selected currency.
+			if ( ! WC()->session->has_session() ) {
+				WC()->session->set_customer_session_cookie( true );
+			}
 		} elseif ( $user_id ) {
 			update_user_meta( $user_id, self::CURRENCY_META_KEY, $currency->get_code() );
 		}

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -251,7 +251,7 @@ class Multi_Currency {
 		if ( 0 === $user_id && WC()->session ) {
 			WC()->session->set( self::CURRENCY_SESSION_KEY, $currency->get_code() );
 			// Set the session cookie if is not yet to persist the selected currency.
-			if ( ! WC()->session->has_session() ) {
+			if ( ! WC()->session->has_session() && ! headers_sent() ) {
 				WC()->session->set_customer_session_cookie( true );
 			}
 		} elseif ( $user_id ) {


### PR DESCRIPTION
Fixes #1997 

#### Changes proposed in this Pull Request
Used the provided `set_customer_session_cookie` by `WC Session` to avoid getting a new session on every page view. As per method doc `Sets the session cookie on-demand (usually after adding an item to the cart).` is the same behavior expected after adding an item to the cart. So we can do that to ensure the selected currency is preserved across page views.

The only side effect I can think of is that pages will be not cached after selecting a new currency, but I think is the expected behavior to avoid any issue showing the new currency, for example in the cart.

#### Testing instructions
- Navigate to your shop page
- Change the currency from the widget
- You now see all prices in the new currency
- Navigate to the shop page again or just remove `?currency=...` from the URL
- You should see the prices in the selected currency and not in the default one as before.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
