### PR TITLE
fix: UPE opt-in banner flag check

### DIFF
--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -141,10 +141,7 @@ const PaymentMethods = () => {
 	};
 
 	const {
-		featureFlags: {
-			upeSettingsPreview: isUpeSettingsPreviewEnabled,
-			upe: isUpeFeatureEnabled,
-		},
+		featureFlags: { upeSettingsPreview: isUpeSettingsPreviewEnabled },
 	} = useContext( WCPaySettingsContext );
 
 	const { isUpeEnabled, status } = useContext( WcPayUpeContext );
@@ -189,7 +186,7 @@ const PaymentMethods = () => {
 						) }
 					</PaymentMethodsList>
 				</CardBody>
-				{ isUpeSettingsPreviewEnabled && ! isUpeFeatureEnabled && (
+				{ isUpeSettingsPreviewEnabled && ! isUpeEnabled && (
 					<UpeSetupBanner />
 				) }
 

--- a/client/payment-methods/test/index.js
+++ b/client/payment-methods/test/index.js
@@ -205,10 +205,17 @@ describe( 'PaymentMethods', () => {
 			const featureFlagContext = {
 				featureFlags: { upeSettingsPreview, upe },
 			};
+			const upeContext = {
+				isUpeEnabled: upe,
+				setIsUpeEnabled: () => null,
+				status: 'resolved',
+			};
 
 			render(
 				<WCPaySettingsContext.Provider value={ featureFlagContext }>
-					<PaymentMethods />
+					<WcPayUpeContext.Provider value={ upeContext }>
+						<PaymentMethods />
+					</WcPayUpeContext.Provider>
 				</WCPaySettingsContext.Provider>
 			);
 

--- a/client/payment-methods/test/index.js
+++ b/client/payment-methods/test/index.js
@@ -181,10 +181,17 @@ describe( 'PaymentMethods', () => {
 		const featureFlagContext = {
 			featureFlags: { upeSettingsPreview: true, upe: false },
 		};
+		const upeContext = {
+			isUpeEnabled: false,
+			setIsUpeEnabled: () => null,
+			status: 'resolved',
+		};
 
 		render(
 			<WCPaySettingsContext.Provider value={ featureFlagContext }>
-				<PaymentMethods />
+				<WcPayUpeContext.Provider value={ upeContext }>
+					<PaymentMethods />
+				</WcPayUpeContext.Provider>
 			</WCPaySettingsContext.Provider>
 		);
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When enabling->disabling UPE, the opt-in banner in the settings does not appear correctly.

Before:
![2021-07-21 16 31 10](https://user-images.githubusercontent.com/273592/126562827-1c89f6b6-d928-4e0c-aecd-a64afe405de1.gif)


After:
![2021-07-21 16 29 54](https://user-images.githubusercontent.com/273592/126562684-c454631a-be83-4bdd-9b4e-e64723b0c842.gif)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments
- Enable UPE
- Go back to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments
- Disable UPE
- The banner should re-appear

-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
