### PR TITLE
Sort currencies alphabetically by name

### DIFF
--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -237,7 +237,7 @@ class Multi_Currency {
 	}
 
 	/**
-	 * Sets up the available currencies.
+	 * Sets up the available currencies, which are alphabetical by name.
 	 */
 	private function initialize_available_currencies() {
 		// Add default store currency with a rate of 1.0.
@@ -266,6 +266,7 @@ class Multi_Currency {
 		$default_code             = $this->get_default_currency()->get_code();
 		$enabled_currency_codes[] = $default_code;
 
+		// This allows to keep the alphabetical sorting by name.
 		$enabled_currencies = array_filter(
 			$available_currencies,
 			function( $currency ) use ( $enabled_currency_codes ) {

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -99,8 +99,8 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 			'BIF' => 1974,
 		];
 
-		foreach ( $mock_currencies as $k => $v ) {
-			$currency = new WCPay\Multi_Currency\Currency( $k, $v );
+		foreach ( $mock_currencies as $code => $rate ) {
+			$currency = new WCPay\Multi_Currency\Currency( $code, $rate );
 			$currency->set_charm( 0.00 );
 			$currency->set_rounding( 'none' );
 			$expected[ $currency->get_code() ] = $currency;

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -92,46 +92,28 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_get_enabled_currencies_returns_correctly() {
-		$expected = (object) [
-			'USD' => (object) [
-				'code'       => 'USD',
-				'rate'       => 1,
-				'name'       => 'United States (US) dollar',
-				'id'         => 'usd',
-				'is_default' => true,
-				'flag'       => '🇺🇸',
-				'symbol'     => '$',
-			],
-			'BIF' => (object) [
-				'code'       => 'BIF',
-				'rate'       => 1974,
-				'name'       => 'Burundian franc',
-				'id'         => 'bif',
-				'is_default' => false,
-				'flag'       => '🇧🇮',
-				'symbol'     => 'Fr',
-			],
-			'CAD' => (object) [
-				'code'       => 'CAD',
-				'rate'       => 1.206823,
-				'name'       => 'Canadian dollar',
-				'id'         => 'cad',
-				'is_default' => false,
-				'flag'       => '🇨🇦',
-				'symbol'     => '$',
-			],
-			'GBP' => (object) [
-				'code'       => 'GBP',
-				'rate'       => 0.708099,
-				'name'       => 'Pound sterling',
-				'id'         => 'gbp',
-				'is_default' => false,
-				'flag'       => '🇬🇧',
-				'symbol'     => '£',
-			],
+		$mock_currencies = [
+			'USD' => 1,
+			'CAD' => 1.206823,
+			'GBP' => 0.708099,
+			'BIF' => 1974,
 		];
 
-		$this->assertSame( $expected, $this->multi_currency->get_enabled_currencies() );
+		foreach ( $mock_currencies as $k => $v ) {
+			$currency = new WCPay\Multi_Currency\Currency( $k, $v );
+			$currency->set_charm( 0.00 );
+			$currency->set_rounding( 'none' );
+			$expected[ $currency->get_code() ] = $currency;
+		}
+		$expected['GBP']->set_charm( '-0.1' );
+		$expected['GBP']->set_rounding( '0' );
+
+		$this->assertEquals( $expected, $this->multi_currency->get_enabled_currencies() );
+	}
+
+	public function test_get_enabled_currencies_returns_sorted_currencies() {
+		$expected = [ 'USD', 'BIF', 'CAD', 'GBP' ];
+		$this->assertSame( $expected, array_keys( $this->multi_currency->get_enabled_currencies() ) );
 	}
 
 	public function test_set_enabled_currencies() {

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -92,48 +92,46 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_get_enabled_currencies_returns_correctly() {
-		$expected = wp_json_encode(
-			(object) [
-				'USD' => (object) [
-					'code'       => 'USD',
-					'rate'       => 1,
-					'name'       => 'United States (US) dollar',
-					'id'         => 'usd',
-					'is_default' => true,
-					'flag'       => '🇺🇸',
-					'symbol'     => '$',
-				],
-				'BIF' => (object) [
-					'code'       => 'BIF',
-					'rate'       => 1974,
-					'name'       => 'Burundian franc',
-					'id'         => 'bif',
-					'is_default' => false,
-					'flag'       => '🇧🇮',
-					'symbol'     => 'Fr',
-				],
-				'CAD' => (object) [
-					'code'       => 'CAD',
-					'rate'       => 1.206823,
-					'name'       => 'Canadian dollar',
-					'id'         => 'cad',
-					'is_default' => false,
-					'flag'       => '🇨🇦',
-					'symbol'     => '$',
-				],
-				'GBP' => (object) [
-					'code'       => 'GBP',
-					'rate'       => 0.708099,
-					'name'       => 'Pound sterling',
-					'id'         => 'gbp',
-					'is_default' => false,
-					'flag'       => '🇬🇧',
-					'symbol'     => '£',
-				],
-			]
-		);
+		$expected = (object) [
+			'USD' => (object) [
+				'code'       => 'USD',
+				'rate'       => 1,
+				'name'       => 'United States (US) dollar',
+				'id'         => 'usd',
+				'is_default' => true,
+				'flag'       => '🇺🇸',
+				'symbol'     => '$',
+			],
+			'BIF' => (object) [
+				'code'       => 'BIF',
+				'rate'       => 1974,
+				'name'       => 'Burundian franc',
+				'id'         => 'bif',
+				'is_default' => false,
+				'flag'       => '🇧🇮',
+				'symbol'     => 'Fr',
+			],
+			'CAD' => (object) [
+				'code'       => 'CAD',
+				'rate'       => 1.206823,
+				'name'       => 'Canadian dollar',
+				'id'         => 'cad',
+				'is_default' => false,
+				'flag'       => '🇨🇦',
+				'symbol'     => '$',
+			],
+			'GBP' => (object) [
+				'code'       => 'GBP',
+				'rate'       => 0.708099,
+				'name'       => 'Pound sterling',
+				'id'         => 'gbp',
+				'is_default' => false,
+				'flag'       => '🇬🇧',
+				'symbol'     => '£',
+			],
+		];
 
-		$this->assertSame( $expected, wp_json_encode( $this->multi_currency->get_enabled_currencies() ) );
+		$this->assertSame( $expected, $this->multi_currency->get_enabled_currencies() );
 	}
 
 	public function test_set_enabled_currencies() {


### PR DESCRIPTION
Fixes #2086 

#### Changes proposed in this Pull Request

* Updated available and enabled currency arrays to be sorted alphabetically by currency name.
* Updated tests to work better (thanks for all the help @luizreis )

#### Testing instructions

* Navigate to WooCommerce > Settings > Multi-Currency.
* Enabled currencies (if any) will be sorted alphabetically by name.
* Click on _Add Currencies_.
* Available currencies will be sorted alphabetically by name.
* Unit tests should pass.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
