### PR TITLE
Add fee breakdown in payments timeline.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@
 * Update - Bump minimum supported version of WooCommerce from 5.2 to 5.3.
 * Update - Bump minimum supported version of WordPress from 5.5 to 5.6.
 * Fix - Stop refund process when using an invalid amount
+* Add - Show fee breakup in transaction details timeline.
 
 = 2.7.1 - 2021-07-26 =
 * Fix - Ensure test mode setting value is correctly saved.

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,7 +18,7 @@
 * Update - Bump minimum supported version of WooCommerce from 5.2 to 5.3.
 * Update - Bump minimum supported version of WordPress from 5.5 to 5.6.
 * Fix - Stop refund process when using an invalid amount
-* Add - Show fee breakup in transaction details timeline.
+* Add - Show fee breakdown in transaction details timeline.
 
 = 2.7.1 - 2021-07-26 =
 * Fix - Ensure test mode setting value is correctly saved.

--- a/client/payment-details/timeline/index.js
+++ b/client/payment-details/timeline/index.js
@@ -14,6 +14,8 @@ import { useTimeline } from 'data';
 import mapTimelineEvents from './map-events';
 import Loadable, { LoadableBlock } from 'components/loadable';
 
+import './style.scss';
+
 const PaymentDetailsTimeline = ( { chargeId } ) => {
 	const { timeline, timelineError, isLoading } = useTimeline( chargeId );
 

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -230,6 +230,13 @@ const composeFXString = ( event ) => {
 	);
 };
 
