### PR TITLE
Add zero amount fee item to payment params without items

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1181,8 +1181,22 @@ class WC_Payments_API_Client {
 	 */
 	private function request_with_level3_data( $params, $api, $method, $is_site_specific = true ) {
 		// If level3 data is not present for some reason, simply proceed normally.
-		if ( ! isset( $params['level3'] ) ) {
+		if ( ! isset( $params['level3'] ) || ! is_array( $params['level3'] ) ) {
 			return $this->request( $params, $api, $method, $is_site_specific );
+		}
+
+		// If level3 data doesn't contain any items, add a zero priced fee to meet Stripe's requirement
+		if ( !isset( $params['level3']['line_items'] ) || !is_array( $params['level3']['line_items'] ) || 0 === count( $params['level3']['line_items'] ) ) {
+			$params['level3']['line_items'] = [
+				[
+					'discount_amount' 		=> 0,
+					'product_code' 			=> '0-00-fee',
+					'product_description' 	=> '$0.00 fee',
+					'quantity' 				=> 1,
+					'tax_amount' 			=> 0,
+					'unit_cost' 			=> 0,
+				],
+			];
 		}
 
 		try {

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1185,16 +1185,16 @@ class WC_Payments_API_Client {
 			return $this->request( $params, $api, $method, $is_site_specific );
 		}
 
-		// If level3 data doesn't contain any items, add a zero priced fee to meet Stripe's requirement
-		if ( !isset( $params['level3']['line_items'] ) || !is_array( $params['level3']['line_items'] ) || 0 === count( $params['level3']['line_items'] ) ) {
+		// If level3 data doesn't contain any items, add a zero priced fee to meet Stripe's requirement.
+		if ( ! isset( $params['level3']['line_items'] ) || ! is_array( $params['level3']['line_items'] ) || 0 === count( $params['level3']['line_items'] ) ) {
 			$params['level3']['line_items'] = [
 				[
-					'discount_amount' 		=> 0,
-					'product_code' 			=> '0-00-fee',
-					'product_description' 	=> '$0.00 fee',
-					'quantity' 				=> 1,
-					'tax_amount' 			=> 0,
-					'unit_cost' 			=> 0,
+					'discount_amount'     => 0,
+					'product_code'        => '0-00-fee',
+					'product_description' => '$0.00 fee',
+					'quantity'            => 1,
+					'tax_amount'          => 0,
+					'unit_cost'           => 0,
 				],
 			];
 		}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1190,8 +1190,8 @@ class WC_Payments_API_Client {
 			$params['level3']['line_items'] = [
 				[
 					'discount_amount'     => 0,
-					'product_code'        => '0-00-fee',
-					'product_description' => '$0.00 fee',
+					'product_code'        => 'zero-cost-fee',
+					'product_description' => 'Zero cost fee',
 					'quantity'            => 1,
 					'tax_amount'          => 0,
 					'unit_cost'           => 0,


### PR DESCRIPTION
Fixes #1463

#### Changes proposed in this Pull Request

Add zero amount fee item to payment params without items

This PR contains the checks for the empty items list and adds a zero priced item before sending the parameters to Stripe. Stripe returns a `missing parameter` error when the level3 items array is empty, so this will allow WooCommerce to take only the shipping payment even if there are no items present in the order.

#### Testing instructions

- Create a new order in the admin.
- Use Add item(s) and then Add shipping.
- Make sure the order status is Pending payment and then create the order.
- Use the Customer payment page link to go to the checkout page for the order.
- Attempt to checkout.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)