### PR TITLE
Dispatch 'maybe_redirect_to_onboarding' action after onboarding redirection logic in `WC_Payments_Admin`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@
 * Add - Dispute Status Chip into the header of the Dispute Details page.
 * Fix - Use a singular label in the summary of Transactions and Deposits lists.
 * Add - Disable payment gateway when not in test mode and not using https or ssl checkout enforcement.
+* Fix - Onboarding redirection occasionally not finalizing account connection.
 
 = 2.7.0 - 2021-07-14 =
 * Add - Add a link to the snackbar notice that appears after submitting or saving evidence for a dispute challenge.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -65,7 +65,7 @@ class WC_Payments_Admin {
 
 		// Add menu items.
 		add_action( 'admin_menu', [ $this, 'add_payments_menu' ], 0 );
-		add_action( 'admin_menu', [ $this, 'maybe_redirect_to_onboarding' ], 1 );
+		add_action( 'admin_init', [ $this, 'maybe_redirect_to_onboarding' ], 11 ); // Run this after the WC setup wizard and onboarding redirection logic.
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_payments_scripts' ] );
 		add_action( 'woocommerce_admin_field_payment_gateways', [ $this, 'payment_gateways_container' ] );
 

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -622,6 +622,9 @@ class WC_Payments_Admin {
 	 * if it is not and the user is attempting to view a WCPay admin page.
 	 */
 	public function maybe_redirect_to_onboarding() {
+		if ( wp_doing_ajax() ) {
+			return false;
+		}
 		$url_params = wp_unslash( $_GET ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		if ( empty( $url_params['page'] ) || 'wc-admin' !== $url_params['page'] ) {

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -41,7 +41,7 @@ class WC_Payments_Account {
 		$this->payments_api_client = $payments_api_client;
 
 		add_action( 'admin_init', [ $this, 'maybe_handle_oauth' ] );
-		add_action( 'admin_init', [ $this, 'maybe_redirect_to_onboarding' ], 11 ); // Run this after the WC setup wizard redirection logic.
+		add_action( 'admin_init', [ $this, 'maybe_redirect_to_onboarding' ], 11 ); // Run this after the WC setup wizard and onboarding redirection logic.
 		add_action( 'woocommerce_payments_account_refreshed', [ $this, 'handle_instant_deposits_inbox_note' ] );
 		add_action( 'wcpay_instant_deposit_reminder', [ $this, 'handle_instant_deposits_inbox_reminder' ] );
 		add_filter( 'allowed_redirect_hosts', [ $this, 'allowed_redirect_hosts' ] );

--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Dispute Status Chip into the header of the Dispute Details page.
 * Fix - Use a singular label in the summary of Transactions and Deposits lists.
 * Add - Disable payment gateway when not in test mode and not using https or ssl checkout enforcement.
+* Fix - Onboarding redirection occasionally not finalizing account connection.
 
 = 2.7.0 - 2021-07-14 =
 * Add - Add a link to the snackbar notice that appears after submitting or saving evidence for a dispute challenge.


### PR DESCRIPTION
Fixes #2513

As described in the issue, there's probably a race condition somewhere which occasionally makes the onboarding redirection not finalize the account connection in the client.

When testing with a local server, the onboarding redirection will fail most times, while testing with the production server, it seems to _almost always_ work (p1626741938458500-slack-CGGCLBN58).

#### Changes proposed in this Pull Request

The `admin_menu` hook is triggered before `admin_init`, so this PR changes when `maybe_redirect_to_onboarding` is called in `includes/admin/class-wc-payments-admin.php`, to make sure it's called only after the onboarding redirection logic.

#### Testing instructions

Since this seems to be a race condition problem (which I didn't identify), and works intermittently, I'd ask you to try to reproduce the issue in `develop` and in this branch a couple times, so we can confirm a consistent behavior and see if this change is really what's fixing the issue:

1. Remove any existing account record from `wcpay_accounts`.
2. Try onboarding in dev mode with API requests being redirected to a local server.
3. After KYC completion, most of the time you should be redirected to `/payments/connect`. (I'd say when testing with a local server, 9 out of 10 times I'd be able to reproduce the issue).
4. Please repeat the steps above while in this branch and notice you should be correctly redirected to `/payments/overview` at all attempts.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)