### PR TITLE
Psalm: suppress DuplicateClass errors

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -21,5 +21,6 @@
 		<UndefinedConstant errorLevel="suppress" />
 		<ParadoxicalCondition errorLevel="suppress" />
 		<MissingFile errorLevel="suppress" />
+		<DuplicateClass errorLevel="suppress" />
 	</issueHandlers>
 </psalm>


### PR DESCRIPTION
#### Changes proposed

This PR suppresses `DuplicateClass` warnings that show in PhpStorm due to this Youtrack bug https://youtrack.jetbrains.com/issue/WI-57977

#### Testing instructions

`./vendor/bin/psalm` (or `npm run psalm`) and check the results.