### PR TITLE
Fix add enabled currencies modal overflow margins

### DIFF
--- a/client/multi-currency/enabled-currencies-list/style.scss
+++ b/client/multi-currency/enabled-currencies-list/style.scss
@@ -124,7 +124,7 @@
 		flex: 1;
 		display: flex;
 		flex-direction: column;
-		margin: 0 -24px -24px 0;
+		margin: 0 -#{$grid-unit-30} -#{$grid-unit-30} 0;
 	}
 
 	&__search {

--- a/client/multi-currency/enabled-currencies-list/style.scss
+++ b/client/multi-currency/enabled-currencies-list/style.scss
@@ -124,9 +124,7 @@
 		flex: 1;
 		display: flex;
 		flex-direction: column;
-		padding-right: 16px;
-		padding-left: 5px;
-		margin-left: -5px;
+		margin: 0 -24px -24px 0;
 	}
 
 	&__search {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Quick fix to remove empty spaces on add enabled currencies overflow section. The scrollbar shouldn't have any space with the modal border, and the bottom space cause a weird look to elements that dis/appears on scroll.

| Before | After |
|:-:|:-:|
|<img width="426" alt="Screenshot 2021-07-22 at 10 07 12" src="https://user-images.githubusercontent.com/7670276/126608343-3c3bd2e0-1229-46a4-a5f1-1c00bf775a43.png">|<img width="406" alt="Screenshot 2021-07-22 at 10 08 14" src="https://user-images.githubusercontent.com/7670276/126608351-cfce3daa-4e19-4c5e-951e-8e8a7f35a69f.png">|

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
