### PR TITLE
Load subscriptions base and update `is_subscriptions_enabled()` to check for either subscription version

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,1 @@
+includes/subscriptions/subscriptions-base/**/*.css

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -131,7 +131,7 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 
 		// TODO: Remove admin payment method JS hack for Subscriptions <= 3.0.7 when we drop support for those versions.
 		// Enqueue JS hack when Subscriptions does not provide the meta input filter.
-		if ( version_compare( WC_Subscriptions::$version, '3.0.7', '<=' ) ) {
+		if ( version_compare( $this->get_subscriptions_version(), '3.0.7', '<=' ) ) {
 			add_action( 'woocommerce_admin_order_data_after_billing_address', [ $this, 'add_payment_method_select_to_subscription_edit' ] );
 		}
 

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -131,7 +131,7 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 
 		// TODO: Remove admin payment method JS hack for Subscriptions <= 3.0.7 when we drop support for those versions.
 		// Enqueue JS hack when Subscriptions does not provide the meta input filter.
-		if ( version_compare( $this->get_subscriptions_version(), '3.0.7', '<=' ) ) {
+		if ( $this->is_subscriptions_plugin_active() && version_compare( $this->get_subscriptions_plugin_version(), '3.0.7', '<=' ) ) {
 			add_action( 'woocommerce_admin_order_data_after_billing_address', [ $this, 'add_payment_method_select_to_subscription_edit' ] );
 		}
 

--- a/includes/compat/subscriptions/trait-wc-payments-subscriptions-utilities.php
+++ b/includes/compat/subscriptions/trait-wc-payments-subscriptions-utilities.php
@@ -17,10 +17,17 @@ trait WC_Payments_Subscriptions_Utilities {
 	/**
 	 * Checks if subscriptions are enabled on the site.
 	 *
+	 * Subscriptions functionality is enabled if the WC Subscriptions plugin is active and greater than v 2.2, or the base feature is turned on.
+	 *
 	 * @return bool Whether subscriptions is enabled or not.
 	 */
 	public function is_subscriptions_enabled() {
-		return version_compare( $this->get_subscriptions_version(), '2.2.0', '>=' );
+		if ( $this->is_subscriptions_plugin_active() ) {
+			return version_compare( $this->get_subscriptions_plugin_version(), '2.2.0', '>=' );
+		}
+
+		// TODO update this once we know how the base library feature will be enabled.
+		return true;
 	}
 
 	/**
@@ -80,21 +87,31 @@ trait WC_Payments_Subscriptions_Utilities {
 	}
 
 	/**
-	 * Get the version of WooCommerce Subscriptions that is active. Returns null when
-	 * Subscriptions is not active/loaded.
+	 * Checks if the WC Subscriptions plugin is active.
 	 *
-	 * @return null|string
+	 * @return bool Whether the plugin is active or not.
 	 */
-	public function get_subscriptions_version() {
-		$version = null;
-
-		if ( class_exists( 'WC_Subscriptions' ) ) {
-			$version = WC_Subscriptions::$version;
-		} elseif ( class_exists( 'WC_Subscriptions_Base_Plugin' ) ) {
-			$version = WC_Subscriptions_Base_Plugin::instance()->get_plugin_version();
-		}
-
-		return $version;
+	public function is_subscriptions_plugin_active() {
+		return Automattic\WooCommerce\Admin\PluginsHelper::is_plugin_active( 'woocommerce-subscriptions/woocommerce-subscriptions.php' );
 	}
 
+	/**
+	 * Gets the version of WooCommerce Subscriptions that is active.
+	 *
+	 * @return null|string The plugin version. Returns null when WC Subscriptions is not active/loaded.
+	 */
+	public function get_subscriptions_plugin_version() {
+		return class_exists( 'WC_Subscriptions' ) ? WC_Subscriptions::$version : null;
+	}
+
+	/**
+	 * Gets the version of the Subscriptions base library running.
+	 *
+	 * This may be the version of the package in WC Payments or WC Subscriptions. Which ever one happens to be loaded.
+	 *
+	 * @return null|string The base Subscriptions libary version.
+	 */
+	public function get_subscriptions_base_version() {
+		return WC_Subscriptions_Base_Plugin::instance()->get_plugin_version();
+	}
 }

--- a/includes/compat/subscriptions/trait-wc-payments-subscriptions-utilities.php
+++ b/includes/compat/subscriptions/trait-wc-payments-subscriptions-utilities.php
@@ -27,7 +27,7 @@ trait WC_Payments_Subscriptions_Utilities {
 		}
 
 		// TODO update this once we know how the base library feature will be enabled.
-		return true;
+		return class_exists( 'WC_Subscriptions_Base_Plugin' );
 	}
 
 	/**

--- a/includes/compat/subscriptions/trait-wc-payments-subscriptions-utilities.php
+++ b/includes/compat/subscriptions/trait-wc-payments-subscriptions-utilities.php
@@ -79,4 +79,22 @@ trait WC_Payments_Subscriptions_Utilities {
 		return wcs_cart_contains_renewal();
 	}
 
+	/**
+	 * Get the version of WooCommerce Subscriptions that is active. Returns null when
+	 * Subscriptions is not active/loaded.
+	 *
+	 * @return null|string
+	 */
+	public function get_subscriptions_version() {
+		$version = null;
+
+		if ( class_exists( 'WC_Subscriptions' ) ) {
+			$version = WC_Subscriptions::$version;
+		} elseif ( class_exists( 'WC_Subscriptions_Base_Plugin' ) ) {
+			$version = WC_Subscriptions_Base_Plugin::instance()->get_plugin_version();
+		}
+
+		return $version;
+	}
+
 }

--- a/includes/compat/subscriptions/trait-wc-payments-subscriptions-utilities.php
+++ b/includes/compat/subscriptions/trait-wc-payments-subscriptions-utilities.php
@@ -92,7 +92,7 @@ trait WC_Payments_Subscriptions_Utilities {
 	 * @return bool Whether the plugin is active or not.
 	 */
 	public function is_subscriptions_plugin_active() {
-		return Automattic\WooCommerce\Admin\PluginsHelper::is_plugin_active( 'woocommerce-subscriptions/woocommerce-subscriptions.php' );
+		return class_exists( 'WC_Subscriptions' );
 	}
 
 	/**

--- a/includes/compat/subscriptions/trait-wc-payments-subscriptions-utilities.php
+++ b/includes/compat/subscriptions/trait-wc-payments-subscriptions-utilities.php
@@ -20,7 +20,7 @@ trait WC_Payments_Subscriptions_Utilities {
 	 * @return bool Whether subscriptions is enabled or not.
 	 */
 	public function is_subscriptions_enabled() {
-		return class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '2.2.0', '>=' );
+		return version_compare( $this->get_subscriptions_version(), '2.2.0', '>=' );
 	}
 
 	/**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,6 +10,7 @@
 	<exclude-pattern>./release/*</exclude-pattern>
 	<exclude-pattern>./docker/*</exclude-pattern>
 	<exclude-pattern>./node_modules/*</exclude-pattern>
+	<exclude-pattern>./includes/subscriptions/subscriptions-base/*</exclude-pattern>
 	<exclude-pattern>./vendor/*</exclude-pattern>
 	<exclude-pattern>*\.(?!php$)</exclude-pattern>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,9 @@
 	<filter>
 		<whitelist>
 			<directory suffix=".php">includes</directory>
+			<exclude>
+				<directory suffix=".php">includes/subscriptions/subscriptions-base</directory>
+			</exclude>
 		</whitelist>
 	</filter>
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -127,4 +127,9 @@
       <code>Automattic\Jetpack\Connection\Client::remote_request( $args, $body )</code>
     </UndefinedDocblockClass>
   </file>
+  <file src="woocommerce-payments.php">
+    <UndefinedClass occurrences="1">
+      <code>WC_Subscriptions_Base_Plugin</code>
+    </UndefinedClass>
+  </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -112,9 +112,10 @@
     </UndefinedFunction>
   </file>
   <file src="includes/compat/subscriptions/trait-wc-payments-subscriptions-utilities.php">
-    <UndefinedClass occurrences="2">
+    <UndefinedClass occurrences="3">
       <code>WC_Subscriptions_Cart</code>
       <code>WC_Subscriptions_Cart</code>
+      <code>WC_Subscriptions_Base_Plugin</code>
     </UndefinedClass>
     <UndefinedFunction occurrences="1">
       <code>wcs_is_subscription( wc_clean( wp_unslash( $_GET['change_payment_method'] ) ) )</code>

--- a/psalm.xml
+++ b/psalm.xml
@@ -14,6 +14,7 @@
 			<directory name="client" />
 			<directory name="docker" />
             <directory name="vendor" />
+            <directory name="includes/subscriptions/subscriptions-base" />
         </ignoreFiles>
     </projectFiles>
 

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -83,3 +83,12 @@ require $_tests_dir . '/includes/bootstrap.php';
 if ( defined( 'PHP_VERSION_ID' ) && PHP_VERSION_ID >= 70400 ) {
 	error_reporting( error_reporting() ^ E_DEPRECATED ); // phpcs:ignore
 }
+
+/**
+ * Don't init the subscriptions-base when running WCPAY unit tests.
+ *
+ * Init'ing the subscriptions-base loads all subscriptions class and hooks, which breaks existing WCPAY unit tests.
+ * WCPAY already mocks the WC Subscriptions classes/functions it needs so there's no need to load them anyway.
+ */
+function wcpay_init_subscriptions_base() {
+}

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -21,6 +21,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'WCPAY_PLUGIN_FILE', __FILE__ );
 define( 'WCPAY_ABSPATH', __DIR__ . '/' );
 define( 'WCPAY_MIN_WC_ADMIN_VERSION', '0.23.2' );
