### PR TITLE
Add changelog entry headers for 2.9.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 *** WooCommerce Payments Changelog ***
 
+= 2.9.0 - 2021-xx-xx =
+
 = 2.8.0 - 2021-08-04 =
 * Add - Allow merchants to add additional currencies to their store, allowing a store’s customers to shop and browse in the currency of their choice.
 * Add - *Early access*: allow your store to collect payments with Giropay and Sofort. Enable the feature in settings!

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,8 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 2.9.0 - 2021-xx-xx =
+
 = 2.8.0 - 2021-08-04 =
 * Add - Allow merchants to add additional currencies to their store, allowing a store’s customers to shop and browse in the currency of their choice.
 * Add - *Early access*: allow your store to collect payments with Giropay and Sofort. Enable the feature in settings!


### PR DESCRIPTION
After the release of version 2.8.0. It's a simple one, just the headers, the rest of the files are up to date.