### PR TITLE
Update subscription variations on variable product name changes

### DIFF
--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -189,7 +189,7 @@ class WC_Payments_Product_Service {
 			$this->set_stripe_price_id( $product, $stripe_product['stripe_price_id'] );
 			$this->add_product_update_listeners();
 		} catch ( API_Exception $e ) {
-			Logger::log( 'There was a problem creating the product in Stripe:', $e->getMessage() );
+			Logger::log( 'There was a problem creating the product in Stripe: ' . $e->getMessage() );
 		}
 	}
 
@@ -237,7 +237,7 @@ class WC_Payments_Product_Service {
 
 				$this->add_product_update_listeners();
 			} catch ( API_Exception $e ) {
-				Logger::log( 'There was a problem updating the product in Stripe:', $e->getMessage() );
+				Logger::log( 'There was a problem updating the product in Stripe: ' . $e->getMessage() );
 			}
 		}
 	}
@@ -292,7 +292,7 @@ class WC_Payments_Product_Service {
 			$this->archive_price( $this->get_stripe_price_id( $product ) );
 			$this->payments_api_client->update_product( $stripe_product_id, [ 'active' => 'false' ] );
 		} catch ( API_Exception $e ) {
-			Logger::log( 'There was a problem archiving the product in Stripe:', $e->getMessage() );
+			Logger::log( 'There was a problem archiving the product in Stripe: ' . $e->getMessage() );
 		}
 	}
 
@@ -312,7 +312,7 @@ class WC_Payments_Product_Service {
 			$this->unarchive_price( $this->get_stripe_price_id( $product ) );
 			$this->payments_api_client->update_product( $stripe_product_id, [ 'active' => 'true' ] );
 		} catch ( API_Exception $e ) {
-			Logger::log( 'There was a problem unarchiving the product in Stripe:', $e->getMessage() );
+			Logger::log( 'There was a problem unarchiving the product in Stripe: ' . $e->getMessage() );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After updating a variable subscription product's name and/or description field we weren't triggering an update for the variations to have their name updated in Stripe. See this comments https://github.com/Automattic/woocommerce-payments/pull/2669#issuecomment-899160614

This PR fixes that by scheduling an update for all variations in need of an update when a variable product is saved. 

#### Testing instructions

1. Create a variable subscription product with variations. 
2. Note in the account dashboard that all the variations have been created product.
3. Change the variable product's name in WC. 
   - Before this fix, the variations wouldn't be updated in the dashboard.
   - On this branch, the names of the variations are updated in Stripe. 


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This PR also fixes PHP errors thown when trying to write logs. When the logging functions were updated, the old logging functions signature/format was kept. With WC Pay's logger, the second param is the message type (`'error'` etc). This commit (3ca845d) fixes those. 


Just making a note that there is some redundancy in the way we check if all variations need updating potentially multiple times, however, it's pretty minor given I try to do as much skipping of checks where I can. Possible fixes to that redundancy have other potential problems too.  

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
