### PR TITLE
Added admin note about multi-currency being available.

### DIFF
--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -115,6 +115,7 @@ class Multi_Currency {
 
 		if ( is_admin() ) {
 			add_filter( 'woocommerce_get_settings_pages', [ $this, 'init_settings_pages' ] );
+			add_action( 'admin_init', [ __CLASS__, 'add_woo_admin_notes' ] );
 		}
 	}
 
@@ -494,5 +495,25 @@ class Multi_Currency {
 		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-prices.php';
 		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-currencies.php';
 		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-user-settings.php';
+	}
+
+	/**
+	 * Adds Multi-Currency notes to the WC-Admin inbox.
+	 */
+	public static function add_woo_admin_notes() {
+		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+			require_once WCPAY_ABSPATH . 'includes/multi-currency/notes/class-note-multi-currency-available.php';
+			Note_Multi_Currency_Available::possibly_add_note();
+		}
+	}
+
+	/**
+	 * Removes Multi-Currency notes from the WC-Admin inbox.
+	 */
+	public static function remove_woo_admin_notes() {
+		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+			require_once WCPAY_ABSPATH . 'includes/multi-currency/notes/class-note-multi-currency-available.php';
+			Note_Multi_Currency_Available::possibly_delete_note();
+		}
 	}
 }

--- a/includes/multi-currency/notes/class-note-multi-currency-available.php
+++ b/includes/multi-currency/notes/class-note-multi-currency-available.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Notify merchant that Multi-Currency is available.
+ *
+ * @package WooCommerce\Payments\Multi_Currency
+ */
+
+namespace WCPay\Multi_Currency;
+
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Note_Multi_Currency_Available
+ */
+class Note_Multi_Currency_Available {
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-payments-notes-multi-currency-available';
+
+	/**
+	 * Url to start the setup process.
+	 */
+	// TODO: Proper url needed for setup process.
+	const NOTE_SETUP_URL = 'admin.php?page=wc-settings&tab=wcpay_multi_currency';
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		$note_class = \WC_Payment_Woo_Compat_Utils::get_note_class();
+		$note       = new $note_class();
+
+		$note->set_title( __( 'Sell worldwide in multiple currencies', 'woocommerce-payments' ) );
+		$note->set_content( __( 'Boost your international sales by allowing your customers to shop and pay in their local currency.', 'woocommerce-payments' ) );
+		$note->set_content_data( (object) [] );
+		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-payments' );
+		$note->add_action(
+			self::NOTE_NAME,
+			__( 'Set up now', 'woocommerce-payments' ),
+			self::NOTE_SETUP_URL,
+			'unactioned',
+			true
+		);
+
+		return $note;
+	}
+}

--- a/includes/multi-currency/wc-payments-multi-currency.php
+++ b/includes/multi-currency/wc-payments-multi-currency.php
@@ -22,3 +22,14 @@ function WC_Payments_Multi_Currency() { // phpcs:ignore WordPress.NamingConventi
 }
 
 add_action( 'plugins_loaded', 'WC_Payments_Multi_Currency', 12 );
+
+$basename = explode( '/', plugin_basename( __FILE__ ) )[0] . '/woocommerce-payments.php';
+register_deactivation_hook( $basename, 'wcpay_multi_currency_deactivated' );
+
+/**
+ * Plugin deactivation hook.
+ */
+function wcpay_multi_currency_deactivated() {
+	require_once WCPAY_ABSPATH . '/includes/multi-currency/class-multi-currency.php';
+	WCPay\Multi_Currency\Multi_Currency::remove_woo_admin_notes();
+}

--- a/includes/multi-currency/wc-payments-multi-currency.php
+++ b/includes/multi-currency/wc-payments-multi-currency.php
@@ -23,8 +23,7 @@ function WC_Payments_Multi_Currency() { // phpcs:ignore WordPress.NamingConventi
 
 add_action( 'plugins_loaded', 'WC_Payments_Multi_Currency', 12 );
 
-$basename = explode( '/', plugin_basename( __FILE__ ) )[0] . '/woocommerce-payments.php';
-register_deactivation_hook( $basename, 'wcpay_multi_currency_deactivated' );
+register_deactivation_hook( WCPAY_PLUGIN_FILE, 'wcpay_multi_currency_deactivated' );
 
 /**
  * Plugin deactivation hook.

--- a/tests/unit/multi-currency/notes/test-class-note-multi-currency-available-test.php
+++ b/tests/unit/multi-currency/notes/test-class-note-multi-currency-available-test.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Class Note_Multi_Currency_Available_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\Multi_Currency\Note_Multi_Currency_Available;
+
+/**
+ * Class Note_Multi_Currency_Available_Test tests.
+ */
+class Note_Multi_Currency_Available_Test extends WP_UnitTestCase {
+	public function test_removes_note_on_extension_deactivation() {
+		if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+			// Trigger WCPay extension deactivation callback.
+			wcpay_multi_currency_deactivated();
+
+			$note_id = Note_Multi_Currency_Available::NOTE_NAME;
+			$this->assertSame( [], ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( $note_id ) );
+		} else {
+			$this->markTestSkipped( 'The used WC components are not backward compatible' );
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1779

#### Changes proposed in this Pull Request

* Added admin note to let merchant know Multi-Currency is available.

#### Testing instructions

* Note should automatically be in inbox once switching to branch.
* If WCPay is deactivated, note should be removed.

#### Notes

~Not totally sure if `register_deactivation_hook` can get the proper file handed in better [here](https://github.com/Automattic/woocommerce-payments/pull/2103/files#diff-eea19c6675e055e8e4c197bef248dc3e2b8002b93edfc4303f95d544e9453395R26)~ Updated!

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
