### PR TITLE
Enable UPE and redirect to onboarding wizard

### DIFF
--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -14,6 +14,8 @@ import {
 	Button,
 } from '@wordpress/components';
 import classNames from 'classnames';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -31,6 +33,7 @@ import GiropayIcon from '../gateway-icons/giropay';
 import SofortIcon from '../gateway-icons/sofort';
 import SepaIcon from '../gateway-icons/sepa';
 import WCPaySettingsContext from '../settings/wcpay-settings-context';
+import { NAMESPACE } from '../data/constants';
 
 const methodsConfiguration = {
 	card: {
@@ -92,6 +95,25 @@ const PaymentMethods = () => {
 		);
 	};
 
+	const handleEnableUpeClick = () => {
+		return apiFetch( {
+			path: `${ NAMESPACE }/upe_flag_toggle`,
+			method: 'POST',
+			// eslint-disable-next-line camelcase
+			data: { is_upe_enabled: true },
+		} )
+			.then( () => {
+				console.log( 'success' );
+				window.location.href = addQueryArgs( 'admin.php', {
+					page: 'wc-admin',
+					task: 'woocommerce-payments--additional-payment-methods',
+				} );
+			} )
+			.catch( () => {
+				// error handling
+			} );
+	};
+
 	const {
 		featureFlags: {
 			upeSettingsPreview: isUPESettingsPreviewEnabled,
@@ -145,9 +167,12 @@ const PaymentMethods = () => {
 
 							<div className="payment-methods__express-checkouts-actions">
 								<span className="payment-methods__express-checkouts-get-started">
-									<Button isPrimary href="">
+									<Button
+										isPrimary
+										onClick={ handleEnableUpeClick }
+									>
 										{ __(
-											'Get started',
+											'Enable in your store',
 											'woocommerce-payments'
 										) }
 									</Button>

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -14,7 +14,6 @@ import {
 	Button,
 } from '@wordpress/components';
 import classNames from 'classnames';
-import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -33,7 +32,7 @@ import GiropayIcon from '../gateway-icons/giropay';
 import SofortIcon from '../gateway-icons/sofort';
 import SepaIcon from '../gateway-icons/sepa';
 import WCPaySettingsContext from '../settings/wcpay-settings-context';
-import { NAMESPACE } from '../data/constants';
+import useIsUpeEnabled from '../settings/wcpay-upe-toggle/hook';
 
 const methodsConfiguration = {
 	card: {
@@ -95,23 +94,15 @@ const PaymentMethods = () => {
 		);
 	};
 
+	const [ , setIsUpeEnabled ] = useIsUpeEnabled();
+
 	const handleEnableUpeClick = () => {
-		return apiFetch( {
-			path: `${ NAMESPACE }/upe_flag_toggle`,
-			method: 'POST',
-			// eslint-disable-next-line camelcase
-			data: { is_upe_enabled: true },
-		} )
-			.then( () => {
-				console.log( 'success' );
-				window.location.href = addQueryArgs( 'admin.php', {
-					page: 'wc-admin',
-					task: 'woocommerce-payments--additional-payment-methods',
-				} );
-			} )
-			.catch( () => {
-				// error handling
+		setIsUpeEnabled( true ).then( () => {
+			window.location.href = addQueryArgs( 'admin.php', {
+				page: 'wc-admin',
+				task: 'woocommerce-payments--additional-payment-methods',
 			} );
+		} );
 	};
 
 	const {

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -21,6 +21,7 @@ import SaveSettingsSection from '../save-settings-section';
 import TransactionsAndDeposits from '../transactions-and-deposits';
 import WCPaySettingsContext from '../wcpay-settings-context';
 import LoadableSettingsSection from '../loadable-settings-section';
+import WcPayUpeContextProvider from '../wcpay-upe-toggle/provider';
 
 const PaymentMethodsDescription = () => (
 	<>
@@ -91,7 +92,10 @@ const TransactionsAndDepositsDescription = () => (
 
 const SettingsManager = () => {
 	const {
-		featureFlags: { upeSettingsPreview: isUPESettingsPreviewEnabled },
+		featureFlags: {
+			upeSettingsPreview: isUPESettingsPreviewEnabled,
+			upe: isUPEEnabled,
+		},
 	} = useContext( WCPaySettingsContext );
 
 	return (
@@ -104,7 +108,11 @@ const SettingsManager = () => {
 			{ isUPESettingsPreviewEnabled && (
 				<SettingsSection Description={ PaymentMethodsDescription }>
 					<LoadableSettingsSection numLines={ 20 }>
-						<PaymentMethods />
+						<WcPayUpeContextProvider
+							defaultIsUpeEnabled={ isUPEEnabled }
+						>
+							<PaymentMethods />
+						</WcPayUpeContextProvider>
 					</LoadableSettingsSection>
 				</SettingsSection>
 			) }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/2323

#### Changes proposed in this Pull Request
Clicking "Enable in your store" will enable the `_wcpay_feature_upe` feature flag, and will redirect user to the following onboarding task list:
![image](https://user-images.githubusercontent.com/572862/125361192-3909b080-e32a-11eb-9e69-2a57e88e7c60.png)

#### Considerations
In the [first commit](https://github.com/Automattic/woocommerce-payments/pull/2402/commits/0356abb5dea10fc13014981f1d296a16c2c67c94), I used a side effect to make an API call to update the upe feature flag. This works well but it duplicated the same API call codes [here](https://github.com/Automattic/woocommerce-payments/blob/develop/client/settings/wcpay-upe-toggle/provider.js).

In the second commit, I attempt to reuse existing `<WcPayUpeContextProvider>` context by wrapping this context provider around our payment method section. One thing to note is that `<PaymentMethods>` now uses 2 context; 1 from [WCPaySettingsContext](https://github.com/Automattic/woocommerce-payments/blob/add/2323-link-get-started-to-onboarding-wizard/client/payment-methods/index.js#L108-L113), the other from `WcPayUpeContextProvider`. `WCPaySettingsContext` is used to get global feature flags include `_wcpay_feature_upe_settings_preview` and `_wcpay_feature_upe`. `WcPayUpeContextProvider` is to update the `_wcpay_feature_upe` flag.

I also thought about following the `/settings` approach by adding soemething like `setUpeFeature()` to our [settings data store](https://github.com/Automattic/woocommerce-payments/blob/cd60e648d16e5f659b23a9f03bffca182826c018/client/data/settings/resolvers.js#L19). One benefit of this approach is that I can use `yield dispatch( 'core/notices' ).createErrorNotice(..)` to display an error if feature flag failed to toggle. 

At the end, I think re-using the `<WcPayUpeContextProvider>` is the best approach. 

#### Testing instructions
1. Enable `_wcpay_feature_upe_settings_preview` and disable `_wcpay_feature_upe`  feature flag. Confirm seeing the banner: 
![image](https://user-images.githubusercontent.com/572862/125361342-6c4c3f80-e32a-11eb-8846-7ac2bc4cb6cd.png)
2. Click "Enable in your store". You should be redirected to `wp-admin/admin.php?page=wc-admin&task=woocommerce-payments--additional-payment-methods`
3. Check database `SELECT * FROM `wp_options` where option_name like '%_wcpay_feature_upe%'`. You should see there is an entry and the value is set to `1`. 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
