### PR TITLE
Created Locale class and moved locale functions into it.

### DIFF
--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -21,11 +21,11 @@ class FrontendCurrencies {
 	protected $multi_currency;
 
 	/**
-	 * Utils instance.
+	 * Locale instance.
 	 *
-	 * @var Utils
+	 * @var Locale
 	 */
-	protected $utils;
+	protected $locale;
 
 	/**
 	 * Multi-Currency currency formatting map.
@@ -38,13 +38,11 @@ class FrontendCurrencies {
 	 * Constructor.
 	 *
 	 * @param MultiCurrency $multi_currency The MultiCurrency instance.
-	 * @param Utils         $utils          The Utils instance.
+	 * @param Locale        $locale          The Locale instance.
 	 */
-	public function __construct( MultiCurrency $multi_currency, Utils $utils ) {
+	public function __construct( MultiCurrency $multi_currency, Locale $locale ) {
 		$this->multi_currency = $multi_currency;
-		$this->utils          = $utils;
-
-		$this->load_locale_data();
+		$this->locale         = $locale;
 
 		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
 			// Currency hooks.
@@ -148,51 +146,14 @@ class FrontendCurrencies {
 			'num_decimals' => 2,
 		];
 
-		$country = $this->utils->get_user_locale_country();
+		$country = $this->locale->get_user_locale_country();
 
-		if ( ! empty( $this->currency_format[ $currency_code ] ) ) {
-			$currency_options = $this->currency_format[ $currency_code ];
+		if ( $this->locale->get_currency_format( $currency_code ) ) {
+			$currency_options = $this->locale->get_currency_format( $currency_code );
 			// If there's no country-specific formatting, default to the first entry in the array.
 			$currency_format = $currency_options[ $country ] ?? reset( $currency_options );
 		}
 
 		return apply_filters( 'wcpay_multi_currency_' . strtolower( $currency_code ) . '_format', $currency_format, $country );
-	}
-
-	/**
-	 * Loads locale data from WooCommerce core (/i18n/locale-info.php) and maps it
-	 * to be used by currency.
-	 *
-	 * @return void
-	 */
-	private function load_locale_data() {
-		$locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
-
-		if ( is_array( $locale_info ) && 0 < count( $locale_info ) ) {
-			$countries          = array_keys( $locale_info );
-			$first_country_data = $locale_info[ $countries[0] ];
-
-			// If the loaded locale_info doesn't contain the locales keys, load the fallback file.
-			if ( is_array( $first_country_data ) && ! array_key_exists( 'locales', $first_country_data ) ) {
-				$locale_info = include WCPAY_ABSPATH . 'i18n/locale-info.php';
-			}
-
-			// Extract the currency formatting options from the locale info.
-			foreach ( $locale_info as $country => $locale ) {
-				$currency_code = $locale['currency_code'];
-
-				// Convert Norwegian Krone symbol to its ISO 4217 currency code.
-				if ( 'Kr' === $currency_code ) {
-					$currency_code = 'NOK';
-				}
-
-				$this->currency_format[ $currency_code ][ $country ] = [
-					'currency_pos' => $locale['currency_pos'],
-					'thousand_sep' => $locale['thousand_sep'],
-					'decimal_sep'  => $locale['decimal_sep'],
-					'num_decimals' => $locale['num_decimals'],
-				];
-			}
-		}
 	}
 }

--- a/includes/multi-currency/Locale.php
+++ b/includes/multi-currency/Locale.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * WooCommerce Payments Multi Currency Locale Class
+ *
+ * @package WooCommerce\Admin
+ */
+
+namespace WCPay\MultiCurrency;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Locale.
+ */
+class Locale {
+	/**
+	 * Multi-Currency currency formatting map.
+	 *
+	 * @var array
+	 */
+	protected $currency_format = [];
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->load_locale_data();
+	}
+
+	/**
+	 * Gets the currency formatting options.
+	 *
+	 * @param string $currency_code The 3 letter currency code.
+	 *
+	 * @return array|bool Returns array of the formatting data if found, false if not.
+	 */
+	public function get_currency_format( string $currency_code ) {
+		if ( ! empty( $this->currency_format[ $currency_code ] ) ) {
+			return $this->currency_format[ $currency_code ];
+		}
+		return false;
+	}
+
+	/**
+	 * Returns the user locale country.
+	 *
+	 * @return string The country code.
+	 */
+	public function get_user_locale_country(): string {
+		$locale = explode( '_', get_user_locale() );
+		return end( $locale );
+	}
+
+	/**
+	 * Loads locale data from WooCommerce core (/i18n/locale-info.php) and maps it
+	 * to be used by currency.
+	 *
+	 * @return void
+	 */
+	private function load_locale_data() {
+		$locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
+
+		if ( is_array( $locale_info ) && 0 < count( $locale_info ) ) {
+			$countries          = array_keys( $locale_info );
+			$first_country_data = $locale_info[ $countries[0] ];
+
+			// If the loaded locale_info doesn't contain the locales keys, load the fallback file.
+			if ( is_array( $first_country_data ) && ! array_key_exists( 'locales', $first_country_data ) ) {
+				$locale_info = include WCPAY_ABSPATH . 'i18n/locale-info.php';
+			}
+
+			// Extract the currency formatting options from the locale info.
+			foreach ( $locale_info as $country => $locale ) {
+				$currency_code = $locale['currency_code'];
+
+				// Convert Norwegian Krone symbol to its ISO 4217 currency code.
+				if ( 'Kr' === $currency_code ) {
+					$currency_code = 'NOK';
+				}
+
+				$this->currency_format[ $currency_code ][ $country ] = [
+					'currency_pos' => $locale['currency_pos'],
+					'thousand_sep' => $locale['thousand_sep'],
+					'decimal_sep'  => $locale['decimal_sep'],
+					'num_decimals' => $locale['num_decimals'],
+				];
+			}
+		}
+	}
+}

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -46,6 +46,13 @@ class MultiCurrency {
 	protected $compatibility;
 
 	/**
+	 * Locale instance.
+	 *
+	 * @var Locale
+	 */
+	protected $locale;
+
+	/**
 	 * Utils instance.
 	 *
 	 * @var Utils
@@ -116,6 +123,7 @@ class MultiCurrency {
 	 */
 	public function __construct( WC_Payments_API_Client $payments_api_client ) {
 		$this->payments_api_client = $payments_api_client;
+		$this->locale              = new Locale();
 		$this->utils               = new Utils();
 		$this->compatibility       = new Compatibility( $this->utils );
 
@@ -158,7 +166,7 @@ class MultiCurrency {
 		new UserSettings( $this );
 
 		$this->frontend_prices     = new FrontendPrices( $this, $this->compatibility );
-		$this->frontend_currencies = new FrontendCurrencies( $this, $this->utils );
+		$this->frontend_currencies = new FrontendCurrencies( $this, $this->locale );
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_scripts' ] );
 

--- a/includes/multi-currency/Utils.php
+++ b/includes/multi-currency/Utils.php
@@ -29,14 +29,4 @@ class Utils {
 		}
 		return false;
 	}
-
-	/**
-	 * Returns the user locale country.
-	 *
-	 * @return string The country code.
-	 */
-	public function get_user_locale_country(): string {
-		$locale = explode( '_', get_user_locale() );
-		return end( $locale );
-	}
 }

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -5,38 +5,43 @@
  * @package WooCommerce\Payments\Tests
  */
 
+use WCPay\MultiCurrency\Currency;
+use WCPay\MultiCurrency\FrontendCurrencies;
+use WCPay\MultiCurrency\MultiCurrency;
+use WCPay\MultiCurrency\Locale;
+
 /**
- * WCPay\MultiCurrency\FrontendCurrencies unit tests.
+ * FrontendCurrencies unit tests.
  */
 class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	/**
-	 * Mock WCPay\MultiCurrency\Locale.
+	 * Mock Locale.
 	 *
-	 * @var WCPay\MultiCurrency\Locale|PHPUnit_Framework_MockObject_MockObject
+	 * @var Locale|PHPUnit_Framework_MockObject_MockObject
 	 */
 	private $mock_locale;
 
 	/**
-	 * Mock WCPay\MultiCurrency\MultiCurrency.
+	 * Mock MultiCurrency.
 	 *
-	 * @var WCPay\MultiCurrency\MultiCurrency|PHPUnit_Framework_MockObject_MockObject
+	 * @var MultiCurrency|PHPUnit_Framework_MockObject_MockObject
 	 */
 	private $mock_multi_currency;
 
 	/**
-	 * WCPay\MultiCurrency\FrontendCurrencies instance.
+	 * FrontendCurrencies instance.
 	 *
-	 * @var WCPay\MultiCurrency\FrontendCurrencies
+	 * @var FrontendCurrencies
 	 */
 	private $frontend_currencies;
 
 	public function setUp() {
 		parent::setUp();
 
-		$this->mock_locale         = $this->createMock( WCPay\MultiCurrency\Locale::class );
-		$this->mock_multi_currency = $this->createMock( WCPay\MultiCurrency\MultiCurrency::class );
+		$this->mock_locale         = $this->createMock( Locale::class );
+		$this->mock_multi_currency = $this->createMock( MultiCurrency::class );
 
-		$this->frontend_currencies = new WCPay\MultiCurrency\FrontendCurrencies( $this->mock_multi_currency, $this->mock_locale );
+		$this->frontend_currencies = new FrontendCurrencies( $this->mock_multi_currency, $this->mock_locale );
 	}
 
 	public function tearDown() {
@@ -68,143 +73,191 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_get_woocommerce_currency() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'USD' );
+		$current_currency = new Currency( 'USD' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 
 		$this->assertSame( 'USD', $this->frontend_currencies->get_woocommerce_currency() );
 	}
 
 	public function test_get_price_decimals_returns_default_settings() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'RANDOM_CODE' );
+		$current_currency = new Currency( 'RANDOM_CODE' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->once() )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( 2, $this->frontend_currencies->get_price_decimals() );
 	}
 
 	public function test_get_price_decimals_returns_currency_settings() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'JPY' );
