### PR TITLE
Pre-fill OAuth flow with WC store country

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@
 * Update - Payment request button should guide users to login when necessary.
 * Add - When setting WooCommerce Payments up, inform if merchant business country is not supported.
 * Add - Introduce advance filters on deposits page.
+* Update: Prefill OAuth flow with WC store country
 
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -248,7 +248,7 @@ class WC_Payments_Admin {
 		$wcpay_settings = [
 			'connect'               => [
 				'url'                => WC_Payments_Account::get_connect_url(),
-				'country'            => wc_get_base_location()['country'],
+				'country'            => WC()->countries->get_base_country(),
 				'availableCountries' => WC_Payments_Utils::supported_countries(),
 			],
 			'testMode'              => $this->wcpay_gateway->is_in_test_mode(),

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -535,7 +535,7 @@ class WC_Payments_Account {
 		$return_url   = $this->get_oauth_return_url( $wcpay_connect_from );
 
 		$country = WC()->countries->get_base_country();
-		if ( ! in_array( $country, array_keys( WC_Payments_Utils::supported_countries() ), true ) ) {
+		if ( ! array_key_exists( $country, WC_Payments_Utils::supported_countries() ) ) {
 			$country = null;
 		}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -534,13 +534,18 @@ class WC_Payments_Account {
 		$current_user = wp_get_current_user();
 		$return_url   = $this->get_oauth_return_url( $wcpay_connect_from );
 
+		$country = WC()->countries->get_base_country();
+		if ( ! in_array( $country, array_keys( WC_Payments_Utils::supported_countries() ), true ) ) {
+			$country = null;
+		}
+
 		$oauth_data = $this->payments_api_client->get_oauth_data(
 			$return_url,
 			[
 				'email'         => $current_user->user_email,
 				'business_name' => get_bloginfo( 'name' ),
 				'url'           => get_home_url(),
-				'country'       => WC()->countries->get_base_country(),
+				'country'       => $country,
 			],
 			[
 				'site_username' => $current_user->user_login,

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -540,6 +540,7 @@ class WC_Payments_Account {
 				'email'         => $current_user->user_email,
 				'business_name' => get_bloginfo( 'name' ),
 				'url'           => get_home_url(),
+				'country'       => WC()->countries->get_base_country(),
 			],
 			[
 				'site_username' => $current_user->user_login,

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,7 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Payment request button should guide users to login when necessary.
 * Add - When setting WooCommerce Payments up, inform if merchant business country is not supported.
 * Add - Introduce advance filters on deposits page.
+* Update: Prefill OAuth flow with WC store country
 
 = 2.5.0 - 2021-06-02 =
 * Fix - Fix hover dialog for close button on modals, unify styling and layout of modal buttons.


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/2105

Depends on server change to add `country` to allowed fields (899-gh-Automattic/woocommerce-payments-server), but nothing will break without that change.

#### Changes proposed in this Pull Request

If the store country is supported in WCPay, pass it along with the OAuth request to **prefill the country selector**, for convenience and to unify the broader merchant experience.

&nbsp; | Dev platform | Live platform
-- | -- | --
Supported country | <img width="430" src="https://user-images.githubusercontent.com/1867547/122626413-7905ac80-d078-11eb-85b2-39c1000cf436.png"> | <img width="435" src="https://user-images.githubusercontent.com/1867547/122626414-799e4300-d078-11eb-8e87-fdf144cbec3d.png">
Unsupported country without https://github.com/Automattic/woocommerce-payments/commit/0f249729d7ee377c945ae89a438ca944d335e170 | <img width="439" src="https://user-images.githubusercontent.com/1867547/122626416-7a36d980-d078-11eb-8da4-3a4f0bd2e83d.png"> | <img width="454" src="https://user-images.githubusercontent.com/1867547/122626415-799e4300-d078-11eb-95db-afe8e2309785.png">
Unsupported country with https://github.com/Automattic/woocommerce-payments/commit/0f249729d7ee377c945ae89a438ca944d335e170  | <img width="429" src="https://user-images.githubusercontent.com/1867547/122626411-786d1600-d078-11eb-850b-d26b7c862a68.png"> | <img width="428" src="https://user-images.githubusercontent.com/1867547/122626412-7905ac80-d078-11eb-94a8-c62e16f73693.png">

The specific business data is not covered with automated tests, and probably not worth it since this whole flow is slated to change soon.

#### Testing instructions

Set the "Country / State" in WooCommerce » Settings » General, then initialize the OAuth flow (e.g. with "Reonboard" if using the dev tools plugin), and verify that the proper country is already filled when appropriate.

Can test with:
- non-US supported countries, to verify the country is pre-filled
- US and/or unsupported countries, to verify the same behavior as before

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->