### PR TITLE
Update subscriptions to not inherit from gateway POC

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -204,10 +204,7 @@ class WC_Payments {
 		$sofort_class  = Sofort_Payment_Gateway::class;
 
 		// TODO: Remove admin payment method JS hack for Subscriptions <= 3.0.7 when we drop support for those versions.
-		if ( class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '2.2.0', '>=' ) ) {
-			include_once __DIR__ . '/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php';
-			$gateway_class = 'WC_Payment_Gateway_WCPay_Subscriptions_Compat';
-		} elseif ( WC_Payments_Features::is_upe_enabled() ) {
+		if ( WC_Payments_Features::is_upe_enabled() ) {
 			$gateway_class = UPE_Payment_Gateway::class;
 		}
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
@@ -99,9 +99,7 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WP_UnitTestCase {
 			->method( 'add_payment_method_to_user' )
 			->willReturn( $this->token );
 
-		// Arrange: Mock WC_Payment_Gateway_WCPay so that some of its methods can be
-		// mocked, and their return values can be used for testing.
-		$this->mock_wcpay_gateway = $this->getMockBuilder( 'WC_Payment_Gateway_WCPay_Subscriptions_Compat' )
+		$this->mock_wcpay_gateway = $this->getMockBuilder( 'WC_Payment_Gateway_WCPay' )
 			->setConstructorArgs(
 				[
 					$this->mock_api_client,
@@ -119,6 +117,10 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WP_UnitTestCase {
 				]
 			)
 			->getMock();
+
+		$this->wcpay_gateway_subscriptions = new \WC_Payment_Gateway_WCPay_Subscriptions_Compat(
+			$this->mock_wcpay_gateway
+		);
 
 		// Arrange: Define a $_POST array which includes the payment method,
 		// so that get_payment_method_from_request() does not throw error.
@@ -233,6 +235,6 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WP_UnitTestCase {
 			)
 			->will( $this->returnValue( $intent ) );
 
-		$this->mock_wcpay_gateway->scheduled_subscription_payment( 100, $order );
+		$this->wcpay_gateway_subscriptions->scheduled_subscription_payment( 100, $order );
 	}
 }

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-payment-method-order-note.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-payment-method-order-note.php
@@ -83,12 +83,16 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Payment_Method_Order_Note_Test exte
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->wcpay_gateway = new \WC_Payment_Gateway_WCPay_Subscriptions_Compat(
+		$this->wcpay_gateway = new \WC_Payment_Gateway_WCPay(
 			$this->mock_api_client,
 			$this->wcpay_account,
 			$this->mock_customer_service,
 			$this->mock_token_service,
 			$this->mock_action_scheduler_service
+		);
+
+		$this->wcpay_subscriptions = new \WC_Payment_Gateway_WCPay_Subscriptions_Compat(
+			$this->wcpay_gateway
 		);
 
 		$this->renewal_order = WC_Helper_Order::create_order( self::USER_ID );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -119,7 +119,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->mock_wcpay_gateway = $this->getMockBuilder( '\WC_Payment_Gateway_WCPay_Subscriptions_Compat' )
+		$this->mock_wcpay_gateway = $this->getMockBuilder( '\WC_Payment_Gateway_WCPay' )
 			->setConstructorArgs(
 				[
 					$this->mock_api_client,
@@ -138,6 +138,10 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 				]
 			)
 			->getMock();
+
+		$this->wcpay_subscriptions = new \WC_Payment_Gateway_WCPay_Subscriptions_Compat(
+			$this->mock_wcpay_gateway
+		);
 
 		$this->mock_customer_service
 			->expects( $this->once() )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -83,12 +83,16 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->wcpay_gateway = new \WC_Payment_Gateway_WCPay_Subscriptions_Compat(
+		$this->cc_gateway = new \WC_Payment_Gateway_WCPay(
 			$this->mock_api_client,
 			$this->wcpay_account,
 			$this->mock_customer_service,
 			$this->mock_token_service,
 			$this->mock_action_scheduler_service
+		);
+
+		$this->wcpay_gateway = new \WC_Payment_Gateway_WCPay_Subscriptions_Compat(
+			$this->cc_gateway
 		);
 	}
 
@@ -302,7 +306,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 
 	public function test_subscription_payment_method_filter_adds_card_details() {
 		$subscription = WC_Helper_Order::create_order( self::USER_ID );
-		$subscription->set_payment_method( $this->wcpay_gateway->id );
+		$subscription->set_payment_method( $this->wcpay_gateway->gateway->id );
 		$subscription->add_payment_token( WC_Helper_Token::create_token( 'new_payment_method_1', self::USER_ID ) );
 
 		$last_token = WC_Helper_Token::create_token( 'new_payment_method_2', self::USER_ID );
@@ -352,7 +356,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 					],
 				],
 			],
