### PR TITLE
Fix currency switcher settings not being saved

### DIFF
--- a/includes/multi-currency/CurrencySwitcherWidget.php
+++ b/includes/multi-currency/CurrencySwitcherWidget.php
@@ -7,14 +7,14 @@
 
 namespace WCPay\MultiCurrency;
 
-use WP_Widget;
+use WC_Widget;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Currency Switcher Widget Class
  */
-class CurrencySwitcherWidget extends WP_Widget {
+class CurrencySwitcherWidget extends WC_Widget {
 
 	const DEFAULT_SETTINGS = [
 		'title'  => '',
@@ -46,11 +46,28 @@ class CurrencySwitcherWidget extends WP_Widget {
 		$this->multi_currency = $multi_currency;
 		$this->compatibility  = $compatibility;
 
-		parent::__construct(
-			'currency_switcher_widget',
-			__( 'Currency Switcher', 'woocommerce-payments' ),
-			[ 'description' => __( 'Let your customers switch between your enabled currencies', 'woocommerce-payments' ) ]
-		);
+		$this->widget_id          = 'currency_switcher_widget';
+		$this->widget_name        = __( 'Currency Switcher', 'woocommerce-payments' );
+		$this->widget_description = __( 'Let your customers switch between your enabled currencies', 'woocommerce-payments' );
+		$this->settings           = [
+			'title'  => [
+				'type'  => 'text',
+				'std'   => '',
+				'label' => __( 'Title', 'woocommerce-payments' ),
+			],
+			'symbol' => [
+				'type'  => 'checkbox',
+				'std'   => true,
+				'label' => __( 'Display currency symbols', 'woocommerce-payments' ),
+			],
+			'flag'   => [
+				'type'  => 'checkbox',
+				'std'   => false,
+				'label' => __( 'Display flags in supported devices', 'woocommerce-payments' ),
+			],
+		];
+
+		parent::__construct();
 	}
 
 	/**
@@ -93,71 +110,6 @@ class CurrencySwitcherWidget extends WP_Widget {
 		<?php
 
 		echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput
-	}
-
-	/**
-	 * Back-end widget form.
-	 *
-	 * @param array $instance Previously saved values from database.
-	 */
-	public function form( $instance ) {
-		$instance = wp_parse_args(
-			$instance,
-			self::DEFAULT_SETTINGS
-		);
-		?>
-		<p>
-			<label for="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>">
-				<?php esc_html_e( 'Title:', 'woocommerce-payments' ); ?>
-			</label>
-			<input
-				class="widefat"
-				id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"
-				name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"
-				type="text"
-				value="<?php echo esc_attr( $instance['title'] ); ?>"
-			/>
-		</p>
-		<p>
-			<input
-				class="checkbox"
-				id="<?php echo esc_attr( $this->get_field_id( 'symbol' ) ); ?>"
-				name="<?php echo esc_attr( $this->get_field_name( 'symbol' ) ); ?>"
-				type="checkbox"<?php checked( $instance['symbol'] ); ?>
-			/>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'symbol' ) ); ?>">
-				<?php esc_html_e( 'Display currency symbols', 'woocommerce-payments' ); ?>
-			</label>
-			<br/>
-			<input
-				class="checkbox"
-				id="<?php echo esc_attr( $this->get_field_id( 'flag' ) ); ?>"
-				name="<?php echo esc_attr( $this->get_field_name( 'flag' ) ); ?>"
-				type="checkbox"<?php checked( $instance['flag'] ); ?>
-			/>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'flag' ) ); ?>">
-				<?php esc_html_e( 'Display flags in supported devices', 'woocommerce-payments' ); ?>
-			</label>
-		</p>
-		<?php
-	}
-
-	/**
-	 * Sanitize widget form values as they are saved.
-	 *
-	 * @param array $new_instance Values just sent to be saved.
-	 * @param array $old_instance Previously saved values from database.
-	 *
-	 * @return array Updated safe values to be saved.
-	 */
-	public function update( $new_instance, $old_instance ) {
-		$instance = [
-			'title'  => sanitize_text_field( $new_instance['title'] ),
-			'symbol' => isset( $new_instance['symbol'] ) ? 1 : 0,
-			'flag'   => isset( $new_instance['flag'] ) ? 1 : 0,
-		];
-
-		return $instance;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2575 

#### Changes proposed in this Pull Request

There was an issue with the new WP v5.8 widgets section. It calls `WP_Widget->update` function twice, causing settings to reset.

Instead of just fixing the issue, I choose to leverage and refactor the widget to use `WC_Widget` instead. This allows us to reduce code boilerplate and prevent any mistake on the settings part.

#### Testing instructions
Currency switcher settings should work in any case:
- Customizer
- Widgets section on WP v5.8
- Widgets section on WP < v5.8

_Look at #2575 for some GIFs._

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
