### PR TITLE
fix: confirmation modal rulers

### DIFF
--- a/client/components/confirmation-modal/styles.scss
+++ b/client/components/confirmation-modal/styles.scss
@@ -6,7 +6,7 @@
 	}
 
 	&__separator {
-		margin: 24px -24px;
+		margin: $grid-unit-30 -#{$grid-unit-30};
 	}
 
 	&__footer {

--- a/client/components/confirmation-modal/styles.scss
+++ b/client/components/confirmation-modal/styles.scss
@@ -5,6 +5,11 @@
 		min-width: 400px;
 	}
 
+	// to ensure that the separator extends all the way, even with different versions of Gutenberg
+	.components-modal__content {
+		padding: 0 $grid-unit-30 $grid-unit-30;
+	}
+
 	&__separator {
 		margin: $grid-unit-30 -#{$grid-unit-30};
 	}

--- a/client/multi-currency/enabled-currencies-list/delete-button.js
+++ b/client/multi-currency/enabled-currencies-list/delete-button.js
@@ -3,9 +3,10 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Modal, Button, Icon } from '@wordpress/components';
+import { Button, Icon } from '@wordpress/components';
 import interpolateComponents from 'interpolate-components';
 import { useCallback, useState } from '@wordpress/element';
+import ConfirmationModal from '../../components/confirmation-modal';
 
 // TODO: Delete button and modal should be separated.
 // TODO: This removes the item, but the list does not refresh.
