### PR TITLE
Add store settings to enabled currencies screen

### DIFF
--- a/client/data/multi-currency/actions.js
+++ b/client/data/multi-currency/actions.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
  * Internal Dependencies
  */
 import TYPES from './action-types';
-import { NAMESPACE, STORE_NAME } from '../constants';
+import { NAMESPACE } from '../constants';
 
 export function updateCurrencies( data ) {
 	return {
@@ -50,12 +50,8 @@ export function* submitEnabledCurrenciesUpdate( currencies ) {
 				enabled: currencies,
 			},
 		} );
-		yield updateCurrencies( result );
 
-		// Need to invalidate the resolution so that the components will render again.
-		yield dispatch( STORE_NAME ).invalidateResolutionForStoreSelector(
-			'getCurrencies'
-		);
+		yield updateCurrencies( result );
 
 		yield dispatch( 'core/notices' ).createSuccessNotice(
 			__( 'Enabled currencies updated.', 'woocommerce-payments' )

--- a/client/multi-currency/index.js
+++ b/client/multi-currency/index.js
@@ -22,6 +22,34 @@ if ( currencyContainer ) {
 }
 
 /**
+ * Store settings section
+ */
+const enabledCurrenciesList = document.querySelector(
+	'.enabled-currencies-list'
+);
+const storeSettingsSection = document.querySelector(
+	'#wcpay_currencies_settings_section'
+);
+const submitButton = document.querySelector( 'p.submit' );
+
+const toggleSettingsSectionDisplay = () => {
+	const display =
+		1 >= enabledCurrenciesList.children.length ? 'none' : 'block';
+	storeSettingsSection.style.display = display;
+	submitButton.style.display = display;
+};
+
+const enabledCurrenciesObserver = new MutationObserver(
+	toggleSettingsSectionDisplay
+);
+
+enabledCurrenciesObserver.observe( enabledCurrenciesList, {
+	childList: true,
+} );
+
+toggleSettingsSectionDisplay();
+
+/**
  * Single currency settings
  */
 let rateType = 'automatic';
@@ -94,22 +122,3 @@ document.querySelectorAll( '.exchange-rate-selector' ).forEach( ( radio ) => {
 	.forEach( ( element ) =>
 		element.addEventListener( 'input', () => updatePreview() )
 	);
-
-/**
- * Store settings section
- */
-const enabledCurrenciesList = document.querySelector(
-	'.enabled-currencies-list'
-);
-const storeSettingsSection = document.querySelector(
-	'#wcpay_currencies_settings_section'
-);
-
-const enabledCurrenciesObserver = new MutationObserver( () => {
-	storeSettingsSection.style.display =
-		1 >= enabledCurrenciesList.children.length ? 'none' : 'block';
-} );
-
-enabledCurrenciesObserver.observe( enabledCurrenciesList, {
-	childList: true,
-} );

--- a/client/multi-currency/index.js
+++ b/client/multi-currency/index.js
@@ -10,6 +10,9 @@ import ReactDOM from 'react-dom';
  */
 import EnabledCurrencies from './enabled-currencies-list';
 
+/**
+ * Mount React Component
+ */
 const currencyContainer = document.getElementById(
 	'wcpay_enabled_currencies_list'
 );
@@ -18,6 +21,9 @@ if ( currencyContainer ) {
 	ReactDOM.render( <EnabledCurrencies />, currencyContainer );
 }
 
+/**
+ * Single currency settings
+ */
 let rateType = 'automatic';
 
 const automaticRate = document.querySelector(
@@ -83,6 +89,27 @@ document.querySelectorAll( '.exchange-rate-selector' ).forEach( ( radio ) => {
 	} );
 } );
 
-[ manualRate, rounding, charm, previewAmount ].forEach( ( element ) =>
-	element.addEventListener( 'input', () => updatePreview() )
+[ manualRate, rounding, charm, previewAmount ]
+	.filter( ( _ ) => _ )
+	.forEach( ( element ) =>
+		element.addEventListener( 'input', () => updatePreview() )
+	);
+
+/**
+ * Store settings section
+ */
+const enabledCurrenciesList = document.querySelector(
+	'.enabled-currencies-list'
 );
+const storeSettingsSection = document.querySelector(
+	'#wcpay_currencies_settings_section'
+);
+
+const enabledCurrenciesObserver = new MutationObserver( () => {
+	storeSettingsSection.style.display =
+		1 >= enabledCurrenciesList.children.length ? 'none' : 'block';
+} );
+
+enabledCurrenciesObserver.observe( enabledCurrenciesList, {
+	childList: true,
+} );

--- a/includes/multi-currency/class-multi-currency.php
+++ b/includes/multi-currency/class-multi-currency.php
@@ -275,6 +275,8 @@ class Multi_Currency {
 			}
 		);
 
+		$this->enabled_currencies = [];
+
 		foreach ( $enabled_currencies as $enabled_currency ) {
 			// Get the charm and rounding for each enabled currency and add the currencies to the object property.
 			$currency = clone $enabled_currency;
@@ -341,6 +343,7 @@ class Multi_Currency {
 	public function set_enabled_currencies( $currencies = [] ) {
 		if ( 0 < count( $currencies ) ) {
 			update_option( $this->id . '_enabled_currencies', $currencies );
+			$this->initialize_enabled_currencies();
 		}
 	}
 

--- a/includes/multi-currency/class-settings.php
+++ b/includes/multi-currency/class-settings.php
@@ -109,7 +109,7 @@ class Settings extends \WC_Settings_Page {
 
 					[
 						'title' => __( 'Store settings', 'woocommerce-payments' ),
-						// TODO: Need learn more link.
+						// TODO: Learn more documentation link, to be done on #1780.
 						'desc'  => sprintf(
 							/* translators: %s: url to documentation. */
 							__( 'Store settings allow your customers to choose which currency they would like to use when shopping at your store. <a href="%s">Learn more</a>', 'woocommerce-payments' ),
@@ -123,9 +123,9 @@ class Settings extends \WC_Settings_Page {
 					[
 						'title'         => __( 'Store settings', 'woocommerce-payments' ),
 						'desc'          => __( 'Automatically switch customers to the local currency if it is enabled above.', 'woocommerce-payments' ),
-						// TODO: Need preview link... what is expected?
+						// TODO: Preview link, to be done on #2258.
 						'desc_tip'      => sprintf(
-							/* translators: %s: url to preview? */
+							/* translators: %s: url to a preview of alert banner */
 							__( 'Customers will be notified via store alert banner. <a href="%s">Preview</a>', 'woocommerce-payments' ),
 							''
 						),
@@ -137,11 +137,10 @@ class Settings extends \WC_Settings_Page {
 
 					[
 						'desc'          => __( 'Add a currency switcher to the cart widget', 'woocommerce-payments' ),
-						// TODO: Need configure link... what is expected? Widgets?
 						'desc_tip'      => sprintf(
-							/* translators: %s: url to the widgets? */
+							/* translators: %s: url to the widgets page */
 							__( 'A currency switcher is also available in your widgets. <a href="%s">Configure now</a>', 'woocommerce-payments' ),
-							''
+							'widgets.php'
 						),
 						'id'            => $this->id . '_enable_cart_switcher',
 						'default'       => 'yes',

--- a/includes/multi-currency/class-settings.php
+++ b/includes/multi-currency/class-settings.php
@@ -48,6 +48,9 @@ class Settings extends \WC_Settings_Page {
 		$this->label          = _x( 'Multi-currency', 'Settings tab label', 'woocommerce-payments' );
 
 		add_action( 'woocommerce_admin_field_wcpay_enabled_currencies_list', [ $this, 'enabled_currencies_list' ] );
+		add_action( 'woocommerce_admin_field_wcpay_currencies_settings_section_start', [ $this, 'currencies_settings_section_start' ] );
+		add_action( 'woocommerce_admin_field_wcpay_currencies_settings_section_end', [ $this, 'currencies_settings_section_end' ] );
+
 		add_action( 'woocommerce_admin_field_wcpay_single_currency_preview_helper', [ $this, 'single_currency_preview_helper' ] );
 		parent::__construct();
 	}
@@ -73,13 +76,9 @@ class Settings extends \WC_Settings_Page {
 	 * @return array
 	 */
 	public function get_settings( $current_section = '' ) {
-		global $hide_save_button;
-
 		$settings = [];
 
 		if ( '' === $current_section ) {
-			$hide_save_button = true;
-
 			$settings = apply_filters(
 				$this->id . '_enabled_currencies_settings',
 				[
@@ -103,13 +102,11 @@ class Settings extends \WC_Settings_Page {
 						'type' => 'sectionend',
 						'id'   => $this->id . '_enabled_currencies',
 					],
-				]
-			);
-		} elseif ( 'store' === $current_section ) {
-			// TODO: Store settings are not available at the moment.
-			$settings = apply_filters(
-				$this->id . 'store_settings',
-				[
+
+					[
+						'type' => 'wcpay_currencies_settings_section_start',
+					],
+
 					[
 						'title' => __( 'Store settings', 'woocommerce-payments' ),
 						// TODO: Need learn more link.
@@ -120,6 +117,7 @@ class Settings extends \WC_Settings_Page {
 						),
 						'type'  => 'title',
 						'id'    => $this->id . '_store_settings',
+						'class' => $this->id . '_store_settings_input',
 					],
 
 					[
@@ -132,7 +130,7 @@ class Settings extends \WC_Settings_Page {
 							''
 						),
 						'id'            => $this->id . '_enable_auto_currency',
-						'default'       => 'no',
+						'default'       => 'yes',
 						'type'          => 'checkbox',
 						'checkboxgroup' => 'start',
 					],
@@ -146,7 +144,7 @@ class Settings extends \WC_Settings_Page {
 							''
 						),
 						'id'            => $this->id . '_enable_cart_switcher',
-						'default'       => 'no',
+						'default'       => 'yes',
 						'type'          => 'checkbox',
 						'checkboxgroup' => 'end',
 					],
@@ -154,6 +152,10 @@ class Settings extends \WC_Settings_Page {
 					[
 						'type' => 'sectionend',
 						'id'   => $this->id . 'store_settings',
+					],
+
+					[
+						'type' => 'wcpay_currencies_settings_section_end',
 					],
 				]
 			);
@@ -184,6 +186,24 @@ class Settings extends \WC_Settings_Page {
 				<div id="wcpay_enabled_currencies_list" aria-describedby="wcpay_enabled_currencies-description"></div>
 			</td>
 		</tr>
+		<?php
+	}
+
+	/**
+	 * Output section start for store settings.
+	 */
+	public function currencies_settings_section_start() {
+		?>
+		<div id="wcpay_currencies_settings_section" style="display: none;">
+		<?php
+	}
+
+	/**
+	 * Output section end for store settings.
+	 */
+	public function currencies_settings_section_end() {
+		?>
+		</div>
 		<?php
 	}
 
@@ -223,6 +243,8 @@ class Settings extends \WC_Settings_Page {
 		</tr>
 		<?php
 	}
+
+
 
 	/**
 	 * Returns the settings for the single currency.
@@ -391,7 +413,7 @@ class Settings extends \WC_Settings_Page {
 		\WC_Admin_Settings::save_fields( $this->get_settings( $current_section ) );
 
 		// If we are saving the settings for an individual currency, we have some additional logic.
-		if ( '' !== $current_section && 'store' !== $current_section ) {
+		if ( '' !== $current_section ) {
 			// If the manual rate was blank, or zero, we set it to the automatic rate.
 			$manual_rate = get_option( $this->id . '_manual_rate_' . $current_section, false );
 			if ( ! $manual_rate || 0 >= $manual_rate || '' === $manual_rate ) {


### PR DESCRIPTION
Fixes #2147

#### Changes proposed in this Pull Request

Update `Settings` class to output store settings section on the same page that currencies. This left us with a single settings page for Multi-Currency.

Toggle visibility using `MutationObserver` over enabled currencies list. Showing store settings only when enabled currencies is greater than one (the first one is the default currency).

With the quick solution included for #2244. This implementation works good in terms of UX. Without it, the settings hide and show on every currencies list update.

Opted for this solution because I think it's a good compromise between results and time invested. Taking into account that it's for legacy settings. We can get advantage of Settings API for a quick implementation and still toggle visibility based on the enabled currencies list using `MutationObserver`. I thought of using a React implementation, cause we will need it later. But think that it's better to use the React implementation for the new settings and don't had legacy code there.

#### Working example
![Screen Recording 2021-06-18 at 11 50 08](https://user-images.githubusercontent.com/7670276/122543007-9ceed100-d02b-11eb-8c72-29a2103a7c25.gif)

#### TODOs
I thought of adding the missing TODO parts to their related issues, keeping the scope of this PR leaner.

#### Testing instructions
- Go to [**WooCommerce > Settings > Multi-currency**](http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=wcpay_multi_currency).
- Having only the default currency in the enabled list should hide the **Store settings** section.
- Having at least one additional currency in the enabled list should show the **Store settings** section.
- You should be able to change the 2 available settings and save them properly.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
