### PR TITLE
Remove duplicate symbols from currency switcher widget

### DIFF
--- a/includes/multi-currency/CurrencySwitcherWidget.php
+++ b/includes/multi-currency/CurrencySwitcherWidget.php
@@ -121,11 +121,12 @@ class CurrencySwitcherWidget extends WC_Widget {
 	 * @return void Displays HTML of currency <option>
 	 */
 	private function display_currency_option( Currency $currency, bool $with_symbol, bool $with_flag ) {
-		$code     = $currency->get_code();
-		$text     = $code;
-		$selected = $this->multi_currency->get_selected_currency()->code === $code ? ' selected' : '';
+		$code        = $currency->get_code();
+		$same_symbol = html_entity_decode( $currency->get_symbol() ) === $code;
+		$text        = $code;
+		$selected    = $this->multi_currency->get_selected_currency()->code === $code ? ' selected' : '';
 
-		if ( $with_symbol ) {
+		if ( $with_symbol && ! $same_symbol ) {
 			$text = $currency->get_symbol() . ' ' . $text;
 		}
 		if ( $with_flag ) {

--- a/tests/unit/multi-currency/test-class-currency-switcher-widget.php
+++ b/tests/unit/multi-currency/test-class-currency-switcher-widget.php
@@ -47,7 +47,7 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WP_UnitTestCas
 					new Currency( 'USD' ),
 					new Currency( 'CAD', 1.2 ),
 					new Currency( 'EUR', 0.8 ),
-					new Currency( 'CHF', 1.1 )
+					new Currency( 'CHF', 1.1 ),
 				]
 			);
 

--- a/tests/unit/multi-currency/test-class-currency-switcher-widget.php
+++ b/tests/unit/multi-currency/test-class-currency-switcher-widget.php
@@ -47,6 +47,7 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WP_UnitTestCas
 					new Currency( 'USD' ),
 					new Currency( 'CAD', 1.2 ),
 					new Currency( 'EUR', 0.8 ),
+					new Currency( 'CHF', 1.1 )
 				]
 			);
 
@@ -71,6 +72,7 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WP_UnitTestCas
 		$this->expectOutputRegex( '/<option value="USD">&#36; USD<\/option>/' );
 		$this->expectOutputRegex( '/<option value="CAD">&#36; CAD<\/option>/' );
 		$this->expectOutputRegex( '/<option value="EUR">&euro; EUR<\/option>/' );
+		$this->expectOutputRegex( '/<option value="CHF">CHF<\/option>/' );
 	}
 
 	public function test_widget_renders_enabled_currencies_without_symbol() {
@@ -82,6 +84,8 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WP_UnitTestCas
 		$this->expectOutputRegex( '/<option value="USD">USD<\/option>/' );
 		$this->expectOutputRegex( '/<option value="CAD">CAD<\/option>/' );
 		$this->expectOutputRegex( '/<option value="EUR">EUR<\/option>/' );
+		$this->expectOutputRegex( '/<option value="CHF">CHF<\/option>/' );
+
 	}
 
 	public function test_widget_renders_enabled_currencies_with_symbol_and_flag() {
@@ -94,6 +98,8 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WP_UnitTestCas
 		$this->expectOutputRegex( '/<option value="USD">🇺🇸 &#36; USD<\/option>/' );
 		$this->expectOutputRegex( '/<option value="CAD">🇨🇦 &#36; CAD<\/option>/' );
 		$this->expectOutputRegex( '/<option value="EUR">🇪🇺 &euro; EUR<\/option>/' );
+		$this->expectOutputRegex( '/<option value="CHF">🇨🇭 CHF<\/option>/' );
+
 	}
 
 	public function test_widget_renders_hidden_input() {
@@ -115,6 +121,7 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WP_UnitTestCas
 		$this->expectOutputRegex( '/<option value="USD">&#36; USD<\/option>/' );
 		$this->expectOutputRegex( '/<option value="CAD" selected>&#36; CAD<\/option>/' );
 		$this->expectOutputRegex( '/<option value="EUR">&euro; EUR<\/option>/' );
+		$this->expectOutputRegex( '/<option value="CHF">CHF<\/option>/' );
 	}
 
 	public function test_widget_submits_form_on_change() {


### PR DESCRIPTION
Fixes #2641

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

This PR fixes the duplicate currency code display on currency switcher widget, by removing the currency code when it's the same with the currency symbol. It only affects the text of the select input option texts, the values stay the same.   

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

<table>
	<thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody><tr><td>
<img src='https://user-images.githubusercontent.com/3295/128410674-60fdf058-f726-4421-a56f-a7b9d756328e.png'>
</td><td>
<img src='https://user-images.githubusercontent.com/3295/128410657-cb1b608c-5a9f-4925-82b9-a2df12d940b1.png'>

</td></tr></tbody>
</table>

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Visual testing

* Add some currencies that use the currency code as the symbol such as CHF (Swiss Franc) or DKK (Danish Krona)
* Add some items to the cart, then go to the cart page
* Check if the currency selector displays the currency codes for those currencies only once.

##### Automated testing
* Run `npm run test:php -- --filter WCPay_Multi_Currency_Currency_Switcher_Widget_Tests`

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
