### PR TITLE
Fix legacy currency switcher removing url params

### DIFF
--- a/includes/multi-currency/class-currency-switcher-widget.php
+++ b/includes/multi-currency/class-currency-switcher-widget.php
@@ -65,6 +65,7 @@ class Currency_Switcher_Widget extends WP_Widget {
 
 		?>
 		<form>
+			<?php $this->output_get_params(); ?>
 			<select
 				name="currency"
 				aria-label="<?php echo esc_attr( $title ); ?>"
@@ -168,5 +169,25 @@ class Currency_Switcher_Widget extends WP_Widget {
 		}
 
 		echo "<option value=\"$code\"$selected>$text</option>"; // phpcs:ignore WordPress.Security.EscapeOutput
+	}
+
+	/**
+	 * Output hidden inputs for every $_GET param.
+	 * This prevent the switcher form to remove them on submit.
+	 *
+	 * @return void
+	 */
+	private function output_get_params() {
+		// phpcs:disable WordPress.Security.NonceVerification
+		if ( empty( $_GET ) ) {
+			return;
+		}
+		foreach ( $_GET as $name => $value ) {
+			if ( 'currency' === $name ) {
+				continue;
+			}
+			echo '<input type="hidden" name="' . esc_attr( $name ) . '" value="' . esc_attr( $value ) . '" />';
+		}
+		// phpcs:enable WordPress.Security.NonceVerification
 	}
 }

--- a/includes/multi-currency/class-currency-switcher-widget.php
+++ b/includes/multi-currency/class-currency-switcher-widget.php
@@ -182,7 +182,11 @@ class Currency_Switcher_Widget extends WP_Widget {
 		if ( empty( $_GET ) ) {
 			return;
 		}
-		foreach ( $_GET as $name => $value ) {
+		$params = explode( '&', urldecode( http_build_query( $_GET ) ) );
+		foreach ( $params as $param ) {
+			$name_value = explode( '=', $param );
+			$name       = $name_value[0];
+			$value      = $name_value[1];
 			if ( 'currency' === $name ) {
 				continue;
 			}

--- a/tests/unit/multi-currency/test-class-currency-switcher-widget.php
+++ b/tests/unit/multi-currency/test-class-currency-switcher-widget.php
@@ -86,10 +86,14 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WP_UnitTestCas
 	}
 
 	public function test_widget_renders_hidden_input() {
-		$_GET = [ 'test_name' => 'test_value' ];
+		$_GET = [
+			'test_name'  => 'test_value',
+			'test_array' => [ 0 => [ 0 => 'test_array_value' ] ],
+		];
 		$this->render_widget();
 		$this->expectOutputRegex( '/<input type="hidden" name="test_name" value="test_value" \/>/' );
-	}
+		$this->expectOutputRegex( '/<input type="hidden" name="test_array\[0\]\[0\]" value="test_array_value" \/>/' );
+	} //<input type="hidden" name="test_array[0][0]" value="test_array_value" />
 
 	public function test_widget_selects_selected_currency() {
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( 'CAD' ) );

--- a/tests/unit/multi-currency/test-class-currency-switcher-widget.php
+++ b/tests/unit/multi-currency/test-class-currency-switcher-widget.php
@@ -89,10 +89,12 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WP_UnitTestCas
 		$_GET = [
 			'test_name'  => 'test_value',
 			'test_array' => [ 0 => [ 0 => 'test_array_value' ] ],
+			'named_key'  => [ 'key' => 'value' ],
 		];
 		$this->render_widget();
 		$this->expectOutputRegex( '/<input type="hidden" name="test_name" value="test_value" \/>/' );
 		$this->expectOutputRegex( '/<input type="hidden" name="test_array\[0\]\[0\]" value="test_array_value" \/>/' );
+		$this->expectOutputRegex( '/<input type="hidden" name="named_key\[key\]" value="value" \/>/' );
 	} //<input type="hidden" name="test_array[0][0]" value="test_array_value" />
 
 	public function test_widget_selects_selected_currency() {

--- a/tests/unit/multi-currency/test-class-currency-switcher-widget.php
+++ b/tests/unit/multi-currency/test-class-currency-switcher-widget.php
@@ -85,6 +85,12 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WP_UnitTestCas
 		$this->expectOutputRegex( '/<option value="EUR">🇪🇺 &euro; EUR<\/option>/' );
 	}
 
+	public function test_widget_renders_hidden_input() {
+		$_GET = [ 'test_name' => 'test_value' ];
+		$this->render_widget();
+		$this->expectOutputRegex( '/<input type="hidden" name="test_name" value="test_value" \/>/' );
+	}
+
 	public function test_widget_selects_selected_currency() {
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( 'CAD' ) );
 		$this->render_widget();


### PR DESCRIPTION
Fixes #2151 

#### Changes proposed in this Pull Request
We need to preserve the url params after selecting a new currency in the legacy widget. I opted to just output hidden inputs from $_GET except `currency` to keep them. The only alternative I considered was to use JS to redirect, checking if there are any params before adding/replacing currency. But I think this is a simpler solution without need for any additional JS code.

#### Testing instructions
You can test this following the **Steps to replicate** from #2151 or just adding any param to the url and then changing the currency with the widget. In both cases the params should be preserved.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)