### PR TITLE
Improve currency display in cases of common or unknown symbols

### DIFF
--- a/client/components/account-status/account-fees/test/__snapshots__/index.js.snap
+++ b/client/components/account-status/account-fees/test/__snapshots__/index.js.snap
@@ -207,19 +207,19 @@ exports[`AccountFees renders discounted non-USD base fee 1`] = `
       <span
         class="progressbar__outer-progress-label"
       >
-        £12,345.56
+        GBP £12,345.56
       </span>
     </div>
     <span
       class="progressbar__total-label"
     >
-      £1,000,000.00
+      GBP £1,000,000.00
     </span>
   </div>
   <p
     class="description"
   >
-    Discounted base fee expires after the first £1,000,000.00 of total payment volume.
+    Discounted base fee expires after the first GBP £1,000,000.00 of total payment volume.
   </p>
   <p>
     <a

--- a/client/components/deposits-information/test/__snapshots__/index.js.snap
+++ b/client/components/deposits-information/test/__snapshots__/index.js.snap
@@ -242,7 +242,7 @@ exports[`Deposits information renders correctly with multiple currencies 1`] = `
         <div
           class="wcpay-deposits-information-block__value"
         >
-          €33,43
+          EUR €33,43
         </div>
         <div
           class="wcpay-deposits-information-block__extra"
@@ -266,7 +266,7 @@ exports[`Deposits information renders correctly with multiple currencies 1`] = `
         <div
           class="wcpay-deposits-information-block__value"
         >
-          €33,43
+          EUR €33,43
         </div>
         <div
           class="wcpay-deposits-information-block__extra"
@@ -294,7 +294,7 @@ exports[`Deposits information renders correctly with multiple currencies 1`] = `
         <div
           class="wcpay-deposits-information-block__value"
         >
-          €31,60
+          EUR €31,60
         </div>
         <div
           class="wcpay-deposits-information-block__extra"
@@ -318,7 +318,7 @@ exports[`Deposits information renders correctly with multiple currencies 1`] = `
         <div
           class="wcpay-deposits-information-block__value"
         >
-          €20,30
+          EUR €20,30
         </div>
         <div
           class="wcpay-deposits-information-block__extra"
@@ -523,7 +523,7 @@ exports[`Deposits information renders instant deposit button only where applicab
         <div
           class="wcpay-deposits-information-block__value"
         >
-          €33,43
+          EUR €33,43
         </div>
         <div
           class="wcpay-deposits-information-block__extra"
