### PR TITLE
Display Storefront Widget option when settings loaded with 1 currency

### DIFF
--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -225,7 +225,7 @@ class MultiCurrency {
 
 		// Check to make sure there are enabled currencies, then for Storefront being active, and then load the integration.
 		$theme = wp_get_theme();
-		if ( 1 < count( $this->get_enabled_currencies() ) && ( 'storefront' === $theme->get_stylesheet() || 'storefront' === $theme->get_template() ) ) {
+		if ( 'storefront' === $theme->get_stylesheet() || 'storefront' === $theme->get_template() ) {
 			$this->storefront_integration = new StorefrontIntegration( $this );
 		}
 

--- a/includes/multi-currency/StorefrontIntegration.php
+++ b/includes/multi-currency/StorefrontIntegration.php
@@ -146,6 +146,12 @@ class StorefrontIntegration {
 	 */
 	private function init_actions_and_filters() {
 		add_filter( $this->id . '_enabled_currencies_settings', [ $this, 'filter_store_settings' ] );
+
+		// Do not enable the breadcrumb widget if there's only one currency active.
+		if ( 1 >= count( $this->multi_currency->get_enabled_currencies() ) ) {
+			return;
+		}
+
 		// We want this enabled by default, so we default the option to 'yes'.
 		if ( 'yes' === get_option( $this->id . '_enable_storefront_switcher', 'yes' ) ) {
 			add_filter( 'woocommerce_breadcrumb_defaults', [ $this, 'modify_breadcrumb_defaults' ], 9999 );

--- a/tests/unit/multi-currency/test-class-storefront-integration.php
+++ b/tests/unit/multi-currency/test-class-storefront-integration.php
@@ -35,7 +35,13 @@ class WCPay_Multi_Currency_Storefront_Integration_Tests extends WP_UnitTestCase 
 		parent::tearDown();
 	}
 
-	public function test_register_settings_on_init() {
+	public function test_always_register_settings_on_init() {
+		// Settings should be registered even when only one currency is enabled.
+		$this->mock_multi_currency->method( 'get_enabled_currencies' )->willReturn( [ [] ] );
+
+		// Settings should be registered even when the switcher is not enabled.
+		update_option( 'wcpay_multi_currency_enable_storefront_switcher', 'no' );
+
 		$this->assertSame(
 			10,
 			has_filter( 'wcpay_multi_currency_enabled_currencies_settings', [ $this->storefront_integration, 'filter_store_settings' ] ),
@@ -46,7 +52,27 @@ class WCPay_Multi_Currency_Storefront_Integration_Tests extends WP_UnitTestCase 
 	/**
 	 * @dataProvider switcher_filter_provider
 	 */
+	public function test_does_not_register_actions_when_less_than_2_currencies( $filter, $function_name ) {
+		// The breadcrumbs widget should only be registered when 2 or more currencies are enabled.
+		$this->mock_multi_currency->method( 'get_enabled_currencies' )->willReturn( [ [] ] );
+
+		update_option( 'wcpay_multi_currency_enable_storefront_switcher', 'yes' );
+		// Reinit class to re-evaluate conditional hooks.
+		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
+
+		$this->assertFalse(
+			has_filter( $filter, [ $this->storefront_integration, $function_name ] ),
+			"The filter '$filter' with function '$function_name' was found."
+		);
+	}
+
+	/**
+	 * @dataProvider switcher_filter_provider
+	 */
 	public function test_does_not_register_actions_when_switcher_disabled( $filter, $function_name ) {
+		// The breadcrumbs widget should only be registered when 2 or more currencies are enabled.
+		$this->mock_multi_currency->method( 'get_enabled_currencies' )->willReturn( [ [], [] ] );
+
 		update_option( 'wcpay_multi_currency_enable_storefront_switcher', 'no' );
 		// Reinit class to re-evaluate conditional hooks.
 		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
@@ -62,6 +88,9 @@ class WCPay_Multi_Currency_Storefront_Integration_Tests extends WP_UnitTestCase 
 	 * @dataProvider switcher_filter_provider
 	 */
 	public function test_registers_actions_when_switcher_default( $filter, $function_name ) {
+		// The breadcrumbs widget should only be registered when 2 or more currencies are enabled.
+		$this->mock_multi_currency->method( 'get_enabled_currencies' )->willReturn( [ [], [] ] );
+
 		delete_option( 'wcpay_multi_currency_enable_storefront_switcher' );
 		// Reinit class to re-evaluate conditional hooks.
 		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );
@@ -77,6 +106,9 @@ class WCPay_Multi_Currency_Storefront_Integration_Tests extends WP_UnitTestCase 
 	 * @dataProvider switcher_filter_provider
 	 */
 	public function test_registers_actions_when_switcher_enabled( $filter, $function_name ) {
+		// The breadcrumbs widget should only be registered when 2 or more currencies are enabled.
+		$this->mock_multi_currency->method( 'get_enabled_currencies' )->willReturn( [ [], [] ] );
+
 		update_option( 'wcpay_multi_currency_enable_storefront_switcher', 'yes' );
 		// Reinit class to re-evaluate conditional hooks.
 		$this->storefront_integration = new StorefrontIntegration( $this->mock_multi_currency );


### PR DESCRIPTION
Fixes #2627 

#### Changes proposed in this Pull Request

We currently override the settings to show the Storefront option on the StorefrontIntegration class, but since that class is not instantiated when enabled_currencies is 1 or less, the option is not displayed on the first page load when there's only one currency enabled.

This commit moves the enabled currencies check before adding the widget actions, instead of when instantiating the StorefrontIntegration class.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Remove all enabled currencies and reload the Multi-Currency settings page
* Add an additional currency
* Make sure that the Store settings show up, and that the Storefront option is also listed

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
