### PR TITLE
Recalculate cart on account currency update

### DIFF
--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -388,8 +388,10 @@ class Multi_Currency {
 		}
 
 		// Recalculate cart when currency changes.
-		if ( WC()->cart ) {
-			WC()->cart->calculate_totals();
+		if ( did_action( 'wp_loaded' ) ) {
+			$this->recalculate_cart();
+		} else {
+			add_action( 'wp_loaded', [ $this, 'recalculate_cart' ] );
 		}
 	}
 
@@ -404,6 +406,13 @@ class Multi_Currency {
 		}
 
 		$this->update_selected_currency( sanitize_text_field( wp_unslash( $_GET['currency'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
+	}
+
+	/**
+	 * Recalculates WooCommerce cart totals.
+	 */
+	public function recalculate_cart() {
+		WC()->cart->calculate_totals();
 	}
 
 	/**

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -375,6 +375,11 @@ class Multi_Currency {
 		} elseif ( $user_id ) {
 			update_user_meta( $user_id, self::CURRENCY_META_KEY, $currency->get_code() );
 		}
+
+		// Recalculate cart when currency changes.
+		if ( WC()->cart ) {
+			WC()->cart->calculate_totals();
+		}
 	}
 
 	/**
@@ -399,9 +404,6 @@ class Multi_Currency {
 		}
 
 		$this->update_selected_currency( sanitize_text_field( wp_unslash( $_GET['currency'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
-
-		// Recalculate cart when currency changes.
-		add_action( 'wp_loaded', [ $this, 'recalculate_cart' ] );
 	}
 
 	/**
@@ -441,13 +443,6 @@ class Multi_Currency {
 			: in_array( $type, $charm_compatible_types, true );
 
 		return $this->get_adjusted_price( $converted_price, $apply_charm_pricing, $currency );
-	}
-
-	/**
-	 * Recalculates WooCommerce cart totals.
-	 */
-	public function recalculate_cart() {
-		WC()->cart->calculate_totals();
 	}
 
 	/**

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -334,6 +334,17 @@ class Multi_Currency {
 	}
 
 	/**
+	 * Sets the enabled currencies for the store.
+	 *
+	 * @param array $currencies Array of currency codes to be enabled.
+	 */
+	public function set_enabled_currencies( $currencies = [] ) {
+		if ( 0 < count( $currencies ) ) {
+			update_option( $this->id . '_enabled_currencies', $currencies );
+		}
+	}
+
+	/**
 	 * Gets the user selected currency, or `$default_currency` if is not set.
 	 *
 	 * @return Currency
@@ -379,17 +390,6 @@ class Multi_Currency {
 		// Recalculate cart when currency changes.
 		if ( WC()->cart ) {
 			WC()->cart->calculate_totals();
-		}
-	}
-
-	/**
-	 * Sets the enabled currencies for the store.
-	 *
-	 * @param array $currencies Array of currency codes to be enabled.
-	 */
-	public function set_enabled_currencies( $currencies = [] ) {
-		if ( 0 < count( $currencies ) ) {
-			update_option( $this->id . '_enabled_currencies', $currencies );
 		}
 	}
 

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -190,6 +190,18 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->assertSame( 'GBP', get_user_meta( self::LOGGED_IN_USER_ID, WCPay\Multi_Currency\Multi_Currency::CURRENCY_META_KEY, true ) );
 	}
 
+	public function test_update_selected_currency_recalculates_cart() {
+		wp_set_current_user( self::LOGGED_IN_USER_ID );
+
+		$this->assertContains( '&#36;', WC()->cart->get_total() );
+
+		$this->multi_currency->update_selected_currency( 'GBP' );
+
+		$this->assertContains( '&pound;', WC()->cart->get_total() );
+		$this->assertNotContains( '&#36;', WC()->cart->get_total() );
+
+	}
+
 	public function test_update_selected_currency_by_url_does_not_set_session_when_parameter_not_set() {
 		$this->multi_currency->update_selected_currency_by_url();
 
@@ -210,19 +222,6 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->multi_currency->update_selected_currency_by_url();
 
 		$this->assertSame( 'GBP', WC()->session->get( WCPay\Multi_Currency\Multi_Currency::CURRENCY_SESSION_KEY ) );
-	}
-
-	public function test_update_selected_currency_by_url_recalculates_cart() {
-		wp_set_current_user( self::LOGGED_IN_USER_ID );
-		$_GET['currency'] = 'GBP';
-
-		$this->assertContains( '&#36;', WC()->cart->get_total() );
-
-		$this->multi_currency->update_selected_currency_by_url();
-
-		$this->assertContains( '&pound;', WC()->cart->get_total() );
-		$this->assertNotContains( '&#36;', WC()->cart->get_total() );
-
 	}
 
 	public function test_get_price_returns_price_in_default_currency() {


### PR DESCRIPTION
Fixes #2134 

#### Changes proposed in this Pull Request
We were recalculating the cart only on currency update by URL, this is called by the legacy widget. But for **My account** selector to work properly, we need to move the cart calculate call to `update_selected_currency`.

Using `wp_loaded` prevent it to run when this method is called from **My account** select. ~~So I replaced it with a check for `WC()->cart`. We need to use `wp_loaded` here @luizreis? I can't see any error using `calculate_totals` directly.~~
Thanks to @luizreis comment. **My account** update happens after `wp_loaded` loaded, so just need to check it with `did_action` and call `recalculate_cart` directly to fix it.

#### Testing instructions
- Add a product to the cart.
- Got to **My account > Account details** and select a new **Default currency**.
- After clicking **Save changes** cart amount and currency should be right.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)