### PR TITLE
HTTPS checkout note is not dismissed after following the "Read more" link

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Update - Removed "Branded" and "Custom label" options on Payment request buttons to align with design guidelines.
 * Update - Converted payment request button size value to distinct options to align with design guidelines.
 * Tweak - Run post-upgrade actions during any request instead of only on wp-admin requests.
+* Fix - HTTPS checkout note is now dismissed after following the "Read more" link.
 
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.

--- a/includes/notes/class-wc-payments-notes-set-https-for-checkout.php
+++ b/includes/notes/class-wc-payments-notes-set-https-for-checkout.php
@@ -58,7 +58,7 @@ class WC_Payments_Notes_Set_Https_For_Checkout {
 			self::NOTE_NAME,
 			__( 'Read more', 'woocommerce-payments' ),
 			self::NOTE_DOCUMENTATION_URL,
-			'unactioned',
+			'actioned',
 			true
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,7 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Pass currency to wc_price when adding intent notes to orders.
 * Update - Instant deposit inbox note wording.
 * Fix - Deposit overview details for non instant ones.
+* Fix - HTTPS checkout note is now dismissed after following the "Read more" link.
 
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

WooCommerce Payments create a note if checkout page is not served with HTTPS protocol. The intent is to let merchant check the documentation and update their settings. Thus, note can be dismissed once merchant visits the documentation page but it didn't happen because of the incorrect note settings.

#### Testing instructions

 * Ensure there is no record with `name="wc-payments-notes-set-https-for-checkout"` in the `wp_wc_admin_notes` table.
 * Open the **WooCommerce Overview** page in WP Admin.
 * Ensure that the following note is there:
 
<img width="696" alt="image" src="https://user-images.githubusercontent.com/683297/122394719-94888e80-cf76-11eb-8e84-aa6a7e98eead.png">

 * Click on the **Read more** link.
 * Reload the **WooCommerce Overview** page.
 * Observe that related note is not displayed anymore.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
