### PR TITLE
Fix for Currency Formatting Issue When Converting for Analytics

### DIFF
--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -244,7 +244,7 @@ class Analytics {
 	 * @return float The converted amount.
 	 */
 	private function convert_amount( float $amount, float $exchange_rate, int $dp = 2 ): float {
-		return number_format( $amount * ( 1 / $exchange_rate ), $dp );
+		return number_format( $amount * ( 1 / $exchange_rate ), $dp, '.', '' );
 	}
 
 	/**

--- a/tests/unit/multi-currency/test-class-analytics.php
+++ b/tests/unit/multi-currency/test-class-analytics.php
@@ -100,6 +100,25 @@ class WCPay_Multi_Currency_Analytics_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @group underTest
+	 */
+	public function test_update_order_stats_data_with_large_order() {
+		$this->mock_multi_currency->expects( $this->once() )
+			->method( 'get_default_currency' )
+			->willReturn( new Currency( 'USD', 1.0 ) );
+
+		$args  = $this->order_args_provider( 123, 0, 1, 130500.75, 20000, 10000, 100500.75 );
+		$order = wc_create_order();
+		$order->set_currency( 'GBP' );
+		$order->update_meta_data( '_wcpay_multi_currency_order_exchange_rate', 0.78 );
+		$order->update_meta_data( '_wcpay_multi_currency_order_default_currency', 'USD' );
+
+		$expected = $this->order_args_provider( 123, 0, 1, 167308.66, 25641.03, 12820.51, 128847.12 );
+		$this->assertEquals( $expected, $this->analytics->update_order_stats_data( $args, $order ) );
+	}
+
+
+	/**
 	 * @dataProvider select_clause_provider
 	 */
 	public function test_filter_select_clauses( $context, $clauses, $expected ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- This PR fixes an issue where the conversion for large amounts (which had a comma separator, e.g. anything >1,000) were not stored in the database properly, because `number_format` was being called to truncate the number to the appropriate amount of DP, but `thousands_separator` argument was not set to `''`, meaning, for example the number `1,432` would be stored in the DB as just `1`.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make a new order, greater than 10,000 in value (in both the WC default currency and the customer currency).
* Either wait a few minutes, or run the `wc-admin_import_orders` job for the Order ID in the `Scheduled Actions` section of WP Admin.
* Verify in the `wp_wc_order_stats` table in the database that the order has been inserted, and stored in the appropriate amount in the store default currency. (check the `total_sales`, `tax_total`, `shipping_total`, and `net_total` columns).
* Verify the amount displays properly in the `Orders` section of analytics, in the store default currency.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
