### PR TITLE
Adds subscription product service

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -133,6 +133,13 @@ class WC_Payments {
 	private static $apple_pay_registration;
 
 	/**
+	 * Instance of WC_Payments_Product_Service, created in init function.
+	 *
+	 * @var WC_Payments_Product_Service
+	 */
+	private static $product_service;
+
+	/**
 	 * Cache for plugin headers to avoid multiple calls to get_file_data
 	 *
 	 * @var array
@@ -184,6 +191,7 @@ class WC_Payments {
 		include_once __DIR__ . '/payment-methods/class-giropay-payment-method.php';
 		include_once __DIR__ . '/payment-methods/class-sofort-payment-method.php';
 		include_once __DIR__ . '/payment-methods/class-ideal-payment-method.php';
+		include_once __DIR__ . '/subscriptions/class-wc-payments-product-service.php';
 		include_once __DIR__ . '/class-wc-payment-token-wcpay-sepa.php';
 		include_once __DIR__ . '/class-wc-payments-token-service.php';
 		include_once __DIR__ . '/class-wc-payments-payment-request-button-handler.php';
@@ -214,6 +222,7 @@ class WC_Payments {
 
 		self::$account                  = new WC_Payments_Account( self::$api_client );
 		self::$customer_service         = new WC_Payments_Customer_Service( self::$api_client, self::$account );
+		self::$product_service          = new WC_Payments_Product_Service( self::$api_client );
 		self::$token_service            = new WC_Payments_Token_Service( self::$api_client, self::$customer_service );
 		self::$remote_note_service      = new WC_Payments_Remote_Note_Service( WC_Data_Store::load( 'admin-note' ) );
 		self::$action_scheduler_service = new WC_Payments_Action_Scheduler_Service( self::$api_client );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -133,13 +133,6 @@ class WC_Payments {
 	private static $apple_pay_registration;
 
 	/**
-	 * Instance of WC_Payments_Product_Service, created in init function.
-	 *
-	 * @var WC_Payments_Product_Service
-	 */
-	private static $product_service;
-
-	/**
 	 * Cache for plugin headers to avoid multiple calls to get_file_data
 	 *
 	 * @var array
@@ -191,7 +184,6 @@ class WC_Payments {
 		include_once __DIR__ . '/payment-methods/class-giropay-payment-method.php';
 		include_once __DIR__ . '/payment-methods/class-sofort-payment-method.php';
 		include_once __DIR__ . '/payment-methods/class-ideal-payment-method.php';
-		include_once __DIR__ . '/subscriptions/class-wc-payments-product-service.php';
 		include_once __DIR__ . '/class-wc-payment-token-wcpay-sepa.php';
 		include_once __DIR__ . '/class-wc-payments-token-service.php';
 		include_once __DIR__ . '/class-wc-payments-payment-request-button-handler.php';
@@ -222,7 +214,6 @@ class WC_Payments {
 
 		self::$account                  = new WC_Payments_Account( self::$api_client );
 		self::$customer_service         = new WC_Payments_Customer_Service( self::$api_client, self::$account );
-		self::$product_service          = new WC_Payments_Product_Service( self::$api_client );
 		self::$token_service            = new WC_Payments_Token_Service( self::$api_client, self::$customer_service );
 		self::$remote_note_service      = new WC_Payments_Remote_Note_Service( WC_Data_Store::load( 'admin-note' ) );
 		self::$action_scheduler_service = new WC_Payments_Action_Scheduler_Service( self::$api_client );
@@ -303,6 +294,10 @@ class WC_Payments {
 				new WC_Payments_Admin_Sections_Overwrite( self::get_account_service() );
 			}
 		}
+
+		// Load subscriptions (Stripe Billing).
+		include_once WCPAY_ABSPATH . '/includes/subscriptions/class-wc-payments-subscriptions.php';
+		WC_Payments_Subscriptions::init( self::$api_client );
 
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ __CLASS__, 'set_plugin_activation_timestamp' ] );

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -1,0 +1,354 @@
+<?php
+/**
+ * Class WC_Payments_Product_Service
+ *
+ * @package WooCommerce\Payments
+ */
+
+use WCPay\Exceptions\API_Exception;
+use WCPay\Logger;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class handling any subscription product functionality
+ */
+class WC_Payments_Product_Service {
+	/**
+	 * The product meta key used to store the product data we last sent to Stripe as a hash. Used to compare current WC product data with Stripe data.
+	 *
+	 * @const string
+	 */
+	const PRODUCT_HASH_KEY = '_wcpay_product_hash';
+
+	/**
+	 * The product meta key used to store the product's ID in Stripe.
+	 *
+	 * @const string
+	 */
+	const PRODUCT_ID_KEY = '_wcpay_product_id';
+
+	/**
+	 * The product meta key used to store the product's Stripe Price object ID.
+	 *
+	 * @const string
+	 */
+	const PRICE_ID_KEY = '_wcpay_product_price_id';
+
+	/**
+	 * Client for making requests to the WooCommerce Payments API
+	 *
+	 * @var WC_Payments_API_Client
+	 */
+	private $payments_api_client;
+
+	/**
+	 * The list of products we need to update at the end of each request.
+	 *
+	 * @var array
+	 */
+	private $products_to_update = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Payments_API_Client $payments_api_client Payments API client.
+	 */
+	public function __construct( WC_Payments_API_Client $payments_api_client ) {
+		$this->payments_api_client = $payments_api_client;
+
+		add_action( 'woocommerce_update_product_variation', [ $this, 'maybe_schedule_product_create_or_update' ], 10, 2 );
+		add_action( 'woocommerce_update_product', [ $this, 'maybe_schedule_product_create_or_update' ], 10, 2 );
+		add_action( 'shutdown', [ $this, 'create_or_update_products' ] );
+		add_action( 'wp_trash_post', [ $this, 'maybe_archive_product' ] );
+		add_action( 'untrashed_post', [ $this, 'maybe_unarchive_product' ] );
+	}
+
+	/**
+	 * Gets the Stripe product hash associated with a WC product.
+	 *
+	 * @param WC_Product $product The product to get the hash for.
+	 * @return string             The product's hash or an empty string.
+	 */
+	public static function get_stripe_product_hash( WC_Product $product ) : string {
+		return $product->get_meta( self::PRODUCT_HASH_KEY, true );
+	}
+
+	/**
+	 * Gets the Stripe product ID associated with a WC product.
+	 *
+	 * @param WC_Product $product The product to get the Stripe ID for.
+	 * @return string             The Stripe product ID or an empty string.
+	 */
+	public static function get_stripe_product_id( WC_Product $product ) : string {
+		return $product->get_meta( self::PRODUCT_ID_KEY, true );
+	}
+
+	/**
+	 * Gets the Stripe price ID associated with a WC product.
+	 *
+	 * @param WC_Product $product The product to get the Stripe price ID for.
+	 * @return string             The product's Stripe price ID or an empty string.
+	 */
+	public static function get_stripe_price_id( WC_Product $product ) : string {
+		return $product->get_meta( self::PRICE_ID_KEY, true );
+	}
+
+	/**
+	 * Creates or updates a subscription product in Stripe.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int        $product_id The ID of the product to handle.
+	 * @param WC_Product $product    The product object to handle. Only subscription products will be created or updated in Stripe.
+	 */
+	public function maybe_schedule_product_create_or_update( int $product_id, WC_Product $product ) {
+		// We're only interested in subscription products. The variable products aren't tracked in Stripe so skip them.
+		if ( WC_Subscriptions_Product::is_subscription( $product ) && ! $product->is_type( 'variable-subscription' ) ) {
+			foreach ( $this->get_products_to_update( $product ) as $product_to_update ) {
+				$this->products_to_update[ $product_to_update->get_id() ] = $product_to_update->get_id();
+			}
+		}
+	}
+
+	/**
+	 * Creates and updates all products which have been scheduled for an update.
+	 *
+	 * Hooked onto shutdown so all products which have been changed in the current request can be updated once.
+	 *
+	 * @since x.x.x
+	 */
+	public function create_or_update_products() {
+		foreach ( $this->products_to_update as $product_id ) {
+			$product = wc_get_product( $product_id );
+
+			if ( ! $product ) {
+				continue;
+			}
+
+			// If this product already has a Stripe ID update it, otherwise create a new one.
+			if ( $this->get_stripe_product_id( $product ) ) {
+				$this->update_product( $product );
+			} else {
+				$this->create_product( $product );
+			}
+		}
+	}
+
+	/**
+	 * Creates a product in Stripe.
+	 *
+	 * @param WC_Product $product The product to create.
+	 */
+	public function create_product( WC_Product $product ) {
+		try {
+			$product_data   = $this->get_product_data( $product );
+			$stripe_product = $this->payments_api_client->create_product( $product_data );
+
+			$this->set_stripe_product_hash( $product, $this->get_product_hash( $product ) );
+			$this->set_stripe_product_id( $product, $stripe_product['stripe_product_id'] );
+			$this->set_stripe_price_id( $product, $stripe_product['stripe_price_id'] );
+		} catch ( API_Exception $e ) {
+			Logger::log( 'There was a problem creating the product in Stripe:', $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Updates a product in Stripe.
+	 *
+	 * @param WC_Product $product The product to update.
+	 */
+	public function update_product( WC_Product $product ) {
+		$stripe_product_id = $this->get_stripe_product_id( $product );
+
+		// If the product doesn't have a Stripe ID yet, create it instead.
+		if ( ! $stripe_product_id ) {
+			$this->create_product( $product );
+			return;
+		}
+
+		// If the product has changed since our last update, update it. Uses a hash of product data at the time of last update to determine if it has changed.
+		if ( $this->get_product_hash( $product ) !== $this->get_stripe_product_hash( $product ) ) {
+			try {
+				$stripe_product = $this->payments_api_client->update_product( $stripe_product_id, $this->get_product_data( $product ) );
+
+				$this->set_stripe_product_hash( $product, $this->get_product_hash( $product ) );
+
+				if ( isset( $stripe_product['stripe_price_id'] ) ) {
+					$old_stripe_price_id = $this->get_stripe_price_id( $product );
+
+					$this->set_stripe_price_id( $product, $stripe_product['stripe_price_id'] );
+					$this->archive_price( $old_stripe_price_id );
+				}
+			} catch ( API_Exception $e ) {
+				Logger::log( 'There was a problem updating the product in Stripe:', $e->getMessage() );
+			}
+		}
+	}
+
+	/**
+	 * Archives a subscription product in Stripe.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int $post_id The ID of the post to handle. Only subscription product IDs will be archived in Stripe.
+	 */
+	public function maybe_archive_product( int $post_id ) {
+		$product = wc_get_product( $post_id );
+
+		if ( $product && WC_Subscriptions_Product::is_subscription( $product ) ) {
+			foreach ( $this->get_products_to_update( $product ) as $product ) {
+				$this->archive_product( $product );
+			}
+		}
+	}
+
+	/**
+	 * Unarchives a subscription product in Stripe.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int $post_id The ID of the post to handle. Only Subscription product post IDs will be unarchived in Stripe.
+	 */
+	public function maybe_unarchive_product( int $post_id ) {
+		$product = wc_get_product( $post_id );
+
+		if ( $product && WC_Subscriptions_Product::is_subscription( $product ) ) {
+			foreach ( $this->get_products_to_update( $product ) as $product ) {
+				$this->unarchive_product( $product );
+			}
+		}
+	}
+
+	/**
+	 * Gets data relevant to Stripe from a WC product.
+	 *
+	 * @param WC_Product $product The product to get data from.
+	 * @return array
+	 */
+	private function get_product_data( WC_Product $product ) : array {
+		return [
+			'currency'       => get_woocommerce_currency(),
+			'description'    => $product->get_description() ? $product->get_description() : 'N/A',
+			'name'           => $product->get_name(),
+			'interval'       => WC_Subscriptions_Product::get_period( $product ),
+			'interval_count' => WC_Subscriptions_Product::get_interval( $product ),
+			'unit_amount'    => floatval( $product->get_price() ) * 100,
+		];
+	}
+
+	/**
+	 * Gets the products to update from a given product.
+	 *
+	 * If applicable, returns the product's variations otherwise returns the product by itself.
+	 *
+	 * @param WC_Product $product The product.
+	 *
+	 * @return array The products to update.
+	 */
+	private function get_products_to_update( WC_Product $product ) : array {
+		return $product->is_type( 'variable-subscription' ) ? $product->get_available_variations( 'object' ) : [ $product ];
+	}
+
+	/**
+	 * Archives a product in Stripe.
+	 *
+	 * @param WC_Product $product The product to archive.
+	 */
+	private function archive_product( WC_Product $product ) {
+		$stripe_product_id = $this->get_stripe_product_id( $product );
+
+		if ( ! $stripe_product_id ) {
+			return;
+		}
+
+		try {
+			$this->archive_price( $this->get_stripe_price_id( $product ) );
+			$this->payments_api_client->update_product( $stripe_product_id, [ 'active' => 'false' ] );
+		} catch ( API_Exception $e ) {
+			Logger::log( 'There was a problem archiving the product in Stripe:', $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Unarchives a product in Stripe.
+	 *
+	 * @param WC_Product $product The product unarchive.
+	 */
+	private function unarchive_product( WC_Product $product ) {
+		$stripe_product_id = $this->get_stripe_product_id( $product );
+
+		if ( ! $stripe_product_id ) {
+			return;
+		}
+
+		try {
+			$this->unarchive_price( $this->get_stripe_price_id( $product ) );
+			$this->payments_api_client->update_product( $stripe_product_id, [ 'active' => 'true' ] );
+		} catch ( API_Exception $e ) {
+			Logger::log( 'There was a problem unarchiving the product in Stripe:', $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Gets a hash of the product's name and description.
+	 * Used to compare WC changes with Stripe data.
+	 *
+	 * @param WC_Product $product The product to generate the hash for.
+	 * @return string             The product's price hash.
+	 */
+	private function get_product_hash( WC_Product $product ) : string {
+		return md5( implode( $this->get_product_data( $product ) ) );
+	}
+
+	/**
+	 * Archives a Stripe price object.
+	 *
+	 * @param string $stripe_price_id The price object's ID to archive.
+	 */
+	private function archive_price( string $stripe_price_id ) {
+		$this->payments_api_client->update_price( $stripe_price_id, [ 'active' => 'false' ] );
+	}
+
+	/**
+	 * Unarchives a Stripe Price object.
+	 *
+	 * @param string $stripe_price_id The Price object's ID to unarchive.
+	 */
+	private function unarchive_price( string $stripe_price_id ) {
+		$this->payments_api_client->update_price( $stripe_price_id, [ 'active' => 'true' ] );
+	}
+
+	/**
+	 * Sets a Stripe product hash on a WC product.
+	 *
+	 * @param WC_Product $product The product to set the Stripe price hash for.
+	 * @param string     $value   The Stripe product hash.
+	 */
+	private function set_stripe_product_hash( WC_Product $product, string $value ) {
+		$product->update_meta_data( self::PRODUCT_HASH_KEY, $value );
+		$product->save();
+	}
+
+	/**
+	 * Sets a Stripe product ID on a WC product.
+	 *
+	 * @param WC_Product $product The product to set the Stripe ID for.
+	 * @param string     $value   The Stripe product ID.
+	 */
+	private function set_stripe_product_id( WC_Product $product, string $value ) {
+		$product->update_meta_data( self::PRODUCT_ID_KEY, $value );
+		$product->save();
+	}
+
+	/**
+	 * Set a Stripe price ID on a WC product.
+	 *
+	 * @param WC_Product $product The product to set the Stripe price ID for.
+	 * @param string     $value   The Stripe price ID.
+	 */
+	private function set_stripe_price_id( WC_Product $product, string $value ) {
+		$product->update_meta_data( self::PRICE_ID_KEY, $value );
+		$product->save();
+	}
+}

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -221,6 +221,64 @@ class WC_Payments_Product_Service {
 	}
 
 	/**
+	 * Archives a product in Stripe.
+	 *
+	 * @param WC_Product $product The product to archive.
+	 */
+	public function archive_product( WC_Product $product ) {
+		$stripe_product_id = $this->get_stripe_product_id( $product );
+
+		if ( ! $stripe_product_id ) {
+			return;
+		}
+
+		try {
+			$this->archive_price( $this->get_stripe_price_id( $product ) );
+			$this->payments_api_client->update_product( $stripe_product_id, [ 'active' => 'false' ] );
+		} catch ( API_Exception $e ) {
+			Logger::log( 'There was a problem archiving the product in Stripe:', $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Unarchives a product in Stripe.
+	 *
+	 * @param WC_Product $product The product unarchive.
+	 */
+	public function unarchive_product( WC_Product $product ) {
+		$stripe_product_id = $this->get_stripe_product_id( $product );
+
+		if ( ! $stripe_product_id ) {
+			return;
+		}
+
+		try {
+			$this->unarchive_price( $this->get_stripe_price_id( $product ) );
+			$this->payments_api_client->update_product( $stripe_product_id, [ 'active' => 'true' ] );
+		} catch ( API_Exception $e ) {
+			Logger::log( 'There was a problem unarchiving the product in Stripe:', $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Archives a Stripe price object.
+	 *
+	 * @param string $stripe_price_id The price object's ID to archive.
+	 */
+	public function archive_price( string $stripe_price_id ) {
+		$this->payments_api_client->update_price( $stripe_price_id, [ 'active' => 'false' ] );
+	}
+
+	/**
+	 * Unarchives a Stripe Price object.
+	 *
+	 * @param string $stripe_price_id The Price object's ID to unarchive.
+	 */
+	public function unarchive_price( string $stripe_price_id ) {
+		$this->payments_api_client->update_price( $stripe_price_id, [ 'active' => 'true' ] );
+	}
+
+	/**
 	 * Gets data relevant to Stripe from a WC product.
 	 *
 	 * @param WC_Product $product The product to get data from.
@@ -251,46 +309,6 @@ class WC_Payments_Product_Service {
 	}
 
 	/**
-	 * Archives a product in Stripe.
-	 *
-	 * @param WC_Product $product The product to archive.
-	 */
-	private function archive_product( WC_Product $product ) {
-		$stripe_product_id = $this->get_stripe_product_id( $product );
-
-		if ( ! $stripe_product_id ) {
-			return;
-		}
-
-		try {
-			$this->archive_price( $this->get_stripe_price_id( $product ) );
-			$this->payments_api_client->update_product( $stripe_product_id, [ 'active' => 'false' ] );
-		} catch ( API_Exception $e ) {
-			Logger::log( 'There was a problem archiving the product in Stripe:', $e->getMessage() );
-		}
-	}
-
-	/**
-	 * Unarchives a product in Stripe.
-	 *
-	 * @param WC_Product $product The product unarchive.
-	 */
-	private function unarchive_product( WC_Product $product ) {
-		$stripe_product_id = $this->get_stripe_product_id( $product );
-
-		if ( ! $stripe_product_id ) {
-			return;
-		}
-
-		try {
-			$this->unarchive_price( $this->get_stripe_price_id( $product ) );
-			$this->payments_api_client->update_product( $stripe_product_id, [ 'active' => 'true' ] );
-		} catch ( API_Exception $e ) {
-			Logger::log( 'There was a problem unarchiving the product in Stripe:', $e->getMessage() );
-		}
-	}
-
-	/**
 	 * Gets a hash of the product's name and description.
 	 * Used to compare WC changes with Stripe data.
 	 *
@@ -299,24 +317,6 @@ class WC_Payments_Product_Service {
 	 */
 	private function get_product_hash( WC_Product $product ) : string {
 		return md5( implode( $this->get_product_data( $product ) ) );
-	}
-
-	/**
-	 * Archives a Stripe price object.
-	 *
-	 * @param string $stripe_price_id The price object's ID to archive.
-	 */
-	private function archive_price( string $stripe_price_id ) {
-		$this->payments_api_client->update_price( $stripe_price_id, [ 'active' => 'false' ] );
-	}
-
-	/**
-	 * Unarchives a Stripe Price object.
-	 *
-	 * @param string $stripe_price_id The Price object's ID to unarchive.
-	 */
-	private function unarchive_price( string $stripe_price_id ) {
-		$this->payments_api_client->update_price( $stripe_price_id, [ 'active' => 'true' ] );
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -291,7 +291,7 @@ class WC_Payments_Product_Service {
 			'name'           => $product->get_name(),
 			'interval'       => WC_Subscriptions_Product::get_period( $product ),
 			'interval_count' => WC_Subscriptions_Product::get_interval( $product ),
-			'unit_amount'    => floatval( $product->get_price() ) * 100,
+			'unit_amount'    => $product->get_price() * 100,
 		];
 	}
 

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Class WC_Payments_Subscriptions.
+ *
+ * @package WooCommerce\Payments
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class for loading WooCommerce Payments Subscriptions.
+ */
+class WC_Payments_Subscriptions {
+
+	/**
+	 * Instance of WC_Payments_Product_Service, created in init function.
+	 *
+	 * @var WC_Payments_Product_Service
+	 */
+	private static $product_service;
+
+	/**
+	 * Initialize WooCommerce Payments subscriptions. (Stripe Billing)
+	 *
+	 * @param WC_Payments_API_Client $api_client WCPay API client.
+	 */
+	public static function init( WC_Payments_API_Client $api_client ) {
+		include_once __DIR__ . '/class-wc-payments-product-service.php';
+		self::$product_service = new WC_Payments_Product_Service( $api_client );
+	}
+}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -42,6 +42,10 @@ class WC_Payments_API_Client {
 	const PAYMENT_METHODS_API = 'payment_methods';
 	const SETUP_INTENTS_API   = 'setup_intents';
 	const TRACKING_API        = 'tracking';
+	const PRODUCTS_API        = 'products';
+	const PRICES_API          = 'products/prices';
+	const SUBSCRIPTIONS_API   = 'subscriptions';
+	const INVOICES_API        = 'invoices';
 
 	/**
 	 * Common keys in API requests/responses that we might want to redact.
@@ -958,6 +962,73 @@ class WC_Payments_API_Client {
 		$this->request(
 			$customer_data,
 			self::CUSTOMERS_API . '/' . $customer_id,
+			self::POST
+		);
+	}
+
+	/**
+	 * Create a product.
+	 *
+	 * @param array $product_data Product data.
+	 *
+	 * @return array The created product's product, price, and tax rate IDs.
+	 *
+	 * @throws API_Exception Error creating the product.
+	 */
+	public function create_product( array $product_data ): array {
+		$product_array = $this->request(
+			$product_data,
+			self::PRODUCTS_API,
+			self::POST
+		);
+
+		return $product_array;
+	}
+
+	/**
+	 * Update a product.
+	 *
+	 * @param string $product_id    ID of product to update.
+	 * @param array  $product_data  Data to be updated.
+	 *
+	 * @throws API_Exception Error updating product.
+	 */
+	public function update_product( $product_id, $product_data = [] ) {
+		if ( null === $product_id || '' === trim( $product_id ) ) {
+			throw new API_Exception(
+				__( 'Product ID is required', 'woocommerce-payments' ),
+				'wcpay_mandatory_product_id_missing',
+				400
+			);
+		}
+
+		$this->request(
+			$product_data,
+			self::PRODUCTS_API . '/' . $product_id,
+			self::POST
+		);
+	}
+
+	/**
+	 * Update a price.
+	 *
+	 * @param string $price_id    ID of price to update.
+	 * @param array  $price_data  Data to be updated.
+	 *
+	 * @throws API_Exception Error updating price.
+	 */
+	public function update_price( $price_id, $price_data = [] ) {
+		if ( null === $price_id || '' === trim( $price_id ) ) {
+			throw new API_Exception(
+				__( 'Price ID is required', 'woocommerce-payments' ),
+				'wcpay_mandatory_price_id_missing',
+				400
+			);
+		}
+
+		$this->request(
+			$price_data,
+			self::PRICES_API . '/' . $price_id,
 			self::POST
 		);
 	}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -971,18 +971,16 @@ class WC_Payments_API_Client {
 	 *
 	 * @param array $product_data Product data.
 	 *
-	 * @return array The created product's product, price, and tax rate IDs.
+	 * @return array The created product's product and price IDs.
 	 *
 	 * @throws API_Exception Error creating the product.
 	 */
 	public function create_product( array $product_data ): array {
-		$product_array = $this->request(
+		return $this->request(
 			$product_data,
 			self::PRODUCTS_API,
 			self::POST
 		);
-
-		return $product_array;
 	}
 
 	/**
@@ -991,9 +989,11 @@ class WC_Payments_API_Client {
 	 * @param string $product_id    ID of product to update.
 	 * @param array  $product_data  Data to be updated.
 	 *
+	 * @return array The updated product's product and/or price IDs.
+	 *
 	 * @throws API_Exception Error updating product.
 	 */
-	public function update_product( $product_id, $product_data = [] ) {
+	public function update_product( string $product_id, array $product_data = [] ) : array {
 		if ( null === $product_id || '' === trim( $product_id ) ) {
 			throw new API_Exception(
 				__( 'Product ID is required', 'woocommerce-payments' ),
@@ -1002,7 +1002,7 @@ class WC_Payments_API_Client {
 			);
 		}
 
-		$this->request(
+		return $this->request(
 			$product_data,
 			self::PRODUCTS_API . '/' . $product_id,
 			self::POST
@@ -1017,7 +1017,7 @@ class WC_Payments_API_Client {
 	 *
 	 * @throws API_Exception Error updating price.
 	 */
-	public function update_price( $price_id, $price_data = [] ) {
+	public function update_price( string $price_id, array $price_data = [] ) {
 		if ( null === $price_id || '' === trim( $price_id ) ) {
 			throw new API_Exception(
 				__( 'Price ID is required', 'woocommerce-payments' ),

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -121,6 +121,11 @@
       <code>wcs_is_subscription( wc_clean( wp_unslash( $_GET['change_payment_method'] ) ) )</code>
     </UndefinedFunction>
   </file>
+  <file src="includes/subscriptions/class-wc-payments-product-service.php">
+    <UndefinedClass occurrences="5">
+      <code>WC_Subscriptions_Product</code>
+    </UndefinedClass>
+  </file>
   <file src="includes/wc-payment-api/class-wc-payments-http.php">
     <UndefinedDocblockClass occurrences="3">
       <code>$response</code>

--- a/tests/unit/helpers/class-wc-helper-subscriptions-product.php
+++ b/tests/unit/helpers/class-wc-helper-subscriptions-product.php
@@ -44,6 +44,24 @@ class WC_Subscriptions_Product {
 	}
 
 	/**
+	 * Mock for static get_sign_up_fee.
+	 *
+	 * @param Product $product WC Product.
+	 */
+	public static function get_sign_up_fee( $product ) {
+		return 0;
+	}
+
+	/**
+	 * Mock for static get_trial_length.
+	 *
+	 * @param Product $product WC Product.
+	 */
+	public static function get_trial_length( $product ) {
+		return 0;
+	}
+
+	/**
 	 * Mock for static is_subscription.
 	 *
 	 * @param Product $product WC Product.

--- a/tests/unit/helpers/class-wc-helper-subscriptions-product.php
+++ b/tests/unit/helpers/class-wc-helper-subscriptions-product.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Subscription WC_Subscriptions_Product helper.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * Class WC_Subscriptions_Product.
+ *
+ * This helper class should ONLY be used for unit tests!.
+ */
+class WC_Subscriptions_Product {
+	/**
+	 * Subscription product period.
+	 *
+	 * @var string
+	 */
+	public static $subscription_product_period = null;
+
+	/**
+	 * Subsscription product interval.
+	 *
+	 * @var int
+	 */
+	public static $subscription_product_interval = null;
+
+	/**
+	 * Mock for static get_period.
+	 *
+	 * @param Product $product WC Product.
+	 */
+	public static function get_period( $product ) {
+		return self::$subscription_product_period;
+	}
+
+	/**
+	 * Mock for static get_interval.
+	 *
+	 * @param Product $product WC Product.
+	 */
+	public static function get_interval( $product ) {
+		return self::$subscription_product_interval;
+	}
+
+	/**
+	 * Mock for static is_subscription.
+	 *
+	 * @param Product $product WC Product.
+	 */
+	public static function is_subscription( $product ) {
+		return true;
+	}
+
+	/**
+	 * Setter for get_period.
+	 *
+	 * @param string $result Result for get_period.
+	 */
+	public static function set_period( $result ) {
+		self::$subscription_product_period = $result;
+	}
+
+	/**
+	 * Setter for get_interval.
+	 *
+	 * @param int $result Result for get_interval.
+	 */
+	public static function set_interval( $result ) {
+		self::$subscription_product_interval = $result;
+	}
+}

--- a/tests/unit/subscriptions/test-class-wc-payments-product-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-product-service.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Class WC_Payments_Product_Service_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Exceptions\API_Exception;
+
+/**
+ * WC_Payments_Product_Service unit tests.
+ */
+class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
+
+	const PRODUCT_HASH_KEY = '_wcpay_product_hash';
+	const PRODUCT_ID_KEY   = '_wcpay_product_id';
+	const PRICE_ID_KEY     = '_wcpay_product_price_id';
+
+	/**
+	 * System under test.
+	 *
+	 * @var WC_Payments_Product_Service
+	 */
+	private $product_service;
+
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_API_Client|MockObject
+	 */
+	private $mock_api_client;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->mock_api_client = $this->createMock( WC_Payments_API_Client::class );
+		$this->product_service = new WC_Payments_Product_Service( $this->mock_api_client );
+	}
+
+	/**
+	 * Test create product.
+	 *
+	 * @throws API_Exception
+	 */
+	public function test_create_product() {
+		$mock_product      = $this->get_mock_product();
+		$mock_product_data = $this->get_mock_product_data();
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'create_product' )
+			->with( $mock_product_data )
+			->willReturn(
+				[
+					'stripe_product_id' => 'prod_test123',
+					'stripe_price_id'   => 'price_test123',
+				]
+			);
+
+		$this->product_service->create_product( $mock_product );
+		$this->assertEquals( 'prod_test123', $mock_product->get_meta( self::PRODUCT_ID_KEY, true ) );
+		$this->assertEquals( 'price_test123', $mock_product->get_meta( self::PRICE_ID_KEY, true ) );
+	}
+
+	/**
+	 * Test update product.
+	 *
+	 * @throws API_Exception
+	 */
+	public function test_update_product() {
+		$user = new WP_User( 0 );
+
+		$mock_product      = $this->get_mock_product();
+		$mock_product_data = $this->get_mock_product_data();
+
+		$mock_product->update_meta_data( self::PRODUCT_ID_KEY, 'prod_test123' );
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'update_product' )
+			->with(
+				'prod_test123',
+				$mock_product_data
+			)
+			->willReturn(
+				[
+					'stripe_product_id' => 'prod_test123',
+					'stripe_price_id'   => 'price_test123',
+				]
+			);
+
+		$this->product_service->update_product( $mock_product );
+		$this->assertEquals( 'price_test123', $mock_product->get_meta( self::PRICE_ID_KEY, true ) );
+	}
+
+	private function get_mock_product() {
+		$product = new WC_Product();
+
+		$product->set_name( 'Test product' );
+		$product->set_description( 'Test product description' );
+		$product->set_price( 100 );
+		$product->update_meta_data( 'subscription_period', 'month' );
+		$product->update_meta_data( 'subscription_period_interval', 3 );
+		$product->save();
+
+		return $product;
+	}
+
+	private function get_mock_product_data( $overrides = [] ) {
+		return array_merge(
+			[
+				'currency'       => 'usd',
+				'description'    => 'Test product description',
+				'name'           => 'Test product',
+				'interval'       => 'month',
+				'interval_count' => 3,
+				'unit_amount'    => 10000,
+			],
+			$overrides
+		);
+	}
+}

--- a/tests/unit/subscriptions/test-class-wc-payments-product-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-product-service.php
@@ -71,8 +71,6 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 	 * @throws API_Exception
 	 */
 	public function test_update_product() {
-		$user = new WP_User( 0 );
-
 		$mock_product      = $this->get_mock_product();
 		$mock_product_data = $this->get_mock_product_data();
 
@@ -93,6 +91,70 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 
 		$this->product_service->update_product( $mock_product );
 		$this->assertEquals( 'price_test123', $mock_product->get_meta( self::PRICE_ID_KEY, true ) );
+	}
+
+	/**
+	 * Test archive product.
+	 *
+	 * Note: This also tests unarchive_product
+	 *
+	 * @throws API_Exception
+	 */
+	public function test_archive_product() {
+		$mock_product = $this->get_mock_product();
+
+		$mock_product->update_meta_data( self::PRODUCT_ID_KEY, 'prod_test123' );
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'update_price' )
+			->with(
+				'price_test123',
+				[ 'active' => 'false' ],
+			)
+			->willReturn(
+				[
+					'stripe_price_id' => 'price_test123',
+					'object'          => 'price',
+				]
+			);
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'update_product' )
+			->with(
+				'prod_test123',
+				[ 'active' => 'false' ],
+			)
+			->willReturn(
+				[
+					'stripe_product_id' => 'prod_test123',
+				]
+			);
+
+		$this->product_service->archive_product( $mock_product );
+	}
+
+	/**
+	 * Test archive product price.
+	 *
+	 * Note: This also tests unarchive_price
+	 *
+	 * @throws API_Exception
+	 */
+	public function test_archive_price() {
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'update_price' )
+			->with(
+				'price_test123',
+				[ 'active' => 'false' ]
+			)
+			->willReturn(
+				[
+					'stripe_price_id' => 'price_test123',
+					'object'          => 'price',
+				]
+			);
+
+		$this->product_service->archive_price( 'price_test123' );
 	}
 
 	private function get_mock_product() {


### PR DESCRIPTION
**Important:** This PR relies on another [WIP PR in WCPay Server](1005-gh-Automattic/woocommerce-payments-server)

See pb0GrA-1g9-p2

#### Changes proposed in this Pull Request

This adds a subscription product service that handles syncing WC subscription products with Stripe. When new subscription products are created or updated in WP-Admin, they are also created in the Stripe connect account.

#### Testing instructions

- In WP-Admin create a simple subscription product
- From the connected Stripe account, verify this was created properly:
  - Name
  - Description
  - Price
  - Interval
  - Period
  - Currency
- Update the simple subscription product
- From the connected Stripe account, verify this was updated properly
- Trash the simple subscription product in WC
- From the connected Stripe account, verify the product AND price have been archived
- Untrash the simple subscription product in WC
- From the connected Stripe account, verify the product AND price have been unarchived
- Follow the above steps for a variable subscription product, this time checking for all variations in Stripe

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)