### PR TITLE
Remove an extra period in changelog and add a missing changelog line to readme.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@
 * Add - *Early access*: allow your store to collect payments with Bancontact, iDEAL, and Przelewy24 (P24). Enable the feature in settings!
 * Add - Split discount line in timeline into variable fee and fixed fee.
 * Fix - Align table items according to design correctly.
-* Fix - Fatal error if wcpay_multi_currency_enabled_currencies is a string..
+* Fix - Fatal error if wcpay_multi_currency_enabled_currencies is a string.
 * Fix - Show the estimated deposit date in the transactions CSV export rather than the deposit ID.
 * Fix - Keep track of customer id in non logged in users.
 

--- a/readme.txt
+++ b/readme.txt
@@ -102,7 +102,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - *Early access*: allow your store to collect payments with Bancontact, iDEAL, and Przelewy24 (P24). Enable the feature in settings!
 * Add - Split discount line in timeline into variable fee and fixed fee.
 * Fix - Align table items according to design correctly.
-* Fix - Fatal error if wcpay_multi_currency_enabled_currencies is a string..
+* Fix - Fatal error if wcpay_multi_currency_enabled_currencies is a string.
 * Fix - Show the estimated deposit date in the transactions CSV export rather than the deposit ID.
 * Fix - Keep track of customer id in non logged in users.
 
@@ -144,6 +144,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Show fee breakdown in transaction details timeline.
 * Add - REST endpoint to get customer id from an order.
 * Fix - Explat not caching when no variation is returned.
+* Add - Add a new hook to get a list of enabled payment request methods.
 
 = 2.7.1 - 2021-07-26 =
 * Fix - Ensure test mode setting value is correctly saved.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I noticed an extra period [added unintentionally](https://github.com/Automattic/woocommerce-payments/commit/9440ded8a423b9b416fc67629afb8f6af4a72ad6#diff-b40cd67182487ef24807d9c9268329d35fbd96aa2b0a9cae69e2e0d746b1c666L7-R7), I assume.
While at it, I also found a missing line in `readme.txt` if compared with `changelog.txt`, so added that as well.

#### Testing instructions

Make sure changelog and readme look good.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
