### PR TITLE
Change check to enable subscriptions column

### DIFF
--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -264,7 +264,7 @@ class WC_Payments_Admin {
 			'onBoardingDisabled'     => WC_Payments_Account::is_on_boarding_disabled(),
 			'errorMessage'           => $error_message,
 			'featureFlags'           => $this->get_frontend_feature_flags(),
-			'isSubscriptionsActive'  => class_exists( 'WC_Payment_Gateway_WCPay_Subscriptions_Compat' ),
+			'isSubscriptionsActive'  => class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '2.2.0', '>=' ),
 			// used in the settings page by the AccountFees component.
 			'zeroDecimalCurrencies'  => WC_Payments_Utils::zero_decimal_currencies(),
 			'fraudServices'          => $this->account->get_fraud_services_config(),

--- a/tests/e2e/specs/merchant/merchant-admin-transactions.spec.js
+++ b/tests/e2e/specs/merchant/merchant-admin-transactions.spec.js
@@ -6,7 +6,12 @@ const { merchant } = require( '@woocommerce/e2e-utils' );
 /**
  * Internal dependencies
  */
-import { merchantWCP, takeScreenshot } from '../../utils';
+import {
+	RUN_SUBSCRIPTIONS_TESTS,
+	merchantWCP,
+	takeScreenshot,
+	describeif,
+} from '../../utils';
 
 describe( 'Admin transactions', () => {
 	beforeAll( async () => {
@@ -17,5 +22,19 @@ describe( 'Admin transactions', () => {
 		await merchantWCP.openTransactions();
 		await expect( page ).toMatchElement( 'h2', { text: 'Transactions' } );
 		await takeScreenshot( 'merchant-admin-transactions' );
+	} );
+} );
+
+describeif( RUN_SUBSCRIPTIONS_TESTS, () => {
+	beforeAll( async () => {
+		await merchant.login();
+	} );
+
+	it( 'page should load without any errors', async () => {
+		await merchantWCP.openTransactions();
+		await expect( page ).toContain( { text: 'Subscription #' } );
+		await takeScreenshot(
+			'merchant-admin-transactions-subscriptions-active'
+		);
 	} );
 } );


### PR DESCRIPTION
Fixes #2630 

#### Changes proposed in this Pull Request

This PR re-enables the display of Subscription Number column in the Payments > Transactions table, which was accidentally removed by removing a class dependency in `class-wc-payments.php` file and the flag was dependent on the existence of that class. This PR changes the check for the class availability to the parent check, which checks for the Subscriptions plugin presence and minimum version that supports this change.

![image](https://user-images.githubusercontent.com/3295/127838684-bc1aaade-b5d8-4a35-81f6-1b74c1001ad3.png)


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* run `npm run test:e2e-setup` to create setup environment with subscriptions enabled
* run `npm run test:e2e-dev ./tests/e2e/specs/merchant/merchant-admin-transactions.spec.js` to run the related test 

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
