### PR TITLE
Use currency settings charm and rounding when calculating prices

### DIFF
--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -452,7 +452,7 @@ class Multi_Currency {
 		}
 
 		if ( $apply_charm_pricing ) {
-			$price -= floatval( $currency->get_charm() );
+			$price += floatval( $currency->get_charm() );
 		}
 
 		// Do not return negative prices (possible because of $currency->get_charm()).

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -392,24 +392,6 @@ class Multi_Currency {
 	}
 
 	/**
-	 * Gets the rounding precision in the format used by round().
-	 *
-	 * @return int The rounding precision.
-	 */
-	public function get_round_precision(): float {
-		return apply_filters( 'wcpay_multi_currency_round_precision', 0 );
-	}
-
-	/**
-	 * Gets the charm pricing to be added to the converted price after rounding.
-	 *
-	 * @return float The charm pricing.
-	 */
-	public function get_charm_pricing(): float {
-		return apply_filters( 'wcpay_multi_currency_charm_pricing', -0.1 );
-	}
-
-	/**
 	 * Gets the configured value for apply charm pricing only to products.
 	 *
 	 * @return bool The configured value.

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -452,7 +452,7 @@ class Multi_Currency {
 		}
 
 		if ( $apply_charm_pricing ) {
-			$price += floatval( $currency->get_charm() );
+			$price -= floatval( $currency->get_charm() );
 		}
 
 		// Do not return negative prices (possible because of $currency->get_charm()).

--- a/includes/multi-currency/class-settings.php
+++ b/includes/multi-currency/class-settings.php
@@ -336,7 +336,7 @@ class Settings extends \WC_Settings_Page {
 					'id'       => $this->id . '_price_charm_' . $currency->get_id(),
 					'default'  => 0.00,
 					'type'     => 'text',
-					'desc_tip' => __( 'A value of 0.01 would reduce 20.00 to 19.99.', 'woocommerce-payments' ),
+					'desc_tip' => __( 'A value of -0.01 would reduce 20.00 to 19.99.', 'woocommerce-payments' ),
 				],
 
 				[

--- a/includes/multi-currency/class-settings.php
+++ b/includes/multi-currency/class-settings.php
@@ -225,14 +225,14 @@ class Settings extends \WC_Settings_Page {
 		$rounding_options = apply_filters(
 			$this->id . '_price_rounding_options',
 			[
-				'1000' => $default_currency->get_symbol() . '10.00',
-				'100'  => sprintf(
+				'-1'   => $default_currency->get_symbol() . '10.00',
+				'0'    => sprintf(
 					/* translators: %s: Default currency symbol */
 					__( '%s1.00 (recommended)', 'woocommerce-payments' ),
 					$default_currency->get_symbol()
 				),
-				'10'   => $default_currency->get_symbol() . '0.10',
-				'1'    => $default_currency->get_symbol() . '0.01',
+				'1'    => $default_currency->get_symbol() . '0.10',
+				'2'    => $default_currency->get_symbol() . '0.01',
 				'none' => __( 'None', 'woocommerce-payments' ),
 			]
 		);
@@ -336,7 +336,7 @@ class Settings extends \WC_Settings_Page {
 					'id'       => $this->id . '_price_charm_' . $currency->get_id(),
 					'default'  => 0.00,
 					'type'     => 'text',
-					'desc_tip' => __( 'A value of .01 would reduce 20.00 to 19.99.', 'woocommerce-payments' ),
+					'desc_tip' => __( 'A value of 0.01 would reduce 20.00 to 19.99.', 'woocommerce-payments' ),
 				],
 
 				[

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -24,7 +24,7 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->mock_currency_settings(
 			'GBP',
 			[
-				'price_charm'    => '0.1',
+				'price_charm'    => '-0.1',
 				'price_rounding' => '0',
 			]
 		);

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -24,7 +24,7 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->mock_currency_settings(
 			'GBP',
 			[
-				'price_charm'    => '-0.1',
+				'price_charm'    => '0.1',
 				'price_rounding' => '0',
 			]
 		);


### PR DESCRIPTION
Fixes #2049 

#### Changes proposed in this Pull Request

This PR uses the new currency settings when calculating a price, instead of the old mocking functions. The old functions were removed and the tests updated. The price charm was also inverted, as the settings expect a positive price charm to be subtracted from the converted price, and the rounding values were fixed to match the expected format.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the tests are correct
* Test the price conversion by setting different `rates`, `charm` and `rounding` values for different currencies and checking that the converted price is correct

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
