### PR TITLE
Clear search term on add currency modal close

### DIFF
--- a/client/multi-currency/enabled-currencies-list/modal.js
+++ b/client/multi-currency/enabled-currencies-list/modal.js
@@ -91,10 +91,12 @@ const EnabledCurrenciesModal = ( { className } ) => {
 
 	const handleAddSelectedCancelClick = useCallback( () => {
 		setIsEnabledCurrenciesModalOpen( false );
+		setSearchText( '' );
 	}, [ setIsEnabledCurrenciesModalOpen ] );
 
 	const handleAddSelectedClick = () => {
 		setIsEnabledCurrenciesModalOpen( false );
+		setSearchText( '' );
 		const newCurrencies = Object.entries( selectedCurrencies )
 			.filter( ( [ , enabled ] ) => enabled )
 			.map( ( [ method ] ) => method );

--- a/client/multi-currency/enabled-currencies-list/test/index.js
+++ b/client/multi-currency/enabled-currencies-list/test/index.js
@@ -3,7 +3,8 @@
  * External dependencies
  */
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -222,5 +223,31 @@ describe( 'Multi Currency enabled currencies list', () => {
 		const modal = screen.queryByRole( 'dialog', { name: /remove euro/i } );
 		expect( modal ).toBeInTheDocument();
 		expect( modal ).toMatchSnapshot();
+	} );
+
+	test( 'Modal should clear search term on cancel and update selected', () => {
+		for ( const name of [ /cancel/i, /update selected/i ] ) {
+			render( <EnabledCurrencies /> );
+			userEvent.click(
+				screen.getByRole( 'button', {
+					name: /add currencies/i,
+				} )
+			);
+			userEvent.type( screen.getByRole( 'textbox' ), 'dollar' );
+			userEvent.click(
+				screen.getByRole( 'button', {
+					name,
+				} )
+			);
+			userEvent.click(
+				screen.getByRole( 'button', {
+					name: /add currencies/i,
+				} )
+			);
+			expect(
+				screen.queryByDisplayValue( 'dollar' )
+			).not.toBeInTheDocument();
+			cleanup();
+		}
 	} );
 } );


### PR DESCRIPTION
Fixes #2077 

#### Changes proposed in this Pull Request
Set the search state to an empty string on modal close for both buttons and modal handled events.

#### Testing instructions

- Go to [**WooCommerce > Settings > Multi-currency**](http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=wcpay_multi_currency).
- Click on **Add currencies** button.
- Write anything in the search box.
- The search term should be cleared on modal close, no matter how it's closed.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
