### PR TITLE
Specify labels on task list item buttons

### DIFF
--- a/client/additional-methods-setup/task.js
+++ b/client/additional-methods-setup/task.js
@@ -43,6 +43,7 @@ const createAdditionalMethodsSetupTask = ( {
 			'woocommerce-payments'
 		),
 		isDismissable: true,
+		actionLabel: __( 'Get started', 'woocommerce-payments' ),
 
 		...( '/payments/overview' === getPath()
 			? {

--- a/client/additional-methods-setup/test/task.test.js
+++ b/client/additional-methods-setup/test/task.test.js
@@ -127,4 +127,15 @@ describe( 'createAdditionalMethodsSetupTask()', () => {
 
 		expect( result ).not.toHaveProperty( 'onClick' );
 	} );
+
+	it.each( [ true, false ] )(
+		'sets button label to "Get started"',
+		( isUpeSettingsPreviewEnabled ) => {
+			const result = createAdditionalMethodsSetupTask( {
+				isUpeSettingsPreviewEnabled,
+			} );
+
+			expect( result.actionLabel ).toEqual( 'Get started' );
+		}
+	);
 } );

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -37,6 +37,7 @@ const OverviewPage = () => {
 		additionalMethodsSetup,
 		wpcomReconnectUrl,
 		needsHttpsSetup,
+		isAccountOverviewTasksEnabled: Boolean( accountOverviewTaskList ),
 	} );
 	const queryParams = getQuery();
 

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -65,6 +65,7 @@ export const getTasks = ( {
 						  },
 				visible: true,
 				type: 'extension',
+				actionLabel: __( 'Update', 'woocommerce-payments' ),
 			},
 		isAccountOverviewTasksEnabled &&
 			wpcomReconnectUrl && {
@@ -83,6 +84,7 @@ export const getTasks = ( {
 				onClick: () => {
 					window.location.href = wpcomReconnectUrl;
 				},
+				actionLabel: __( 'Reconnect', 'woocommerce-payments' ),
 			},
 		isAccountOverviewTasksEnabled &&
 			needsHttpsSetup && {

--- a/client/overview/task-list/test/tasks.js
+++ b/client/overview/task-list/test/tasks.js
@@ -166,6 +166,33 @@ describe( 'getTasks()', () => {
 		);
 	} );
 
+	it( 'returns expected button labels on tasks', () => {
+		const tasks = getTasks( {
+			isAccountOverviewTasksEnabled: true,
+			showUpdateDetailsTask: 'yes',
+			wpcomReconnectUrl: 'http://example.com',
+			accountStatus: {},
+			needsHttpsSetup: true,
+		} );
+
+		expect( tasks ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					key: 'update-business-details',
+					actionLabel: 'Update',
+				} ),
+				expect.objectContaining( {
+					key: 'reconnect-wpcom-user',
+					actionLabel: 'Reconnect',
+				} ),
+				expect.objectContaining( {
+					key: 'force-secure-checkout',
+					actionLabel: 'Read more',
+				} ),
+			] )
+		);
+	} );
+
 	describe( 'additional method setup task', () => {
 		beforeEach( () => {
 			createAdditionalMethodsSetupTask.mockReturnValue( {} );


### PR DESCRIPTION
Helps with #2455.

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Currently, some task list buttons are the same as task titles. This PR adds custom labels to these buttons.

I have used the label "Get started" for both APM-related tasks:

* Boost your sales by accepting new payment methods
* Set up additional payment methods

I have also noticed that the "Reconnect WooCommerce Payments" task doesn't have a custom label so I have added one for that task too ("Reconnect"). Please let me know if this is OK!

/cc @LevinMedia

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Without UPE settings preview

<table>
<tr>
<th>Previously</th>
<th>Now</th>
<tr>
<td>

![Markup on 2021-08-05 at 10:34:35](https://user-images.githubusercontent.com/1759681/128320017-2a568f8a-10e2-41ef-bd25-4f3c6d8bbc25.png)

</td>
<td>

![Markup on 2021-08-05 at 10:33:53](https://user-images.githubusercontent.com/1759681/128320064-7b0dd89f-d70b-45c6-ba96-9d540795b1d8.png)

</td>
</tr>
</table>

## With UPE settings preview

Exactly the same as above side from the last item - here the task is "Boost your sales" but the button is still "Get started" like above.

<table>
<tr>
<th>Previously</th>
<th>Now</th>
<tr>
<td>

![Markup on 2021-08-05 at 10:34:57](https://user-images.githubusercontent.com/1759681/128320001-526bd6ba-6eaa-468b-8aed-40646c3aa01e.png)

</td>
<td>

![Markup on 2021-08-05 at 10:33:19](https://user-images.githubusercontent.com/1759681/128320081-61e5a187-8532-41f1-8f30-25b286130ffd.png)

</td>
</tr>
</table>

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In `WC_Payments_Admin::register_payments_scripts()`, find the line where `$wcpay_settings` is defined and just below it add this code to get all tasks to display:
  ```php
  $wcpay_settings['featureFlags']['accountOverviewTaskList'] = true;
  $wcpay_settings['accountStatus']['status'] = 'foo';
  $wcpay_settings['showUpdateDetailsTask'] = 'yes';
  $wcpay_settings['wpcomReconnectUrl'] = 'https://example.org';
  $wcpay_settings['needsHttpsSetup'] = true;
  $wcpay_settings['additionalMethodsSetup']['isTaskVisible'] = true;
  $wcpay_settings['additionalMethodsSetup']['isSetupCompleted'] = false;
  ```
* Verify the tasks are displayed like in the "Now" screenshots.

-------------------

- [x] Added changelog entry (or does not apply)
  - Not added - unreleased feature.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
