### PR TITLE
Add breadcrumbs to single currency settings

### DIFF
--- a/includes/multi-currency/class-settings.php
+++ b/includes/multi-currency/class-settings.php
@@ -215,9 +215,9 @@ class Settings extends \WC_Settings_Page {
 					<?php echo esc_html( $currency->get_symbol() ); ?>
 					<span style="display:inline-block;"></span>
 				</div>
-				<input type="hidden" 
-					name="<?php echo esc_attr( $this->id . '_automatic_exchange_rate' ); ?>" 
-					value="<?php echo esc_attr( $available_currencies[ $currency->get_code() ]->get_rate() ); ?>" 
+				<input type="hidden"
+					name="<?php echo esc_attr( $this->id . '_automatic_exchange_rate' ); ?>"
+					value="<?php echo esc_attr( $available_currencies[ $currency->get_code() ]->get_rate() ); ?>"
 				/>
 			</td>
 		</tr>
@@ -235,8 +235,6 @@ class Settings extends \WC_Settings_Page {
 		$available_currencies = $this->multi_currency->get_available_currencies();
 		$default_currency     = $this->multi_currency->get_default_currency();
 		$page_id              = $this->id . '_single_currency';
-
-		$page_title = sprintf( '%1$s (%2$s)', $currency->get_name(), $currency->get_code() );
 
 		$exchange_rate_options = [
 			'automatic' => sprintf(
@@ -291,13 +289,19 @@ class Settings extends \WC_Settings_Page {
 			$currency->get_code()
 		);
 
+		// Output breadcrumbs.
+		?>
+		<h2>
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=wcpay_multi_currency' ) ); ?>"><?php esc_html_e( 'Currencies', 'woocommerce-payments' ); ?></a> &gt; <?php echo esc_html( "{$currency->get_name()} ({$currency->get_code()}) {$currency->get_flag()}" ); ?>
+		</h2>
+		<?php
+
 		return apply_filters(
 			$this->id . '_single_settings',
 			[
 				[
-					'title' => $page_title,
-					'type'  => 'title',
-					'id'    => $page_id,
+					'type' => 'title',
+					'id'   => $page_id,
 				],
 
 				[


### PR DESCRIPTION
Fixes #2092 

#### Changes proposed in this Pull Request
Add the missing breadcrumbs. Discard the idea of using a template and lose the Settings API benefits. Thought on use an action `woocommerce_settings_*` to hook on the title and output the HTML, but I Think is clearer to just put it directly.

#### Screenshots
| Before | After |
| - | - |
|<img width="224" alt="Screenshot 2021-06-16 at 16 55 26" src="https://user-images.githubusercontent.com/7670276/122242504-aa894700-cec3-11eb-9fa9-a6788bd06327.png">|<img width="348" alt="Screenshot 2021-06-16 at 16 54 47" src="https://user-images.githubusercontent.com/7670276/122242520-aeb56480-cec3-11eb-87d4-98c899abcceb.png">|

#### Testing instructions
- Go to [**WooCommerce > Settings > Multi-currency**](http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=wcpay_multi_currency).
- Click edit on any enabled currency.
- You should see the breadcrumbs instead of the old title.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)