### PR TITLE
Fix so that resubscribe prices are not converted a second time

### DIFF
--- a/includes/multi-currency/Compatibility.php
+++ b/includes/multi-currency/Compatibility.php
@@ -41,6 +41,11 @@ class Compatibility {
 			return get_post_meta( $subscription_renewal['subscription_renewal']['renewal_order_id'], '_order_currency', true );
 		}
 
+		$subscription_resubscribe = $this->cart_contains_resubscribe();
+		if ( $subscription_resubscribe ) {
+			return get_post_meta( $subscription_resubscribe['subscription_resubscribe']['subscription_id'], '_order_currency', true );
+		}
+
 		return false;
 	}
 
@@ -50,7 +55,12 @@ class Compatibility {
 	 * @return bool False if it shouldn't be hidden, true if it should.
 	 */
 	public function should_hide_widgets(): bool {
-		return $this->cart_contains_renewal() ? true : false;
+		if ( $this->cart_contains_renewal()
+			|| $this->cart_contains_resubscribe() ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
@@ -62,15 +72,18 @@ class Compatibility {
 	 */
 	public function should_convert_product_price( $product = null ): bool {
 		// If we have a product, and it's a subscription renewal.
-		if ( $product && $this->is_product_subscription_renewal( $product ) ) {
-			$calls = [
-				'WC_Cart_Totals->calculate_item_totals',
-				'WC_Cart->get_product_subtotal',
-				'wc_get_price_excluding_tax',
-				'wc_get_price_including_tax',
-			];
-			if ( $this->utils->is_call_in_backtrace( $calls ) ) {
-				return false;
+		if ( $product ) {
+			if ( $this->is_product_subscription_type_in_cart( $product, 'renewal' )
+				|| $this->is_product_subscription_type_in_cart( $product, 'resubscribe' ) ) {
+				$calls = [
+					'WC_Cart_Totals->calculate_item_totals',
+					'WC_Cart->get_product_subtotal',
+					'wc_get_price_excluding_tax',
+					'wc_get_price_including_tax',
+				];
+				if ( $this->utils->is_call_in_backtrace( $calls ) ) {
+					return false;
+				}
 			}
 		}
 
@@ -90,20 +103,45 @@ class Compatibility {
 	}
 
 	/**
-	 * Checks to see if the product passed is in the cart as a subscription renewal.
+	 * Checks the cart to see if it contains a resubscription.
+	 *
+	 * @return mixed The cart item containing the resubscription as an array, else false.
+	 */
+	private function cart_contains_resubscribe() {
+		if ( ! function_exists( 'wcs_cart_contains_resubscribe' ) ) {
+			return false;
+		}
+		return wcs_cart_contains_resubscribe();
+	}
+
+	/**
+	 * Checks to see if the product passed is in the cart as a subscription type.
 	 *
 	 * @param object $product Product to test.
+	 * @param string $type    Type of subscription.
 	 *
-	 * @return bool True if it's a subscription renewal in the cart, false if not.
+	 * @return bool True if found in the cart, false if not.
 	 */
-	private function is_product_subscription_renewal( $product ): bool {
-		$subscription_renewal = $this->cart_contains_renewal();
-		if ( $subscription_renewal && $product ) {
-			if ( ( isset( $subscription_renewal['variation_id'] ) && $subscription_renewal['variation_id'] === $product->get_id() )
-				|| $subscription_renewal['product_id'] === $product->get_id() ) {
+	private function is_product_subscription_type_in_cart( $product, $type ): bool {
+		$subscription = false;
+
+		switch ( $type ) {
+			case 'renewal':
+				$subscription = $this->cart_contains_renewal();
+				break;
+
+			case 'resubscribe':
+				$subscription = $this->cart_contains_resubscribe();
+				break;
+		}
+
+		if ( $subscription && $product ) {
+			if ( ( isset( $subscription['variation_id'] ) && $subscription['variation_id'] === $product->get_id() )
+				|| $subscription['product_id'] === $product->get_id() ) {
 				return true;
 			}
 		}
+
 		return false;
 	}
 }

--- a/includes/multi-currency/Compatibility.php
+++ b/includes/multi-currency/Compatibility.php
@@ -71,19 +71,21 @@ class Compatibility {
 	 * @return bool True if it should be converted.
 	 */
 	public function should_convert_product_price( $product = null ): bool {
-		// If we have a product, and it's a subscription renewal.
-		if ( $product ) {
-			if ( $this->is_product_subscription_type_in_cart( $product, 'renewal' )
-				|| $this->is_product_subscription_type_in_cart( $product, 'resubscribe' ) ) {
-				$calls = [
-					'WC_Cart_Totals->calculate_item_totals',
-					'WC_Cart->get_product_subtotal',
-					'wc_get_price_excluding_tax',
-					'wc_get_price_including_tax',
-				];
-				if ( $this->utils->is_call_in_backtrace( $calls ) ) {
-					return false;
-				}
+		if ( ! $product ) {
+			return true;
+		}
+
+		// Check for subscription renewal or resubscribe.
+		if ( $this->is_product_subscription_type_in_cart( $product, 'renewal' )
+			|| $this->is_product_subscription_type_in_cart( $product, 'resubscribe' ) ) {
+			$calls = [
+				'WC_Cart_Totals->calculate_item_totals',
+				'WC_Cart->get_product_subtotal',
+				'wc_get_price_excluding_tax',
+				'wc_get_price_including_tax',
+			];
+			if ( $this->utils->is_call_in_backtrace( $calls ) ) {
+				return false;
 			}
 		}
 

--- a/tests/unit/helpers/class-wc-helper-subscriptions.php
+++ b/tests/unit/helpers/class-wc-helper-subscriptions.php
@@ -41,6 +41,13 @@ function wcs_cart_contains_renewal() {
 	return ( WC_Subscriptions::$wcs_cart_contains_renewal )();
 }
 
+function wcs_cart_contains_resubscribe() {
+	if ( ! WC_Subscriptions::$wcs_cart_contains_resubscribe ) {
+		return;
+	}
+	return ( WC_Subscriptions::$wcs_cart_contains_resubscribe )();
+}
+
 /**
  * Class WC_Subscriptions.
  *
@@ -89,6 +96,13 @@ class WC_Subscriptions {
 	 */
 	public static $wcs_cart_contains_renewal = null;
 
+	/**
+	 * wcs_cart_contains_resubscribe mock.
+	 *
+	 * @var function
+	 */
+	public static $wcs_cart_contains_resubscribe = null;
+
 	public static function set_wcs_order_contains_subscription( $function ) {
 		self::$wcs_order_contains_subscription = $function;
 	}
@@ -107,5 +121,9 @@ class WC_Subscriptions {
 
 	public static function wcs_cart_contains_renewal( $function ) {
 		self::$wcs_cart_contains_renewal = $function;
+	}
+
+	public static function wcs_cart_contains_resubscribe( $function ) {
+		self::$wcs_cart_contains_resubscribe = $function;
 	}
 }

--- a/tests/unit/multi-currency/test-class-compatibility.php
+++ b/tests/unit/multi-currency/test-class-compatibility.php
@@ -51,11 +51,19 @@ class WCPay_Multi_Currency_Compatibility_Tests extends WP_UnitTestCase {
 
 	public function test_should_hide_widgets_return_false() {
 		$this->mock_wcs_cart_contains_renewal( false );
+		$this->mock_wcs_cart_contains_resubscribe( false );
 		$this->assertFalse( $this->compatibility->should_hide_widgets() );
 	}
 
-	public function test_should_hide_widgets_return_true() {
+	public function test_should_hide_widgets_return_true_test_1() {
 		$this->mock_wcs_cart_contains_renewal( true );
+		$this->mock_wcs_cart_contains_resubscribe( false );
+		$this->assertTrue( $this->compatibility->should_hide_widgets() );
+	}
+
+	public function test_should_hide_widgets_return_true_test_2() {
+		$this->mock_wcs_cart_contains_renewal( false );
+		$this->mock_wcs_cart_contains_resubscribe( true );
 		$this->assertTrue( $this->compatibility->should_hide_widgets() );
 	}
 
@@ -72,24 +80,45 @@ class WCPay_Multi_Currency_Compatibility_Tests extends WP_UnitTestCase {
 			)
 			->willReturn( true );
 		$this->mock_wcs_cart_contains_renewal( true );
+		$this->mock_wcs_cart_contains_resubscribe( false );
+		$this->assertFalse( $this->compatibility->should_convert_product_price( $this->mock_product ) );
+	}
+
+	public function test_should_convert_product_price_return_false_when_resubscribe_in_cart() {
+		$this->mock_utils
+			->method( 'is_call_in_backtrace' )
+			->with(
+				[
+					'WC_Cart_Totals->calculate_item_totals',
+					'WC_Cart->get_product_subtotal',
+					'wc_get_price_excluding_tax',
+					'wc_get_price_including_tax',
+				]
+			)
+			->willReturn( true );
+		$this->mock_wcs_cart_contains_renewal( false );
+		$this->mock_wcs_cart_contains_resubscribe( true );
 		$this->assertFalse( $this->compatibility->should_convert_product_price( $this->mock_product ) );
 	}
 
 	public function test_should_convert_product_price_return_true_when_backtrace_does_not_match() {
 		$this->mock_utils->method( 'is_call_in_backtrace' )->willReturn( false );
 		$this->mock_wcs_cart_contains_renewal( true );
+		$this->mock_wcs_cart_contains_resubscribe( true );
 		$this->assertTrue( $this->compatibility->should_convert_product_price( $this->mock_product ) );
 	}
 
-	public function test_should_convert_product_price_return_true_with_no_renewal_in_cart() {
+	public function test_should_convert_product_price_return_true_with_no_subscription_actions_in_cart() {
 		$this->mock_utils->method( 'is_call_in_backtrace' )->willReturn( true );
 		$this->mock_wcs_cart_contains_renewal( false );
+		$this->mock_wcs_cart_contains_resubscribe( false );
 		$this->assertTrue( $this->compatibility->should_convert_product_price( $this->mock_product ) );
 	}
 
 	public function test_should_convert_product_price_return_true_when_product_null() {
 		$this->mock_utils->method( 'is_call_in_backtrace' )->willReturn( true );
 		$this->mock_wcs_cart_contains_renewal( true );
+		$this->mock_wcs_cart_contains_resubscribe( true );
 		$this->assertTrue( $this->compatibility->should_convert_product_price( null ) );
 	}
 
@@ -101,6 +130,23 @@ class WCPay_Multi_Currency_Compatibility_Tests extends WP_UnitTestCase {
 						'product_id'           => 42,
 						'subscription_renewal' => [
 							'renewal_order_id' => 42,
+						],
+					];
+				}
+
+				return false;
+			}
+		);
+	}
+
+	private function mock_wcs_cart_contains_resubscribe( $value ) {
+		WC_Subscriptions::wcs_cart_contains_resubscribe(
+			function () use ( $value ) {
+				if ( $value ) {
+					return [
+						'product_id'               => 42,
+						'subscription_resubscribe' => [
+							'subscription_id' => 42,
 						],
 					];
 				}

--- a/tests/unit/multi-currency/test-class-compatibility.php
+++ b/tests/unit/multi-currency/test-class-compatibility.php
@@ -55,13 +55,13 @@ class WCPay_Multi_Currency_Compatibility_Tests extends WP_UnitTestCase {
 		$this->assertFalse( $this->compatibility->should_hide_widgets() );
 	}
 
-	public function test_should_hide_widgets_return_true_test_1() {
+	public function test_should_hide_widgets_return_true_when_renewal_in_cart() {
 		$this->mock_wcs_cart_contains_renewal( true );
 		$this->mock_wcs_cart_contains_resubscribe( false );
 		$this->assertTrue( $this->compatibility->should_hide_widgets() );
 	}
 
-	public function test_should_hide_widgets_return_true_test_2() {
+	public function test_should_hide_widgets_return_true_when_resubscribe_in_cart() {
 		$this->mock_wcs_cart_contains_renewal( false );
 		$this->mock_wcs_cart_contains_resubscribe( true );
 		$this->assertTrue( $this->compatibility->should_hide_widgets() );


### PR DESCRIPTION
Fixes #2353

#### Changes proposed in this Pull Request

* `cart_contains_resubscribe` checks ti see if there is a resubscribe found in the cart.
* `is_product_subscription_type_in_cart` replaces `is_product_subscription_renewal` to check to see if the product being converted is of the type passed in the cart. 
* Force/override the selected currency if there is a resubscribe in the cart. Use the subscription's currency.
* Disable widget(s) if there's a resubscribe in the cart.
* Do not convert the price in the cart if there's a resubscribe in the cart.
* Updated tests accordingly.

#### Testing instructions

1. Purchase a subscription.
2. Go to WooCommerce > Subscriptions in the admin.
3. Hover the new subscription and click Cancel, once the page refreshes hover again and choose Cancel Now.
4. Navigate to My Account > Subscriptions, and then click View for the cancelled subscription.
5. Click the Resubscribe button, and the subscription added to the cart will have the correct price.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