@@ -30,7 +31,7 @@ const DeleteButton = ( { code, label, onClick, className } ) => {
 	return (
 		<>
 			{ isConfirmationModalOpen && (
-				<Modal
+				<ConfirmationModal
 					title={ sprintf(
 						__(
 							/* translators: %1: Name of the currency being removed */
@@ -41,6 +42,26 @@ const DeleteButton = ( { code, label, onClick, className } ) => {
 					) }
 					onRequestClose={ handleDeleteCancelClick }
 					className="enabled-currency-delete-modal"
+					actions={
+						<>
+							<Button
+								onClick={ handleDeleteCancelClick }
+								isSecondary
+							>
+								{ __( 'Cancel', 'woocommerce-payments' ) }
+							</Button>
+							<Button
+								onClick={ handleDeleteConfirmationClick }
+								isPrimary
+								isDestructive
+							>
+								{ __(
+									'Remove currency',
+									'woocommerce-payments'
+								) }
+							</Button>
+						</>
+					}
 				>
 					<p>
 						{ interpolateComponents( {
@@ -53,19 +74,7 @@ const DeleteButton = ( { code, label, onClick, className } ) => {
 							},
 						} ) }
 					</p>
-					<div className="enabled-currency-delete-modal__footer">
-						<Button onClick={ handleDeleteCancelClick } isSecondary>
-							{ __( 'Cancel', 'woocommerce-payments' ) }
-						</Button>
-						<Button
-							onClick={ handleDeleteConfirmationClick }
-							isPrimary
-							isDestructive
-						>
-							{ __( 'Remove currency', 'woocommerce-payments' ) }
-						</Button>
-					</div>
-				</Modal>
+				</ConfirmationModal>
 			) }
 			<Button
 				isLink

--- a/client/multi-currency/enabled-currencies-list/modal.js
+++ b/client/multi-currency/enabled-currencies-list/modal.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button, Modal } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
 
 /**
@@ -16,6 +16,7 @@ import {
 } from 'data';
 import EnabledCurrenciesModalCheckboxList from './modal-checkbox-list';
 import EnabledCurrenciesModalCheckbox from './modal-checkbox';
+import ConfirmationModal from '../../components/confirmation-modal';
 import Search from 'components/search';
 import './style.scss';
 
@@ -134,13 +135,32 @@ const EnabledCurrenciesModal = ( { className } ) => {
 	return (
 		<>
 			{ isEnabledCurrenciesModalOpen && (
-				<Modal
+				<ConfirmationModal
 					title={ __(
 						'Add enabled currencies',
 						'woocommerce-payments'
 					) }
 					onRequestClose={ handleAddSelectedCancelClick }
 					className="add-enabled-currencies-modal"
+					actions={
+						<>
+							<Button
+								isSecondary
+								onClick={ handleAddSelectedCancelClick }
+							>
+								{ __( 'Cancel', 'woocommerce-payments' ) }
+							</Button>
+							<Button
+								isPrimary
+								onClick={ handleAddSelectedClick }
+							>
+								{ __(
+									'Update selected',
+									'woocommerce-payments'
+								) }
+							</Button>
+						</>
+					}
 				>
 					<div className="add-enabled-currencies-modal__search">
 						<Search
@@ -182,18 +202,7 @@ const EnabledCurrenciesModal = ( { className } ) => {
 							) ) }
 						</EnabledCurrenciesModalCheckboxList>
 					</div>
-					<div className="add-enabled-currencies-modal__footer">
-						<Button
-							isSecondary
-							onClick={ handleAddSelectedCancelClick }
-						>
-							{ __( 'Cancel', 'woocommerce-payments' ) }
-						</Button>
-						<Button isPrimary onClick={ handleAddSelectedClick }>
-							{ __( 'Update selected', 'woocommerce-payments' ) }
-						</Button>
-					</div>
-				</Modal>
+				</ConfirmationModal>
 			) }
 			<Button
 				isSecondary

--- a/client/multi-currency/enabled-currencies-list/style.scss
+++ b/client/multi-currency/enabled-currencies-list/style.scss
@@ -93,21 +93,6 @@
 		margin: -24px -24px 0;
 		padding: 16px;
 	}
-
-	&__footer {
-		@include modal-footer-buttons;
-		border-top: 1px solid $studio-gray-5;
-		margin: 0 -24px -24px;
-		padding: 16px;
-	}
-}
-
-.enabled-currency-delete-modal {
-	&__footer {
-		@include modal-footer-buttons;
-		border-top: 1px solid $studio-gray-5;
-		padding: 15px 0 0;
-	}
 }
 
 @media screen and ( max-width: 600px ) {

--- a/client/multi-currency/enabled-currencies-list/test/__snapshots__/index.js.snap
+++ b/client/multi-currency/enabled-currencies-list/test/__snapshots__/index.js.snap
@@ -3,7 +3,7 @@
 exports[`Multi Currency enabled currencies list Available currencies modal renders correctly 1`] = `
 <div
   aria-labelledby="components-modal-header-0"
-  class="components-modal__frame add-enabled-currencies-modal"
+  class="components-modal__frame wcpay-confirmation-modal add-enabled-currencies-modal"
   role="dialog"
   tabindex="-1"
 >
@@ -539,8 +539,11 @@ exports[`Multi Currency enabled currencies list Available currencies modal rende
         </li>
       </ul>
     </div>
+    <hr
+      class="wcpay-confirmation-modal__separator"
+    />
     <div
-      class="add-enabled-currencies-modal__footer"
+      class="wcpay-confirmation-modal__footer"
     >
       <button
         class="components-button is-secondary"
@@ -814,7 +817,7 @@ exports[`Multi Currency enabled currencies list Enabled currencies list renders 
 exports[`Multi Currency enabled currencies list Remove currency modal renders correctly 1`] = `
 <div
   aria-labelledby="components-modal-header-1"
-  class="components-modal__frame enabled-currency-delete-modal"
+  class="components-modal__frame wcpay-confirmation-modal enabled-currency-delete-modal"
   role="dialog"
   tabindex="-1"
 >
@@ -861,8 +864,11 @@ exports[`Multi Currency enabled currencies list Remove currency modal renders co
       </strong>
        as an enabled currency in your store.
     </p>
+    <hr
+      class="wcpay-confirmation-modal__separator"
+    />
     <div
-      class="enabled-currency-delete-modal__footer"
+      class="wcpay-confirmation-modal__footer"
     >
       <button
         class="components-button is-secondary"

--- a/client/stylesheets/abstracts/_mixins.scss
+++ b/client/stylesheets/abstracts/_mixins.scss
@@ -26,7 +26,7 @@
 
 	> * {
 		&:not( :first-child ) {
-			margin-left: 16px;
+			margin-left: $grid-unit-20;
 		}
 	}
 }
@@ -36,7 +36,7 @@
 
 	> * {
 		&:not( :last-child ) {
-			margin-right: 16px;
+			margin-right: $grid-unit-20;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Ensures that the ruler at the bottom of the modal extends all the way.
Reuses the `ConfirmationModal` component.

Before:
![Screen Shot 2021-07-15 at 11 01 08 AM](https://user-images.githubusercontent.com/273592/125821455-c812649b-86a5-4370-9402-eb131a300a59.png)
![Screen Shot 2021-07-15 at 11 00 56 AM](https://user-images.githubusercontent.com/273592/125821590-5cd56c1e-214f-404f-955f-a3aa63665334.png)


After:
![Screen Shot 2021-07-15 at 11 09 39 AM](https://user-images.githubusercontent.com/273592/125821526-dcabcc4c-f21a-45a9-84b2-f10de23ba7d8.png)
![Screen Shot 2021-07-15 at 11 05 58 AM](https://user-images.githubusercontent.com/273592/125821528-e7cb0391-42a6-4260-a73c-d64b0e878276.png)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have the "multi currency" flag enabled
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=wcpay_multi_currency
- Add/remove currencies

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
