### PR TITLE
Customizable frontend currencies

### DIFF
--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -45,21 +45,26 @@ class FrontendCurrencies {
 	public function __construct( MultiCurrency $multi_currency, WC_Payments_Localization_Service $localization_service ) {
 		$this->multi_currency       = $multi_currency;
 		$this->localization_service = $localization_service;
-		$store_currency             = get_option( 'woocommerce_currency' );
 
 		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
 			// Currency hooks.
 			add_filter( 'woocommerce_currency', [ $this, 'get_woocommerce_currency' ], 50 );
-			// If the store currency is the same with the customer currency, disable formatting hooks.
-			if ( $store_currency !== $this->get_woocommerce_currency() ) {
-				add_filter( 'wc_get_price_decimals', [ $this, 'get_price_decimals' ], 50 );
-				add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 50 );
-				add_filter( 'wc_get_price_thousand_separator', [ $this, 'get_price_thousand_separator' ], 50 );
-				add_filter( 'woocommerce_price_format', [ $this, 'get_woocommerce_price_format' ], 50 );
-			}
+			add_filter( 'wc_get_price_decimals', [ $this, 'get_price_decimals' ], 50 );
+			add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 50 );
+			add_filter( 'wc_get_price_thousand_separator', [ $this, 'get_price_thousand_separator' ], 50 );
+			add_filter( 'woocommerce_price_format', [ $this, 'get_woocommerce_price_format' ], 50 );
 		}
 
 		add_filter( 'woocommerce_cart_hash', [ $this, 'add_currency_to_cart_hash' ], 50 );
+	}
+
+	/**
+	 * Gets the store currency.
+	 *
+	 * @return  Currency  The store currency wrapped as a Currency object
+	 */
+	public function get_store_currency() {
+		return new Currency( get_option( 'woocommerce_currency' ) );
 	}
 
 	/**
@@ -74,54 +79,74 @@ class FrontendCurrencies {
 	/**
 	 * Returns the number of decimals to be used by WooCommerce.
 	 *
+	 * @param int $decimals The original decimal count.
+	 *
 	 * @return int The number of decimals.
 	 */
