### PR TITLE
Fix fatal error when WCPay is deactivated when WC is inactive

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -718,7 +718,7 @@ class WC_Payments {
 	 * Adds WCPay notes to the WC-Admin inbox.
 	 */
 	public static function add_woo_admin_notes() {
-		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-qualitative-feedback.php';
 			WC_Payments_Notes_Qualitative_Feedback::possibly_add_note();
@@ -733,9 +733,8 @@ class WC_Payments {
 	 * Removes WCPay notes from the WC-Admin inbox.
 	 */
 	public static function remove_woo_admin_notes() {
-		self::$remote_note_service->delete_notes();
-
-		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+			self::$remote_note_service->delete_notes();
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-refund-policy.php';
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-qualitative-feedback.php';
 			WC_Payments_Notes_Qualitative_Feedback::possibly_delete_note();


### PR DESCRIPTION
Fixes #1664

#### Changes proposed in this Pull Request

Fix fatal error when WCPay is deactivated when WC is inactive

Removing notes on plugin deactivation requires the `self::$remote_note_service` assigned as a `WC_Payments_Remote_Note_Service` instance (which is done on class initialization). The class initialization returns early when the one of the dependencies (WooCommerce plugin in this case) is not present, leaving the `self::$remote_note_service` as null. 

https://github.com/Automattic/woocommerce-payments/blob/aa0155f5f9909a5e89a35749631db0670a18b984/includes/class-wc-payments.php#L146-L149

And when this variable isn't set, the deactivation process tries to call the `delete_notes` method on null, and it results with a fatal error. 

This fix checks if the WC plugin is active before trying to delete the WCPay related notes.

#### Testing instructions
- Create a WCPay dev instance both having WC and WCPay installed
- Deactivate WC
- Deactivate WCPay and see if the plugin deactivates without errors and warnings.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
