### PR TITLE
fix: clipping of focus indicator on modal

### DIFF
--- a/client/multi-currency/enabled-currencies-list/style.scss
+++ b/client/multi-currency/enabled-currencies-list/style.scss
@@ -86,6 +86,8 @@
 		display: flex;
 		flex-direction: column;
 		padding-right: 16px;
+		padding-left: 5px;
+		margin-left: -5px;
 	}
 
 	&__search {


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Before:
![Screen Shot 2021-07-15 at 11 23 31 AM](https://user-images.githubusercontent.com/273592/125823025-0a58be7a-b2c9-4574-a941-e2de7204febd.png)

After:
![Screen Shot 2021-07-15 at 11 23 17 AM](https://user-images.githubusercontent.com/273592/125823038-993efeb1-cfeb-4838-b2b1-ff080d1bd7b3.png)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have the "multi currency" flag enabled
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=wcpay_multi_currency
- Add a currency

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
