### PR TITLE
Update inbox note filter to handle source arg as array

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -602,7 +602,7 @@ class WC_Payments {
 	 * @return string Modified where clause.
 	 */
 	public static function possibly_add_note_source_where_clause( $where_clauses, $args ) {
-		if ( isset( $args['source'] ) && ! empty( $args['source'] ) && false === strpos( $where_clauses, 'AND source IN' ) ) {
+		if ( ! empty( $args['source'] ) && false === strpos( $where_clauses, 'AND source IN' ) ) {
 			$where_source_array = [];
 			foreach ( $args['source'] as $args_type ) {
 				$args_type            = trim( $args_type );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -581,11 +581,10 @@ class WC_Payments {
 	 */
 	public static function possibly_add_source_to_notes_query( $args, $request ) {
 		if ( isset( $request['source'] ) && ! isset( $args['source'] ) ) {
-			$args['source'] = 'woocommerce-payments';
 			return array_merge(
 				$args,
 				[
-					'source' => $request['source'],
+					'source' => wp_parse_list( $request['source'] ),
 				]
 			);
 		}
@@ -603,8 +602,13 @@ class WC_Payments {
 	 * @return string Modified where clause.
 	 */
 	public static function possibly_add_note_source_where_clause( $where_clauses, $args ) {
-		if ( isset( $args['source'] ) && false === strpos( $where_clauses, 'AND source IN' ) ) {
-			$escaped_where_source = sprintf( "'%s'", esc_sql( $args['source'] ) );
+		if ( isset( $args['source'] ) && ! empty( $args['source'] ) && false === strpos( $where_clauses, 'AND source IN' ) ) {
+			$where_source_array = [];
+			foreach ( $args['source'] as $args_type ) {
+				$args_type            = trim( $args_type );
+				$where_source_array[] = "'" . esc_sql( $args_type ) . "'";
+			}
+			$escaped_where_source = implode( ',', $where_source_array );
 			$where_clauses       .= " AND source IN ($escaped_where_source)";
 		}
 		return $where_clauses;

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 2.7.0 - 2021-xx-xx =
 * Fix - WooCommerce Payments admin pages redirect to the onboarding page when the WooCommerce Payments account is disconnected.
+* Fix - Updates the notes query filters to prevent breaking the WooCommerce > Home inbox.
 
 = 2.6.0 - 2021-06-23 =
 * Add - Notify the admin if WordPress.com user connection is broken.


### PR DESCRIPTION
Fixes #2330 

#### Changes proposed in this Pull Request

This updates the notes query filters to support the `source` param as an array versus a string.

In WC Admin 2.4 (not yet released) the source param is supported as a valid query param for retrieving notes. It handles the `source` param as an array, when we were expected a string. This caused us to always add a `AND source IN ()` where clause, which broke the WC Admin home screen.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- Install WooCommerce and [WooCommerce Admin 2.4](https://github.com/woocommerce/woocommerce-admin/releases/tag/v2.4.0) and the latest of WC Payments
- Finish the onboarding flow and navigate to WooCommerce > Home
- The notes should be displayed and not be empty (there are usually at-least 3-4 notes or more)
- Go to **Payments > Overview**
- See if it correctly display's 2 notes (Force secure checkout, and Set up refund policy).
- Disable WooCommerce Admin 2.4 (so it uses our source query logic)
- Go to WooCommerce > Home
- The notes should be displayed and not be empty (there are usually at-least 3-4 notes or more)
- Go to **Payments > Overview**
- See if it correctly display's 2 notes (Force secure checkout, and Set up refund policy).

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
