### PR TITLE
Use expired cached rate data on server error

### DIFF
--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -21,10 +21,10 @@ defined( 'ABSPATH' ) || exit;
  */
 class MultiCurrency {
 
-	const CURRENCY_SESSION_KEY     = 'wcpay_currency';
-	const CURRENCY_META_KEY        = 'wcpay_currency';
-	const CURRENCY_CACHE_OPTION    = 'wcpay_multi_currency_cached_currencies';
-	const CURRENCY_RETRIEVAL_ERROR = 'error';
+	const CURRENCY_SESSION_KEY            = 'wcpay_currency';
+	const CURRENCY_META_KEY               = 'wcpay_currency';
+	const CURRENCY_CACHE_OPTION           = 'wcpay_multi_currency_cached_currencies';
+	const CURRENCY_RETRIEVAL_ERROR_OPTION = 'wcpay_multi_currency_retrieval_error';
 
 	/**
 	 * The plugin's ID.
@@ -287,33 +287,35 @@ class MultiCurrency {
 	 * @return ?array
 	 */
 	public function get_cached_currencies() {
-		if ( ! $this->payments_api_client->is_server_connected() ) {
-			return null;
+
+		$error_expires = get_option( self::CURRENCY_RETRIEVAL_ERROR_OPTION, 0 );
+		$cache_data    = $this->read_currencies_from_cache();
+
+		// If the error has not expired, return cached data or null and do not attempt another API call.
+		if ( $error_expires > time() ) {
+			return $cache_data ?? null;
 		}
 
-		$cache_data = $this->read_currencies_from_cache();
-
-		// If the option contains the error value, return false early and do not attempt another API call.
-		if ( isset( $cache_data['currencies'] ) && self::CURRENCY_RETRIEVAL_ERROR === $cache_data['currencies'] ) {
-			return null;
-		}
-
-		// If an array of currencies was returned from the cache, return it here.
-		if ( null !== $cache_data ) {
+		// If an array of currencies was returned from the cache and has not expired, return it here.
+		if ( null !== $cache_data && $cache_data['expires'] > time() ) {
 			return $cache_data;
 		}
 
-		// If the cache was expired or something went wrong, make a call to the server to get the
-		// currency data.
+		// If connection to server cannot be established, return expired data or null.
+		if ( ! $this->payments_api_client->is_server_connected() ) {
+			return $cache_data ?? null;
+		}
+
+		// If the cache was expired or something went wrong, make a call to the server to get the currency data.
 		try {
 			$currency_data = $this->payments_api_client->get_currency_rates( get_woocommerce_currency() );
 		} catch ( API_Exception $e ) {
 			// Failed to retrieve currencies from the server. Exception is logged in http client.
-			// Rate limit for a short amount of time by caching the failure.
-			$this->cache_currencies( self::CURRENCY_RETRIEVAL_ERROR, time(), 1 * MINUTE_IN_SECONDS );
+			// Rate limit for a short amount of time by persisting the failure.
+			update_option( self::CURRENCY_RETRIEVAL_ERROR_OPTION, time() + 1 * MINUTE_IN_SECONDS, 'no' );
 
-			// Return null to signal currency retrieval error.
-			return null;
+			// Return expired data or null to signal currency retrieval error.
+			return $cache_data ?? null;
 		}
 
 		$updated = time();
@@ -600,8 +602,8 @@ class MultiCurrency {
 
 		$charm_compatible_types = [ 'product', 'shipping' ];
 		$apply_charm_pricing    = $this->get_apply_charm_only_to_products()
-			? 'product' === $type
-			: in_array( $type, $charm_compatible_types, true );
+		? 'product' === $type
+		: in_array( $type, $charm_compatible_types, true );
 
 		return $this->get_adjusted_price( $converted_price, $apply_charm_pricing, $currency );
 	}
@@ -731,9 +733,9 @@ class MultiCurrency {
 	/**
 	 * Caches currency data for a period of time.
 	 *
-	 * @param string|array $currencies - Currency data to cache.
-	 * @param int|null     $updated    - The time the data was fetched from the server.
-	 * @param int|null     $expiration - The length of time to cache the currency data, in seconds.
+	 * @param array    $currencies - Currency data to cache.
+	 * @param int|null $updated    - The time the data was fetched from the server.
+	 * @param int|null $expiration - The length of time to cache the currency data, in seconds.
 	 *
 	 * @return bool
 	 */
@@ -755,14 +757,7 @@ class MultiCurrency {
 			'updated'    => $updated,
 		];
 
-		// Create or update the currency option cache.
-		if ( false === get_option( self::CURRENCY_CACHE_OPTION ) ) {
-			$result = add_option( self::CURRENCY_CACHE_OPTION, $currency_cache, '', 'no' );
-		} else {
-			$result = update_option( self::CURRENCY_CACHE_OPTION, $currency_cache, 'no' );
-		}
-
-		return $result;
+		return update_option( self::CURRENCY_CACHE_OPTION, $currency_cache, 'no' );
 	}
 
 	/**
@@ -811,22 +806,16 @@ class MultiCurrency {
 		}
 	}
 
-
 	/**
 	 * Read the currency data from the WP option we cache it in.
 	 *
 	 * @return ?array
 	 */
 	private function read_currencies_from_cache() {
-		$currency_cache = get_option( self::CURRENCY_CACHE_OPTION );
+		$currency_cache = get_option( self::CURRENCY_CACHE_OPTION, [] );
 
-		if ( false === $currency_cache || ! is_array( $currency_cache ) || ! isset( $currency_cache['currencies'] ) || ! isset( $currency_cache['expires'] ) || ! isset( $currency_cache['updated'] ) ) {
+		if ( ! isset( $currency_cache['currencies'] ) || ! isset( $currency_cache['expires'] ) || ! isset( $currency_cache['updated'] ) ) {
 			// No option found or the data isn't in the format we expect.
-			return null;
-		}
-
-		// Return false if the cache has expired, triggering another fetch.
-		if ( $currency_cache['expires'] < time() ) {
 			return null;
 		}
 

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -12,9 +12,10 @@ use WCPay\MultiCurrency\MultiCurrency;
  * WCPay\MultiCurrency\MultiCurrency unit tests.
  */
 class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
-	const LOGGED_IN_USER_ID         = 1;
-	const ENABLED_CURRENCIES_OPTION = 'wcpay_multi_currency_enabled_currencies';
-	const CACHED_CURRENCIES_OPTION  = 'wcpay_multi_currency_cached_currencies';
+	const LOGGED_IN_USER_ID               = 1;
+	const ENABLED_CURRENCIES_OPTION       = 'wcpay_multi_currency_enabled_currencies';
+	const CACHED_CURRENCIES_OPTION        = 'wcpay_multi_currency_cached_currencies';
+	const CURRENCY_RETRIEVAL_ERROR_OPTION = 'wcpay_multi_currency_retrieval_error';
 
 	/**
 	 * Mock enabled currencies.
@@ -530,25 +531,28 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 
 		$mock_api_client->method( 'is_server_connected' )->willReturn( false );
 
-		$this->multi_currency = new MultiCurrency( $mock_api_client, $this->mock_account, $this->mock_localization_service );
-		$this->multi_currency->init();
-
-		$this->assertNull( $this->multi_currency->get_cached_currencies() );
+		$this->init_multi_currency( $mock_api_client );
+		$this->assertEquals(
+			$this->mock_cached_currencies,
+			$this->multi_currency->get_cached_currencies()
+		);
 	}
 
-	public function test_get_cached_currencies_with_server_retrieval_error() {
-		$current_time = time();
+	public function test_get_expired_cached_currencies_with_server_retrieval_error() {
+		$currency_cache            = $this->mock_cached_currencies;
+		$currency_cache['expires'] = strtotime( 'yesterday' );
 
-		$currency_cache = [
-			'currencies' => MultiCurrency::CURRENCY_RETRIEVAL_ERROR,
-			'updated'    => $current_time,
-			'expires'    => $current_time + DAY_IN_SECONDS,
-		];
+		update_option( self::CACHED_CURRENCIES_OPTION, $currency_cache );
 
-		// Create or update the currency option cache.
-		update_option( MultiCurrency::CURRENCY_CACHE_OPTION, $currency_cache, 'no' );
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_currency_rates' )
+			->willThrowException( new API_Exception( 'Error connecting to server', 'API_ERROR', 500 ) );
 
-		$this->assertNull( $this->multi_currency->get_cached_currencies() );
+		$this->assertEquals(
+			$currency_cache,
+			$this->multi_currency->get_cached_currencies()
+		);
 	}
 
 	public function test_get_cached_currencies_with_valid_cached_data() {
@@ -604,9 +608,9 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 
 		$this->assertNull( $this->multi_currency->get_cached_currencies() );
 
-		// Assert that the cache was correctly set with the error string.
-		$cached_data = get_option( self::CACHED_CURRENCIES_OPTION );
-		$this->assertEquals( MultiCurrency::CURRENCY_RETRIEVAL_ERROR, $cached_data['currencies'] );
+		// Assert that the cache was correctly set with the error expiration time.
+		$this->assertEquals( time() + MINUTE_IN_SECONDS, get_option( self::CURRENCY_RETRIEVAL_ERROR_OPTION ) );
+
 	}
 
 	public function get_price_provider() {
@@ -642,8 +646,8 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		}
 	}
 
-	private function init_multi_currency() {
-		$this->multi_currency = new MultiCurrency( $this->mock_api_client, $this->mock_account, $this->mock_localization_service );
+	private function init_multi_currency( $mock_api_client = null ) {
+		$this->multi_currency = new MultiCurrency( $mock_api_client ?? $this->mock_api_client, $this->mock_account, $this->mock_localization_service );
 		$this->multi_currency->init();
 	}
 }


### PR DESCRIPTION
Fixes #2124 

#### Changes proposed in this Pull Request
Use the available expired cache of currencies rates on server error, instead of returning null.

I tried at first to store the expiration time on the rates cache, but didn't like the result, the code was a bit complex to read and don't like too much the idea of having multiple structures for the same array of data.

So I ended creating a new option to store the error expiration. Opted to keep the code inline instead of creating a get/set private methods for it, cause it's only used once.

#### Testing instructions
Tests should pass. You can try it on the site, changing the code to make the expiration time shorter and/or throwing an error on the server side.

Now the cached data should be returned even if it's expired when server fails.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
