### PR TITLE
Pull in Action Scheduler plugin for e2e tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -13,6 +13,7 @@ env:
   WCP_DEV_TOOLS_REPO:                          ${{ secrets.WCP_DEV_TOOLS_REPO }}
   WCP_SERVER_REPO:                             ${{ secrets.WCP_SERVER_REPO }}
   WC_SUBSCRIPTIONS_REPO:                       ${{ secrets.WC_SUBSCRIPTIONS_REPO}}
+  WC_ACTION_SCHEDULER_REPO:                    ${{ secrets.WC_ACTION_SCHEDULER_REPO}}
   E2E_WCPAY_STRIPE_ACCOUNT_ID:                 ${{ secrets.E2E_WCPAY_STRIPE_ACCOUNT_ID }}
   E2E_WCPAY_STRIPE_TEST_CLIENT_ID:             ${{ secrets.E2E_WCPAY_STRIPE_TEST_CLIENT_ID }}
   E2E_WCPAY_STRIPE_TEST_PUBLIC_KEY:            ${{ secrets.E2E_WCPAY_STRIPE_TEST_PUBLIC_KEY }}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -24,7 +24,7 @@ DEBUG=true
 For local setup:
 
 1. Create file `local.env` in the `tests/e2e/config` folder with required values.
-    * If you have access to the Subscriptions plugin, please follow the instructions from `tests/e2e/specs/subscriptions/README.md` before running the setup.
+    * If you have access to the Subscriptions plugin, please follow the instructions from `tests/e2e/specs/subscriptions/README.md` before running the setup. Make sure to include also Action Scheduler plugin from the same document.
     * If you don't, you may skip Subscriptions setup and tests by adding `SKIP_WC_SUBSCRIPTIONS_TESTS=1` to your `local.env` in the `tests/e2e/config` folder.
 
 1. Make sure to run `npm install`,  `composer install` and `npm run build:client` before running setup script.

--- a/tests/e2e/env/docker-compose.yml
+++ b/tests/e2e/env/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - ${WCP_ROOT}:/var/www/html/wp-content/plugins/woocommerce-payments
       - ${E2E_ROOT}/deps/${DEV_TOOLS_DIR}:/var/www/html/wp-content/plugins/${DEV_TOOLS_DIR}
       - ${E2E_ROOT}/deps/woocommerce-subscriptions:/var/www/html/wp-content/plugins/woocommerce-subscriptions
+      - ${E2E_ROOT}/deps/action-scheduler:/var/www/html/wp-content/plugins/action-scheduler
   db:
     container_name: wcp_e2e_mysql
     image: mariadb:10.5.8

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -198,6 +198,24 @@ else
 	echo "Skipping install of WooCommerce Subscriptions"
 fi
 
+if [[ ! ${SKIP_WC_ACTION_SCHEDULER_TESTS} ]]; then
+	echo "Install and activate the latest release of Action Scheduler"
+	cd $E2E_ROOT/deps
+	LATEST_RELEASE=$(curl -H "Authorization: token $E2E_GH_TOKEN" -sL https://api.github.com/repos/$WC_ACTION_SCHEDULER_REPO/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
+	curl -LJO -H "Authorization: token $E2E_GH_TOKEN" "https://github.com/$WC_ACTION_SCHEDULER_REPO/archive/$LATEST_RELEASE.zip"
+
+	unzip -qq action-scheduler-$LATEST_RELEASE.zip
+
+	echo "Moving the unzipped plugin files. This may require your admin password"
+	sudo mv action-scheduler-$LATEST_RELEASE/* $E2E_ROOT/deps/action-scheduler
+
+	cli wp plugin activate action-scheduler
+
+	rm -rf action-scheduler-$LATEST_RELEASE
+else
+	echo "Skipping install of Action Scheduler"
+fi
+
 echo "Installing basic auth plugin for interfacing with the API"
 cli wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate
 

--- a/tests/e2e/specs/subscriptions/README.md
+++ b/tests/e2e/specs/subscriptions/README.md
@@ -1,8 +1,8 @@
-# WooCommerce Payments e2e tests - WooCommerce Subscriptions
+# WooCommerce Payments e2e tests - WooCommerce Subscriptions & Action Scheduler
 
 The tests included here require the WooCommerce Subscriptions plugin to be installed.
 
-## Installing the plugin
+## Installing the WooCommerce Subscriptions plugin
 
 The setup script requires the below env variables to be configured. Make sure you have the following set in your `local.env` in the `tests/e2e/config` folder:
 
@@ -13,10 +13,26 @@ WC_SUBSCRIPTIONS_REPO='{owner}/{repo}'
 
 For the `E2E_GH_TOKEN`, follow [these instructions to generate a GitHub Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) and assign the `repo` scope to it.
 
-## Skipping tests
+## Skipping WooCommerce Subscriptions tests
 
 Adding the following line to your `local.env` in the `tests/e2e/config` folder and set it to `1` to skip the tests that rely on the plugin:
 
 `SKIP_WC_SUBSCRIPTIONS_TESTS=1` 
 
 With this set, any tests that require the WooCommerce Subscriptions plugin will be skipped.
+
+## Installing the Action Scheduler plugin
+
+The setup script requires the below env variables to be configured. Make sure you have the following set in your `local.env` in the `tests/e2e/config` folder:
+
+```
+WC_ACTION_SCHEDULER_REPO='{owner}/{repo}'
+```
+
+## Skipping Action Scheduler tests
+
+Adding the following line to your `local.env` in the `tests/e2e/config` folder and set it to `1` to skip the tests that rely on the plugin:
+
+`SKIP_WC_ACTION_SCHEDULER_TESTS=1` 
+
+With this set, any tests that require the Action Scheduler plugin will be skipped.

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -34,6 +34,9 @@ const WC_SUBSCRIPTIONS_PAGE =
 export const RUN_SUBSCRIPTIONS_TESTS =
 	'1' !== process.env.SKIP_WC_SUBSCRIPTIONS_TESTS;
 
+export const RUN_ACTION_SCHEDULER_TESTS =
+	'1' !== process.env.SKIP_WC_ACTION_SCHEDULER_TESTS;
+
 // The generic flows will be moved to their own package soon (more details in p7bje6-2gV-p2), so we're
 // keeping our customizations grouped here so it's easier to extend the flows once the move happens.
 export const shopperWCP = {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/2240

#### Changes proposed in this Pull Request

This PR proposes pulling in the Action Scheduler plugin as part of the environment setup to be used in the e2e tests. Additionally, an optional variable has been added that allows skipping the tests if the plugin is not available.

#### Testing instructions

To begin testing these changes, you'll need to make sure you have the following set in your `local.env` in the `tests/e2e/config` folder:

```
E2E_GH_TOKEN='githubPersonalAccessToken'
WC_ACTION_SCHEDULER_REPO='{owner}/{repo}'
```

In case you don't have `E2E_GH_TOKEN` already in your local.env:
To create the `E2E_GH_TOKEN`, follow [these instructions to generate a GitHub Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) and assign the `repo` scope to it.

**Test Steps - Action Scheduler plugin properly installed**

* Spin up the Docker test environment with `npm run test:e2e-setup` and note in the terminal logs there's an entry for `Install and activate the latest release of Action Scheduler`.
* Login to the test environment and navigate to `Plugins > Installed Plugins` and verify Action Scheduler shows in the list and is activated.