### PR TITLE
Move completed task to the bottom

### DIFF
--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -16,7 +16,7 @@ import { TestModeNotice, topics } from 'components/test-mode-notice';
 import AccountStatus from 'components/account-status';
 import DepositsInformation from 'components/deposits-information';
 import TaskList from './task-list';
-import { getTasks } from './task-list/tasks';
+import { getTasks, taskSort } from './task-list/tasks';
 import InboxNotifications from './inbox-notifications';
 import { useDisputes } from 'data';
 
@@ -32,12 +32,14 @@ const OverviewPage = () => {
 	} = wcpaySettings;
 	const { disputes, isLoading } = useDisputes( getQuery() );
 
-	const tasks = getTasks( {
+	const tasksUnsorted = getTasks( {
 		accountStatus,
 		showUpdateDetailsTask,
 		wpcomReconnectUrl,
 		disputes,
 	} );
+	const tasks =
+		Array.isArray( tasksUnsorted ) && tasksUnsorted.sort( taskSort );
 	const queryParams = getQuery();
 
 	const showKycSuccessNotice =

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -131,3 +131,16 @@ export const getTasks = ( {
 		...disputesToResolve,
 	].filter( Boolean );
 };
+
+export const taskSort = ( a, b ) => {
+	if ( a.completed || b.completed ) {
+		return a.completed ? 1 : -1;
+	}
+	// Three is the lowest level.
+	const aLevel = a.level || 3;
+	const bLevel = b.level || 3;
+	if ( aLevel === bLevel ) {
+		return 0;
+	}
+	return aLevel > bLevel ? 1 : -1;
+};

--- a/client/overview/task-list/test/tasks.js
+++ b/client/overview/task-list/test/tasks.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { getTasks } from '../tasks';
+import { getTasks, taskSort } from '../tasks';
 
 jest.mock( 'utils/currency', () => {
 	return {
@@ -178,6 +178,53 @@ describe( 'getTasks()', () => {
 					level: 3,
 				} ),
 			] )
+		);
+	} );
+} );
+
+describe( 'taskSort()', () => {
+	it( 'should sort the tasks', () => {
+		/*eslint-disable camelcase*/
+		const disputes = [
+			{
+				id: 123,
+				amount: 10,
+				currency: 'USD',
+				evidence_details: { due_by: 1624147199 },
+				status: 'won',
+			},
+			{
+				id: 456,
+				amount: 10,
+				currency: 'USD',
+				evidence_details: { due_by: 1624147199 },
+				status: 'needs_response',
+			},
+		];
+		/*eslint-enable camelcase*/
+		const unsortedTasks = getTasks( {
+			accountStatus: {
+				status: 'restricted_soon',
+				currentDeadline: 1620857083,
+				pastDue: false,
+				accountLink: 'http://example.com',
+			},
+			disputes,
+		} );
+		expect( unsortedTasks[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				key: 'dispute-resolution-123',
+				completed: true,
+				level: 3,
+			} )
+		);
+		const sortedTasks = unsortedTasks.sort( taskSort );
+		expect( sortedTasks[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				key: 'dispute-resolution-456',
+				completed: false,
+				level: 3,
+			} )
 		);
 	} );
 } );


### PR DESCRIPTION
Fixes #2238

#### Changes proposed in this Pull Request

As a follow-up of [PR 2148](https://github.com/Automattic/woocommerce-payments/pull/2148), this adds the code necessary to move the completed tasks to the bottom of the task list.


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a dispute. You can do it by buying a product with one of the [Stripe test disputes cards](https://stripe.com/docs/testing#disputes) (E.g.: `4000000000001976` use any date in the future and fill out `CVC` with any number).
* Verify that the information displayed on the card is correct.
* Create another dispute and verify that the new dispute is also visible as a new dispute resolution task.
*  Click on the first dispute card. You should be redirected to the dispute's overview screen.
* On the `Dispute overview` screen press `Accept dispute`.
* That dispute should be shown as completed at the bottom of the list.

![screenshot-fermarichal jurassic tube-2021 06 28-17_09_01](https://user-images.githubusercontent.com/1314156/123697871-cbdb2300-d833-11eb-8b24-8b27b6f6da94.png)


-------------------

- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
