### PR TITLE
In-person payments: account endpoint now provides test_mode property

### DIFF
--- a/includes/admin/class-wc-rest-payments-accounts-controller.php
+++ b/includes/admin/class-wc-rest-payments-accounts-controller.php
@@ -68,6 +68,11 @@ class WC_REST_Payments_Accounts_Controller extends WC_Payments_REST_Controller {
 			];
 		}
 
+		if ( false !== $account ) {
+			// Add extra properties to account if necessary.
+			$account['test_mode'] = WC_Payments::get_gateway()->is_in_test_mode();
+		}
+
 		return rest_ensure_response( $account );
 	}
 }

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -470,11 +470,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return boolean Test mode enabled if true, disabled if false
 	 */
 	public function is_in_test_mode() {
-		if ( $this->is_in_dev_mode() ) {
-			return true;
-		}
-
-		return 'yes' === $this->get_option( 'test_mode' );
+		return $this->is_in_dev_mode() || 'yes' === $this->get_option( 'test_mode' );
 	}
 
 

--- a/tests/unit/admin/test-class-wc-rest-payments-accounts-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-accounts-controller.php
@@ -34,6 +34,7 @@ class WC_REST_Payments_Accounts_Controller_Test extends WP_UnitTestCase {
 
 		// Set the user so that we can pass the authentication.
 		wp_set_current_user( 1 );
+		WC_Payments::get_gateway()->update_option( 'test_mode', 'yes' );
 
 		$this->mock_api_client = $this->createMock( WC_Payments_API_Client::class );
 		$this->controller      = new WC_REST_Payments_Accounts_Controller( $this->mock_api_client );
@@ -48,6 +49,8 @@ class WC_REST_Payments_Accounts_Controller_Test extends WP_UnitTestCase {
 
 	public function tearDown() {
 		parent::tearDown();
+
+		WC_Payments::get_gateway()->update_option( 'test_mode', 'no' );
 
 		// Restore the original client.
 		$account_service     = WC_Payments::get_account_service();
@@ -77,6 +80,7 @@ class WC_REST_Payments_Accounts_Controller_Test extends WP_UnitTestCase {
 		$response_data = $response->get_data();
 
 		$this->assertSame( 200, $response->status );
+		$this->assertTrue( $response_data['test_mode'] );
 		$this->assertSame( 'complete', $response_data['status'] );
 		$this->assertSame( 'DE', $response_data['country'] );
 		$this->assertSame( 'EUR', $response_data['store_currencies']['default'] );
@@ -99,6 +103,7 @@ class WC_REST_Payments_Accounts_Controller_Test extends WP_UnitTestCase {
 		$response_data = $response->get_data();
 
 		$this->assertSame( 200, $response->status );
+		$this->assertTrue( $response_data['test_mode'] );
 		$this->assertSame( 'NOACCOUNT', $response_data['status'] );
 		// The default country and currency have changed in WC 5.3, hence multiple options in assertions.
 		$this->assertContains( $response_data['country'], [ 'US', 'GB' ] );
@@ -121,6 +126,7 @@ class WC_REST_Payments_Accounts_Controller_Test extends WP_UnitTestCase {
 		$response_data = $response->get_data();
 
 		$this->assertSame( 200, $response->status );
+		$this->assertTrue( $response_data['test_mode'] );
 		$this->assertSame( 'ONBOARDING_DISABLED', $response_data['status'] );
 		// The default country and currency have changed in WC 5.3, hence multiple options in assertions.
 		$this->assertContains( $response_data['country'], [ 'US', 'GB' ] );


### PR DESCRIPTION
Follows up #911

#### Changes proposed in this Pull Request

- Provide `test_mode` property in account data

#### Testing instructions

* UTs shall pass

-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
