### PR TITLE
Report E2E test failures to Slack again

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -20,7 +20,7 @@ env:
   E2E_WCPAY_STRIPE_TEST_SECRET_KEY:            ${{ secrets.E2E_WCPAY_STRIPE_TEST_SECRET_KEY }}
   E2E_WCPAY_STRIPE_TEST_WEBHOOK_SIGNATURE_KEY: ${{ secrets.E2E_WCPAY_STRIPE_TEST_WEBHOOK_SIGNATURE_KEY }}
   E2E_SLACKBOT_USER:                           ${{ secrets.E2E_SLACKBOT_USER }}
-  E2E_SLACK_CHANNEL:                           ${{ secrets.E2E_SLACK_CHANNEL }}
+  E2E_CHANNEL_NAME:                            ${{ secrets.E2E_CHANNEL_NAME }}
   E2E_SLACK_TOKEN:                             ${{ secrets.E2E_SLACK_TOKEN }}
 
 jobs:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -19,6 +19,9 @@ env:
   E2E_WCPAY_STRIPE_TEST_PUBLIC_KEY:            ${{ secrets.E2E_WCPAY_STRIPE_TEST_PUBLIC_KEY }}
   E2E_WCPAY_STRIPE_TEST_SECRET_KEY:            ${{ secrets.E2E_WCPAY_STRIPE_TEST_SECRET_KEY }}
   E2E_WCPAY_STRIPE_TEST_WEBHOOK_SIGNATURE_KEY: ${{ secrets.E2E_WCPAY_STRIPE_TEST_WEBHOOK_SIGNATURE_KEY }}
+  E2E_SLACKBOT_USER:                           ${{ secrets.E2E_SLACKBOT_USER }}
+  E2E_SLACK_CHANNEL:                           ${{ secrets.E2E_SLACK_CHANNEL }}
+  E2E_SLACK_TOKEN:                             ${{ secrets.E2E_SLACK_TOKEN }}
 
 jobs:
   e2e:

--- a/tests/e2e/specs/merchant/merchant-admin-transactions.spec.js
+++ b/tests/e2e/specs/merchant/merchant-admin-transactions.spec.js
@@ -15,6 +15,6 @@ describe( 'Admin transactions', () => {
 
 	it( 'page should load without any errors', async () => {
 		await merchantWCP.openTransactions();
-		await expect( page ).toMatchElement( 'h2', { text: 'Transactions' } );
+		await expect( page ).toMatchElement( 'h2', { text: 'Talfhklkefhs' } );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Give E2E testing workflow access to environment variables necessary for reporting failures to Slack (with screenshots).

cc @kalessil (particularly in case omitting these variables was intentional)

#### Testing instructions

Added a temporary commit (https://github.com/Automattic/woocommerce-payments/commit/7f7dde23667041a921572e259b611d7fcaf2c6b1) to trigger a failure and verify report in Slack – will reset/revert before merge.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
