### PR TITLE
Improve explicit currency code check

### DIFF
--- a/includes/class-wc-payments-explicit-price-formatter.php
+++ b/includes/class-wc-payments-explicit-price-formatter.php
@@ -60,11 +60,15 @@ class WC_Payments_Explicit_Price_Formatter {
 			$currency_code = $order->get_currency();
 		}
 
-		if ( substr( $price, - strlen( $currency_code ) ) === $currency_code ) {
-			return $price;
+		if ( ! empty( $currency_code ) ) {
+			$price_to_check = html_entity_decode( wp_strip_all_tags( $price ) );
+
+			if ( false === strpos( $price_to_check, trim( $currency_code ) ) ) {
+				return $price . ' ' . $currency_code;
+			}
 		}
 
-		return $price . ' ' . $currency_code;
+		return $price;
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-explicit-price-formatter.php
+++ b/tests/unit/test-class-wc-payments-explicit-price-formatter.php
@@ -23,4 +23,11 @@ class WC_Payments_Explicit_Price_Formatter_Test extends WP_UnitTestCase {
 	public function test_get_explicit_price_skips_already_explicit_prices() {
 		$this->assertSame( '$10.30 USD', WC_Payments_Explicit_Price_Formatter::get_explicit_price( '$10.30 USD' ) );
 	}
+
+	public function test_get_explicit_price_skips_prefixed_prices() {
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_currency' )->willReturn( 'CHF' );
+
+		$this->assertSame( 'CHF 10.30', WC_Payments_Explicit_Price_Formatter::get_explicit_price( 'CHF 10.30', $order ) );
+	}
 }

--- a/tests/unit/test-class-wc-payments-explicit-price-formatter.php
+++ b/tests/unit/test-class-wc-payments-explicit-price-formatter.php
@@ -170,8 +170,8 @@ class WC_Payments_Explicit_Price_Formatter_Test extends WP_UnitTestCase {
 		$order->method( 'get_currency' )->willReturn( 'CHF' );
 
 		$this->assertSame( 'CHF 10.30', WC_Payments_Explicit_Price_Formatter::get_explicit_price( 'CHF 10.30', $order ) );
-  }
-  
+	}
+
 	public function test_get_explicit_price_with_order_currency_on_frontend_with_one_enabled_currency() {
 		$this->prepare_one_enabled_currency();
 		$order = $this->createMock( WC_Order::class );


### PR DESCRIPTION
Fixes #2640

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

This PR improves the currency code check on prices, previously it was checking if the price ends with the currency code, now it checks if the price contains the currency code. This was causing duplicate currency codes rendered on the price if the currency code was prefixed to the price as the currency symbol for currencies like **CHF**. 

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add 'CHF' as an enabled currency for customers to select in the backend **WooCommerce > Settings > Multi-Currency > Available currencies** screen
* Go to the shop and select CHF as the account currency
* Add an item to the cart and visit cart page
* Check if the cart total shows as **CHF #,###.00** instead of **CHF #,###.00 CHF**
* Select 'USD' from the currency switcher if available, if not, use the **Default currency** select on **My Account > Account Details** page.
* Go to the Cart page again, and check if you see **$##.###,00 USD** 

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
