### PR TITLE
Add notification on store currency change

### DIFF
--- a/includes/multi-currency/AdminNotices.php
+++ b/includes/multi-currency/AdminNotices.php
@@ -1,18 +1,18 @@
 <?php
 /**
- * Class Admin_Notices
+ * Admin notices for Multi-Currency.
  *
- * @package WooCommerce\Payments\Multi_Currency
+ * @package WooCommerce\Payments\MultiCurrency
  */
 
-namespace WCPay\Multi_Currency;
+namespace WCPay\MultiCurrency;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Class that will display admin notices.
  */
-class Admin_Notices {
+class AdminNotices {
 	/**
 	 * Notices.
 	 *

--- a/includes/multi-currency/AdminNotices.php
+++ b/includes/multi-currency/AdminNotices.php
@@ -38,7 +38,7 @@ class AdminNotices {
 
 		$this->check_for_notices();
 
-		foreach ( (array) $this->notices as $notice_key => $notice ) {
+		foreach ( $this->notices as $notice_key => $notice ) {
 			echo '<div class="' . esc_attr( $notice['class'] ) . '" style="position:relative;">';
 
 			if ( $notice['dismissible'] ) {
@@ -76,9 +76,8 @@ class AdminNotices {
 
 			$notice = wc_clean( wp_unslash( $_GET['wcpay-multi-currency-hide-notice'] ) );
 
-			switch ( $notice ) {
-				case 'currency_changed':
-					update_option( 'wcpay_multi_currency_show_store_currency_changed_notice', 'no' );
+			if ( 'currency_changed' === $notice ) {
+				update_option( 'wcpay_multi_currency_show_store_currency_changed_notice', 'no' );
 			}
 		}
 	}

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -132,8 +132,10 @@ class MultiCurrency {
 		$this->initialize_available_currencies();
 		$this->set_default_currency();
 		$this->initialize_enabled_currencies();
+		$this->check_store_currency_for_change();
 
-		new UserSettings( $this );
+		new Admin_Notices();
+		new User_Settings( $this );
 
 		$this->frontend_prices     = new FrontendPrices( $this, $this->compatibility );
 		$this->frontend_currencies = new FrontendCurrencies( $this, $this->utils );
@@ -580,6 +582,24 @@ class MultiCurrency {
 	}
 
 	/**
+<<<<<<< HEAD:includes/multi-currency/MultiCurrency.php
+=======
+	 * Include required core files used in admin and on the frontend.
+	 */
+	protected function includes() {
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-admin-notices.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-compatibility.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-currency.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-currency-switcher-widget.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-country-flags.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-prices.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-currencies.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-user-settings.php';
+		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-utils.php';
+	}
+
+	/**
+>>>>>>> ee6a7490 (Added Admin_Notices class to handle displaying admin notices. Created notice if store currency is changed and enabled currencies have manual rates.):includes/multi-currency/class-multi-currency.php
 	 * Caches currency data for a period of time.
 	 *
 	 * @param string|array $currencies - Currency data to cache.
@@ -614,6 +634,32 @@ class MultiCurrency {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Checks to see if the store currency has changed and puts any manual rate currencies into an option for a notice to display.
+	 */
+	private function check_store_currency_for_change() {
+		$last_known_currency  = get_option( $this->id . '_store_currency', false );
+		$woocommerce_currency = get_woocommerce_currency();
+		$manual_currencies    = [];
+		if ( $last_known_currency && $last_known_currency !== $woocommerce_currency ) {
+			$enabled_currencies = $this->get_enabled_currencies();
+
+			// Check enabled currencies for manual rates.
+			foreach ( $enabled_currencies as $currency ) {
+				$rate_type = get_option( $this->id . '_exchange_rate_' . $currency->get_id(), false );
+				if ( 'manual' === $rate_type ) {
+					$manual_currencies[] = $currency->get_name();
+				}
+			}
+
+			if ( 0 < count( $manual_currencies ) ) {
+				update_option( $this->id . '_show_store_currency_changed_notice', $manual_currencies );
+			}
+		}
+
+		update_option( $this->id . '_store_currency', $woocommerce_currency );
 	}
 
 	/**

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -624,7 +624,12 @@ class MultiCurrency {
 	private function check_store_currency_for_change() {
 		$last_known_currency  = get_option( $this->id . '_store_currency', false );
 		$woocommerce_currency = get_woocommerce_currency();
-		if ( $last_known_currency && $last_known_currency !== $woocommerce_currency ) {
+		if ( ! $last_known_currency ) {
+			update_option( $this->id . '_store_currency', $woocommerce_currency );
+			return;
+		}
+
+		if ( $last_known_currency !== $woocommerce_currency ) {
 			$enabled_currencies = $this->get_enabled_currencies();
 			$manual_currencies  = [];
 
@@ -639,9 +644,8 @@ class MultiCurrency {
 			if ( 0 < count( $manual_currencies ) ) {
 				update_option( $this->id . '_show_store_currency_changed_notice', $manual_currencies );
 			}
+			update_option( $this->id . '_store_currency', $woocommerce_currency );
 		}
-
-		update_option( $this->id . '_store_currency', $woocommerce_currency );
 	}
 
 	/**

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -642,9 +642,9 @@ class MultiCurrency {
 	private function check_store_currency_for_change() {
 		$last_known_currency  = get_option( $this->id . '_store_currency', false );
 		$woocommerce_currency = get_woocommerce_currency();
-		$manual_currencies    = [];
 		if ( $last_known_currency && $last_known_currency !== $woocommerce_currency ) {
 			$enabled_currencies = $this->get_enabled_currencies();
+			$manual_currencies  = [];
 
 			// Check enabled currencies for manual rates.
 			foreach ( $enabled_currencies as $currency ) {

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -134,8 +134,8 @@ class MultiCurrency {
 		$this->initialize_enabled_currencies();
 		$this->check_store_currency_for_change();
 
-		new Admin_Notices();
-		new User_Settings( $this );
+		new AdminNotices();
+		new UserSettings( $this );
 
 		$this->frontend_prices     = new FrontendPrices( $this, $this->compatibility );
 		$this->frontend_currencies = new FrontendCurrencies( $this, $this->utils );
@@ -582,24 +582,6 @@ class MultiCurrency {
 	}
 
 	/**
-<<<<<<< HEAD:includes/multi-currency/MultiCurrency.php
-=======
-	 * Include required core files used in admin and on the frontend.
-	 */
-	protected function includes() {
-		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-admin-notices.php';
-		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-compatibility.php';
-		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-currency.php';
-		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-currency-switcher-widget.php';
-		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-country-flags.php';
-		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-prices.php';
-		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-frontend-currencies.php';
-		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-user-settings.php';
-		include_once WCPAY_ABSPATH . 'includes/multi-currency/class-utils.php';
-	}
-
-	/**
->>>>>>> ee6a7490 (Added Admin_Notices class to handle displaying admin notices. Created notice if store currency is changed and enabled currencies have manual rates.):includes/multi-currency/class-multi-currency.php
 	 * Caches currency data for a period of time.
 	 *
 	 * @param string|array $currencies - Currency data to cache.

--- a/includes/multi-currency/class-admin-notices.php
+++ b/includes/multi-currency/class-admin-notices.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Class Admin_Notices
+ *
+ * @package WooCommerce\Payments\Multi_Currency
+ */
+
+namespace WCPay\Multi_Currency;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class that will display admin notices.
+ */
+class Admin_Notices {
+	/**
+	 * Notices.
+	 *
+	 * @var array
+	 */
+	private $notices = [];
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_action( 'admin_notices', [ $this, 'admin_notices' ] );
+		add_action( 'wp_loaded', [ $this, 'hide_notices' ] );
+	}
+
+	/**
+	 * Display any notices we've collected thus far.
+	 */
+	public function admin_notices() {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
+		$this->check_for_notices();
+
+		foreach ( (array) $this->notices as $notice_key => $notice ) {
+			echo '<div class="' . esc_attr( $notice['class'] ) . '" style="position:relative;">';
+
+			if ( $notice['dismissible'] ) {
+				?>
+				<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wcpay-multi-currency-hide-notice', $notice_key ), 'wcpay_multi_currency_hide_notices_nonce', '_wcpay_multi_currency_notice_nonce' ) ); ?>" class="woocommerce-message-close notice-dismiss" style="position:relative;float:right;padding:9px 0px 9px 9px 9px;text-decoration:none;"></a>
+				<?php
+			}
+
+			echo '<p>';
+			echo wp_kses(
+				$notice['message'],
+				[
+					'a' => [
+						'href'   => [],
+						'target' => [],
+					],
+				]
+			);
+			echo '</p></div>';
+		}
+	}
+
+	/**
+	 * Hides any admin notices.
+	 */
+	public function hide_notices() {
+		if ( isset( $_GET['wcpay-multi-currency-hide-notice'] ) && isset( $_GET['_wcpay_multi_currency_notice_nonce'] ) ) {
+			if ( ! wp_verify_nonce( wc_clean( wp_unslash( $_GET['_wcpay_multi_currency_notice_nonce'] ) ), 'wcpay_multi_currency_hide_notices_nonce' ) ) {
+				wp_die( esc_html__( 'Action failed. Please refresh the page and retry.', 'woocommerce-payments' ) );
+			}
+
+			if ( ! current_user_can( 'manage_woocommerce' ) ) {
+				wp_die( esc_html__( 'Cheatin&#8217; huh?', 'woocommerce-payments' ) );
+			}
+
+			$notice = wc_clean( wp_unslash( $_GET['wcpay-multi-currency-hide-notice'] ) );
+
+			switch ( $notice ) {
+				case 'currency_changed':
+					update_option( 'wcpay_multi_currency_show_store_currency_changed_notice', 'no' );
+			}
+		}
+	}
+
+	/**
+	 * Adds admin notice to be displayed.
+	 *
+	 * @param string $slug        Slug for the notice.
+	 * @param string $class       Class(es) for the notice.
+	 * @param string $message     Message in the notice.
+	 * @param bool   $dismissible Whether the notice can be dismissed or not.
+	 */
+	private function add_admin_notice( $slug, $class, $message, $dismissible = false ) {
+		$this->notices[ $slug ] = [
+			'class'       => $class,
+			'message'     => $message,
+			'dismissible' => $dismissible,
+		];
+	}
+
+	/**
+	 * Checks for notices and add them.
+	 */
+	private function check_for_notices() {
+		$manual_currencies = get_option( 'wcpay_multi_currency_show_store_currency_changed_notice', false );
+
+		if ( is_array( $manual_currencies ) ) {
+			$currencies = implode( ', ', $manual_currencies );
+			// translators: %s List of currencies that are already translated in WooCommerce core.
+			$this->add_admin_notice( 'currency_changed', 'notice notice-warning', sprintf( __( 'The store currency was recently changed. The following currencies are set to manual rates and may need updates: %s', 'woocommerce-payments' ), $currencies ), true );
+		}
+	}
+}

--- a/tests/unit/multi-currency/test-class-admin-notices.php
+++ b/tests/unit/multi-currency/test-class-admin-notices.php
@@ -6,13 +6,13 @@
  */
 
 /**
- * WCPay\Multi_Currency\Admin_Notices unit tests.
+ * WCPay\MultiCurrency\AdminNotices unit tests.
  */
 class WCPay_Multi_Currency_Admin_Notices_Tests extends WP_UnitTestCase {
 	/**
-	 * WCPay\Multi_Currency\Admin_Notices instance.
+	 * WCPay\MultiCurrency\AdminNotices instance.
 	 *
-	 * @var WCPay\Multi_Currency\Admin_Notices
+	 * @var WCPay\MultiCurrency\AdminNotices
 	 */
 	private $admin_notices;
 
@@ -22,7 +22,7 @@ class WCPay_Multi_Currency_Admin_Notices_Tests extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->admin_notices = new WCPay\Multi_Currency\Admin_Notices();
+		$this->admin_notices = new WCPay\MultiCurrency\AdminNotices();
 	}
 
 	public function test_admin_notices_displays_currency_changed_notice() {

--- a/tests/unit/multi-currency/test-class-admin-notices.php
+++ b/tests/unit/multi-currency/test-class-admin-notices.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Class WCPay_Multi_Currency_Admin_Notices_Tests
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * WCPay\Multi_Currency\Admin_Notices unit tests.
+ */
+class WCPay_Multi_Currency_Admin_Notices_Tests extends WP_UnitTestCase {
+	/**
+	 * WCPay\Multi_Currency\Admin_Notices instance.
+	 *
+	 * @var WCPay\Multi_Currency\Admin_Notices
+	 */
+	private $admin_notices;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->admin_notices = new WCPay\Multi_Currency\Admin_Notices();
+	}
+
+	public function test_admin_notices_displays_currency_changed_notice() {
+		wp_set_current_user( 1 );
+
+		$currencies = [ 'Canadian dollar', 'Euro', 'Monopoly money' ];
+		update_option( 'wcpay_multi_currency_show_store_currency_changed_notice', $currencies );
+		$regex = '/The following currencies are set to manual rates and may need updates: Canadian dollar, Euro, Monopoly money/';
+
+		$this->admin_notices->admin_notices();
+		$this->expectOutputRegex( $regex );
+	}
+
+	public function test_admin_notices_hides_currency_changed_notice() {
+		wp_set_current_user( 1 );
+
+		$currencies = [ 'Canadian dollar', 'Euro', 'Monopoly money' ];
+		update_option( 'wcpay_multi_currency_show_store_currency_changed_notice', $currencies );
+		$_GET['_wcpay_multi_currency_notice_nonce'] = wp_create_nonce( 'wcpay_multi_currency_hide_notices_nonce' );
+		$_GET['wcpay-multi-currency-hide-notice']   = 'currency_changed';
+
+		$this->admin_notices->hide_notices();
+		$this->admin_notices->admin_notices();
+		$this->expectOutputString( '' );
+	}
+}


### PR DESCRIPTION
Fixes #2075

#### Changes proposed in this Pull Request

* Add `Admin_Notices` class that allows admin notices to be added through adding/checking options in the `wp_options` table.
* Add tests for `Admin_Notices`.
* Add `check_store_currency_for_change` method in `Multi_Currency` that checks to see if the store currency has been changed. If it has been changed, it checks for any enabled currencies that have manual rates and adds those currencies to the option in the database. ...which then triggers a notice.

#### Testing instructions

* Navigate to WooCommerce > Settings > Multi-Currency.
* Add one or more additional currencies.
* Edit the additional currencies and update them to have manual rates, and save.
* Navigate to WooCommerce > Settings > General.
* Update the store currency and save.
* Notice should appear.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
