### PR TITLE
Fix successive shipping cost conversions

### DIFF
--- a/includes/multi-currency/class-frontend-prices.php
+++ b/includes/multi-currency/class-frontend-prices.php
@@ -182,9 +182,9 @@ class Frontend_Prices {
 	 * @return string The converted cost.
 	 */
 	private function convert_shipping_method_cost( $cost ) {
-		// Store the percentage value before converting all numbers in the cost string.
-		if ( preg_match( '/percent=[\"\'][\d.,]+[\"\']/', $cost, $matches ) ) {
-			$percentage = $matches[0];
+		// Store the percentage values before converting all numbers in the cost string.
+		if ( preg_match_all( '/percent=[\"\'][\d.,]+[\"\']/', $cost, $matches ) ) {
+			$percentages = $matches[0];
 		}
 
 		// Convert all numbers in cost to use the exchange rate.
@@ -197,12 +197,12 @@ class Frontend_Prices {
 			$cost
 		);
 
-		// Reset the percentage value after it's been converted.
-		if ( isset( $percentage ) ) {
+		// Restore the percentages values after they've been converted.
+		if ( isset( $percentages ) ) {
 			$cost = preg_replace_callback(
 				'/percent=[\"\'][\d.,]+[\"\']/',
-				function ( $matches ) use ( $percentage ) {
-					return $percentage;
+				function ( $matches ) use ( &$percentages ) {
+					return array_shift( $percentages );
 				},
 				$cost
 			);

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -417,12 +417,12 @@ class Multi_Currency {
 	 * Gets the converted price using the current currency with the rounding and charm pricing settings.
 	 *
 	 * @param mixed $price The price to be converted.
-	 * @param bool  $type  The type of price being converted. One of 'product', 'shipping', 'tax', or 'coupon'.
+	 * @param bool  $type  The type of price being converted. One of 'product', 'shipping', or 'coupon'.
 	 *
 	 * @return float The converted price.
 	 */
 	public function get_price( $price, $type ): float {
-		$supported_types = [ 'product', 'shipping', 'tax', 'coupon' ];
+		$supported_types = [ 'product', 'shipping', 'coupon' ];
 		$currency        = $this->get_selected_currency();
 
 		if ( ! in_array( $type, $supported_types, true ) || $currency->get_is_default() ) {
@@ -431,7 +431,7 @@ class Multi_Currency {
 
 		$converted_price = ( (float) $price ) * $currency->get_rate();
 
-		if ( 'tax' === $type || 'coupon' === $type ) {
+		if ( 'coupon' === $type ) {
 			return $converted_price;
 		}
 

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -230,6 +230,7 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WP_UnitTestCase {
 			[ '20 + [fee percent="10" min_fee="4" max_fee"10"]', 2, '40 + [fee percent="10" min_fee="8" max_fee"20"]' ],
 			[ '[fee percent="10" min_fee="4" max_fee"10"] + 20', 2, '[fee percent="10" min_fee="8" max_fee"20"] + 40' ],
 			[ '20 + 2 * [qty] + [fee percent="10" min_fee="4" max_fee"10"]', 2, '40 + 4 * [qty] + [fee percent="10" min_fee="8" max_fee"20"]' ],
+			[ '20 + [fee percent="10" min_fee="4" max_fee"10"] + [fee percent="20" min_fee="6" max_fee"12"]', 2, '40 + [fee percent="10" min_fee="8" max_fee"20"] + [fee percent="20" min_fee="12" max_fee"24"]' ],
 		];
 	}
 }

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -269,14 +269,6 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->assertSame( 7.08099, $this->multi_currency->get_price( '10.0', 'coupon' ) );
 	}
 
-	public function test_get_price_returns_converted_tax_price() {
-		WC()->session->set( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY, 'GBP' );
-		add_filter( 'wcpay_multi_currency_apply_charm_only_to_products', '__return_false' );
-
-		// 0.708099 * 10 = 7,08099
-		$this->assertSame( 7.08099, $this->multi_currency->get_price( '10.0', 'tax' ) );
-	}
-
 	/**
 	 * @dataProvider get_price_provider
 	 */


### PR DESCRIPTION
Fixes #2118 

#### Changes proposed in this Pull Request

The woocommerce_package_rates approach has some incompatibilities with Subscriptions since it can be run more than once, resulting in successive conversions of the shipping cost.

This PR modifies the existing free_shipping filters to be applied to all shipping methods and also handles the cost conversion. As a result, we don't need to worry about Subscriptions running the woocommerce_package_rates hook, and also don't have to manually fix the taxes for the shipping packages as the correct value is used in the calculation. Since the tax conversion is not needed anymore, this PR also removes the unused 'tax' type.


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the unit tests changes look good and pass
* Add a free and a flat rate shipping method to the default shipping zone
* Add a free and a flat rate shipping method to a user-defined shipping zone
* Apply some [advanced costs](https://docs.woocommerce.com/document/flat-rate-shipping/#advanced-costs) to the flat rate methods
* Assert that the shipping methods work correctly on the checkout page with simple products
* Set a Minimum order amount for free shipping and assert that the minimum order amount is checked against the selected currency
* Enable taxes and check that the taxes are calculated using the converted price
* Test Subscriptions compatibility with: 
    * Single subscription product in the cart
    * Two subscription products with different renew periods

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
