### PR TITLE
Do not call the API from the plugins_loaded hook

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Payments Changelog ***
 
-= 2.9.0 - 2021-xx-xx =
+= 2.8.2 - 2021-xx-xx =
+* Fix - Fix for the site acting as disconnected after the account cache expires.
 
 = 2.8.1 - 2021-08-04 =
 * Fix - Enable Multi-Currency only if there is a linked WooCommerce Payments account.

--- a/includes/multi-currency/Settings.php
+++ b/includes/multi-currency/Settings.php
@@ -7,7 +7,6 @@
 
 namespace WCPay\MultiCurrency;
 
-use WC_Payments_Account;
 use WCPay\MultiCurrency\Currency;
 
 defined( 'ABSPATH' ) || exit;
@@ -39,13 +38,6 @@ class Settings extends \WC_Settings_Page {
 	protected $multi_currency;
 
 	/**
-	 * Instance of WC_Payments_Account class.
-	 *
-	 * @var WC_Payments_Account
-	 */
-	protected $payments_account;
-
-	/**
 	 * Link to the multi-currency documentation page.
 	 *
 	 * @var string
@@ -55,29 +47,23 @@ class Settings extends \WC_Settings_Page {
 	/**
 	 * Constructor.
 	 *
-	 * @param MultiCurrency       $multi_currency The MultiCurrency instance.
-	 * @param WC_Payments_Account $payments_account The WC_Payments_Account instance.
+	 * @param MultiCurrency $multi_currency The MultiCurrency instance.
 	 */
-	public function __construct( MultiCurrency $multi_currency, WC_Payments_Account $payments_account ) {
-		$this->multi_currency   = $multi_currency;
-		$this->payments_account = $payments_account;
-		$this->id               = $this->multi_currency->id;
-		$this->label            = _x( 'Multi-currency', 'Settings tab label', 'woocommerce-payments' );
+	public function __construct( MultiCurrency $multi_currency ) {
+		$this->multi_currency = $multi_currency;
+		$this->id             = $this->multi_currency->id;
+		$this->label          = _x( 'Multi-currency', 'Settings tab label', 'woocommerce-payments' );
 
-		// If we do not have an account, then we don't need to add these actions.
-		if ( null !== $this->payments_account->get_stripe_account_id() ) {
-			// TODO: We need to re-enable it on every screen we use emoji flags. Until WC Admin decide if they will enable it too: https://github.com/woocommerce/woocommerce-admin/issues/6388.
-			add_action( 'admin_print_scripts', 'print_emoji_detection_script' );
-			add_action( 'woocommerce_admin_field_wcpay_enabled_currencies_list', [ $this, 'enabled_currencies_list' ] );
-			add_action( 'woocommerce_admin_field_wcpay_currencies_settings_section_start', [ $this, 'currencies_settings_section_start' ] );
-			add_action( 'woocommerce_admin_field_wcpay_currencies_settings_section_end', [ $this, 'currencies_settings_section_end' ] );
+		// TODO: We need to re-enable it on every screen we use emoji flags. Until WC Admin decide if they will enable it too: https://github.com/woocommerce/woocommerce-admin/issues/6388.
+		add_action( 'admin_print_scripts', 'print_emoji_detection_script' );
+		add_action( 'woocommerce_admin_field_wcpay_enabled_currencies_list', [ $this, 'enabled_currencies_list' ] );
+		add_action( 'woocommerce_admin_field_wcpay_currencies_settings_section_start', [ $this, 'currencies_settings_section_start' ] );
+		add_action( 'woocommerce_admin_field_wcpay_currencies_settings_section_end', [ $this, 'currencies_settings_section_end' ] );
 
-			add_action( 'woocommerce_admin_field_wcpay_single_currency_preview_helper', [ $this, 'single_currency_preview_helper' ] );
+		add_action( 'woocommerce_admin_field_wcpay_single_currency_preview_helper', [ $this, 'single_currency_preview_helper' ] );
 
-			add_action( 'woocommerce_settings_' . $this->id, [ $this, 'render_single_currency_breadcrumbs' ] );
-		} else {
-			add_action( 'woocommerce_admin_field_wcpay_currencies_settings_onboarding_cta', [ $this, 'currencies_settings_onboarding_cta' ] );
-		}
+		add_action( 'woocommerce_settings_' . $this->id, [ $this, 'render_single_currency_breadcrumbs' ] );
+
 		parent::__construct();
 	}
 
@@ -103,25 +89,6 @@ class Settings extends \WC_Settings_Page {
 	 */
 	public function get_settings( $current_section = '' ) {
 		$settings = [];
-
-		// If we do not have an account, then we display a CTA to finish onboarding.
-		if ( null === $this->payments_account->get_stripe_account_id() ) {
-			return [
-				[
-					'title' => __( 'Enabled currencies', 'woocommerce-payments' ),
-					'desc'  => sprintf(
-						/* translators: %s: url to documentation. */
-						__( 'Accept payments in multiple currencies. Prices are converted based on exchange rates and rounding rules. <a href="%s">Learn more</a>', 'woocommerce-payments' ),
-						self::LEARN_MORE_URL
-					),
-					'type'  => 'title',
-					'id'    => $this->id . '_enabled_currencies',
-				],
-				[
-					'type' => 'wcpay_currencies_settings_onboarding_cta',
-				],
-			];
-		}
 
 		if ( '' === $current_section ) {
 			$settings = apply_filters(
@@ -238,27 +205,6 @@ class Settings extends \WC_Settings_Page {
 	public function currencies_settings_section_end() {
 		?>
 		</div>
-		<?php
-	}
-
-	/**
-	 * Output the call to action button if needing to onboard.
-	 */
-	public function currencies_settings_onboarding_cta() {
-		$params = [
-			'page' => 'wc-admin',
-			'path' => '/payments/connect',
-		];
-		$href   = admin_url( add_query_arg( $params, 'admin.php' ) );
-		?>
-			<div>
-				<p>
-					<?php esc_html_e( 'To add new currencies to your store, please finish setting up WooCommerce Payments.', 'woocommerce-payments' ); ?>
-				</p>
-				<a href="<?php echo esc_url( $href ); ?>" id="wcpay_enabled_currencies_onboarding_cta" type="button" class="button-primary">
-					<?php esc_html_e( 'Get started', 'woocommerce-payments' ); ?>
-				</a>
-			</div>
 		<?php
 	}
 

--- a/includes/multi-currency/SettingsOnboardCta.php
+++ b/includes/multi-currency/SettingsOnboardCta.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * WooCommerce Payments Multi-currency Settings
+ *
+ * @package WooCommerce\Admin
+ */
+
+namespace WCPay\MultiCurrency;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * MultiCurrency settings placeholder containing a CTA to connect the account.
+ */
+class SettingsOnboardCta extends \WC_Settings_Page {
+	/**
+	 * Link to the multi-currency documentation page.
+	 *
+	 * @var string
+	 */
+	const LEARN_MORE_URL = 'https://docs.woocommerce.com/document/payments/currencies/multi-currency-setup/';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param MultiCurrency $multi_currency The MultiCurrency instance.
+	 */
+	public function __construct( MultiCurrency $multi_currency ) {
+		$this->multi_currency = $multi_currency;
+		$this->id             = $this->multi_currency->id;
+		$this->label          = _x( 'Multi-currency', 'Settings tab label', 'woocommerce-payments' );
+
+		add_action( 'woocommerce_admin_field_wcpay_currencies_settings_onboarding_cta', [ $this, 'currencies_settings_onboarding_cta' ] );
+
+		parent::__construct();
+	}
+
+	/**
+	 * Output the call to action button if needing to onboard.
+	 */
+	public function currencies_settings_onboarding_cta() {
+		$params = [
+			'page' => 'wc-admin',
+			'path' => '/payments/connect',
+		];
+		$href   = admin_url( add_query_arg( $params, 'admin.php' ) );
+		?>
+			<div>
+				<p>
+					<?php esc_html_e( 'To add new currencies to your store, please finish setting up WooCommerce Payments.', 'woocommerce-payments' ); ?>
+				</p>
+				<a href="<?php echo esc_url( $href ); ?>" id="wcpay_enabled_currencies_onboarding_cta" type="button" class="button-primary">
+					<?php esc_html_e( 'Get started', 'woocommerce-payments' ); ?>
+				</a>
+			</div>
+		<?php
+	}
+
+	/**
+	 * Get settings array.
+	 *
+	 * @param string $current_section Section being shown.
+	 * @return array
+	 */
+	public function get_settings( $current_section = '' ) {
+		return [
+			[
+				'title' => __( 'Enabled currencies', 'woocommerce-payments' ),
+				'desc'  => sprintf(
+					/* translators: %s: url to documentation. */
+					__( 'Accept payments in multiple currencies. Prices are converted based on exchange rates and rounding rules. <a href="%s">Learn more</a>', 'woocommerce-payments' ),
+					self::LEARN_MORE_URL
+				),
+				'type'  => 'title',
+				'id'    => $this->id . '_enabled_currencies',
+			],
+			[
+				'type' => 'wcpay_currencies_settings_onboarding_cta',
+			],
+		];
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -98,7 +98,8 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
-= 2.9.0 - 2021-xx-xx =
+= 2.8.2 - 2021-xx-xx =
+* Fix - Fix for the site acting as disconnected after the account cache expires.
 
 = 2.8.1 - 2021-08-04 =
 * Fix - Enable Multi-Currency only if there is a linked WooCommerce Payments account.

--- a/tests/unit/multi-currency/test-class-settings.php
+++ b/tests/unit/multi-currency/test-class-settings.php
@@ -19,13 +19,6 @@ class WCPay_Multi_Currency_Settings_Tests extends WP_UnitTestCase {
 	private $mock_multi_currency;
 
 	/**
-	 * Mock WC_Payments_Account.
-	 *
-	 * @var WC_Payments_Account|PHPUnit_Framework_MockObject_MockObject
-	 */
-	private $mock_payments_account;
-
-	/**
 	 * WCPay\MultiCurrency\Settings instance.
 	 *
 	 * @var WCPay\MultiCurrency\Settings
@@ -38,23 +31,18 @@ class WCPay_Multi_Currency_Settings_Tests extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->mock_multi_currency   = $this->createMock( WCPay\MultiCurrency\MultiCurrency::class );
-		$this->mock_payments_account = $this->createMock( WC_Payments_Account::class );
+		$this->mock_multi_currency = $this->createMock( WCPay\MultiCurrency\MultiCurrency::class );
 
 		// The settings pages file is only included in woocommerce_get_settings_pages, so we need to manually include it here.
-		$this->settings = new WCPay\MultiCurrency\Settings( $this->mock_multi_currency, $this->mock_payments_account );
+		$this->settings = new WCPay\MultiCurrency\Settings( $this->mock_multi_currency );
 	}
 
 	/**
 	 * @dataProvider woocommerce_action_provider
 	 */
 	public function test_registers_internal_actions_with_account( $action, $function_name ) {
-		$this->mock_payments_account
-			->method( 'get_stripe_account_id' )
-			->willReturn( [] );
-
 		// Init Settings again to get proper registration of hooks/filters.
-		$this->settings = new WCPay\MultiCurrency\Settings( $this->mock_multi_currency, $this->mock_payments_account );
+		$this->settings = new WCPay\MultiCurrency\Settings( $this->mock_multi_currency );
 
 		$this->assertNotFalse(
 			has_action( $action, [ $this->settings, $function_name ] ),
@@ -73,35 +61,15 @@ class WCPay_Multi_Currency_Settings_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_registers_external_action_with_account() {
-		$this->mock_payments_account
-			->method( 'get_stripe_account_id' )
-			->willReturn( [] );
 
 		// Init Settings again to get proper registration of hooks/filters.
-		$this->settings = new WCPay\MultiCurrency\Settings( $this->mock_multi_currency, $this->mock_payments_account );
+		$this->settings = new WCPay\MultiCurrency\Settings( $this->mock_multi_currency );
 
 		$action        = 'admin_print_scripts';
 		$function_name = 'print_emoji_detection_script';
 
 		$this->assertNotFalse(
 			has_action( $action, $function_name ),
-			"Action '$action' was not registered with '$function_name'"
-		);
-	}
-
-	public function test_registers_internal_action_without_account() {
-		$this->mock_payments_account
-			->method( 'get_stripe_account_id' )
-			->willReturn( null );
-
-		// Init Settings again to get proper registration of hooks/filters.
-		$this->settings = new WCPay\MultiCurrency\Settings( $this->mock_multi_currency, $this->mock_payments_account );
-
-		$action        = 'woocommerce_admin_field_wcpay_currencies_settings_onboarding_cta';
-		$function_name = 'currencies_settings_onboarding_cta';
-
-		$this->assertNotFalse(
-			has_action( $action, [ $this->settings, $function_name ] ),
 			"Action '$action' was not registered with '$function_name'"
 		);
 	}
@@ -130,15 +98,5 @@ class WCPay_Multi_Currency_Settings_Tests extends WP_UnitTestCase {
 		$this->expectOutputRegex( '/<a href=".*\/wp-admin\/admin\.php\?page=wc-settings&#038;tab=wcpay_multi_currency">Currencies<\/a> &gt; Pound sterling \(GBP\) 🇬🇧/' );
 
 		$this->settings->render_single_currency_breadcrumbs();
-	}
-
-	public function test_render_cta_button_when_no_account() {
-		$this->mock_payments_account
-			->method( 'get_stripe_account_id' )
-			->willReturn( null );
-
-		$this->expectOutputRegex( '/<a href=".*\/wp-admin\/admin\.php\?page=wc-admin&#038;path=\/payments\/connect" id="wcpay_enabled_currencies_onboarding_cta" type="button" class="button-primary">/' );
-
-		$this->settings->currencies_settings_onboarding_cta();
 	}
 }


### PR DESCRIPTION
Fixes the error causing the account cache to be empty even though the site is connected

#### Changes proposed in this Pull Request

- Move the calls to the account service out of the MC class constructors
- Add a separate class for the Settings screen containing onboarding CTA

#### Testing instructions

- On a connected site, refresh the account cache
- The account should be refilled with the correct value. Everything, including MC, should work.
- Either start a new site or use the dev tools to force the site to act as disconnected
- No errors should appear. Go to `WooCommerce > Settings > Multi-Currency` and confirm that the CTA is there.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
