### PR TITLE
Extend Currency class to add is_zero_decimal

### DIFF
--- a/includes/multi-currency/class-currency.php
+++ b/includes/multi-currency/class-currency.php
@@ -42,7 +42,7 @@ class Currency implements \JsonSerializable {
 	 *
 	 * @var bool|null
 	 */
-	private $is_default;
+	private $is_default = false;
 
 	/**
 	 * Currency rounding rate after conversion.
@@ -56,7 +56,7 @@ class Currency implements \JsonSerializable {
 	 *
 	 * @var bool|null
 	 */
-	private $is_zero_decimal;
+	private $is_zero_decimal = false;
 
 
 	/**
@@ -131,7 +131,7 @@ class Currency implements \JsonSerializable {
 	 * @return bool
 	 */
 	public function get_is_default(): bool {
-		return $this->is_default || false;
+		return $this->is_default;
 	}
 
 	/**
@@ -177,7 +177,7 @@ class Currency implements \JsonSerializable {
 	 * @return bool
 	 */
 	public function get_is_zero_decimal(): bool {
-		return $this->is_zero_decimal || false;
+		return $this->is_zero_decimal;
 	}
 
 	/**

--- a/includes/multi-currency/class-currency.php
+++ b/includes/multi-currency/class-currency.php
@@ -83,7 +83,7 @@ class Currency implements \JsonSerializable {
 	 *
 	 * @param string $code The currency code.
 	 */
-	public function get_currency_name_from_code( $code ) {
+	public function get_currency_name_from_code( $code ): string {
 		$wc_currencies = get_woocommerce_currencies();
 		return $wc_currencies[ $code ];
 	}
@@ -93,7 +93,7 @@ class Currency implements \JsonSerializable {
 	 *
 	 * @return string Three letter currency code.
 	 */
-	public function get_code() {
+	public function get_code(): string {
 		return $this->code;
 	}
 
@@ -102,7 +102,7 @@ class Currency implements \JsonSerializable {
 	 *
 	 * @return float Charm rate.
 	 */
-	public function get_charm() {
+	public function get_charm(): float {
 		return is_null( $this->charm ) ? 0.00 : $this->charm;
 	}
 
@@ -111,7 +111,7 @@ class Currency implements \JsonSerializable {
 	 *
 	 * @return string Currency flag.
 	 */
-	public function get_flag() {
+	public function get_flag(): string {
 		// Maybe add param img/emoji to return which you want?
 		return Country_Flags::get_by_currency( $this->code );
 	}
@@ -121,7 +121,7 @@ class Currency implements \JsonSerializable {
 	 *
 	 * @return string Currency code lowercased.
 	 */
-	public function get_id() {
+	public function get_id(): string {
 		return strtolower( $this->code );
 	}
 
@@ -130,7 +130,7 @@ class Currency implements \JsonSerializable {
 	 *
 	 * @return bool
 	 */
-	public function get_is_default() {
+	public function get_is_default(): bool {
 		return $this->is_default || false;
 	}
 
@@ -139,7 +139,7 @@ class Currency implements \JsonSerializable {
 	 *
 	 * @return string Currency name.
 	 */
-	public function get_name() {
+	public function get_name(): string {
 		$wc_currencies = get_woocommerce_currencies();
 		return $wc_currencies[ $this->code ];
 	}
@@ -149,7 +149,7 @@ class Currency implements \JsonSerializable {
 	 *
 	 * @return float The conversion rate.
 	 */
-	public function get_rate() {
+	public function get_rate(): float {
 		return $this->rate;
 	}
 
@@ -158,7 +158,7 @@ class Currency implements \JsonSerializable {
 	 *
 	 * @return string Rounding rate.
 	 */
-	public function get_rounding() {
+	public function get_rounding(): string {
 		return is_null( $this->rounding ) ? 'none' : $this->rounding;
 	}
 
@@ -167,7 +167,7 @@ class Currency implements \JsonSerializable {
 	 *
 	 * @return string Currency symbol.
 	 */
-	public function get_symbol() {
+	public function get_symbol(): string {
 		return get_woocommerce_currency_symbol( $this->code );
 	}
 
@@ -176,7 +176,7 @@ class Currency implements \JsonSerializable {
 	 *
 	 * @return bool
 	 */
-	public function get_is_zero_decimal() {
+	public function get_is_zero_decimal(): bool {
 		return $this->is_zero_decimal || false;
 	}
 
@@ -210,9 +210,9 @@ class Currency implements \JsonSerializable {
 	/**
 	 * Specify the data that should be serialized to JSON.
 	 *
-	 * @return mixed Serialized Currency object.
+	 * @return array Serialized Currency object.
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'code'            => $this->code,
 			'rate'            => $this->get_rate(),

--- a/includes/multi-currency/class-currency.php
+++ b/includes/multi-currency/class-currency.php
@@ -7,6 +7,8 @@
 
 namespace WCPay\Multi_Currency;
 
+use WC_Payments_Utils;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -50,6 +52,14 @@ class Currency implements \JsonSerializable {
 	private $rounding;
 
 	/**
+	 * Is currency zero decimal?
+	 *
+	 * @var bool|null
+	 */
+	private $is_zero_decimal;
+
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $code Three letter currency code.
@@ -61,6 +71,10 @@ class Currency implements \JsonSerializable {
 
 		if ( get_woocommerce_currency() === $code ) {
 			$this->is_default = true;
+		}
+
+		if ( in_array( strtolower( $code ), WC_Payments_Utils::zero_decimal_currencies(), true ) ) {
+			$this->is_zero_decimal = true;
 		}
 	}
 
@@ -158,6 +172,15 @@ class Currency implements \JsonSerializable {
 	}
 
 	/**
+	 * Retrieves if the currency is zero decimal.
+	 *
+	 * @return bool
+	 */
+	public function get_is_zero_decimal() {
+		return $this->is_zero_decimal || false;
+	}
+
+	/**
 	 * Sets the currency's charm rate.
 	 *
 	 * @param float $charm Charm rate.
@@ -191,13 +214,14 @@ class Currency implements \JsonSerializable {
 	 */
 	public function jsonSerialize() {
 		return [
-			'code'       => $this->code,
-			'rate'       => $this->get_rate(),
-			'name'       => html_entity_decode( $this->get_name() ),
-			'id'         => $this->get_id(),
-			'is_default' => $this->get_is_default(),
-			'flag'       => $this->get_flag(),
-			'symbol'     => html_entity_decode( $this->get_symbol() ),
+			'code'            => $this->code,
+			'rate'            => $this->get_rate(),
+			'name'            => html_entity_decode( $this->get_name() ),
+			'id'              => $this->get_id(),
+			'is_default'      => $this->get_is_default(),
+			'flag'            => $this->get_flag(),
+			'symbol'          => html_entity_decode( $this->get_symbol() ),
+			'is_zero_decimal' => $this->get_is_zero_decimal(),
 		];
 	}
 }

--- a/tests/unit/multi-currency/test-class-currency.php
+++ b/tests/unit/multi-currency/test-class-currency.php
@@ -29,7 +29,7 @@ class WCPay_Multi_Currency_Currency_Tests extends WP_UnitTestCase {
 		$json = wp_json_encode( $this->currency );
 
 		$this->assertSame(
-			'{"code":"USD","rate":1,"name":"United States (US) dollar","id":"usd","is_default":true,"flag":"\ud83c\uddfa\ud83c\uddf8","symbol":"$"}',
+			'{"code":"USD","rate":1,"name":"United States (US) dollar","id":"usd","is_default":true,"flag":"\ud83c\uddfa\ud83c\uddf8","symbol":"$","is_zero_decimal":false}',
 			$json
 		);
 	}
@@ -38,8 +38,16 @@ class WCPay_Multi_Currency_Currency_Tests extends WP_UnitTestCase {
 		$json = wp_json_encode( new WCPay\Multi_Currency\Currency( 'WST' ) );
 
 		$this->assertSame(
-			'{"code":"WST","rate":1,"name":"Samoan t\u0101l\u0101","id":"wst","is_default":false,"flag":"\ud83c\uddfc\ud83c\uddf8","symbol":"T"}',
+			'{"code":"WST","rate":1,"name":"Samoan t\u0101l\u0101","id":"wst","is_default":false,"flag":"\ud83c\uddfc\ud83c\uddf8","symbol":"T","is_zero_decimal":false}',
 			$json
 		);
+	}
+
+	public function test_is_zero_decimal_returns_right_value() {
+		$decimal_currency      = new WCPay\Multi_Currency\Currency( 'USD' );
+		$zero_decimal_currency = new WCPay\Multi_Currency\Currency( 'BIF' );
+
+		$this->assertFalse( $decimal_currency->get_is_zero_decimal() );
+		$this->assertTrue( $zero_decimal_currency->get_is_zero_decimal() );
 	}
 }


### PR DESCRIPTION
Fixes #2008 

#### Changes proposed in this Pull Request
Add the new property `is_zero_decimal` to `Currency` class. Using `WC_Payments_Utils::zero_decimal_currencies()` to check them.

I thought of setting it on enabled ones only, like @jessepearson suggested in the issue. But then we will have some currencies with true/false and others with null. Think it worth the extra check along with the `is_default` one on construct.

#### Testing instructions

Tests should pass.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)