### PR TITLE
Update multi currency init

### DIFF
--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -97,7 +97,7 @@ class Multi_Currency {
 		$this->set_default_currency();
 		$this->initialize_enabled_currencies();
 
-		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );
+		add_action( 'rest_api_init', [ $this, 'init_rest_api' ] );
 		add_action(
 			'widgets_init',
 			function() {
@@ -132,8 +132,9 @@ class Multi_Currency {
 	/**
 	 * Initialize the REST API controller.
 	 */
-	public static function init_rest_api() {
+	public function init_rest_api() {
 		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-wc-rest-controller.php';
+
 		$api_controller = new WC_REST_Controller( \WC_Payments::create_api_client() );
 		$api_controller->register_routes();
 	}

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -85,6 +85,7 @@ class Multi_Currency {
 	 * Constructor.
 	 */
 	private function __construct() {
+		$this->includes();
 		$this->init();
 	}
 
@@ -92,13 +93,6 @@ class Multi_Currency {
 	 * Init.
 	 */
 	public function init() {
-		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-currency.php';
-		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-country-flags.php';
-		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-currency-switcher-widget.php';
-		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-user-settings.php';
-		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-prices.php';
-		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-currencies.php';
-
 		$this->initialize_available_currencies();
 		$this->set_default_currency();
 		$this->initialize_enabled_currencies();
@@ -486,5 +480,17 @@ class Multi_Currency {
 	protected function ceil_price( $price, $precision ) {
 		$precision_modifier = pow( 10, $precision );
 		return ceil( $price * $precision_modifier ) / $precision_modifier;
+	}
+
+	/**
+	 * Include required core files used in admin and on the frontend.
+	 */
+	protected function includes() {
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-currency.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-currency-switcher-widget.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-country-flags.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-prices.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-currencies.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-user-settings.php';
 	}
 }

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -143,7 +143,9 @@ class Multi_Currency {
 	 * @return array The new settings pages.
 	 */
 	public function init_settings_pages( $settings_pages ) {
-		$settings_pages[] = include_once WCPAY_ABSPATH . 'includes/multi-currency/class-settings.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-settings.php';
+
+		$settings_pages[] = new Settings( $this );
 		return $settings_pages;
 	}
 

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -18,6 +18,13 @@ class Multi_Currency {
 	const CURRENCY_META_KEY    = 'wcpay_currency';
 
 	/**
+	 * The plugin's ID.
+	 *
+	 * @var string
+	 */
+	public $id = 'wcpay_multi_currency';
+
+	/**
 	 * The single instance of the class.
 	 *
 	 * @var Multi_Currency
@@ -92,7 +99,6 @@ class Multi_Currency {
 		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-prices.php';
 		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-currencies.php';
 
-		$this->id = 'wcpay_multi_currency';
 		$this->initialize_available_currencies();
 		$this->set_default_currency();
 		$this->initialize_enabled_currencies();

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -99,12 +99,13 @@ class Multi_Currency {
 
 		add_action( 'rest_api_init', [ $this, 'init_rest_api' ] );
 		add_action( 'widgets_init', [ $this, 'init_widgets' ] );
-		new User_Settings( $this );
 
-		$is_frontend_request = ! is_admin() && ! defined( 'DOING_CRON' ) && ! WC()->is_rest_api_request();
+		new User_Settings( $this );
 
 		$this->frontend_prices     = new Frontend_Prices( $this );
 		$this->frontend_currencies = new Frontend_Currencies( $this );
+
+		$is_frontend_request = ! is_admin() && ! defined( 'DOING_CRON' ) && ! WC()->is_rest_api_request();
 
 		if ( $is_frontend_request ) {
 			add_action( 'init', [ $this, 'update_selected_currency_by_url' ] );

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -114,14 +114,7 @@ class Multi_Currency {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 
 		if ( is_admin() ) {
-			// Multi-currency settings page.
-			add_filter(
-				'woocommerce_get_settings_pages',
-				function( $settings_pages ) {
-					$settings_pages[] = include_once WCPAY_ABSPATH . 'includes/multi-currency/class-settings.php';
-					return $settings_pages;
-				}
-			);
+			add_filter( 'woocommerce_get_settings_pages', [ $this, 'init_settings_pages' ] );
 		}
 	}
 
@@ -140,6 +133,18 @@ class Multi_Currency {
 	 */
 	public function init_widgets() {
 		register_widget( new Currency_Switcher_Widget( $this ) );
+	}
+
+	/**
+	 * Initialize the Settings Pages.
+	 *
+	 * @param array $settings_pages The settings pages.
+	 *
+	 * @return array The new settings pages.
+	 */
+	public function init_settings_pages( $settings_pages ) {
+		$settings_pages[] = include_once WCPAY_ABSPATH . 'includes/multi-currency/class-settings.php';
+		return $settings_pages;
 	}
 
 	/**

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -98,12 +98,7 @@ class Multi_Currency {
 		$this->initialize_enabled_currencies();
 
 		add_action( 'rest_api_init', [ $this, 'init_rest_api' ] );
-		add_action(
-			'widgets_init',
-			function() {
-				register_widget( new Currency_Switcher_Widget( $this ) );
-			}
-		);
+		add_action( 'widgets_init', [ $this, 'init_widgets' ] );
 		new User_Settings( $this );
 
 		$is_frontend_request = ! is_admin() && ! defined( 'DOING_CRON' ) && ! WC()->is_rest_api_request();
@@ -137,6 +132,13 @@ class Multi_Currency {
 
 		$api_controller = new WC_REST_Controller( \WC_Payments::create_api_client() );
 		$api_controller->register_routes();
+	}
+
+	/**
+	 * Initialize the Widgets.
+	 */
+	public function init_widgets() {
+		register_widget( new Currency_Switcher_Widget( $this ) );
 	}
 
 	/**

--- a/includes/multi-currency/class-settings.php
+++ b/includes/multi-currency/class-settings.php
@@ -11,10 +11,6 @@ use WCPay\Multi_Currency\Currency;
 
 defined( 'ABSPATH' ) || exit;
 
-if ( class_exists( Settings::class, false ) ) {
-	return new Settings();
-}
-
 /**
  * Settings.
  */
@@ -43,9 +39,11 @@ class Settings extends \WC_Settings_Page {
 
 	/**
 	 * Constructor.
+	 *
+	 * @param Multi_Currency $multi_currency The Multi_Currency instance.
 	 */
-	public function __construct() {
-		$this->multi_currency = Multi_Currency::instance();
+	public function __construct( Multi_Currency $multi_currency ) {
+		$this->multi_currency = $multi_currency;
 		$this->id             = $this->multi_currency->id;
 		$this->label          = _x( 'Multi-currency', 'Settings tab label', 'woocommerce-payments' );
 
@@ -361,5 +359,3 @@ class Settings extends \WC_Settings_Page {
 		do_action( 'woocommerce_update_options_' . $this->id );
 	}
 }
-
-new Settings();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes a few changes to (hopefully) better organize the init of the plugin and avoid using closures with hooks. It also adds Multi_Currency as a dependency of Settings and instantiates that class from the main one.

- Move Multi_Currency ID to the class' properties
- Add includes function to load the core files
- Remove static from init_rest_api
- Init widgets using a named function
- Reorder is_frontend_request definition
- Init settings pages using a named function
- Add and inject Multi_Currency as a dependency of Settings


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure unit tests are passing
* Make sure the settings page is loaded and works
* Make sure the prices are updated in the frontend when using the widget
* Purchase a product in another currency and make sure it works

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
