### PR TITLE
Disable Sofort as reusable payment method

### DIFF
--- a/includes/payment-methods/class-sofort-payment-method.php
+++ b/includes/payment-methods/class-sofort-payment-method.php
@@ -25,20 +25,6 @@ class Sofort_Payment_Method extends UPE_Payment_Method {
 		parent::__construct( $token_service );
 		$this->stripe_id   = 'sofort';
 		$this->title       = 'Sofort';
-		$this->is_reusable = true;
+		$this->is_reusable = false;
 	}
-
-	/**
-	 * Add payment method to user and return WC payment token
-	 *
-	 * @param WP_User     $user User to get payment token from.
-	 * @param string|bool $payment_method_id Stripe payment method ID string.
-	 *
-	 * @return WC_Payment_Token_WCPay_SEPA WC object for payment token.
-	 */
-	public function get_payment_token_for_user( $user, $payment_method_id = false ) {
-		// TODO: This function will need to work a little differently...
-		return $this->token_service->add_payment_method_to_user( $user, $payment_method_id );
-	}
-
 }

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -694,8 +694,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'Sofort', $sofort_method->get_title() );
 		$this->assertEquals( 'Sofort', $sofort_method->get_title( $mock_sofort_details ) );
 		$this->assertTrue( $sofort_method->is_enabled_at_checkout() );
-		$this->assertTrue( $sofort_method->is_reusable() );
-		$this->assertEquals( $mock_token, $sofort_method->get_payment_token_for_user( $mock_user, $mock_payment_method_id ) );
+		$this->assertFalse( $sofort_method->is_reusable() );
 	}
 
 	public function test_only_reusabled_payment_methods_enabled_with_subscription_item_present() {
@@ -706,7 +705,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( $card_method->is_enabled_at_checkout() );
 		$this->assertFalse( $giropay_method->is_enabled_at_checkout() );
-		$this->assertTrue( $sofort_method->is_enabled_at_checkout() );
+		$this->assertFalse( $sofort_method->is_enabled_at_checkout() );
 	}
 
 	public function test_create_token_from_setup_intent_adds_token() {


### PR DESCRIPTION
Fixes #2445 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
# Disable Sofort as a saveable payment method
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
> For the 2.8 release, we have decided that we will not be enabling the Sofort payment method to be compatible with saved payment methods. This is partly because the feature is currently not yet implemented or tested, but also because Sofort uses the SEPA payment method as a proxy when saving payment method details through Stripe (the Sofort payment method is converted into a SEPA payment method and token stored); we decided it made more sense to enable this feature once SEPA is also available as a payment method within the UPE.
>
> This also implies that Sofort will not support transactions including Subscription products and will consequently not be present as a checkout option when any Subscription products are present in a customer's cart.
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
1. Ensure you have pulled the changes in this PR, are running the latest version of the Payments Server, and have the WC Subscriptions plugin enabled. Also, please enable the UPE gateway using the WCPay Dev Plugin or simply set _wcpay_feature_upe to a value of 1 in your wp_options table.
2. Add a subscription product to your cart and proceed with a checkout. 
3. Sofort should not be available as a payment method at checkout.
4. Remove any subscription items from your cart and add a regular item instead.
5. At checkout Sofort should be available as a payment method, but the `Save payment information to my account for future purchases.` checkbox should not be present when Sofort is selected.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
