### PR TITLE
Remove currency settings when removed as an enabled currency.

### DIFF
--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -760,7 +760,7 @@ class MultiCurrency {
 	 * @return void
 	 */
 	private function remove_currency_settings( $currency ) {
-		$code = is_a( $currency, 'Currency' ) ? $currency->get_code() : strtoupper( $currency );
+		$code = is_a( $currency, Currency::class ) ? $currency->get_code() : strtoupper( $currency );
 
 		// Bail if the currency code passed is not 3 characters, or if the currency is presently enabled.
 		if ( 3 !== strlen( $code ) || isset( $this->enabled_currencies[ $code ] ) ) {

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -767,8 +767,6 @@ class MultiCurrency {
 			return;
 		}
 
-		// The options in the database are lowercased.
-		$id       = strtolower( $code );
 		$settings = [
 			'price_charm',
 			'price_rounding',
@@ -778,7 +776,7 @@ class MultiCurrency {
 
 		// Go through each setting and remove them.
 		foreach ( $settings as $setting ) {
-			delete_option( $this->id . '_' . $setting . '_' . $id );
+			delete_option( $this->id . '_' . $setting . '_' . strtolower( $code ) );
 		}
 	}
 }

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -169,6 +169,19 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->assertSame( $currencies, get_option( self::ENABLED_CURRENCIES_OPTION ) );
 	}
 
+	public function test_set_enabled_currencies_triggers_removing_currency_settings() {
+		update_option( 'wcpay_multi_currency_exchange_rate_bif', 'manual' );
+		update_option( 'wcpay_multi_currency_manual_rate_bif', '2' );
+		update_option( 'wcpay_multi_currency_price_rounding_bif', '10.00' );
+		update_option( 'wcpay_multi_currency_price_charm_bif', '-0.05' );
+		$currencies = [ 'USD', 'CAD', 'GBP' ];
+		$this->multi_currency->set_enabled_currencies( $currencies );
+		$this->assertFalse( get_option( 'wcpay_multi_currency_exchange_rate_bif' ) );
+		$this->assertFalse( get_option( 'wcpay_multi_currency_manual_rate_bif' ) );
+		$this->assertFalse( get_option( 'wcpay_multi_currency_price_rounding_bif' ) );
+		$this->assertFalse( get_option( 'wcpay_multi_currency_price_charm_bif' ) );
+	}
+
 	public function test_enabled_but_unavailable_currencies_are_skipped() {
 		update_option( self::ENABLED_CURRENCIES_OPTION, [ 'RANDOM_CURRENCY', 'USD' ] );
 


### PR DESCRIPTION
Fixes #2376

#### Changes proposed in this Pull Request

* New method `remove_currency_settings` that accepts a `Currency` object or currency code and will remove its settings if the currency is not enabled.
* New method `remove_currencies_settings` which accepts an array of `Currency` objects or currency codes and passes them on to `remove_currency_settings`.
* Added call to `remove_currencies_settings` within `set_enabled_currencies`, which is the method that updates enabled currencies both from the available checkbox list and if the currency is deleted via the trash option.


#### Testing instructions

* Navigate to WooCommerce > Settings > Multi-Currency
* Add a new currency if one is not enabled.
* Edit an enabled currency and update all of the settings, like in the example screenshot below.
* Go back to the currencies page and delete the currency.
* Add the currency back and confirm the default settings have been restored, screenshot below.

Example settings (all changed):
![Screenshot on 2021-07-09 at 13-47-38](https://user-images.githubusercontent.com/4634416/125111607-7c5ee780-e0bc-11eb-85d5-90772dc8320c.png)

Default settings:
![Screenshot on 2021-07-09 at 13-50-07 (1)](https://user-images.githubusercontent.com/4634416/125112042-0c049600-e0bd-11eb-8dd4-6e8a1f655f84.png)

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
