### PR TITLE
fix: bottom margin on settings mobile

### DIFF
--- a/client/settings/settings-section.scss
+++ b/client/settings/settings-section.scss
@@ -12,7 +12,7 @@
 
 	&__details {
 		flex: 0 1 auto;
-		margin-bottom: 12px;
+		margin-bottom: 24px;
 
 		@include breakpoint( '>800px' ) {
 			flex: 0 0 25%;
@@ -28,6 +28,10 @@
 			font-size: 13px;
 			line-height: 17.89px;
 			margin: 12px 0;
+		}
+
+		> :last-child {
+			margin-bottom: 0;
 		}
 	}
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

From p1627051639006200-slack-C01RTUVR81K

Before:
![Markup 2021-07-23 at 11 09 36](https://user-images.githubusercontent.com/273592/126810732-1b5b1d6e-e7be-4a36-9a47-57234c001974.png)


After:
![Markup 2021-07-23 at 11 09 15](https://user-images.githubusercontent.com/273592/126810737-f8fe00c1-0b8c-4229-b0c0-7d5e71e64733.png)


It can happen that the spacing is inconsistent.
It is happening because all `p` elements have a bottom margin applied. Which was in addition to the bottom margin on their container.

Ensuring that now all last elements have zero margin bottom and increased margin on mobile.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments
- Resize to <800px

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)