### PR TITLE
Improve webpack build time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9819,6 +9819,12 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "buffer-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-json/-/buffer-json-2.0.0.tgz",
+      "integrity": "sha512-+jjPFVqyfF1esi9fvfUs3NqM0pH1ziZ36VP4hmA/y/Ssfo/5w5xHKfTw9BwQjoJ1w/oVtpLomqwUHKdefGyuHw==",
+      "dev": true
+    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -9923,6 +9929,53 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
+      }
+    },
+    "cache-loader": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cache-loader/-/cache-loader-4.1.0.tgz",
+      "integrity": "sha512-ftOayxve0PwKzBF/GLsZNC9fJBXl8lkZE3TOsjkboHfVHVkL39iUEs1FO07A33mizmci5Dudt38UZrrYXDtbhw==",
+      "dev": true,
+      "requires": {
+        "buffer-json": "^2.0.0",
+        "find-cache-dir": "^3.0.0",
+        "loader-utils": "^1.2.3",
+        "mkdirp": "^0.5.1",
+        "neo-async": "^2.6.1",
+        "schema-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "schema-utils": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+          "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.5",
+            "ajv": "^6.12.4",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
       }
     },
     "call-bind": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8101,6 +8101,17 @@
             "minimatch": "^3.0.4"
           }
         },
+        "thread-loader": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.3.tgz",
+          "integrity": "sha512-wNrVKH2Lcf8ZrWxDF/khdlLlsTMczdcwPA9VEK4c2exlEPynYWxi9op3nPTo5lAnDIkE0rQEB3VBP+4Zncc9Hg==",
+          "dev": true,
+          "requires": {
+            "loader-runner": "^2.3.1",
+            "loader-utils": "^1.1.0",
+            "neo-async": "^2.6.0"
+          }
+        },
         "throat": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
@@ -23137,35 +23148,23 @@
       "dev": true
     },
     "thread-loader": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.3.tgz",
-      "integrity": "sha512-wNrVKH2Lcf8ZrWxDF/khdlLlsTMczdcwPA9VEK4c2exlEPynYWxi9op3nPTo5lAnDIkE0rQEB3VBP+4Zncc9Hg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-3.0.4.tgz",
+      "integrity": "sha512-ByaL2TPb+m6yArpqQUZvP+5S1mZtXsEP7nWKKlAUTm7fCml8kB5s1uI3+eHRP2bk5mVYfRSBI7FFf+tWEyLZwA==",
       "dev": true,
       "requires": {
-        "loader-runner": "^2.3.1",
-        "loader-utils": "^1.1.0",
-        "neo-async": "^2.6.0"
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^4.1.0",
+        "loader-utils": "^2.0.0",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.0.0"
       },
       "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "loader-utils": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^1.0.1"
-          }
+        "loader-runner": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
+          "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@wordpress/scripts": "12.4.0",
     "archiver": "5.2.0",
     "babel-loader": "8.2.2",
+    "cache-loader": "^4.1.0",
     "classnames": "^2.3.1",
     "colors": "1.4.0",
     "config": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "stylelint": "13.11.0",
     "stylelint-config-prettier": "8.0.2",
     "stylelint-config-wordpress": "17.0.0",
