### PR TITLE
Only add deposits and transactions for the treatment group of Empty State Preview experiment

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -17,6 +17,10 @@
 #adminmenu
 	#toplevel_page_wc-admin-path--payments-connect
 	.menu-icon-generic
+	div.wp-menu-image::before,
+#adminmenu
+	#toplevel_page_wc-admin-path--payments-deposits
+	.menu-icon-generic
 	div.wp-menu-image::before {
 	font-family: 'WCPay' !important;
 	content: '\e900';

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -114,6 +114,41 @@ class WC_Payments_Admin {
 	}
 
 	/**
+	 * Add deposits and transactions menus for wcpay_empty_state_preview_mode_v1 experiment's treatment group.
+	 * This code can be removed once we're done with the experiment.
+	 */
+	public function add_payments_menu_for_treatment() {
+		wc_admin_register_page(
+			[
+				'id'         => 'wc-payments',
+				'title'      => __( 'Payments', 'woocommerce-payments' ),
+				'capability' => 'manage_woocommerce',
+				'path'       => '/payments/deposits',
+				'position'   => '55.7', // After WooCommerce & Product menu items.
+				'nav_args'   => [
+					'title'        => __( 'WooCommerce Payments', 'woocommerce-payments' ),
+					'is_category'  => true,
+					'menuId'       => 'plugins',
+					'is_top_level' => true,
+				],
+			]
+		);
+
+		wc_admin_register_page( $this->admin_child_pages['wc-payments-deposits'] );
+		wc_admin_register_page( $this->admin_child_pages['wc-payments-transactions'] );
+
+		wp_enqueue_style(
+			'wcpay-admin-css',
+			plugins_url( 'assets/css/admin.css', WCPAY_PLUGIN_FILE ),
+			[],
+			WC_Payments::get_file_version( 'assets/css/admin.css' )
+		);
+
+		$this->add_menu_notification_badge();
+		$this->add_update_business_details_task();
+	}
+
+	/**
 	 * Add payments menu items.
 	 */
 	public function add_payments_menu() {
@@ -127,8 +162,9 @@ class WC_Payments_Admin {
 		}
 
 		// When the account is not connected, see if the user is in an A/B test treatment mode.
-		if ( false === $should_render_full_menu ) {
-			$should_render_full_menu = $this->is_in_treatment_mode();
+		if ( false === $should_render_full_menu && $this->is_in_treatment_mode() ) {
+			$this->add_payments_menu_for_treatment();
+			return;
 		}
 
 		$top_level_link = $should_render_full_menu ? '/payments/overview' : '/payments/connect';


### PR DESCRIPTION
Fixes #2556

This PR adds deposits and transactions menus only when a user is in a treatment group of `wcpay_empty_state_preview_mode_v1` experiment.

Note: This branch is based on https://github.com/Automattic/woocommerce-payments/pull/2555. Once https://github.com/Automattic/woocommerce-payments/pull/2555 gets merged, we need to change the base branch to `develop` to merge.


#### Testing instructions

Testing treatment group

1. Head over to Abacus and find`wcpay_empty_state_preview_mode_v1` then add the variation bookmarks.
2. Assign yourself to the treatment group and navigate to WordPress admin.
3. You should see the WC Payment menu with deposits and transactions only

Testing control group

1. Assign yourself to the control group.
2. Navigate to WordPress admin.
3. You should see the WC Payment menu without any submenus since you're in the control group and not connected yet.



#### Screenshot

![Screen Shot 2021-07-25 at 7 39 46 PM](https://user-images.githubusercontent.com/4723145/126926426-38f37744-6c4a-4560-863f-85a2724e8c10.jpg)
