### PR TITLE
Bump wcpay_empty_state_preview_mode Version

### DIFF
--- a/client/deposits/index.js
+++ b/client/deposits/index.js
@@ -22,7 +22,7 @@ const DepositsPage = () => {
 	return (
 		<Page>
 			<Experiment
-				name="wcpay_empty_state_preview_mode_v1"
+				name="wcpay_empty_state_preview_mode_v2"
 				treatmentExperience={
 					<>
 						<EmptyStateTable

--- a/client/transactions/index.tsx
+++ b/client/transactions/index.tsx
@@ -21,7 +21,7 @@ export const TransactionsPage = (): JSX.Element => {
 	return (
 		<Page>
 			<Experiment
-				name="wcpay_empty_state_preview_mode_v1"
+				name="wcpay_empty_state_preview_mode_v2"
 				treatmentExperience={
 					<EmptyStateTable
 						headers={ EmptyStateTableHeaders }

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -614,7 +614,7 @@ class WC_Payments_Admin {
 			'yes' === get_option( 'woocommerce_allow_tracking' )
 		);
 
-		return 'treatment' === $abtest->get_variation( 'wcpay_empty_state_preview_mode_v1' );
+		return 'treatment' === $abtest->get_variation( 'wcpay_empty_state_preview_mode_v2' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2612

#### Changes proposed in this Pull Request

Bumps version number of ExPlat experiment `wcpay_empty_state_preview_mode`

This experiment was stopped in issue #2511 and needs to be re-started for the 2.8 release. This is done by cloning the previous experiment and incrementing the version number in the name.

Note this will need to be bumped again to `v3` just prior to the release of 2.8 to avoid any impact on the results from testing. @RadoslavGeorgiev will this be possible? We are not currently able to use the `staging` mode of ExPlat, which would  have prevented the need for this.

#### Testing instructions

- Check that all instances of `wcpay_empty_state_preview_mode_v1` have been changed.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