-			$payment_meta[ $this->wcpay_gateway->id ]
+			$payment_meta[ $this->wcpay_gateway->gateway->id ]
 		);
 	}
 
@@ -370,7 +374,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 					],
 				],
 			],
-			$payment_meta[ $this->wcpay_gateway->id ]
+			$payment_meta[ $this->wcpay_gateway->gateway->id ]
 		);
 	}
 
@@ -382,7 +386,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 		// but we need to assert something to avoid PHPUnit's risky test warning.
 		$this->assertNull(
 			$this->wcpay_gateway->validate_subscription_payment_meta(
-				$this->wcpay_gateway->id,
+				$this->wcpay_gateway->gateway->id,
 				[ 'wc_order_tokens' => [ 'token' => [ 'value' => strval( $token->get_id() ) ] ] ],
 				$subscription
 			)
@@ -408,7 +412,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 		$subscription = WC_Helper_Order::create_order( self::USER_ID );
 
 		$this->wcpay_gateway->validate_subscription_payment_meta(
-			$this->wcpay_gateway->id,
+			$this->wcpay_gateway->gateway->id,
 			[ 'wc_order_tokens' => [ 'token' => [ 'value' => '' ] ] ],
 			$subscription
 		);
@@ -421,7 +425,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 		$subscription = WC_Helper_Order::create_order( self::USER_ID );
 
 		$this->wcpay_gateway->validate_subscription_payment_meta(
-			$this->wcpay_gateway->id,
+			$this->wcpay_gateway->gateway->id,
 			[ 'wc_order_tokens' => [ 'token' => [ 'value' => '158651' ] ] ],
 			$subscription
 		);
@@ -435,7 +439,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 		$token        = WC_Helper_Token::create_token( self::PAYMENT_METHOD_ID, self::USER_ID + 1 );
 
 		$this->wcpay_gateway->validate_subscription_payment_meta(
-			$this->wcpay_gateway->id,
+			$this->wcpay_gateway->gateway->id,
 			[ 'wc_order_tokens' => [ 'token' => [ 'value' => strval( $token->get_id() ) ] ] ],
 			$subscription
 		);
@@ -535,11 +539,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 
 		WC_Subscriptions::$version = '3.0.7';
 		new \WC_Payment_Gateway_WCPay_Subscriptions_Compat(
-			$this->mock_api_client,
-			$this->wcpay_account,
-			$this->mock_customer_service,
-			$this->mock_token_service,
-			$this->mock_action_scheduler_service
+			$this->cc_gateway
 		);
 
 		$this->assertTrue( has_action( 'woocommerce_admin_order_data_after_billing_address' ) );
@@ -550,11 +550,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 
 		WC_Subscriptions::$version = '3.0.8';
 		new \WC_Payment_Gateway_WCPay_Subscriptions_Compat(
-			$this->mock_api_client,
-			$this->wcpay_account,
-			$this->mock_customer_service,
-			$this->mock_token_service,
-			$this->mock_action_scheduler_service
+			$this->cc_gateway
 		);
 
 		$this->assertFalse( has_action( 'woocommerce_admin_order_data_after_billing_address' ) );


### PR DESCRIPTION
**Do not merge, just a proof of concept**

The goal of this proof of concept was to remove the need for the subscriptions class to inherit from the existing gateway. This opens up the ability to have other payment methods (UPE in this case) inherit from the existing gateway while still having subscription compatibility.

In this proof of concept I took the general idea of a decorator pattern to just add the subscription compatibilities to a gateway that is passed in. Broadly speaking, the subscriptions compatibility class just adds support items and hooks. Within the hook callbacks some are self contained and some update some data and call the parent method. This made the transition a bit clearer. The changes could be summarized as:

- Pass in the reference gateway when initializing the subscriptions class and keep a reference to it.
- Instead of calling parent methods, call the referenced gateway methods.

In my testing I was able to complete all of the following actions with this new structure:

- Checkout with a subscription
- Change payment method for a subscription
- Renew manually

In addition to the manual tests, I also took some time to get the automated unit tests running a little better. I was able to get the results down to 8 failed tests and the issues seemed to be more related to the structure of the tests (as expected with this change).

Additionally, given the end goal of this change, I tested subscriptions with UPE and had moderate success there. The issues I encountered made sense to me why they were happening and should have a clear solution for them.

Rather than spend any more time working out these finer details, I wanted to get this approach in front of more eyes before spending more time on it in case there is a larger issue that I may have missed and to just gather thoughts/concerns as early as possible.