### PR TITLE
Move subscriptions functionality to a trait

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -155,6 +155,7 @@ class WC_Payments {
 
 		self::$api_client = self::create_api_client();
 
+		include_once __DIR__ . '/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-trait.php';
 		include_once __DIR__ . '/class-wc-payments-account.php';
 		include_once __DIR__ . '/class-wc-payments-customer-service.php';
 		include_once __DIR__ . '/class-logger.php';
@@ -203,11 +204,7 @@ class WC_Payments {
 		$sepa_class    = Sepa_Payment_Gateway::class;
 		$sofort_class  = Sofort_Payment_Gateway::class;
 
-		// TODO: Remove admin payment method JS hack for Subscriptions <= 3.0.7 when we drop support for those versions.
-		if ( class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '2.2.0', '>=' ) ) {
-			include_once __DIR__ . '/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php';
-			$gateway_class = 'WC_Payment_Gateway_WCPay_Subscriptions_Compat';
-		} elseif ( WC_Payments_Features::is_upe_enabled() ) {
+		if ( WC_Payments_Features::is_upe_enabled() ) {
 			$gateway_class = UPE_Payment_Gateway::class;
 		}
 

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -60,8 +60,8 @@ function _manually_load_plugin() {
 	require_once $_plugin_dir . 'includes/wc-payment-api/class-wc-payments-http.php';
 
 	// Load the gateway files, so subscriptions can be tested.
+	require_once $_plugin_dir . 'includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-trait.php';
 	require_once $_plugin_dir . 'includes/class-wc-payment-gateway-wcpay.php';
-	require_once $_plugin_dir . 'includes/compat/subscriptions/class-wc-payment-gateway-wcpay-subscriptions-compat.php';
 
 	require_once $_plugin_dir . 'includes/exceptions/class-rest-request-exception.php';
 	require_once $_plugin_dir . 'includes/admin/class-wc-payments-admin.php';

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
@@ -101,7 +101,7 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WP_UnitTestCase {
 
 		// Arrange: Mock WC_Payment_Gateway_WCPay so that some of its methods can be
 		// mocked, and their return values can be used for testing.
-		$this->mock_wcpay_gateway = $this->getMockBuilder( 'WC_Payment_Gateway_WCPay_Subscriptions_Compat' )
+		$this->mock_wcpay_gateway = $this->getMockBuilder( 'WC_Payment_Gateway_WCPay' )
 			->setConstructorArgs(
 				[
 					$this->mock_api_client,

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-payment-method-order-note.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-payment-method-order-note.php
@@ -83,7 +83,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Payment_Method_Order_Note_Test exte
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->wcpay_gateway = new \WC_Payment_Gateway_WCPay_Subscriptions_Compat(
+		$this->wcpay_gateway = new \WC_Payment_Gateway_WCPay(
 			$this->mock_api_client,
 			$this->wcpay_account,
 			$this->mock_customer_service,

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -119,7 +119,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->mock_wcpay_gateway = $this->getMockBuilder( '\WC_Payment_Gateway_WCPay_Subscriptions_Compat' )
+		$this->mock_wcpay_gateway = $this->getMockBuilder( '\WC_Payment_Gateway_WCPay' )
 			->setConstructorArgs(
 				[
 					$this->mock_api_client,

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -83,7 +83,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->wcpay_gateway = new \WC_Payment_Gateway_WCPay_Subscriptions_Compat(
+		$this->wcpay_gateway = new \WC_Payment_Gateway_WCPay(
 			$this->mock_api_client,
 			$this->wcpay_account,
 			$this->mock_customer_service,
@@ -534,7 +534,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 		remove_all_actions( 'woocommerce_admin_order_data_after_billing_address' );
 
 		WC_Subscriptions::$version = '3.0.7';
-		new \WC_Payment_Gateway_WCPay_Subscriptions_Compat(
+		new \WC_Payment_Gateway_WCPay(
 			$this->mock_api_client,
 			$this->wcpay_account,
 			$this->mock_customer_service,
@@ -549,7 +549,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 		remove_all_actions( 'woocommerce_admin_order_data_after_billing_address' );
 
 		WC_Subscriptions::$version = '3.0.8';
-		new \WC_Payment_Gateway_WCPay_Subscriptions_Compat(
+		new \WC_Payment_Gateway_WCPay(
 			$this->mock_api_client,
 			$this->wcpay_account,
 			$this->mock_customer_service,


### PR DESCRIPTION
**Do not merge, just a proof of concept**

This is a second attempt after #2135 and it feels like a much better fit! The goal of this proof of concept was to remove the need for the subscriptions class to inherit from the existing gateway. This opens up the ability to have other payment methods (UPE in this case) inherit from the existing gateway while still having subscription compatibility.

In this proof of concept I moved the subscription gateway in to a PHP trait to allow it to be added to other gateways without needing to inherit from them. Broadly speaking, the subscriptions compatibility class just adds support items and hooks. Within the hook callbacks some are self contained and some update some data and call the parent method. This made the transition a bit clearer.

Some things to note:
- Traits don't allow constants, so I had moved the constants into private static properties to get similar syntax to constants.
- I don't believe traits can be used conditionally without using inheritance (which we were trying to avoid in the first place), so I had to move some includes around and check for subscriptions being enabled before making any calls to the trait's functions.

In my testing I was able to complete all of the following actions with this new structure:

- Checkout with a subscription
- Change payment method for a subscription
- Renew manually
- Automatic renewal on schedule

In addition to the manual tests, I also took some time to get the automated unit tests passing. The automated tests were a lot easier to get up to speed using the trait approach and gave me a strong indication that this is the right approach. All of the automated unit tests are now passing with only minimal changes.

Additionally, given the end goal of this change, I tested subscriptions with UPE and had moderate success there. The issues I encountered made sense to me why they were happening and should have a clear solution for them.

I'm hoping to get a few eyes on this approach before wrapping up the changes into a final PR for review, so let me know if there are any questions, thoughts, or concerns!