### PR TITLE
Update/2071 only show redbadge 7 days after plugin activation

### DIFF
--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -227,14 +227,7 @@ class WC_Payments_Admin {
 			WC_Payments::get_file_version( 'assets/css/admin.css' )
 		);
 
-		// Temporarily don't show the badge at all. This should be removed
-		// when implementing https://github.com/automattic/woocommerce-payments/issues/2071.
-		// There are also unit tests that need to be re-enabled in
-		// tests/unit/admin/test-class-wc-payments-admin.php.
-		if ( true === false ) {
-			$this->add_menu_notification_badge();
-		}
-
+		$this->add_menu_notification_badge();
 		$this->add_update_business_details_task();
 	}
 
@@ -532,6 +525,12 @@ class WC_Payments_Admin {
 	public function add_menu_notification_badge() {
 		global $menu;
 		if ( 'yes' === get_option( 'wcpay_menu_badge_hidden', 'no' ) ) {
+			return;
+		}
+
+		// If plugin activation date is less than 7 days, do not show the badge.
+		$past_7_days = time() - get_option( 'wcpay_activation_timestamp', 0 ) >= WEEK_IN_SECONDS;
+		if ( false === $past_7_days ) {
 			return;
 		}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -262,6 +262,7 @@ class WC_Payments {
 		}
 
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );
+		add_action( 'woocommerce_woocommerce_payments_updated', [ __CLASS__, 'set_plugin_activation_timestamp' ] );
 	}
 
 	/**
@@ -776,7 +777,6 @@ class WC_Payments {
 		if ( version_compare( WCPAY_VERSION_NUMBER, get_option( 'woocommerce_woocommerce_payments_version' ), '>' ) ) {
 			do_action( 'woocommerce_woocommerce_payments_updated' );
 			self::update_plugin_version();
-			self::set_plugin_activation_timestamp();
 		}
 	}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -776,6 +776,7 @@ class WC_Payments {
 		if ( version_compare( WCPAY_VERSION_NUMBER, get_option( 'woocommerce_woocommerce_payments_version' ), '>' ) ) {
 			do_action( 'woocommerce_woocommerce_payments_updated' );
 			self::update_plugin_version();
+			self::set_plugin_activation_timestamp();
 		}
 	}
 
@@ -784,6 +785,15 @@ class WC_Payments {
 	 */
 	public static function update_plugin_version() {
 		update_option( 'woocommerce_woocommerce_payments_version', WCPAY_VERSION_NUMBER );
+	}
+
+	/**
+	 * Sets the plugin activation timestamp.
+	 *
+	 * Use add_option so that we don't overwrite the value.
+	 */
+	public static function set_plugin_activation_timestamp() {
+		add_option( 'wcpay_activation_timestamp', time() );
 	}
 
 	/**

--- a/tests/unit/admin/test-class-wc-payments-admin.php
+++ b/tests/unit/admin/test-class-wc-payments-admin.php
@@ -92,16 +92,11 @@ class WC_Payments_Admin_Test extends WP_UnitTestCase {
 
 	public function test_it_renders_payments_badge_if_stripe_is_not_connected() {
 		global $menu;
-
-		// The badge is temporarily not shown at all. See
-		// class-wc-payments-admin.php line 227. This should be removed when
-		// implementing https://github.com/automattic/woocommerce-payments/issues/2071.
-		static::markTestSkipped( 'Not yet implemented.' );
-
 		$this->mock_current_user_is_admin();
 
 		// Make sure we render the menu with submenu items.
 		$this->mock_account->method( 'try_is_stripe_connected' )->willReturn( false );
+		update_option( 'wcpay_activation_timestamp', time() - ( 86400 * 7 ) );
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls = wp_list_pluck( $menu, 0, 2 );
@@ -111,12 +106,6 @@ class WC_Payments_Admin_Test extends WP_UnitTestCase {
 
 	public function test_it_does_not_render_payments_badge_if_stripe_is_connected() {
 		global $menu;
-
-		// The badge is temporarily not shown at all. See
-		// class-wc-payments-admin.php line 227. This should be removed when
-		// implementing https://github.com/automattic/woocommerce-payments/issues/2071.
-		static::markTestSkipped( 'Not yet implemented.' );
-
 		$this->mock_current_user_is_admin();
 
 		// Make sure we render the menu with submenu items.
@@ -126,6 +115,35 @@ class WC_Payments_Admin_Test extends WP_UnitTestCase {
 		$item_names_by_urls = wp_list_pluck( $menu, 0, 2 );
 		$this->assertEquals( 'Payments', $item_names_by_urls['wc-admin&path=/payments/overview'] );
 		$this->assertArrayNotHasKey( 'wc-admin&path=/payments/connect', $item_names_by_urls );
+	}
+
+	public function test_it_renders_payments_badge_if_activation_date_is_older_than_7_days() {
+		global $menu;
+		$this->mock_current_user_is_admin();
+
+		// Make sure we render the menu with submenu items.
+		$this->mock_account->method( 'try_is_stripe_connected' )->willReturn( false );
+		update_option( 'wcpay_activation_timestamp', time() - ( 86400 * 7 ) );
+		$this->payments_admin->add_payments_menu();
+
+		$item_names_by_urls = wp_list_pluck( $menu, 0, 2 );
+		$this->assertEquals( 'Payments' . WC_Payments_Admin::MENU_NOTIFICATION_BADGE, $item_names_by_urls['wc-admin&path=/payments/connect'] );
+		$this->assertArrayNotHasKey( 'wc-admin&path=/payments/overview', $item_names_by_urls );
+	}
+
+	public function test_it_does_not_render_payments_badge_if_activation_date_is_less_than_7_days() {
+		global $menu;
+		$this->mock_current_user_is_admin();
+
+		// Make sure we render the menu with submenu items.
+		$this->mock_account->method( 'try_is_stripe_connected' )->willReturn( false );
+		update_option( 'wcpay_menu_badge_hidden', 'no' );
+		update_option( 'wcpay_activation_timestamp', time() - ( 86400 * 6 ) );
+		$this->payments_admin->add_payments_menu();
+
+		$item_names_by_urls = wp_list_pluck( $menu, 0, 2 );
+		$this->assertEquals( 'Payments', $item_names_by_urls['wc-admin&path=/payments/connect'] );
+		$this->assertArrayNotHasKey( 'wc-admin&path=/payments/overview', $item_names_by_urls );
 	}
 
 	public function feature_flag_combinations_not_causing_settings_badge_render_provider() {

--- a/tests/unit/admin/test-class-wc-payments-admin.php
+++ b/tests/unit/admin/test-class-wc-payments-admin.php
@@ -90,20 +90,6 @@ class WC_Payments_Admin_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'Settings', $settings_item_name );
 	}
 
-	public function test_it_renders_payments_badge_if_stripe_is_not_connected() {
-		global $menu;
-		$this->mock_current_user_is_admin();
-
-		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'try_is_stripe_connected' )->willReturn( false );
-		update_option( 'wcpay_activation_timestamp', time() - ( 86400 * 7 ) );
-		$this->payments_admin->add_payments_menu();
-
-		$item_names_by_urls = wp_list_pluck( $menu, 0, 2 );
-		$this->assertEquals( 'Payments' . WC_Payments_Admin::MENU_NOTIFICATION_BADGE, $item_names_by_urls['wc-admin&path=/payments/connect'] );
-		$this->assertArrayNotHasKey( 'wc-admin&path=/payments/overview', $item_names_by_urls );
-	}
-
 	public function test_it_does_not_render_payments_badge_if_stripe_is_connected() {
 		global $menu;
 		$this->mock_current_user_is_admin();
@@ -117,13 +103,13 @@ class WC_Payments_Admin_Test extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'wc-admin&path=/payments/connect', $item_names_by_urls );
 	}
 
-	public function test_it_renders_payments_badge_if_activation_date_is_older_than_7_days() {
+	public function test_it_renders_payments_badge_if_activation_date_is_older_than_7_days_and_stripe_is_not_connected() {
 		global $menu;
 		$this->mock_current_user_is_admin();
 
 		// Make sure we render the menu with submenu items.
 		$this->mock_account->method( 'try_is_stripe_connected' )->willReturn( false );
-		update_option( 'wcpay_activation_timestamp', time() - ( 86400 * 7 ) );
+		update_option( 'wcpay_activation_timestamp', time() - WEEK_IN_SECONDS );
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls = wp_list_pluck( $menu, 0, 2 );
@@ -138,7 +124,7 @@ class WC_Payments_Admin_Test extends WP_UnitTestCase {
 		// Make sure we render the menu with submenu items.
 		$this->mock_account->method( 'try_is_stripe_connected' )->willReturn( false );
 		update_option( 'wcpay_menu_badge_hidden', 'no' );
-		update_option( 'wcpay_activation_timestamp', time() - ( 86400 * 6 ) );
+		update_option( 'wcpay_activation_timestamp', time() - ( DAY_IN_SECONDS * 6 ) );
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls = wp_list_pluck( $menu, 0, 2 );


### PR DESCRIPTION
Fixes #2071 

This PR adds changes to show the notification badge 7 days after the plugin activation timestamp. I've added `wcpay_activation_timestamp` option to track the initial activation date.


#### Testing instructions

Make sure you haven't connected WC Payments to Stripe and `wcpay_menu_badge_hidden` option is set to `no`.

1. Update the existing `woocommerce_woocommerce_payments_version` value to something lower. If you have `2.6.0`, change it to `2.5.0`.
2. Navigate to the admin area.
2. Confirm that the `wcpay_activation_timestamp` has been created in `wp_options` table. 
3. Navigate to the admin area and confirm the notification badge isn't shown. 
4. Execute `update wp_options set option_value = option_value - (86400 * 7) where option_name = 'wcpay_activation_timestamp'` to make the activation timestamp to -7 days.
6. Navigate to the admin area again. The notification badge should be rendered.


#### Screenshots

![Screen Shot 2021-06-23 at 4 26 12 PM](https://user-images.githubusercontent.com/4723145/123180270-d0709780-d43f-11eb-90c1-21456ba0c3e9.jpg)

