### PR TITLE
Add Jest snap files to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,5 +24,3 @@ trim_trailing_whitespace = false
 trim_trailing_whitespace = false
 indent_style = space
 indent_size = 2
-
-

--- a/.editorconfig
+++ b/.editorconfig
@@ -20,7 +20,9 @@ trim_trailing_whitespace = true
 [*.txt]
 trim_trailing_whitespace = false
 
-[*.{md,json,yml}]
+[*.{md,json,yml,snap}]
 trim_trailing_whitespace = false
 indent_style = space
 indent_size = 2
+
+


### PR DESCRIPTION
This PR provides editorconfig settings for `.snap` files, without this modification, VSCode settings are not enough for preventing the editor to keep trailing whitespace for jest snapshots, which prevents tests from succeeding. 