### PR TITLE
Fix duplicate currency codes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Use of deprecated call-style to registerPaymentMethods. WooCommerce Payments now requires WooCommerce Blocks of at least version 3.9.0.
 * Fix - Deposit date on Transactions list page.
 * Add - Error message when total size of dispute evidence files uploaded goes over limit.
+* Fix - Remove duplicate text from the list inside enable currency modal when the symbol and code is the same.
 
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,6 @@
 * Fix - Use of deprecated call-style to registerPaymentMethods. WooCommerce Payments now requires WooCommerce Blocks of at least version 3.9.0.
 * Fix - Deposit date on Transactions list page.
 * Add - Error message when total size of dispute evidence files uploaded goes over limit.
-* Fix - Remove duplicate text from the list inside enable currency modal when the symbol and code is the same.
 
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.

--- a/client/multi-currency/enabled-currencies-list/modal-checkbox.js
+++ b/client/multi-currency/enabled-currencies-list/modal-checkbox.js
@@ -36,7 +36,8 @@ const EnabledCurrenciesModalCheckbox = ( {
 						name: <span>{ name }</span>,
 						code: (
 							<span className="enabled-currency-checkbox__code">
-								({ symbol } { code })
+								({ symbol }
+								{ symbol === code ? null : ' ' + code })
 							</span>
 						),
 					},

--- a/client/multi-currency/enabled-currencies-list/modal-checkbox.js
+++ b/client/multi-currency/enabled-currencies-list/modal-checkbox.js
@@ -37,7 +37,7 @@ const EnabledCurrenciesModalCheckbox = ( {
 						code: (
 							<span className="enabled-currency-checkbox__code">
 								({ symbol }
-								{ symbol === code ? null : ' ' + code })
+								{ symbol !== code && ' ' + code })
 							</span>
 						),
 					},


### PR DESCRIPTION
Fixes #2094

#### Changes proposed in this Pull Request

When the currency code is the same as its symbol, it shows the line as if the symbol was duplicated. This PR checks if the code and the symbol is same, and therefore skips the code from displaying.

After the fix:

<img src="https://user-images.githubusercontent.com/3295/121573755-43d0dd00-ca2e-11eb-89ab-ada117057f5a.png" width="300px">

#### Testing instructions

- Navigate to the multi-currency settings page ( WooCommerce > Settings > Multi-Currency)
- Click **Add currencies** button below the *Enabled Currencies* box
- See if the duplicates remain

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
