### PR TITLE
Use parent gateway to process payment request buttons from UPE

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 2.8.3 - 2021-xx-xx =
+* Fix - Fix for payment request buttons when the new payment methods gateway is enabled.
+
 = 2.8.2 - 2021-08-05 =
 * Fix - If account is disconnected or not set up do not display onboarding task and UPE inbox note.
 * Fix - Fix for the site acting as disconnected after the account cache expires.

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -320,6 +320,9 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	 * @return array|null An array with result of payment and redirect URL, or nothing.
 	 */
 	public function process_payment( $order_id ) {
+		if ( isset( $_POST['payment_request_type'] ) && ( 'google_pay' === $_POST['payment_request_type'] || 'apple_pay' === $_POST['payment_request_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			return parent::process_payment( $order_id );
+		}
 		$payment_intent_id         = isset( $_POST['wc_payment_intent_id'] ) ? wc_clean( wp_unslash( $_POST['wc_payment_intent_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$order                     = wc_get_order( $order_id );
 		$amount                    = $order->get_total();

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -302,13 +302,13 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	}
 
 	/**
-	 * Create and confirm payment intent. Saved payment methods do not follow UPE workflow.
+	 * Create and confirm payment intent. Function used to route any payments that do not use the UPE flow through the parent process payment.
 	 *
 	 * @param int $order_id Order ID to process the payment for.
 	 *
 	 * @return array|null An array with result of payment and redirect URL, or nothing.
 	 */
-	public function process_payment_using_saved_method( $order_id ) {
+	public function parent_process_payment( $order_id ) {
 		return parent::process_payment( $order_id );
 	}
 
@@ -320,9 +320,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	 * @return array|null An array with result of payment and redirect URL, or nothing.
 	 */
 	public function process_payment( $order_id ) {
-		if ( isset( $_POST['payment_request_type'] ) && ( 'google_pay' === $_POST['payment_request_type'] || 'apple_pay' === $_POST['payment_request_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-			return parent::process_payment( $order_id );
-		}
 		$payment_intent_id         = isset( $_POST['wc_payment_intent_id'] ) ? wc_clean( wp_unslash( $_POST['wc_payment_intent_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$order                     = wc_get_order( $order_id );
 		$amount                    = $order->get_total();
@@ -347,8 +344,8 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 					$selected_upe_payment_type
 				);
 			}
-		} elseif ( $token ) {
-			return $this->process_payment_using_saved_method( $order_id );
+		} else {
+			return $this->parent_process_payment( $order_id );
 		}
 
 		return [

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,9 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 2.8.3 - 2021-xx-xx =
+* Fix - Fix for payment request buttons when the new payment methods gateway is enabled.
+
 = 2.8.2 - 2021-08-05 =
 * Fix - If account is disconnected or not set up do not display onboarding task and UPE inbox note.
 * Fix - Fix for the site acting as disconnected after the account cache expires.

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -194,7 +194,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 				[
 					'get_return_url',
 					'manage_customer_details_for_order',
-					'process_payment_using_saved_method',
+					'parent_process_payment',
 				]
 			)
 			->getMock();
@@ -208,7 +208,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			);
 		$this->mock_upe_gateway
 			->expects( $this->any() )
-			->method( 'process_payment_using_saved_method' )
+			->method( 'parent_process_payment' )
 			->will(
 				$this->returnValue( $this->mock_payment_result )
 			);
@@ -429,12 +429,15 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	}
 
 	public function test_process_payment_returns_correct_redirect_url() {
-		$order    = WC_Helper_Order::create_order();
-		$order_id = $order->get_id();
+		$order                         = WC_Helper_Order::create_order();
+		$order_id                      = $order->get_id();
+		$_POST['wc_payment_intent_id'] = 'pi_abc123';
 
 		$this->set_cart_contains_subscription_items( false );
 
 		$result = $this->mock_upe_gateway->process_payment( $order->get_id() );
+
+		unset( $_POST['wc_payment_intent_id'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 		$this->assertEquals( 'success', $result['result'] );
 		$this->assertEquals( true, $result['payment_needed'] );
@@ -447,15 +450,17 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$order    = WC_Helper_Order::create_order();
 		$order_id = $order->get_id();
 
-		$gateway_id                   = UPE_Payment_Gateway::GATEWAY_ID;
-		$save_payment_param           = "wc-$gateway_id-new-payment-method";
-		$_POST[ $save_payment_param ] = 'yes';
+		$gateway_id                    = UPE_Payment_Gateway::GATEWAY_ID;
+		$save_payment_param            = "wc-$gateway_id-new-payment-method";
+		$_POST[ $save_payment_param ]  = 'yes';
+		$_POST['wc_payment_intent_id'] = 'pi_abc123';
 
 		$this->set_cart_contains_subscription_items( false );
 
 		$result = $this->mock_upe_gateway->process_payment( $order->get_id() );
 
-		unset( $_POST[ $save_payment_param ] );// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		unset( $_POST[ $save_payment_param ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		unset( $_POST['wc_payment_intent_id'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 		$this->assertEquals( 'success', $result['result'] );
 		$this->assertRegExp( "/order_id=$order_id/", $result['redirect_url'] );
@@ -470,6 +475,25 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->set_cart_contains_subscription_items( false );
 
 		$result = $this->mock_upe_gateway->process_payment( $order->get_id() );
+
+		$this->mock_upe_gateway
+			->expects( $this->never() )
+			->method( 'manage_customer_details_for_order' );
+		$this->assertEquals( 'success', $result['result'] );
+		$this->assertRegExp( '/key=mock_order_key/', $result['redirect'] );
+	}
+
+	public function test_process_payment_returns_correct_redirect_when_using_payment_request() {
+		$order                         = WC_Helper_Order::create_order();
+		$_POST['payment_request_type'] = 'google_pay';
+
+		$this->set_cart_contains_subscription_items( false );
+
+		$result = $this->mock_upe_gateway->process_payment( $order->get_id() );
+
+		$this->mock_upe_gateway
+			->expects( $this->never() )
+			->method( 'manage_customer_details_for_order' );
 		$this->assertEquals( 'success', $result['result'] );
 		$this->assertRegExp( '/key=mock_order_key/', $result['redirect'] );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With the release of UPE, an error was introduced that caused Payment Request buttons (Google Pay and Apple Pay) to fail when UPE was enabled. This was caused by the UPE gateway overriding the `process_payment` function for the WCPay gateway. This caused the following error when trying to make a purchase with a payment request button while UPE was enabled:

![Payment-Request-UPE-Error](https://user-images.githubusercontent.com/68524302/128722414-b664e99c-238e-4f97-87c0-2e12e1d79ed9.png)

This PR introduces a fix for this scenario by sending any requests that do not have the proper UPE parameters through the parent gateway's `process_payment`. There were several approaches I considered for this that ultimately fell into two categories:

1. Add a flag-like parameter to any request coming from UPE and always confirm that flag is set before processing with the UPE `process_payment`.
2. Look for specific flags that we should route through the parent gateway instead of processing through UPE.

This PR uses approach 1 by catching anything that doesn't appear to be UPE related and routing it through the parent gateway. This should also catch any possible future incidents similar to this where the overriding of `process_payment` was too greedy before. This was a small adjustment from just handling saved payment methods that way, to instead now handling any requests that don't appear to be using UPE.

This PR also adds a test to check for this flow and confirm it goes through the parent gateway's `process_payment` instead.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

* Start with a site with UPE and payment request buttons enabled.
* You will need a Google Pay card set up to test this. You can check this by making sure you are logged in to pay.google.com and have a credit card on file there. To test Google Pay, you will need to be using the Chrome browser.
* Go to a product page and confirm the Google Pay button is displayed.
* Click on Google Pay and go through with the transaction.
* The order should complete successfully with this branch.
* Be sure to do thorough testing of paying with a saved payment method using UPE as well.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
