### PR TITLE
fix: all payment methods icons column display

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -292,6 +292,16 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			// no longer valid options.
 			unset( $this->form_fields['payment_request_button_type']['options']['branded'] );
 			unset( $this->form_fields['payment_request_button_type']['options']['custom'] );
+
+			add_filter(
+				'woocommerce_payment_gateways_setting_columns',
+				[ $this, 'add_all_payment_methods_logos_column' ]
+			);
+
+			add_action(
+				'woocommerce_payment_gateways_setting_column_logos',
+				[ $this, 'add_all_payment_methods_icon_logos' ]
+			);
 		}
 
 		// Giropay option hidden behind feature flag.
@@ -354,21 +364,50 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// Update the current request logged_in cookie after a guest user is created to avoid nonce inconsistencies.
 		add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
+	}
 
-		/**
-		 * Add a new logo column on the right of "method" in the payment methods table.
-		 */
-		add_filter(
-			'woocommerce_payment_gateways_setting_columns',
-			function( $columns ) {
-				$logos  = [ 'logos' => '' ]; // Setting an ID for the column, but not a label.
-				$offset = array_search( 'name', array_keys( $columns ), true ) + 1;
+	/**
+	 * Add a new logo column on the right of "method" in the payment methods table.
+	 *
+	 * @param array $columns the columns in the "all payment methods" page.
+	 * @return array
+	 */
+	public function add_all_payment_methods_logos_column( $columns ) {
+		$logos  = [ 'logos' => '' ]; // Setting an ID for the column, but not a label.
+		$offset = array_search( 'name', array_keys( $columns ), true ) + 1;
 
-				$columns = array_merge( array_slice( $columns, 0, $offset ), $logos, array_slice( $columns, $offset ) );
+		return array_merge( array_slice( $columns, 0, $offset ), $logos, array_slice( $columns, $offset ) );
+	}
 
-				return $columns;
-			}
-		);
+	/**
+	 * Add a list of payment method logos to WooCommerce Payment in the logo column.
+	 *
+	 * @param WC_Payment_Gateway $gateway the current gateway iterated over to be displayed in the "all payment methods" page.
+	 */
+	public function add_all_payment_methods_icon_logos( $gateway ) {
+		if ( 'woocommerce_payments' !== $gateway->id ) {
+			echo '<td class="logo"></td>';
+
+			return;
+		}
+
+		$icons = [
+			'visa',
+			'mastercard',
+			'amex',
+			'apple-pay',
+			'google-pay',
+		];
+
+		echo '<td class="logo">';
+		?>
+		<div>
+			<?php foreach ( $icons as $icon ) : ?>
+				<span class="payment-method__icon payment-method__brand payment-method__brand--<?php echo esc_attr( $icon ); ?>"/></span>
+			<?php endforeach; ?>
+		</div>
+		<?php
+		echo '</td>';
 	}
 
 	/**

--- a/includes/payment-methods/class-cc-payment-gateway.php
+++ b/includes/payment-methods/class-cc-payment-gateway.php
@@ -19,47 +19,4 @@ use WC_Payments_Token_Service;
  * Right now behaves exactly like WC_Payment_Gateway_WCPay for max compatibility.
  */
 class CC_Payment_Gateway extends WC_Payment_Gateway_WCPay {
-	/**
-	 * Constructor same parameters as WC_Payment_Gateway_WCPay constructor.
-	 *
-	 * @param WC_Payments_API_Client               $payments_api_client      - WooCommerce Payments API client.
-	 * @param WC_Payments_Account                  $account                  - Account class instance.
-	 * @param WC_Payments_Customer_Service         $customer_service         - Customer class instance.
-	 * @param WC_Payments_Token_Service            $token_service            - Token class instance.
-	 * @param WC_Payments_Action_Scheduler_Service $action_scheduler_service - Action Scheduler service instance.
-	 */
-	public function __construct( WC_Payments_API_Client $payments_api_client, WC_Payments_Account $account, WC_Payments_Customer_Service $customer_service, WC_Payments_Token_Service $token_service, WC_Payments_Action_Scheduler_Service $action_scheduler_service ) {
-		parent::__construct( $payments_api_client, $account, $customer_service, $token_service, $action_scheduler_service );
-
-		/**
-		 * Add a list of payment method logos to WooCommerce Payment in the logo column.
-		 */
-		add_action(
-			'woocommerce_payment_gateways_setting_column_logos',
-			function( $gateway ) {
-				if ( 'woocommerce_payments' !== $gateway->id ) {
-					echo '<td class="logo"></td>';
-					return;
-				}
-
-				$icons = [
-					'visa',
-					'mastercard',
-					'amex',
-					'apple-pay',
-					'google-pay',
-				];
-
-				echo '<td class="logo">';
-				?>
-					<div>
-						<?php foreach ( $icons as $icon ) : ?>
-							<span class="payment-method__icon payment-method__brand payment-method__brand--<?php echo esc_attr( $icon ); ?>"/></span>
-						<?php endforeach; ?>
-					</div>
-					<?php
-					echo '</td>';
-			}
-		);
-	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/2298

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Fixes the columns being displayed in the "all payment methods" section when WC Subscriptions is activated

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section
- Notice changes with/without [WC subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/) active (plugin needs to be _active_

Before changes (without WC subscriptions):
![Screen Shot 2021-06-22 at 1 33 20 PM](https://user-images.githubusercontent.com/273592/122981785-bfe8f000-d35f-11eb-9da4-d5ad8a606800.png)

Before changes (with WC subscriptions):
![Screen Shot 2021-06-22 at 1 35 05 PM](https://user-images.githubusercontent.com/273592/122981808-c70ffe00-d35f-11eb-8e6a-09e70dc11778.png)

After changes (without WC subscriptions):
![Screen Shot 2021-06-22 at 1 33 45 PM](https://user-images.githubusercontent.com/273592/122981836-cf683900-d35f-11eb-9826-8f27893b92d7.png)

After changes (with WC subscriptions):
![Screen Shot 2021-06-22 at 1 34 45 PM](https://user-images.githubusercontent.com/273592/122981870-d727dd80-d35f-11eb-8b99-62192145bc7a.png)


-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
