### PR TITLE
Change mysql image used for e2e client tests for ARM64 processors

### DIFF
--- a/tests/e2e/env/docker-compose.yml
+++ b/tests/e2e/env/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ${E2E_ROOT}/deps/woocommerce-subscriptions:/var/www/html/wp-content/plugins/woocommerce-subscriptions
   db:
     container_name: wcp_e2e_mysql
-    image: mysql:5.7
+    image: mariadb:10.5.8
     ports:
       - "5698:3306"
     env_file:


### PR DESCRIPTION
Fixes #2058

#### Changes proposed in this Pull Request

Change mysql image used for e2e client tests for ARM64 processors

Current configuration `./tests/e2e/env/docker-compose.yml` includes `mysql:5.7` image to be used for the database container, which currently doesn't support ARM64 architecture, and people from the docker community suggests to use replacement images, and one of them is using `mariadb:10.5.8`, as suggested by @ismaeldcom (thanks!). This PR replaces the mysql image with the mariadb to enable cross-platform support when preparing the E2E testing environment using the command `npm run test:e2e-setup`.

#### Testing Instructions

On a computer which has the ARM64 processor arch, 

- Prepare the client environment
- Run the command `npm run test:e2e-setup`

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
