### PR TITLE
Fix explat not caching when no variation is returned

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@
 * Fix - Improve sanitization of ExPlat cookie.
 * Add - Show fee breakdown in transaction details timeline.
 * Add - REST endpoint to get customer id from an order.
+* Fix - Explat not caching when no variation is returned.
 
 = 2.7.1 - 2021-07-26 =
 * Fix - Ensure test mode setting value is correctly saved.

--- a/includes/class-experimental-abtest.php
+++ b/includes/class-experimental-abtest.php
@@ -127,7 +127,7 @@ final class Experimental_Abtest {
 		$results = json_decode( $response['body'], true );
 
 		// Bail if there were no results or there is no test variation returned.
-		if ( ! is_array( $results ) || empty( $results['variations'] ) || empty( $results['variations'][ $test_name ] ) ) {
+		if ( ! is_array( $results ) || empty( $results['variations'] ) ) {
 			return new \WP_Error( 'unexpected_data_format', 'Data was not returned in the expected format.' );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -118,6 +118,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Improve sanitization of ExPlat cookie.
 * Add - Show fee breakdown in transaction details timeline.
 * Add - REST endpoint to get customer id from an order.
+* Fix - Explat not caching when no variation is returned.
 
 = 2.7.1 - 2021-07-26 =
 * Fix - Ensure test mode setting value is correctly saved.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes Explat A/B test not saving the result of experiment API when there are no variations returned.

#### Testing instructions

1. Delete the transient `_transient_abtest_variation_wcpay_empty_state_preview_mode_v2`.
2. Modify the following to make sure you get the "control" variant:

https://github.com/Automattic/woocommerce-payments/blob/266f9056751146caa4e00aae6482d86dc48ea9af/includes/class-experimental-abtest.php#L127

```
$results = array( 'variations' => array( 'wcpay_empty_state_preview_mode_v2' => null ), 'ttl' => 7200 );
```
3. Navigate to anywhere within wp-admin.
4. Query for `_transient_abtest_variation_wcpay_empty_state_preview_mode_v2` transient in your `options` table, observe that it exists with the value `control`.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
