### PR TITLE
Show previous details for non instant deposits

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Add - Error message when total size of dispute evidence files uploaded goes over limit.
 * Update - Pass currency to wc_price when adding intent notes to orders.
 * Update - Instant deposit inbox note wording.
+* Fix - Deposit overview details for non instant ones.
 
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.

--- a/client/deposits/details/index.js
+++ b/client/deposits/details/index.js
@@ -6,6 +6,7 @@
 import { dateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import moment from 'moment';
+import { Card, CardBody } from '@wordpress/components';
 import {
 	SummaryListPlaceholder,
 	SummaryList,
@@ -58,28 +59,43 @@ export const DepositOverview = ( { depositId } ) => {
 		? __( 'Deposit date', 'woocommerce-payments' )
 		: __( 'Instant deposit date', 'woocommerce-payments' );
 
+	const depositDateItem = (
+		<SummaryItem
+			key="depositDate"
+			label={
+				`${ depositDateLabel }: ` +
+				dateI18n(
+					'M j, Y',
+					moment.utc( deposit.date ).toISOString(),
+					true // TODO Change call to gmdateI18n and remove this deprecated param once WP 5.4 support ends.
+				)
+			}
+			value={ <Status status={ deposit.status } /> }
+			detail={ deposit.bankAccount }
+		/>
+	);
+
+	if ( isLoading ) return <SummaryListPlaceholder numberOfItems={ 2 } />;
 	return (
 		<div className="wcpay-deposit-overview">
-			{ isLoading ? (
-				<SummaryListPlaceholder numberOfItems={ 4 } />
+			{ deposit.automatic ? (
+				<Card className="wcpay-deposit-automatic">
+					<CardBody>
+						{ depositDateItem }
+						<div className="wcpay-deposit-amount">
+							{ formatCurrency(
+								deposit.amount,
+								deposit.currency
+							) }
+						</div>
+					</CardBody>
+				</Card>
 			) : (
 				<SummaryList
 					label={ __( 'Deposits overview', 'woocommerce-payments' ) }
 				>
 					{ () => [
-						<SummaryItem
-							key="depositDate"
-							label={
-								`${ depositDateLabel }: ` +
-								dateI18n(
-									'M j, Y',
-									moment.utc( deposit.date ).toISOString(),
-									true // TODO Change call to gmdateI18n and remove this deprecated param once WP 5.4 support ends.
-								)
-							}
-							value={ <Status status={ deposit.status } /> }
-							detail={ deposit.bankAccount }
-						/>,
+						depositDateItem,
 						<SummaryItem
 							key="depositAmount"
 							label={ __(

--- a/client/deposits/details/index.js
+++ b/client/deposits/details/index.js
@@ -6,7 +6,7 @@
 import { dateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import moment from 'moment';
-import { Card, CardBody } from '@wordpress/components';
+import { Card } from '@wordpress/components';
 import {
 	SummaryListPlaceholder,
 	SummaryList,
@@ -80,15 +80,15 @@ export const DepositOverview = ( { depositId } ) => {
 		<div className="wcpay-deposit-overview">
 			{ deposit.automatic ? (
 				<Card className="wcpay-deposit-automatic">
-					<CardBody>
+					<ul>
 						{ depositDateItem }
-						<div className="wcpay-deposit-amount">
+						<li className="wcpay-deposit-amount">
 							{ formatCurrency(
 								deposit.amount,
 								deposit.currency
 							) }
-						</div>
-					</CardBody>
+						</li>
+					</ul>
 				</Card>
 			) : (
 				<SummaryList

--- a/client/deposits/details/index.js
+++ b/client/deposits/details/index.js
@@ -92,7 +92,7 @@ export const DepositOverview = ( { depositId } ) => {
 				</Card>
 			) : (
 				<SummaryList
-					label={ __( 'Deposits overview', 'woocommerce-payments' ) }
+					label={ __( 'Deposit overview', 'woocommerce-payments' ) }
 				>
 					{ () => [
 						depositDateItem,

--- a/client/deposits/details/style.scss
+++ b/client/deposits/details/style.scss
@@ -40,4 +40,27 @@
 	.wcpay-deposit-net {
 		color: $studio-green-30;
 	}
+
+	.wcpay-deposit-automatic .components-card__body {
+		display: flex;
+		list-style-type: none;
+		padding: 0;
+
+		.woocommerce-summary__item {
+			border-bottom: 0;
+			background-color: inherit;
+			color: inherit;
+			.woocommerce-summary__item-label:hover {
+				color: inherit;
+			}
+		}
+
+		.wcpay-deposit-amount {
+			flex-grow: 1;
+			padding: 24px;
+			text-align: right;
+			font-size: 36px;
+			line-height: 82px;
+		}
+	}
 }

--- a/client/deposits/details/style.scss
+++ b/client/deposits/details/style.scss
@@ -41,10 +41,10 @@
 		color: $studio-green-30;
 	}
 
-	.wcpay-deposit-automatic .components-card__body {
+	.wcpay-deposit-automatic ul {
 		display: flex;
+		margin: 0;
 		list-style-type: none;
-		padding: 0;
 
 		.woocommerce-summary__item {
 			border-bottom: 0;

--- a/client/deposits/details/test/__snapshots__/index.js.snap
+++ b/client/deposits/details/test/__snapshots__/index.js.snap
@@ -1,6 +1,62 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Deposit overview renders correctly 1`] = `
+exports[`Deposit overview renders automatic deposit correctly 1`] = `
+<div>
+  <div
+    class="wcpay-deposit-overview"
+  >
+    <div
+      class="components-card is-size-medium wcpay-deposit-automatic css-1xs3c37-CardUI e1q7k77g0"
+    >
+      <div
+        class="components-card__body is-size-medium css-xmjzce-BodyUI e1q7k77g3"
+      >
+        <li
+          class="woocommerce-summary__item-container"
+        >
+          <div
+            class="woocommerce-summary__item"
+          >
+            <div
+              class="woocommerce-summary__item-label"
+            >
+              Deposit date: Jan 2, 2020
+            </div>
+            <div
+              class="woocommerce-summary__item-data"
+            >
+              <div
+                class="woocommerce-summary__item-value"
+              >
+                <div
+                  class="woocommerce-order-status"
+                >
+                  <span
+                    class="woocommerce-order-status__indicator is-paid"
+                  />
+                  Paid
+                </div>
+              </div>
+            </div>
+            <div
+              class="wcpay-summary__item-detail"
+            >
+              MOCK BANK •••• 1234 (USD)
+            </div>
+          </div>
+        </li>
+        <div
+          class="wcpay-deposit-amount"
+        >
+          $20.00
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Deposit overview renders instant deposit correctly 1`] = `
 <div>
   <div
     class="wcpay-deposit-overview"
@@ -29,7 +85,7 @@ exports[`Deposit overview renders correctly 1`] = `
             <div
               class="woocommerce-summary__item-label"
             >
-              Deposit date: Jan 2, 2020
+              Instant deposit date: Jan 2, 2020
             </div>
             <div
               class="woocommerce-summary__item-data"

--- a/client/deposits/details/test/__snapshots__/index.js.snap
+++ b/client/deposits/details/test/__snapshots__/index.js.snap
@@ -8,9 +8,7 @@ exports[`Deposit overview renders automatic deposit correctly 1`] = `
     <div
       class="components-card is-size-medium wcpay-deposit-automatic css-1xs3c37-CardUI e1q7k77g0"
     >
-      <div
-        class="components-card__body is-size-medium css-xmjzce-BodyUI e1q7k77g3"
-      >
+      <ul>
         <li
           class="woocommerce-summary__item-container"
         >
@@ -45,12 +43,12 @@ exports[`Deposit overview renders automatic deposit correctly 1`] = `
             </div>
           </div>
         </li>
-        <div
+        <li
           class="wcpay-deposit-amount"
         >
           $20.00
-        </div>
-      </div>
+        </li>
+      </ul>
     </div>
   </div>
 </div>

--- a/client/deposits/details/test/__snapshots__/index.js.snap
+++ b/client/deposits/details/test/__snapshots__/index.js.snap
@@ -63,7 +63,7 @@ exports[`Deposit overview renders instant deposit correctly 1`] = `
   >
     <div
       aria-describedby="woocommerce-summary-helptext-1"
-      aria-label="Deposits overview"
+      aria-label="Deposit overview"
       aria-orientation="horizontal"
       role="menu"
     >

--- a/client/deposits/details/test/index.js
+++ b/client/deposits/details/test/index.js
@@ -35,9 +35,21 @@ describe( 'Deposit overview', () => {
 		};
 	} );
 
-	test( 'renders correctly', () => {
+	test( 'renders automatic deposit correctly', () => {
 		useDeposit.mockReturnValue( {
 			deposit: mockDeposit,
+			isLoading: false,
+		} );
+
+		const { container: overview } = render(
+			<DepositOverview depositId="po_mock" />
+		);
+		expect( overview ).toMatchSnapshot();
+	} );
+
+	test( 'renders instant deposit correctly', () => {
+		useDeposit.mockReturnValue( {
+			deposit: { ...mockDeposit, automatic: false },
 			isLoading: false,
 		} );
 

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Error message when total size of dispute evidence files uploaded goes over limit.
 * Update - Pass currency to wc_price when adding intent notes to orders.
 * Update - Instant deposit inbox note wording.
+* Fix - Deposit overview details for non instant ones.
 
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.


### PR DESCRIPTION


Fixes #2164 

#### Changes proposed in this Pull Request

As commented in #2164 and slack thread. We should use the previous details implementation for non instant deposits. The one with only deposit date and amount, without service fee and gross/net amount.

I tried an implementation using only `<SummaryList>`. But I didn't find a way to force the grid to show the two columns on the same row on mobile, without interfering with the 4 columns version. So opted to go back to a basic `<Card>` implementation, but using the same `<SummaryItem>` just with some custom styles overrides.

#### Testing instructions

- Go to **Payments > Deposits**.
- You should see, after clicking on a deposit:
  - Two old columns with date and amount for automatic deposits.
  - Four columns with date, gross/net amounts and fees for instant deposits.

#### Screenshots

| Automatic | Instant |
| - | - |
|<img width="746" alt="Screenshot 2021-06-15 at 14 14 27" src="https://user-images.githubusercontent.com/7670276/122050786-1eecb900-cde4-11eb-9dfe-0767deeaf0dd.png">|<img width="744" alt="Screenshot 2021-06-15 at 14 14 36" src="https://user-images.githubusercontent.com/7670276/122050792-201de600-cde4-11eb-99a8-2c61def927b6.png">|
|<img width="379" alt="Screenshot 2021-06-15 at 14 15 00" src="https://user-images.githubusercontent.com/7670276/122050802-23b16d00-cde4-11eb-8da6-7a45e40728df.png">|<img width="376" alt="Screenshot 2021-06-15 at 14 15 10" src="https://user-images.githubusercontent.com/7670276/122050803-23b16d00-cde4-11eb-8d50-0e2cff36c7c8.png">|


-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
