### PR TITLE
Replace OAuth instances from the code with new connect onboarding flow

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@
 * Fix - Translations in transaction/deposit exports
 * Fix - Update shipping cost in payment sheet when changing payment method.
 * Fix - Transaction search with translated terms
+* Update - Replace REST endpoint for onboarding initialization.
 
 = 3.0.0 - 2021-09-16 =
 * Add - Download deposits report in CSV.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -477,7 +477,7 @@ class WC_Payments_Admin {
 			)
 		);
 
-		$track_stripe_connected = get_option( '_wcpay_oauth_stripe_connected' );
+		$track_stripe_connected = get_option( '_wcpay_onboarding_stripe_connected' );
 
 		if ( $tos_agreement_declined || $tos_agreement_required || $track_stripe_connected ) {
 			// phpcs:ignore WordPress.Security.NonceVerification

--- a/includes/admin/class-wc-rest-payments-tos-controller.php
+++ b/includes/admin/class-wc-rest-payments-tos-controller.php
@@ -170,14 +170,14 @@ class WC_REST_Payments_Tos_Controller extends WC_Payments_REST_Controller {
 	}
 
 	/**
-	 * Deletes _wcpay_oauth_stripe_connected option after KYC completion has been tracked.
+	 * Deletes _wcpay_onboarding_stripe_connected option after KYC completion has been tracked.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 *
 	 * @return WP_REST_Response
 	 */
 	public function remove_stripe_connect_track( $request ) {
-		delete_option( '_wcpay_oauth_stripe_connected' );
+		delete_option( '_wcpay_onboarding_stripe_connected' );
 		return new WP_REST_Response( [ 'result' => self::RESULT_SUCCESS ] );
 	}
 }

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -38,7 +38,7 @@ class WC_Payments_API_Client {
 	const TRANSACTIONS_API       = 'transactions';
 	const DISPUTES_API           = 'disputes';
 	const FILES_API              = 'files';
-	const OAUTH_API              = 'oauth';
+	const ONBOARDING_API         = 'onboarding';
 	const TIMELINE_API           = 'timeline';
 	const PAYMENT_METHODS_API    = 'payment_methods';
 	const SETUP_INTENTS_API      = 'setup_intents';
@@ -903,7 +903,7 @@ class WC_Payments_API_Client {
 			]
 		);
 
-		return $this->request( $request_args, self::OAUTH_API . '/init', self::POST, true, true );
+		return $this->request( $request_args, self::ONBOARDING_API . '/init', self::POST, true, true );
 	}
 
 	/**

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -880,7 +880,7 @@ class WC_Payments_API_Client {
 	}
 
 	/**
-	 * Get data needed to initialize the OAuth flow
+	 * Get data needed to initialize the onboarding flow
 	 *
 	 * @param string $return_url     - URL to redirect to at the end of the flow.
 	 * @param array  $business_data  - Data to prefill the form.
@@ -891,9 +891,9 @@ class WC_Payments_API_Client {
 	 *
 	 * @throws API_Exception Exception thrown on request failure.
 	 */
-	public function get_oauth_data( $return_url, array $business_data = [], array $site_data = [], array $actioned_notes = [] ) {
+	public function get_onboarding_data( $return_url, array $business_data = [], array $site_data = [], array $actioned_notes = [] ) {
 		$request_args = apply_filters(
-			'wc_payments_get_oauth_data_args',
+			'wc_payments_get_onboarding_data_args',
 			[
 				'return_url'          => $return_url,
 				'business_data'       => $business_data,

--- a/readme.txt
+++ b/readme.txt
@@ -114,6 +114,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Translations in transaction/deposit exports
 * Fix - Update shipping cost in payment sheet when changing payment method.
 * Fix - Transaction search with translated terms
+* Update - Replace REST endpoint for onboarding initialization.
 
 = 3.0.0 - 2021-09-16 =
 * Add - Download deposits report in CSV.

--- a/tests/unit/admin/test-class-wc-rest-payments-tos-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-tos-controller.php
@@ -107,11 +107,11 @@ class WC_REST_Payments_Tos_Controller_Test extends WP_UnitTestCase {
 	}
 
 	public function test_remove_stripe_connect_track_should_delete_option() {
-		add_option( '_wcpay_oauth_stripe_connected', [ 'props' => true ] );
+		add_option( '_wcpay_onboarding_stripe_connected', [ 'props' => true ] );
 
 		// Run the test.
 		$this->controller->remove_stripe_connect_track( $this->request );
 
-		$this->assertFalse( get_option( '_wcpay_oauth_stripe_connected', false ) );
+		$this->assertFalse( get_option( '_wcpay_onboarding_stripe_connected', false ) );
 	}
 }

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -579,7 +579,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 			->method( 'remote_request' )
 			->with(
 				[
-					'url'             => 'https://public-api.wordpress.com/wpcom/v2/sites/%s/wcpay/oauth/init',
+					'url'             => 'https://public-api.wordpress.com/wpcom/v2/sites/%s/wcpay/onboarding/init',
 					'method'          => 'POST',
 					'headers'         => [
 						'Content-Type' => 'application/json; charset=utf-8',

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -569,11 +569,11 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test getting initial oauth data.
+	 * Test getting initial onboarding data.
 	 *
 	 * @throws API_Exception
 	 */
-	public function test_get_oauth_data() {
+	public function test_get_onboarding_data() {
 		$this->mock_http_client
 			->expects( $this->once() )
 			->method( 'remote_request' )
@@ -609,7 +609,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 					]
 				),
 				true,
-				true // get_oauth_data should use user token auth.
+				true // get_onboarding_data should use user token auth.
 			)
 			->willReturn(
 				[
@@ -622,7 +622,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 			);
 
 		// Call the method under test.
-		$result = $this->payments_api_client->get_oauth_data(
+		$result = $this->payments_api_client->get_onboarding_data(
 			'http://localhost',
 			[
 				'a' => 1,


### PR DESCRIPTION
Depends on 1180-gh-Automattic/woocommerce-payments-server.

#### Changes proposed in this Pull Request

Rename onboarding endpoint from `oauth/init` to `onboarding/init` and remove all "OAuth" mentions from the code, except for changelog entries and the server constant `WCPAY_OAUTH_ENCRYPT_KEY` in e2e tests.

We're doing this now, so that we can remove all legacy OAuth mentions from the server as well in the future.

#### Testing instructions

1. Make sure 914-gh-Automattic/woocommerce-payments-server is already merged or you have checked out to that branch.
2. Make sure you are not onboarded in WCPay.
3. Try onboarding from **Payments > Settings** (Finish setup), from **WooCommerce > Home** (Set up WooCommerce Payments) or from WCPay Dev Utils (Reonboard).
4. Everything should work as expected.
5. Notice everything should work as expected too if you've started, but not finished onboarding in `develop` with the old `oauth` state transient, but you'll need to click the onboarding call to action again.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
