### PR TITLE
Show the estimated deposit date in the transactions CSV export rather than the deposit ID

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Add - *Early access*: allow your store to collect payments with iDEAL. Enable the feature in settings!
 * Add - Split discount line in timeline into variable fee and fixed fee.
 * Fix - Align table items according to design correctly.
+* Fix - Show the estimated deposit date in the transactions CSV export rather than the deposit ID.
 
 = 2.8.3 - 2021-08-10 =
 * Fix - Fix for payment request buttons when the new payment methods gateway is enabled.

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -171,8 +171,8 @@ const getColumns = (
 		},
 		includeDeposit && {
 			key: 'deposit',
-			label: __( 'Deposit', 'woocommerce-payments' ),
-			screenReaderLabel: __( 'Deposit', 'woocommerce-payments' ),
+			label: __( 'Deposit date', 'woocommerce-payments' ),
+			screenReaderLabel: __( 'Deposit date', 'woocommerce-payments' ),
 			cellClassName: 'deposit',
 			isLeftAligned: true,
 		},

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -320,7 +320,7 @@ export const TransactionsList = (
 				value: calculateRiskMapping( txn.risk_level ),
 				display: clickable( riskLevel ),
 			},
-			deposit: { value: txn.deposit_id, display: deposit },
+			deposit: { value: txn.available_on, display: deposit },
 		};
 
 		return columnsToDisplay.map(

--- a/client/transactions/list/test/__snapshots__/index.tsx.snap
+++ b/client/transactions/list/test/__snapshots__/index.tsx.snap
@@ -464,12 +464,12 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   <span
                     aria-hidden="true"
                   >
-                    Deposit
+                    Deposit date
                   </span>
                   <span
                     class="screen-reader-text"
                   >
-                    Deposit
+                    Deposit date
                   </span>
                 </th>
               </tr>
@@ -1195,12 +1195,12 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   <span
                     aria-hidden="true"
                   >
-                    Deposit
+                    Deposit date
                   </span>
                   <span
                     class="screen-reader-text"
                   >
-                    Deposit
+                    Deposit date
                   </span>
                 </th>
               </tr>
@@ -2535,12 +2535,12 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   <span
                     aria-hidden="true"
                   >
-                    Deposit
+                    Deposit date
                   </span>
                   <span
                     class="screen-reader-text"
                   >
-                    Deposit
+                    Deposit date
                   </span>
                 </th>
               </tr>
@@ -3294,12 +3294,12 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                   <span
                     aria-hidden="true"
                   >
-                    Deposit
+                    Deposit date
                   </span>
                   <span
                     class="screen-reader-text"
                   >
-                    Deposit
+                    Deposit date
                   </span>
                 </th>
               </tr>
@@ -4040,12 +4040,12 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                   <span
                     aria-hidden="true"
                   >
-                    Deposit
+                    Deposit date
                   </span>
                   <span
                     class="screen-reader-text"
                   >
-                    Deposit
+                    Deposit date
                   </span>
                 </th>
               </tr>

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -425,7 +425,7 @@ describe( 'Transactions list', () => {
 				'Email',
 				'Country',
 				'"Risk level"',
-				'Deposit',
+				'"Deposit date"',
 			];
 
 			// checking if columns in CSV are rendered correctly

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - *Early access*: allow your store to collect payments with iDEAL. Enable the feature in settings!
 * Add - Split discount line in timeline into variable fee and fixed fee.
 * Fix - Align table items according to design correctly.
+* Fix - Show the estimated deposit date in the transactions CSV export rather than the deposit ID.
 
 = 2.8.3 - 2021-08-10 =
 * Fix - Fix for payment request buttons when the new payment methods gateway is enabled.


### PR DESCRIPTION
Fixes #2697

#### Changes proposed in this Pull Request

Changes the "Deposit" column in the transactions CSV export to show the estimated deposit date rather than the deposit ID.

#### Testing instructions

- Have an onboarded store.
- Make a test purchase.
- Navigate to **Payments > Transactions** in the WP admin.
- Click the "Download" button to download a CSV export for the transactions.
- Observe the "Deposit" column in the CSV should contain the estimated deposit date.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
