### PR TITLE
Adding the `i18n` directory to release.js

### DIFF
--- a/tasks/release.js
+++ b/tasks/release.js
@@ -15,6 +15,7 @@ const filesToCopy = [
 	'assets',
 	'dist',
 	'includes',
+	'i18n',
 	'languages',
 	'vendor',
 	'woocommerce-payments.php',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

https://github.com/Automattic/woocommerce-payments/pull/2357 introduced the `i18n` directory (and its contents) to the plugin, but the necessary files to include the new directory in the release were not added.

This PR simply adds the new directory to `release.js`, which is used to prepare the plugin for release.

#### Testing instructions

1. Run `php ~/woorelease.phar simulate --product_version=2.8.0 https://github.com/Automattic/woocommerce-payments/tree/add/i18n-to-release`
2. Look for `woocommerce-payments.zip` in the temporary folder (displayed at the beginning of `woorelease` output).
3. Make sure that the `i18n` directory is included in the zip.