### PR TITLE
fix: settings multi currency when feature disabled

### DIFF
--- a/client/additional-methods-setup/upe-preview-methods-selector/setup-complete-task.js
+++ b/client/additional-methods-setup/upe-preview-methods-selector/setup-complete-task.js
@@ -13,10 +13,13 @@ import { useDispatch } from '@wordpress/data';
 import CollapsibleBody from '../wizard/collapsible-body';
 import WizardTaskItem from '../wizard/task-item';
 import WizardTaskContext from '../wizard/task/context';
+import WCPaySettingsContext from '../../settings/wcpay-settings-context';
 
 const SetupComplete = () => {
 	const { isActive } = useContext( WizardTaskContext );
-
+	const {
+		featureFlags: { multiCurrency },
+	} = useContext( WCPaySettingsContext );
 	const { updateOptions } = useDispatch( 'wc/admin/options' );
 
 	useEffect( () => {
@@ -54,15 +57,17 @@ const SetupComplete = () => {
 							'woocommerce-payments'
 						) }
 					</Button>
-					<Button
-						href="admin.php?page=wc-settings&tab=wcpay_multi_currency"
-						isTertiary
-					>
-						{ __(
-							'Go to multi-currency settings',
-							'woocommerce-payments'
-						) }
-					</Button>
+					{ multiCurrency && (
+						<Button
+							href="admin.php?page=wc-settings&tab=wcpay_multi_currency"
+							isTertiary
+						>
+							{ __(
+								'Go to multi-currency settings',
+								'woocommerce-payments'
+							) }
+						</Button>
+					) }
 				</div>
 			</CollapsibleBody>
 		</WizardTaskItem>

--- a/client/additional-methods-setup/upe-preview-methods-selector/test/add-payment-methods-task.test.js
+++ b/client/additional-methods-setup/upe-preview-methods-selector/test/add-payment-methods-task.test.js
@@ -18,6 +18,7 @@ import {
 	useCurrencies,
 	useEnabledCurrencies,
 } from '../../../data';
+import WCPaySettingsContext from '../../../settings/wcpay-settings-context';
 
 jest.mock( '../../../data', () => ( {
 	useGetAvailablePaymentMethodIds: jest.fn(),
@@ -26,6 +27,14 @@ jest.mock( '../../../data', () => ( {
 	useCurrencies: jest.fn(),
 	useEnabledCurrencies: jest.fn(),
 } ) );
+
+const SettingsContextProvider = ( { children } ) => (
+	<WCPaySettingsContext.Provider
+		value={ { featureFlags: { multiCurrency: true }, accountFees: {} } }
+	>
+		{ children }
+	</WCPaySettingsContext.Provider>
+);
 
 describe( 'AddPaymentMethodsTask', () => {
 	beforeEach( () => {
@@ -55,11 +64,13 @@ describe( 'AddPaymentMethodsTask', () => {
 	it( 'should not call the useSettings hook if the task is not active', () => {
 		useGetAvailablePaymentMethodIds.mockReturnValue( [] );
 		render(
-			<WizardTaskContext.Provider
-				value={ { setCompleted: () => null, isActive: false } }
-			>
-				<AddPaymentMethodsTask />
-			</WizardTaskContext.Provider>
+			<SettingsContextProvider>
+				<WizardTaskContext.Provider
+					value={ { setCompleted: () => null, isActive: false } }
+				>
+					<AddPaymentMethodsTask />
+				</WizardTaskContext.Provider>
+			</SettingsContextProvider>
 		);
 
 		expect(
@@ -74,11 +85,13 @@ describe( 'AddPaymentMethodsTask', () => {
 	it( 'should not allow to move forward if no payment methods are selected', () => {
 		const setCompletedMock = jest.fn();
 		render(
-			<WizardTaskContext.Provider
-				value={ { setCompleted: setCompletedMock, isActive: true } }
-			>
-				<AddPaymentMethodsTask />
-			</WizardTaskContext.Provider>
+			<SettingsContextProvider>
+				<WizardTaskContext.Provider
+					value={ { setCompleted: setCompletedMock, isActive: true } }
+				>
+					<AddPaymentMethodsTask />
+				</WizardTaskContext.Provider>
+			</SettingsContextProvider>
 		);
 
 		expect(
@@ -118,11 +131,13 @@ describe( 'AddPaymentMethodsTask', () => {
 			updateEnabledPaymentMethodsMock,
 		] );
 		render(
-			<WizardTaskContext.Provider
-				value={ { setCompleted: setCompletedMock, isActive: true } }
-			>
-				<AddPaymentMethodsTask />
-			</WizardTaskContext.Provider>
+			<SettingsContextProvider>
+				<WizardTaskContext.Provider
+					value={ { setCompleted: setCompletedMock, isActive: true } }
+				>
+					<AddPaymentMethodsTask />
+				</WizardTaskContext.Provider>
+			</SettingsContextProvider>
 		);
 
 		expect(
@@ -164,11 +179,13 @@ describe( 'AddPaymentMethodsTask', () => {
 			updateEnabledPaymentMethodsMock,
 		] );
 		render(
-			<WizardTaskContext.Provider
-				value={ { setCompleted: setCompletedMock, isActive: true } }
-			>
-				<AddPaymentMethodsTask />
-			</WizardTaskContext.Provider>
+			<SettingsContextProvider>
+				<WizardTaskContext.Provider
+					value={ { setCompleted: setCompletedMock, isActive: true } }
+				>
+					<AddPaymentMethodsTask />
+				</WizardTaskContext.Provider>
+			</SettingsContextProvider>
 		);
 
 		// the payment methods should all be checked

--- a/client/components/currency-information-for-methods/index.js
+++ b/client/components/currency-information-for-methods/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useContext } from 'react';
 import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
 import interpolateComponents from 'interpolate-components';
@@ -11,6 +11,7 @@ import interpolateComponents from 'interpolate-components';
  */
 import { useCurrencies, useEnabledCurrencies } from '../../data';
 import './styles.scss';
+import WCPaySettingsContext from '../../settings/wcpay-settings-context';
 
 const CurrencyInformationForMethods = ( { selectedMethods } ) => {
 	const { isLoading: isLoadingCurrencyInformation } = useCurrencies();
@@ -56,4 +57,15 @@ const CurrencyInformationForMethods = ( { selectedMethods } ) => {
 	);
 };
 
-export default CurrencyInformationForMethods;
+const CurrencyInformationForMethodsWrapper = ( props ) => {
+	const {
+		featureFlags: { multiCurrency },
+	} = useContext( WCPaySettingsContext );
+
+	// prevents loading currency data when the feature flag is disabled
+	if ( ! multiCurrency ) return null;
+
+	return <CurrencyInformationForMethods { ...props } />;
+};
+
+export default CurrencyInformationForMethodsWrapper;

--- a/client/components/currency-information-for-methods/test/index.test.js
+++ b/client/components/currency-information-for-methods/test/index.test.js
@@ -10,11 +10,20 @@ import { render, screen } from '@testing-library/react';
 import { useCurrencies, useEnabledCurrencies } from '../../../data';
 
 import CurrencyInformationForMethods from '..';
+import WCPaySettingsContext from '../../../settings/wcpay-settings-context';
 
 jest.mock( '../../../data', () => ( {
 	useCurrencies: jest.fn(),
 	useEnabledCurrencies: jest.fn(),
 } ) );
+
+const FlagsContextWrapper = ( { children, multiCurrency = true } ) => (
+	<WCPaySettingsContext.Provider
+		value={ { featureFlags: { multiCurrency } } }
+	>
+		{ children }
+	</WCPaySettingsContext.Provider>
+);
 
 describe( 'CurrencyInformationForMethods', () => {
 	beforeEach( () => {
@@ -28,12 +37,28 @@ describe( 'CurrencyInformationForMethods', () => {
 		} );
 	} );
 
+	it( 'should not display content when the feature flag is disabled', () => {
+		const { container } = render(
+			<FlagsContextWrapper multiCurrency={ false }>
+				<CurrencyInformationForMethods
+					selectedMethods={ [ 'card', 'giropay' ] }
+				/>
+			</FlagsContextWrapper>
+		);
+
+		expect( container.firstChild ).toBeNull();
+	} );
+
 	it( 'should not display content when the currency data is being loaded', () => {
 		useCurrencies.mockReturnValue( {
 			isLoading: true,
 		} );
 		const { container } = render(
-			<CurrencyInformationForMethods selectedMethods={ [] } />
+			<FlagsContextWrapper>
+				<CurrencyInformationForMethods
+					selectedMethods={ [ 'card', 'giropay' ] }
+				/>
+			</FlagsContextWrapper>
 		);
 
 		expect(
@@ -52,9 +77,11 @@ describe( 'CurrencyInformationForMethods', () => {
 			},
 		} );
 		const { container } = render(
-			<CurrencyInformationForMethods
-				selectedMethods={ [ 'giropay', 'card' ] }
-			/>
+			<FlagsContextWrapper>
+				<CurrencyInformationForMethods
+					selectedMethods={ [ 'giropay', 'card' ] }
+				/>
+			</FlagsContextWrapper>
 		);
 
 		expect(
@@ -67,9 +94,11 @@ describe( 'CurrencyInformationForMethods', () => {
 
 	it( 'should not display content when all the enabled method are not Euro methods', () => {
 		const { container } = render(
-			<CurrencyInformationForMethods
-				selectedMethods={ [ 'card', 'dummy' ] }
-			/>
+			<FlagsContextWrapper>
+				<CurrencyInformationForMethods
+					selectedMethods={ [ 'card', 'dummy' ] }
+				/>
+			</FlagsContextWrapper>
 		);
 
 		expect(
@@ -82,9 +111,11 @@ describe( 'CurrencyInformationForMethods', () => {
 
 	it( 'should display a notice when one of the enabled methods is a Euro method', () => {
 		render(
-			<CurrencyInformationForMethods
-				selectedMethods={ [ 'card', 'giropay' ] }
-			/>
+			<FlagsContextWrapper>
+				<CurrencyInformationForMethods
+					selectedMethods={ [ 'card', 'giropay' ] }
+				/>
+			</FlagsContextWrapper>
 		);
 
 		expect(

--- a/client/settings/payment-methods-selector/index.js
+++ b/client/settings/payment-methods-selector/index.js
@@ -2,9 +2,9 @@
 /**
  * External dependencies
  */
+import React, { useContext, useState, useCallback } from 'react';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { useState, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -18,6 +18,7 @@ import PaymentMethodCheckboxes from '../../components/payment-methods-checkboxes
 import PaymentMethodCheckbox from '../../components/payment-methods-checkboxes/payment-method-checkbox';
 import ConfirmationModal from '../../components/confirmation-modal';
 import CurrencyInformationForMethods from '../../components/currency-information-for-methods';
+import WCPaySettingsContext from '../wcpay-settings-context';
 
 const AddPaymentMethodsModal = ( { onClose } ) => {
 	const availablePaymentMethods = useGetAvailablePaymentMethodIds();
@@ -105,9 +106,17 @@ const AddPaymentMethodsModal = ( { onClose } ) => {
 	);
 };
 
-const PaymentMethodsSelector = () => {
+const LoadCurrencyData = () => {
 	// ensures that the currency data is present before the modal is opened
 	useCurrencies();
+
+	return null;
+};
+
+const PaymentMethodsSelector = () => {
+	const {
+		featureFlags: { multiCurrency },
+	} = useContext( WCPaySettingsContext );
 
 	const availablePaymentMethods = useGetAvailablePaymentMethodIds();
 	const [ enabledPaymentMethods ] = useEnabledPaymentMethodIds();
@@ -127,6 +136,7 @@ const PaymentMethodsSelector = () => {
 			{ isModalOpen && (
 				<AddPaymentMethodsModal onClose={ handleModalClose } />
 			) }
+			{ multiCurrency && <LoadCurrencyData /> }
 			<Button
 				isSecondary
 				onClick={ handleModalOpen }

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -88,6 +88,7 @@ class WC_Payments_Features {
 			[
 				'upe'                => self::is_upe_enabled(),
 				'upeSettingsPreview' => self::is_upe_settings_preview_enabled(),
+				'multiCurrency'      => self::is_customer_multi_currency_enabled(),
 			]
 		);
 	}

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -11,8 +11,9 @@
 class WC_Payments_Features_Test extends WP_UnitTestCase {
 
 	const FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING = [
-		'_wcpay_feature_upe'                  => 'upe',
-		'_wcpay_feature_upe_settings_preview' => 'upeSettingsPreview',
+		'_wcpay_feature_upe'                     => 'upe',
+		'_wcpay_feature_upe_settings_preview'    => 'upeSettingsPreview',
+		'_wcpay_feature_customer_multi_currency' => 'multiCurrency',
 	];
 
 	/**


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Prevents showing the error message when the multi currency flag is disabled, just in case.
Done so that GlobalStep doesn't freak out.

![Screen Shot 2021-07-22 at 1 18 52 PM](https://user-images.githubusercontent.com/273592/126693018-5f18ff0b-0c88-4f5c-a4d5-21778b5df4ec.png)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
