### PR TITLE
Storefront integration for Multi-Currency

### DIFF
--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -104,6 +104,13 @@ class MultiCurrency {
 	protected $enabled_currencies;
 
 	/**
+	 * The theme's stylesheet name.
+	 *
+	 * @var string
+	 */
+	protected $theme_stylesheet;
+
+	/**
 	 * Client for making requests to the WooCommerce Payments API
 	 *
 	 * @var WC_Payments_API_Client
@@ -200,11 +207,12 @@ class MultiCurrency {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_scripts' ] );
 
 		// Check for Storefront being active and load the integration if it is.
-		$theme = wp_get_theme();
-		if ( 'storefront' === $theme->stylesheet || 'storefront' === $theme->template ) {
+		$theme                  = wp_get_theme();
+		$this->theme_stylesheet = $theme->get_stylesheet();
+		if ( 'storefront' === $this->theme_stylesheet || 'storefront' === $theme->get_template() ) {
 			// The Hotel child theme has no easy place to add the widget except the widget area in the sidebar.
-			if ( 'hotel' !== $theme->stylesheet ) {
-				new StorefrontIntegration( $this, $theme );
+			if ( 'hotel' !== $this->theme_stylesheet ) {
+				new StorefrontIntegration( $this );
 			}
 		}
 
@@ -378,6 +386,15 @@ class MultiCurrency {
 	 */
 	public function get_frontend_currencies(): FrontendCurrencies {
 		return $this->frontend_currencies;
+	}
+
+	/**
+	 * Returns the theme stylesheet name.
+	 *
+	 * @return string
+	 */
+	public function get_theme_stylesheet(): string {
+		return $this->theme_stylesheet;
 	}
 
 	/**

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -55,6 +55,13 @@ class MultiCurrency {
 	protected $geolocation;
 
 	/**
+	 * The Currency Switcher Widget instance.
+	 *
+	 * @var null|CurrencySwitcherWidget
+	 */
+	protected $currency_switcher_widget;
+
+	/**
 	 * Utils instance.
 	 *
 	 * @var Utils
@@ -194,8 +201,11 @@ class MultiCurrency {
 
 		// Check for Storefront being active and load the integration if it is.
 		$theme = wp_get_theme();
-		if ( 'storefront' === $theme->stylesheet || 'storefront' === $theme->parent ) {
-			new StorefrontIntegration( $this );
+		if ( 'storefront' === $theme->stylesheet || 'storefront' === $theme->template ) {
+			// The Hotel child theme has no easy place to add the widget except the widget area in the sidebar.
+			if ( 'hotel' !== $theme->stylesheet ) {
+				new StorefrontIntegration( $this, $theme );
+			}
 		}
 
 		if ( is_admin() ) {
@@ -220,7 +230,8 @@ class MultiCurrency {
 	 * @return void
 	 */
 	public function init_widgets() {
-		register_widget( new CurrencySwitcherWidget( $this, $this->compatibility ) );
+		$this->currency_switcher_widget = new CurrencySwitcherWidget( $this, $this->compatibility );
+		register_widget( $this->currency_switcher_widget );
 	}
 
 	/**
@@ -340,6 +351,15 @@ class MultiCurrency {
 	 */
 	public function get_compatibility() {
 		return $this->compatibility;
+	}
+
+	/**
+	 * Returns the Currency Switcher Widget instance.
+	 *
+	 * @return CurrencySwitcherWidget
+	 */
+	public function get_currency_switcher_widget() {
+		return $this->currency_switcher_widget;
 	}
 
 	/**

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -83,6 +83,13 @@ class MultiCurrency {
 	protected $frontend_currencies;
 
 	/**
+	 * StorefrontIntegration instance.
+	 *
+	 * @var StorefrontIntegration
+	 */
+	protected $storefront_integration;
+
+	/**
 	 * The available currencies.
 	 *
 	 * @var array
@@ -202,7 +209,7 @@ class MultiCurrency {
 		// Check for Storefront being active and load the integration if it is.
 		$theme = wp_get_theme();
 		if ( 'storefront' === $theme->get_stylesheet() || 'storefront' === $theme->get_template() ) {
-			new StorefrontIntegration( $this );
+			$this->storefront_integration = new StorefrontIntegration( $this );
 		}
 
 		if ( is_admin() ) {
@@ -375,6 +382,15 @@ class MultiCurrency {
 	 */
 	public function get_frontend_currencies(): FrontendCurrencies {
 		return $this->frontend_currencies;
+	}
+
+	/**
+	 * Returns the StorefrontIntegration instance.
+	 *
+	 * @return StorefrontIntegration|null
+	 */
+	public function get_storefront_integration() {
+		return $this->storefront_integration;
 	}
 
 	/**

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -192,6 +192,12 @@ class MultiCurrency {
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_scripts' ] );
 
+		// Check for Storefront being active and load the integration if it is.
+		$theme = wp_get_theme();
+		if ( 'storefront' === $theme->stylesheet || 'storefront' === $theme->parent ) {
+			new StorefrontIntegration( $this );
+		}
+
 		if ( is_admin() ) {
 			add_filter( 'woocommerce_get_settings_pages', [ $this, 'init_settings_pages' ] );
 			add_action( 'admin_init', [ __CLASS__, 'add_woo_admin_notes' ] );

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -206,9 +206,9 @@ class MultiCurrency {
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_scripts' ] );
 
-		// Check for Storefront being active and load the integration if it is.
+		// Check to make sure there are enabled currencies, then for Storefront being active, and then load the integration.
 		$theme = wp_get_theme();
-		if ( 'storefront' === $theme->get_stylesheet() || 'storefront' === $theme->get_template() ) {
+		if ( 1 < count( $this->get_enabled_currencies() ) && ( 'storefront' === $theme->get_stylesheet() || 'storefront' === $theme->get_template() ) ) {
 			$this->storefront_integration = new StorefrontIntegration( $this );
 		}
 

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -104,13 +104,6 @@ class MultiCurrency {
 	protected $enabled_currencies;
 
 	/**
-	 * The theme's stylesheet name.
-	 *
-	 * @var string
-	 */
-	protected $theme_stylesheet;
-
-	/**
 	 * Client for making requests to the WooCommerce Payments API
 	 *
 	 * @var WC_Payments_API_Client
@@ -207,13 +200,9 @@ class MultiCurrency {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_scripts' ] );
 
 		// Check for Storefront being active and load the integration if it is.
-		$theme                  = wp_get_theme();
-		$this->theme_stylesheet = $theme->get_stylesheet();
-		if ( 'storefront' === $this->theme_stylesheet || 'storefront' === $theme->get_template() ) {
-			// The Hotel child theme has no easy place to add the widget except the widget area in the sidebar.
-			if ( 'hotel' !== $this->theme_stylesheet ) {
-				new StorefrontIntegration( $this );
-			}
+		$theme = wp_get_theme();
+		if ( 'storefront' === $theme->get_stylesheet() || 'storefront' === $theme->get_template() ) {
+			new StorefrontIntegration( $this );
 		}
 
 		if ( is_admin() ) {
@@ -386,15 +375,6 @@ class MultiCurrency {
 	 */
 	public function get_frontend_currencies(): FrontendCurrencies {
 		return $this->frontend_currencies;
-	}
-
-	/**
-	 * Returns the theme stylesheet name.
-	 *
-	 * @return string
-	 */
-	public function get_theme_stylesheet(): string {
-		return $this->theme_stylesheet;
 	}
 
 	/**

--- a/includes/multi-currency/Settings.php
+++ b/includes/multi-currency/Settings.php
@@ -125,14 +125,23 @@ class Settings extends \WC_Settings_Page {
 					],
 
 					[
-						'title'         => __( 'Store settings', 'woocommerce-payments' ),
-						'desc'          => __( 'Automatically switch customers to their local currency if it is enabled above.', 'woocommerce-payments' ),
+						'title'    => __( 'Store settings', 'woocommerce-payments' ),
+						'desc'     => __( 'Automatically switch customers to their local currency if it is enabled above.', 'woocommerce-payments' ),
 						// TODO: Preview link, to be done on #2523.
-						'desc_tip'      => __( 'Customers will be notified via store alert banner.', 'woocommerce-payments' ),
-						'id'            => $this->id . '_enable_auto_currency',
-						'default'       => 'yes',
-						'type'          => 'checkbox',
-						'checkboxgroup' => 'start',
+						'desc_tip' => __( 'Customers will be notified via store alert banner.', 'woocommerce-payments' ),
+						'id'       => $this->id . '_enable_auto_currency',
+						'default'  => 'yes',
+						'type'     => 'checkbox',
+					],
+
+					[
+						'desc' => sprintf(
+						/* translators: %s: url to the widgets page */
+							__( 'A currency switcher is available in your widgets. <a href="%s">Configure now</a>', 'woocommerce-payments' ),
+							'widgets.php'
+						),
+						'type' => 'title',
+						'id'   => $this->id . '_store_settings_widgets_link',
 					],
 
 					[

--- a/includes/multi-currency/Settings.php
+++ b/includes/multi-currency/Settings.php
@@ -136,19 +136,6 @@ class Settings extends \WC_Settings_Page {
 					],
 
 					[
-						'desc'          => __( 'Add a currency switcher to the cart widget', 'woocommerce-payments' ),
-						'desc_tip'      => sprintf(
-							/* translators: %s: url to the widgets page */
-							__( 'A currency switcher is also available in your widgets. <a href="%s">Configure now</a>', 'woocommerce-payments' ),
-							'widgets.php'
-						),
-						'id'            => $this->id . '_enable_cart_switcher',
-						'default'       => 'yes',
-						'type'          => 'checkbox',
-						'checkboxgroup' => 'end',
-					],
-
-					[
 						'type' => 'sectionend',
 						'id'   => $this->id . 'store_settings',
 					],

--- a/includes/multi-currency/StorefrontIntegration.php
+++ b/includes/multi-currency/StorefrontIntegration.php
@@ -28,13 +28,6 @@ class StorefrontIntegration {
 	protected $multi_currency;
 
 	/**
-	 * WP_Theme instance.
-	 *
-	 * @var \WP_Theme
-	 */
-	protected $theme;
-
-	/**
 	 * Themes where we need to add a wrapper around the breadcrumbs before adding the widget.
 	 *
 	 * @var array
@@ -45,12 +38,10 @@ class StorefrontIntegration {
 	 * Constructor.
 	 *
 	 * @param MultiCurrency $multi_currency The MultiCurrency instance.
-	 * @param \WP_Theme     $theme          The instance of the theme in use.
 	 */
-	public function __construct( MultiCurrency $multi_currency, \WP_Theme $theme ) {
+	public function __construct( MultiCurrency $multi_currency ) {
 		$this->multi_currency = $multi_currency;
 		$this->id             = $this->multi_currency->id;
-		$this->theme          = $theme;
 		$this->wrapper_themes = [ 'arcade', 'boutique', 'homestore', 'stationery' ];
 		$this->init_actions_and_filters();
 	}
@@ -190,7 +181,7 @@ class StorefrontIntegration {
 			}
 		';
 
-		switch ( $this->theme->stylesheet ) {
+		switch ( $this->multi_currency->get_theme_stylesheet() ) {
 			case 'arcade':
 			case 'boutique':
 				$css = '
@@ -316,6 +307,6 @@ class StorefrontIntegration {
 	 * @return bool
 	 */
 	private function is_wrapper_theme(): bool {
-		return in_array( $this->theme->stylesheet, $this->wrapper_themes, true );
+		return in_array( $this->multi_currency->get_theme_stylesheet(), $this->wrapper_themes, true );
 	}
 }

--- a/includes/multi-currency/StorefrontIntegration.php
+++ b/includes/multi-currency/StorefrontIntegration.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Class StorefrontIntegration
+ *
+ * @package WooCommerce\Payments\StorefrontIntegration
+ */
+
+namespace WCPay\MultiCurrency;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class that controls Multi Currency Storefront Integration.
+ */
+class StorefrontIntegration {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param MultiCurrency $multi_currency The MultiCurrency instance.
+	 */
+	public function __construct( MultiCurrency $multi_currency ) {
+		$this->multi_currency = $multi_currency;
+		$this->id             = $this->multi_currency->id;
+
+		add_filter( $this->id . '_enabled_currencies_settings', [ $this, 'filter_store_settings' ] );
+	}
+
+	/**
+	 * Adds the checkbox to the store settings to toggle the currency switched in the Storefront header.
+	 *
+	 * @param array $settings The settings from the Settings class.
+	 */
+	public function filter_store_settings( $settings ) {
+		foreach ( $settings as $setting ) {
+			if ( isset( $setting['id'] ) && $this->id . '_enable_auto_currency' === $setting['id'] ) {
+				// Add the checkboxgroup prop to the store settings section, then add the Storefront checkbox below it.
+				$setting['checkboxgroup'] = 'start';
+				$new_settings[]           = $setting;
+				$new_settings[]           = [
+					'desc'          => __( 'Add a currency switcher to the Storefront header and mobile menu.', 'woocommerce-payments' ),
+					'desc_tip'      => sprintf(
+						/* translators: %s: url to the widgets page */
+						__( 'A currency switcher is also available in your widgets. <a href="%s">Configure now</a>', 'woocommerce-payments' ),
+						'widgets.php'
+					),
+					'id'            => $this->id . '_enable_storefront_switcher',
+					'default'       => 'no',
+					'type'          => 'checkbox',
+					'checkboxgroup' => 'end',
+				];
+
+			} else {
+				// Otherwise just pass the setting to the new array.
+				$new_settings[] = $setting;
+			}
+		}
+		return $new_settings;
+	}
+}

--- a/includes/multi-currency/StorefrontIntegration.php
+++ b/includes/multi-currency/StorefrontIntegration.php
@@ -47,24 +47,25 @@ class StorefrontIntegration {
 	 */
 	public function filter_store_settings( array $settings ): array {
 		foreach ( $settings as $key => $value ) {
-			if ( isset( $value['id'] ) ) {
-				if ( $this->id . '_enable_auto_currency' === $value['id'] ) {
-					$settings[ $key ]['checkboxgroup'] = 'start';
-				}
-				if ( $this->id . '_store_settings_widgets_link' === $value['id'] ) {
-					$settings[ $key ] = [
-						'desc'          => __( 'Add a currency switcher to the Storefront theme on breadcrumb section. ', 'woocommerce-payments' ),
-						'desc_tip'      => sprintf(
-							/* translators: %s: url to the widgets page */
-							__( 'A currency switcher is also available in your widgets. <a href="%s">Configure now</a>', 'woocommerce-payments' ),
-							'widgets.php'
-						),
-						'id'            => $this->id . '_enable_storefront_switcher',
-						'default'       => 'yes',
-						'type'          => 'checkbox',
-						'checkboxgroup' => 'end',
-					];
-				}
+			if ( ! isset( $value['id'] ) ) {
+				continue;
+			}
+			if ( $this->id . '_enable_auto_currency' === $value['id'] ) {
+				$settings[ $key ]['checkboxgroup'] = 'start';
+			}
+			if ( $this->id . '_store_settings_widgets_link' === $value['id'] ) {
+				$settings[ $key ] = [
+					'desc'          => __( 'Add a currency switcher to the Storefront theme on breadcrumb section. ', 'woocommerce-payments' ),
+					'desc_tip'      => sprintf(
+						/* translators: %s: url to the widgets page */
+						__( 'A currency switcher is also available in your widgets. <a href="%s">Configure now</a>', 'woocommerce-payments' ),
+						'widgets.php'
+					),
+					'id'            => $this->id . '_enable_storefront_switcher',
+					'default'       => 'yes',
+					'type'          => 'checkbox',
+					'checkboxgroup' => 'end',
+				];
 			}
 		}
 		return $settings;

--- a/includes/multi-currency/StorefrontIntegration.php
+++ b/includes/multi-currency/StorefrontIntegration.php
@@ -28,13 +28,6 @@ class StorefrontIntegration {
 	protected $multi_currency;
 
 	/**
-	 * Themes where we need to add a wrapper around the breadcrumbs before adding the widget.
-	 *
-	 * @var array
-	 */
-	protected $wrapper_themes;
-
-	/**
 	 * Constructor.
 	 *
 	 * @param MultiCurrency $multi_currency The MultiCurrency instance.
@@ -42,7 +35,6 @@ class StorefrontIntegration {
 	public function __construct( MultiCurrency $multi_currency ) {
 		$this->multi_currency = $multi_currency;
 		$this->id             = $this->multi_currency->id;
-		$this->wrapper_themes = [ 'arcade', 'boutique', 'homestore', 'stationery' ];
 		$this->init_actions_and_filters();
 	}
 
@@ -52,234 +44,65 @@ class StorefrontIntegration {
 	 * @return void
 	 */
 	public function add_inline_css() {
+		$css = '
+			#woocommerce-payments-multi-currency-storefront-widget {
+				float: right;
+			}
+			#woocommerce-payments-multi-currency-storefront-widget form {
+				margin: 0;
+			}
+		';
+
 		wp_add_inline_style(
 			'storefront-style',
-			apply_filters( $this->id . '_storefront_widget_css', $this->get_css() )
+			apply_filters( $this->id . '_storefront_widget_css', $css )
 		);
 	}
 
 	/**
-	 * Adds the switcher widget.
+	 * Generates the switcher widget markup.
 	 *
-	 * @return void
+	 * @return string The widget markup.
 	 */
-	public function add_switcher_widget() {
+	public function switcher_widget_markup(): string {
 		/**
 		 * The spl_object_hash function is used here due to we register the widget with an instance of the widget and
 		 * not the class name of the widget. WordPress core takes the instance and passes it through spl_object_hash
 		 * to get a hash and adds that as the widget's name in the $wp_widget_factory->widgets[] array. In order to
 		 * call the_widget, you need to have the name of the widget, so we get the instance and hash to use.
 		 */
+		ob_start();
 		the_widget(
 			spl_object_hash( $this->multi_currency->get_currency_switcher_widget() ),
-			apply_filters(
-				$this->id . '_storefront_widget_options',
-				[
-					'symbol' => true,
-					'flag'   => true,
-				]
-			),
+			null,
 			apply_filters(
 				$this->id . '_storefront_widget_args',
 				[
-					'before_widget' => '<div id="woocommerce-payments-multi-currency-storefront-widget">',
+					'before_widget' => '<div id="woocommerce-payments-multi-currency-storefront-widget" class="woocommerce-breadcrumb">',
 					'after_widget'  => '</div>',
 				]
 			)
 		);
+		return ob_get_clean();
 	}
 
-	/**
-	 * This closes the div tags opened in modify_breadcrumb_wrapper.
-	 *
-	 * @return void
-	 */
-	public function close_breadcrumb_wrapper() {
-		if ( $this->is_wrapper_theme() ) {
-			echo '</div>';
-		} else {
-			echo '</div></div>';
-		}
-	}
+
 
 	/**
-	 * Adds the checkbox to the store settings to toggle the currency switched in the Storefront header.
+	 * This modifies the breadcrumb defaults for us to be able to place the widget.
 	 *
-	 * @param array $settings The settings from the Settings class.
+	 * @param array $defaults The defaults breadcrumb properties.
 	 *
-	 * @return array The modified settings array.
+	 * @return array The modified defaults properties.
 	 */
-	public function filter_store_settings( array $settings ): array {
-		foreach ( $settings as $setting ) {
-			if ( isset( $setting['id'] ) && $this->id . '_enable_auto_currency' === $setting['id'] ) {
-				// Add the checkboxgroup prop to the store settings section, then add the setting to the new array.
-				$setting['checkboxgroup'] = 'start';
-				$new_settings[]           = $setting;
-
-				// Add the checkbox to be able to toggle the widget.
-				$new_settings[] = [
-					'desc'          => __( 'Add a currency switcher to the Storefront theme. ', 'woocommerce-payments' ),
-					'desc_tip'      => sprintf(
-						/* translators: %s: url to the widgets page */
-						__( 'A currency switcher is also available in your widgets. <a href="%s">Configure now</a>', 'woocommerce-payments' ),
-						'widgets.php'
-					),
-					'id'            => $this->id . '_enable_storefront_switcher',
-					'default'       => 'yes',
-					'type'          => 'checkbox',
-					'checkboxgroup' => 'end',
-				];
-
-			} else {
-				// Otherwise just pass the setting to the new array.
-				$new_settings[] = $setting;
-			}
-		}
-		return $new_settings;
-	}
-
-	/**
-	 * This modifies the wrapper(s) around the breadcrumb for us to be able to place the widget in the wrapper.
-	 *
-	 * @param array $defaults The default breadcrumb wrapper elements.
-	 *
-	 * @return array The modified wrapper elements.
-	 */
-	public function modify_breadcrumb_wrapper( array $defaults ): array {
-		if ( $this->is_wrapper_theme() ) {
-			// This adds the opening div tag so we can make use of it for these themes.
-			$defaults['wrap_before'] = '<div class="storefront-breadcrumb-wrapper"><nav class="woocommerce-breadcrumb">';
-		} else {
-			// This removes the closing div tags for all other Storefront themes.
-			$defaults['wrap_after'] = '</nav>';
-		}
+	public function modify_breadcrumb_defaults( array $defaults ): array {
+		/**
+		 * Some storefront child themes uses different wrappers and styles. We need to place the widget before
+		 * the <nav> to display it properly.
+		 */
+		$defaults['wrap_before'] = str_replace( '<nav', $this->switcher_widget_markup() . '<nav', $defaults['wrap_before'] );
 
 		return $defaults;
-	}
-
-	/**
-	 * Gets the css for the current Storefront theme.
-	 *
-	 * @return string The css to be added to the header.
-	 */
-	private function get_css(): string {
-		$flex_rules = '
-			display: flex;
-			flex-wrap: wrap;
-			justify-content: space-between;
-			align-items: center;
-		';
-
-		$without_wrapper = '
-			div.storefront-breadcrumb div.col-full {
-				' . $flex_rules . '
-			}
-
-			div.storefront-breadcrumb div.col-full:before,
-			div.storefront-breadcrumb div.col-full:after {
-				display: none;
-			}
-		';
-
-		switch ( $this->multi_currency->get_theme_stylesheet() ) {
-			case 'arcade':
-			case 'boutique':
-				$css = '
-					div.storefront-breadcrumb-wrapper {
-						' . $flex_rules . '
-						margin: 0 0 1.618em;
-					}
-
-					div.storefront-breadcrumb-wrapper nav.woocommerce-breadcrumb {
-						margin: 0;
-					}
-				';
-				break;
-			case 'bistro':
-				$css = $without_wrapper . '
-					div.storefront-breadcrumb div.col-full {
-						margin-top: 4.236em;
-					}
-
-					div.storefront-breadcrumb nav.woocommerce-breadcrumb {
-						margin: 0;
-					}
-				';
-				break;
-			case 'deli':
-				$css = $without_wrapper . '
-					div.storefront-breadcrumb div.col-full {
-						margin-bottom: 0;
-					}
-
-					div.storefront-breadcrumb nav.woocommerce-breadcrumb {
-						margin: 0;
-					}
-				';
-				break;
-			case 'galleria':
-			case 'outlet':
-				$css = $without_wrapper . '
-					#woocommerce-payments-multi-currency-storefront-widget {
-						font-size: .8rem;
-					}
-				';
-				break;
-			case 'homestore':
-				$css = '
-					div.storefront-breadcrumb-wrapper {
-						' . $flex_rules . '
-						font-size: 0.9em;
-						border-bottom: 3px solid #151515;
-						color: #a2a1a1;
-						margin: -3em 0 3.24rem;
-						padding: 0 0 .6rem;
-					}
-
-					div.storefront-breadcrumb-wrapper nav.woocommerce-breadcrumb {
-						border: none;
-						margin: 0;
-						padding: 0;
-					}
-				';
-				break;
-			case 'stationery':
-				$css = '
-					div.storefront-breadcrumb-wrapper {
-						' . $flex_rules . '
-						margin: 0 0 1.861em;
-						padding: 1.861em 0;
-					}
-
-					div.storefront-breadcrumb-wrapper nav.woocommerce-breadcrumb {
-						margin: 0;
-						padding: 0;
-					}
-				';
-				break;
-			case 'toyshop':
-				$css = $without_wrapper . '
-					div.storefront-breadcrumb div.col-full {
-						margin-bottom: 2rem;
-					}
-
-					div.storefront-breadcrumb nav.woocommerce-breadcrumb {
-						margin: 0;
-					}
-				';
-				break;
-			default:
-				$css = $without_wrapper;
-				break;
-		}
-
-		$css .= '
-			#woocommerce-payments-multi-currency-storefront-widget form {
-				margin: 0;
-			}
-		';
-
-		return $css;
 	}
 
 	/**
@@ -288,25 +111,10 @@ class StorefrontIntegration {
 	 * @return void
 	 */
 	private function init_actions_and_filters() {
-		add_filter( $this->id . '_enabled_currencies_settings', [ $this, 'filter_store_settings' ] );
-
 		// We specifically look for 'no', because we want it enabled by default.
 		if ( 'no' !== get_option( $this->id . '_enable_storefront_switcher' ) ) {
-			add_filter( 'woocommerce_breadcrumb_defaults', [ $this, 'modify_breadcrumb_wrapper' ], 9999 );
+			add_filter( 'woocommerce_breadcrumb_defaults', [ $this, 'modify_breadcrumb_defaults' ], 9999 );
 			add_action( 'wp_enqueue_scripts', [ $this, 'add_inline_css' ], 50 );
-
-			$breadcrumb_action = $this->is_wrapper_theme() ? 'storefront_content_top' : 'storefront_before_content';
-			add_action( $breadcrumb_action, [ $this, 'add_switcher_widget' ], 11 );
-			add_action( $breadcrumb_action, [ $this, 'close_breadcrumb_wrapper' ], 12 );
 		}
-	}
-
-	/**
-	 * Returns if a wrapper theme is in use or not.
-	 *
-	 * @return bool
-	 */
-	private function is_wrapper_theme(): bool {
-		return in_array( $this->multi_currency->get_theme_stylesheet(), $this->wrapper_themes, true );
 	}
 }

--- a/includes/multi-currency/StorefrontIntegration.php
+++ b/includes/multi-currency/StorefrontIntegration.php
@@ -146,8 +146,8 @@ class StorefrontIntegration {
 	 */
 	private function init_actions_and_filters() {
 		add_filter( $this->id . '_enabled_currencies_settings', [ $this, 'filter_store_settings' ] );
-		// We specifically look for 'no', because we want it enabled by default.
-		if ( 'no' !== get_option( $this->id . '_enable_storefront_switcher' ) ) {
+		// We want this enabled by default, so we default the option to 'yes'.
+		if ( 'yes' === get_option( $this->id . '_enable_storefront_switcher', 'yes' ) ) {
 			add_filter( 'woocommerce_breadcrumb_defaults', [ $this, 'modify_breadcrumb_defaults' ], 9999 );
 			add_action( 'wp_enqueue_scripts', [ $this, 'add_inline_css' ], 50 );
 		}

--- a/includes/multi-currency/StorefrontIntegration.php
+++ b/includes/multi-currency/StorefrontIntegration.php
@@ -13,33 +13,121 @@ defined( 'ABSPATH' ) || exit;
  * Class that controls Multi Currency Storefront Integration.
  */
 class StorefrontIntegration {
+	/**
+	 * The plugin's ID.
+	 *
+	 * @var string
+	 */
+	public $id;
+
+	/**
+	 * Multi-Currency instance.
+	 *
+	 * @var MultiCurrency
+	 */
+	protected $multi_currency;
+
+	/**
+	 * WP_Theme instance.
+	 *
+	 * @var \WP_Theme
+	 */
+	protected $theme;
+
+	/**
+	 * Themes where we need to add a wrapper around the breadcrumbs before adding the widget.
+	 *
+	 * @var array
+	 */
+	protected $wrapper_themes;
 
 	/**
 	 * Constructor.
 	 *
 	 * @param MultiCurrency $multi_currency The MultiCurrency instance.
+	 * @param \WP_Theme     $theme          The instance of the theme in use.
 	 */
-	public function __construct( MultiCurrency $multi_currency ) {
+	public function __construct( MultiCurrency $multi_currency, \WP_Theme $theme ) {
 		$this->multi_currency = $multi_currency;
 		$this->id             = $this->multi_currency->id;
+		$this->theme          = $theme;
+		$this->wrapper_themes = [ 'arcade', 'boutique', 'homestore', 'stationery' ];
+		$this->init_actions_and_filters();
+	}
 
-		add_filter( $this->id . '_enabled_currencies_settings', [ $this, 'filter_store_settings' ] );
-		add_action( 'storefront_before_content', [ $this, 'maybe_add_switcher_after_breadcrumb' ], 11 );
+	/**
+	 * Adds the CSS to the head of the page.
+	 *
+	 * @return void
+	 */
+	public function add_inline_css() {
+		wp_add_inline_style(
+			'storefront-style',
+			apply_filters( $this->id . '_storefront_widget_css', $this->get_css() )
+		);
+	}
+
+	/**
+	 * Adds the switcher widget.
+	 *
+	 * @return void
+	 */
+	public function add_switcher_widget() {
+		/**
+		 * The spl_object_hash function is used here due to we register the widget with an instance of the widget and
+		 * not the class name of the widget. WordPress core takes the instance and passes it through spl_object_hash
+		 * to get a hash and adds that as the widget's name in the $wp_widget_factory->widgets[] array. In order to
+		 * call the_widget, you need to have the name of the widget, so we get the instance and hash to use.
+		 */
+		the_widget(
+			spl_object_hash( $this->multi_currency->get_currency_switcher_widget() ),
+			apply_filters(
+				$this->id . '_storefront_widget_options',
+				[
+					'symbol' => true,
+					'flag'   => true,
+				]
+			),
+			apply_filters(
+				$this->id . '_storefront_widget_args',
+				[
+					'before_widget' => '<div id="woocommerce-payments-multi-currency-storefront-widget">',
+					'after_widget'  => '</div>',
+				]
+			)
+		);
+	}
+
+	/**
+	 * This closes the div tags opened in modify_breadcrumb_wrapper.
+	 *
+	 * @return void
+	 */
+	public function close_breadcrumb_wrapper() {
+		if ( $this->is_wrapper_theme() ) {
+			echo '</div>';
+		} else {
+			echo '</div></div>';
+		}
 	}
 
 	/**
 	 * Adds the checkbox to the store settings to toggle the currency switched in the Storefront header.
 	 *
 	 * @param array $settings The settings from the Settings class.
+	 *
+	 * @return array The modified settings array.
 	 */
-	public function filter_store_settings( $settings ) {
+	public function filter_store_settings( array $settings ): array {
 		foreach ( $settings as $setting ) {
 			if ( isset( $setting['id'] ) && $this->id . '_enable_auto_currency' === $setting['id'] ) {
-				// Add the checkboxgroup prop to the store settings section, then add the Storefront checkbox below it.
+				// Add the checkboxgroup prop to the store settings section, then add the setting to the new array.
 				$setting['checkboxgroup'] = 'start';
 				$new_settings[]           = $setting;
-				$new_settings[]           = [
-					'desc'          => __( 'Add a currency switcher to the Storefront theme.', 'woocommerce-payments' ),
+
+				// Add the checkbox to be able to toggle the widget.
+				$new_settings[] = [
+					'desc'          => __( 'Add a currency switcher to the Storefront theme. ', 'woocommerce-payments' ),
 					'desc_tip'      => sprintf(
 						/* translators: %s: url to the widgets page */
 						__( 'A currency switcher is also available in your widgets. <a href="%s">Configure now</a>', 'woocommerce-payments' ),
@@ -60,15 +148,174 @@ class StorefrontIntegration {
 	}
 
 	/**
-	 * Checks to see if the widget should be added, and then adds it.
+	 * This modifies the wrapper(s) around the breadcrumb for us to be able to place the widget in the wrapper.
+	 *
+	 * @param array $defaults The default breadcrumb wrapper elements.
+	 *
+	 * @return array The modified wrapper elements.
 	 */
-	public function maybe_add_switcher_after_breadcrumb() {
-		// We specifically look for 'no', because we want it enabled by default.
-		if ( 'no' === get_option( $this->id . '_enable_storefront_switcher' ) ) {
-			return;
+	public function modify_breadcrumb_wrapper( array $defaults ): array {
+		if ( $this->is_wrapper_theme() ) {
+			// This adds the opening div tag so we can make use of it for these themes.
+			$defaults['wrap_before'] = '<div class="storefront-breadcrumb-wrapper"><nav class="woocommerce-breadcrumb">';
+		} else {
+			// This removes the closing div tags for all other Storefront themes.
+			$defaults['wrap_after'] = '</nav>';
 		}
-		// If so, add it.
-		the_widget( CurrencySwitcherWidget::class );
-		// What about CSS changes?
+
+		return $defaults;
+	}
+
+	/**
+	 * Gets the css for the current Storefront theme.
+	 *
+	 * @return string The css to be added to the header.
+	 */
+	private function get_css(): string {
+		$flex_rules = '
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: space-between;
+			align-items: center;
+		';
+
+		$without_wrapper = '
+			div.storefront-breadcrumb div.col-full {
+				' . $flex_rules . '
+			}
+
+			div.storefront-breadcrumb div.col-full:before,
+			div.storefront-breadcrumb div.col-full:after {
+				display: none;
+			}
+		';
+
+		switch ( $this->theme->stylesheet ) {
+			case 'arcade':
+			case 'boutique':
+				$css = '
+					div.storefront-breadcrumb-wrapper {
+						' . $flex_rules . '
+						margin: 0 0 1.618em;
+					}
+
+					div.storefront-breadcrumb-wrapper nav.woocommerce-breadcrumb {
+						margin: 0;
+					}
+				';
+				break;
+			case 'bistro':
+				$css = $without_wrapper . '
+					div.storefront-breadcrumb div.col-full {
+						margin-top: 4.236em;
+					}
+
+					div.storefront-breadcrumb nav.woocommerce-breadcrumb {
+						margin: 0;
+					}
+				';
+				break;
+			case 'deli':
+				$css = $without_wrapper . '
+					div.storefront-breadcrumb div.col-full {
+						margin-bottom: 0;
+					}
+
+					div.storefront-breadcrumb nav.woocommerce-breadcrumb {
+						margin: 0;
+					}
+				';
+				break;
+			case 'galleria':
+			case 'outlet':
+				$css = $without_wrapper . '
+					#woocommerce-payments-multi-currency-storefront-widget {
+						font-size: .8rem;
+					}
+				';
+				break;
+			case 'homestore':
+				$css = '
+					div.storefront-breadcrumb-wrapper {
+						' . $flex_rules . '
+						font-size: 0.9em;
+						border-bottom: 3px solid #151515;
+						color: #a2a1a1;
+						margin: -3em 0 3.24rem;
+						padding: 0 0 .6rem;
+					}
+
+					div.storefront-breadcrumb-wrapper nav.woocommerce-breadcrumb {
+						border: none;
+						margin: 0;
+						padding: 0;
+					}
+				';
+				break;
+			case 'stationery':
+				$css = '
+					div.storefront-breadcrumb-wrapper {
+						' . $flex_rules . '
+						margin: 0 0 1.861em;
+						padding: 1.861em 0;
+					}
+
+					div.storefront-breadcrumb-wrapper nav.woocommerce-breadcrumb {
+						margin: 0;
+						padding: 0;
+					}
+				';
+				break;
+			case 'toyshop':
+				$css = $without_wrapper . '
+					div.storefront-breadcrumb div.col-full {
+						margin-bottom: 2rem;
+					}
+
+					div.storefront-breadcrumb nav.woocommerce-breadcrumb {
+						margin: 0;
+					}
+				';
+				break;
+			default:
+				$css = $without_wrapper;
+				break;
+		}
+
+		$css .= '
+			#woocommerce-payments-multi-currency-storefront-widget form {
+				margin: 0;
+			}
+		';
+
+		return $css;
+	}
+
+	/**
+	 * Adds the actions and filters.
+	 *
+	 * @return void
+	 */
+	private function init_actions_and_filters() {
+		add_filter( $this->id . '_enabled_currencies_settings', [ $this, 'filter_store_settings' ] );
+
+		// We specifically look for 'no', because we want it enabled by default.
+		if ( 'no' !== get_option( $this->id . '_enable_storefront_switcher' ) ) {
+			add_filter( 'woocommerce_breadcrumb_defaults', [ $this, 'modify_breadcrumb_wrapper' ], 9999 );
+			add_action( 'wp_enqueue_scripts', [ $this, 'add_inline_css' ], 50 );
+
+			$breadcrumb_action = $this->is_wrapper_theme() ? 'storefront_content_top' : 'storefront_before_content';
+			add_action( $breadcrumb_action, [ $this, 'add_switcher_widget' ], 11 );
+			add_action( $breadcrumb_action, [ $this, 'close_breadcrumb_wrapper' ], 12 );
+		}
+	}
+
+	/**
+	 * Returns if a wrapper theme is in use or not.
+	 *
+	 * @return bool
+	 */
+	private function is_wrapper_theme(): bool {
+		return in_array( $this->theme->stylesheet, $this->wrapper_themes, true );
 	}
 }

--- a/includes/multi-currency/StorefrontIntegration.php
+++ b/includes/multi-currency/StorefrontIntegration.php
@@ -39,6 +39,39 @@ class StorefrontIntegration {
 	}
 
 	/**
+	 * Adds the checkbox to the store settings to toggle the currency switched in the Storefront breadcrumb section.
+	 *
+	 * @param array $settings The settings from the Settings class.
+	 *
+	 * @return array The modified settings array.
+	 */
+	public function filter_store_settings( array $settings ): array {
+		foreach ( $settings as $key => $value ) {
+			if ( isset( $value['id'] ) ) {
+				if ( $this->id . '_enable_auto_currency' === $value['id'] ) {
+					$settings[ $key ]['checkboxgroup'] = 'start';
+				}
+				if ( $this->id . '_store_settings_widgets_link' === $value['id'] ) {
+					$settings[ $key ] = [
+						'desc'          => __( 'Add a currency switcher to the Storefront theme on breadcrumb section. ', 'woocommerce-payments' ),
+						'desc_tip'      => sprintf(
+							/* translators: %s: url to the widgets page */
+							__( 'A currency switcher is also available in your widgets. <a href="%s">Configure now</a>', 'woocommerce-payments' ),
+							'widgets.php'
+						),
+						'id'            => $this->id . '_enable_storefront_switcher',
+						'default'       => 'yes',
+						'type'          => 'checkbox',
+						'checkboxgroup' => 'end',
+					];
+				}
+			}
+		}
+		return $settings;
+	}
+
+
+	/**
 	 * Adds the CSS to the head of the page.
 	 *
 	 * @return void
@@ -111,6 +144,7 @@ class StorefrontIntegration {
 	 * @return void
 	 */
 	private function init_actions_and_filters() {
+		add_filter( $this->id . '_enabled_currencies_settings', [ $this, 'filter_store_settings' ] );
 		// We specifically look for 'no', because we want it enabled by default.
 		if ( 'no' !== get_option( $this->id . '_enable_storefront_switcher' ) ) {
 			add_filter( 'woocommerce_breadcrumb_defaults', [ $this, 'modify_breadcrumb_defaults' ], 9999 );

--- a/includes/multi-currency/StorefrontIntegration.php
+++ b/includes/multi-currency/StorefrontIntegration.php
@@ -24,6 +24,7 @@ class StorefrontIntegration {
 		$this->id             = $this->multi_currency->id;
 
 		add_filter( $this->id . '_enabled_currencies_settings', [ $this, 'filter_store_settings' ] );
+		add_action( 'storefront_before_content', [ $this, 'maybe_add_switcher_after_breadcrumb' ], 11 );
 	}
 
 	/**
@@ -38,14 +39,14 @@ class StorefrontIntegration {
 				$setting['checkboxgroup'] = 'start';
 				$new_settings[]           = $setting;
 				$new_settings[]           = [
-					'desc'          => __( 'Add a currency switcher to the Storefront header and mobile menu.', 'woocommerce-payments' ),
+					'desc'          => __( 'Add a currency switcher to the Storefront theme.', 'woocommerce-payments' ),
 					'desc_tip'      => sprintf(
 						/* translators: %s: url to the widgets page */
 						__( 'A currency switcher is also available in your widgets. <a href="%s">Configure now</a>', 'woocommerce-payments' ),
 						'widgets.php'
 					),
 					'id'            => $this->id . '_enable_storefront_switcher',
-					'default'       => 'no',
+					'default'       => 'yes',
 					'type'          => 'checkbox',
 					'checkboxgroup' => 'end',
 				];
@@ -56,5 +57,18 @@ class StorefrontIntegration {
 			}
 		}
 		return $new_settings;
+	}
+
+	/**
+	 * Checks to see if the widget should be added, and then adds it.
+	 */
+	public function maybe_add_switcher_after_breadcrumb() {
+		// We specifically look for 'no', because we want it enabled by default.
+		if ( 'no' === get_option( $this->id . '_enable_storefront_switcher' ) ) {
+			return;
+		}
+		// If so, add it.
+		the_widget( CurrencySwitcherWidget::class );
+		// What about CSS changes?
 	}
 }

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -531,7 +531,7 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 
 		$mock_api_client->method( 'is_server_connected' )->willReturn( false );
 
-		$this->init_multi_currency();
+		$this->init_multi_currency( $mock_api_client );
 		$this->assertNull( $this->multi_currency->get_cached_currencies() );
 	}
 
@@ -657,8 +657,8 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		}
 	}
 
-	private function init_multi_currency() {
-		$this->multi_currency = new MultiCurrency( $this->mock_api_client, $this->mock_account, $this->mock_localization_service );
+	private function init_multi_currency( $mock_api_client = null ) {
+		$this->multi_currency = new MultiCurrency( $mock_api_client ?? $this->mock_api_client, $this->mock_account, $this->mock_localization_service );
 		$this->multi_currency->init();
 	}
 

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -622,7 +622,7 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 
 		$this->init_multi_currency();
 		$this->assertNull( $this->multi_currency->get_storefront_integration() );
-  }
+	}
 
 	public function test_add_order_meta_on_refund_skips_default_currency() {
 		$order = wc_create_order();

--- a/tests/unit/multi-currency/test-class-storefront-integration.php
+++ b/tests/unit/multi-currency/test-class-storefront-integration.php
@@ -47,7 +47,7 @@ class WCPay_Multi_Currency_Storefront_Integration_Tests extends WP_UnitTestCase 
 	 * @dataProvider switcher_filter_provider
 	 */
 	public function test_does_not_register_actions_when_switcher_disabled( $filter, $function_name ) {
-		$this->mock_option( 'no' );
+		update_option( 'wcpay_multi_currency_enable_storefront_switcher', 'no' );
 		// Reinit class to re-evaluate conditional hooks.
 		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
 
@@ -62,7 +62,7 @@ class WCPay_Multi_Currency_Storefront_Integration_Tests extends WP_UnitTestCase 
 	 * @dataProvider switcher_filter_provider
 	 */
 	public function test_registers_actions_when_switcher_default( $filter, $function_name ) {
-		$this->mock_option( '' );
+		delete_option( 'wcpay_multi_currency_enable_storefront_switcher' );
 		// Reinit class to re-evaluate conditional hooks.
 		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
 
@@ -77,7 +77,7 @@ class WCPay_Multi_Currency_Storefront_Integration_Tests extends WP_UnitTestCase 
 	 * @dataProvider switcher_filter_provider
 	 */
 	public function test_registers_actions_when_switcher_enabled( $filter, $function_name ) {
-		$this->mock_option( 'yes' );
+		update_option( 'wcpay_multi_currency_enable_storefront_switcher', 'yes' );
 		// Reinit class to re-evaluate conditional hooks.
 		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
 
@@ -93,14 +93,5 @@ class WCPay_Multi_Currency_Storefront_Integration_Tests extends WP_UnitTestCase 
 			[ 'woocommerce_breadcrumb_defaults', 'modify_breadcrumb_defaults' ],
 			[ 'wp_enqueue_scripts', 'add_inline_css' ],
 		];
-	}
-
-	private function mock_option( $value ) {
-		add_filter(
-			'pre_option_wcpay_multi_currency_enable_storefront_switcher',
-			function() use ( $value ) {
-				return $value;
-			}
-		);
 	}
 }

--- a/tests/unit/multi-currency/test-class-storefront-integration.php
+++ b/tests/unit/multi-currency/test-class-storefront-integration.php
@@ -29,94 +29,81 @@ class WCPay_Multi_Currency_Storefront_Integration_Tests extends WP_UnitTestCase 
 		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
 	}
 
-	public function test_registers_settings_filter() {
-		$this->assertSame(
-			10,
-			has_filter(
-				'wcpay_multi_currency_enabled_currencies_settings',
-				[ $this->storefront_integration, 'filter_store_settings' ]
-			)
-		);
+	public function tearDown() {
+		remove_all_filters( 'stylesheet' );
+		remove_all_filters( 'option_wcpay_multi_currency_enable_storefront_switcher' );
+
+		parent::tearDown();
 	}
 
-	public function test_does_not_register_actions_when_switcher_disabled() {
-		$this->mock_multi_currency->method( 'get_theme_stylesheet' )->willReturn( 'storefront' );
-
-		// Update the option, and then recreate the instance before testing.
-		update_option( 'wcpay_multi_currency_enable_storefront_switcher', 'no' );
+	/**
+	 * @dataProvider switcher_filter_provider
+	 */
+	public function test_does_not_register_actions_when_switcher_disabled( $filter, $function_name ) {
+		$this->mock_theme( 'storefront' );
+		$this->mock_option( 'no' );
+		// Reinit class to re-evaluate conditional hooks.
 		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
 
 		$this->assertFalse(
-			has_filter( 'woocommerce_breadcrumb_defaults', [ $this->storefront_integration, 'modify_breadcrumb_wrapper' ] ),
-			"The filter 'woocommerce_breadcrumb_defaults' with function 'modify_breadcrumb_wrapper' was found."
-		);
-		$this->assertFalse(
-			has_action( 'wp_enqueue_scripts', [ $this->storefront_integration, 'add_inline_css' ] ),
-			"The action 'wp_enqueue_scripts' with function 'add_inline_css' was found."
-		);
-		$this->assertFalse(
-			has_action( 'storefront_before_content', [ $this->storefront_integration, 'add_switcher_widget' ] ),
-			"The action 'storefront_before_content' with function 'add_switcher_widget' was found."
-		);
-		$this->assertFalse(
-			has_action( 'storefront_before_content', [ $this->storefront_integration, 'close_breadcrumb_wrapper' ] ),
-			"The action 'storefront_before_content' with function 'close_breadcrumb_wrapper' was found."
+			has_filter( $filter, [ $this->storefront_integration, $function_name ] ),
+			"The filter '$filter' with function '$function_name' was found."
 		);
 	}
 
-	public function test_registers_default_actions_when_switcher_enabled() {
-		$this->mock_multi_currency->method( 'get_theme_stylesheet' )->willReturn( 'storefront' );
 
-		// Due to we are testing conditional actions/filters, we need to reinit the class.
+	/**
+	 * @dataProvider switcher_filter_provider
+	 */
+	public function test_registers_default_actions_when_switcher_enabled( $filter, $function_name ) {
+		$this->mock_theme( 'storefront' );
+		// Reinit class to re-evaluate conditional hooks.
 		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
 
 		$this->assertGreaterThan(
 			10,
-			has_filter( 'woocommerce_breadcrumb_defaults', [ $this->storefront_integration, 'modify_breadcrumb_wrapper' ] ),
-			"The filter 'woocommerce_breadcrumb_defaults' with function 'modify_breadcrumb_wrapper' was not registered with a priority above 10."
-		);
-		$this->assertGreaterThan(
-			10,
-			has_action( 'wp_enqueue_scripts', [ $this->storefront_integration, 'add_inline_css' ] ),
-			"The action 'wp_enqueue_scripts' with function 'add_inline_css' was not registered with a priority above 10."
-		);
-		$this->assertGreaterThan(
-			10,
-			has_action( 'storefront_before_content', [ $this->storefront_integration, 'add_switcher_widget' ] ),
-			"The action 'storefront_before_content' with function 'add_switcher_widget' was not registered with a priority above 10."
-		);
-		$this->assertGreaterThan(
-			10,
-			has_action( 'storefront_before_content', [ $this->storefront_integration, 'close_breadcrumb_wrapper' ] ),
-			"The action 'storefront_before_content' with function 'close_breadcrumb_wrapper' was not registered with a priority above 10."
+			has_filter( $filter, [ $this->storefront_integration, $function_name ] ),
+			"The filter '$filter' with function '$function_name' was not registered with a priority above 10."
 		);
 	}
 
-	public function test_registers_wrapper_theme_actions_when_switcher_enabled_and_wrapper_theme_found() {
-		$this->mock_multi_currency->method( 'get_theme_stylesheet' )->willReturn( 'arcade' );
-
-		// Due to we are testing conditional actions/filters, we need to reinit the class.
+	/**
+	 * @dataProvider switcher_filter_provider
+	 */
+	public function test_registers_actions_when_switcher_enabled_and_storefront_theme_found( $filter, $function_name ) {
+		$this->mock_theme( 'storefront' );
+		// Reinit class to re-evaluate conditional hooks.
 		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
 
 		$this->assertGreaterThan(
 			10,
-			has_filter( 'woocommerce_breadcrumb_defaults', [ $this->storefront_integration, 'modify_breadcrumb_wrapper' ] ),
-			"The filter 'woocommerce_breadcrumb_defaults' with function 'modify_breadcrumb_wrapper' was not registered with a priority above 10."
+			has_filter( $filter, [ $this->storefront_integration, $function_name ] ),
+			"The filter '$filter' with function '$function_name' was not registered with a priority above 10."
 		);
-		$this->assertGreaterThan(
-			10,
-			has_action( 'wp_enqueue_scripts', [ $this->storefront_integration, 'add_inline_css' ] ),
-			"The action 'wp_enqueue_scripts' with function 'add_inline_css' was not registered with a priority above 10."
+	}
+
+	public function switcher_filter_provider() {
+		return [
+			[ 'woocommerce_breadcrumb_defaults', 'modify_breadcrumb_defaults' ],
+			[ 'wp_enqueue_scripts', 'add_inline_css' ],
+		];
+	}
+
+	private function mock_theme( $theme ) {
+		add_filter(
+			'stylesheet',
+			function() use ( $theme ) {
+				return $theme;
+			}
 		);
-		$this->assertGreaterThan(
-			10,
-			has_action( 'storefront_content_top', [ $this->storefront_integration, 'add_switcher_widget' ] ),
-			"The action 'storefront_content_top' with function 'add_switcher_widget' was not registered with a priority above 10."
-		);
-		$this->assertGreaterThan(
-			10,
-			has_action( 'storefront_content_top', [ $this->storefront_integration, 'close_breadcrumb_wrapper' ] ),
-			"The action 'storefront_content_top' with function 'close_breadcrumb_wrapper' was not registered with a priority above 10."
+	}
+
+	private function mock_option( $value ) {
+		add_filter(
+			'pre_option_wcpay_multi_currency_enable_storefront_switcher',
+			function() use ( $value ) {
+				return $value;
+			}
 		);
 	}
 }

--- a/tests/unit/multi-currency/test-class-storefront-integration.php
+++ b/tests/unit/multi-currency/test-class-storefront-integration.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Class WCPay_Multi_Currency_Storefront_Integration_Tests
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\MultiCurrency\MultiCurrency;
+use WCPay\MultiCurrency\StorefrontIntegration;
+
+/**
+ * WCPay\MultiCurrency\StorefrontIntegration unit tests.
+ */
+class WCPay_Multi_Currency_Storefront_Integration_Tests extends WP_UnitTestCase {
+	/**
+	 * Mock MultiCurrency.
+	 *
+	 * @var MultiCurrency|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_multi_currency;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->mock_multi_currency    = $this->createMock( MultiCurrency::class );
+		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
+	}
+
+	public function test_registers_settings_filter() {
+		$this->assertSame(
+			10,
+			has_filter(
+				'wcpay_multi_currency_enabled_currencies_settings',
+				[ $this->storefront_integration, 'filter_store_settings' ]
+			)
+		);
+	}
+
+	public function test_does_not_register_actions_when_switcher_disabled() {
+		$this->mock_multi_currency->method( 'get_theme_stylesheet' )->willReturn( 'storefront' );
+
+		// Update the option, and then recreate the instance before testing.
+		update_option( 'wcpay_multi_currency_enable_storefront_switcher', 'no' );
+		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
+
+		$this->assertFalse(
+			has_filter( 'woocommerce_breadcrumb_defaults', [ $this->storefront_integration, 'modify_breadcrumb_wrapper' ] ),
+			"The filter 'woocommerce_breadcrumb_defaults' with function 'modify_breadcrumb_wrapper' was found."
+		);
+		$this->assertFalse(
+			has_action( 'wp_enqueue_scripts', [ $this->storefront_integration, 'add_inline_css' ] ),
+			"The action 'wp_enqueue_scripts' with function 'add_inline_css' was found."
+		);
+		$this->assertFalse(
+			has_action( 'storefront_before_content', [ $this->storefront_integration, 'add_switcher_widget' ] ),
+			"The action 'storefront_before_content' with function 'add_switcher_widget' was found."
+		);
+		$this->assertFalse(
+			has_action( 'storefront_before_content', [ $this->storefront_integration, 'close_breadcrumb_wrapper' ] ),
+			"The action 'storefront_before_content' with function 'close_breadcrumb_wrapper' was found."
+		);
+	}
+
+	public function test_registers_default_actions_when_switcher_enabled() {
+		$this->mock_multi_currency->method( 'get_theme_stylesheet' )->willReturn( 'storefront' );
+
+		// Due to we are testing conditional actions/filters, we need to reinit the class.
+		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
+
+		$this->assertGreaterThan(
+			10,
+			has_filter( 'woocommerce_breadcrumb_defaults', [ $this->storefront_integration, 'modify_breadcrumb_wrapper' ] ),
+			"The filter 'woocommerce_breadcrumb_defaults' with function 'modify_breadcrumb_wrapper' was not registered with a priority above 10."
+		);
+		$this->assertGreaterThan(
+			10,
+			has_action( 'wp_enqueue_scripts', [ $this->storefront_integration, 'add_inline_css' ] ),
+			"The action 'wp_enqueue_scripts' with function 'add_inline_css' was not registered with a priority above 10."
+		);
+		$this->assertGreaterThan(
+			10,
+			has_action( 'storefront_before_content', [ $this->storefront_integration, 'add_switcher_widget' ] ),
+			"The action 'storefront_before_content' with function 'add_switcher_widget' was not registered with a priority above 10."
+		);
+		$this->assertGreaterThan(
+			10,
+			has_action( 'storefront_before_content', [ $this->storefront_integration, 'close_breadcrumb_wrapper' ] ),
+			"The action 'storefront_before_content' with function 'close_breadcrumb_wrapper' was not registered with a priority above 10."
+		);
+	}
+
+	public function test_registers_wrapper_theme_actions_when_switcher_enabled_and_wrapper_theme_found() {
+		$this->mock_multi_currency->method( 'get_theme_stylesheet' )->willReturn( 'arcade' );
+
+		// Due to we are testing conditional actions/filters, we need to reinit the class.
+		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
+
+		$this->assertGreaterThan(
+			10,
+			has_filter( 'woocommerce_breadcrumb_defaults', [ $this->storefront_integration, 'modify_breadcrumb_wrapper' ] ),
+			"The filter 'woocommerce_breadcrumb_defaults' with function 'modify_breadcrumb_wrapper' was not registered with a priority above 10."
+		);
+		$this->assertGreaterThan(
+			10,
+			has_action( 'wp_enqueue_scripts', [ $this->storefront_integration, 'add_inline_css' ] ),
+			"The action 'wp_enqueue_scripts' with function 'add_inline_css' was not registered with a priority above 10."
+		);
+		$this->assertGreaterThan(
+			10,
+			has_action( 'storefront_content_top', [ $this->storefront_integration, 'add_switcher_widget' ] ),
+			"The action 'storefront_content_top' with function 'add_switcher_widget' was not registered with a priority above 10."
+		);
+		$this->assertGreaterThan(
+			10,
+			has_action( 'storefront_content_top', [ $this->storefront_integration, 'close_breadcrumb_wrapper' ] ),
+			"The action 'storefront_content_top' with function 'close_breadcrumb_wrapper' was not registered with a priority above 10."
+		);
+	}
+}

--- a/tests/unit/multi-currency/test-class-storefront-integration.php
+++ b/tests/unit/multi-currency/test-class-storefront-integration.php
@@ -30,17 +30,23 @@ class WCPay_Multi_Currency_Storefront_Integration_Tests extends WP_UnitTestCase 
 	}
 
 	public function tearDown() {
-		remove_all_filters( 'stylesheet' );
 		remove_all_filters( 'option_wcpay_multi_currency_enable_storefront_switcher' );
 
 		parent::tearDown();
+	}
+
+	public function test_register_settings_on_init() {
+		$this->assertSame(
+			10,
+			has_filter( 'wcpay_multi_currency_enabled_currencies_settings', [ $this->storefront_integration, 'filter_store_settings' ] ),
+			"The filter 'wcpay_multi_currency_enabled_currencies_settings' with function 'filter_store_settings' was not registered with a priority of 10."
+		);
 	}
 
 	/**
 	 * @dataProvider switcher_filter_provider
 	 */
 	public function test_does_not_register_actions_when_switcher_disabled( $filter, $function_name ) {
-		$this->mock_theme( 'storefront' );
 		$this->mock_option( 'no' );
 		// Reinit class to re-evaluate conditional hooks.
 		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
@@ -55,8 +61,8 @@ class WCPay_Multi_Currency_Storefront_Integration_Tests extends WP_UnitTestCase 
 	/**
 	 * @dataProvider switcher_filter_provider
 	 */
-	public function test_registers_default_actions_when_switcher_enabled( $filter, $function_name ) {
-		$this->mock_theme( 'storefront' );
+	public function test_registers_actions_when_switcher_default( $filter, $function_name ) {
+		$this->mock_option( '' );
 		// Reinit class to re-evaluate conditional hooks.
 		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
 
@@ -70,8 +76,8 @@ class WCPay_Multi_Currency_Storefront_Integration_Tests extends WP_UnitTestCase 
 	/**
 	 * @dataProvider switcher_filter_provider
 	 */
-	public function test_registers_actions_when_switcher_enabled_and_storefront_theme_found( $filter, $function_name ) {
-		$this->mock_theme( 'storefront' );
+	public function test_registers_actions_when_switcher_enabled( $filter, $function_name ) {
+		$this->mock_option( 'yes' );
 		// Reinit class to re-evaluate conditional hooks.
 		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
 
@@ -87,15 +93,6 @@ class WCPay_Multi_Currency_Storefront_Integration_Tests extends WP_UnitTestCase 
 			[ 'woocommerce_breadcrumb_defaults', 'modify_breadcrumb_defaults' ],
 			[ 'wp_enqueue_scripts', 'add_inline_css' ],
 		];
-	}
-
-	private function mock_theme( $theme ) {
-		add_filter(
-			'stylesheet',
-			function() use ( $theme ) {
-				return $theme;
-			}
-		);
 	}
 
 	private function mock_option( $value ) {


### PR DESCRIPTION
Fixes #2264 

#### Changes proposed in this Pull Request

**edited by @ismaeldcom**

- Create the new `StorefrontIntegration` class to implement the functionality of adding the switcher widget to Storefront theme through settings.
- Check if the option `Add a currency switcher to the Storefront theme` is enabled (on by default) and the used theme is Storefront or a child of it.
- Add the widget on the breadcrumb section of the store, as per final decision on the issue.

@jessepearson already did a good implementation, thanks! I simplified the code to make it more maintainable, removing the need for custom CSS code for each Storefront child theme. Using the available wrapper instead of adding a new one.
Removed unneeded code.

Updated the option description to mention that the widget will be added to breadcrumb section. **Hotel** theme for example have breadcrumb removed, so will not show the widget.

As per @LevinMedia comment below. I modified the settings to only show the switcher checkbox when a compatible theme is active and the message `A currency switcher is available in your widgets. Configure now` as fallback. You can see both of them in the screenshots below.

#### Screenshots
Here are some pics to see how it looks on different Storefront based themes.

|Storefront|
|:--:|
|<img width="772" alt="storefront" src="https://user-images.githubusercontent.com/7670276/126311569-7b3430ac-b436-49cf-8031-e3a1002978d7.png">|
|Arcade|
|<img width="774" alt="arcade" src="https://user-images.githubusercontent.com/7670276/126311570-7c23feb7-3680-4d4f-80f3-d3ccdb207c4b.png">|
|Galleria|
|<img width="775" alt="galleria" src="https://user-images.githubusercontent.com/7670276/126311574-a1486526-1a51-42d5-aae8-a0600e47ec8d.png">|
|Boutique|
|<img width="729" alt="boutique" src="https://user-images.githubusercontent.com/7670276/126311575-0ee17f10-111f-41f8-bb63-28e092bc3263.png">|

|Store settings with compatible theme|
|:--:|
|<img width="775" alt="Screenshot 2021-07-21 at 08 55 43" src="https://user-images.githubusercontent.com/7670276/126451656-168bcd9e-8727-436d-b92d-69b32d433fc3.png">|
|Store settings with incompatible theme|
|<img width="782" alt="Screenshot 2021-07-21 at 08 56 17" src="https://user-images.githubusercontent.com/7670276/126451747-d9a9dbaf-8387-4406-a554-f37d5d2612d0.png">|


#### Testing instructions
- Navigate to **WooCommerce > Settings > Multi-currency**, toggle `Add a currency switcher to the Storefront theme on breadcrumb section`. Check that the widget got included (or not) on the breadcrumb section of the store.
- Check that it works with different Storefront themes.
- It shouldn't be included on themes not based on Storefront or those without the breadcrumb section.
- The store settings should be like the attached screenshots when switching themes.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
