### PR TITLE
Fix to not double convert subscription percentage coupons

### DIFF
--- a/includes/multi-currency/Compatibility.php
+++ b/includes/multi-currency/Compatibility.php
@@ -187,8 +187,8 @@ class Compatibility {
 	/**
 	 * Checks to see if the coupon passed is of a specified type.
 	 *
-	 * @param WC_Coupon $coupon Coupon to test.
-	 * @param string    $type   Type of coupon to test for.
+	 * @param \WC_Coupon $coupon Coupon to test.
+	 * @param string     $type   Type of coupon to test for.
 	 *
 	 * @return bool True on match.
 	 */

--- a/tests/unit/multi-currency/test-class-compatibility.php
+++ b/tests/unit/multi-currency/test-class-compatibility.php
@@ -202,6 +202,19 @@ class WCPay_Multi_Currency_Compatibility_Tests extends WP_UnitTestCase {
 		$this->assertTrue( $this->compatibility->should_convert_coupon_amount( $this->mock_coupon ) );
 	}
 
+	public function test_should_convert_coupon_amount_return_false_when_percentage_coupon_used() {
+		$this->mock_utils
+			->expects( $this->exactly( 0 ) )
+			->method( 'is_call_in_backtrace' );
+
+		$this->mock_coupon
+			->method( 'get_discount_type' )
+			->willReturn( 'recurring_percent' );
+
+		$this->mock_wcs_cart_contains_renewal( false );
+		$this->assertFalse( $this->compatibility->should_convert_coupon_amount( $this->mock_coupon ) );
+	}
+
 	private function mock_wcs_cart_contains_renewal( $value ) {
 		WC_Subscriptions::wcs_cart_contains_renewal(
 			function () use ( $value ) {


### PR DESCRIPTION
Fixes #2355 

#### Changes proposed in this Pull Request

* Add new method `is_coupon_type` to `Compatibility` to test for specific coupon types.
* Test if the coupon type is a subscription percentage type, and do not convert if it is.
* This works for _Recurring Product % Discount_ and _Sign Up Fee % Discount_ coupons
* Add test to match.

#### Testing instructions

Note: If you have taxes enabled and have signup fees on your product, there is currently an open bug report about percentage amounts not being calculated correctly: 4126-gh-woocommerce/woocommerce-subscriptions

1. Make sure you have _Early Renewals_ enabled under WooCommerce > Settings > Subscriptions.
1. Create a _Recurring Product % Discount_ coupon.
1. Add the subscription product to your cart along with the coupon.
2. Confirm that the amount discounted in the cart has only been converted once.
3. Complete the transaction.
2. Go to My Account > Subscriptions, and then that subscription.
3. Click _Renew now_, and confirm the amount in the cart has not been converted a second time.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->