-	public function get_price_decimals(): int {
+	public function get_price_decimals( $decimals ): int {
 		$currency_code = $this->multi_currency->get_selected_currency()->get_code();
-		return absint( $this->localization_service->get_currency_format( $currency_code )['num_decimals'] );
+		if ( $currency_code !== $this->get_store_currency()->get_code() ) {
+			return absint( $this->localization_service->get_currency_format( $currency_code )['num_decimals'] );
+		}
+		return $decimals;
 	}
 
 	/**
 	 * Returns the decimal separator to be used by WooCommerce.
 	 *
+	 * @param string $separator The original separator.
+	 *
 	 * @return string The decimal separator.
 	 */
-	public function get_price_decimal_separator(): string {
+	public function get_price_decimal_separator( $separator ): string {
 		$currency_code = $this->multi_currency->get_selected_currency()->get_code();
-		return $this->localization_service->get_currency_format( $currency_code )['decimal_sep'];
+		if ( $currency_code !== $this->get_store_currency()->get_code() ) {
+			return $this->localization_service->get_currency_format( $currency_code )['decimal_sep'];
+		}
+		return $separator;
 	}
 
 	/**
 	 * Returns the thousand separator to be used by WooCommerce.
 	 *
+	 * @param string $separator The original separator.
+	 *
 	 * @return string The thousand separator.
 	 */
-	public function get_price_thousand_separator(): string {
+	public function get_price_thousand_separator( $separator ): string {
 		$currency_code = $this->multi_currency->get_selected_currency()->get_code();
-		return $this->localization_service->get_currency_format( $currency_code )['thousand_sep'];
+		if ( $currency_code !== $this->get_store_currency()->get_code() ) {
+			return $this->localization_service->get_currency_format( $currency_code )['thousand_sep'];
+		}
+		return $separator;
 	}
 
 	/**
 	 * Returns the currency format to be used by WooCommerce.
 	 *
+	 * @param string $format The original currency format.
+	 *
 	 * @return string The currency format.
 	 */
-	public function get_woocommerce_price_format(): string {
+	public function get_woocommerce_price_format( $format ): string {
 		$currency_code = $this->multi_currency->get_selected_currency()->get_code();
-		$currency_pos  = $this->localization_service->get_currency_format( $currency_code )['currency_pos'];
+		if ( $currency_code !== $this->get_store_currency()->get_code() ) {
+			$currency_pos = $this->localization_service->get_currency_format( $currency_code )['currency_pos'];
 
-		switch ( $currency_pos ) {
-			case 'left':
-				return '%1$s%2$s';
-			case 'right':
-				return '%2$s%1$s';
-			case 'left_space':
-				return '%1$s&nbsp;%2$s';
-			case 'right_space':
-				return '%2$s&nbsp;%1$s';
-			default:
-				return '%1$s%2$s';
+			switch ( $currency_pos ) {
+				case 'left':
+					return '%1$s%2$s';
+				case 'right':
+					return '%2$s%1$s';
+				case 'left_space':
+					return '%1$s&nbsp;%2$s';
+				case 'right_space':
+					return '%2$s&nbsp;%1$s';
+				default:
+					return '%1$s%2$s';
+			}
 		}
+		return $format;
 	}
 
 	/**

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -45,12 +45,13 @@ class FrontendCurrencies {
 	public function __construct( MultiCurrency $multi_currency, WC_Payments_Localization_Service $localization_service ) {
 		$this->multi_currency       = $multi_currency;
 		$this->localization_service = $localization_service;
+		$store_currency             = get_option( 'woocommerce_currency' );
 
 		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
+			// Currency hooks.
 			add_filter( 'woocommerce_currency', [ $this, 'get_woocommerce_currency' ], 50 );
 			// If the store currency is the same with the customer currency, disable formatting hooks.
-			if ( $this->multi_currency->get_default_currency() !== $this->multi_currency->get_selected_currency() ) {
-				// Currency hooks.
+			if ( $store_currency !== $this->get_woocommerce_currency() ) {
 				add_filter( 'wc_get_price_decimals', [ $this, 'get_price_decimals' ], 50 );
 				add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 50 );
 				add_filter( 'wc_get_price_thousand_separator', [ $this, 'get_price_thousand_separator' ], 50 );

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -47,12 +47,17 @@ class FrontendCurrencies {
 		$this->localization_service = $localization_service;
 
 		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
-			// Currency hooks.
+
 			add_filter( 'woocommerce_currency', [ $this, 'get_woocommerce_currency' ], 50 );
-			add_filter( 'wc_get_price_decimals', [ $this, 'get_price_decimals' ], 50 );
-			add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 50 );
-			add_filter( 'wc_get_price_thousand_separator', [ $this, 'get_price_thousand_separator' ], 50 );
-			add_filter( 'woocommerce_price_format', [ $this, 'get_woocommerce_price_format' ], 50 );
+
+			// If the store currency is the same with the customer currency, disable formatting hooks.
+			if ( $this->get_woocommerce_currency() !== get_woocommerce_currency() ) {
+				// Currency hooks.
+				add_filter( 'wc_get_price_decimals', [ $this, 'get_price_decimals' ], 50 );
+				add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 50 );
+				add_filter( 'wc_get_price_thousand_separator', [ $this, 'get_price_thousand_separator' ], 50 );
+				add_filter( 'woocommerce_price_format', [ $this, 'get_woocommerce_price_format' ], 50 );
+			}
 		}
 
 		add_filter( 'woocommerce_cart_hash', [ $this, 'add_currency_to_cart_hash' ], 50 );

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -47,11 +47,9 @@ class FrontendCurrencies {
 		$this->localization_service = $localization_service;
 
 		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
-
 			add_filter( 'woocommerce_currency', [ $this, 'get_woocommerce_currency' ], 50 );
-
 			// If the store currency is the same with the customer currency, disable formatting hooks.
-			if ( $this->get_woocommerce_currency() !== get_woocommerce_currency() ) {
+			if ( $this->multi_currency->get_default_currency() !== $this->multi_currency->get_selected_currency() ) {
 				// Currency hooks.
 				add_filter( 'wc_get_price_decimals', [ $this, 'get_price_decimals' ], 50 );
 				add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 50 );

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -53,10 +53,9 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	 * @dataProvider woocommerce_filter_provider
 	 */
 	public function test_registers_woocommerce_filter_with_same_customer_currency( $filter, $function_name, $load_when_same_currency ) {
-
-		$current_currency = new Currency( get_woocommerce_currency() );
-		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
+		$current_currency = new Currency( 'USD' );
 		$this->mock_multi_currency->method( 'get_default_currency' )->willReturn( $current_currency );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $current_currency );
 		$this->remove_all_multicurrency_filters();
 		$this->frontend_currencies = new FrontendCurrencies( $this->mock_multi_currency, $this->mock_localization_service );
 
@@ -75,7 +74,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 	 * @dataProvider woocommerce_filter_provider
 	 */
 	public function test_registers_woocommerce_filter_with_different_customer_currency( $filter, $function_name ) {
-		$current_currency   = new Currency( get_woocommerce_currency() );
+		$current_currency   = new Currency( 'USD' );
 		$different_currency = new Currency( 'GBP' );
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( $different_currency );
 		$this->mock_multi_currency->method( 'get_default_currency' )->willReturn( $current_currency );
@@ -88,7 +87,6 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 			"Filter '$filter' was not registered with '$function_name' with a priority higher than the default"
 		);
 	}
-
 
 	public function remove_all_multicurrency_filters() {
 		$filters = $this->woocommerce_filter_provider();


### PR DESCRIPTION
Fixes #2658

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

Enable format overrides only for the store currency on frontend

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR brings the store currency format customizations located in **WooCommerce > Settings** back by disabling some of the filters that `\WCPay\MultiCurrency\FrontendCurrencies` class when the request came from the frontend, and the customer's currency is the same currency with the store.
 
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

I've also splitted the test for checking the filters into two, the first part tests what happens when the customer currency is the same with the store currency, and the second part tests which filters are loaded and which are not when the customer has a different currency set.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Manual testing
* Prepare your store currency settings with modified values for decimal separator, thousand separator, currency position and decimal places to something that you can easily distinguish. For example I've chosen `d` as the decimal separator, `t` as the thousand separator, 3 as the decimal places and right space as the symbol position.
* Go to your store and ensure the account currency is the same with the store currency
* Check if the modified formats are applied. 
* Enter to the details of one product from the home page/shop page
* Using the currency switcher change the account currency, check if the format for that currency applies instead of your modified format settings
* Revert back to the store currency using the currency switcher widget, and check if your modified settings are applied.
* Do the same tests without the currency switcher, changing the currency from _My Account > Account Details > Default Currency_ select box.
**Bonus test**: Check if the totals are shown in their explicit formats (Currency code appended)

Automated Testing
* run `npm run test`

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