@@ -547,7 +547,7 @@ exports[`Deposits information renders instant deposit button only where applicab
         <div
           class="wcpay-deposits-information-block__value"
         >
-          €33,43
+          EUR €33,43
         </div>
         <div
           class="wcpay-deposits-information-block__extra"
@@ -575,7 +575,7 @@ exports[`Deposits information renders instant deposit button only where applicab
         <div
           class="wcpay-deposits-information-block__value"
         >
-          €31,60
+          EUR €31,60
         </div>
         <div
           class="wcpay-deposits-information-block__extra"
@@ -599,7 +599,7 @@ exports[`Deposits information renders instant deposit button only where applicab
         <div
           class="wcpay-deposits-information-block__value"
         >
-          €20,30
+          EUR €20,30
         </div>
         <div
           class="wcpay-deposits-information-block__extra"

--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -97,7 +97,8 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 							>
 								{ formatCurrency(
 									charge.amount,
-									charge.currency
+									charge.currency,
+									true
 								) }
 								<span className="payment-details-summary__amount-currency">
 									{ charge.currency || 'USD' }
@@ -112,7 +113,8 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 								<p>
 									{ formatCurrency(
 										balance.amount,
-										balance.currency
+										balance.currency,
+										true
 									) }{ ' ' }
 									{ balance.currency.toUpperCase() }
 								</p>

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -230,12 +230,12 @@ Array [
   },
   Object {
     "body": Array [
-      "€1,00 → $1.19944: $21.59",
+      "EUR €1,00 → $1.19944: $21.59",
       "Fee (2.9% + $0.30): $-0.62",
       "Net deposit: $20.97",
     ],
     "date": 2020-04-01T14:37:54.000Z,
-    "headline": "A payment of €18,00 was successfully charged.",
+    "headline": "A payment of EUR €18,00 was successfully charged.",
     "icon": <t
       className="is-success"
       icon="checkmark"
@@ -277,12 +277,12 @@ Array [
   },
   Object {
     "body": Array [
-      "€1,00 → $1.19944: $21.59",
-      "Fee: €0,52",
+      "EUR €1,00 → $1.19944: $21.59",
+      "Fee: EUR €0,52",
       "Net deposit: $20.97",
     ],
     "date": 2020-04-01T14:37:54.000Z,
-    "headline": "A payment of €18,00 was successfully charged.",
+    "headline": "A payment of EUR €18,00 was successfully charged.",
     "icon": <t
       className="is-success"
       icon="checkmark"
@@ -306,8 +306,8 @@ Array [
   },
   Object {
     "body": Array [
-      "Disputed amount: €18,00",
-      "€1,00 → $1.2: $21.60",
+      "Disputed amount: EUR €18,00",
+      "EUR €1,00 → $1.2: $21.60",
       "Fee: $15.00",
     ],
     "date": 2020-04-02T02:06:14.000Z,
@@ -407,10 +407,10 @@ Array [
   },
   Object {
     "body": Array [
-      "€1,00 → $1.20222: $21.64",
+      "EUR €1,00 → $1.20222: $21.64",
     ],
     "date": 2020-04-04T13:51:06.000Z,
-    "headline": "A payment of €18,00 was successfully refunded.",
+    "headline": "A payment of EUR €18,00 was successfully refunded.",
     "icon": <t
       className="is-success"
       icon="checkmark"
@@ -444,10 +444,10 @@ Array [
   },
   Object {
     "body": Array [
-      "€1,00 → $1.2: $6.00",
+      "EUR €1,00 → $1.2: $6.00",
     ],
     "date": 2020-04-03T18:58:01.000Z,
-    "headline": "A payment of €5,00 was successfully refunded.",
+    "headline": "A payment of EUR €5,00 was successfully refunded.",
     "icon": <t
       className="is-success"
       icon="checkmark"

--- a/client/utils/account-fees.js
+++ b/client/utils/account-fees.js
@@ -25,7 +25,7 @@ export const formatAccountFeesDescription = ( accountFees ) => {
 		/* translators: %1: Percentage part of the fee. %2: Fixed part of the fee */
 		__( '%1$.1f%% + %2$s per transaction', 'woocommerce-payments' ),
 		baseFee.percentage_rate * 100,
-		formatCurrency( baseFee.fixed_rate, baseFee.currency )
+		formatCurrency( baseFee.fixed_rate, baseFee.currency, true )
 	);
 
 	if ( currentFee !== baseFee ) {
@@ -50,7 +50,7 @@ export const formatAccountFeesDescription = ( accountFees ) => {
 			),
 			feeDescription,
 			percentage * 100,
-			formatCurrency( fixed, baseFee.currency )
+			formatCurrency( fixed, baseFee.currency, true )
 		);
 
 		if ( currentFee.discount ) {

--- a/client/utils/currency/index.js
+++ b/client/utils/currency/index.js
@@ -66,12 +66,17 @@ const isZeroDecimalCurrency = ( currencyCode ) => {
 /**
  * Formats amount according to the given currency.
  *
- * @param {number} amount       Amount
- * @param {string} currencyCode Currency code
+ * @param {number}  amount       Amount
+ * @param {string}  currencyCode Currency code
+ * @param {boolean} omitCode     Whether to render fallback without currency code
  *
  * @return {string} formatted currency representation
  */
-export const formatCurrency = ( amount, currencyCode = 'USD' ) => {
+export const formatCurrency = (
+	amount,
+	currencyCode = 'USD',
+	omitCode = false
+) => {
 	// Normalize amount with respect to zer decimal currencies and provided data formats
 	const isZeroDecimal = isZeroDecimalCurrency( currencyCode );
 	if ( ! isZeroDecimal ) {
@@ -80,7 +85,11 @@ export const formatCurrency = ( amount, currencyCode = 'USD' ) => {
 
 	const currency = getCurrency( currencyCode );
 	if ( null === currency ) {
-		return composeFallbackCurrency( amount, currencyCode, isZeroDecimal );
+		return composeFallbackCurrency(
+			amount,
+			omitCode ? null : currencyCode,
+			isZeroDecimal
+		);
 	}
 
 	try {
@@ -88,7 +97,11 @@ export const formatCurrency = ( amount, currencyCode = 'USD' ) => {
 			? currency.formatAmount( amount )
 			: currency.formatCurrency( amount );
 	} catch ( err ) {
-		return composeFallbackCurrency( amount, currencyCode, isZeroDecimal );
+		return composeFallbackCurrency(
+			amount,
+			omitCode ? null : currencyCode,
+			isZeroDecimal
+		);
 	}
 };
 
@@ -158,11 +171,9 @@ function formatExchangeRate( from, to ) {
 
 function composeFallbackCurrency( amount, currencyCode, isZeroDecimal ) {
 	// Fallback for unsupported currencies: currency code and amount
-	return sprintf(
-		isZeroDecimal ? '%s %i' : '%s %.2f',
-		currencyCode.toUpperCase(),
-		amount
-	);
+	const numericFormat = isZeroDecimal ? '%1$i' : '%1$.2f';
+	const format = currencyCode ? `%2$s ${ numericFormat }` : numericFormat;
+	return sprintf( format, amount, currencyCode?.toUpperCase() );
 }
 
 function trimEndingZeroes( formattedCurrencyAmount = '' ) {

--- a/client/utils/currency/index.js
+++ b/client/utils/currency/index.js
@@ -3,9 +3,27 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import Currency, { getCurrencyData } from '@woocommerce/currency';
-import { find, trimEnd, endsWith } from 'lodash';
+import { find, trimEnd, endsWith, values } from 'lodash';
 
-const currencyData = getCurrencyData();
+const currencyData = [
+	...values( getCurrencyData() ),
+	{
+		code: 'NZD',
+		symbol: '$',
+		symbolPosition: 'left',
+		thousandSeparator: ',',
+		decimalSeparator: '.',
+		precision: 2,
+	},
+	{
+		code: 'AUD',
+		symbol: '$',
+		symbolPosition: 'left',
+		thousandSeparator: ',',
+		decimalSeparator: '.',
+		precision: 2,
+	},
+];
 
 const currencyNames = {
 	aud: 'Australian dollar',

--- a/client/utils/currency/index.js
+++ b/client/utils/currency/index.js
@@ -93,9 +93,19 @@ export const formatCurrency = (
 	}
 
 	try {
-		return 'function' === typeof currency.formatAmount
-			? currency.formatAmount( amount )
-			: currency.formatCurrency( amount );
+		const formattedAmount =
+			'function' === typeof currency.formatAmount
+				? currency.formatAmount( amount )
+				: currency.formatCurrency( amount );
+
+		if (
+			omitCode ||
+			wcSettings.currency.code === currencyCode.toUpperCase()
+		) {
+			return formattedAmount;
+		}
+
+		return `${ currencyCode.toUpperCase() } ${ formattedAmount }`;
 	} catch ( err ) {
 		return composeFallbackCurrency(
 			amount,

--- a/client/utils/currency/test/index.js
+++ b/client/utils/currency/test/index.js
@@ -24,7 +24,7 @@ describe( 'Currency utilities', () => {
 	} );
 
 	test( 'format unsupported currency', () => {
-		expect( utils.formatCurrency( 1000, 'AUD' ) ).toEqual( 'AUD 10.00' );
+		expect( utils.formatCurrency( 1000, 'NOK' ) ).toEqual( 'NOK 10.00' );
 		expect( utils.formatCurrency( 1000, 'JPY' ) ).toEqual( 'JPY 1000' );
 		expect( utils.formatCurrencyName( 'jpy' ) ).toEqual( 'JPY' );
 	} );

--- a/client/utils/currency/test/index.js
+++ b/client/utils/currency/test/index.js
@@ -31,11 +31,11 @@ describe( 'Currency utilities', () => {
 
 	test.each`
 		source                                   | target                                 | expected
-		${ { currency: 'EUR', amount: 1242 } }   | ${ { currency: 'USD', amount: 1484 } } | ${ '€1,00 → $1.19485: $14.84' }
+		${ { currency: 'EUR', amount: 1242 } }   | ${ { currency: 'USD', amount: 1484 } } | ${ 'EUR €1,00 → $1.19485: $14.84' }
 		${ { currency: 'CHF', amount: 1500 } }   | ${ { currency: 'USD', amount: 1675 } } | ${ 'CHF 1.00 → $1.11667: $16.75' }
-		${ { currency: 'GBP', amount: 1800 } }   | ${ { currency: 'USD', amount: 2439 } } | ${ '£1.00 → $1.355: $24.39' }
-		${ { currency: 'INR', amount: 131392 } } | ${ { currency: 'USD', amount: 1779 } } | ${ '₹1.00 → $0.01354: $17.79' }
-		${ { currency: 'RUB', amount: 136746 } } | ${ { currency: 'USD', amount: 1777 } } | ${ '1,00₽ → $0.012995: $17.77' }
+		${ { currency: 'GBP', amount: 1800 } }   | ${ { currency: 'USD', amount: 2439 } } | ${ 'GBP £1.00 → $1.355: $24.39' }
+		${ { currency: 'INR', amount: 131392 } } | ${ { currency: 'USD', amount: 1779 } } | ${ 'INR ₹1.00 → $0.01354: $17.79' }
+		${ { currency: 'RUB', amount: 136746 } } | ${ { currency: 'USD', amount: 1777 } } | ${ 'RUB 1,00₽ → $0.012995: $17.77' }
 		${ { currency: 'JPY', amount: 1894 } }   | ${ { currency: 'USD', amount: 1786 } } | ${ 'JPY 1 → $0.00943: $17.86' }
 	`(
 		'format FX string $source.currency -> $target.currency',

--- a/tests/js/jest-test-file-setup.js
+++ b/tests/js/jest-test-file-setup.js
@@ -46,7 +46,7 @@ wooCommercePackages.forEach( ( lib ) => {
 global.wcSettings = {
 	// adminUrl: 'https://vagrant.local/wp/wp-admin/',
 	// locale: 'en-US',
-	// currency: { code: 'USD', precision: 2, symbol: '$' },
+	currency: { code: 'USD', precision: 2, symbol: '$' },
 	// date: {
 	// 	dow: 0,
 	// },


### PR DESCRIPTION
Fixes #1301
Fixes #1389

#### Changes proposed in this Pull Request

The biggest change in this PR (https://github.com/Automattic/woocommerce-payments/commit/7d4474f1802bd225117ddba8f6538af70d3680f6) is to err on the side of showing the currency code in too many places: any time the displayed amount does not match the WC store currency, the currency code will be displayed along with the formatted amount in order to:
- disambiguate between currencies that share the same symbol, and
- add clarity when a merchant is not familiar with a given symbol.

The cases of duplicate currency codes described in #1389 are explicitly prevented in https://github.com/Automattic/woocommerce-payments/commit/076241428e052aaf8d640e2962199dd39697fc48.

Also, formatting info for NZD and AUD is _temporarily_ appended to the list of currencies retrieved from the `@woocommerce/currency` package (https://github.com/Automattic/woocommerce-payments/commit/651bf6e9122d552b7346db3f5be96ce37913ae0a), so as to most quickly support these (being primary currencies for supported countries) in the plugin. I'd be fine with either removing this (<s>and awaiting currency package update, which I plan to open a PR for</s> _Edit:_ nevermind, see [comment](https://github.com/Automattic/woocommerce-payments/pull/2171#discussion_r652127055) below) or adding more currencies, such as all currencies generally found in our supported countries (i.e. [these](https://github.com/Automattic/woocommerce-payments/blob/23418a0a69b55cd30b61650e6b8253e9b56d0767/client/utils/currency/index.js#L11-L20)).

(I considered always showing currency codes whenever a _conversion_ was being described, but backed off – might still be worthwhile for the timeline though.)

Store country is USD for all of the below examples. If one or more settlement currencies were to differ from the store currency, those deposit and transaction amounts would all be formatted with the currency code as well, but I didn't specifically test such a case.

Before | After
-- | --
<img width="265" src="https://user-images.githubusercontent.com/1867547/121975904-bdc7d580-cd50-11eb-9774-e15e0c45915b.png"> | <img width="265" src="https://user-images.githubusercontent.com/1867547/121975903-bdc7d580-cd50-11eb-82ac-921fbcb47ff1.png">
<img width="255" src="https://user-images.githubusercontent.com/1867547/121975902-bdc7d580-cd50-11eb-9efd-88eb80baf917.png"> | <img width="255" src="https://user-images.githubusercontent.com/1867547/121975900-bd2f3f00-cd50-11eb-921a-cdd5d1ae4c2a.png">
<img width="316" src="https://user-images.githubusercontent.com/1867547/121975907-be606c00-cd50-11eb-8495-a072396d96aa.png"> | <img width="316" src="https://user-images.githubusercontent.com/1867547/121975905-be606c00-cd50-11eb-8729-8c79b03e6bf5.png">
<img width="230" src="https://user-images.githubusercontent.com/1867547/121975912-bef90280-cd50-11eb-86df-d1dd275b57c4.png"> | <img width="230" src="https://user-images.githubusercontent.com/1867547/121975909-bef90280-cd50-11eb-8a77-4d80f76fa01c.png">
<img width="250" src="https://user-images.githubusercontent.com/1867547/121975921-c02a2f80-cd50-11eb-9692-90ae89795798.png"> | <img width="250" src="https://user-images.githubusercontent.com/1867547/121975920-c02a2f80-cd50-11eb-8891-235857a6e66c.png">
<img width="250" src="https://user-images.githubusercontent.com/1867547/121975917-bf919900-cd50-11eb-8a22-53c3fc3c8ffc.png"> | <img width="250" src="https://user-images.githubusercontent.com/1867547/121975916-bf919900-cd50-11eb-8e45-7c33986a02ba.png">
<img width="257" src="https://user-images.githubusercontent.com/1867547/121975914-bef90280-cd50-11eb-9adb-fc82c4a3e999.png"> | <img width="257" src="https://user-images.githubusercontent.com/1867547/121975913-bef90280-cd50-11eb-94ce-5f3d9dc65bc7.png">

More examples can be found in the automated snapshot updates (https://github.com/Automattic/woocommerce-payments/commit/27e2de506a43229360e8b7568d777d995f325e68).

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

Check out with a variety of currencies (by using multi-currency functionality or by temporarily switching store currency):
- NZD or AUD
- a currency unsupported in [the currency package](https://github.com/woocommerce/woocommerce-admin/blob/b00318547fe061376cb4cb42b2bdefa810259781/packages/currency/src/index.js#L226-L329)
- a currency (supported in the currency package) with the same symbol as the store currency

Make sure that the currency code shows up (without duplication) in all cases where the symbol alone could be confusing.

cc @kalessil @jrodger just in case you have any input, and @reykjalin (last week's designated Fractal reviewer)

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
