### PR TITLE
Format the currency properly in the exchange preview field

### DIFF
--- a/client/multi-currency/index.js
+++ b/client/multi-currency/index.js
@@ -60,10 +60,6 @@ const automaticRate = document.querySelector(
 	'[name=wcpay_multi_currency_automatic_exchange_rate]'
 );
 
-const numDecimals = document.querySelector(
-	'[name=wcpay_multi_currency_num_decimals]'
-);
-
 const manualRate = document.querySelector(
 	'[name^=wcpay_multi_currency_manual_rate_]'
 );
@@ -87,6 +83,9 @@ const previewDisplay = document.querySelector(
 function updatePreview() {
 	// Get needed field values and update field.
 	const rate = 'manual' === rateType ? manualRate.value : automaticRate.value;
+	const currencyCode = new URLSearchParams( document.location.search )
+		.get( 'section' )
+		.toUpperCase();
 	let total = previewAmount.value * rate;
 
 	if ( 'none' !== rounding.value ) {
@@ -94,11 +93,22 @@ function updatePreview() {
 	}
 
 	total += parseFloat( charm.value );
-	total = total.toFixed( parseInt( numDecimals.value, 10 ) );
-	total = isNaN( total )
-		? __( 'Please enter a valid number', 'woocommerce-payments' )
-		: total;
-	previewDisplay.innerHTML = total;
+	if ( isNaN( total ) ) {
+		previewDisplay.innerHTML = __(
+			'Please enter a valid number',
+			'woocommerce-payments'
+		);
+		return;
+	}
+
+	previewDisplay.innerHTML = total.toLocaleString(
+		undefined, // Use the default locale for the given currency.
+		{
+			style: 'currency',
+			currency: currencyCode,
+			currencyDisplay: 'narrowSymbol',
+		}
+	);
 }
 
 const hideShowManualField = ( show ) => {

--- a/includes/multi-currency/Settings.php
+++ b/includes/multi-currency/Settings.php
@@ -231,16 +231,11 @@ class Settings extends \WC_Settings_Page {
 			</th>
 			<td>
 				<div id="wcpay_multi_currency_preview_converted">
-					<?php echo esc_html( $currency->get_symbol() ); ?>
 					<span style="display:inline-block;"></span>
 				</div>
 				<input type="hidden"
 					name="<?php echo esc_attr( $this->id . '_automatic_exchange_rate' ); ?>"
 					value="<?php echo esc_attr( $available_currencies[ $currency->get_code() ]->get_rate() ); ?>"
-				/>
-				<input type="hidden"
-					name="<?php echo esc_attr( $this->id . '_num_decimals' ); ?>"
-					value="<?php echo esc_attr( $currency->get_is_zero_decimal() ? 0 : 2 ); ?>"
 				/>
 			</td>
 		</tr>


### PR DESCRIPTION
Fixes #2375

#### Changes proposed in this Pull Request

Properly format the "Preview" money amount in the currency exchange settings. This includes:
- Putting the currency symbol in the right/left side of the amount, as expected.
- Proper thousands and decimal separators.
- Correct amount of decimal digits.

Instead of using the `@woocommerce/currency` package, or trying to replicate the PHP logic in JS, I just used the built-in [`Number.toLocaleString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString#browser_compatibility) function. It will take care of every localization issue.

Note that, as the locale, I passed `undefined`. That's equivalent of using the `"default"` locale for a given currency. Since this is the admin user seeing it, that seemed like the most sensible approach. We can't know at this point where will the customer visit the store from, so any locale we put there would be a guess.

#### To test:
- Set your store to USD.
- Go to the Multi-currency settings.
- Add a second currency (EUR, for example).
- Click on "manage" to get to the `Euro (EUR)` settings screen.
- On the Preview section, you'll see that the amount has a valid format (or, at least, valid for some locale. As a Spaniard, I find the `€99` quite weird, but a default is a default).
- Try and break it. Non-numeric amounts, price rounding, charm pricing, manual exchange, thousands, decimals, zero-decimal currencies...