### PR TITLE
Hide Payment Request Buttons when cart contains multiple packages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 2.8.0 - 2021-xx-xx =
 * Add - Use date picker for applicable dispute evidence fields.
+* Fix - Disabled Payment Request Buttons when order has to be split into multiple packages because Payment Requests do not support that use case.
 
 = 2.7.0 - 2021-07-14 =
 * Add - Add a link to the snackbar notice that appears after submitting or saving evidence for a dispute challenge.

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -537,6 +537,12 @@ class WC_Payments_Payment_Request_Button_Handler {
 			}
 		}
 
+		// We don't support multiple packages with Payment Request Buttons because we can't offer a good UX.
+		$packages = WC()->cart->get_shipping_packages();
+		if ( 1 < count( $packages ) ) {
+			return false;
+		}
+
 		return true;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 2.8.0 - 2021-xx-xx =
 * Add - Use date picker for applicable dispute evidence fields.
+* Fix - Disabled Payment Request Buttons when order has to be split into multiple packages because Payment Requests do not support that use case.
 
 = 2.7.0 - 2021-07-14 =
 * Add - Add a link to the snackbar notice that appears after submitting or saving evidence for a dispute challenge.

--- a/tests/unit/test-class-wc-payments-payment-request-button-handler.php
+++ b/tests/unit/test-class-wc-payments-payment-request-button-handler.php
@@ -284,4 +284,21 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WP_UnitTestCase {
 
 		delete_option( '_wcpay_feature_grouped_settings' );
 	}
+
+	public function test_multiple_packages_in_cart_not_allowed() {
+		// Add fake packages to the cart.
+		add_filter(
+			'woocommerce_cart_shipping_packages',
+			function() {
+				return [
+					'fake_package_1',
+					'fake_package_2',
+				];
+			}
+		);
+		$this->mock_wcpay_gateway = $this->make_wcpay_gateway();
+		$this->pr                 = new WC_Payments_Payment_Request_Button_Handler( $this->mock_wcpay_account, $this->mock_wcpay_gateway );
+
+		$this->assertFalse( $this->pr->has_allowed_items_in_cart() );
+	}
 }


### PR DESCRIPTION
Fixes #1563 

Exact copy of https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1591 in function and form. Please refer to testing instructions and further information there.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
