### PR TITLE
Decode html entities on currencies name

### DIFF
--- a/includes/multi-currency/class-currency.php
+++ b/includes/multi-currency/class-currency.php
@@ -193,7 +193,7 @@ class Currency implements \JsonSerializable {
 		return [
 			'code'       => $this->code,
 			'rate'       => $this->get_rate(),
-			'name'       => $this->get_name(),
+			'name'       => html_entity_decode( $this->get_name() ),
 			'id'         => $this->get_id(),
 			'is_default' => $this->get_is_default(),
 			'flag'       => $this->get_flag(),

--- a/tests/unit/multi-currency/test-class-currency.php
+++ b/tests/unit/multi-currency/test-class-currency.php
@@ -33,4 +33,13 @@ class WCPay_Multi_Currency_Currency_Tests extends WP_UnitTestCase {
 			$json
 		);
 	}
+
+	public function test_should_decode_entities_when_serialized() {
+		$json = wp_json_encode( new WCPay\Multi_Currency\Currency( 'WST' ) );
+
+		$this->assertSame(
+			'{"code":"WST","rate":1,"name":"Samoan t\u0101l\u0101","id":"wst","is_default":false,"flag":"\ud83c\uddfc\ud83c\uddf8","symbol":"T"}',
+			$json
+		);
+	}
 }


### PR DESCRIPTION


Fixes #2128 

#### Changes proposed in this Pull Request
Update `Currency` class `jsonSerialize` to decode HTML entities and prevent any issue rendering currencies name on the client side.

#### Screenshots

| Before | After |
| - | - |
|<img width="471" alt="Screenshot 2021-06-11 at 14 46 16" src="https://user-images.githubusercontent.com/7670276/121689198-a07ed700-cac4-11eb-9a3a-6f3a63f246eb.png">|<img width="366" alt="Screenshot 2021-06-11 at 14 51 39" src="https://user-images.githubusercontent.com/7670276/121689211-a379c780-cac4-11eb-8e6c-311b1224dabc.png">|

#### Testing instructions
- You need PR #2042 as base until it got merged.
- Go to [**WooCommerce > Settings > Multy-currency**](http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=wcpay_multi_currency)
- Click on **Add currencies**, you should see then rendered properly. Check for`Vietnamese đồng` and 

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)