### PR TITLE
Fire a new action when payment request is ready

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -46,6 +46,7 @@
 * Add - Show fee breakdown in transaction details timeline.
 * Add - REST endpoint to get customer id from an order.
 * Fix - Explat not caching when no variation is returned.
+* Add - Add a new hook to get a list of enabled payment request methods.
 
 = 2.7.1 - 2021-07-26 =
 * Fix - Ensure test mode setting value is correctly saved.

--- a/client/payment-request/index.js
+++ b/client/payment-request/index.js
@@ -658,6 +658,11 @@ jQuery( ( $ ) => {
 		const getEnabledMethods = async function ( paymentRequest ) {
 			const result = await paymentRequest.canMakePayment();
 			let ret = [];
+
+			if ( ! result ) {
+				return ret;
+			}
+
 			if ( result.applePay ) {
 				ret = [ 'applePay' ];
 			} else if ( result.googlePay ) {

--- a/client/payment-request/index.js
+++ b/client/payment-request/index.js
@@ -617,16 +617,24 @@ jQuery( ( $ ) => {
 		},
 	};
 
+	let getEnabledPaymentRequestMethodsCache = null;
+
 	wcpayPaymentRequest.init();
 
 	// We need to refresh payment request data when total is updated.
 	$( document.body ).on( 'updated_cart_totals', () => {
 		wcpayPaymentRequest.init();
+
+		// Expire getEnabledPaymentRequestMethods cache.
+		getEnabledPaymentRequestMethodsCache = null;
 	} );
 
 	// We need to refresh payment request data when total is updated.
 	$( document.body ).on( 'updated_checkout', () => {
 		wcpayPaymentRequest.init();
+
+		// Expire getEnabledPaymentRequestMethods cache.
+		getEnabledPaymentRequestMethodsCache = null;
 	} );
 
 	function setBackgroundImageWithFallback( element, background, fallback ) {
@@ -643,15 +651,21 @@ jQuery( ( $ ) => {
 	 * Get a list of enabled payment request methods.
 	 */
 	async function getEnabledPaymentRequestMethods() {
+		if ( getEnabledPaymentRequestMethodsCache ) {
+			return getEnabledPaymentRequestMethodsCache;
+		}
+
 		const getEnabledMethods = async function ( paymentRequest ) {
 			const result = await paymentRequest.canMakePayment();
+			let ret = [];
 			if ( result.applePay ) {
-				return [ 'applePay' ];
+				ret = [ 'applePay' ];
 			} else if ( result.googlePay ) {
-				return [ 'googlePay' ];
+				ret = [ 'googlePay' ];
 			}
 
-			return [];
+			getEnabledPaymentRequestMethodsCache = ret;
+			return ret;
 		};
 
 		if ( wcpayPaymentRequestParams.is_product_page ) {

--- a/client/payment-request/index.js
+++ b/client/payment-request/index.js
@@ -1,4 +1,8 @@
 /* global jQuery, wcpayPaymentRequestParams, wc_add_to_cart_variation_params */
+/**
+ * External dependencies
+ */
+import { defaultHooks } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -180,16 +184,25 @@ jQuery( ( $ ) => {
 		 */
 		startPaymentRequest: ( options ) => {
 			const paymentRequest = getPaymentRequest( options );
-
 			const elements = api.getStripe().elements();
 			const prButton = wcpayPaymentRequest.createPaymentRequestButton(
 				elements,
 				paymentRequest
 			);
 
+			const doActionPaymentRequestAvailability = ( args ) => {
+				defaultHooks.doAction(
+					'wcpay.payment-request.availability',
+					args
+				);
+			};
+
 			// Check the availability of the Payment Request API first.
 			paymentRequest.canMakePayment().then( ( result ) => {
 				if ( ! result ) {
+					doActionPaymentRequestAvailability( {
+						paymentRequestType: null,
+					} );
 					return;
 				}
 
@@ -202,6 +215,10 @@ jQuery( ( $ ) => {
 				} else {
 					paymentRequestType = 'payment_request_api';
 				}
+
+				doActionPaymentRequestAvailability( {
+					paymentRequestType: paymentRequestType,
+				} );
 
 				wcpayPaymentRequest.attachPaymentRequestButtonEventListeners(
 					prButton,

--- a/client/payment-request/index.js
+++ b/client/payment-request/index.js
@@ -2,8 +2,7 @@
 /**
  * External dependencies
  */
-import { defaultHooks } from '@wordpress/hooks';
-
+import { doAction } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
@@ -191,10 +190,7 @@ jQuery( ( $ ) => {
 			);
 
 			const doActionPaymentRequestAvailability = ( args ) => {
-				defaultHooks.doAction(
-					'wcpay.payment-request.availability',
-					args
-				);
+				doAction( 'wcpay.payment-request.availability', args );
 			};
 
 			// Check the availability of the Payment Request API first.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3892,6 +3892,15 @@
                 }
               }
             },
+            "@wordpress/hooks": {
+              "version": "2.12.3",
+              "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.12.3.tgz",
+              "integrity": "sha512-LmKiwKldZt6UYqOxV/a6+eUFXdvALFnB/pQx3RmrMvO64sgFhfR6dhrlv+uVbuuezSuv8dce1jx8lUWAT0krMA==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            },
             "@wordpress/i18n": {
               "version": "3.19.2",
               "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.19.2.tgz",
@@ -4946,6 +4955,17 @@
             "memize": "^1.1.0",
             "sprintf-js": "^1.1.1",
             "tannin": "^1.2.0"
+          },
+          "dependencies": {
+            "@wordpress/hooks": {
+              "version": "2.12.3",
+              "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.12.3.tgz",
+              "integrity": "sha512-LmKiwKldZt6UYqOxV/a6+eUFXdvALFnB/pQx3RmrMvO64sgFhfR6dhrlv+uVbuuezSuv8dce1jx8lUWAT0krMA==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            }
           }
         }
       }
@@ -5149,6 +5169,15 @@
             "lodash": "^4.17.19"
           }
         },
+        "@wordpress/hooks": {
+          "version": "2.12.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.12.3.tgz",
+          "integrity": "sha512-LmKiwKldZt6UYqOxV/a6+eUFXdvALFnB/pQx3RmrMvO64sgFhfR6dhrlv+uVbuuezSuv8dce1jx8lUWAT0krMA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10"
+          }
+        },
         "@wordpress/i18n": {
           "version": "3.19.2",
           "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.19.2.tgz",
@@ -5286,6 +5315,17 @@
             "memize": "^1.1.0",
             "sprintf-js": "^1.1.1",
             "tannin": "^1.2.0"
+          },
+          "dependencies": {
+            "@wordpress/hooks": {
+              "version": "2.12.3",
+              "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.12.3.tgz",
+              "integrity": "sha512-LmKiwKldZt6UYqOxV/a6+eUFXdvALFnB/pQx3RmrMvO64sgFhfR6dhrlv+uVbuuezSuv8dce1jx8lUWAT0krMA==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            }
           }
         }
       }
@@ -5319,6 +5359,17 @@
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@wordpress/hooks": "^2.12.2"
+      },
+      "dependencies": {
+        "@wordpress/hooks": {
+          "version": "2.12.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.12.3.tgz",
+          "integrity": "sha512-LmKiwKldZt6UYqOxV/a6+eUFXdvALFnB/pQx3RmrMvO64sgFhfR6dhrlv+uVbuuezSuv8dce1jx8lUWAT0krMA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10"
+          }
+        }
       }
     },
     "@wordpress/dom": {
@@ -5461,9 +5512,9 @@
       }
     },
     "@wordpress/hooks": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.12.2.tgz",
-      "integrity": "sha512-fTgo8CFuqJ3ZFrcHB1U8D43ydn+9m+8DmdcvQmWPRr0lJ3tzngEpGB3MxZE3s+jMfuESa28kDD0ukburyA5u/g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.0.tgz",
+      "integrity": "sha512-nVR6V9kPxl8+aYQzQJdoDt+aKBKHHD0zplcYZbu2MHxjmHMvppAeL9mjzVhQZj/3n10NR2Ftk94mHQzHWfhCCg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.13.10"
@@ -5705,6 +5756,17 @@
             "memize": "^1.1.0",
             "sprintf-js": "^1.1.1",
             "tannin": "^1.2.0"
+          },
+          "dependencies": {
+            "@wordpress/hooks": {
+              "version": "2.12.3",
+              "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.12.3.tgz",
+              "integrity": "sha512-LmKiwKldZt6UYqOxV/a6+eUFXdvALFnB/pQx3RmrMvO64sgFhfR6dhrlv+uVbuuezSuv8dce1jx8lUWAT0krMA==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@wordpress/dependency-extraction-webpack-plugin": "3.0.1",
     "@wordpress/e2e-test-utils": "4.11.0",
     "@wordpress/element": "^2.20.3",
+    "@wordpress/hooks": "^3.2.0",
     "@wordpress/i18n": "^4.1.1",
     "@wordpress/icons": "^2.10.3",
     "@wordpress/jest-preset-default": "4.0.0",


### PR DESCRIPTION
Fixes #2608

#### Changes proposed in this Pull Request

~This PR adds a new method `getEnabledPaymentRequestMethods` to get a list of enabled payment request methods (Apple or Google pay). The method is globally available.~

This PR fires `wcpay.payment-request.availability` action with an available payment request type after checking payment request availability.


#### Testing instructions

1. Prepare a store with a live WC Payment account. I wasn't able to find a way to test Google or Apple pay without a live account. Either create a new site on wp.com or JN.
2. Enable express checkout by navigating to WooCommerce -> Settings -> Payments.
3. Visit a product page on Safari and open the inspector. Make sure Apple Pay button is visible on the page.
4. Add a new product to the shopping cart.
5. Go to the shopping cart.
6. Open inspector and paste the following snippet.

```
wp.hooks.addAction('wcpay.payment-request.availability', 'wcpay', (args) => {
    console.log(args);
});
```

7. Increase/decrease the item quantity and click the "Update cart" button.

You should see `{paymentRequestType: null}` console output. The value of `paymentRequestType` can be one of applePay, googlePay, and null.

-------------------

- [X] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
