### PR TITLE
Update Escaping for A/B Test Cookie

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@
 * Update - Bump minimum supported version of WooCommerce from 5.2 to 5.3.
 * Update - Bump minimum supported version of WordPress from 5.5 to 5.6.
 * Fix - Stop refund process when using an invalid amount
+* Fix - Improve sanitization of ExPlat cookie.
 
 = 2.7.1 - 2021-07-26 =
 * Fix - Ensure test mode setting value is correctly saved.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -609,7 +609,7 @@ class WC_Payments_Admin {
 		}
 
 		$abtest = new \WCPay\Experimental_Abtest(
-			esc_url_raw( wp_unslash( $_COOKIE['tk_ai'] ) ),
+			sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ),
 			'woocommerce',
 			'yes' === get_option( 'woocommerce_allow_tracking' )
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -114,6 +114,7 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Bump minimum supported version of WooCommerce from 5.2 to 5.3.
 * Update - Bump minimum supported version of WordPress from 5.5 to 5.6.
 * Fix - Stop refund process when using an invalid amount
+* Fix - Improve sanitization of ExPlat cookie.
 
 = 2.7.1 - 2021-07-26 =
 * Fix - Ensure test mode setting value is correctly saved.


### PR DESCRIPTION
Fixes #2631

#### Changes proposed in this Pull Request

Updates escaping for A/B test cookie.

Sanitizing with `esc_url_raw` was returning a blank value for the cookie. This seems to still works within ExPlat, however might cause all users to share a unique ID.

I considered removing the sanitization completely, but it is required by PHPCS. Instead, I've used `sanitize_text_field` which seems to fit the bill.

> Checks for invalid UTF-8,
> Converts single < characters to entities
> Strips all tags
> Removes line breaks, tabs, and extra whitespace
> Strips octets

https://developer.wordpress.org/reference/functions/sanitize_text_field/

Note that the cookie values are in the form of `woo:<random alphanumeric string>` or `jetpack:<random alphanumeric string>`.

The change doesn’t affect existing automated tests.

#### Testing instructions

This is tricky to test against a ExPlat test until #2631 is merged. However the `anon_id` property of class `WCPay\Experimental_Abtest` could be inspected, e.g.

In `class-wc-payments-admin.php`, add `var_dump($abtest); die();` after:

https://github.com/Automattic/woocommerce-payments/blob/2b03941b3a3e8a832bc70a3f864721d2a02641e9/includes/admin/class-wc-payments-admin.php#L623-L628

- See that `anon_id` is the same value as your `tk_ai` cookie value.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
