### PR TITLE
Disable gateway when the currency is not supported in the country account

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -354,7 +354,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
 		add_action( 'admin_notices', [ $this, 'display_errors' ], 9999 );
 		add_action( 'woocommerce_woocommerce_payments_admin_notices', [ $this, 'display_test_mode_notice' ] );
-		add_action( 'woocommerce_woocommerce_payments_admin_notices', [ $this, 'display_not_supported_currency_notice' ] );
+		add_action( 'admin_notices', [ $this, 'display_not_supported_currency_notice' ], 9999 );
 		add_action( 'woocommerce_order_actions', [ $this, 'add_order_actions' ] );
 		add_action( 'woocommerce_order_action_capture_charge', [ $this, 'capture_charge' ] );
 		add_action( 'woocommerce_order_action_cancel_authorization', [ $this, 'cancel_authorization' ] );
@@ -565,6 +565,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * Add notice explaining that the selected currency is not available.
 	 */
 	public function display_not_supported_currency_notice() {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
 		if ( ! $this->is_available_for_current_currency() ) {
 			?>
 			<div id="wcpay-unsupported-currency-notice" class="notice notice-warning">

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -532,7 +532,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 *
 	 * @return bool Whether the currency is supported in the country set in the account.
 	 */
-	protected function is_available_for_current_currency() {
+	public function is_available_for_current_currency() {
 		$supported_currencies = $this->account->get_account_presentment_currencies();
 		$current_currency     = strtolower( get_woocommerce_currency() );
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -199,6 +199,16 @@ class WC_Payments_Account {
 	}
 
 	/**
+	 * Gets the presentment currencies supported by Stripe available for the account.
+	 *
+	 * @return array Currencies.
+	 */
+	public function get_account_presentment_currencies() {
+		$account = $this->get_cached_account_data();
+		return ! empty( $account ) && isset( $account['presentment_currencies'] ) ? $account['presentment_currencies'] : [];
+	}
+
+	/**
 	 * Gets the account live mode value.
 	 *
 	 * @return bool|null Account is_live value.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -1445,4 +1445,27 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->assertEquals( [ 'default', 'buy', 'donate', 'book' ], array_keys( $form_fields['payment_request_button_type']['options'] ) );
 		$this->assertEquals( [ 'dark', 'light', 'light-outline' ], array_keys( $form_fields['payment_request_button_theme']['options'] ) );
 	}
+
+	public function test_payment_gateway_enabled_for_supported_currency() {
+		$current_currency = strtolower( get_woocommerce_currency() );
+		$this->mock_wcpay_account->expects( $this->once() )->method( 'get_account_presentment_currencies' )->will(
+			$this->returnValue(
+				[
+					$current_currency,
+				]
+			)
+		);
+		$this->assertTrue( $this->wcpay_gateway->is_available_for_current_currency() );
+	}
+
+	public function test_payment_gateway_disabled_for_unsupported_currency() {
+		$this->mock_wcpay_account->expects( $this->once() )->method( 'get_account_presentment_currencies' )->will(
+			$this->returnValue(
+				[
+					'btc',
+				]
+			)
+		);
+		$this->assertFalse( $this->wcpay_gateway->is_available_for_current_currency() );
+	}
 }

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -1458,6 +1458,16 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$this->assertTrue( $this->wcpay_gateway->is_available_for_current_currency() );
 	}
 
+	public function test_payment_gateway_enabled_for_empty_supported_currency_list() {
+		// We want to avoid disabling the gateway in case the API doesn't give back any currency suppported.
+		$this->mock_wcpay_account->expects( $this->once() )->method( 'get_account_presentment_currencies' )->will(
+			$this->returnValue(
+				[]
+			)
+		);
+		$this->assertTrue( $this->wcpay_gateway->is_available_for_current_currency() );
+	}
+
 	public function test_payment_gateway_disabled_for_unsupported_currency() {
 		$this->mock_wcpay_account->expects( $this->once() )->method( 'get_account_presentment_currencies' )->will(
 			$this->returnValue(


### PR DESCRIPTION
Fixes #2481 

#### Changes proposed in this Pull Request

Disable gateway when the currency is not supported in the country account

- Adds methods in the Payment Gateway to disable it if the selected currency is not supported by Stripe, using the `presentment_currencies` inside of Account (requires 992-gh-Automattic/woocommerce-payments-server)
- Adds a notice in the admin view if the currency is not part of `presentment_currencies`.

After #2496 has been merged this PR is mostly a fallback, as the currencies are already filtered out using the same `presentment_currencies` in the Multi Currency selector.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make [this method](https://github.com/Automattic/woocommerce-payments/blob/95ee60b6b7944be7909fa711593c4c654bef901e/includes/class-wc-payment-gateway-wcpay.php#L535) return false
* Go to checkout and see the payment form disabled
* Go to Payments settings and see the notice text.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