+		$current_currency = new Currency( 'JPY' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( 0, $this->frontend_currencies->get_price_decimals() );
 	}
 
 	public function test_get_price_decimals_returns_currency_settings_by_country() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'EUR' );
+		$current_currency = new Currency( 'EUR' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 		$this->mock_locale->method( 'get_user_locale_country' )->willReturn( 'DE' );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( 2, $this->frontend_currencies->get_price_decimals() );
 	}
 
 	public function test_get_price_decimals_returns_filtered_settings() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'JPY' );
+		$current_currency = new Currency( 'JPY' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 		$this->mock_currency_format( 'jpy', [ 'num_decimals' => 1 ] );
 
 		$this->assertEquals( 1, $this->frontend_currencies->get_price_decimals() );
 	}
 
 	public function test_get_price_decimal_separator_returns_default_settings() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'RANDOM_CODE' );
+		$current_currency = new Currency( 'RANDOM_CODE' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->once() )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( '.', $this->frontend_currencies->get_price_decimal_separator() );
 	}
 
 	public function test_get_price_decimal_separator_returns_currency_settings() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'BRL' );
+		$current_currency = new Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( ',', $this->frontend_currencies->get_price_decimal_separator() );
 	}
 
 	public function test_get_price_decimal_separator_returns_currency_settings_by_country() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'EUR' );
