### PR TITLE
Initial fix for disabling Multi-Currency if there is not a connected account

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Payments Changelog ***
 
-= 2.9.0 - 2021-xx-xx =
+= 2.8.1 - 2021-xx-xx =
+* Fix - Enable Multi-Currency only if there is a linked WooCommerce Payments account.
 
 = 2.8.0 - 2021-08-04 =
 * Add - Allow merchants to add additional currencies to their store, allowing a store’s customers to shop and browse in the currency of their choice.

--- a/client/multi-currency/index.js
+++ b/client/multi-currency/index.js
@@ -51,6 +51,14 @@ if ( storeSettingsSection ) {
 	toggleSettingsSectionDisplay();
 }
 
+const enabledCurrenciesOnboarding = document.querySelector(
+	'#wcpay_enabled_currencies_onboarding_cta'
+);
+
+if ( enabledCurrenciesOnboarding ) {
+	submitButton.style.display = 'none';
+}
+
 /**
  * Single currency settings
  */

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -176,6 +176,16 @@ class MultiCurrency {
 		$this->compatibility        = new Compatibility( $this, $this->utils );
 		$this->analytics            = new Analytics( $this );
 
+		if ( is_admin() ) {
+			add_filter( 'woocommerce_get_settings_pages', [ $this, 'init_settings_pages' ] );
+			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_scripts' ] );
+		}
+
+		// Check to see if the account is connected.
+		if ( null === $this->payments_account->get_stripe_account_id() ) {
+			return;
+		}
+
 		add_action( 'init', [ $this, 'init' ] );
 		add_action( 'rest_api_init', [ $this, 'init_rest_api' ] );
 		add_action( 'widgets_init', [ $this, 'init_widgets' ] );
@@ -220,7 +230,6 @@ class MultiCurrency {
 		$this->frontend_currencies = new FrontendCurrencies( $this, $this->localization_service );
 		$this->backend_currencies  = new BackendCurrencies( $this, $this->localization_service );
 
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_scripts' ] );
 		add_action( 'woocommerce_order_refunded', [ $this, 'add_order_meta_on_refund' ], 50, 2 );
 
 		// Check to make sure there are enabled currencies, then for Storefront being active, and then load the integration.
@@ -230,7 +239,6 @@ class MultiCurrency {
 		}
 
 		if ( is_admin() ) {
-			add_filter( 'woocommerce_get_settings_pages', [ $this, 'init_settings_pages' ] );
 			add_action( 'admin_init', [ __CLASS__, 'add_woo_admin_notes' ] );
 		}
 	}
@@ -263,7 +271,7 @@ class MultiCurrency {
 	 * @return array The new settings pages.
 	 */
 	public function init_settings_pages( $settings_pages ): array {
-		$settings_pages[] = new Settings( $this );
+		$settings_pages[] = new Settings( $this, $this->payments_account );
 		return $settings_pages;
 	}
 

--- a/includes/multi-currency/Settings.php
+++ b/includes/multi-currency/Settings.php
@@ -7,6 +7,7 @@
 
 namespace WCPay\MultiCurrency;
 
+use WC_Payments_Account;
 use WCPay\MultiCurrency\Currency;
 
 defined( 'ABSPATH' ) || exit;
@@ -38,6 +39,13 @@ class Settings extends \WC_Settings_Page {
 	protected $multi_currency;
 
 	/**
+	 * Instance of WC_Payments_Account class.
+	 *
+	 * @var WC_Payments_Account
+	 */
+	protected $payments_account;
+
+	/**
 	 * Link to the multi-currency documentation page.
 	 *
 	 * @var string
@@ -47,22 +55,29 @@ class Settings extends \WC_Settings_Page {
 	/**
 	 * Constructor.
 	 *
-	 * @param MultiCurrency $multi_currency The MultiCurrency instance.
+	 * @param MultiCurrency       $multi_currency The MultiCurrency instance.
+	 * @param WC_Payments_Account $payments_account The WC_Payments_Account instance.
 	 */
-	public function __construct( MultiCurrency $multi_currency ) {
-		$this->multi_currency = $multi_currency;
-		$this->id             = $this->multi_currency->id;
-		$this->label          = _x( 'Multi-currency', 'Settings tab label', 'woocommerce-payments' );
+	public function __construct( MultiCurrency $multi_currency, WC_Payments_Account $payments_account ) {
+		$this->multi_currency   = $multi_currency;
+		$this->payments_account = $payments_account;
+		$this->id               = $this->multi_currency->id;
+		$this->label            = _x( 'Multi-currency', 'Settings tab label', 'woocommerce-payments' );
 
-		// TODO: We need to re-enable it on every screen we use emoji flags. Until WC Admin decide if they will enable it too: https://github.com/woocommerce/woocommerce-admin/issues/6388.
-		add_action( 'admin_print_scripts', 'print_emoji_detection_script' );
-		add_action( 'woocommerce_admin_field_wcpay_enabled_currencies_list', [ $this, 'enabled_currencies_list' ] );
-		add_action( 'woocommerce_admin_field_wcpay_currencies_settings_section_start', [ $this, 'currencies_settings_section_start' ] );
-		add_action( 'woocommerce_admin_field_wcpay_currencies_settings_section_end', [ $this, 'currencies_settings_section_end' ] );
+		// If we do not have an account, then we don't need to add these actions.
+		if ( null !== $this->payments_account->get_stripe_account_id() ) {
+			// TODO: We need to re-enable it on every screen we use emoji flags. Until WC Admin decide if they will enable it too: https://github.com/woocommerce/woocommerce-admin/issues/6388.
+			add_action( 'admin_print_scripts', 'print_emoji_detection_script' );
+			add_action( 'woocommerce_admin_field_wcpay_enabled_currencies_list', [ $this, 'enabled_currencies_list' ] );
+			add_action( 'woocommerce_admin_field_wcpay_currencies_settings_section_start', [ $this, 'currencies_settings_section_start' ] );
+			add_action( 'woocommerce_admin_field_wcpay_currencies_settings_section_end', [ $this, 'currencies_settings_section_end' ] );
 
-		add_action( 'woocommerce_admin_field_wcpay_single_currency_preview_helper', [ $this, 'single_currency_preview_helper' ] );
+			add_action( 'woocommerce_admin_field_wcpay_single_currency_preview_helper', [ $this, 'single_currency_preview_helper' ] );
 
-		add_action( 'woocommerce_settings_' . $this->id, [ $this, 'render_single_currency_breadcrumbs' ] );
+			add_action( 'woocommerce_settings_' . $this->id, [ $this, 'render_single_currency_breadcrumbs' ] );
+		} else {
+			add_action( 'woocommerce_admin_field_wcpay_currencies_settings_onboarding_cta', [ $this, 'currencies_settings_onboarding_cta' ] );
+		}
 		parent::__construct();
 	}
 
@@ -88,6 +103,25 @@ class Settings extends \WC_Settings_Page {
 	 */
 	public function get_settings( $current_section = '' ) {
 		$settings = [];
+
+		// If we do not have an account, then we display a CTA to finish onboarding.
+		if ( null === $this->payments_account->get_stripe_account_id() ) {
+			return [
+				[
+					'title' => __( 'Enabled currencies', 'woocommerce-payments' ),
+					'desc'  => sprintf(
+						/* translators: %s: url to documentation. */
+						__( 'Accept payments in multiple currencies. Prices are converted based on exchange rates and rounding rules. <a href="%s">Learn more</a>', 'woocommerce-payments' ),
+						self::LEARN_MORE_URL
+					),
+					'type'  => 'title',
+					'id'    => $this->id . '_enabled_currencies',
+				],
+				[
+					'type' => 'wcpay_currencies_settings_onboarding_cta',
+				],
+			];
+		}
 
 		if ( '' === $current_section ) {
 			$settings = apply_filters(
@@ -208,6 +242,27 @@ class Settings extends \WC_Settings_Page {
 	}
 
 	/**
+	 * Output the call to action button if needing to onboard.
+	 */
+	public function currencies_settings_onboarding_cta() {
+		$params = [
+			'page' => 'wc-admin',
+			'path' => '/payments/connect',
+		];
+		$href   = admin_url( add_query_arg( $params, 'admin.php' ) );
+		?>
+			<div>
+				<p>
+					<?php esc_html_e( 'To add new currencies to your store, please finish setting up WooCommerce Payments.', 'woocommerce-payments' ); ?>
+				</p>
+				<a href="<?php echo esc_url( $href ); ?>" id="wcpay_enabled_currencies_onboarding_cta" type="button" class="button-primary">
+					<?php esc_html_e( 'Add currencies', 'woocommerce-payments' ); ?>
+				</a>
+			</div>
+		<?php
+	}
+
+	/**
 	 * Output hidden fields for preview.
 	 */
 	public function single_currency_preview_helper() {
@@ -242,8 +297,6 @@ class Settings extends \WC_Settings_Page {
 		</tr>
 		<?php
 	}
-
-
 
 	/**
 	 * Returns the settings for the single currency.

--- a/includes/multi-currency/Settings.php
+++ b/includes/multi-currency/Settings.php
@@ -256,7 +256,7 @@ class Settings extends \WC_Settings_Page {
 					<?php esc_html_e( 'To add new currencies to your store, please finish setting up WooCommerce Payments.', 'woocommerce-payments' ); ?>
 				</p>
 				<a href="<?php echo esc_url( $href ); ?>" id="wcpay_enabled_currencies_onboarding_cta" type="button" class="button-primary">
-					<?php esc_html_e( 'Add currencies', 'woocommerce-payments' ); ?>
+					<?php esc_html_e( 'Get started', 'woocommerce-payments' ); ?>
 				</a>
 			</div>
 		<?php

--- a/readme.txt
+++ b/readme.txt
@@ -98,7 +98,8 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
-= 2.9.0 - 2021-xx-xx =
+= 2.8.1 - 2021-xx-xx =
+* Fix - Enable Multi-Currency only if there is a linked WooCommerce Payments account.
 
 = 2.8.0 - 2021-08-04 =
 * Add - Allow merchants to add additional currencies to their store, allowing a store’s customers to shop and browse in the currency of their choice.

--- a/tests/unit/multi-currency/test-class-settings.php
+++ b/tests/unit/multi-currency/test-class-settings.php
@@ -48,10 +48,14 @@ class WCPay_Multi_Currency_Settings_Tests extends WP_UnitTestCase {
 	/**
 	 * @dataProvider woocommerce_action_provider
 	 */
-	public function test_registers_woocommerce_action_with_account( $action, $function_name ) {
+	public function test_registers_internal_actions_with_account( $action, $function_name ) {
 		$this->mock_payments_account
 			->method( 'get_stripe_account_id' )
 			->willReturn( [] );
+
+		// Init Settings again to get proper registration of hooks/filters.
+		$this->settings = new WCPay\MultiCurrency\Settings( $this->mock_multi_currency, $this->mock_payments_account );
+
 		$this->assertNotFalse(
 			has_action( $action, [ $this->settings, $function_name ] ),
 			"Action '$action' was not registered with '$function_name'"
@@ -60,8 +64,7 @@ class WCPay_Multi_Currency_Settings_Tests extends WP_UnitTestCase {
 
 	public function woocommerce_action_provider() {
 		return [
-			[ 'admin_print_scripts', 'enabled_currencies_list' ],
-			[ 'woocommerce_admin_field_wcpay_enabled_currencies_list', 'print_emoji_detection_script' ],
+			[ 'woocommerce_admin_field_wcpay_enabled_currencies_list', 'enabled_currencies_list' ],
 			[ 'woocommerce_admin_field_wcpay_currencies_settings_section_start', 'currencies_settings_section_start' ],
 			[ 'woocommerce_admin_field_wcpay_currencies_settings_section_end', 'currencies_settings_section_end' ],
 			[ 'woocommerce_admin_field_wcpay_single_currency_preview_helper', 'single_currency_preview_helper' ],
@@ -69,10 +72,31 @@ class WCPay_Multi_Currency_Settings_Tests extends WP_UnitTestCase {
 		];
 	}
 
-	public function test_registers_woocommerce_action_without_account() {
+	public function test_registers_external_action_with_account() {
+		$this->mock_payments_account
+			->method( 'get_stripe_account_id' )
+			->willReturn( [] );
+
+		// Init Settings again to get proper registration of hooks/filters.
+		$this->settings = new WCPay\MultiCurrency\Settings( $this->mock_multi_currency, $this->mock_payments_account );
+
+		$action        = 'admin_print_scripts';
+		$function_name = 'print_emoji_detection_script';
+
+		$this->assertNotFalse(
+			has_action( $action, $function_name ),
+			"Action '$action' was not registered with '$function_name'"
+		);
+	}
+
+	public function test_registers_internal_action_without_account() {
 		$this->mock_payments_account
 			->method( 'get_stripe_account_id' )
 			->willReturn( null );
+
+		// Init Settings again to get proper registration of hooks/filters.
+		$this->settings = new WCPay\MultiCurrency\Settings( $this->mock_multi_currency, $this->mock_payments_account );
+
 		$action        = 'woocommerce_admin_field_wcpay_currencies_settings_onboarding_cta';
 		$function_name = 'currencies_settings_onboarding_cta';
 

--- a/tests/unit/multi-currency/test-class-settings.php
+++ b/tests/unit/multi-currency/test-class-settings.php
@@ -31,16 +31,20 @@ class WCPay_Multi_Currency_Settings_Tests extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->mock_multi_currency = $this->createMock( WCPay\MultiCurrency\MultiCurrency::class );
+		$this->mock_multi_currency      = $this->createMock( WCPay\MultiCurrency\MultiCurrency::class );
+		$this->mock_wc_payments_account = $this->createMock( WC_Payments_Account::class );
 
 		// The settings pages file is only included in woocommerce_get_settings_pages, so we need to manually include it here.
-		$this->settings = new WCPay\MultiCurrency\Settings( $this->mock_multi_currency );
+		$this->settings = new WCPay\MultiCurrency\Settings( $this->mock_multi_currency, $this->mock_wc_payments_account );
 	}
 
 	/**
 	 * @dataProvider woocommerce_action_provider
 	 */
 	public function test_registers_woocommerce_action( $action, $function_name ) {
+		$this->mock_wc_payments_account
+			->method( 'get_stripe_account_id' )
+			->willReturn( [] );
 		$this->assertNotFalse(
 			has_action( $action, [ $this->settings, $function_name ] ),
 			"Action '$action' was not registered with '$function_name'"


### PR DESCRIPTION
Fixes #2657

#### Changes proposed in this Pull Request

* Check to see if there's a linked account to WCPay before allowing use of Multi-Currency. 
* `MultiCurrency` was updated to include the actions/filters for `Settings` before checking for the account, so that the Multi-Currency tab will still display. If there's no account, the rest of the feature is not initialized, including the currencies.
* `Settings` also checks for a linked account and applies the proper filters/actions according to what's needed. From there the proper settings are displayed, if there's no account then a call to action button is displayed to direct the merchant to complete onboarding.

#### Testing instructions

* With your account linked navigate to WooCommerce > Settings > Multi-Currency.
* Confirm that you are able to add new currencies with the _Add Currencies_ button.
* Remove all currencies.
* Using dev tools, check the _Force the plugin to act as disconnected from WCPay_ option and save.
* Navigate back to WooCommerce > Settings > Multi-Currency.
* Enabled currencies table should not load, there should be a message stating, "To add new currencies to your store, please finish setting up WooCommerce Payments." along with a button.
* Click _Get Started_ button, it should take you to the onboarding page to "Finish setup".

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
