### PR TITLE
Support emoji flags on unsupported browsers/OS

### DIFF
--- a/includes/multi-currency/class-currency-switcher-widget.php
+++ b/includes/multi-currency/class-currency-switcher-widget.php
@@ -136,7 +136,7 @@ class Currency_Switcher_Widget extends WP_Widget {
 				type="checkbox"<?php checked( $instance['flag'] ); ?>
 			/>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'flag' ) ); ?>">
-				<?php esc_html_e( 'Display flags', 'woocommerce-payments' ); ?>
+				<?php esc_html_e( 'Display flags in supported devices', 'woocommerce-payments' ); ?>
 			</label>
 		</p>
 		<?php

--- a/includes/multi-currency/class-settings.php
+++ b/includes/multi-currency/class-settings.php
@@ -47,6 +47,7 @@ class Settings extends \WC_Settings_Page {
 		$this->id             = $this->multi_currency->id;
 		$this->label          = _x( 'Multi-currency', 'Settings tab label', 'woocommerce-payments' );
 
+		// TODO: We need to re-enable it on every screen we use emoji flags. Until WC Admin decide if they will enable it too: https://github.com/woocommerce/woocommerce-admin/issues/6388.
 		add_action( 'admin_print_scripts', 'print_emoji_detection_script' );
 		add_action( 'woocommerce_admin_field_wcpay_enabled_currencies_list', [ $this, 'enabled_currencies_list' ] );
 		add_action( 'woocommerce_admin_field_wcpay_currencies_settings_section_start', [ $this, 'currencies_settings_section_start' ] );

--- a/includes/multi-currency/class-settings.php
+++ b/includes/multi-currency/class-settings.php
@@ -47,6 +47,7 @@ class Settings extends \WC_Settings_Page {
 		$this->id             = $this->multi_currency->id;
 		$this->label          = _x( 'Multi-currency', 'Settings tab label', 'woocommerce-payments' );
 
+		add_action( 'admin_print_scripts', 'print_emoji_detection_script' );
 		add_action( 'woocommerce_admin_field_wcpay_enabled_currencies_list', [ $this, 'enabled_currencies_list' ] );
 		add_action( 'woocommerce_admin_field_wcpay_currencies_settings_section_start', [ $this, 'currencies_settings_section_start' ] );
 		add_action( 'woocommerce_admin_field_wcpay_currencies_settings_section_end', [ $this, 'currencies_settings_section_end' ] );


### PR DESCRIPTION
Fixes #2080 

#### Changes proposed in this Pull Request
After some digging found this solution, I think will provide a good compromise. As @LevinMedia  asked in the issue, we could try to use the SVG images from WP admin like https://s.w.org/images/core/emoji/13.0.1/svg/1f1e6-1f1fa.svg

Those images come from a handy **WP** helper `print_emoji_detection_script` that check for browser compatibility and replaces the emojis for unsupported browsers with an SVG image.

It's not working now, because **WC Admin** disables it [here](https://github.com/woocommerce/woocommerce-admin/blob/6468742c6e1df872ad99e907dfbe67473d52e2b1/src/Loader.php#L99-L103). Looks like the detection is a bit exhaustive and check for the latest added flags, so it falls back to images almost always.

To not interfere with how **WC Admin works**, I added the script only in the settings part of Multi-Currency, where we use the flags. This will show the same flag in almost every browser, providing a good user experience. But we should notice that in order to show the flags correctly in any other screen, we'll need to call the same function or propose **WC Admin** to delete the `remove_action`.

The only missing part is the legacy widget, which will continue showing flags only on supported browsers, but looks like we agree that this is an acceptable drawback to avoid the use of custom select element.

What do you think about this solution @LevinMedia?

And about testing, I can't see an easy way of testing this other than using E2E. Any other suggestion?

#### Screenshots
<img width="883" alt="Screenshot 2021-06-15 at 16 05 13" src="https://user-images.githubusercontent.com/7670276/122067021-83634480-cdf3-11eb-866c-145408c3103d.png">

#### Testing instructions
- Go to [**WooCommerce > Settings > Multi-Currency**](http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=wcpay_multi_currency)
- You should see the currency flags like in the screenshot, with any browser/OS.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
