### PR TITLE
Unsupported country modal: extend supported countries list

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Fix - Disabled Payment Request Buttons when order has to be split into multiple packages because Payment Requests do not support that use case.
 * Fix - Fee discounts should use the discount currency rather than the base fee currency.
 * Add - Allow the customer to perform SCA authentication on Subscription renewals.
+* Update - Actualized supported countries list for onboarding.
 
 = 2.7.0 - 2021-07-14 =
 * Add - Add a link to the snackbar notice that appears after submitting or saving evidence for a dispute challenge.

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -177,15 +177,24 @@ class WC_Payments_Utils {
 	 */
 	public static function supported_countries(): array {
 		return [
+			'AT' => __( 'Austria', 'woocommerce-payments' ),
 			'AU' => __( 'Australia', 'woocommerce-payments' ),
+			'BE' => __( 'Belgium', 'woocommerce-payments' ),
 			'CA' => __( 'Canada', 'woocommerce-payments' ),
+			'CH' => __( 'Switzerland', 'woocommerce-payments' ),
 			'DE' => __( 'Germany', 'woocommerce-payments' ),
 			'ES' => __( 'Spain', 'woocommerce-payments' ),
 			'FR' => __( 'France', 'woocommerce-payments' ),
 			'GB' => __( 'United Kingdom (UK)', 'woocommerce-payments' ),
+			'HK' => __( 'Hong Kong', 'woocommerce-payments' ),
 			'IE' => __( 'Ireland', 'woocommerce-payments' ),
 			'IT' => __( 'Italy', 'woocommerce-payments' ),
+			'MY' => __( 'Malaysia', 'woocommerce-payments' ),
+			'NL' => __( 'Netherlands', 'woocommerce-payments' ),
 			'NZ' => __( 'New Zealand', 'woocommerce-payments' ),
+			'PL' => __( 'Poland', 'woocommerce-payments' ),
+			'PT' => __( 'Portugal', 'woocommerce-payments' ),
+			'SG' => __( 'Singapore', 'woocommerce-payments' ),
 			'US' => __( 'United States (US)', 'woocommerce-payments' ),
 		];
 	}

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -189,7 +189,6 @@ class WC_Payments_Utils {
 			'HK' => __( 'Hong Kong', 'woocommerce-payments' ),
 			'IE' => __( 'Ireland', 'woocommerce-payments' ),
 			'IT' => __( 'Italy', 'woocommerce-payments' ),
-			'MY' => __( 'Malaysia', 'woocommerce-payments' ),
 			'NL' => __( 'Netherlands', 'woocommerce-payments' ),
 			'NZ' => __( 'New Zealand', 'woocommerce-payments' ),
 			'PL' => __( 'Poland', 'woocommerce-payments' ),

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Disabled Payment Request Buttons when order has to be split into multiple packages because Payment Requests do not support that use case.
 * Fix - Fee discounts should use the discount currency rather than the base fee currency.
 * Add - Allow the customer to perform SCA authentication on Subscription renewals.
+* Update - Actualized supported countries list for onboarding.
 
 = 2.7.0 - 2021-07-14 =
 * Add - Add a link to the snackbar notice that appears after submitting or saving evidence for a dispute challenge.


### PR DESCRIPTION
Fixes #2452 

#### Changes proposed in this Pull Request

- Adds new countries to the list of supported for the modal

#### Testing instructions

- Change store country to one of the new countries
- Test onboarding - when starting onboarding, modal should not appear

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
