### PR TITLE
UPE reads customer details from checkout fields

### DIFF
--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -214,9 +214,7 @@ jQuery( function ( $ ) {
 	const getBillingDetails = ( fields ) => {
 		return {
 			name: (
-				fields.billing_first_name +
-				' ' +
-				fields.billing_last_name
+				`${fields.billing_first_name} ${fields.billing_last_name}`
 			).trim(),
 			email: fields.billing_email,
 			phone: fields.billing_phone,

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -213,9 +213,7 @@ jQuery( function ( $ ) {
 	 */
 	const getBillingDetails = ( fields ) => {
 		return {
-			name: (
-				`${fields.billing_first_name} ${fields.billing_last_name}`
-			).trim(),
+			name: `${ fields.billing_first_name } ${ fields.billing_last_name }`.trim(),
 			email: fields.billing_email,
 			phone: fields.billing_phone,
 			address: {

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -244,6 +244,7 @@ jQuery( function ( $ ) {
 
 		// If paying from order, we need to create Payment Intent from order not cart.
 		const isOrderPay = getConfig( 'isOrderPay' );
+		const isCheckout = getConfig( 'isCheckout' );
 		let orderId;
 		if ( isOrderPay ) {
 			orderId = getConfig( 'orderId' );
@@ -271,13 +272,18 @@ jQuery( function ( $ ) {
 				const appearance = getAppearance();
 				hiddenElementsForUPE.cleanup();
 				const businessName = getConfig( 'accountDescriptor' );
-
-				upeElement = elements.create( 'payment', {
+				const upeSettings = {
 					clientSecret,
 					appearance,
 					business: { name: businessName },
-					fields: { billingDetails: hiddenBillingFields },
-				} );
+				};
+				if ( isCheckout && ! isOrderPay ) {
+					upeSettings.fields = {
+						billingDetails: hiddenBillingFields,
+					};
+				}
+
+				upeElement = elements.create( 'payment', upeSettings );
 				upeElement.mount( '#wcpay-upe-element' );
 				unblockUI( $upeContainer );
 				upeElement.on( 'change', ( event ) => {

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -496,6 +496,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		$payment_fields['addPaymentReturnURL']  = wc_get_account_endpoint_url( 'payment-methods' );
 		$payment_fields['gatewayId']            = self::GATEWAY_ID;
 		$payment_fields['paymentMethodsConfig'] = $this->get_enabled_payment_method_config();
+		$payment_fields['isCheckout']           = is_checkout();
 
 		if ( is_wc_endpoint_url( 'order-pay' ) ) {
 			if ( $this->is_subscriptions_enabled() && $this->is_changing_payment_method_for_subscription() ) {


### PR DESCRIPTION
Fixes #1981 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
# UPE Reads Customer Details from Checkout Fields
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
> As noted in this Github thread, the customer details are not displayed when checking out with UPE. The most likely issue is that the customer details are not being properly added to the UPE transaction.
> ...
> We have gotten the latest feature description from Stripe for how to implement the additional billing details and hide the appropriate fields from UPE to avoid the customer having to enter information twice. We can now hide the fields that are duplicated in the billing details from UPE and instead provide the details from the billing details when confirming the payment. The fields in particular that should be hidden are: name, country, and postal code.
>
> In addition to the fields to hide, we should also provide as many of the billing fields as possible when confirming the intent. In particular: name, email, phone, and address fields.

This PR allows checkout fields to be read by the UPE upon the point of payment confirmation, so that we can add the customer's details to the payment transaction details. This should only affect the UPE when it is loaded on the checkout page: in other pages, such as the Order Pay page or the Add Payment Method page, there are no customer details present, so these pages will continue to work as they have been.

Once concern that I noticed is that even though we tell Stripe to hide certain fields when we mount the UPE, I noticed that with Sofort the country field remained present inside the UPE. If I remove the country argument from the `payment_method_data` billing details when I confirm the payment, I receive this error.

> You specified "never" for fields.billing_details.address.country when creating the payment Element, but did not pass confirmParams.payment_method_data.billing_details.address.country when calling stripe.confirmPayment or stripe.confirmSetup. If you opt out of collecting data via the payment Element using the fields option, the data must be passed at confirm-time.

This implies that I'm setting the flag for Stripe to hide this field correctly, but for whatever reason, it doesn't seem to hide the field, so I'm not entirely clear what's going on here. 

Everything else seems to be working smoothly enough.
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
1. Ensure you have pulled the changes in this PR and the latest version of the Payments Server. Also, please enable the UPE gateway using the WCPay Dev Plugin or simply set _wcpay_feature_upe to a value of 1 in your wp_options table. 
2. Add a product to your cart and proceed to the checkout screen. 
3. Complete the checkout process as usual.
4. Either go to **Payments > Transactions** and select the completed transaction or view the completed order and click on the payment intent ID near the top of the page to be transported to the details page for this latest transaction.
![Payment intent ID on order page](https://cdn-std.droplr.net/files/acc_1104206/5nfx4d)
_Payment intent ID on order page_

5. Confirm that customer details from checkout are present on the transaction.
6. Confirm that you can still add a payment method to a customer account or pay for an order through the Order Pay page without any issues.
7. Make a wish for lucky step number 7.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
