### PR TITLE
Replace unsupported mysql image for ARM64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ project.properties
 .settings*
 .idea
 .vscode
+*.code-workspace
 *.sublime-project
 *.sublime-workspace
 .sublimelinterrc

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ project.properties
 .settings*
 .idea
 .vscode
-*.code-workspace
 *.sublime-project
 *.sublime-workspace
 .sublimelinterrc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - ./docker/bin:/var/scripts
   db:
     container_name: woocommerce_payments_mysql
-    image: mysql:5.7
+    image: mariadb:10.5.8
     ports:
       - "5678:3306"
     env_file:


### PR DESCRIPTION
Fixes #1547 

#### Changes proposed in this Pull Request

Replace unsupported mysql image for ARM64

Current configuration in `docker-compose.yml` includes `mysql:5.7` image to be used for the database container, which currently doesn't support ARM64 architecture, and people from the docker community suggests to use replacement images, and one of them is using `mariadb:10.5.8`, as suggested by @ismaeldcom (thanks!). This PR replaces the **mysql** image with the **mariadb** to enable cross-platform support again in this repo. 

The error raised by `npm run up` with using the current `mysql:5.7` configuration on M1 MBP:

````
Pulling db (mysql:5.7)...
5.7: Pulling from library/mysql
ERROR: no matching manifest for linux/arm64/v8 in the manifest list entries
````

And after replacing it with `mariadb:10.5.8`:

```
Building wordpress
[+] Building 2.0s (10/10) FINISHED   
```

#### Testing instructions

* clone the repo on a computer that has ARM64 architecture
* run `npm run up` and wati for it to complete
* open `http://localhost:8082` and see if you can login with the default credentials.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)