### PR TITLE
fix: wcpay banner logo width

### DIFF
--- a/client/banner/banner.scss
+++ b/client/banner/banner.scss
@@ -1,6 +1,10 @@
 .woocommerce-payments-banner {
 	margin-bottom: 32px;
 
+	svg {
+		max-width: 100%;
+	}
+
 	&.account-page {
 		border: none;
 		border-bottom: 1px solid $studio-gray-5;


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

From p1627051639006200-slack-C01RTUVR81K

On mobile view, the logo is expanding its boundaries.

Before:
![Screen Shot 2021-07-23 at 11 58 55 AM](https://user-images.githubusercontent.com/273592/126816257-c265e89f-dd03-46cf-a0ea-2af46ec7c05a.png)


After:
![Screen Shot 2021-07-23 at 11 58 12 AM](https://user-images.githubusercontent.com/273592/126816196-7ac25c6e-4d1b-48d4-803e-67b1fcc28600.png)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments
- Open in mobile view

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)