### PR TITLE
fix: settings cards spacing

### DIFF
--- a/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
+++ b/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
@@ -25,6 +25,7 @@
 
 	&__info {
 		> * {
+
 			margin: 0;
 			color: $gray-600;
 		}

--- a/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
+++ b/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
@@ -25,7 +25,6 @@
 
 	&__info {
 		> * {
-
 			margin: 0;
 			color: $gray-600;
 		}

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -8,7 +8,6 @@ import { __ } from '@wordpress/i18n';
 import {
 	Button,
 	Card,
-	CardBody,
 	CardDivider,
 	CardHeader,
 	DropdownMenu,
@@ -34,13 +33,13 @@ import WcPayUpeContext from '../settings/wcpay-upe-toggle/context';
 import WcPaySurveyContextProvider from '../settings/survey-modal/provider';
 import SurveyModal from '../settings/survey-modal';
 import DisableUPEModal from '../settings/disable-upe-modal';
-
 import PaymentMethodsList from 'components/payment-methods-list';
 import PaymentMethod from 'components/payment-methods-list/payment-method';
 import PaymentMethodsSelector from 'settings/payment-methods-selector';
 import WCPaySettingsContext from '../settings/wcpay-settings-context';
 import Pill from '../components/pill';
 import methodsConfiguration from '../payment-methods-map';
+import CardBody from '../settings/card-body';
 
 const PaymentMethodsDropdownMenu = ( { setOpenModal } ) => {
 	return (

--- a/client/settings/card-body/styles.scss
+++ b/client/settings/card-body/styles.scss
@@ -6,21 +6,28 @@
 		}
 	}
 
-	> :first-child {
+	> * {
 		margin-top: 0;
-	}
+		margin-bottom: 1em;
 
-	> :last-child {
-		margin-bottom: 0;
-
-		> .components-base-control__help {
+		// fixing the spacing on the inputs and their help text, to ensure it is consistent
+		&:last-child {
 			margin-bottom: 0;
+
+			> :last-child {
+				margin-bottom: 0;
+			}
 		}
 	}
 
 	input,
 	select {
 		margin: 0;
+	}
+
+	// spacing adjustment on "Express checkouts > Show express checkouts on" list
+	ul > li:last-child {
+		margin-bottom: 0;
 	}
 
 	.components-radio-control__option {

--- a/client/settings/card-body/styles.scss
+++ b/client/settings/card-body/styles.scss
@@ -6,6 +6,11 @@
 		}
 	}
 
+	h4 {
+		margin-top: 0;
+		margin-bottom: 1em;
+	}
+
 	> * {
 		margin-top: 0;
 		margin-bottom: 1em;

--- a/client/settings/card-body/styles.scss
+++ b/client/settings/card-body/styles.scss
@@ -28,14 +28,15 @@
 	// spacing adjustment on "Express checkouts > Show express checkouts on" list
 	ul > li:last-child {
 		margin-bottom: 0;
-	}
 
-	.components-radio-control__option {
-		margin-bottom: 8px;
-
-		&:last-child {
+		.components-base-control__field {
 			margin-bottom: 0;
 		}
+	}
+
+	// spacing in the "Express checkouts" settings page
+	.components-radio-control__option {
+		margin-bottom: 8px;
 	}
 
 	.components-base-control__help {

--- a/client/settings/card-body/styles.scss
+++ b/client/settings/card-body/styles.scss
@@ -1,10 +1,21 @@
 .wcpay-card-body {
+	&.is-size-medium {
+		// increasing the specificity of the styles to override the Gutenberg ones
+		&#{&} {
+			padding: $grid-unit-30;
+		}
+	}
+
 	> :first-child {
 		margin-top: 0;
 	}
 
 	> :last-child {
 		margin-bottom: 0;
+
+		> .components-base-control__help {
+			margin-bottom: 0;
+		}
 	}
 
 	input,
@@ -14,6 +25,10 @@
 
 	.components-radio-control__option {
 		margin-bottom: 8px;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	.components-base-control__help {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/2547

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Fighting with the Gutenberg styles to create some spacing consistency.

Padding around most cards has been adjusted to `24px` on all sides.

Before:
![Screen Shot 2021-07-26 at 12 42 35 PM](https://user-images.githubusercontent.com/273592/127034298-cd0f254a-0552-4650-bd4d-4b4688acf4d7.png)
![Screen Shot 2021-07-26 at 12 43 34 PM](https://user-images.githubusercontent.com/273592/127034386-cefaaf18-e9f3-4b19-a19d-79f2343fe73f.png)


After:
![Markup 2021-07-26 at 12 41 15](https://user-images.githubusercontent.com/273592/127034229-d33ef8b1-6e58-45b8-8b8f-89d3d0c3f4ed.png)
![Markup 2021-07-26 at 12 41 43](https://user-images.githubusercontent.com/273592/127034250-59d5a706-4cc7-40af-8060-2af3c074e53f.png)
![Screen Shot 2021-07-26 at 12 48 18 PM](https://user-images.githubusercontent.com/273592/127034952-a4c5a3d6-fbed-475e-9760-e5008b5a99c5.png)



#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments&method=payment_request
- Spacing is adjusted

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
