### PR TITLE
Added Title and Description fields to the settings page (draft)

### DIFF
--- a/client/data/settings/actions.js
+++ b/client/data/settings/actions.js
@@ -47,6 +47,14 @@ export function updateIsWCPayEnabled( isEnabled ) {
 	return updateSettingsValues( { is_wcpay_enabled: isEnabled } );
 }
 
+export function updateTitle( title ) {
+	return updateSettingsValues( { title } );
+}
+
+export function updateDescription( description ) {
+	return updateSettingsValues( { description } );
+}
+
 export function updateIsDigitalWalletsEnabled( isEnabled ) {
 	// eslint-disable-next-line camelcase
 	return updateSettingsValues( { is_digital_wallets_enabled: isEnabled } );

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -105,6 +105,32 @@ export const useIsWCPayEnabled = () => {
 	);
 };
 
+export const useTitle = () => {
+	const { updateTitle } = useDispatch( STORE_NAME );
+
+	return useSelect(
+		( select ) => {
+			const { getTitle } = select( STORE_NAME );
+
+			return [ getTitle(), updateTitle ];
+		},
+		[ updateTitle ]
+	);
+};
+
+export const useDescription = () => {
+	const { updateDescription } = useDispatch( STORE_NAME );
+
+	return useSelect(
+		( select ) => {
+			const { getDescription } = select( STORE_NAME );
+
+			return [ getDescription(), updateDescription ];
+		},
+		[ updateDescription ]
+	);
+};
+
 export const useGetAvailablePaymentMethodIds = () =>
 	useSelect( ( select ) => {
 		const { getAvailablePaymentMethodIds } = select( STORE_NAME );

--- a/client/data/settings/selectors.js
+++ b/client/data/settings/selectors.js
@@ -19,6 +19,14 @@ export const getIsWCPayEnabled = ( state ) => {
 	return getSettings( state ).is_wcpay_enabled || false;
 };
 
+export const getTitle = ( state ) => {
+	return getSettings( state ).title || '';
+};
+
+export const getDescription = ( state ) => {
+	return getSettings( state ).description || '';
+};
+
 export const getEnabledPaymentMethodIds = ( state ) => {
 	return getSettings( state ).enabled_payment_method_ids || EMPTY_ARR;
 };

--- a/client/data/settings/test/hooks.js
+++ b/client/data/settings/test/hooks.js
@@ -10,6 +10,8 @@ import {
 	useAccountStatementDescriptor,
 	useEnabledPaymentMethodIds,
 	useIsWCPayEnabled,
+	useTitle,
+	useDescription,
 	useManualCapture,
 	useSettings,
 	useTestMode,
@@ -104,6 +106,54 @@ describe( 'Settings hooks tests', () => {
 
 			expect( actions.updateIsWCPayEnabled ).toHaveBeenCalledWith(
 				false
+			);
+		} );
+	} );
+
+	describe( 'useTitle()', () => {
+		test( 'returns the title value and a function', () => {
+			actions = {
+				updateTitle: jest.fn(),
+			};
+
+			selectors = {
+				getTitle: jest.fn().mockReturnValue( 'Credit card' ),
+			};
+
+			const [ title, updateTitle ] = useTitle();
+
+			expect( title ).toEqual( 'Credit card' );
+			expect( updateTitle ).toHaveBeenCalledTimes( 0 );
+
+			updateTitle( 'Credit card - update' );
+
+			expect( actions.updateTitle ).toHaveBeenCalledWith(
+				'Credit card - update'
+			);
+		} );
+	} );
+
+	describe( 'useDescription()', () => {
+		test( 'returns the description value and a function', () => {
+			actions = {
+				updateDescription: jest.fn(),
+			};
+
+			selectors = {
+				getDescription: jest
+					.fn()
+					.mockReturnValue( 'Enter your card details' ),
+			};
+
+			const [ description, updateDescription ] = useDescription();
+
+			expect( description ).toEqual( 'Enter your card details' );
+			expect( updateDescription ).toHaveBeenCalledTimes( 0 );
+
+			updateDescription( 'Enter your card details - update' );
+
+			expect( actions.updateDescription ).toHaveBeenCalledWith(
+				'Enter your card details - update'
 			);
 		} );
 	} );

--- a/client/data/settings/test/reducer.js
+++ b/client/data/settings/test/reducer.js
@@ -5,6 +5,8 @@ import reducer from '../reducer';
 import {
 	updateSettings,
 	updateIsWCPayEnabled,
+	updateTitle,
+	updateDescription,
 	updateEnabledPaymentMethodIds,
 	updateIsSavingSettings,
 	updateIsManualCaptureEnabled,
@@ -173,6 +175,88 @@ describe( 'Settings reducer tests', () => {
 				foo: 'bar',
 				data: {
 					is_wcpay_enabled: true, // eslint-disable-line
+					baz: 'quux',
+				},
+			} );
+		} );
+	} );
+
+	describe( 'SET_TITLE', () => {
+		test( 'sets `data.title`', () => {
+			const oldState = {
+				data: {
+					title: 'Credit card',
+				},
+			};
+
+			const state = reducer(
+				oldState,
+				updateTitle( 'Credit card - update' )
+			);
+
+			expect( state.data.title ).toEqual( 'Credit card - update' );
+		} );
+
+		test( 'leaves other fields unchanged', () => {
+			const oldState = {
+				foo: 'bar',
+				data: {
+					title: 'Credit card',
+					baz: 'quux',
+				},
+			};
+
+			const state = reducer(
+				oldState,
+				updateTitle( 'Credit card - update' )
+			);
+
+			expect( state ).toEqual( {
+				foo: 'bar',
+				data: {
+					title: 'Credit card - update',
+					baz: 'quux',
+				},
+			} );
+		} );
+	} );
+
+	describe( 'SET_DESCRIPTION', () => {
+		test( 'sets `data.description`', () => {
+			const oldState = {
+				data: {
+					description: 'Enter your card details',
+				},
+			};
+
+			const state = reducer(
+				oldState,
+				updateDescription( 'Enter your card details - update' )
+			);
+
+			expect( state.data.description ).toEqual(
+				'Enter your card details - update'
+			);
+		} );
+
+		test( 'leaves other fields unchanged', () => {
+			const oldState = {
+				foo: 'bar',
+				data: {
+					description: 'Enter your card details',
+					baz: 'quux',
+				},
+			};
+
+			const state = reducer(
+				oldState,
+				updateDescription( 'Enter your card details - update' )
+			);
+
+			expect( state ).toEqual( {
+				foo: 'bar',
+				data: {
+					description: 'Enter your card details - update',
 					baz: 'quux',
 				},
 			} );

--- a/client/data/settings/test/selectors.js
+++ b/client/data/settings/test/selectors.js
@@ -4,6 +4,8 @@
 import {
 	getSettings,
 	getIsWCPayEnabled,
+	getTitle,
+	getDescription,
 	getEnabledPaymentMethodIds,
 	getIsManualCaptureEnabled,
 	getAccountStatementDescriptor,
@@ -56,6 +58,60 @@ describe( 'Settings selectors tests', () => {
 		] )( 'returns false if missing (tested state: %j)', ( state ) => {
 			expect( getIsWCPayEnabled( state ) ).toBeFalsy();
 		} );
+	} );
+
+	describe( 'getTitle()', () => {
+		test( 'returns the value of state.settings.data.title', () => {
+			const state = {
+				settings: {
+					data: {
+						title: 'Credit card',
+					},
+				},
+			};
+
+			expect( getTitle( state ) ).toEqual( 'Credit card' );
+		} );
+
+		test.each( [
+			[ undefined ],
+			[ {} ],
+			[ { settings: {} } ],
+			[ { settings: { data: {} } } ],
+		] )(
+			'returns an empty string if missing (tested state: %j)',
+			( state ) => {
+				expect( getTitle( state ) ).toEqual( '' );
+			}
+		);
+	} );
+
+	describe( 'getDescription()', () => {
+		test( 'returns the value of state.settings.data.description', () => {
+			const state = {
+				settings: {
+					data: {
+						description: 'Enter your card details',
+					},
+				},
+			};
+
+			expect( getDescription( state ) ).toEqual(
+				'Enter your card details'
+			);
+		} );
+
+		test.each( [
+			[ undefined ],
+			[ {} ],
+			[ { settings: {} } ],
+			[ { settings: { data: {} } } ],
+		] )(
+			'returns an empty string if missing (tested state: %j)',
+			( state ) => {
+				expect( getDescription( state ) ).toEqual( '' );
+			}
+		);
 	} );
 
 	describe( 'getEnabledPaymentMethodIds()', () => {

--- a/client/settings/general-settings/index.js
+++ b/client/settings/general-settings/index.js
@@ -3,18 +3,26 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Card, CheckboxControl } from '@wordpress/components';
+import { Card, CheckboxControl, TextControl } from '@wordpress/components';
 import interpolateComponents from 'interpolate-components';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import { useDevMode, useIsWCPayEnabled, useTestMode } from 'data';
+import {
+	useDevMode,
+	useIsWCPayEnabled,
+	useTitle,
+	useDescription,
+	useTestMode,
+} from 'data';
 import CardBody from '../card-body';
 
 const GeneralSettings = () => {
 	const [ isWCPayEnabled, setIsWCPayEnabled ] = useIsWCPayEnabled();
+	const [ title, updateTitle ] = useTitle();
+	const [ description, updateDescription ] = useDescription();
 	const [ isEnabled, updateIsTestModeEnabled ] = useTestMode();
 	const isDevModeEnabled = useDevMode();
 
@@ -32,6 +40,26 @@ const GeneralSettings = () => {
 						'When enabled, payment methods powered by WooCommerce Payments will appear on checkout.',
 						'woocommerce-payments'
 					) }
+				/>
+				<TextControl
+					className="general-settings__account-statement-input"
+					help={ __(
+						'This controls the title which the user sees during checkout.',
+						'woocommerce-payments'
+					) }
+					label={ __( 'Title', 'woocommerce-payments' ) }
+					onChange={ updateTitle }
+					value={ title }
+				/>
+				<TextControl
+					className="general-settings__account-statement-input"
+					help={ __(
+						'This controls the description which the user sees during checkout.',
+						'woocommerce-payments'
+					) }
+					label={ __( 'Description', 'woocommerce-payments' ) }
+					onChange={ updateDescription }
+					value={ description }
 				/>
 				<h4>{ __( 'Test mode', 'woocommerce-payments' ) }</h4>
 				<CheckboxControl

--- a/client/settings/general-settings/test/general-settings.test.js
+++ b/client/settings/general-settings/test/general-settings.test.js
@@ -38,6 +38,8 @@ describe( 'GeneralSettings', () => {
 		expect(
 			screen.queryByText( 'Enable WooCommerce Payments' )
 		).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Title' ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Description' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Enable test mode' ) ).toBeInTheDocument();
 	} );
 
@@ -81,4 +83,35 @@ describe( 'GeneralSettings', () => {
 			);
 		}
 	);
+
+	it( 'calls updateTitle() when the title field value changes', () => {
+		const updateTitle = jest.fn();
+		useTitle.mockReturnValue( [ 'Credit card', updateTitle ] );
+
+		render( <GeneralSettings /> );
+
+		fireEvent.change( screen.getByLabelText( 'Title' ), {
+			target: { value: 'Credit card - update' },
+		} );
+
+		expect( updateTitle ).toHaveBeenCalledWith( 'Credit card - update' );
+	} );
+
+	it( 'calls updateDescription() when the description field value changes', () => {
+		const updateDescription = jest.fn();
+		useDescription.mockReturnValue( [
+			'Enter your card details',
+			updateDescription,
+		] );
+
+		render( <GeneralSettings /> );
+
+		fireEvent.change( screen.getByLabelText( 'Description' ), {
+			target: { value: 'Enter your card details - update' },
+		} );
+
+		expect( updateDescription ).toHaveBeenCalledWith(
+			'Enter your card details - update'
+		);
+	} );
 } );

--- a/client/settings/general-settings/test/general-settings.test.js
+++ b/client/settings/general-settings/test/general-settings.test.js
@@ -7,12 +7,20 @@ import { fireEvent, render, screen } from '@testing-library/react';
  * Internal dependencies
  */
 import GeneralSettings from '..';
-import { useDevMode, useIsWCPayEnabled, useTestMode } from 'data';
+import {
+	useDevMode,
+	useIsWCPayEnabled,
+	useTestMode,
+	useTitle,
+	useDescription,
+} from 'data';
 
 jest.mock( 'data', () => ( {
 	useDevMode: jest.fn(),
 	useIsWCPayEnabled: jest.fn(),
 	useTestMode: jest.fn(),
+	useTitle: jest.fn(),
+	useDescription: jest.fn(),
 } ) );
 
 describe( 'GeneralSettings', () => {
@@ -20,6 +28,8 @@ describe( 'GeneralSettings', () => {
 		useDevMode.mockReturnValue( false );
 		useIsWCPayEnabled.mockReturnValue( [ false, jest.fn() ] );
 		useTestMode.mockReturnValue( [ false, jest.fn() ] );
+		useTitle.mockReturnValue( [ '', jest.fn() ] );
+		useDescription.mockReturnValue( [ '', jest.fn() ] );
 	} );
 
 	it( 'renders', () => {

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -68,6 +68,16 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
+					'title'                             => [
+						'description'       => __( 'The title which the user sees during checkout.', 'woocommerce-payments' ),
+						'type'              => 'string',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
+					'description'                       => [
+						'description'       => __( 'The description which the user sees during checkout.', 'woocommerce-payments' ),
+						'type'              => 'string',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
 					'enabled_payment_method_ids'        => [
 						'description'       => __( 'Payment method IDs that should be enabled. Other methods will be disabled.', 'woocommerce-payments' ),
 						'type'              => 'array',
@@ -150,6 +160,8 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 				'enabled_payment_method_ids'        => $this->wcpay_gateway->get_upe_enabled_payment_method_ids(),
 				'available_payment_method_ids'      => $this->wcpay_gateway->get_upe_available_payment_methods(),
 				'is_wcpay_enabled'                  => $this->wcpay_gateway->is_enabled(),
+				'title'                             => $this->wcpay_gateway->get_option( 'title' ),
+				'description'                       => $this->wcpay_gateway->get_option( 'description' ),
 				'is_manual_capture_enabled'         => 'yes' === $this->wcpay_gateway->get_option( 'manual_capture' ),
 				'is_test_mode_enabled'              => 'yes' === $this->wcpay_gateway->is_in_test_mode(),
 				'is_dev_mode_enabled'               => $this->wcpay_gateway->is_in_dev_mode(),
@@ -172,6 +184,8 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	public function update_settings( WP_REST_Request $request ) {
 		$this->update_is_wcpay_enabled( $request );
 		$this->update_enabled_payment_methods( $request );
+		$this->update_title( $request );
+		$this->update_description( $request );
 		$this->update_is_manual_capture_enabled( $request );
 		$this->update_is_test_mode_enabled( $request );
 		$this->update_is_debug_log_enabled( $request );
@@ -200,6 +214,36 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		} else {
 			$this->wcpay_gateway->disable();
 		}
+	}
+
+	/**
+	 * Updates WooCommerce Payments title setting.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 */
+	private function update_title( WP_REST_Request $request ) {
+		if ( ! $request->has_param( 'title' ) ) {
+			return;
+		}
+
+		$title = $request->get_param( 'title' );
+
+		$this->wcpay_gateway->update_option( 'title', $title );
+	}
+
+	/**
+	 * Updates WooCommerce Payments description setting.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 */
+	private function update_description( WP_REST_Request $request ) {
+		if ( ! $request->has_param( 'description' ) ) {
+			return;
+		}
+
+		$description = $request->get_param( 'description' );
+
+		$this->wcpay_gateway->update_option( 'description', $description );
 	}
 
 	/**

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -201,6 +201,24 @@ class WC_REST_Payments_Settings_Controller_Test extends WP_UnitTestCase {
 		remove_filter( 'user_has_cap', $cb );
 	}
 
+	public function test_update_settings_title() {
+		$request = new WP_REST_Request();
+		$request->set_param( 'title', 'Credit card (WooCommerce Payments)' );
+
+		$this->controller->update_settings( $request );
+
+		$this->assertSame( 'Credit card (WooCommerce Payments)', $this->gateway->get_option( 'title' ) );
+	}
+
+	public function test_update_settings_description() {
+		$request = new WP_REST_Request();
+		$request->set_param( 'description', 'Pay with your credit card, please.' );
+
+		$this->controller->update_settings( $request );
+
+		$this->assertSame( 'Pay with your credit card, please.', $this->gateway->get_option( 'description' ) );
+	}
+
 	public function test_update_settings_enables_manual_capture() {
 		$request = new WP_REST_Request();
 		$request->set_param( 'is_manual_capture_enabled', true );


### PR DESCRIPTION
Fixes #532 

#### Changes proposed in this Pull Request

Adds Title and Description fields to the settings page.

## Old settings page

| Before | After |
|-|-|
|<img width="986" alt="old-settings-page-before" src="https://user-images.githubusercontent.com/1527164/121299726-338b0600-c939-11eb-991a-d171264ba7bb.png">|<img width="983" alt="old-settings-page-after" src="https://user-images.githubusercontent.com/1527164/121299759-3ede3180-c939-11eb-83f1-f811437e03c3.png">|

The question mark tooltip content:
- **Title:** `This controls the title which the user sees during checkout.`
- **Description:** `This controls the description which the user sees during checkout.`

These were borrowed from the Stripe plugin.

## New settings page
| Before | After |
|-|-|
|<img width="1059" alt="new-settings-page-before" src="https://user-images.githubusercontent.com/1527164/121299871-5ddcc380-c939-11eb-9305-3c1cd95366de.png">|<img width="1057" alt="new-settings-page-after" src="https://user-images.githubusercontent.com/1527164/121299892-6634fe80-c939-11eb-89c0-c92efd26a33c.png">|

I have [requested feedback](https://github.com/Automattic/woocommerce-payments/issues/532#issuecomment-857396816) on the design of this implementation from @LevinMedia.

---

For reference, this is what the Stripe payment gateway settings page looks like:

<img width="676" alt="old-settings-page-stripe" src="https://user-images.githubusercontent.com/1527164/121299977-85cc2700-c939-11eb-9151-92b97214a521.png">

### Testing instructions

#### Old settings page

Ensure the `_wcpay_feature_grouped_settings` option in the `wp_options` table is set to `0`.

1. Navigate to `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments`.
2. Observe the new "Title" and "Description" fields.
3. The Title field should have a default value of `Credit card`.
4. The Description field should have a default value of `Enter your card details`.
5. Visit the store on the front end and navigate to the checkout.
6. The title and description should be present in the payment method box (see image below).

<img width="347" alt="Screen Shot 2021-06-10 at 10 46 31 am" src="https://user-images.githubusercontent.com/1527164/121447567-3806fb80-c9d9-11eb-934d-e758b9f23e83.png">

You should be able to change the value of these fields and save and have it reflected on the checkout page. It's also valid to leave these fields empty.

#### New settings page

Ensure the `_wcpay_feature_grouped_settings` option in the `wp_options` table is set to `1`.

Follow the steps above.

-------------------

- [ ] Added changelog entry
- [x] Covered with tests
- [ ] Tested on mobile