### PR TITLE
Add border around giropay logo

### DIFF
--- a/client/settings/payment-method-icon/index.js
+++ b/client/settings/payment-method-icon/index.js
@@ -45,7 +45,9 @@ const PaymentMethodIcon = ( props ) => {
 
 	return (
 		<span className="woocommerce-payments__payment-method-icon">
-			<Icon />
+			<span className="woocommerce-payments__payment-method-has-icon-border">
+				<Icon />
+			</span>
 			{ showName && (
 				<span className="woocommerce-payments__payment-method-icon__label">
 					{ label }

--- a/client/settings/payment-method-icon/index.js
+++ b/client/settings/payment-method-icon/index.js
@@ -17,18 +17,22 @@ const paymentMethods = {
 	card: {
 		label: __( 'Credit card / debit card', 'woocommerce-payments' ),
 		Icon: CreditCardIcon,
+		hasBorder: false,
 	},
 	giropay: {
 		label: __( 'GiroPay', 'woocommerce-payments' ),
 		Icon: GiropayIcon,
+		hasBorder: true,
 	},
 	sepa_debit: {
 		label: __( 'Direct Debit Payments', 'woocommerce-payments' ),
 		Icon: SepaIcon,
+		hasBorder: true,
 	},
 	sofort: {
 		label: __( 'Sofort', 'woocommerce-payments' ),
 		Icon: SofortIcon,
+		hasBorder: true,
 	},
 };
 
@@ -41,11 +45,14 @@ const PaymentMethodIcon = ( props ) => {
 		return <></>;
 	}
 
-	const { label, Icon } = paymentMethod;
+	const { label, Icon, hasBorder } = paymentMethod;
+	const iconBorderClassName = hasBorder
+		? 'woocommerce-payments__payment-method-has-icon-border'
+		: '';
 
 	return (
 		<span className="woocommerce-payments__payment-method-icon">
-			<span className="woocommerce-payments__payment-method-has-icon-border">
+			<span className={ iconBorderClassName }>
 				<Icon />
 			</span>
 			{ showName && (

--- a/client/settings/payment-method-icon/style.scss
+++ b/client/settings/payment-method-icon/style.scss
@@ -11,14 +11,14 @@
 	&__label {
 		margin-left: 4px;
 	}
-}
-.woocommerce-payments__payment-method-has-icon-border {
-	box-shadow: 0 0 0 1px #ddd;
-	width: 38px;
-	height: 24px;
 
 	svg {
 		width: 38px;
 		height: 24px;
 	}
+}
+.woocommerce-payments__payment-method-has-icon-border {
+	box-shadow: 0 0 0 1px #ddd;
+	width: 38px;
+	height: 24px;
 }

--- a/client/settings/payment-method-icon/style.scss
+++ b/client/settings/payment-method-icon/style.scss
@@ -4,16 +4,21 @@
 	vertical-align: middle;
 	max-width: 160px;
 
-	svg {
-		width: 41px;
-		height: auto;
-	}
-
 	@include breakpoint( '>660px' ) {
 		max-width: inherit;
 	}
 
 	&__label {
 		margin-left: 4px;
+	}
+}
+.woocommerce-payments__payment-method-has-icon-border {
+	box-shadow: 0 0 0 1px #ddd;
+	width: 38px;
+	height: 24px;
+
+	svg {
+		width: 38px;
+		height: auto;
 	}
 }

--- a/client/settings/payment-method-icon/style.scss
+++ b/client/settings/payment-method-icon/style.scss
@@ -19,6 +19,7 @@
 }
 .woocommerce-payments__payment-method-has-icon-border {
 	box-shadow: 0 0 0 1px #ddd;
+	border-radius: 2px;
 	width: 38px;
 	height: 24px;
 }

--- a/client/settings/payment-method-icon/style.scss
+++ b/client/settings/payment-method-icon/style.scss
@@ -19,6 +19,6 @@
 
 	svg {
 		width: 38px;
-		height: auto;
+		height: 24px;
 	}
 }


### PR DESCRIPTION
Fixes #https://github.com/Automattic/woocommerce-payments/issues/2544

#### Changes proposed in this Pull Request
Wrap the `<Icon>` with a separate span, introduce box-shadow around it similar to how we did it in the "Payments accepted on checkout" section inside `wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments`

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
1. Go to `wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments`
2. Click "Payment method"
3. Confirm there is border around the icons:
![image](https://user-images.githubusercontent.com/572862/126840974-23fd8efb-cf33-4f86-bfbd-800e1e878e4d.png)

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
