### PR TITLE
refactor: payment method name consistency

### DIFF
--- a/client/additional-methods-setup/methods-selector/test/add-payment-methods-task.test.js
+++ b/client/additional-methods-setup/methods-selector/test/add-payment-methods-task.test.js
@@ -68,13 +68,13 @@ describe( 'AddPaymentMethodsTask', () => {
 			screen.getByRole( 'checkbox', { name: 'Credit card / debit card' } )
 		).toBeChecked();
 		expect(
-			screen.getByRole( 'checkbox', { name: 'GiroPay' } )
+			screen.getByRole( 'checkbox', { name: 'giropay' } )
 		).toBeChecked();
 		expect(
 			screen.getByRole( 'checkbox', { name: 'Sofort' } )
 		).not.toBeChecked();
 		expect(
-			screen.getByRole( 'checkbox', { name: 'Direct Debit Payments' } )
+			screen.getByRole( 'checkbox', { name: 'Direct debit payment' } )
 		).not.toBeChecked();
 		expect(
 			screen.getByRole( 'checkbox', {
@@ -101,13 +101,13 @@ describe( 'AddPaymentMethodsTask', () => {
 			} )
 		).toBeInTheDocument();
 		expect(
-			screen.queryByRole( 'checkbox', { name: 'GiroPay' } )
+			screen.queryByRole( 'checkbox', { name: 'giropay' } )
 		).toBeInTheDocument();
 		expect(
 			screen.queryByRole( 'checkbox', { name: 'Sofort' } )
 		).not.toBeInTheDocument();
 		expect(
-			screen.queryByRole( 'checkbox', { name: 'Direct Debit Payments' } )
+			screen.queryByRole( 'checkbox', { name: 'Direct debit payment' } )
 		).not.toBeInTheDocument();
 	} );
 
@@ -140,7 +140,7 @@ describe( 'AddPaymentMethodsTask', () => {
 		// Marks the Giropay payment method as checked
 		userEvent.click(
 			screen.getByRole( 'checkbox', {
-				name: 'GiroPay',
+				name: 'giropay',
 			} )
 		);
 

--- a/client/additional-methods-setup/upe-preview-methods-selector/test/add-payment-methods-task.test.js
+++ b/client/additional-methods-setup/upe-preview-methods-selector/test/add-payment-methods-task.test.js
@@ -101,19 +101,19 @@ describe( 'AddPaymentMethodsTask', () => {
 		expect( useSettings ).toHaveBeenCalled();
 		// the payment methods should all be checked
 		expect(
-			screen.getByRole( 'checkbox', { name: 'GiroPay' } )
+			screen.getByRole( 'checkbox', { name: 'giropay' } )
 		).toBeChecked();
 		expect(
-			screen.getByRole( 'checkbox', { name: 'Direct Debit Payments' } )
+			screen.getByRole( 'checkbox', { name: 'Direct debit payment' } )
 		).toBeChecked();
 		expect(
 			screen.queryByRole( 'checkbox', { name: /Credit/ } )
 		).not.toBeInTheDocument();
 
 		// un-checking the checkboxes and clicking "add payment methods" should display a notice
-		userEvent.click( screen.getByRole( 'checkbox', { name: 'GiroPay' } ) );
+		userEvent.click( screen.getByRole( 'checkbox', { name: 'giropay' } ) );
 		userEvent.click(
-			screen.getByRole( 'checkbox', { name: 'Direct Debit Payments' } )
+			screen.getByRole( 'checkbox', { name: 'Direct debit payment' } )
 		);
 
 		// no "euro" text when no elements are checked
@@ -147,10 +147,10 @@ describe( 'AddPaymentMethodsTask', () => {
 		expect( useSettings ).toHaveBeenCalled();
 		// the payment methods should all be checked
 		expect(
-			screen.getByRole( 'checkbox', { name: 'GiroPay' } )
+			screen.getByRole( 'checkbox', { name: 'giropay' } )
 		).toBeChecked();
 		expect(
-			screen.getByRole( 'checkbox', { name: 'Direct Debit Payments' } )
+			screen.getByRole( 'checkbox', { name: 'Direct debit payment' } )
 		).toBeChecked();
 		expect(
 			screen.queryByRole( 'checkbox', { name: /Credit/ } )
@@ -190,14 +190,14 @@ describe( 'AddPaymentMethodsTask', () => {
 
 		// the payment methods should all be checked
 		expect(
-			screen.getByRole( 'checkbox', { name: 'GiroPay' } )
+			screen.getByRole( 'checkbox', { name: 'giropay' } )
 		).toBeChecked();
 		expect(
-			screen.getByRole( 'checkbox', { name: 'Direct Debit Payments' } )
+			screen.getByRole( 'checkbox', { name: 'Direct debit payment' } )
 		).toBeChecked();
 
 		// un-check giropay
-		userEvent.click( screen.getByRole( 'checkbox', { name: 'GiroPay' } ) );
+		userEvent.click( screen.getByRole( 'checkbox', { name: 'giropay' } ) );
 		userEvent.click( screen.getByText( 'Add payment methods' ) );
 
 		// giropay is removed

--- a/client/settings/payment-method-icon/index.js
+++ b/client/settings/payment-method-icon/index.js
@@ -2,38 +2,16 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import CreditCardIcon from '../../gateway-icons/credit-card';
-import GiropayIcon from '../../gateway-icons/giropay';
-import SepaIcon from '../../gateway-icons/sepa';
-import SofortIcon from '../../gateway-icons/sofort';
-
-const paymentMethods = {
-	card: {
-		label: __( 'Credit card / debit card', 'woocommerce-payments' ),
-		Icon: CreditCardIcon,
-	},
-	giropay: {
-		label: __( 'GiroPay', 'woocommerce-payments' ),
-		Icon: GiropayIcon,
-	},
-	sepa_debit: {
-		label: __( 'Direct Debit Payments', 'woocommerce-payments' ),
-		Icon: SepaIcon,
-	},
-	sofort: {
-		label: __( 'Sofort', 'woocommerce-payments' ),
-		Icon: SofortIcon,
-	},
-};
+import paymentMethodsMap from '../../payment-methods-map';
 
 const PaymentMethodIcon = ( { name, showName } ) => {
-	const paymentMethod = paymentMethods[ name ];
+	const paymentMethod = paymentMethodsMap[ name ];
 
 	if ( ! paymentMethod ) {
 		return <></>;

--- a/client/settings/payment-method-icon/test/index.js
+++ b/client/settings/payment-method-icon/test/index.js
@@ -11,7 +11,7 @@ import '@testing-library/jest-dom/extend-expect';
 import PaymentMethodIcon from '..';
 
 describe( 'PaymentMethodIcon', () => {
-	test( 'renders GiroPay payment method icon', () => {
+	test( 'renders giropay payment method icon', () => {
 		const { container } = render( <PaymentMethodIcon name="giropay" /> );
 		expect( container.querySelector( 'svg' ) ).toBeInTheDocument();
 	} );
@@ -21,26 +21,26 @@ describe( 'PaymentMethodIcon', () => {
 		expect( container.querySelector( 'svg' ) ).toBeInTheDocument();
 	} );
 
-	test( 'renders GiroPay payment method icon', () => {
+	test( 'renders giropay payment method icon', () => {
 		const { container } = render( <PaymentMethodIcon name="sofort" /> );
 		expect( container.querySelector( 'svg' ) ).toBeInTheDocument();
 	} );
 
-	test( 'renders GiroPay payment method icon and label', () => {
+	test( 'renders giropay payment method icon and label', () => {
 		render( <PaymentMethodIcon name="giropay" showName /> );
 
-		const label = screen.queryByText( 'GiroPay' );
+		const label = screen.queryByText( 'giropay' );
 		expect( label ).toBeInTheDocument();
 	} );
 
 	test( 'renders Sepa payment method icon and label', () => {
 		render( <PaymentMethodIcon name="sepa_debit" showName /> );
 
-		const label = screen.queryByText( 'Direct Debit Payments' );
+		const label = screen.queryByText( 'Direct debit payment' );
 		expect( label ).toBeInTheDocument();
 	} );
 
-	test( 'renders GiroPay payment method icon and label', () => {
+	test( 'renders giropay payment method icon and label', () => {
 		render( <PaymentMethodIcon name="sofort" showName /> );
 
 		const label = screen.queryByText( 'Sofort' );

--- a/client/settings/payment-methods-selector/test/index.js
+++ b/client/settings/payment-methods-selector/test/index.js
@@ -77,7 +77,7 @@ describe( 'PaymentMethodsSelector', () => {
 		expect( paymentMethods ).toHaveLength( 3 );
 
 		const giroPayCheckbox = screen.getByRole( 'checkbox', {
-			name: 'GiroPay',
+			name: 'giropay',
 		} );
 		expect( giroPayCheckbox ).not.toBeChecked();
 
@@ -87,7 +87,7 @@ describe( 'PaymentMethodsSelector', () => {
 		expect( sofortCheckbox ).not.toBeChecked();
 
 		const sepaCheckbox = screen.getByRole( 'checkbox', {
-			name: 'Direct Debit Payments',
+			name: 'Direct debit payment',
 		} );
 		expect( sepaCheckbox ).not.toBeChecked();
 
@@ -220,7 +220,7 @@ describe( 'PaymentMethodsSelector', () => {
 		user.click( addPaymentMethodButton );
 
 		const giroPayCheckbox = screen.getByRole( 'checkbox', {
-			name: 'GiroPay',
+			name: 'giropay',
 		} );
 		user.click( giroPayCheckbox );
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed some inconsistencies when we're displaying payment method names.
Sometimes we call giropay "GiroPay" (with an uppercase "G"/"P"), sometimes SEPA is called "Direct Debit Payments".

The purpose of this PR is to bring some consistency on the naming.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments
- Naming of giropay/SEPA should be consistent
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-admin&task=woocommerce-payments--additional-payment-methods
- Naming consistency of giropay/SEPA should also be improved

Before:
![Screen Shot 2021-07-27 at 11 08 55 AM](https://user-images.githubusercontent.com/273592/127190597-26a7878e-b7c2-4d71-9873-4d211b521bc8.png)
![Screen Shot 2021-07-27 at 11 08 07 AM](https://user-images.githubusercontent.com/273592/127190603-8a90bb9a-4f30-4bf3-af88-7369a1493eff.png)
![Screen Shot 2021-07-27 at 11 08 01 AM](https://user-images.githubusercontent.com/273592/127190604-340d6b8c-f15a-4bf5-b4b5-8f63fc3409f4.png)


After:
![Screen Shot 2021-07-27 at 11 16 22 AM](https://user-images.githubusercontent.com/273592/127190670-1a65bdcc-fa28-4674-973b-5decd89e8a8a.png)
![Screen Shot 2021-07-27 at 11 16 01 AM](https://user-images.githubusercontent.com/273592/127190673-3322c175-f101-42bf-8cb0-f756a4c7dd9b.png)


-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