+    "thread-loader": "^3.0.4",
     "ts-jest": "26.5.1",
     "ts-loader": "^8.0.17",
     "typescript": "4.1.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ const WordPressExternalDependenciesPlugin = require( '@wordpress/dependency-extr
 
 const webpackConfig = {
 	mode: NODE_ENV,
-	devtool: process.env.SOURCEMAP === 'none' ? undefined : 'source-map',
+	devtool: process.env.SOURCEMAP === 'none' ? undefined : 'eval-source-map',
 	entry: {
 		index: './client/index.js',
 		settings: './client/settings/index.js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,18 +30,19 @@ const webpackConfig = {
 		rules: [
 			{
 				test: /\.tsx?$/,
-				use: [ 'babel-loader', 'ts-loader' ],
+				use: [ 'cache-loader', 'babel-loader', 'ts-loader' ],
 				exclude: /node_modules/,
 			},
 			{
 				test: /\.jsx?$/,
-				loader: 'babel-loader',
+				use: [ 'cache-loader', 'babel-loader' ],
 				exclude: /node_modules/,
 			},
 			{
 				test: /\.(scss|css)$/,
 				use: [
 					MiniCssExtractPlugin.loader,
+					'cache-loader',
 					'css-loader',
 					{
 						loader: 'sass-loader',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,12 +69,6 @@ const webpackConfig = {
 				],
 			},
 			{
-				enforce: 'pre',
-				test: /\.js$/,
-				exclude: /node_modules/,
-				loader: 'source-map-loader',
-			},
-			{
 				test: /\.(svg|png)$/,
 				exclude: /node_modules/,
 				loader: 'url-loader',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,12 +30,22 @@ const webpackConfig = {
 		rules: [
 			{
 				test: /\.tsx?$/,
-				use: [ 'cache-loader', 'babel-loader', 'ts-loader' ],
+				use: [
+					'cache-loader',
+					'thread-loader',
+					'babel-loader',
+					{
+						loader: 'ts-loader',
+						options: {
+							happyPackMode: true,
+						},
+					},
+				],
 				exclude: /node_modules/,
 			},
 			{
 				test: /\.jsx?$/,
-				use: [ 'cache-loader', 'babel-loader' ],
+				use: [ 'cache-loader', 'thread-loader', 'babel-loader' ],
 				exclude: /node_modules/,
 			},
 			{
@@ -43,6 +53,7 @@ const webpackConfig = {
 				use: [
 					MiniCssExtractPlugin.loader,
 					'cache-loader',
+					'thread-loader',
 					'css-loader',
 					{
 						loader: 'sass-loader',


### PR DESCRIPTION
I've been working on adding HMR, and to make it usable we need to improve our build times. Mainly rebuild ones, but I hink is a good moment to improve it in general.

I tried a lot of things, but the most interesting ones have been:
### Update to webpack v5
This alone cut the build times in half, and can be improved a bit more with something similar to this PR.

Unfortunately, looks like we have some incompatibilities yet. One of them is with `@wordpress/dependency-extraction-webpack-plugin` producing some deprecation warnings. That I'll try to fix in https://github.com/WordPress/gutenberg/pull/33090. And the other one, thanks @naman03malhotra for pointing it! Is related to `@wordpress/babel-plugin-makepot` not working properly with the emitted v5 source.

But we should definitely keep looking at this as the main point to improve build times.

### Replace babel with esbuild
For those who doesn't know about esbuild, their official site had a quite good resume on the main page https://esbuild.github.io/

Using it with webpack is not that fast as using it alone, but will reduce TS/JS build times in half at least. But we'll need to implement a custom solution for pot files, cause `@wordpress/babel-plugin-makepot` only works with babel. Maybe it's worth to create a webpack loader version.

I think we should discuss it, being so simple to configure and fast to build.

### SASS
I didn't have enough time to look at it yet. But it's the slowest part so far. We are using the deprecated `node-sass` package, the bad news are that the alternative package `sass` is slower. Not so strange being a JS version of the Dart lib, instead of using the, also deprecated, libsass.

On the other hand. Using the new supported `sass` package will be the more reasonable thing, even if it's slower. To have support for new features and M1 chips (guilty here 😄).

We could use the Dart version, but will break our easy of use, having to install a binary to be able to run the repo.

### Optimize webpack v4 - This PR solution so far
Optimizations applied:
- Use `eval-source-map` instead of `source-map`. As we only use source maps for development, we could take advantage of the eval version to reduce build time, having the same development experience. We could tune it even more with other modes. But then we'll lose some functionalities like JS breakpoints or source lines numbers.
- Use `cache-loader` with TS, JS and CSS modules. Tried also the `babel-loader` caching solution, but in my benchmarks the `cache-loader` works way better.
- Remove `source-map-loader`. This was added with the support for TS, but isn't needed. Is enough to use the `devtool` property.

### Benchmarks - 10 runs M1 MacBook 16GB
I have run then incrementally, in the same order as the commits, so we can see the accumulated improvement, rather that the individual one. Used one warm up call to have a cleaner mean, this initial run will be slower than the second one, to generate the cache.

| Build | Mean | Deviation |
| - | -: | -: |
| Initial | 25.886 s | ± 0.540 s |
| eval-source-map | 22.910 s | ± 0.324 s |
| Cache TS/JS | 10.110 s | ± 0.172 s |
| Cache CSS | 8.953 s | ± 0.213 s |
| Remove source-map-loader | 8.787 s | ± 0.325 s |

| Rebuild | Mean | Deviation |
| - | -: | -: |
| Initial | 1.756 s | ± 4.783 s |
| Optimized | 0.719 s | ± 0.602 |

-------------------
#### Testing instructions
- You can run `npm run start` or `npm run build:client` to check compare the new build times.
- The output should work the same way as always.

