### PR TITLE
Add - split discount line into variable and fixed fee

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 2.9.0 - 2021-xx-xx =
 * Add - *Early access*: allow your store to collect payments with iDEAL. Enable the feature in settings!
+* Add - Split discount line in timeline into variable fee and fixed fee.
 
 = 2.8.2 - 2021-08-05 =
 * Fix - If account is disconnected or not set up do not display onboarding task and UPE inbox note.

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -277,19 +277,20 @@ const feeBreakdown = ( event ) => {
 						'Foreign exchange fee: %1$s%%',
 						'woocommerce-payments'
 				  ),
-		discount:
-			0 !== fixedRate
-				? __(
-						/* translators: %1$s% is the fee amount and %2$s is the fixed rate */
-						'Discount: %1$s%% + %2$s',
-						'woocommerce-payments'
-				  )
-				: __(
-						/* translators: %1$s% is the fee amount */
-						'Discount: %1$s%%',
-						'woocommerce-payments'
-				  ),
+		discount: __( 'Discount', 'woocommerce-payments' ),
 	} );
+
+	const renderDiscountSplit = (
+		percentageRateFormatted,
+		fixedRateFormatted
+	) => {
+		return (
+			<ul className="discount-split-list">
+				<li>Variable fee: { percentageRateFormatted }%</li>
+				<li>Fixed fee: { fixedRateFormatted }</li>
+			</ul>
+		);
+	};
 
 	const feeHistoryList = history.map( ( fee ) => {
 		let labelKey = fee.type;
@@ -303,13 +304,22 @@ const feeBreakdown = ( event ) => {
 			currency,
 		} = fee;
 
+		const percentageRateFormatted = formatFee( percentageRate );
+		const fixedRateFormatted = formatCurrency( fixedRate, currency );
+
 		return (
 			<li key={ labelKey }>
 				{ sprintf(
 					feeLabelMapping( fixedRate )[ labelKey ],
-					formatFee( percentageRate ),
-					formatCurrency( fixedRate, currency )
+					percentageRateFormatted,
+					fixedRateFormatted
 				) }
+
+				{ 'discount' === fee.type &&
+					renderDiscountSplit(
+						percentageRateFormatted,
+						fixedRateFormatted
+					) }
 			</li>
 		);
 	} );

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -286,8 +286,14 @@ const feeBreakdown = ( event ) => {
 	) => {
 		return (
 			<ul className="discount-split-list">
-				<li>Variable fee: { percentageRateFormatted }%</li>
-				<li>Fixed fee: { fixedRateFormatted }</li>
+				<li>
+					{ __( 'Variable fee: ', 'woocommerce-payments' ) }
+					{ percentageRateFormatted }%
+				</li>
+				<li>
+					{ __( 'Fixed fee: ', 'woocommerce-payments' ) }
+					{ fixedRateFormatted }
+				</li>
 			</ul>
 		);
 	};

--- a/client/payment-details/timeline/style.scss
+++ b/client/payment-details/timeline/style.scss
@@ -1,9 +1,17 @@
 .woocommerce-timeline
 	.woocommerce-timeline-item
 	.woocommerce-timeline-item__body {
-	.fee-breakdown-list {
-		list-style-type: disc;
+	.fee-breakdown-list,
+	.discount-split-list {
 		margin-left: 16px;
 		line-height: 1.5;
+	}
+
+	.fee-breakdown-list {
+		list-style-type: disc;
+	}
+
+	.discount-split-list {
+		list-style-type: circle;
 	}
 }

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -512,7 +512,20 @@ Array [
           Foreign exchange fee: 2%
         </li>
         <li>
-          Discount: -4.9% + £-0.20
+          Discount
+          <ul
+            className="discount-split-list"
+          >
+            <li>
+              Variable fee: 
+              -4.9
+              %
+            </li>
+            <li>
+              Fixed fee: 
+              £-0.20
+            </li>
+          </ul>
         </li>
       </ul>,
       "Net deposit: $59.50 USD",

--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 2.9.0 - 2021-xx-xx =
 * Add - *Early access*: allow your store to collect payments with iDEAL. Enable the feature in settings!
+* Add - Split discount line in timeline into variable fee and fixed fee.
 
 = 2.8.2 - 2021-08-05 =
 * Fix - If account is disconnected or not set up do not display onboarding task and UPE inbox note.


### PR DESCRIPTION
Fixes #2628 

#### Changes proposed in this Pull Request
This PR further splits the discount line into two for a better UX. More context: https://github.com/Automattic/woocommerce-payments/pull/2500#issuecomment-889330454
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure you have a discount enabled. You can do so by running `wp wcpay add_fee_structure_to_account <id> --fee_structure_id=promo-1`
- Make a transaction preferably which includes int. and fx fee.
- Make sure you see fee breakdown that includes discount line.

![image](https://user-images.githubusercontent.com/15019298/128533457-ea3c325c-27c7-427c-af4c-620f0baa71e7.png)


-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
