### PR TITLE
Enable frontend prices and currencies for cart and checkout blocks

### DIFF
--- a/includes/multi-currency/class-frontend-currencies.php
+++ b/includes/multi-currency/class-frontend-currencies.php
@@ -37,9 +37,7 @@ class Frontend_Currencies {
 
 		$this->load_locale_data();
 
-		$frontend_request = ! is_admin() && ! defined( 'DOING_CRON' ) && ! WC()->is_rest_api_request();
-
-		if ( $frontend_request ) {
+		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
 			// Currency hooks.
 			add_filter( 'woocommerce_currency', [ $this, 'get_woocommerce_currency' ], 50 );
 			add_filter( 'wc_get_price_decimals', [ $this, 'get_price_decimals' ], 50 );

--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -28,9 +28,7 @@ class Frontend_Prices {
 	public function __construct( Multi_Currency $multi_currency ) {
 		$this->multi_currency = $multi_currency;
 
-		$frontend_request = ! is_admin() && ! defined( 'DOING_CRON' ) && ! WC()->is_rest_api_request();
-
-		if ( $frontend_request ) {
+		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
 			// Simple product price hooks.
 			add_filter( 'woocommerce_product_get_price', [ $this, 'get_product_price' ], 50 );
 			add_filter( 'woocommerce_product_get_regular_price', [ $this, 'get_product_price' ], 50 );


### PR DESCRIPTION
Fixes #1898

#### Changes proposed in this Pull Request

The cart and checkout blocks work using the WC REST API. So, to enable the customer-facing prices when using them, we need to load the Frontend classes also on API requests.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install the [WooCommerce Blocks](https://wordpress.org/plugins/woo-gutenberg-products-block/) plugin
* Add two new pages with the Cart and Checkout blocks
* Follow the [customer-facing prices test instructions](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-2.6.0#test-scenario-3) described in the Test Scenario 3
* Make sure any pages in the admin and products quick-edit still show the prices in the default store currency

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
