### PR TITLE
Add support for phase 2 countries

### DIFF
--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -177,15 +177,23 @@ class WC_Payments_Utils {
 	 */
 	public static function supported_countries(): array {
 		return [
+			'AT' => __( 'Austria', 'woocommerce-payments' ),
 			'AU' => __( 'Australia', 'woocommerce-payments' ),
+			'BE' => __( 'Belgium', 'woocommerce-payments' ),
 			'CA' => __( 'Canada', 'woocommerce-payments' ),
+			'CH' => __( 'Switzerland', 'woocommerce-payments' ),
 			'DE' => __( 'Germany', 'woocommerce-payments' ),
 			'ES' => __( 'Spain', 'woocommerce-payments' ),
 			'FR' => __( 'France', 'woocommerce-payments' ),
 			'GB' => __( 'United Kingdom (UK)', 'woocommerce-payments' ),
+			'HK' => __( 'Hong Kong', 'woocommerce-payments' ),
 			'IE' => __( 'Ireland', 'woocommerce-payments' ),
 			'IT' => __( 'Italy', 'woocommerce-payments' ),
+			'NL' => __( 'Netherlands', 'woocommerce-payments' ),
 			'NZ' => __( 'New Zealand', 'woocommerce-payments' ),
+			'PL' => __( 'Poland', 'woocommerce-payments' ),
+			'PT' => __( 'Portugal', 'woocommerce-payments' ),
+			'SG' => __( 'Singapore', 'woocommerce-payments' ),
 			'US' => __( 'United States (US)', 'woocommerce-payments' ),
 		];
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add support for international launch phase 2 countries: Austria (AT), Belgium (BE), Netherlands (NL), Poland (PL), Portugal (PT), Switzerland (CH), Singapore (SG), Hong Kong (HK).

See 966-gh-Automattic/woocommerce-payments-server

**Screenshots**

Netherlands (NL) merchant - 1 x €100 transaction on an NL card

| Overview page | Transaction page |
|-|-|
|<img width="697" alt="Screen Shot 2021-07-14 at 1 10 05 pm" src="https://user-images.githubusercontent.com/1527164/125555013-975c61db-7ddf-4b63-9f5f-762aa38e71a3.png">|<img width="734" alt="Screen Shot 2021-07-14 at 1 09 46 pm" src="https://user-images.githubusercontent.com/1527164/125555041-7c1aaddd-5b57-44a4-9612-680af3d1526b.png">|

Switzerland (CH) merchant - 1 x CHF 100 transaction on a CH card

| Overview page | Transaction page |
|-|-|
|<img width="699" alt="Screen Shot 2021-07-14 at 1 39 23 pm" src="https://user-images.githubusercontent.com/1527164/125557453-567bbedd-37de-4796-9223-50a5bc4ce62d.png">|<img width="731" alt="Screen Shot 2021-07-14 at 1 38 41 pm" src="https://user-images.githubusercontent.com/1527164/125557465-64c31e0e-7f0f-4944-8aba-0345824c274a.png">|

Singapore (SG) merchant - 1 x $100 (SGD) transaction on a SG card

| Overview page | Transaction page |
|-|-|
|<img width="691" alt="Screen Shot 2021-07-14 at 1 55 11 pm" src="https://user-images.githubusercontent.com/1527164/125558755-e47cc2de-b814-4283-b2bc-ea2baf737007.png">|<img width="728" alt="Screen Shot 2021-07-14 at 1 57 37 pm" src="https://user-images.githubusercontent.com/1527164/125558788-ae69f33c-a420-46e6-8ac1-3bd5d7d46b01.png">|

Hong Kong (HK) merchant - 1 x $100 (HKD) transaction on a HK card

| Overview page | Transaction page |
|-|-|
|<img width="697" alt="Screen Shot 2021-07-14 at 2 04 51 pm" src="https://user-images.githubusercontent.com/1527164/125559582-213fb200-cca3-4066-af15-7929a623dc3d.png">|<img width="728" alt="Screen Shot 2021-07-14 at 2 05 50 pm" src="https://user-images.githubusercontent.com/1527164/125559620-644cb462-e4b7-4c6c-9528-eefd11df8f50.png">|

#### Testing instructions

* Switch to the `add/895-base-fees-for-phase-2-countries` server branch.
* Navigate to **WooCommerce** > **Settings** > **General** and change the store location and currency to one of the newly supported countries
* Navigate to **WCPay Dev**
* Ensure "Force onboarding" is checked and click "Reonboard"
* Complete the merchant onboarding.
* Navigate to the store's front-end.
* Make a purchase using a domestic card (see https://stripe.com/docs/testing#international-cards)
* Navigate to **Payments** > **Overview** to confirm the pending deposit amount is correct
* Navigate to **Payments** > **Transactions** to confirm the transaction fees are correct

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)