### PR TITLE
Check for storeSettingsSection before toggling code

### DIFF
--- a/client/multi-currency/index.js
+++ b/client/multi-currency/index.js
@@ -32,22 +32,24 @@ const storeSettingsSection = document.querySelector(
 );
 const submitButton = document.querySelector( 'p.submit' );
 
-const toggleSettingsSectionDisplay = () => {
-	const display =
-		1 >= enabledCurrenciesList.children.length ? 'none' : 'block';
-	storeSettingsSection.style.display = display;
-	submitButton.style.display = display;
-};
+if ( storeSettingsSection ) {
+	const toggleSettingsSectionDisplay = () => {
+		const display =
+			1 >= enabledCurrenciesList.children.length ? 'none' : 'block';
+		storeSettingsSection.style.display = display;
+		submitButton.style.display = display;
+	};
 
-const enabledCurrenciesObserver = new MutationObserver(
-	toggleSettingsSectionDisplay
-);
+	const enabledCurrenciesObserver = new MutationObserver(
+		toggleSettingsSectionDisplay
+	);
 
-enabledCurrenciesObserver.observe( enabledCurrenciesList, {
-	childList: true,
-} );
+	enabledCurrenciesObserver.observe( enabledCurrenciesList, {
+		childList: true,
+	} );
 
-toggleSettingsSectionDisplay();
+	toggleSettingsSectionDisplay();
+}
 
 /**
  * Single currency settings


### PR DESCRIPTION
The storeSettingsSection does not exist when viewing the settings for a specific currency, which causes some issues when toggling its display. This commit only runs that code if storeSettingsSection is defined.

Fixes #2243 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that the preview value is displayed correctly and there are no issues with the specific currency settings page

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
