### PR TITLE
Enable group settings for everyone using _wcpay_feature_grouped_settings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,7 +10,9 @@
 * Update - Pass currency to wc_price when adding intent notes to orders.
 * Update - Instant deposit inbox note wording.
 * Fix - Deposit overview details for non instant ones.
-* Add - Introduce new settings layout for WooCommerce Payments
+* Add - Introduce new settings layout
+* Update - Removed "Branded" and "Custom label" options on Payment request buttons to align with design guidelines.
+* Update - Converted payment request button size value to distinct options to align with design guidelines.
 
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Update - Pass currency to wc_price when adding intent notes to orders.
 * Update - Instant deposit inbox note wording.
 * Fix - Deposit overview details for non instant ones.
+* Add - Introduce new settings layout for WooCommerce Payments
 
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -19,7 +19,7 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_grouped_settings_enabled() {
-		return '1' === get_option( '_wcpay_feature_grouped_settings', '0' );
+		return '1' === get_option( '_wcpay_feature_grouped_settings', '1' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/1990

#### Changes proposed in this Pull Request
Enable the new WooCommerce Payments settings page by defaulting our existing feature flag `_wcpay_feature_grouped_settings` to `1`.

Before
![image](https://user-images.githubusercontent.com/572862/121262185-f4917d80-c870-11eb-917f-9a319bff88fc.png)

After
![image](https://user-images.githubusercontent.com/572862/121262205-fb1ff500-c870-11eb-8afa-4266be07f42d.png)


#### Testing instructions
1. Remove this option from your database if you have one `_wcpay_feature_grouped_settings`. `DELETE FROM `wp_options` WHERE option_name = '_wcpay_feature_grouped_settings'`
2. Go to WooCommerce > Settings > Payments (`wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments`), you should see the new layout above.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
