### PR TITLE
Remove connected email from account overview page

### DIFF
--- a/client/components/account-status/index.js
+++ b/client/components/account-status/index.js
@@ -76,13 +76,6 @@ const AccountStatusDetails = ( props ) => {
 
 	return (
 		<AccountStatusCard title={ cardTitle }>
-			{ accountStatus.email && (
-				<AccountStatusItem
-					label={ __( 'Connected email:', 'woocommerce-payments' ) }
-				>
-					{ accountStatus.email }
-				</AccountStatusItem>
-			) }
 			<AccountStatusItem
 				label={ __( 'Payments:', 'woocommerce-payments' ) }
 			>


### PR DESCRIPTION
Fixes #2732

#### Changes proposed in this Pull Request

Remove connected email value from account details card on overview page, because Stripe doesn't really allow us to access the authentication or business email for an account, except for when the account is first connected.

#### Testing instructions

- Notice there's no "Connected email" value on the overview page.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
