### PR TITLE
Display errors from WC form when using UPE.

### DIFF
--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -320,12 +320,21 @@ export default class WCPayAPI {
 			action: 'create_payment_intent',
 			// eslint-disable-next-line camelcase
 			_ajax_nonce: getConfig( 'createPaymentIntentNonce' ),
-		} ).then( ( response ) => {
-			if ( ! response.success ) {
-				throw response.data.error;
-			}
-			return response.data;
-		} );
+		} )
+			.then( ( response ) => {
+				if ( ! response.success ) {
+					throw response.data.error;
+				}
+				return response.data;
+			} )
+			.catch( ( error ) => {
+				if ( error.message ) {
+					throw error;
+				} else {
+					// Covers the case of error on the Ajax request.
+					throw new Error( error.statusText );
+				}
+			} );
 	}
 
 	/**
@@ -344,12 +353,17 @@ export default class WCPayAPI {
 		} )
 			.then( ( response ) => {
 				if ( 'failure' === response.result ) {
-					throw { message: response.messages };
+					throw new Error( response.messages );
 				}
 				return response;
 			} )
 			.catch( ( error ) => {
-				throw error;
+				if ( error.message ) {
+					throw error;
+				} else {
+					// Covers the case of error on the Ajaxrequest.
+					throw new Error( error.statusText );
+				}
 			} );
 	}
 

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -344,12 +344,12 @@ export default class WCPayAPI {
 		} )
 			.then( ( response ) => {
 				if ( 'failure' === response.result ) {
-					throw response.messages;
+					throw { message: response.messages };
 				}
 				return response;
 			} )
 			.catch( ( error ) => {
-				throw `Error submitting form! ${ error.status }: ${ error.statusText }.`;
+				throw error;
 			} );
 	}
 

--- a/client/checkout/classic/index.js
+++ b/client/checkout/classic/index.js
@@ -539,11 +539,11 @@ jQuery( function ( $ ) {
 				},
 			} );
 			if ( error ) {
-				throw error.message;
+				throw error;
 			}
 		} catch ( error ) {
 			$form.removeClass( 'processing' ).unblock();
-			showError( error );
+			showError( error.message );
 		}
 	};
 

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -58,13 +58,13 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	/**
 	 * Handle AJAX request for creating a payment intent for Stripe UPE.
 	 *
-	 * @throws Exception - If nonce or setup intent is invalid.
+	 * @throws Process_Payment_Exception - If nonce or setup intent is invalid.
 	 */
 	public function create_payment_intent_ajax() {
 		try {
 			$is_nonce_valid = check_ajax_referer( 'wcpay_create_payment_intent_nonce', false, false );
 			if ( ! $is_nonce_valid ) {
-				throw new Exception(
+				throw new Process_Payment_Exception(
 					__( 'Something terrible has happened. Please refresh the page and try again.', 'woocommerce-payments' ),
 					'wcpay_upe_intent_error'
 				);


### PR DESCRIPTION
Fixes #1961 

#### Changes proposed in this Pull Request

Display errors on checkout coming from WooCommerce form and UPE form when using UPE.

For consistency with other functions, I have changed `processCheckout` to return the error message inside of an object with the `message` property.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With UPE Enabled, add a product to the cart and go to checkout.
* Select UPE as payment method, leave some of the fields incomplete, click on 'Place Order'
* Check UPE errors are displayed
* Fill out all UPE fields, remove the zip code from WooCommerce form
* Click on 'Place Order'
* Check that WooCommerce error message for that field is displayed.
<img width="951" alt="ZipCodeError" src="https://user-images.githubusercontent.com/8002881/121098486-9191df00-c7bb-11eb-95fe-c5ecdc4eb773.png">


-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
