### PR TITLE
Rename presentment currencies to customer supported currencies

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -520,7 +520,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return bool Whether the currency is supported in the country set in the account.
 	 */
 	public function is_available_for_current_currency() {
-		$supported_currencies = $this->account->get_account_presentment_currencies();
+		$supported_currencies = $this->account->get_account_customer_supported_currencies();
 		$current_currency     = strtolower( get_woocommerce_currency() );
 
 		if ( count( $supported_currencies ) === 0 ) {

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -199,13 +199,13 @@ class WC_Payments_Account {
 	}
 
 	/**
-	 * Gets the presentment currencies supported by Stripe available for the account.
+	 * Gets the customer currencies supported by Stripe available for the account.
 	 *
 	 * @return array Currencies.
 	 */
-	public function get_account_presentment_currencies() {
+	public function get_account_customer_supported_currencies() {
 		$account = $this->get_cached_account_data();
-		return ! empty( $account ) && isset( $account['presentment_currencies'] ) ? $account['presentment_currencies'] : [];
+		return ! empty( $account ) && isset( $account['customer_currencies']['supported'] ) ? $account['customer_currencies']['supported'] : [];
 	}
 
 	/**

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -934,10 +934,10 @@ class MultiCurrency {
 		$wc_currencies      = array_keys( get_woocommerce_currencies() );
 		$account_currencies = $wc_currencies;
 
-		$account = $this->payments_account->get_cached_account_data();
-
-		if ( $account && ! empty( $account['presentment_currencies'] ) ) {
-			$account_currencies = array_map( 'strtoupper', $account['presentment_currencies'] );
+		$account              = $this->payments_account->get_cached_account_data();
+		$supported_currencies = $this->payments_account->get_account_customer_supported_currencies();
+		if ( $account && ! empty( $supported_currencies ) ) {
+			$account_currencies = array_map( 'strtoupper', $supported_currencies );
 		}
 
 		/**

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -148,7 +148,7 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->assertEquals( sort( $expected_currencies ), sort( $available_currencies ) );
 	}
 
-	public function test_available_currencies_uses_wc_currencies_when_stripe_account_has_no_presentment_currencies() {
+	public function test_available_currencies_uses_wc_currencies_when_stripe_account_has_no_customer_supported_currencies() {
 		$this->mock_account->method( 'get_cached_account_data' )->willReturn( [ 'id' => 'acct' ] );
 
 		$this->init_multi_currency();
@@ -159,12 +159,19 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->assertEquals( sort( $expected_currencies ), sort( $available_currencies ) );
 	}
 
-	public function test_available_currencies_uses_only_presentment_currencies_when_enabled_in_wc() {
+	public function test_available_currencies_uses_only_customer_supported_currencies_when_enabled_in_wc() {
 		$this->mock_account
 			->method( 'get_cached_account_data' )
 			->willReturn(
 				[
-					'presentment_currencies' => [ 'usd', 'cad', 'random', 'brl' ],
+					'customer_currencies' => [
+						'supported' => [
+							'usd',
+							'cad',
+							'random',
+							'brl',
+						],
+					],
 				]
 			);
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -1476,7 +1476,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 	public function test_payment_gateway_enabled_for_supported_currency() {
 		$current_currency = strtolower( get_woocommerce_currency() );
-		$this->mock_wcpay_account->expects( $this->once() )->method( 'get_account_presentment_currencies' )->will(
+		$this->mock_wcpay_account->expects( $this->once() )->method( 'get_account_customer_supported_currencies' )->will(
 			$this->returnValue(
 				[
 					$current_currency,
@@ -1488,7 +1488,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 
 	public function test_payment_gateway_enabled_for_empty_supported_currency_list() {
 		// We want to avoid disabling the gateway in case the API doesn't give back any currency suppported.
-		$this->mock_wcpay_account->expects( $this->once() )->method( 'get_account_presentment_currencies' )->will(
+		$this->mock_wcpay_account->expects( $this->once() )->method( 'get_account_customer_supported_currencies' )->will(
 			$this->returnValue(
 				[]
 			)
@@ -1497,7 +1497,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_payment_gateway_disabled_for_unsupported_currency() {
-		$this->mock_wcpay_account->expects( $this->once() )->method( 'get_account_presentment_currencies' )->will(
+		$this->mock_wcpay_account->expects( $this->once() )->method( 'get_account_customer_supported_currencies' )->will(
 			$this->returnValue(
 				[
 					'btc',


### PR DESCRIPTION
Fixes server-1007

#### Changes proposed in this Pull Request
- The server is going to stop using `presentment_currencies` to use `customer_currencies['supported']`
- This change makes it compatible with that new format

#### Testing instructions

* Clean cache account and see `customer_currencies['supported']` are there
* In Multi Currencies, try to add a currency that is not supported by Stripe (like Bitcoin) and see it doesn't show up in the list.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
