### PR TITLE
Add Spain to list of available countries for Sofort.

### DIFF
--- a/client/payment-methods-map.js
+++ b/client/payment-methods-map.js
@@ -34,7 +34,7 @@ export default {
 		id: 'sofort',
 		label: __( 'Sofort', 'woocommerce-payments' ),
 		description: __(
-			'Accept secure bank transfers from Austria, Belgium, Germany, Italy, and Netherlands.',
+			'Accept secure bank transfers from Austria, Belgium, Germany, Italy, Netherlands, and Spain.',
 			'woocommerce-payments'
 		),
 		Icon: SofortIcon,


### PR DESCRIPTION
Fixes #2667 

#### Changes proposed in this Pull Request

Pretty simple, just an outdated countries list for Sofort on the settings page.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
