### PR TITLE
fix: confirmation modal scoll bars

### DIFF
--- a/client/components/confirmation-modal/styles.scss
+++ b/client/components/confirmation-modal/styles.scss
@@ -10,6 +10,10 @@
 		padding: 0 $grid-unit-30 $grid-unit-30;
 	}
 
+	.components-modal__header {
+		margin: 0 -#{$grid-unit-30} $grid-unit-30;
+	}
+
 	&__separator {
 		margin: $grid-unit-30 -#{$grid-unit-30};
 	}


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Removing the horizontal scroll bars on the confirmation modal.

Before:
![Screen Shot 2021-07-23 at 8 40 59 AM](https://user-images.githubusercontent.com/273592/126790374-5771dc68-3f60-4823-a1f3-741474672a2c.png)

After:
![Screen Shot 2021-07-23 at 8 40 49 AM](https://user-images.githubusercontent.com/273592/126790385-11891c6a-8c13-43c2-8778-40635431ce59.png)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure "Enable UPE checkout" is enabled
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments
- Click "Add payment method"
- Modals should no longer have scroll bars

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
