### PR TITLE
feat: overlay over disabled DW controls

### DIFF
--- a/client/settings/digital-wallets/index.js
+++ b/client/settings/digital-wallets/index.js
@@ -10,17 +10,19 @@ import {
 	CardDivider,
 	CheckboxControl,
 } from '@wordpress/components';
+import classNames from 'classnames';
 import interpolateComponents from 'interpolate-components';
-import { getPaymentMethodSettingsUrl } from '../../utils';
 
 /**
  * Internal dependencies
  */
+import { getPaymentMethodSettingsUrl } from '../../utils';
 import {
 	useDigitalWalletsEnabledSettings,
 	useDigitalWalletsLocations,
 } from 'data';
 import CardBody from '../card-body';
+import './style.scss';
 
 const DigitalWallets = () => {
 	const [
@@ -88,50 +90,68 @@ const DigitalWallets = () => {
 					} ) }
 					/* eslint-enable jsx-a11y/anchor-has-content */
 				/>
-				<h4>
-					{ __(
-						'Show express checkouts on',
-						'woocommerce-payments'
+				<div
+					className={ classNames(
+						'digital-wallets__additional-controls-wrapper',
+						{ 'is-enabled': isDigitalWalletsEnabled }
 					) }
-				</h4>
-				<ul>
-					<li>
-						<CheckboxControl
-							disabled={ ! isDigitalWalletsEnabled }
-							checked={
-								isDigitalWalletsEnabled &&
-								digitalWalletsLocations.includes( 'checkout' )
-							}
-							onChange={ makeLocationChangeHandler( 'checkout' ) }
-							label={ __( 'Checkout', 'woocommerce-payments' ) }
-						/>
-					</li>
-					<li>
-						<CheckboxControl
-							disabled={ ! isDigitalWalletsEnabled }
-							checked={
-								isDigitalWalletsEnabled &&
-								digitalWalletsLocations.includes( 'product' )
-							}
-							onChange={ makeLocationChangeHandler( 'product' ) }
-							label={ __(
-								'Product page',
-								'woocommerce-payments'
-							) }
-						/>
-					</li>
-					<li>
-						<CheckboxControl
-							disabled={ ! isDigitalWalletsEnabled }
-							checked={
-								isDigitalWalletsEnabled &&
-								digitalWalletsLocations.includes( 'cart' )
-							}
-							onChange={ makeLocationChangeHandler( 'cart' ) }
-							label={ __( 'Cart', 'woocommerce-payments' ) }
-						/>
-					</li>
-				</ul>
+				>
+					<h4>
+						{ __(
+							'Show express checkouts on',
+							'woocommerce-payments'
+						) }
+					</h4>
+					<ul>
+						<li>
+							<CheckboxControl
+								disabled={ ! isDigitalWalletsEnabled }
+								checked={
+									isDigitalWalletsEnabled &&
+									digitalWalletsLocations.includes(
+										'checkout'
+									)
+								}
+								onChange={ makeLocationChangeHandler(
+									'checkout'
+								) }
+								label={ __(
+									'Checkout',
+									'woocommerce-payments'
+								) }
+							/>
+						</li>
+						<li>
+							<CheckboxControl
+								disabled={ ! isDigitalWalletsEnabled }
+								checked={
+									isDigitalWalletsEnabled &&
+									digitalWalletsLocations.includes(
+										'product'
+									)
+								}
+								onChange={ makeLocationChangeHandler(
+									'product'
+								) }
+								label={ __(
+									'Product page',
+									'woocommerce-payments'
+								) }
+							/>
+						</li>
+						<li>
+							<CheckboxControl
+								disabled={ ! isDigitalWalletsEnabled }
+								checked={
+									isDigitalWalletsEnabled &&
+									digitalWalletsLocations.includes( 'cart' )
+								}
+								onChange={ makeLocationChangeHandler( 'cart' ) }
+								label={ __( 'Cart', 'woocommerce-payments' ) }
+							/>
+						</li>
+					</ul>
+				</div>
 			</CardBody>
 			<CardDivider />
 			<CardBody>

--- a/client/settings/digital-wallets/style.scss
+++ b/client/settings/digital-wallets/style.scss
@@ -1,0 +1,22 @@
+.digital-wallets {
+	&__additional-controls-wrapper {
+		position: relative;
+
+		&::after {
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 100%;
+			content: ' ';
+			background: $white;
+			opacity: 0.5;
+		}
+
+		&.is-enabled {
+			&::after {
+				opacity: 0;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/1949

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Added an overlay on the "Express checkout" controls when the "Express checkout" flag is disabled.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have the "grouped settings" flag enabled
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments
- Enable/disable the "express checkout" flag to see the overlay over the inputs

![2021-06-07 12 37 51](https://user-images.githubusercontent.com/273592/121064431-334e0780-c78d-11eb-9da9-abcc61b63698.gif)


-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
