### PR TITLE
Check for payment method details before referencing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 2.8.2 - 2021-xx-xx =
 * Fix - Fix for the site acting as disconnected after the account cache expires.
+* Fix - Fix for failed Giropay and Sofort transactions causing an error.
 
 = 2.8.1 - 2021-08-04 =
 * Fix - Enable Multi-Currency only if there is a linked WooCommerce Payments account.

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -474,7 +474,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 				$payment_method_id      = $intent['payment_method'];
 				$payment_method_details = false;
 				$payment_method_options = array_keys( $intent['payment_method_options'] );
-				$payment_method_type    = $payment_method_options[0];
+				$payment_method_type    = $payment_method_options ? $payment_method_options[0] : null;
 				$error                  = $intent['last_setup_error'];
 			}
 

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -463,7 +463,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 				$currency               = $intent->get_currency();
 				$payment_method_id      = $intent->get_payment_method_id();
 				$payment_method_details = $intent->get_payment_method_details();
-				$payment_method_type    = $payment_method_details['type'];
+				$payment_method_type    = $payment_method_details ? $payment_method_details['type'] : null;
 				$error                  = $intent->get_last_payment_error();
 			} else {
 				$intent                 = $this->payments_api_client->get_setup_intent( $intent_id );

--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 2.8.2 - 2021-xx-xx =
 * Fix - Fix for the site acting as disconnected after the account cache expires.
+* Fix - Fix for failed Giropay and Sofort transactions causing an error.
 
 = 2.8.1 - 2021-08-04 =
 * Fix - Enable Multi-Currency only if there is a linked WooCommerce Payments account.


### PR DESCRIPTION
Fixes #2665

#### Changes proposed in this Pull Request

This PR is to check for the payment_method_details before referencing it as an array. This error would show up when a Giropay or Sofort payment was failed and kicked back to the store site.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable giropay and sofort payment method from wcpay settings page.
* Purchase with giropay / sofort.
* Fail the payment.
* Get generic error message: "We're not able to process this payment. Please try again later."

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
