### PR TITLE
feat: add UPE settings preview feature flag

### DIFF
--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -91,7 +91,7 @@ const TransactionsAndDepositsDescription = () => (
 
 const SettingsManager = () => {
 	const {
-		featureFlags: { upe_settings_preview: isUPESettingsEnabled },
+		featureFlags: { upeSettingsPreview: isUPESettingsPreviewEnabled },
 	} = useContext( WCPaySettingsContext );
 
 	return (
@@ -101,7 +101,7 @@ const SettingsManager = () => {
 					<GeneralSettings />
 				</LoadableSettingsSection>
 			</SettingsSection>
-			{ isUPESettingsEnabled && (
+			{ isUPESettingsPreviewEnabled && (
 				<SettingsSection Description={ PaymentMethodsDescription }>
 					<LoadableSettingsSection numLines={ 20 }>
 						<PaymentMethods />

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -91,7 +91,7 @@ const TransactionsAndDepositsDescription = () => (
 
 const SettingsManager = () => {
 	const {
-		featureFlags: { upe: isUPEEnabled },
+		featureFlags: { upe_settings_preview: isUPESettingsEnabled },
 	} = useContext( WCPaySettingsContext );
 
 	return (
@@ -101,7 +101,7 @@ const SettingsManager = () => {
 					<GeneralSettings />
 				</LoadableSettingsSection>
 			</SettingsSection>
-			{ isUPEEnabled && (
+			{ isUPESettingsEnabled && (
 				<SettingsSection Description={ PaymentMethodsDescription }>
 					<LoadableSettingsSection numLines={ 20 }>
 						<PaymentMethods />

--- a/client/settings/settings-manager/test/index.test.js
+++ b/client/settings/settings-manager/test/index.test.js
@@ -12,8 +12,7 @@ import WCPaySettingsContext from '../../wcpay-settings-context';
 
 describe( 'SettingsManager', () => {
 	it( 'renders the PaymentMethods section if the UPE feature flag is enabled', () => {
-		// eslint-disable-next-line camelcase
-		const context = { featureFlags: { upe_settings_preview: true } };
+		const context = { featureFlags: { upeSettingsPreview: true } };
 
 		render(
 			<WCPaySettingsContext.Provider value={ context }>

--- a/client/settings/settings-manager/test/index.test.js
+++ b/client/settings/settings-manager/test/index.test.js
@@ -12,7 +12,8 @@ import WCPaySettingsContext from '../../wcpay-settings-context';
 
 describe( 'SettingsManager', () => {
 	it( 'renders the PaymentMethods section if the UPE feature flag is enabled', () => {
-		const context = { featureFlags: { upe: true } };
+		// eslint-disable-next-line camelcase
+		const context = { featureFlags: { upe_settings_preview: true } };
 
 		render(
 			<WCPaySettingsContext.Provider value={ context }>

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -59,6 +59,15 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Checks whether the UPE settings redesign is enabled
+	 *
+	 * @return bool
+	 */
+	public static function is_upe_settings_preview_enabled() {
+		return '1' === get_option( '_wcpay_feature_upe_settings_preview', '0' );
+	}
+
+	/**
 	 * Checks whether the customer multi-currency feature is enabled
 	 *
 	 * @return bool
@@ -73,10 +82,11 @@ class WC_Payments_Features {
 	 * @return bool[]
 	 */
 	public static function to_array() {
-		$flags = [
-			'upe' => self::is_upe_enabled(),
-		];
-
-		return array_filter( $flags );
+		return array_filter(
+			[
+				'upe'                  => self::is_upe_enabled(),
+				'upe_settings_preview' => self::is_upe_settings_preview_enabled(),
+			]
+		);
 	}
 }

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -84,8 +84,8 @@ class WC_Payments_Features {
 	public static function to_array() {
 		return array_filter(
 			[
-				'upe'                  => self::is_upe_enabled(),
-				'upe_settings_preview' => self::is_upe_settings_preview_enabled(),
+				'upe'                => self::is_upe_enabled(),
+				'upeSettingsPreview' => self::is_upe_settings_preview_enabled(),
 			]
 		);
 	}

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -11,7 +11,8 @@
 class WC_Payments_Features_Test extends WP_UnitTestCase {
 
 	const FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING = [
-		'_wcpay_feature_upe' => 'upe',
+		'_wcpay_feature_upe'                  => 'upe',
+		'_wcpay_feature_upe_settings_preview' => 'upeSettingsPreview',
 	];
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/2154

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Adding a new feature flag for the UPE settings preview.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have the latest version of WCPay Dev tools `cd docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools && git pull`
- WCPay dev tools will have a "Enable UPE settings changes" checkbox, toggle it
- Settings page with "Enable UPE settings changes"
![Screen Shot 2021-06-16 at 10 06 13 AM](https://user-images.githubusercontent.com/273592/122244437-7e9d9f80-ce8a-11eb-8f7f-52b66ac06aa0.png)
- Settings page without "Enable UPE settings changes"
![Screen Shot 2021-06-16 at 10 06 38 AM](https://user-images.githubusercontent.com/273592/122244498-8bba8e80-ce8a-11eb-90e8-d9dc5aa183bb.png)


-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
