### PR TITLE
fix: pill spacing

### DIFF
--- a/client/additional-methods-setup/upe-preview-methods-selector/enable-upe-preview-task.js
+++ b/client/additional-methods-setup/upe-preview-methods-selector/enable-upe-preview-task.js
@@ -32,10 +32,12 @@ const EnableUpePreviewTask = () => {
 		<WizardTaskItem
 			title={ interpolateComponents( {
 				mixedString: __(
-					'Enable the new WooCommerce Payments checkout experience {{earlyAccessWrapper}}Early access{{/earlyAccessWrapper}}',
+					'{{wrapper}}Enable the new WooCommerce Payments checkout experience{{/wrapper}} ' +
+						'{{earlyAccessWrapper}}Early access{{/earlyAccessWrapper}}',
 					'woocommerce-payments'
 				),
 				components: {
+					wrapper: <span />,
 					earlyAccessWrapper: <Pill />,
 				},
 			} ) }

--- a/client/additional-methods-setup/wizard/task-item.scss
+++ b/client/additional-methods-setup/wizard/task-item.scss
@@ -39,6 +39,12 @@
 		display: flex;
 		align-items: center;
 		flex-wrap: wrap;
+
+		> * {
+			&:not( :last-child ) {
+				margin-right: 4px;
+			}
+		}
 	}
 
 	&__icon-wrapper {

--- a/client/additional-methods-setup/wizard/task-item.scss
+++ b/client/additional-methods-setup/wizard/task-item.scss
@@ -36,6 +36,9 @@
 
 	&__title {
 		padding: 0 16px;
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
 	}
 
 	&__icon-wrapper {

--- a/client/components/pill/style.scss
+++ b/client/components/pill/style.scss
@@ -6,4 +6,9 @@
 	padding: 2px $gap-smaller;
 	font-size: 12px;
 	font-weight: 400;
+	line-height: 1.4em;
+}
+
+* ~ .wcpay-pill {
+	margin-left: 4px;
 }

--- a/client/components/pill/style.scss
+++ b/client/components/pill/style.scss
@@ -8,7 +8,3 @@
 	font-weight: 400;
 	line-height: 1.4em;
 }
-
-* ~ .wcpay-pill {
-	margin-left: 4px;
-}

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -157,7 +157,12 @@ const PaymentMethods = () => {
 				{ isUpeEnabled && (
 					<CardHeader className="payment-methods__header">
 						<h4 className="payment-methods__heading">
-							Payment methods{ ' ' }
+							<span>
+								{ __(
+									'Payment methods',
+									'woocommerce-payments'
+								) }
+							</span>{ ' ' }
 							<Pill>
 								{ __( 'Early access', 'woocommerce-payments' ) }
 							</Pill>

--- a/client/payment-methods/style.scss
+++ b/client/payment-methods/style.scss
@@ -17,6 +17,12 @@
 		align-items: center;
 		flex-wrap: wrap;
 		line-height: 2em;
+
+		> * {
+			&:not( :last-child ) {
+				margin-right: 4px;
+			}
+		}
 	}
 
 	&__available-methods-container {

--- a/client/payment-methods/style.scss
+++ b/client/payment-methods/style.scss
@@ -13,6 +13,10 @@
 	&__heading {
 		margin: 0;
 		font-size: 16px;
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		line-height: 2em;
 	}
 
 	&__available-methods-container {

--- a/client/payment-methods/test/index.js
+++ b/client/payment-methods/test/index.js
@@ -245,9 +245,9 @@ describe( 'PaymentMethods', () => {
 		} );
 
 		expect( disableUPEButton ).toBeInTheDocument();
-		expect( screen.queryByText( 'Payment methods' ) ).toHaveTextContent(
-			'Payment methods Early access'
-		);
+		expect(
+			screen.queryByText( 'Payment methods' ).parentElement
+		).toHaveTextContent( 'Payment methods Early access' );
 	} );
 
 	test( 'Does not render the feedback elements when UPE is disabled', () => {


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

From p1627051639006200-slack-C01RTUVR81K

Ensuring that the pill component has a 4px spacing on the left, when placed before other elements.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have "Enable UPE checkout" disabled
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments
- Pill spacing is adjusted
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-admin&task=woocommerce-payments--additional-payment-methods
- Pill spacing is adjusted

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)