### PR TITLE
Pass config object to registerPaymentMethod, instead of function

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 2.6.0 - 2021-xx-xx =
 * Add - Notify the admin if WordPress.com user connection is broken.
+* Update - call registerPaymentMethod of WooCommerce Blocks with config object. Minimum supported version of WooCommerce Blocks is 3.9.0
 
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@
 
 = 2.6.0 - 2021-xx-xx =
 * Add - Notify the admin if WordPress.com user connection is broken.
-* Update - call registerPaymentMethod of WooCommerce Blocks with config object. Minimum supported version of WooCommerce Blocks is 3.9.0
+* Fix - Use of deprecated call-style to registerPaymentMethods. WooCommerce Payments now require WooCommerce Blocks of at least version 3.9.0
 
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@
 
 = 2.6.0 - 2021-xx-xx =
 * Add - Notify the admin if WordPress.com user connection is broken.
-* Fix - Use of deprecated call-style to registerPaymentMethods. WooCommerce Payments now require WooCommerce Blocks of at least version 3.9.0
+* Fix - Use of deprecated call-style to registerPaymentMethods. WooCommerce Payments now requires WooCommerce Blocks of at least version 3.9.0.
 
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -32,22 +32,18 @@ const api = new WCPayAPI(
 	request
 );
 
-// Add the payment method to the blocks registry.
-registerPaymentMethod(
-	( PaymentMethodConfig ) =>
-		new PaymentMethodConfig( {
-			name: PAYMENT_METHOD_NAME_CARD,
-			content: <WCPayFields api={ api } />,
-			edit: <WCPayFields api={ api } />,
-			canMakePayment: () => !! api.getStripe(),
-			paymentMethodId: PAYMENT_METHOD_NAME_CARD,
-			label: __( 'Credit Card', 'woocommerce-payments' ),
-			ariaLabel: __( 'Credit Card', 'woocommerce-payments' ),
-			supports: {
-				features: getConfig( 'features' ),
-			},
-		} )
-);
+registerPaymentMethod( {
+	name: PAYMENT_METHOD_NAME_CARD,
+	content: <WCPayFields api={ api } />,
+	edit: <WCPayFields api={ api } />,
+	canMakePayment: () => !! api.getStripe(),
+	paymentMethodId: PAYMENT_METHOD_NAME_CARD,
+	label: __( 'Credit Card', 'woocommerce-payments' ),
+	ariaLabel: __( 'Credit Card', 'woocommerce-payments' ),
+	supports: {
+		features: getConfig( 'features' ),
+	},
+} );
 
 registerExpressPaymentMethod( paymentRequestPaymentMethod( api ) );
 


### PR DESCRIPTION
Fixes #1308

#### Changes proposed in this Pull Request

Since the 3.9.0 release of WooCommerce Blocks calling registerPaymentMethod with a function is deprecated. The registerPaymentMethod should be passed an options JS object.

- Passes config object to registerPaymentMethod instead of function.

#### Testing instructions

1. Install WooCommerce blocks plugin
2. Setup a page using the checkout block.
3. Ensure that we can add payment method and checkout using the new page.

**Note**
- This change drops WooCommerce Payments support for WooCommerce Blocks < 3.9.0

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
