### PR TITLE
Bump Required Versions for 2.8 Release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@
 * Fix - Improved errors handling during onboarding and page overview.
 * Update - Remove Account in the old Settings page.
 * Update - Bump minimum supported version of WooCommerce from 5.2 to 5.3.
+* Update - Bump minimum supported version of WordPress from 5.5 to 5.6.
 
 = 2.7.1 - 2021-07-26 =
 * Fix - Ensure test mode setting value is correctly saved.

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Add - Disable payment gateway when not in test mode and not using https or ssl checkout enforcement.
 * Fix - Improved errors handling during onboarding and page overview.
 * Update - Remove Account in the old Settings page.
+* Update - Bump minimum supported version of WooCommerce from 5.2 to 5.3.
 
 = 2.7.1 - 2021-07-26 =
 * Fix - Ensure test mode setting value is correctly saved.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,7 +14,7 @@
 	<exclude-pattern>*\.(?!php$)</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="5.5" />
+	<config name="minimum_supported_wp_version" value="5.6" />
 	<config name="testVersion" value="7.0-" />
 
 	<!-- Rules -->

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ Our global support team is available to answer questions you may have about WooC
 = Requirements =
 
 * WordPress 5.5 or newer.
-* WooCommerce 5.2 or newer.
+* WooCommerce 5.3 or newer.
 * PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
 
 = Try it now =
@@ -111,6 +111,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Disable payment gateway when not in test mode and not using https or ssl checkout enforcement.
 * Fix - Improved errors handling during onboarding and page overview.
 * Update - Remove Account in the old Settings page.
+* Update - Bump minimum supported version of WooCommerce from 5.2 to 5.3.
 
 = 2.7.1 - 2021-07-26 =
 * Fix - Ensure test mode setting value is correctly saved.

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Payments ===
 Contributors: woocommerce, automattic
 Tags: woocommerce, payment, payment request, credit card, automattic
-Requires at least: 5.5
+Requires at least: 5.6
 Tested up to: 5.7
 Requires PHP: 7.0
 Stable tag: 2.7.1
@@ -38,7 +38,7 @@ Our global support team is available to answer questions you may have about WooC
 
 = Requirements =
 
-* WordPress 5.5 or newer.
+* WordPress 5.6 or newer.
 * WooCommerce 5.3 or newer.
 * PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
 
@@ -112,6 +112,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Improved errors handling during onboarding and page overview.
 * Update - Remove Account in the old Settings page.
 * Update - Bump minimum supported version of WooCommerce from 5.2 to 5.3.
+* Update - Bump minimum supported version of WordPress from 5.5 to 5.6.
 
 = 2.7.1 - 2021-07-26 =
 * Fix - Ensure test mode setting value is correctly saved.

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  * WC requires at least: 4.0
  * WC tested up to: 5.5
- * Requires WP: 5.5
+ * Requires WP: 5.6
  * Version: 2.7.1
  *
  * @package WooCommerce\Payments

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -9,7 +9,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 4.0
- * WC tested up to: 5.4
+ * WC tested up to: 5.5
  * Requires WP: 5.5
  * Version: 2.7.1
  *


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Bumps minimum required versions for the 2.8 release.

Per L-2 policy, this PR bumps the required versions of WordPress to 5.6 and WooCommerce to 5.3.

Note the `WC requires at least` version remains at 4.0, as it is pending improvements in issue https://github.com/Automattic/woocommerce-payments/issues/1775 first.
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

Nothing to test 🙂 

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Please read P7bbVw-3ww-p2 before opening the PR, assign the correct status to it, __and make sure that the related issue uses the Has PR status!__.
-->
