### PR TITLE
Change subscription payment with UPE.

### DIFF
--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -269,7 +269,14 @@ jQuery( function ( $ ) {
 			isUPEEnabled &&
 			! upeElement
 		) {
-			const useSetUpIntent = $( 'form#add_payment_method' ).length;
+			const isChangingPayment = getConfig( 'isChangingPayment' );
+			const useSetUpIntent =
+				$( 'form#add_payment_method' ).length || isChangingPayment;
+			if ( isChangingPayment && getConfig( 'newTokenFormId' ) ) {
+				const token = getConfig( 'newTokenFormId' );
+				$( token ).prop( 'selected', true ).trigger( 'click' );
+				$( 'form#order_review' ).submit();
+			}
 			mountUPEElement( useSetUpIntent );
 		}
 	}
@@ -364,7 +371,7 @@ jQuery( function ( $ ) {
 		blockUI( $form );
 
 		try {
-			const returnUrl = getConfig( 'paymentMethodsURL' );
+			const returnUrl = getConfig( 'addPaymentReturnURL' );
 
 			const { error } = await api.getStripe().confirmSetup( {
 				element: upeElement,
@@ -519,6 +526,10 @@ jQuery( function ( $ ) {
 	// Handle the Pay for Order form if WooCommerce Payments is chosen.
 	$( '#order_review' ).on( 'submit', () => {
 		if ( ! isUsingSavedPaymentMethod() ) {
+			if ( getConfig( 'isChangingPayment' ) ) {
+				handleUPEAddPayment( $( '#order_review' ) );
+				return false;
+			}
 			handleUPEOrderPay( $( '#order_review' ) );
 			return false;
 		}

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -270,9 +270,15 @@ jQuery( function ( $ ) {
 			! upeElement
 		) {
 			const isChangingPayment = getConfig( 'isChangingPayment' );
+
+			// We use a setup intent if we are on the screens to add a new payment method or to change a subscription payment.
 			const useSetUpIntent =
 				$( 'form#add_payment_method' ).length || isChangingPayment;
+
 			if ( isChangingPayment && getConfig( 'newTokenFormId' ) ) {
+				// Changing the method for a subscription takes two steps:
+				// 1. Create the new payment method that will redirect back.
+				// 2. Select the new payment method and resubmit the form to update the subscription.
 				const token = getConfig( 'newTokenFormId' );
 				$( token ).prop( 'selected', true ).trigger( 'click' );
 				$( 'form#order_review' ).submit();

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -144,7 +144,7 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 	 *
 	 * @return bool
 	 */
-	private function is_changing_payment_method_for_subscription() {
+	protected function is_changing_payment_method_for_subscription() {
 		if ( isset( $_GET['change_payment_method'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return wcs_is_subscription( wc_clean( wp_unslash( $_GET['change_payment_method'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
 		}

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -498,7 +498,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		$payment_fields['paymentMethodsConfig'] = $this->get_enabled_payment_method_config();
 
 		if ( is_wc_endpoint_url( 'order-pay' ) ) {
-			if ( $this->is_changing_payment_method_for_subscription() ) {
+			if ( $this->is_subscriptions_enabled() && $this->is_changing_payment_method_for_subscription() ) {
 				$payment_fields['isChangingPayment']   = true;
 				$payment_fields['addPaymentReturnURL'] = esc_url_raw( home_url( add_query_arg( [] ) ) );
 

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -8,6 +8,7 @@
 namespace WCPay\Payment_Methods;
 
 use WC_Order;
+use WP_User;
 use WCPay\Exceptions\Add_Payment_Method_Exception;
 use WCPay\Logger;
 use WCPay\Payment_Information;
@@ -17,6 +18,7 @@ use WC_Payments_Action_Scheduler_Service;
 use WC_Payments_API_Client;
 use WC_Payments_Customer_Service;
 use WC_Payments_Token_Service;
+use WC_Payment_Token_CC;
 use WC_Payments;
 use WC_Payments_Utils;
 
@@ -552,7 +554,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			$setup_intent      = $this->payments_api_client->get_setup_intent( $setup_intent_id );
 			$payment_method_id = $setup_intent['payment_method'];
 			// TODO: When adding SEPA and Sofort, we will need a new API call to get the payment method and from there get the type.
-			// Leaving 'card' as a hardcoded value for now to avoid a new API call.
+			// Leaving 'card' as a hardcoded value for now to avoid the extra API call.
 			$payment_method = $this->payment_methods['card'];
 
 			return $payment_method->get_payment_token_for_user( $user, $payment_method_id );


### PR DESCRIPTION
Fixes #2190 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
Add the ability to change subscription payment with UPE
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
On this PR we mount the UPE element with a setup intent when we are changing a payment method for a subscription.
Once the customer selects to use a new payment method, fills in the UPE element and clicks on submit, the setup intent is confirmed.
There is a redirection after the creation of the setup intent back to the change payment method page. 
We then get the setup intent id, add the token to the user, display the form, select the new payment method and resubmit the form.

Resubmitting the form is not ideal. We decided to have this double resubmission to avoid rewriting the subscriptions functionality that happens on form submission.
The reasoning behind that decision:
1) Minimize the risk of introducing bugs.
2) This is not a critical screen.
3) It can be improved in the future if needed.

Note: This PR does not add the capacity to update all subscriptions at once.
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With UPE and subscriptions enabled.
* Place an order for a subscription product.
* Go to my Account > Subscriptions > View Subscription > Change Payment Method.
* Select a new payment method.
* Enter the payment method details.
* Submit the form.
* Check that (at the end) you are redirected to 'View Subscription' and there is a message the subscription has been updated.
![PaymentUpdated](https://user-images.githubusercontent.com/8002881/125142309-0c148e00-e0dd-11eb-98fc-8d61d3430e27.png)

* Renew the subscription and check the card you added has been used.

-------------------

- [ ] Added changelog entry (or does not apply) does not apply
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply) does not apply

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