+		$current_currency = new Currency( 'EUR' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 		$this->mock_locale->method( 'get_user_locale_country' )->willReturn( 'NL' );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( ',', $this->frontend_currencies->get_price_decimal_separator() );
 	}
 
 	public function test_get_price_decimal_separator_returns_filtered_settings() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'BRL' );
+		$current_currency = new Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 		$this->mock_currency_format( 'brl', [ 'decimal_sep' => '/' ] );
 
 		$this->assertEquals( '/', $this->frontend_currencies->get_price_decimal_separator() );
 	}
 
 	public function test_get_price_thousand_separator_returns_default_settings() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'RANDOM_CODE' );
+		$current_currency = new Currency( 'RANDOM_CODE' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->once() )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( ',', $this->frontend_currencies->get_price_thousand_separator() );
 	}
 
 	public function test_get_price_thousand_separator_returns_currency_settings() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'BRL' );
+		$current_currency = new Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( '.', $this->frontend_currencies->get_price_thousand_separator() );
 	}
 
 	public function test_get_price_thousand_separator_returns_currency_settings_by_country() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'EUR' );
+		$current_currency = new Currency( 'EUR' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 		$this->mock_locale->method( 'get_user_locale_country' )->willReturn( 'BE' );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( '.', $this->frontend_currencies->get_price_thousand_separator() );
 	}
 
 	public function test_get_price_thousand_separator_returns_filtered_settings() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'BRL' );
