### PR TITLE
Add geolocation automatic currency switch notice

### DIFF
--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -612,7 +612,7 @@ class MultiCurrency {
 
 		$message = sprintf(
 			/* translators: %1 User's country, %2 Selected currency name, %3 Default store currency name */
-			__( 'We noticed you\'re visiting from %1$s. We\'ve updated our prices to %2$s for your shopping convenience. Use <a>%3$s</a> instead.', 'woocommerce-payments' ),
+			__( 'We noticed you\'re visiting from %1$s. We\'ve updated our prices to %2$s for your shopping convenience. <a>Use %3$s instead.</a>', 'woocommerce-payments' ),
 			WC()->countries->countries[ $country ],
 			$current_currency->get_name(),
 			$currencies[ $store_currency ]

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -605,6 +605,11 @@ class MultiCurrency {
 		$country          = $this->locale->get_country_by_customer_location();
 		$currencies       = get_woocommerce_currencies();
 
+		// Do not display notice if using the store's default currency.
+		if ( $store_currency === $current_currency->get_code() ) {
+			return;
+		}
+
 		$message = sprintf(
 			/* translators: %1 User's country, %2 Selected currency name, %3 Default store currency name */
 			__( 'We noticed you\'re visiting from %1$s. We\'ve updated our prices to %2$s for your shopping convenience. Use <a>%3$s</a> instead.', 'woocommerce-payments' ),

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -536,7 +536,13 @@ class MultiCurrency {
 	public function update_selected_currency_by_geolocation() {
 		// We only want to automatically set the currency if it's already not set.
 		if ( $this->is_using_auto_currency_switching() && ! $this->get_stored_currency_code() ) {
-			$this->update_selected_currency( $this->locale->get_currency_by_customer_location() );
+			$currency = $this->locale->get_currency_by_customer_location();
+
+			// Update currency and display notice if enabled.
+			if ( ! empty( $this->get_enabled_currencies()[ $currency ] ) ) {
+				$this->update_selected_currency( $currency );
+				add_action( 'wp_footer', [ $this, 'display_geolocation_currency_update_notice' ] );
+			}
 		}
 	}
 
@@ -587,6 +593,37 @@ class MultiCurrency {
 	 */
 	public function recalculate_cart() {
 		WC()->cart->calculate_totals();
+	}
+
+	/**
+	 * Displays a notice on the frontend informing the customer of the
+	 * automatic currency switch.
+	 */
+	public function display_geolocation_currency_update_notice() {
+		$current_currency = $this->get_selected_currency();
+		$store_currency   = get_option( 'woocommerce_currency' );
+		$country          = $this->locale->get_country_by_customer_location();
+		$currencies       = get_woocommerce_currencies();
+
+		$message = sprintf(
+			/* translators: %1 User's country, %2 Selected currency name, %3 Default store currency name */
+			__( 'We noticed you\'re visiting from %1$s. We\'ve updated our prices to %2$s for your shopping convenience. Use <a>%3$s</a> instead.', 'woocommerce-payments' ),
+			WC()->countries->countries[ $country ],
+			$current_currency->get_name(),
+			$currencies[ $store_currency ]
+		);
+
+		$notice_id = md5( $message );
+
+		echo '<p class="woocommerce-store-notice demo_store" data-notice-id="' . esc_attr( $notice_id . 2 ) . '" style="display:none;">';
+		echo \WC_Payments_Utils::esc_interpolated_html(
+			$message,
+			[
+				'a' => '<a href="?currency=' . $store_currency . '">',
+			]
+		);
+		echo ' <a href="#" class="woocommerce-store-notice__dismiss-link">' . esc_html__( 'Dismiss', 'woocommerce-payments' ) . '</a></p>';
+
 	}
 
 	/**

--- a/includes/multi-currency/Settings.php
+++ b/includes/multi-currency/Settings.php
@@ -127,12 +127,8 @@ class Settings extends \WC_Settings_Page {
 					[
 						'title'         => __( 'Store settings', 'woocommerce-payments' ),
 						'desc'          => __( 'Automatically switch customers to their local currency if it is enabled above.', 'woocommerce-payments' ),
-						// TODO: Preview link, to be done on #2258.
-						'desc_tip'      => sprintf(
-							/* translators: %s: url to a preview of alert banner */
-							__( 'Customers will be notified via store alert banner. <a href="%s">Preview</a>', 'woocommerce-payments' ),
-							''
-						),
+						// TODO: Preview link, to be done on #2523.
+						'desc_tip'      => __( 'Customers will be notified via store alert banner.', 'woocommerce-payments' ),
 						'id'            => $this->id . '_enable_auto_currency',
 						'default'       => 'yes',
 						'type'          => 'checkbox',

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -343,7 +343,7 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 
 		$this->expectOutputRegex( '/<p class="woocommerce-store-notice demo_store" data-notice-id="cd4c082cbdfa742c13d944c867a45cd92" style="display:none;">/' );
 		$this->expectOutputRegex( '/We noticed you&#039;re visiting from Canada. We&#039;ve updated our prices to Canadian dollar for your shopping convenience./' );
-		$this->expectOutputRegex( '/Use <a href="?currency=USD">United States (US) dollar<\/a> instead./' );
+		$this->expectOutputRegex( '/<a href="?currency=USD">Use United States (US) dollar instead.<\/a>/' );
 		$this->expectOutputRegex( '/<a href="#" class="woocommerce-store-notice__dismiss-link">Dismiss<\/a><\/p>/' );
 	}
 

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -347,6 +347,20 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->expectOutputRegex( '/<a href="#" class="woocommerce-store-notice__dismiss-link">Dismiss<\/a><\/p>/' );
 	}
 
+	public function test_display_geolocation_currency_update_notice_does_not_display_if_using_default_currency() {
+		WC()->session->set( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY, 'US' );
+		add_filter(
+			'woocommerce_geolocate_ip',
+			function() {
+				return 'US';
+			}
+		);
+
+		$this->multi_currency->display_geolocation_currency_update_notice();
+
+		$this->expectOutputString( '' );
+	}
+
 	public function test_get_price_returns_price_in_default_currency() {
 		WC()->session->set( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY, get_woocommerce_currency() );
 

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -315,6 +315,38 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->assertSame( 'CAD', WC()->session->get( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY ) );
 	}
 
+	public function test_update_selected_currency_by_geolocation_displays_notice() {
+		update_option( 'wcpay_multi_currency_enable_auto_currency', 'yes' );
+
+		add_filter(
+			'woocommerce_geolocate_ip',
+			function() {
+				return 'CA';
+			}
+		);
+
+		$this->multi_currency->update_selected_currency_by_geolocation();
+
+		$this->assertNotFalse( has_filter( 'wp_footer', [ $this->multi_currency, 'display_geolocation_currency_update_notice' ] ) );
+	}
+
+	public function test_display_geolocation_currency_update_notice() {
+		WC()->session->set( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY, 'CAD' );
+		add_filter(
+			'woocommerce_geolocate_ip',
+			function() {
+				return 'CA';
+			}
+		);
+
+		$this->multi_currency->display_geolocation_currency_update_notice();
+
+		$this->expectOutputRegex( '/<p class="woocommerce-store-notice demo_store" data-notice-id="cd4c082cbdfa742c13d944c867a45cd92" style="display:none;">/' );
+		$this->expectOutputRegex( '/We noticed you&#039;re visiting from Canada. We&#039;ve updated our prices to Canadian dollar for your shopping convenience./' );
+		$this->expectOutputRegex( '/Use <a href="?currency=USD">United States (US) dollar<\/a> instead./' );
+		$this->expectOutputRegex( '/<a href="#" class="woocommerce-store-notice__dismiss-link">Dismiss<\/a><\/p>/' );
+	}
+
 	public function test_get_price_returns_price_in_default_currency() {
 		WC()->session->set( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY, get_woocommerce_currency() );
 


### PR DESCRIPTION
Fixes #2258 

#### Changes proposed in this Pull Request


Display a notice informing that the currency has been automatically switched to the user's country currency, with a link to go back to the store's default one.

![image](https://user-images.githubusercontent.com/7714042/126528873-630c29db-c5d4-4c10-8cab-ec1a48155364.png)

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in to a WC user
    * Remove the user currency with `npm run wp user meta delete <user_id> wcpay_currency`
    * Navigate to the shop page
    * Assert that the notice appears informing that the currency was switched automatically
    * Assert that the notice can be dismissed and that it doesn't appear again while navigating
* Repeat these steps for a guest user, removing the WooCommerce session cookie, if present
* Set the store current to the same as the geolocated country, or use the `woocommerce_geolocate_ip` filter to mock your country
    * Assert that the note does not appear if the geolocation currency is the same as the store currency

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