+/**
+ * Returns an array containing fee breakup.
+ *
+ * @param {Object} event Event object
+ *
+ * @return {Array} Array of formatted fee strings
+ */
 const feeBreakup = ( event ) => {
 	if ( ! event?.fee_rates?.history ) {
 		return [];

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -257,12 +257,12 @@ const feeBreakdown = ( event ) => {
 			0 !== fixedRate
 				? __(
 						/* translators: %1$s% is the fee amount and %2$s is the fixed rate */
-						'International fee: %1$s%% + %2$s',
+						'International card fee: %1$s%% + %2$s',
 						'woocommerce-payments'
 				  )
 				: __(
 						/* translators: %1$s% is the fee amount */
-						'International fee: %1$s%%',
+						'International card fee: %1$s%%',
 						'woocommerce-payments'
 				  ),
 		'additional-fx':

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -247,12 +247,15 @@ const feeBreakup = ( event ) => {
 	} = event;
 
 	const feeLabelMapping = {
+		/* translators: %s is the fee amount */
 		base: __( '\u00A0 • Base fee %s%%', 'woocommerce-payments' ),
 		'additional-international': __(
+			/* translators: %s is the fee amount */
 			'\u00A0 • International fee %s%%',
 			'woocommerce-payments'
 		),
 		'additional-fx': __(
+			/* translators: %s is the fee amount */
 			'\u00A0 • Foreign exchange fee %s%%',
 			'woocommerce-payments'
 		),

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -230,6 +230,41 @@ const composeFXString = ( event ) => {
 	);
 };
 
+const feeBreakup = ( event ) => {
+	if ( ! event?.fee_rates?.history ) {
+		return [];
+	}
+
+	const {
+		fee_rates: { history },
+	} = event;
+
+	const feeLabelMapping = {
+		base: __( '\u00A0 • Base fee %s%%', 'woocommerce-payments' ),
+		'additional-international': __(
+			'\u00A0 • International fee %s%%',
+			'woocommerce-payments'
+		),
+		'additional-fx': __(
+			'\u00A0 • Foreign exchange fee %s%%',
+			'woocommerce-payments'
+		),
+	};
+
+	return history.map( ( fee ) => {
+		let labelKey = fee.type;
+		if ( fee.additional_type ) {
+			labelKey += `-${ fee.additional_type }`;
+		}
+
+		const { percentage_rate: percentageRate } = fee;
+		return sprintf(
+			feeLabelMapping[ labelKey ],
+			formatFee( percentageRate )
+		);
+	} );
+};
+
 /**
  * Formats an event into one or more payment timeline items
  *
@@ -337,6 +372,7 @@ const mapEventToTimelineItems = ( event ) => {
 					[
 						composeFXString( event ),
 						feeString,
+						...feeBreakup( event ),
 						sprintf(
 							/* translators: %s is a monetary amount */
 							__( 'Net deposit: %s', 'woocommerce-payments' ),

--- a/client/payment-details/timeline/style.scss
+++ b/client/payment-details/timeline/style.scss
@@ -1,0 +1,9 @@
+.woocommerce-timeline
+	.woocommerce-timeline-item
+	.woocommerce-timeline-item__body {
+	.fee-breakdown-list {
+		list-style-type: disc;
+		margin-left: 16px;
+		line-height: 1.5;
+	}
+}

--- a/client/payment-details/timeline/test/__snapshots__/index.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/index.js.snap
@@ -848,6 +848,7 @@ exports[`PaymentDetailsTimeline renders correctly (with a mocked Timeline compon
                   <span>
                     Fee: $3.50
                   </span>
+                  <span />
                   <span>
                     Net deposit: $59.50 USD
                   </span>

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -752,3 +752,51 @@ Array [
   },
 ]
 `;
+
+exports[`mapTimelineEvents single currency events should not render fee breakup when fee history is not present 1`] = `
+Array [
+  Object {
+    "body": Array [],
+    "date": 2020-04-01T14:37:54.000Z,
+    "headline": "Payment status changed to Paid.",
+    "icon": <t
+      className=""
+      icon="sync"
+      size={24}
+    />,
+  },
+  Object {
+    "body": Array [],
+    "date": 2020-04-01T14:37:54.000Z,
+    "headline": <React.Fragment>
+      $59.50 was added to your 
+      <Link
+        href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
+        type="wc-admin"
+      >
+        Apr 2, 2020 deposit
+      </Link>
+      .
+    </React.Fragment>,
+    "icon": <t
+      className=""
+      icon="plus"
+      size={24}
+    />,
+  },
+  Object {
+    "body": Array [
+      undefined,
+      "Fee (1.95% + $0.15): $-3.50",
+      "Net deposit: $59.50",
+    ],
+    "date": 2020-04-01T14:37:54.000Z,
+    "headline": "A payment of $63.00 was successfully charged.",
+    "icon": <t
+      className="is-success"
+      icon="checkmark"
+      size={24}
+    />,
+  },
+]
+`;

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -514,7 +514,7 @@ Array [
           Base fee: 1.4% + £0.20
         </li>
         <li>
-          International fee: 1.5%
+          International card fee: 1.5%
         </li>
         <li>
           Foreign exchange fee: 2%

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -234,12 +234,8 @@ Array [
     "body": Array [
       "1,00 EUR → 1.19944 USD: $21.59 USD",
       "Fee (2.9% + $0.30): $-0.62",
-<<<<<<< HEAD
-      "Net deposit: $20.97 USD",
-=======
       undefined,
-      "Net deposit: $20.97",
->>>>>>> 2474d4c7 (feedback changes)
+      "Net deposit: $20.97 USD",
     ],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "A payment of €18,00 EUR was successfully charged.",
@@ -287,12 +283,8 @@ Array [
     "body": Array [
       "1,00 EUR → 1.19944 USD: $21.59 USD",
       "Fee: €0,52",
-<<<<<<< HEAD
-      "Net deposit: $20.97 USD",
-=======
       undefined,
-      "Net deposit: $20.97",
->>>>>>> 2474d4c7 (feedback changes)
+      "Net deposit: $20.97 USD",
     ],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "A payment of €18,00 EUR was successfully charged.",
@@ -523,7 +515,7 @@ Array [
           Discount: -4.9% + £-0.20
         </li>
       </ul>,
-      "Net deposit: $59.50",
+      "Net deposit: $59.50 USD",
     ],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "A payment of $63.00 USD was successfully charged.",
@@ -571,12 +563,8 @@ Array [
     "body": Array [
       undefined,
       "Fee: $3.50",
-<<<<<<< HEAD
-      "Net deposit: $59.50 USD",
-=======
       undefined,
-      "Net deposit: $59.50",
->>>>>>> 2474d4c7 (feedback changes)
+      "Net deposit: $59.50 USD",
     ],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "A payment of $63.00 USD was successfully charged.",
@@ -797,7 +785,7 @@ Array [
     "body": Array [],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": <React.Fragment>
-      $59.50 was added to your 
+      $59.50 USD was added to your 
       <Link
         href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
         type="wc-admin"
@@ -817,10 +805,10 @@ Array [
       undefined,
       "Fee (1.95% + $0.15): $-3.50",
       undefined,
-      "Net deposit: $59.50",
+      "Net deposit: $59.50 USD",
     ],
     "date": 2020-04-01T14:37:54.000Z,
-    "headline": "A payment of $63.00 was successfully charged.",
+    "headline": "A payment of $63.00 USD was successfully charged.",
     "icon": <t
       className="is-success"
       icon="checkmark"

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -234,7 +234,12 @@ Array [
     "body": Array [
       "1,00 EUR → 1.19944 USD: $21.59 USD",
       "Fee (2.9% + $0.30): $-0.62",
+<<<<<<< HEAD
       "Net deposit: $20.97 USD",
+=======
+      undefined,
+      "Net deposit: $20.97",
+>>>>>>> 2474d4c7 (feedback changes)
     ],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "A payment of €18,00 EUR was successfully charged.",
@@ -282,7 +287,12 @@ Array [
     "body": Array [
       "1,00 EUR → 1.19944 USD: $21.59 USD",
       "Fee: €0,52",
+<<<<<<< HEAD
       "Net deposit: $20.97 USD",
+=======
+      undefined,
+      "Net deposit: $20.97",
+>>>>>>> 2474d4c7 (feedback changes)
     ],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "A payment of €18,00 EUR was successfully charged.",
@@ -497,10 +507,23 @@ Array [
     "body": Array [
       undefined,
       "Fee (1.95% + $0.15): $-3.50",
-      "  • Base fee 1.4%",
-      "  • International fee 1.5%",
-      "  • Foreign exchange fee 2%",
-      "Net deposit: $59.50 USD",
+      <ul
+        className="fee-breakdown-list"
+      >
+        <li>
+          Base fee: 1.4% + £0.20
+        </li>
+        <li>
+          International fee: 1.5%
+        </li>
+        <li>
+          Foreign exchange fee: 2%
+        </li>
+        <li>
+          Discount: -4.9% + £-0.20
+        </li>
+      </ul>,
+      "Net deposit: $59.50",
     ],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "A payment of $63.00 USD was successfully charged.",
@@ -548,7 +571,12 @@ Array [
     "body": Array [
       undefined,
       "Fee: $3.50",
+<<<<<<< HEAD
       "Net deposit: $59.50 USD",
+=======
+      undefined,
+      "Net deposit: $59.50",
+>>>>>>> 2474d4c7 (feedback changes)
     ],
     "date": 2020-04-01T14:37:54.000Z,
     "headline": "A payment of $63.00 USD was successfully charged.",
@@ -788,6 +816,7 @@ Array [
     "body": Array [
       undefined,
       "Fee (1.95% + $0.15): $-3.50",
+      undefined,
       "Net deposit: $59.50",
     ],
     "date": 2020-04-01T14:37:54.000Z,

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -497,6 +497,9 @@ Array [
     "body": Array [
       undefined,
       "Fee (1.95% + $0.15): $-3.50",
+      "  • Base fee 1.4%",
+      "  • International fee 1.5%",
+      "  • Foreign exchange fee 2%",
       "Net deposit: $59.50 USD",
     ],
     "date": 2020-04-01T14:37:54.000Z,

--- a/client/payment-details/timeline/test/map-events.js
+++ b/client/payment-details/timeline/test/map-events.js
@@ -140,6 +140,29 @@ describe( 'mapTimelineEvents', () => {
 			).toMatchSnapshot();
 		} );
 
+		test( 'should not render fee breakup when fee history is not present', () => {
+			expect(
+				mapTimelineEvents( [
+					{
+						amount: 6300,
+						currency: 'USD',
+						datetime: 1585751874,
+						deposit: {
+							arrival_date: 1585838274,
+							id: 'dummy_po_5eaada696b281',
+						},
+						fee: 350,
+						fee_rates: {
+							percentage: 0.0195,
+							fixed: 15,
+							fixed_currency: 'USD',
+						},
+						type: 'captured',
+					},
+				] )
+			).toMatchSnapshot();
+		} );
+
 		test( 'formats captured events with fee details', () => {
 			expect(
 				mapTimelineEvents( [

--- a/client/payment-details/timeline/test/map-events.js
+++ b/client/payment-details/timeline/test/map-events.js
@@ -156,6 +156,28 @@ describe( 'mapTimelineEvents', () => {
 							percentage: 0.0195,
 							fixed: 15,
 							fixed_currency: 'USD',
+							history: [
+								{
+									type: 'base',
+									percentage_rate: 0.014,
+									fixed_rate: 20,
+									currency: 'gbp',
+								},
+								{
+									type: 'additional',
+									additional_type: 'international',
+									percentage_rate: 0.014999999999999998,
+									fixed_rate: 0,
+									currency: 'gbp',
+								},
+								{
+									type: 'additional',
+									additional_type: 'fx',
+									percentage_rate: 0.020000000000000004,
+									fixed_rate: 0,
+									currency: 'gbp',
+								},
+							],
 						},
 						type: 'captured',
 					},

--- a/client/payment-details/timeline/test/map-events.js
+++ b/client/payment-details/timeline/test/map-events.js
@@ -200,6 +200,12 @@ describe( 'mapTimelineEvents', () => {
 									fixed_rate: 0,
 									currency: 'gbp',
 								},
+								{
+									type: 'discount',
+									percentage_rate: -0.049,
+									fixed_rate: -20,
+									currency: 'gbp',
+								},
 							],
 						},
 						type: 'captured',

--- a/readme.txt
+++ b/readme.txt
@@ -115,7 +115,7 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Bump minimum supported version of WooCommerce from 5.2 to 5.3.
 * Update - Bump minimum supported version of WordPress from 5.5 to 5.6.
 * Fix - Stop refund process when using an invalid amount
-* Add - Show fee breakup in transaction details timeline.
+* Add - Show fee breakdown in transaction details timeline.
 
 = 2.7.1 - 2021-07-26 =
 * Fix - Ensure test mode setting value is correctly saved.

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,7 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Bump minimum supported version of WooCommerce from 5.2 to 5.3.
 * Update - Bump minimum supported version of WordPress from 5.5 to 5.6.
 * Fix - Stop refund process when using an invalid amount
+* Add - Show fee breakup in transaction details timeline.
 
 = 2.7.1 - 2021-07-26 =
 * Fix - Ensure test mode setting value is correctly saved.


### PR DESCRIPTION
Fixes #2233

#### Changes proposed in this Pull Request
Display fee breakdown in transactions timeline as Base fee, International fee, FX fee.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
- switch to `add/fx-fee-ui` on client and `add/fx-fees-breakdown` on sever.
- make a new transaction, preferably which includes all types of fees (including discount).
- goto transactions detail view.
- make sure the sum of fee is correct.
#### Timeline screenshot
![image](https://user-images.githubusercontent.com/15019298/127406930-9c06f031-c4eb-49bb-b4bf-c6124fd2b224.png)

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
