### PR TITLE
Fix/2621 enqueue admin assets when needed

### DIFF
--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -272,7 +272,7 @@ class MultiCurrency {
 	 *
 	 * @return void
 	 */
-	public function register_admin_scripts() {
+	private function register_admin_scripts() {
 		$script_src_url    = plugins_url( 'dist/multi-currency.js', WCPAY_PLUGIN_FILE );
 		$script_asset_path = WCPAY_ABSPATH . 'dist/multi-currency.asset.php';
 		$script_asset      = file_exists( $script_asset_path ) ? require_once $script_asset_path : [ 'dependencies' => [] ];
@@ -298,14 +298,14 @@ class MultiCurrency {
 	 * @return void
 	 */
 	public function enqueue_admin_scripts() {
-		global $current_tab, $current_section;
+		global $current_tab;
 
-		$this->register_admin_scripts();
-
-		// TODO: Set this to only display when needed.
 		// Output the settings JS and CSS only on the settings page.
-		wp_enqueue_script( 'WCPAY_MULTI_CURRENCY_SETTINGS' );
-		wp_enqueue_style( 'WCPAY_MULTI_CURRENCY_SETTINGS' );
+		if ( 'wcpay_multi_currency' === $current_tab ) {
+			$this->register_admin_scripts();
+			wp_enqueue_script( 'WCPAY_MULTI_CURRENCY_SETTINGS' );
+			wp_enqueue_style( 'WCPAY_MULTI_CURRENCY_SETTINGS' );
+		}
 	}
 
 	/**

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -268,31 +268,6 @@ class MultiCurrency {
 	}
 
 	/**
-	 * Register the CSS and JS admin scripts.
-	 *
-	 * @return void
-	 */
-	private function register_admin_scripts() {
-		$script_src_url    = plugins_url( 'dist/multi-currency.js', WCPAY_PLUGIN_FILE );
-		$script_asset_path = WCPAY_ABSPATH . 'dist/multi-currency.asset.php';
-		$script_asset      = file_exists( $script_asset_path ) ? require_once $script_asset_path : [ 'dependencies' => [] ];
-		wp_register_script(
-			'WCPAY_MULTI_CURRENCY_SETTINGS',
-			$script_src_url,
-			$script_asset['dependencies'],
-			\WC_Payments::get_file_version( 'dist/multi-currency.js' ),
-			true
-		);
-
-		wp_register_style(
-			'WCPAY_MULTI_CURRENCY_SETTINGS',
-			plugins_url( 'dist/multi-currency.css', WCPAY_PLUGIN_FILE ),
-			[ 'wc-components' ],
-			\WC_Payments::get_file_version( 'dist/multi-currency.css' )
-		);
-	}
-
-	/**
 	 * Load the admin assets.
 	 *
 	 * @return void
@@ -987,5 +962,30 @@ class MultiCurrency {
 	 */
 	private function is_using_auto_currency_switching(): bool {
 		return 'yes' === get_option( $this->id . '_enable_auto_currency', false );
+	}
+
+	/**
+	 * Register the CSS and JS admin scripts.
+	 *
+	 * @return void
+	 */
+	private function register_admin_scripts() {
+		$script_src_url    = plugins_url( 'dist/multi-currency.js', WCPAY_PLUGIN_FILE );
+		$script_asset_path = WCPAY_ABSPATH . 'dist/multi-currency.asset.php';
+		$script_asset      = file_exists( $script_asset_path ) ? require_once $script_asset_path : [ 'dependencies' => [] ];
+		wp_register_script(
+			'WCPAY_MULTI_CURRENCY_SETTINGS',
+			$script_src_url,
+			$script_asset['dependencies'],
+			\WC_Payments::get_file_version( 'dist/multi-currency.js' ),
+			true
+		);
+
+		wp_register_style(
+			'WCPAY_MULTI_CURRENCY_SETTINGS',
+			plugins_url( 'dist/multi-currency.css', WCPAY_PLUGIN_FILE ),
+			[ 'wc-components' ],
+			\WC_Payments::get_file_version( 'dist/multi-currency.css' )
+		);
 	}
 }


### PR DESCRIPTION
Fixes #2621 

#### Changes proposed in this Pull Request

* Navigate to WooCommerce > Settings > Multi-Currency.
* Ensure Enabled Currencies still work.
* Navigate into an enabled currency.
* Ensure settings in currency still work as expected.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
