### PR TITLE
Filter out error messages that shouldn't be displayed to customers

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix - Clear the list of selected currencies after closing the modal for adding currencies.
 * Fix - Fix subscription change payment method errors after entering a payment method that fails.
 * Fix - Prevent duplicate account onboarding requests.
+* Fix - Filter out merchant-facing payment errors from customer error notices.
 
 = 2.9.1 - 2021-09-07 =
 * Fix - Error while checking out with UPE when fields are hidden.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-use WCPay\Exceptions\{ Add_Payment_Method_Exception, Process_Payment_Exception, Intent_Authentication_Exception, API_Exception, Connection_Exception };
+use WCPay\Exceptions\{ Add_Payment_Method_Exception, Process_Payment_Exception, Intent_Authentication_Exception, API_Exception };
 use WCPay\Logger;
 use WCPay\Payment_Information;
 use WCPay\Constants\Payment_Type;
@@ -800,15 +800,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$payment_information = $this->prepare_payment_information( $order );
 			return $this->process_payment_for_order( WC()->cart, $payment_information );
 		} catch ( Exception $e ) {
-			// TODO: Create more exceptions to handle merchant specific errors.
-			$error_message = $e->getMessage();
-			if ( $e instanceof Connection_Exception ) {
-				$error_message = __( 'There was an error while processing the payment. If you continue to see this notice, please contact the admin.', 'woocommerce-payments' );
-			} elseif ( $e instanceof API_Exception && 'wcpay_bad_request' === $e->get_error_code() ) {
-				$error_message = __( 'We\'re not able to process this payment. Please refresh the page and try again.', 'woocommerce-payments' );
-			}
 
-			wc_add_notice( $error_message, 'error' );
+			wc_add_notice( WC_Payments_Utils::get_redacted_error_message( $e ), 'error' );
 
 			if ( empty( $payment_information ) || ! $payment_information->is_changing_payment_method_for_subscription() ) {
 				$order->update_status( 'failed' );
@@ -2087,7 +2080,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'redirect' => apply_filters( 'wcpay_get_add_payment_method_redirect_url', wc_get_endpoint_url( 'payment-methods' ) ),
 			];
 		} catch ( Exception $e ) {
-			wc_add_notice( $e->getMessage(), 'error', [ 'icon' => 'error' ] );
+			wc_add_notice( WC_Payments_Utils::get_redacted_error_message( $e ), 'error', [ 'icon' => 'error' ] );
 			Logger::log( 'Error when adding payment method: ' . $e->getMessage() );
 			return [
 				'result' => 'error',
@@ -2185,7 +2178,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			wp_send_json_error(
 				[
 					'error' => [
-						'message' => $e->getMessage(),
+						'message' => WC_Payments_Utils::get_redacted_error_message( $e ),
 					],
 				]
 			);

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -801,7 +801,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return $this->process_payment_for_order( WC()->cart, $payment_information );
 		} catch ( Exception $e ) {
 
-			wc_add_notice( WC_Payments_Utils::get_redacted_error_message( $e ), 'error' );
+			wc_add_notice( WC_Payments_Utils::get_filtered_error_message( $e ), 'error' );
 
 			if ( empty( $payment_information ) || ! $payment_information->is_changing_payment_method_for_subscription() ) {
 				$order->update_status( 'failed' );
@@ -2080,7 +2080,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'redirect' => apply_filters( 'wcpay_get_add_payment_method_redirect_url', wc_get_endpoint_url( 'payment-methods' ) ),
 			];
 		} catch ( Exception $e ) {
-			wc_add_notice( WC_Payments_Utils::get_redacted_error_message( $e ), 'error', [ 'icon' => 'error' ] );
+			wc_add_notice( WC_Payments_Utils::get_filtered_error_message( $e ), 'error', [ 'icon' => 'error' ] );
 			Logger::log( 'Error when adding payment method: ' . $e->getMessage() );
 			return [
 				'result' => 'error',
@@ -2178,7 +2178,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			wp_send_json_error(
 				[
 					'error' => [
-						'message' => WC_Payments_Utils::get_redacted_error_message( $e ),
+						'message' => WC_Payments_Utils::get_filtered_error_message( $e ),
 					],
 				]
 			);

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+use WCPay\Exceptions\{ API_Exception, Connection_Exception };
+
 /**
  * WC Payments Utils class
  */
@@ -476,5 +478,32 @@ class WC_Payments_Utils {
 
 		// Return 'auto' so Stripe.js uses the browser locale.
 		return 'auto';
+	}
+
+	/**
+	 * Returns redacted customer-facing error messages for notices.
+	 *
+	 * This function tries to filter out API exceptions that should not be displayed to customers.
+	 * Generally, only Stripe exceptions with type of `card_error` should be displayed.
+	 * Other API errors should be redacted (https://stripe.com/docs/api/errors#errors-message).
+	 *
+	 * @param Exception $e Exception to get the message from.
+	 *
+	 * @return string
+	 */
+	public static function get_redacted_error_message( Exception $e ) {
+		$error_message = method_exists( $e, 'getLocalizedMessage' ) ? $e->getLocalizedMessage() : $e->getMessage();
+
+		// These notices can be shown when placing an order or adding a new payment method,
+		// so we aim for more generic error messages when the API Exception is redacted.
+		if ( $e instanceof Connection_Exception ) {
+			$error_message = __( 'There was an error while processing this request. If you continue to see this notice, please contact the admin.', 'woocommerce-payments' );
+		} elseif ( $e instanceof API_Exception && 'wcpay_bad_request' === $e->get_error_code() ) {
+			$error_message = __( 'We\'re not able to process this request. Please refresh the page and try again.', 'woocommerce-payments' );
+		} elseif ( $e instanceof API_Exception && ! empty( $e->get_error_type() ) && 'card_error' !== $e->get_error_type() ) {
+			$error_message = __( 'We\'re not able to process this request. Please refresh the page and try again.', 'woocommerce-payments' );
+		}
+
+		return $error_message;
 	}
 }

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -491,11 +491,11 @@ class WC_Payments_Utils {
 	 *
 	 * @return string
 	 */
-	public static function get_redacted_error_message( Exception $e ) {
+	public static function get_filtered_error_message( Exception $e ) {
 		$error_message = method_exists( $e, 'getLocalizedMessage' ) ? $e->getLocalizedMessage() : $e->getMessage();
 
-		// These notices can be shown when placing an order or adding a new payment method,
-		// so we aim for more generic error messages when the API Exception is redacted.
+		// These notices can be shown when placing an order or adding a new payment method, so we aim for
+		// more generic messages instead of specific order/payment messages when the API Exception is redacted.
 		if ( $e instanceof Connection_Exception ) {
 			$error_message = __( 'There was an error while processing this request. If you continue to see this notice, please contact the admin.', 'woocommerce-payments' );
 		} elseif ( $e instanceof API_Exception && 'wcpay_bad_request' === $e->get_error_code() ) {

--- a/includes/exceptions/class-api-exception.php
+++ b/includes/exceptions/class-api-exception.php
@@ -21,16 +21,25 @@ class API_Exception extends Base_Exception {
 	private $http_code = 0;
 
 	/**
+	 * Error type attribute from the server.
+	 *
+	 * @var string
+	 */
+	private $error_type = null;
+
+	/**
 	 * Constructor
 	 *
 	 * @param string     $message    The Exception message to throw.
 	 * @param string     $error_code Error code returned by the server, for example wcpay_account_not_found.
 	 * @param int        $http_code  HTTP response code.
+	 * @param string     $error_type Error type attribute.
 	 * @param int        $code       The Exception code.
 	 * @param \Throwable $previous   The previous exception used for the exception chaining.
 	 */
-	public function __construct( $message, $error_code, $http_code, $code = 0, $previous = null ) {
-		$this->http_code = $http_code;
+	public function __construct( $message, $error_code, $http_code, $error_type = null, $code = 0, $previous = null ) {
+		$this->http_code  = $http_code;
+		$this->error_type = $error_type;
 
 		parent::__construct( $message, $error_code, $code, $previous );
 	}
@@ -42,5 +51,14 @@ class API_Exception extends Base_Exception {
 	 */
 	public function get_http_code() {
 		return $this->http_code;
+	}
+
+	/**
+	 * Returns the error type attribute from the server.
+	 *
+	 * @return string Error type, for example 'api_error' or 'card_error'.
+	 */
+	public function get_error_type() {
+		return $this->error_type;
 	}
 }

--- a/includes/exceptions/class-api-exception.php
+++ b/includes/exceptions/class-api-exception.php
@@ -56,7 +56,7 @@ class API_Exception extends Base_Exception {
 	/**
 	 * Returns the error type attribute from the server.
 	 *
-	 * @return string Error type, for example 'api_error' or 'card_error'.
+	 * @return string|null Error type, for example 'api_error' or 'card_error'.
 	 */
 	public function get_error_type() {
 		return $this->error_type;

--- a/includes/payment-methods/class-giropay-payment-gateway.php
+++ b/includes/payment-methods/class-giropay-payment-gateway.php
@@ -7,7 +7,6 @@
 
 namespace WCPay\Payment_Methods;
 
-use WCPay\Exceptions\Connection_Exception;
 use WCPay\Logger;
 use WC_Payment_Gateway_WCPay;
 use WC_Payments_Account;

--- a/includes/payment-methods/class-giropay-payment-gateway.php
+++ b/includes/payment-methods/class-giropay-payment-gateway.php
@@ -125,7 +125,7 @@ class Giropay_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			/* translators: localized exception message */
 			$order->update_status( 'failed', sprintf( __( 'Giropay payment failed: %s', 'woocommerce-payments' ), $e->getLocalizedMessage() ) );
 
-			wc_add_notice( WC_Payments_Utils::get_redacted_error_message( $e ), 'error' );
+			wc_add_notice( WC_Payments_Utils::get_filtered_error_message( $e ), 'error' );
 			wp_safe_redirect( wc_get_checkout_url() );
 			exit;
 		}
@@ -232,7 +232,7 @@ class Giropay_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 			return $this->process_payment_for_order( WC()->cart, $payment_information, $intent_api_parameters );
 		} catch ( Exception $e ) {
-			wc_add_notice( WC_Payments_Utils::get_redacted_error_message( $e ), 'error' );
+			wc_add_notice( WC_Payments_Utils::get_filtered_error_message( $e ), 'error' );
 
 			$order->update_status( 'failed' );
 

--- a/includes/payment-methods/class-giropay-payment-gateway.php
+++ b/includes/payment-methods/class-giropay-payment-gateway.php
@@ -125,7 +125,7 @@ class Giropay_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			/* translators: localized exception message */
 			$order->update_status( 'failed', sprintf( __( 'Giropay payment failed: %s', 'woocommerce-payments' ), $e->getLocalizedMessage() ) );
 
-			wc_add_notice( $e->getLocalizedMessage(), 'error' );
+			wc_add_notice( WC_Payments_Utils::get_redacted_error_message( $e ), 'error' );
 			wp_safe_redirect( wc_get_checkout_url() );
 			exit;
 		}
@@ -232,13 +232,7 @@ class Giropay_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 			return $this->process_payment_for_order( WC()->cart, $payment_information, $intent_api_parameters );
 		} catch ( Exception $e ) {
-			// TODO: Create more exceptions to handle merchant specific errors.
-			$error_message = $e->getMessage();
-			if ( is_a( $e, Connection_Exception::class ) ) {
-				$error_message = __( 'There was an error while processing the payment. If you continue to see this notice, please contact the admin.', 'woocommerce-payments' );
-			}
-
-			wc_add_notice( $error_message, 'error' );
+			wc_add_notice( WC_Payments_Utils::get_redacted_error_message( $e ), 'error' );
 
 			$order->update_status( 'failed' );
 

--- a/includes/payment-methods/class-sofort-payment-gateway.php
+++ b/includes/payment-methods/class-sofort-payment-gateway.php
@@ -116,7 +116,7 @@ class Sofort_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			/* translators: localized exception message */
 			$order->update_status( 'failed', sprintf( __( 'Sofort payment failed: %s', 'woocommerce-payments' ), $e->getLocalizedMessage() ) );
 
-			wc_add_notice( WC_Payments_Utils::get_redacted_error_message( $e ), 'error' );
+			wc_add_notice( WC_Payments_Utils::get_filtered_error_message( $e ), 'error' );
 			wp_safe_redirect( wc_get_checkout_url() );
 			exit;
 		}
@@ -223,7 +223,7 @@ class Sofort_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 			return $this->process_payment_for_order( WC()->cart, $payment_information, $intent_api_parameters );
 		} catch ( Exception $e ) {
-			wc_add_notice( WC_Payments_Utils::get_redacted_error_message( $e ), 'error' );
+			wc_add_notice( WC_Payments_Utils::get_filtered_error_message( $e ), 'error' );
 
 			$order->update_status( 'failed' );
 

--- a/includes/payment-methods/class-sofort-payment-gateway.php
+++ b/includes/payment-methods/class-sofort-payment-gateway.php
@@ -7,7 +7,6 @@
 
 namespace WCPay\Payment_Methods;
 
-use WCPay\Exceptions\Connection_Exception;
 use WCPay\Logger;
 use WC_Payment_Gateway_WCPay;
 use WC_Payments_Account;

--- a/includes/payment-methods/class-sofort-payment-gateway.php
+++ b/includes/payment-methods/class-sofort-payment-gateway.php
@@ -116,7 +116,7 @@ class Sofort_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			/* translators: localized exception message */
 			$order->update_status( 'failed', sprintf( __( 'Sofort payment failed: %s', 'woocommerce-payments' ), $e->getLocalizedMessage() ) );
 
-			wc_add_notice( $e->getLocalizedMessage(), 'error' );
+			wc_add_notice( WC_Payments_Utils::get_redacted_error_message( $e ), 'error' );
 			wp_safe_redirect( wc_get_checkout_url() );
 			exit;
 		}
@@ -223,13 +223,7 @@ class Sofort_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 			return $this->process_payment_for_order( WC()->cart, $payment_information, $intent_api_parameters );
 		} catch ( Exception $e ) {
-			// TODO: Create more exceptions to handle merchant specific errors.
-			$error_message = $e->getMessage();
-			if ( is_a( $e, Connection_Exception::class ) ) {
-				$error_message = __( 'There was an error while processing the payment. If you continue to see this notice, please contact the admin.', 'woocommerce-payments' );
-			}
-
-			wc_add_notice( $error_message, 'error' );
+			wc_add_notice( WC_Payments_Utils::get_redacted_error_message( $e ), 'error' );
 
 			$order->update_status( 'failed' );
 

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -141,7 +141,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			wp_send_json_error(
 				[
 					'error' => [
-						'message' => $e->getMessage(),
+						'message' => WC_Payments_Utils::get_redacted_error_message( $e ),
 					],
 				]
 			);
@@ -211,7 +211,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			wp_send_json_error(
 				[
 					'error' => [
-						'message' => $e->getMessage(),
+						'message' => WC_Payments_Utils::get_redacted_error_message( $e ),
 					],
 				]
 			);
@@ -273,7 +273,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			wp_send_json_error(
 				[
 					'error' => [
-						'message' => $e->getMessage(),
+						'message' => WC_Payments_Utils::get_redacted_error_message( $e ),
 					],
 				]
 			);
@@ -549,7 +549,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			/* translators: localized exception message */
 			$order->update_status( 'failed', sprintf( __( 'UPE payment failed: %s', 'woocommerce-payments' ), $e->getMessage() ) );
 
-			wc_add_notice( $e->getMessage(), 'error' );
+			wc_add_notice( WC_Payments_Utils::get_redacted_error_message( $e ), 'error' );
 			wp_safe_redirect( wc_get_checkout_url() );
 			exit;
 		}
@@ -635,7 +635,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 			return $payment_method->get_payment_token_for_user( $user, $payment_method_id );
 		} catch ( Exception $e ) {
-			wc_add_notice( $e->getMessage(), 'error', [ 'icon' => 'error' ] );
+			wc_add_notice( WC_Payments_Utils::get_redacted_error_message( $e ), 'error', [ 'icon' => 'error' ] );
 			Logger::log( 'Error when adding payment method: ' . $e->getMessage() );
 			return [
 				'result' => 'error',
@@ -791,7 +791,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			wp_send_json_error(
 				[
 					'error' => [
-						'message' => $e->getMessage(),
+						'message' => WC_Payments_Utils::get_redacted_error_message( $e ),
 					],
 				]
 			);

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -141,7 +141,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			wp_send_json_error(
 				[
 					'error' => [
-						'message' => WC_Payments_Utils::get_redacted_error_message( $e ),
+						'message' => WC_Payments_Utils::get_filtered_error_message( $e ),
 					],
 				]
 			);
@@ -211,7 +211,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			wp_send_json_error(
 				[
 					'error' => [
-						'message' => WC_Payments_Utils::get_redacted_error_message( $e ),
+						'message' => WC_Payments_Utils::get_filtered_error_message( $e ),
 					],
 				]
 			);
@@ -273,7 +273,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			wp_send_json_error(
 				[
 					'error' => [
-						'message' => WC_Payments_Utils::get_redacted_error_message( $e ),
+						'message' => WC_Payments_Utils::get_filtered_error_message( $e ),
 					],
 				]
 			);
@@ -549,7 +549,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			/* translators: localized exception message */
 			$order->update_status( 'failed', sprintf( __( 'UPE payment failed: %s', 'woocommerce-payments' ), $e->getMessage() ) );
 
-			wc_add_notice( WC_Payments_Utils::get_redacted_error_message( $e ), 'error' );
+			wc_add_notice( WC_Payments_Utils::get_filtered_error_message( $e ), 'error' );
 			wp_safe_redirect( wc_get_checkout_url() );
 			exit;
 		}
@@ -635,7 +635,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 			return $payment_method->get_payment_token_for_user( $user, $payment_method_id );
 		} catch ( Exception $e ) {
-			wc_add_notice( WC_Payments_Utils::get_redacted_error_message( $e ), 'error', [ 'icon' => 'error' ] );
+			wc_add_notice( WC_Payments_Utils::get_filtered_error_message( $e ), 'error', [ 'icon' => 'error' ] );
 			Logger::log( 'Error when adding payment method: ' . $e->getMessage() );
 			return [
 				'result' => 'error',
@@ -791,7 +791,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			wp_send_json_error(
 				[
 					'error' => [
-						'message' => WC_Payments_Utils::get_redacted_error_message( $e ),
+						'message' => WC_Payments_Utils::get_filtered_error_message( $e ),
 					],
 				]
 			);

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1314,9 +1314,11 @@ class WC_Payments_API_Client {
 
 		// Check error codes for 4xx and 5xx responses.
 		if ( 400 <= $response_code ) {
+			$error_type = null;
 			if ( isset( $response_body['error'] ) ) {
 				$error_code    = $response_body['error']['code'] ?? $response_body['error']['type'] ?? null;
 				$error_message = $response_body['error']['message'] ?? null;
+				$error_type    = $response_body['error']['type'] ?? null;
 			} elseif ( isset( $response_body['code'] ) ) {
 				$error_code    = $response_body['code'];
 				$error_message = $response_body['message'];
@@ -1332,7 +1334,7 @@ class WC_Payments_API_Client {
 			);
 
 			Logger::error( "$error_message ($error_code)" );
-			throw new API_Exception( $message, $error_code, $response_code );
+			throw new API_Exception( $message, $error_code, $response_code, $error_type );
 		}
 
 		// Make sure empty metadata serialized on the client as an empty object {} rather than array [].

--- a/readme.txt
+++ b/readme.txt
@@ -107,6 +107,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Clear the list of selected currencies after closing the modal for adding currencies.
 * Fix - Fix subscription change payment method errors after entering a payment method that fails.
 * Fix - Prevent duplicate account onboarding requests.
+* Fix - Filter out merchant-facing payment errors from customer error notices.
 
 = 2.9.1 - 2021-09-07 =
 * Fix - Error while checking out with UPE when fields are hidden.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -517,7 +517,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	public function test_connection_exception_thrown() {
 		// Arrange: Reusable data.
 		$error_message = 'Test error.';
-		$error_notice  = 'There was an error while processing the payment. If you continue to see this notice, please contact the admin.';
+		$error_notice  = 'There was an error while processing this request. If you continue to see this notice, please contact the admin.';
 
 		// Arrange: Create an order to test with.
 		$order = WC_Helper_Order::create_order();
@@ -587,7 +587,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 
 	public function test_bad_request_exception_thrown() {
 		$error_message = 'Test error.';
-		$error_notice  = 'We\'re not able to process this payment. Please refresh the page and try again.';
+		$error_notice  = 'We\'re not able to process this request. Please refresh the page and try again.';
 
 		$order = WC_Helper_Order::create_order();
 


### PR DESCRIPTION
Fixes #470

I think this change is positive as it doesn't display errors that don't pertain to customers, but at the same time it might be harder for store admins to debug issues, as they will need to rely only on logs and order notes, when these apply.

#### Changes proposed in this Pull Request

Stripe recommends only displaying card errors to customers - [Ref](https://stripe.com/docs/api/errors#errors-message).

In this PR, we're adding the `type` attribute that Stripe provides to the `API_Exception` class, so that we can filter out other API errors that don't pertain to customers.

#### Testing instructions

* Try paying with a [test card](https://stripe.com/docs/testing) which returns a customer-facing error (e.g `4000000000000069`) and notice a "card expired" error is displayed.
* To test a Stripe API (merchant-facing) error, try breaking the request from the code (e.g changing the currency to an invalid one e.g `xyz` in `process_payment_for_order` in `class-wc-payment-gateway-wcpay.php` and notice a generic error message is displayed. Try doing the same in trunk and notice a Stripe error about invalid currency is displayed.
* The above should also work for cards added from the my account page, where there's a WC notice in case any errors are thrown.

#### Caveats
* For the non-UPE block checkout, this doesn't apply as we're currently throwing generic error messages at all times due to #2803.
* For UPE payments, the same behavior should apply, but it won't add an order note nor fail the order due to #2702.
* For other payment methods like SEPA, SOFORT and Giropay, we're using the same utility function, but user-facing errors will never be displayed from Stripe directly to users due to the nature of these payment methods (ref p1629994061002400-slack-C9976E5MJ).

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)