### PR TITLE
Add subscriptions webhook event handler stubs

### DIFF
--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -130,6 +130,15 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 				case 'payment_intent.succeeded':
 					$this->process_webhook_payment_intent_succeeded( $body );
 					break;
+				case 'invoice.upcoming':
+					$this->handle_invoice_upcoming( $body );
+					break;
+				case 'invoice.paid':
+					$this->handle_invoice_paid( $body );
+					break;
+				case 'invoice.payment_failed':
+					$this->handle_invoice_payment_failed( $body );
+					break;
 			}
 
 			try {
@@ -289,5 +298,41 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 			);
 		}
 		return $array[ $key ];
+	}
+
+	/**
+	 * Adds fee, discount, and shipping related invoice items to Stripe subscription.
+	 *
+	 * @param array $event_body The event that triggered the webhook.
+	 *
+	 * @throws Rest_Request_Exception Required parameters not found.
+	 */
+	private function handle_invoice_upcoming( array $event_body ) {
+		// Stub.
+		Logger::debug( 'Invoice upcoming!' );
+	}
+
+	/**
+	 * Renews a subscription associated with paid invoice.
+	 *
+	 * @param array $event_body The event that triggered the webhook.
+	 *
+	 * @throws Rest_Request_Exception Required parameters not found.
+	 */
+	private function handle_invoice_paid( array $event_body ) {
+		// Stub.
+		Logger::debug( 'Invoice paid!' );
+	}
+
+	/**
+	 * Marks a subscription payment associated with invoice as failed.
+	 *
+	 * @param array $event_body The event that triggered the webhook.
+	 *
+	 * @throws Rest_Request_Exception Required parameters not found.
+	 */
+	private function handle_invoice_payment_failed( array $event_body ) {
+		// Stub.
+		Logger::debug( 'Invoice payment failed :(' );
 	}
 }

--- a/tests/unit/admin/test-class-wc-rest-payments-webhook.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-webhook.php
@@ -605,4 +605,28 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( [ 'result' => 'success' ], $response_data );
 	}
+
+	/**
+	 * Tests that an invoice upoming event creates invoice items for subscription.
+	 */
+	public function test_invoice_upcoming_webhook() {
+		// Stub.
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Tests that an invoice paid event renews a subscription.
+	 */
+	public function test_invoice_paid_webhook() {
+		// Stub.
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Tests that an invoice payment failed event places a subscription on-hold.
+	 */
+	public function test_invoice_payment_failed_webhook() {
+		// Stub.
+		$this->assertTrue( true );
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds stubs for webhook event handlers and tests:

- invoice.upcoming
- invoice.paid
- invoice.payment_failed

Right now these only log a debug string to the WCPay logs, but its necessary to get these set up as some of our other functionally rely on webhooks, and we'll need to add these as we go.

#### Testing instructions
There isn't too much to test other than making sure webhooks triggered from Stripe actually make it to the client:

* From Stripe, get one of each of the above events to trigger. It's important that these events be for actual subscriptions associated with your test Stripe connect account and not a test webhook (which doesn't contain a correct account ID).
* Check the logs for each of the following strings, each associated with their respective events: `Invoice upcoming!`, `Invoice paid!`, and `Invoice payment failed :(`

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