+		$current_currency = new Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 		$this->mock_currency_format( 'brl', [ 'thousand_sep' => '/' ] );
 
 		$this->assertEquals( '/', $this->frontend_currencies->get_price_thousand_separator() );
 	}
 
 	public function test_get_woocommerce_price_format_returns_default_settings() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'RANDOM_CODE' );
+		$current_currency = new Currency( 'RANDOM_CODE' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->once() )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( '%1$s%2$s', $this->frontend_currencies->get_woocommerce_price_format() );
 	}
 
 	public function test_get_woocommerce_price_format_returns_currency_settings() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'HUF' );
+		$current_currency = new Currency( 'HUF' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( '%2$s&nbsp;%1$s', $this->frontend_currencies->get_woocommerce_price_format() );
 	}
 
 	public function test_get_woocommerce_price_format_returns_currency_settings_by_country() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'EUR' );
+		$current_currency = new Currency( 'EUR' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 		$this->mock_locale->method( 'get_user_locale_country' )->willReturn( 'ES' );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( '%2$s&nbsp;%1$s', $this->frontend_currencies->get_woocommerce_price_format() );
 	}
 
 	public function test_get_woocommerce_price_format_returns_filtered_settings() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'HUF' );
+		$current_currency = new Currency( 'HUF' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 		$this->mock_currency_format( 'huf', [ 'currency_pos' => 'left_space' ] );
 
 		$this->assertEquals( '%1$s&nbsp;%2$s', $this->frontend_currencies->get_woocommerce_price_format() );
@@ -214,9 +267,12 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	 * @dataProvider currency_format_provider
 	 */
 	public function test_get_woocommerce_price_format_outputs_right_format( $currency_pos, $expected_format ) {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'USD' );
+		$current_currency = new Currency( 'USD' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
+		$this->mock_locale
+			->expects( $this->once() )
+			->method( 'get_currency_format' )
+			->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->mock_currency_format( 'usd', [ 'currency_pos' => $currency_pos ] );
 		$this->assertEquals( $expected_format, $this->frontend_currencies->get_woocommerce_price_format() );
@@ -234,7 +290,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_add_currency_to_cart_hash_adds_currency_and_rate() {
-		$current_currency = new WCPay\MultiCurrency\Currency( 'GBP', 0.71 );
+		$current_currency = new Currency( 'GBP', 0.71 );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 
 		$this->assertSame(

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -10,18 +10,18 @@
  */
 class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	/**
+	 * Mock WCPay\MultiCurrency\Locale.
+	 *
+	 * @var WCPay\MultiCurrency\Locale|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_locale;
+
+	/**
 	 * Mock WCPay\MultiCurrency\MultiCurrency.
 	 *
 	 * @var WCPay\MultiCurrency\MultiCurrency|PHPUnit_Framework_MockObject_MockObject
 	 */
 	private $mock_multi_currency;
-
-	/**
-	 * Mock WCPay\MultiCurrency\Utils.
-	 *
-	 * @var WCPay\MultiCurrency\Utils|PHPUnit_Framework_MockObject_MockObject
-	 */
-	private $mock_utils;
 
 	/**
 	 * WCPay\MultiCurrency\FrontendCurrencies instance.
@@ -33,10 +33,10 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
+		$this->mock_locale         = $this->createMock( WCPay\MultiCurrency\Locale::class );
 		$this->mock_multi_currency = $this->createMock( WCPay\MultiCurrency\MultiCurrency::class );
-		$this->mock_utils          = $this->createMock( WCPay\MultiCurrency\Utils::class );
 
-		$this->frontend_currencies = new WCPay\MultiCurrency\FrontendCurrencies( $this->mock_multi_currency, $this->mock_utils );
+		$this->frontend_currencies = new WCPay\MultiCurrency\FrontendCurrencies( $this->mock_multi_currency, $this->mock_locale );
 	}
 
 	public function tearDown() {
@@ -77,6 +77,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_price_decimals_returns_default_settings() {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'RANDOM_CODE' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( 2, $this->frontend_currencies->get_price_decimals() );
 	}
@@ -84,6 +85,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_price_decimals_returns_currency_settings() {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'JPY' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( 0, $this->frontend_currencies->get_price_decimals() );
 	}
@@ -91,7 +93,8 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_price_decimals_returns_currency_settings_by_country() {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'EUR' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_utils->method( 'get_user_locale_country' )->willReturn( 'DE' );
+		$this->mock_locale->method( 'get_user_locale_country' )->willReturn( 'DE' );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( 2, $this->frontend_currencies->get_price_decimals() );
 	}
@@ -99,6 +102,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_price_decimals_returns_filtered_settings() {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'JPY' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 		$this->mock_currency_format( 'jpy', [ 'num_decimals' => 1 ] );
 
 		$this->assertEquals( 1, $this->frontend_currencies->get_price_decimals() );
@@ -107,6 +111,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_price_decimal_separator_returns_default_settings() {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'RANDOM_CODE' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( '.', $this->frontend_currencies->get_price_decimal_separator() );
 	}
@@ -114,6 +119,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_price_decimal_separator_returns_currency_settings() {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( ',', $this->frontend_currencies->get_price_decimal_separator() );
 	}
@@ -121,7 +127,8 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_price_decimal_separator_returns_currency_settings_by_country() {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'EUR' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_utils->method( 'get_user_locale_country' )->willReturn( 'NL' );
+		$this->mock_locale->method( 'get_user_locale_country' )->willReturn( 'NL' );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( ',', $this->frontend_currencies->get_price_decimal_separator() );
 	}
@@ -129,6 +136,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_price_decimal_separator_returns_filtered_settings() {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 		$this->mock_currency_format( 'brl', [ 'decimal_sep' => '/' ] );
 
 		$this->assertEquals( '/', $this->frontend_currencies->get_price_decimal_separator() );
@@ -137,6 +145,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_price_thousand_separator_returns_default_settings() {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'RANDOM_CODE' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( ',', $this->frontend_currencies->get_price_thousand_separator() );
 	}
@@ -144,6 +153,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_price_thousand_separator_returns_currency_settings() {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( '.', $this->frontend_currencies->get_price_thousand_separator() );
 	}
@@ -151,7 +161,8 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_price_thousand_separator_returns_currency_settings_by_country() {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'EUR' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_utils->method( 'get_user_locale_country' )->willReturn( 'BE' );
+		$this->mock_locale->method( 'get_user_locale_country' )->willReturn( 'BE' );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( '.', $this->frontend_currencies->get_price_thousand_separator() );
 	}
@@ -159,6 +170,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_price_thousand_separator_returns_filtered_settings() {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'BRL' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 		$this->mock_currency_format( 'brl', [ 'thousand_sep' => '/' ] );
 
 		$this->assertEquals( '/', $this->frontend_currencies->get_price_thousand_separator() );
@@ -167,6 +179,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_woocommerce_price_format_returns_default_settings() {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'RANDOM_CODE' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( '%1$s%2$s', $this->frontend_currencies->get_woocommerce_price_format() );
 	}
@@ -174,6 +187,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_woocommerce_price_format_returns_currency_settings() {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'HUF' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( '%2$s&nbsp;%1$s', $this->frontend_currencies->get_woocommerce_price_format() );
 	}
@@ -181,7 +195,8 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_woocommerce_price_format_returns_currency_settings_by_country() {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'EUR' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
-		$this->mock_utils->method( 'get_user_locale_country' )->willReturn( 'ES' );
+		$this->mock_locale->method( 'get_user_locale_country' )->willReturn( 'ES' );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->assertEquals( '%2$s&nbsp;%1$s', $this->frontend_currencies->get_woocommerce_price_format() );
 	}
@@ -189,6 +204,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_woocommerce_price_format_returns_filtered_settings() {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'HUF' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 		$this->mock_currency_format( 'huf', [ 'currency_pos' => 'left_space' ] );
 
 		$this->assertEquals( '%1$s&nbsp;%2$s', $this->frontend_currencies->get_woocommerce_price_format() );
@@ -200,6 +216,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	public function test_get_woocommerce_price_format_outputs_right_format( $currency_pos, $expected_format ) {
 		$current_currency = new WCPay\MultiCurrency\Currency( 'USD' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$this->mock_locale->method( 'get_currency_format' )->willReturn( $this->mock_get_currency_format( $current_currency ) );
 
 		$this->mock_currency_format( 'usd', [ 'currency_pos' => $currency_pos ] );
 		$this->assertEquals( $expected_format, $this->frontend_currencies->get_woocommerce_price_format() );
@@ -233,5 +250,74 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 				return $currency_settings;
 			}
 		);
+	}
+
+	private function mock_get_currency_format( $currency ) {
+		$currency_code = $currency->get_code();
+		// Formats are based on what's returned from Locale.
+		$currency_format = [
+			'BRL' => [
+				'BR' => [
+					'currency_pos' => 'left_space',
+					'thousand_sep' => '.',
+					'decimal_sep'  => ',',
+					'num_decimals' => 2,
+				],
+			],
+			'GBP' => [
+				'GB' => [
+					'currency_pos' => 'left',
+					'thousand_sep' => ',',
+					'decimal_sep'  => '.',
+					'num_decimals' => 2,
+				],
+			],
+			'EUR' => [
+				'BE' => [
+					'currency_pos' => 'left_space',
+					'thousand_sep' => '.',
+					'decimal_sep'  => ',',
+					'num_decimals' => 2,
+				],
+				'DE' => [
+					'currency_pos' => 'right_space',
+					'thousand_sep' => '.',
+					'decimal_sep'  => ',',
+					'num_decimals' => 2,
+				],
+				'ES' => [
+					'currency_pos' => 'right_space',
+					'thousand_sep' => '.',
+					'decimal_sep'  => ',',
+					'num_decimals' => 2,
+				],
+				'NL' => [
+					'currency_pos' => 'left_space',
+					'thousand_sep' => '.',
+					'decimal_sep'  => ',',
+					'num_decimals' => 2,
+				],
+			],
+			'HUF' => [
+				'HU' => [
+					'currency_pos' => 'right_space',
+					'thousand_sep' => '',
+					'decimal_sep'  => ',',
+					'num_decimals' => 0,
+				],
+			],
+			'JPY' => [
+				'JP' => [
+					'currency_pos' => 'left',
+					'thousand_sep' => ',',
+					'decimal_sep'  => '.',
+					'num_decimals' => 0,
+				],
+			],
+		];
+		if ( ! empty( $currency_format[ $currency_code ] ) ) {
+			return $currency_format[ $currency_code ];
+		}
+		return false;
 	}
 }

--- a/tests/unit/multi-currency/test-class-locale.php
+++ b/tests/unit/multi-currency/test-class-locale.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Class WCPay_Multi_Currency_Locale_Tests
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * WCPay\MultiCurrency\Locale unit tests.
+ */
+class WCPay_Multi_Currency_Locale_Tests extends WP_UnitTestCase {
+	/**
+	 * WCPay\MultiCurrency\Locale instance.
+	 *
+	 * @var WCPay\MultiCurrency\Locale
+	 */
+	private $locale;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->locale = new WCPay\MultiCurrency\Locale();
+	}
+
+	public function tearDown() {
+		wp_set_current_user( 0 );
+		remove_all_filters( 'locale' );
+	}
+
+	public function test_get_currency_format_returns_false() {
+		$this->assertFalse( $this->locale->get_currency_format( 'FFF' ) );
+	}
+
+	public function test_get_currency_format_returns_single_locale_correctly() {
+		$expected = $this->mock_get_currency_format( 'JPY' );
+		$this->assertSame( $expected, $this->locale->get_currency_format( 'JPY' ) );
+	}
+
+	public function test_get_currency_format_returns_multiple_locale_correctly() {
+		$expected = $this->mock_get_currency_format( 'GBP' );
+		$this->assertSame( $expected, $this->locale->get_currency_format( 'GBP' ) );
+	}
+
+	public function test_get_user_locale_country_returns_default_locale_country() {
+		$this->assertSame( 'US', $this->locale->get_user_locale_country() );
+	}
+
+	public function test_get_user_locale_country_returns_filtered_locale_country() {
+		$this->mock_locale( 'pt_BR' );
+
+		$this->assertSame( 'BR', $this->locale->get_user_locale_country() );
+	}
+
+	public function test_get_user_locale_country_returns_user_locale_country() {
+		$this->mock_locale( 'pt_BR' ); // Make sure filtered locale is ignored.
+
+		wp_set_current_user( 1 );
+		wp_get_current_user()->locale = 'en_GB';
+
+		$this->assertSame( 'GB', $this->locale->get_user_locale_country() );
+	}
+
+	private function mock_locale( $locale ) {
+		add_filter(
+			'locale',
+			function () use ( $locale ) {
+				return $locale;
+			}
+		);
+	}
+
+	private function mock_get_currency_format( $currency_code ) {
+		// Formats are based on what's returned from load_locale_data.
+		$currency_format = [
+			'GBP' => [
+				'GB' => [
+					'currency_pos' => 'left',
+					'thousand_sep' => ',',
+					'decimal_sep'  => '.',
+					'num_decimals' => 2,
+				],
+				'GG' => [
+					'currency_pos' => 'left_space',
+					'thousand_sep' => '.',
+					'decimal_sep'  => ',',
+					'num_decimals' => 2,
+				],
+				'IM' => [
+					'currency_pos' => 'left',
+					'thousand_sep' => ',',
+					'decimal_sep'  => '.',
+					'num_decimals' => 2,
+				],
+				'JE' => [
+					'currency_pos' => 'left',
+					'thousand_sep' => ',',
+					'decimal_sep'  => '.',
+					'num_decimals' => 2,
+				],
+			],
+			'JPY' => [
+				'JP' => [
+					'currency_pos' => 'left',
+					'thousand_sep' => ',',
+					'decimal_sep'  => '.',
+					'num_decimals' => 0,
+				],
+			],
+		];
+		if ( ! empty( $currency_format[ $currency_code ] ) ) {
+			return $currency_format[ $currency_code ];
+		}
+		return false;
+	}
+}

--- a/tests/unit/multi-currency/test-class-utils.php
+++ b/tests/unit/multi-currency/test-class-utils.php
@@ -25,44 +25,11 @@ class WCPay_Multi_Currency_Utils_Tests extends WP_UnitTestCase {
 		$this->utils = new WCPay\MultiCurrency\Utils();
 	}
 
-	public function tearDown() {
-		wp_set_current_user( 0 );
-		remove_all_filters( 'locale' );
-	}
-
 	public function test_is_call_in_backtrace_return_false() {
 		$this->assertFalse( $this->utils->is_call_in_backtrace( [ 'test' ] ) );
 	}
 
 	public function test_is_call_in_backtrace_return_true() {
 		$this->assertTrue( $this->utils->is_call_in_backtrace( [ 'WCPay_Multi_Currency_Utils_Tests->test_is_call_in_backtrace_return_true' ] ) );
-	}
-
-	public function test_get_user_locale_country_returns_default_locale_country() {
-		$this->assertSame( 'US', $this->utils->get_user_locale_country() );
-	}
-
-	public function test_get_user_locale_country_returns_filtered_locale_country() {
-		$this->mock_locale( 'pt_BR' );
-
-		$this->assertSame( 'BR', $this->utils->get_user_locale_country() );
-	}
-
-	public function test_get_user_locale_country_returns_user_locale_country() {
-		$this->mock_locale( 'pt_BR' ); // Make sure filtered locale is ignored.
-
-		wp_set_current_user( 1 );
-		wp_get_current_user()->locale = 'en_GB';
-
-		$this->assertSame( 'GB', $this->utils->get_user_locale_country() );
-	}
-
-	private function mock_locale( $locale ) {
-		add_filter(
-			'locale',
-			function () use ( $locale ) {
-				return $locale;
-			}
-		);
 	}
 }


### PR DESCRIPTION
Fixes: #2407

#### Changes proposed in this Pull Request

* Create `Locale` class to give locale based functions and data to live.
* Moved `load_locale_data` from `FrontendCurrencies` to `Locale`, and updated calls within `FrontendCurrencies` accordingly.
* Moved `get_currency_format` from `Utils` to `Locale`, updated calls to it accordingly.
* `FrontendCurrencies`  now has a dependency on `Locale` and not `Utils`.
* Added and updated tests.

#### Testing instructions

* Set your store default currency to USD.
* Enable EUR in your store under WooCommerce > Settings > Multi-Currency.
* View the shop page and switch from USD to EUR
* The formatting should (still) change from $1,000.00 to 1.000,00 €.
* Tests should pass.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
