### PR TITLE
Remove "Enter VAT" link from additional methods onboarding wizard

### DIFF
--- a/client/additional-methods-setup/methods-selector/setup-complete-task.js
+++ b/client/additional-methods-setup/methods-selector/setup-complete-task.js
@@ -57,23 +57,14 @@ const SetupComplete = () => {
 				<p className="wcpay-wizard-task__description-element is-muted-color">
 					{ interpolateComponents( {
 						mixedString: __(
-							'{{vatInformationLink /}} and {{setupTaxesLink /}} ' +
-								'to ensure smooth transactions if you plan to sell to customers in Europe.',
+							'{{setupTaxesLink /}} to ensure smooth transactions if you plan to sell to customers in Europe.',
 							'woocommerce-payments'
 						),
 						components: {
-							vatInformationLink: (
-								<a href="admin.php?page=wc-settings">
-									{ __(
-										'Enter your VAT account information',
-										'woocommerce-payments'
-									) }
-								</a>
-							),
 							setupTaxesLink: (
 								<a href="admin.php?page=wc-settings&tab=tax">
 									{ __(
-										'set up taxes',
+										'Set up taxes',
 										'woocommerce-payments'
 									) }
 								</a>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

We had a chat with @jarekmorawski during which he mentioned the "Enter your VAT account information" link should be removed from the additional payment methods onboarding wizard at this point. This PR removes that link.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

**Before:**

![Markup on 2021-06-04 at 20:06:34](https://user-images.githubusercontent.com/1759681/120844914-5f407180-c570-11eb-8012-31b2e5b58227.png)

**After:**

![Markup on 2021-06-04 at 20:05:13](https://user-images.githubusercontent.com/1759681/120844929-62d3f880-c570-11eb-9f54-adafbc69b1d3.png)

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1.  Enable the `_wcpay_feature_grouped_settings` and `_wcpay_feature_upe` feature flags.
2. Go to WooCommerce > Home and click the "Set up additional payment methods" task.
3. Verify that the copy in the second step of the wizard is as displayed on the "After" screenshot above.

-------------------

- [x] Added changelog entry (or does not apply)
    -  Changelog not added - change behind feature flag.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
