### PR TITLE
Created changelog entry for 2.8.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,12 +1,14 @@
 *** WooCommerce Payments Changelog ***
 
+= 2.8.0 - 2021-xx-xx =
+* Add - Use date picker for applicable dispute evidence fields.
+
 = 2.7.0 - 2021-07-14 =
 * Add - Add a link to the snackbar notice that appears after submitting or saving evidence for a dispute challenge.
 * Add - Support saving new cards and paying with previously saved cards in the WooCommerce Checkout Block.
 * Fix - WooCommerce Payments admin pages redirect to the onboarding page when the WooCommerce Payments account is disconnected.
 * Fix - Do not overwrite admin pages when account is disconnected.
 * Update - Set a description when creating payment intents.
-* Add - Use date picker for applicable dispute evidence fields.
 
 = 2.6.1 - 2021-07-01 =
 * Fix - Updates the notes query filters to prevent breaking the WooCommerce > Home inbox.

--- a/readme.txt
+++ b/readme.txt
@@ -101,12 +101,15 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 2.8.0 - 2021-xx-xx =
+* Add - Use date picker for applicable dispute evidence fields.
+
 = 2.7.0 - 2021-07-14 =
 * Add - Add a link to the snackbar notice that appears after submitting or saving evidence for a dispute challenge.
 * Add - Support saving new cards and paying with previously saved cards in the WooCommerce Checkout Block.
 * Fix - WooCommerce Payments admin pages redirect to the onboarding page when the WooCommerce Payments account is disconnected.
+* Fix - Do not overwrite admin pages when account is disconnected.
 * Update - Set a description when creating payment intents.
-* Add - Use date picker for applicable dispute evidence fields.
 
 = 2.6.1 - 2021-07-01 =
 * Fix - Updates the notes query filters to prevent breaking the WooCommerce > Home inbox.


### PR DESCRIPTION
### Created changelog entry for 2.8.0

 changes
- Created changelog entry for 2.8.0
- added missing readme.txt entry for 'Fix - Do not overwrite admin pages when account is disconnected'. More on this context - p1626270913338400/1626264024.329600-slack-CGGCLBN58