### PR TITLE
Fix fatal error if store currency is changed after enabled currencies are set

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 2.6.0 - 2021-xx-xx =
 * Add - Notify the admin if WordPress.com user connection is broken.
+* Fix - Fix fatal error if store currency is changed after enabled (multi) currencies set.
 
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -260,6 +260,12 @@ class Multi_Currency {
 		$enabled_currencies[] = $default_code;
 
 		foreach ( $enabled_currencies as $code ) {
+			// If the currency code is not found in the available currencies we skip it.
+			// This is due to merchants can use filters to add more currencies, then remove them at any time.
+			if ( ! isset( $available_currencies[ $code ] ) ) {
+				continue;
+			}
+
 			// Get the charm and rounding for each enabled currency and add the currencies to the object property.
 			$currency = clone $available_currencies[ $code ];
 			$charm    = get_option( $this->id . '_price_charm_' . $currency->get_id(), 0.00 );

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -224,6 +224,19 @@ class Multi_Currency {
 	}
 
 	/**
+	 * Gets the currencies stored in the db.
+	 *
+	 * @return array Multi-dimensional array of currencies and rates.
+	 */
+	private function get_stored_currencies(): array {
+		$stored_currencies = get_option( $this->id . '_stored_currencies', false );
+		if ( ! $stored_currencies ) {
+			$stored_currencies = $this->get_mock_currencies();
+		}
+		return $stored_currencies;
+	}
+
+	/**
 	 * Sets up the available currencies.
 	 */
 	private function initialize_available_currencies() {
@@ -231,8 +244,7 @@ class Multi_Currency {
 		$woocommerce_currency                                = get_woocommerce_currency();
 		$this->available_currencies[ $woocommerce_currency ] = new Currency( $woocommerce_currency, 1.0 );
 
-		// TODO: This will need to get stored data, then build and return it accordingly.
-		$currencies = $this->get_mock_currencies();
+		$currencies = $this->get_stored_currencies();
 		foreach ( $currencies as $currency ) {
 			$this->available_currencies[ $currency[0] ] = new Currency( $currency[0], $currency[1] );
 		}
@@ -243,24 +255,9 @@ class Multi_Currency {
 	 */
 	private function initialize_enabled_currencies() {
 		$available_currencies = $this->get_available_currencies();
-		$enabled_currencies   = get_option( $this->id . '_enabled_currencies', false );
+		$enabled_currencies   = get_option( $this->id . '_enabled_currencies', [] );
 		$default_code         = $this->get_default_currency()->get_code();
-
-		if ( ! $enabled_currencies ) {
-			// TODO: Remove dev mode option here.
-			if ( get_option( 'wcpaydev_dev_mode', false ) ) {
-				$count = 0;
-				foreach ( $available_currencies as $currency ) {
-					$enabled_currencies[] = $currency->get_code();
-					if ( $count >= 3 ) {
-						break;
-					}
-					$count++;
-				}
-			} else {
-				$enabled_currencies[] = $default_code;
-			}
-		}
+		$enabled_currencies[] = $default_code;
 
 		foreach ( $enabled_currencies as $code ) {
 			// Get the charm and rounding for each enabled currency and add the currencies to the object property.

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 2.6.0 - 2021-xx-xx =
 * Add - Notify the admin if WordPress.com user connection is broken.
+* Fix - Fix fatal error if store currency is changed after enabled (multi) currencies set.
 
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -133,10 +133,6 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 			]
 		);
 
-		// Recreate Multi_Currency instance to use the recently set currencies.
-		$this->reset_multi_currency_instance();
-		$this->multi_currency = WCPay\Multi_Currency\Multi_Currency::instance();
-
 		$this->assertSame( $expected, wp_json_encode( $this->multi_currency->get_enabled_currencies() ) );
 	}
 
@@ -144,6 +140,16 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$currencies = [ 'USD', 'EUR', 'GBP', 'CLP' ];
 		$this->multi_currency->set_enabled_currencies( $currencies );
 		$this->assertSame( $currencies, get_option( 'wcpay_multi_currency_enabled_currencies' ) );
+	}
+
+	public function test_enabled_but_unavailable_currencies_are_skipped() {
+		update_option( 'wcpay_multi_currency_enabled_currencies', [ 'RANDOM_CURRENCY', 'USD' ] );
+
+		// Recreate Multi_Currency instance to use the recently set currencies.
+		$this->reset_multi_currency_instance();
+		$this->multi_currency = WCPay\Multi_Currency\Multi_Currency::instance();
+
+		$this->assertSame( [ 'USD' ], array_keys( $this->multi_currency->get_enabled_currencies() ) );
 	}
 
 	public function test_get_selected_currency_returns_default_currency_for_empty_session_and_user() {

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -17,6 +17,7 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 	 * @var array
 	 */
 	public $mock_available_currencies = [
+		[ 'USD', 1 ],
 		[ 'CAD', 1.206823 ],
 		[ 'GBP', 0.708099 ],
 		[ 'EUR', 0.826381 ],
@@ -49,6 +50,8 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 				'price_rounding' => '0',
 			]
 		);
+		update_option( 'wcpay_multi_currency_stored_currencies', $this->mock_available_currencies );
+		update_option( 'wcpay_multi_currency_enabled_currencies', $this->mock_enabled_currencies );
 
 		$this->multi_currency = WCPay\Multi_Currency\Multi_Currency::instance();
 	}
@@ -63,6 +66,8 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		wp_set_current_user( 0 );
 
 		$this->remove_currency_settings_mock( 'GBP', [ 'price_charm', 'price_rounding' ] );
+		delete_option( 'wcpay_multi_currency_stored_currencies' );
+		delete_option( 'wcpay_multi_currency_enabled_currencies' );
 
 		parent::tearDown();
 	}
@@ -87,8 +92,6 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_get_enabled_currencies_returns_correctly() {
-		update_option( 'wcpay_multi_currency_enabled_currencies', $this->mock_enabled_currencies );
-
 		$expected = wp_json_encode(
 			(object) [
 				'USD' => (object) [
@@ -138,8 +141,9 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_set_enabled_currencies() {
-		$this->multi_currency->set_enabled_currencies( $this->mock_enabled_currencies );
-		$this->assertSame( $this->mock_enabled_currencies, get_option( 'wcpay_multi_currency_enabled_currencies' ) );
+		$currencies = [ 'USD', 'EUR', 'GBP', 'CLP' ];
+		$this->multi_currency->set_enabled_currencies( $currencies );
+		$this->assertSame( $currencies, get_option( 'wcpay_multi_currency_enabled_currencies' ) );
 	}
 
 	public function test_get_selected_currency_returns_default_currency_for_empty_session_and_user() {
@@ -207,7 +211,7 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_update_selected_currency_by_url_does_not_set_session_when_currency_not_enabled() {
-		$_GET['currency'] = 'BIF';
+		$_GET['currency'] = 'CLP';
 
 		$this->multi_currency->update_selected_currency_by_url();
 


### PR DESCRIPTION
Fixes #2068 #2004

#### Changes proposed in this Pull Request

* Removed loop that created enabled currencies from available currencies.
* Add store currency into enabled currencies.
* Added option query to get stored currencies with a fallback to mock currencies.
* Updated tests to use new option, and to match what was available/enabled.

#### Testing instructions

* Navigate to WooCommerce > Settings > General.
* Set your store currency to USD.
* Navigate to WooCommerce > Settings > Multi-Currency.
* Use _Add Currencies_ and enable CAD and EUR.
* Navigate to WooCommerce > Settings > General.
* Set your store currency to EUR.
* Navigate to WooCommerce > Settings > Multi-Currency.
* Everything should still work.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
