### PR TITLE
refactor: UPE opt-in messages visibility

### DIFF
--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -663,7 +663,7 @@ class WC_Payments_Admin {
 		}
 
 		if ( WC_Payments_Features::is_upe_settings_preview_enabled() ) {
-			return true;
+			return false === WC_Payments_Features::did_merchant_disable_upe();
 		}
 
 		$available_methods = $this->wcpay_gateway->get_upe_available_payment_methods();

--- a/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
@@ -121,6 +121,10 @@ class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
 			return;
 		}
 
+		// marking the flag as "disabled", so that we can keep track that the merchant explicitly disabled it.
+		update_option( WC_Payments_Features::UPE_FLAG_NAME, 'disabled' );
+
+		// resetting a few other things:
 		// removing the UPE payment methods and _only_ leaving "card",
 		// just in case the user added additional payment method types.
 		$this->wcpay_gateway->update_option(
@@ -129,6 +133,12 @@ class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
 				'card',
 			]
 		);
-		delete_option( WC_Payments_Features::UPE_FLAG_NAME );
+		// resetting the onboarding task status.
+		delete_option( 'wcpay_additional_methods_setup_completed' );
+		// removing the note from the database.
+		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-additional-payment-methods.php';
+			WC_Payments_Notes_Additional_Payment_Methods::possibly_delete_note();
+		}
 	}
 }

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -61,6 +61,15 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Checks whether the UPE gateway is enabled
+	 *
+	 * @return bool
+	 */
+	public static function did_merchant_disable_upe() {
+		return 'disabled' === get_option( self::UPE_FLAG_NAME, '0' );
+	}
+
+	/**
 	 * Checks whether the UPE settings redesign is enabled
 	 *
 	 * @return bool

--- a/includes/notes/class-wc-payments-notes-additional-payment-methods.php
+++ b/includes/notes/class-wc-payments-notes-additional-payment-methods.php
@@ -31,7 +31,15 @@ class WC_Payments_Notes_Additional_Payment_Methods {
 	 */
 	public static function get_note() {
 		// Show this notice only if UPE settings preview is disabled, and UPE flag is not enabled.
-		if ( ! WC_Payments_Features::is_upe_settings_preview_enabled() || WC_Payments_Features::is_upe_enabled() ) {
+		if ( false === WC_Payments_Features::is_upe_settings_preview_enabled() ) {
+			return;
+		}
+
+		if ( WC_Payments_Features::is_upe_enabled() ) {
+			return;
+		}
+
+		if ( WC_Payments_Features::did_merchant_disable_upe() ) {
 			return;
 		}
 

--- a/tests/unit/admin/test-class-wc-rest-upe-flag-toggle-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-upe-flag-toggle-controller.php
@@ -84,7 +84,7 @@ class WC_REST_UPE_Flag_Toggle_Controller_Test extends WP_UnitTestCase {
 		$response = $this->controller->set_flag( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( null, get_option( '_wcpay_feature_upe', null ) );
+		$this->assertEquals( 'disabled', get_option( '_wcpay_feature_upe', null ) );
 		$this->assertEquals(
 			[
 				'card',


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/2563

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Adjusting the visibility of the UPE opt-in messaging.

We want to hide the inbox notice and the onboarding task when UPE has been manually disabled by the merchant.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- In WCPay Dev tools, ensure you have "Enable UPE checkout" disabled
- Go to WC Home: http://localhost:8082/wp-admin/admin.php?page=wc-admin
- You should see the onboarding task & the inbox notice in regards of UPE
![Screen Shot 2021-07-26 at 2 59 48 PM](https://user-images.githubusercontent.com/273592/127051111-585ef227-71b1-4f62-8066-6a42b42e0ad1.png)
- Using either of those, go through the onboarding by enabling UPE
- Go to WC Home: http://localhost:8082/wp-admin/admin.php?page=wc-admin
- You should now see the task marked as "completed" and the inbox notice disappeared
![Screen Shot 2021-07-26 at 3 01 26 PM](https://user-images.githubusercontent.com/273592/127051301-ec6e0a40-144a-43b4-b485-02a212b4c5c2.png)
- Go to the settings page: http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments
- Disable UPE through the hamburger menu
- Go to WC Home: http://localhost:8082/wp-admin/admin.php?page=wc-admin
- Inbox notice should not appear, onboarding task has disappeared
![Screen Shot 2021-07-26 at 3 02 25 PM](https://user-images.githubusercontent.com/273592/127051417-eca3af48-f608-444b-a53f-b6ec694c289d.png)
- You can reset everything by going into WCPay Dev tools and disable the "Enable UPE checkout" flag

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