+define( 'WCPAY_SUBSCRIPTIONS_ABSPATH', __DIR__ . '/includes/subscriptions/subscriptions-base/' );
 
 require_once __DIR__ . '/vendor/autoload_packages.php';
 
@@ -97,6 +98,30 @@ function wcpay_init() {
 // Make sure this is run *after* WooCommerce has a chance to initialize its packages (wc-admin, etc). That is run with priority 10.
 // If you change the priority of this action, you'll need to change it in the wcpay_check_old_jetpack_version function too.
 add_action( 'plugins_loaded', 'wcpay_init', 11 );
+
+/**
+ * Initialise subscriptions-base if WC Subscriptions (the plugin) isn't loaded
+ */
+function wcpay_init_subscriptions_base() {
+	$wc_subscriptions_plugin_slug = 'woocommerce-subscriptions/woocommerce-subscriptions.php';
+	$wcs_is_being_activated       = isset( $_GET['action'], $_GET['plugin'] ) && 'activate' === $_GET['action'] && $wc_subscriptions_plugin_slug === $_GET['plugin']; //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+	/**
+	* If the current request is to activate subscriptions, don't load our subscriptions base plugin.
+	*
+	* WP loads the newly activated plugin's base file later than `plugins_loaded`, and so there's no opportunity for us to not load our base feature set on a consistent hook.
+	* We also cannot init the base plugin too late, because if we do, we miss hooks that register the subscription post types etc.
+	*/
+	if ( $wcs_is_being_activated ) {
+		return;
+	}
+
+	if ( ! Automattic\WooCommerce\Admin\PluginsHelper::is_plugin_active( $wc_subscriptions_plugin_slug ) ) {
+		require_once WCPAY_SUBSCRIPTIONS_ABSPATH . 'includes/class-wc-subscriptions-base-plugin.php';
+		new WC_Subscriptions_Base_Plugin();
+	}
+}
+wcpay_init_subscriptions_base();
 
 /**
  * Check if WCPay is installed alongside an old version of Jetpack (8.1 or earlier). Due to the autoloader code in those old

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -99,26 +99,29 @@ function wcpay_init() {
 // If you change the priority of this action, you'll need to change it in the wcpay_check_old_jetpack_version function too.
 add_action( 'plugins_loaded', 'wcpay_init', 11 );
 
-/**
- * Initialise subscriptions-base if WC Subscriptions (the plugin) isn't loaded
- */
-function wcpay_init_subscriptions_base() {
-	$wc_subscriptions_plugin_slug = 'woocommerce-subscriptions/woocommerce-subscriptions.php';
-	$wcs_is_being_activated       = isset( $_GET['action'], $_GET['plugin'] ) && 'activate' === $_GET['action'] && $wc_subscriptions_plugin_slug === $_GET['plugin']; //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+if ( ! function_exists( 'wcpay_init_subscriptions_base' ) ) {
 
 	/**
-	* If the current request is to activate subscriptions, don't load our subscriptions base plugin.
-	*
-	* WP loads the newly activated plugin's base file later than `plugins_loaded`, and so there's no opportunity for us to not load our base feature set on a consistent hook.
-	* We also cannot init the base plugin too late, because if we do, we miss hooks that register the subscription post types etc.
-	*/
-	if ( $wcs_is_being_activated ) {
-		return;
-	}
+	 * Initialise subscriptions-base if WC Subscriptions (the plugin) isn't loaded
+	 */
+	function wcpay_init_subscriptions_base() {
+		$wc_subscriptions_plugin_slug = 'woocommerce-subscriptions/woocommerce-subscriptions.php';
+		$wcs_is_being_activated       = isset( $_GET['action'], $_GET['plugin'] ) && 'activate' === $_GET['action'] && $wc_subscriptions_plugin_slug === $_GET['plugin']; //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-	if ( ! Automattic\WooCommerce\Admin\PluginsHelper::is_plugin_active( $wc_subscriptions_plugin_slug ) ) {
-		require_once WCPAY_SUBSCRIPTIONS_ABSPATH . 'includes/class-wc-subscriptions-base-plugin.php';
-		new WC_Subscriptions_Base_Plugin();
+		/**
+		* If the current request is to activate subscriptions, don't load our subscriptions base plugin.
+		*
+		* WP loads the newly activated plugin's base file later than `plugins_loaded`, and so there's no opportunity for us to not load our base feature set on a consistent hook.
+		* We also cannot init the base plugin too late, because if we do, we miss hooks that register the subscription post types etc.
+		*/
+		if ( $wcs_is_being_activated ) {
+			return;
+		}
+
+		if ( ! Automattic\WooCommerce\Admin\PluginsHelper::is_plugin_active( $wc_subscriptions_plugin_slug ) ) {
+			require_once WCPAY_SUBSCRIPTIONS_ABSPATH . 'includes/class-wc-subscriptions-base-plugin.php';
+			new WC_Subscriptions_Base_Plugin();
+		}
 	}
 }
 wcpay_init_subscriptions_base();


### PR DESCRIPTION
Internal link: paJDYF-2gd-p2

---

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

 - **Load the `subscriptions-base` files when WooCommerce Subscriptions isn't active**

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

In 272a1dbf324bb474040422901c6b55714638a516, I added the `subscriptions-base` files into WooCommerce Payments. These files can be found in `woocommerce-payments/includes/subscriptions/subscriptions-base`.

In this PR, I'm adding a new public function to `woocommerce-payments.php` to init/load the `subscriptions-base` plugin (91ec10e). This function should only load the subscriptions-base when the main WooCommerce Subscriptions extension is not active and we're not in the middle of a request to activate the Subscriptions extension.

Now that WC Pay may load the `subscriptions-base`, we need to update a few functions in `WC_Payment_Gateway_WCPay_Subscriptions_Trait` which was using `WC_Subscriptions::$version` to get the subscriptions version and check if subscriptions is enabled. To reduce duplicate code I added a new `get_subscriptions_version()` function to the subscriptions util trait (7e59bfe) and updated `is_subscriptions_enabled()` function to use this new util function instead (0a101e6)

- **Modify phpcs and lint:css to not run on subscriptions-base**

When trying to push up the `subscriptions-base` there was a lot of phpcs/lint:css issues so I've added a new line and file to ignore these files. Once subscriptions base is in a separate repository we'll have our own coding standing checks.

---

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

**Before testing checkout branch`stripe_billing/load_subscriptions_base`.**

Test case 1: `subscriptions-base` is loading when WC Subscriptions is deactivated

1. Deactivate the WooCommerce Subscriptions plugin
3. Go to the Subscriptions Settings: **WooCommerce > Settings > Subscriptions**
4. You should only see basic subscription settings available (mixed checkout settings and sync [screenshot](https://d.pr/i/u9tv4V))
4. Check the subscriptions table is loading: **WooCommerce > Subscriptions**


Test case 2: `subscriptions-base` is _not_ loaded when WC Subscriptions is active

1. Activate the WooCommerce Subscriptions plugin
2. Check all the Subscriptions settings are loading

Test case 3: basic subscriptions functionality is provided with `subscriptions-base`

1. Make sure WooCommerce Subscriptions plugin is deactivated
2. Add a subscription product to your cart
3. Complete the checkout process
4. Confirm a subscription was created

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
