### PR TITLE
Remove explicit prices where a single currency is active

### DIFF
--- a/includes/class-wc-payments-explicit-price-formatter.php
+++ b/includes/class-wc-payments-explicit-price-formatter.php
@@ -6,7 +6,6 @@
  */
 
 use WCPay\MultiCurrency\MultiCurrency;
-use WCPay\Logger;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.

--- a/includes/class-wc-payments-explicit-price-formatter.php
+++ b/includes/class-wc-payments-explicit-price-formatter.php
@@ -5,6 +5,9 @@
  * @package WooCommerce\Payments
  */
 
+use WCPay\MultiCurrency\MultiCurrency;
+use WCPay\Logger;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -13,14 +16,63 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class for displaying the explicit prices on total amounts.
  */
 class WC_Payments_Explicit_Price_Formatter {
+
+	/**
+	 * The multi currency instance for checking the number of enabled currencies
+	 *
+	 * @var MultiCurrency
+	 */
+	private static $multi_currency_instance = null;
+
 	/**
 	 * Inits the formatter, registering the necessary hooks.
 	 */
 	public static function init() {
+		self::$multi_currency_instance = WC_Payments_Multi_Currency();
 		add_filter( 'woocommerce_cart_total', [ __CLASS__, 'get_explicit_price' ], 100 );
 		add_filter( 'woocommerce_get_formatted_order_total', [ __CLASS__, 'get_explicit_price' ], 100, 2 );
 		add_action( 'woocommerce_admin_order_totals_after_tax', [ __CLASS__, 'register_formatted_woocommerce_price_filter' ] );
 		add_action( 'woocommerce_admin_order_totals_after_total', [ __CLASS__, 'unregister_formatted_woocommerce_price_filter' ] );
+	}
+
+	/**
+	 * Overrides the MultiCurrency instance that the class uses.
+	 *
+	 * @param   MultiCurrency $multi_currency  MultCurrency class.
+	 *
+	 * @return  void
+	 */
+	public static function set_multi_currency_instance( MultiCurrency $multi_currency ) {
+		self::$multi_currency_instance = $multi_currency;
+	}
+
+	/**
+	 * Checks if the method should output explicit price on frontend
+	 *
+	 * @return  bool  Whether if it should return explicit price or not
+	 */
+	private static function should_output_explicit_price() {
+		// Only check for frontend requests.
+		if ( ! is_admin() ) {
+			// If customer multi currency is disabled, don't use explicit currencies on frontend.
+			// Because it'll have only the store currency active, same as count == 1.
+			if ( ! WC_Payments_Features::is_customer_multi_currency_enabled() ) {
+				return false;
+			}
+
+			$enabled_currencies = self::$multi_currency_instance->get_enabled_currencies();
+
+			if ( empty( $enabled_currencies ) ) {
+				return false;
+			}
+
+			// Don't attach explicit price filters on frontend with a single currency setup.
+			if ( is_array( $enabled_currencies ) && 1 === count( $enabled_currencies ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -54,6 +106,9 @@ class WC_Payments_Explicit_Price_Formatter {
 	 * @return string
 	 */
 	public static function get_explicit_price( string $price, WC_Order $order = null ) {
+		if ( false === static::should_output_explicit_price() ) {
+			return $price;
+		}
 		if ( null === $order ) {
 			$currency_code = get_woocommerce_currency();
 		} else {
@@ -75,6 +130,9 @@ class WC_Payments_Explicit_Price_Formatter {
 	 * @return  array        The modified arguments
 	 */
 	public static function get_explicit_price_args( $args ) {
+		if ( false === static::should_output_explicit_price() ) {
+			return $args;
+		}
 		if ( false === strpos( $args['price_format'], $args['currency'] ) ) {
 			$args['price_format'] = sprintf( '%s&nbsp;%s', $args['price_format'], $args['currency'] );
 		}

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -108,7 +108,7 @@ class MultiCurrency {
 	 *
 	 * @var array
 	 */
-	protected $available_currencies;
+	protected $available_currencies = [];
 
 	/**
 	 * The default currency.
@@ -122,7 +122,7 @@ class MultiCurrency {
 	 *
 	 * @var array
 	 */
-	protected $enabled_currencies;
+	protected $enabled_currencies = [];
 
 	/**
 	 * Client for making requests to the WooCommerce Payments API

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -41,6 +41,13 @@ class MultiCurrency {
 	protected static $instance = null;
 
 	/**
+	 * Static flag to show if the currencies initialization has been completed
+	 *
+	 * @var bool
+	 */
+	protected static $is_initialized = false;
+
+	/**
 	 * Compatibility instance.
 	 *
 	 * @var Compatibility
@@ -240,6 +247,8 @@ class MultiCurrency {
 		if ( is_admin() ) {
 			add_action( 'admin_init', [ __CLASS__, 'add_woo_admin_notes' ] );
 		}
+
+		static::$is_initialized = true;
 	}
 
 	/**
@@ -1020,5 +1029,14 @@ class MultiCurrency {
 			[ 'wc-components' ],
 			\WC_Payments::get_file_version( 'dist/multi-currency.css' )
 		);
+	}
+
+	/**
+	 * Returns if the currency initialization are completed
+	 *
+	 * @return  bool    If the initializations have been completedÎ
+	 */
+	public static function is_initialized() : bool {
+		return static::$is_initialized;
 	}
 }

--- a/tests/unit/test-class-wc-payments-explicit-price-formatter.php
+++ b/tests/unit/test-class-wc-payments-explicit-price-formatter.php
@@ -5,22 +5,238 @@
  * @package WooCommerce\Payments\Tests
  */
 
+use WCPay\MultiCurrency\MultiCurrency;
+
 /**
  * WC_Payments_Explicit_Price_Formatter unit tests.
  */
 class WC_Payments_Explicit_Price_Formatter_Test extends WP_UnitTestCase {
-	public function test_get_explicit_price_with_order_currency() {
+
+	const LOGGED_IN_USER_ID               = 1;
+	const ENABLED_CURRENCIES_OPTION       = 'wcpay_multi_currency_enabled_currencies';
+	const CACHED_CURRENCIES_OPTION        = 'wcpay_multi_currency_cached_currencies';
+	const CURRENCY_RETRIEVAL_ERROR_OPTION = 'wcpay_multi_currency_retrieval_error';
+
+	/**
+	 * Mock enabled currencies.
+	 *
+	 * @var array
+	 */
+	private $mock_enabled_currencies = [ 'USD', 'CAD', 'GBP', 'BIF' ];
+
+	/**
+	 * @var int
+	 */
+	private $timestamp_for_testing;
+
+	/**
+	 * Mock available currencies with their rates.
+	 *
+	 * @var array
+	 */
+	private $mock_available_currencies = [
+		'USD' => 1,
+		'CAD' => 1.206823,
+		'GBP' => 0.708099,
+		'EUR' => 0.826381,
+		'CDF' => 2000,
+		'BIF' => 1974, // Zero decimal currency.
+		'CLP' => 706.8, // Zero decimal currency.
+	];
+
+	/**
+	 * Mock cached currencies return array
+	 *
+	 * @var array
+	 */
+	private $mock_cached_currencies;
+
+	/**
+	 * MultiCurrency instance.
+	 *
+	 * @var MultiCurrency
+	 */
+	private $multi_currency;
+
+	/**
+	 * Mock of the API client.
+	 *
+	 * @var WC_Payments_API_Client
+	 */
+	private $mock_api_client;
+
+	/**
+	 * Mock of the WC_Payments_Account.
+	 *
+	 * @var WC_Payments_Account
+	 */
+	private $mock_account;
+
+	/**
+	 * Mock of the WC_Payments_Localization_Service.
+	 *
+	 * @var WC_Payments_Localization_Service
+	 */
+	private $mock_localization_service;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->mock_currency_settings(
+			'GBP',
+			[
+				'price_charm'    => '-0.1',
+				'price_rounding' => '0.50',
+			]
+		);
+
+		$this->timestamp_for_testing = strtotime( 'today midnight' );
+
+		$this->mock_cached_currencies = [
+			'currencies' => $this->mock_available_currencies,
+			'updated'    => $this->timestamp_for_testing,
+			'expires'    => $this->timestamp_for_testing + DAY_IN_SECONDS,
+		];
+
+		update_option( self::CACHED_CURRENCIES_OPTION, $this->mock_cached_currencies );
+		update_option( self::ENABLED_CURRENCIES_OPTION, $this->mock_enabled_currencies );
+
+		$this->init_multi_currency();
+	}
+
+	public function tearDown() {
+		set_current_screen( 'front' );
+		WC()->session->__unset( MultiCurrency::CURRENCY_SESSION_KEY );
+		remove_all_filters( 'wcpay_multi_currency_apply_charm_only_to_products' );
+		remove_all_filters( 'wcpay_multi_currency_available_currencies' );
+		remove_all_filters( 'woocommerce_currency' );
+		remove_all_filters( 'stylesheet' );
+
+		delete_user_meta( self::LOGGED_IN_USER_ID, MultiCurrency::CURRENCY_META_KEY );
+		wp_set_current_user( 0 );
+
+		$this->remove_currency_settings_mock( 'GBP', [ 'price_charm', 'price_rounding', 'manual_rate', 'exchange_rate' ] );
+		delete_option( self::CACHED_CURRENCIES_OPTION );
+		delete_option( self::ENABLED_CURRENCIES_OPTION );
+		update_option( 'wcpay_multi_currency_enable_auto_currency', 'no' );
+
+		WC_Payments_Explicit_Price_Formatter::set_multi_currency_instance( WC_Payments_Multi_Currency() );
+
+		parent::tearDown();
+	}
+
+	public function test_get_explicit_price_with_order_currency_on_backend_with_one_enabled_currency() {
+		set_current_screen( 'edit-page' );
+		$this->prepare_one_enabled_currency();
 		$order = $this->createMock( WC_Order::class );
 		$order->method( 'get_currency' )->willReturn( 'BRL' );
 
 		$this->assertSame( 'R$ 5,90 BRL', WC_Payments_Explicit_Price_Formatter::get_explicit_price( 'R$ 5,90', $order ) );
 	}
 
-	public function test_get_explicit_price_with_store_currency() {
+	public function test_get_explicit_price_with_store_currency_on_backend_with_one_enabled_currency() {
+		set_current_screen( 'edit-page' );
+		$this->prepare_one_enabled_currency();
 		$this->assertSame( '$10.30 USD', WC_Payments_Explicit_Price_Formatter::get_explicit_price( '$10.30' ) );
 	}
 
-	public function test_get_explicit_price_skips_already_explicit_prices() {
+	public function test_get_explicit_price_skips_already_explicit_prices_on_backend_with_one_enabled_currency() {
+		set_current_screen( 'edit-page' );
+		$this->prepare_one_enabled_currency();
 		$this->assertSame( '$10.30 USD', WC_Payments_Explicit_Price_Formatter::get_explicit_price( '$10.30 USD' ) );
+	}
+
+	public function test_get_explicit_price_with_order_currency_on_backend_with_multiple_enabled_currencies() {
+		set_current_screen( 'edit-page' );
+
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_currency' )->willReturn( 'BRL' );
+
+		$this->assertSame( 'R$ 5,90 BRL', WC_Payments_Explicit_Price_Formatter::get_explicit_price( 'R$ 5,90', $order ) );
+	}
+
+	public function test_get_explicit_price_with_store_currency_on_backend_with_multiple_enabled_currencies() {
+		set_current_screen( 'edit-page' );
+		$this->assertSame( '$10.30 USD', WC_Payments_Explicit_Price_Formatter::get_explicit_price( '$10.30' ) );
+	}
+
+	public function test_get_explicit_price_skips_already_explicit_prices_on_backend_with_multiple_enabled_currencies() {
+		set_current_screen( 'edit-page' );
+		$this->assertSame( '$10.30 USD', WC_Payments_Explicit_Price_Formatter::get_explicit_price( '$10.30 USD' ) );
+	}
+
+	public function test_get_explicit_price_with_order_currency_on_frontend_with_one_enabled_currency() {
+		$this->prepare_one_enabled_currency();
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_currency' )->willReturn( 'BRL' );
+
+		$this->assertSame( 'R$ 5,90', WC_Payments_Explicit_Price_Formatter::get_explicit_price( 'R$ 5,90', $order ) );
+	}
+
+	public function test_get_explicit_price_with_store_currency_on_frontend_with_one_enabled_currency() {
+		$this->prepare_one_enabled_currency();
+		$this->assertSame( '$10.30', WC_Payments_Explicit_Price_Formatter::get_explicit_price( '$10.30' ) );
+	}
+
+	public function test_get_explicit_price_skips_already_explicit_prices_on_frontend_with_one_enabled_currency() {
+		$this->prepare_one_enabled_currency();
+		$this->assertSame( '$10.30 USD', WC_Payments_Explicit_Price_Formatter::get_explicit_price( '$10.30 USD' ) );
+	}
+
+	public function test_get_explicit_price_with_order_currency_on_frontend_with_multiple_enabled_currencies() {
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_currency' )->willReturn( 'BRL' );
+
+		$this->assertSame( 'R$ 5,90 BRL', WC_Payments_Explicit_Price_Formatter::get_explicit_price( 'R$ 5,90', $order ) );
+	}
+
+	public function test_get_explicit_price_with_store_currency_on_frontend_with_multiple_enabled_currencies() {
+		$this->assertSame( '$10.30 USD', WC_Payments_Explicit_Price_Formatter::get_explicit_price( '$10.30' ) );
+	}
+
+	public function test_get_explicit_price_skips_already_explicit_prices_on_frontend_with_multiple_enabled_currencies() {
+		$this->assertSame( '$10.30 USD', WC_Payments_Explicit_Price_Formatter::get_explicit_price( '$10.30 USD' ) );
+	}
+
+	private function prepare_one_enabled_currency() {
+		$this->multi_currency->set_enabled_currencies( [ 'USD' ] );
+	}
+
+
+	private function mock_currency_settings( $currency_code, $settings ) {
+		foreach ( $settings as $setting => $value ) {
+			update_option( 'wcpay_multi_currency_' . $setting . '_' . strtolower( $currency_code ), $value );
+		}
+	}
+
+	private function remove_currency_settings_mock( $currency_code, $settings ) {
+		foreach ( $settings as $setting ) {
+			delete_option( 'wcpay_multi_currency_' . $setting . '_' . strtolower( $currency_code ) );
+		}
+	}
+
+	private function init_multi_currency( $mock_api_client = null, $wcpay_account_connected = true ) {
+		$this->mock_api_client = $this->createMock( WC_Payments_API_Client::class );
+
+		$this->mock_account = $this->createMock( WC_Payments_Account::class );
+		$this->mock_account->method( 'is_stripe_connected' )->willReturn( $wcpay_account_connected );
+
+		$this->mock_localization_service = $this->createMock( WC_Payments_Localization_Service::class );
+
+		$this->mock_api_client->method( 'is_server_connected' )->willReturn( true );
+
+		$this->mock_localization_service->method( 'get_currency_format' )->willReturn(
+			[
+				'currency_pos' => 'left',
+				'thousand_sep' => ',',
+				'decimal_sep'  => '.',
+				'num_decimals' => 2,
+			]
+		);
+
+		$this->multi_currency = new MultiCurrency( $mock_api_client ?? $this->mock_api_client, $this->mock_account, $this->mock_localization_service );
+		$this->multi_currency->init();
+
+		WC_Payments_Explicit_Price_Formatter::set_multi_currency_instance( $this->multi_currency );
 	}
 }


### PR DESCRIPTION
Fixes #2672

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

As per @LevinMedia said right after the release of 2.8.0,

> In order to resolve this - lets ignore, or not apply any CLDR formatting to the store's default currency. This should only be the case on the front end of a store (customer facing prices) The only exception to this rule would be the addition of the currency code (explicit format) to things like the order totals in the cart / checkout.  The addition of the explicit format should only happen if merchant is using the multi currency feature. We should continue to use CLDR formatting for all prices through out the admin for consistency and clarity.

This PR provides these changes according to the comment above:

- Prices on frontend will be all displayed in short format when:
	- Multi-Currency feature is disabled
	- There is only one currency available on the MC available currencies list.
- Key prices on frontend should have explicit format when:
	- Multi Currency feature is enabled
	- There are more than one currency available on the MC Available Currencies list
- Prices on backend will act like it was before

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go the multicurrency settings and make the list only have the store currency.
* Go to the **Payments > Transactions** screen and check if the total amounts are displayed in explicit format.
* Go to the store and add an item to the cart, then go to the cart page and check if the total shows in short format. 
* Go back to multicurrency settings and add another available currency to the list.
* Go to the **Payments > Transactions** screen and check if the total amounts are still displayed in explicit format. 
* Go to the store and add an item to the cart, then go to the cart page and check if the total shows in explicit format. 

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
