### PR TITLE
Fix - The "Finish Setup" button just reloads the setup page and doesn't redirect to Stripe onboarding.

### DIFF
--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -97,11 +97,8 @@ const ConnectPageOnboardingDisabled = () => (
 
 const ConnectPageOnboarding = () => {
 	const [ isSubmitted, setSubmitted ] = useState( false );
-	const {
-		availableCountries,
-		country,
-		url: connectUrl,
-	} = wcpaySettings.connect;
+	const { url: connectUrl } = wcpaySettings;
+	const { availableCountries, country } = wcpaySettings.connect;
 
 	const handleLocationCheck = () => {
 		// Reset the 'Set up' button state if merchant decided to stop
@@ -110,8 +107,7 @@ const ConnectPageOnboarding = () => {
 		};
 		// Redirect the merchant if merchant decided to continue
 		const handleModalConfirmed = () => {
-			// The raw URL value has ampersands escaped and we need to unescape them for redirect to happen
-			window.location = connectUrl.replaceAll( '&amp;', '&' );
+			window.location = connectUrl;
 		};
 
 		// Populate translated list of supported countries we want to render in the modal window.

--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -98,7 +98,7 @@ const ConnectPageOnboardingDisabled = () => (
 const ConnectPageOnboarding = () => {
 	const [ isSubmitted, setSubmitted ] = useState( false );
 	const {
-		url: connectUrl,
+		connectUrl,
 		connect: { availableCountries, country },
 	} = wcpaySettings;
 

--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -97,8 +97,10 @@ const ConnectPageOnboardingDisabled = () => (
 
 const ConnectPageOnboarding = () => {
 	const [ isSubmitted, setSubmitted ] = useState( false );
-	const { url: connectUrl } = wcpaySettings;
-	const { availableCountries, country } = wcpaySettings.connect;
+	const {
+		url: connectUrl,
+		connect: { availableCountries, country },
+	} = wcpaySettings;
 
 	const handleLocationCheck = () => {
 		// Reset the 'Set up' button state if merchant decided to stop

--- a/client/connect-account-page/test/index.js
+++ b/client/connect-account-page/test/index.js
@@ -14,7 +14,7 @@ describe( 'ConnectAccountPage', () => {
 	beforeEach( () => {
 		window.location.assign = jest.fn();
 		global.wcpaySettings = {
-			url: '/wcpay-connect-url',
+			connectUrl: '/wcpay-connect-url',
 			connect: {
 				country: 'US',
 				availableCountries: { US: 'United States (US)' },
@@ -35,7 +35,7 @@ describe( 'ConnectAccountPage', () => {
 
 	test( 'should prompt unsupported countries', () => {
 		global.wcpaySettings = {
-			url: '/wcpay-connect-url',
+			connectUrl: '/wcpay-connect-url',
 			connect: {
 				country: 'CA',
 				availableCountries: {

--- a/client/connect-account-page/test/index.js
+++ b/client/connect-account-page/test/index.js
@@ -14,8 +14,8 @@ describe( 'ConnectAccountPage', () => {
 	beforeEach( () => {
 		window.location.assign = jest.fn();
 		global.wcpaySettings = {
+			url: '/wcpay-connect-url',
 			connect: {
-				url: '/wcpay-connect-url',
 				country: 'US',
 				availableCountries: { US: 'United States (US)' },
 			},
@@ -35,8 +35,8 @@ describe( 'ConnectAccountPage', () => {
 
 	test( 'should prompt unsupported countries', () => {
 		global.wcpaySettings = {
+			url: '/wcpay-connect-url',
 			connect: {
-				url: '/wcpay-connect-url',
 				country: 'CA',
 				availableCountries: {
 					GB: 'United Kingdom (UK)',

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -258,7 +258,7 @@ class WC_Payments_Admin {
 		delete_transient( WC_Payments_Account::ERROR_MESSAGE_TRANSIENT );
 
 		$wcpay_settings = [
-			'url'                   => WC_Payments_Account::get_connect_url(),
+			'connectUrl'            => WC_Payments_Account::get_connect_url(),
 			'connect'               => [
 				'country'            => WC()->countries->get_base_country(),
 				'availableCountries' => WC_Payments_Utils::supported_countries(),

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -258,8 +258,8 @@ class WC_Payments_Admin {
 		delete_transient( WC_Payments_Account::ERROR_MESSAGE_TRANSIENT );
 
 		$wcpay_settings = [
+			'url'                   => WC_Payments_Account::get_connect_url(),
 			'connect'               => [
-				'url'                => WC_Payments_Account::get_connect_url(),
 				'country'            => WC()->countries->get_base_country(),
 				'availableCountries' => WC_Payments_Utils::supported_countries(),
 			],


### PR DESCRIPTION
Fixes #2288 

#### Changes proposed in this Pull Request
Fixed the redirecting for finish setup button on connect page.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
- switch to `fix/2288-fix-reload`.
- Now force onboard using the dev plugin and try clicking on finish setup, you should be redirected to stripe.
- Now switch your country to one of the non-supported countries ([see supported countries list](https://github.com/Automattic/woocommerce-payments/blob/add/694-onboarding-store-location-check/includes/class-wc-payments-utils.php#L178)).
- Now when you click on finish setup, a prompt should appear - now click on finish setup on the prompt - you should be redirected to stripe.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
