### PR TITLE
chore: remove e2e settings flag logic

### DIFF
--- a/tests/e2e/specs/merchant/merchant-payment-gateways-confirmation.spec.js
+++ b/tests/e2e/specs/merchant/merchant-payment-gateways-confirmation.spec.js
@@ -9,29 +9,12 @@ const WCADMIN_GATEWAYS_LIST = `${ config.get(
 	'url'
 ) }wp-admin/admin.php?page=wc-settings&tab=checkout&section`;
 
-const WCPAY_DEV_TOOLS = `${ config.get(
-	'url'
-) }wp-admin/admin.php?page=wcpaydev`;
-
 const WC_GATEWAYS_LIST_TABLE__WC_PAYMENTS_TOGGLE =
 	'tr[data-gateway_id="woocommerce_payments"] .wc-payment-gateway-method-toggle-enabled';
 
 describe( 'payment gateways disable confirmation', () => {
 	beforeAll( async () => {
 		await merchant.login();
-
-		await page.goto( WCPAY_DEV_TOOLS, {
-			waitUntil: 'networkidle0',
-		} );
-
-		// Enable the "Enable grouped settings" checkbox and save
-		await expect( page ).toClick( 'label', {
-			text: 'Enable grouped settings',
-		} );
-		await expect( page ).toClick( 'input[type="submit"]' );
-		await page.waitForNavigation( {
-			waitUntil: 'networkidle0',
-		} );
 	} );
 
 	beforeEach( async () => {
@@ -41,19 +24,6 @@ describe( 'payment gateways disable confirmation', () => {
 	} );
 
 	afterAll( async () => {
-		await page.goto( WCPAY_DEV_TOOLS, {
-			waitUntil: 'networkidle0',
-		} );
-
-		// Disable the "Enable grouped settings" checkbox and save
-		await expect( page ).toClick( 'label', {
-			text: 'Enable grouped settings',
-		} );
-		await expect( page ).toClick( 'input[type="submit"]' );
-		await page.waitForNavigation( {
-			waitUntil: 'networkidle0',
-		} );
-
 		await merchant.logout();
 	} );
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

There's no need to check/uncheck the "Grouped settings" flag in the dev tools, since the new settings are enabled by default now.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
