### PR TITLE
Adds subscription invoice service

### DIFF
--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -93,14 +93,14 @@ class WC_Payments_Invoice_Service {
 				return;
 			}
 
-			$order_completed = in_array( $new_status, [ apply_filters( 'woocommerce_payment_complete_order_status', 'processing', $order_id, $order ), 'processing', 'completed' ], true ) && in_array( $old_status, apply_filters( 'woocommerce_valid_order_statuses_for_payment', [ 'pending', 'on-hold', 'failed' ], $order ), true );
+			$needed_payment  = in_array( $old_status, apply_filters( 'woocommerce_valid_order_statuses_for_payment', [ 'pending', 'on-hold', 'failed' ], $order ), true );
+			$order_completed = in_array( $new_status, [ apply_filters( 'woocommerce_payment_complete_order_status', 'processing', $order_id, $order ), 'processing', 'completed' ], true );
 			$invoice_id      = self::get_order_invoice_id( $order );
 
-			if ( $invoice_id && $order_completed ) {
+			if ( $invoice_id && $needed_payment && $order_completed ) {
 				// TODO: Maybe get the invoice first and check if it's not already completed
 				// update the status of the invoice to paid but don't charge the customer by using paid_out_of_band parameter.
 				$this->payments_api_client->charge_invoice( $invoice_id, [ 'paid_out_of_band' => 'true' ] );
-
 			}
 		}
 	}

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -1,0 +1,308 @@
+<?php
+/**
+ * Class WC_Payments_Invoice_Service
+ *
+ * @package WooCommerce\Payments
+ */
+
+use WCPay\Exceptions\API_Exception;
+use WCPay\Logger;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class handling any subscription invoice functionality.
+ */
+class WC_Payments_Invoice_Service {
+
+	/**
+	 * Subscription meta key used to store subscription's last invoice ID.
+	 *
+	 * @const string
+	 */
+	const PENDING_INVOICE_ID_KEY = '_wcpay_pending_invoice_id';
+
+	/**
+	 * Meta key used to store invoice IDs on orders.
+	 *
+	 * @const
+	 */
+	const ORDER_INVOICE_ID_KEY = '_wcpay_billing_invoice_id';
+
+	/**
+	 * Client for making requests to the WooCommerce Payments API.
+	 *
+	 * @var WC_Payments_API_Client
+	 */
+	private $payments_api_client;
+
+	/**
+	 * Tax Service.
+	 *
+	 * @var WC_Payments_Tax_Service Add the tax service class.
+	 */
+	private $tax_service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Payments_API_Client  $payments_api_client WooCommerce Payments API client.
+	 * @param WC_Payments_Tax_Service $tax_service         The Tax service.
+	 */
+	public function __construct( WC_Payments_API_Client $payments_api_client, $tax_service ) {
+		$this->payments_api_client = $payments_api_client;
+		$this->tax_service         = $tax_service;
+
+		add_action( 'woocommerce_order_status_changed', [ $this, 'maybe_record_first_invoice_payment' ], 10, 3 );
+	}
+
+	/**
+	 * Sets a pending invoice ID meta for a subscription.
+	 *
+	 * @param WC_Subscription $subscription The subscription to set the invoice on.
+	 * @param string          $invoice_id   The invoice ID.
+	 */
+	public function mark_pending_invoice_for_subscription( WC_Subscription $subscription, string $invoice_id ) {
+		$this->set_pending_invoice_id( $subscription, $invoice_id );
+	}
+
+	/**
+	 * Removes pending invoice id meta from subscription.
+	 *
+	 * @param WC_Subscription $subscription The Subscription.
+	 */
+	public function mark_pending_invoice_paid_for_subscription( WC_Subscription $subscription ) {
+		$this->set_pending_invoice_id( $subscription, '' );
+	}
+
+	/**
+	 * Marks the initial subscription invoice as paid after a parent order is completed.
+	 *
+	 * When a subscription's parent order goes from a pending payment status to a payment completed status,
+	 * make sure the invoice is marked as paid (without charging the customer since it was charged on checkout).
+	 *
+	 * @param int    $order_id   The order which is updating status.
+	 * @param string $old_status The order's old status.
+	 * @param string $new_status The order's new status.
+	 */
+	public function maybe_record_first_invoice_payment( int $order_id, string $old_status, string $new_status ) {
+		if ( wcs_order_contains_subscription( $order_id, 'parent' ) ) {
+			$order = wc_get_order( $order_id );
+
+			if ( ! $order ) {
+				return;
+			}
+
+			$order_completed = in_array( $new_status, [ apply_filters( 'woocommerce_payment_complete_order_status', 'processing', $order_id, $order ), 'processing', 'completed' ], true ) && in_array( $old_status, apply_filters( 'woocommerce_valid_order_statuses_for_payment', [ 'pending', 'on-hold', 'failed' ], $order ), true );
+			$invoice_id      = self::get_order_invoice_id( $order );
+
+			if ( $invoice_id && $order_completed ) {
+				// TODO: Maybe get the invoice first and check if it's not already completed
+				// update the status of the invoice to paid but don't charge the customer by using paid_out_of_band parameter.
+				$this->payments_api_client->charge_invoice( $invoice_id, [ 'paid_out_of_band' => 'true' ] );
+
+			}
+		}
+	}
+
+	/**
+	 * Creates invoice items for discounts, fees, and shipping if applicable.
+	 *
+	 * @param WC_Subscription $subscription           The WC Subscription object.
+	 * @param string          $customer_id            The WCPay Customer ID.
+	 * @param string          $wcpay_subscription_id  The WCPay Billing subscription ID.
+	 *
+	 * @throws \Exception When there's an error preparing the invoice item data.
+	 *
+	 * @return string[]|WP_Error Invoice item ids.
+	 */
+	public function create_invoice_items_for_subscription( WC_Subscription $subscription, string $customer_id, string $wcpay_subscription_id = '' ) {
+		$invoice_item_ids = [];
+
+		try {
+			$invoice_item_data = $this->prepare_invoice_item_data( $subscription );
+
+			if ( is_wp_error( $invoice_item_data ) ) {
+				throw new \Exception( 'There was a problem preparing invoice item data: ' . wp_json_encode( $invoice_item_data ) );
+			}
+
+			foreach ( $invoice_item_data as $data ) {
+				if ( $wcpay_subscription_id ) {
+					$data['subscription'] = $wcpay_subscription_id;
+				}
+
+				$data['customer'] = $customer_id;
+				$result           = $this->payments_api_client->create_invoice_item( $data );
+
+				if ( is_wp_error( $result ) ) {
+					throw new \Exception( "There was a problem creating the {$data['description']} invoice item: " . wp_json_encode( $result ) );
+				}
+
+				$invoice_item_ids[] = $result['id'];
+			}
+		} catch ( \Exception $e ) {
+			$this->delete_invoice_items( $invoice_item_ids );
+
+			return new WP_Error( $e->getMessage() );
+		}
+
+		return $invoice_item_ids;
+	}
+
+	/**
+	 * Deletes invoice items from an upcoming invoice.
+	 *
+	 * @param string[] $invoice_item_ids The invoice items to delete.
+	 */
+	public function delete_invoice_items( array $invoice_item_ids ) {
+		foreach ( $invoice_item_ids as $invoice_item_id ) {
+			$this->payments_api_client->delete_invoice_item( $invoice_item_id );
+		}
+	}
+
+	/**
+	 * Prepares fee, shipping, and discount subscription item data.
+	 *
+	 * @param WC_Subscription $subscription The subscription.
+	 *
+	 * @return array|WP_Error Invoice item data or WP_Error.
+	 */
+	private function prepare_invoice_item_data( WC_Subscription $subscription ) {
+		$data       = [];
+		$items      = [];
+		$is_delayed = false;
+		$is_new     = $subscription->get_parent()->needs_payment();
+
+		// We need to get the discount from the parent order to check for signup fee coupon when subscription is new.
+		$discount = $is_new ? $subscription->get_parent()->get_total_discount( false ) : $subscription->get_total_discount( false );
+
+		if ( $discount ) {
+			$data[] = $this->format_invoice_item_data( -$discount, $subscription->get_currency(), __( 'Discount', 'woocommerce-payments' ) );
+		}
+
+		if ( $is_new ) {
+			// TODO: replace the line below once the subscription service has been copied over.
+			// $is_delayed = WCS_Stripe_Billing_Subscription_Service::has_delayed_payment( $subscription );.
+			$is_delayed = false;
+			$items      = $subscription->get_items();
+		}
+
+		if ( ! $is_delayed ) {
+			$items = array_merge(
+				$items,
+				$subscription->get_fees(),
+				// Similarly, we need to get shipping methods from parent order to check for one-time shipping when subscription is new.
+				( $is_new ? $subscription->get_parent()->get_shipping_methods() : $subscription->get_shipping_methods() )
+			);
+		}
+
+		foreach ( $items as $item ) {
+			if ( $item->is_type( 'line_item' ) ) {
+				$amount      = floatval( WC_Subscriptions_Product::get_sign_up_fee( $item->get_product() ) );
+				$description = __( 'Sign-up Fee', 'woocommerce-payments' );
+			} else {
+				$amount      = $item->get_total();
+				$description = ucfirst( $item->get_name() );
+			}
+
+			if ( $amount ) {
+				// TODO: Replace the line below once the tax rates service is copied over.
+				// $tax_rates = $this->tax_service->get_tax_rates_for_item( $item, $subscription );.
+				$tax_rates = [];
+
+				if ( is_wp_error( $tax_rates ) ) {
+					return $tax_rates;
+				}
+
+				$data[] = $this->format_invoice_item_data( $amount, $subscription->get_currency(), $description, $tax_rates );
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Formats invoice item data.
+	 *
+	 * @param float  $amount      The invoice item amount.
+	 * @param string $currency    The item's currency.
+	 * @param string $description The item's description.
+	 * @param array  $tax_rates   The item's taxes. Optional. Default is an empty array.
+	 *
+	 * @return array Structured invoice item array.
+	 */
+	private function format_invoice_item_data( float $amount, string $currency, string $description, array $tax_rates = [] ) : array {
+		return [
+			'amount'      => $amount * 100,
+			'currency'    => $currency,
+			'description' => $description,
+			'tax_rates'   => $tax_rates,
+		];
+	}
+
+	/**
+	 * Gets the subscription last invoice ID from WC subscription.
+	 *
+	 * @param WC_Subscription $subscription The subscription.
+	 *
+	 * @return string Invoice ID.
+	 */
+	public static function get_pending_invoice_id( WC_Subscription $subscription ) : string {
+		return $subscription->get_meta( self::PENDING_INVOICE_ID_KEY, true );
+	}
+
+	/**
+	 * Sets the subscription last invoice ID meta for WC subscription.
+	 *
+	 * @param WC_Subscription $subscription The subscription.
+	 * @param string          $invoice_id   The invoice ID.
+	 */
+	private function set_pending_invoice_id( WC_Subscription $subscription, string $invoice_id ) {
+		$subscription->update_meta_data( self::PENDING_INVOICE_ID_KEY, $invoice_id );
+		$subscription->save();
+	}
+
+	/**
+	 * Gets the invoice ID from a WC order.
+	 *
+	 * @param WC_Order $order The order.
+	 * @return string Invoice ID.
+	 */
+	public static function get_order_invoice_id( WC_Order $order ) : string {
+		return $order->get_meta( self::ORDER_INVOICE_ID_KEY, true );
+	}
+
+	/**
+	 * Sets the subscription's last invoice ID meta for WC subscription.
+	 *
+	 * @param WC_Order $order      The order.
+	 * @param string   $invoice_id The invoice ID.
+	 */
+	public function set_order_invoice_id( WC_Order $order, string $invoice_id ) {
+		$order->update_meta_data( self::ORDER_INVOICE_ID_KEY, $invoice_id );
+		$order->save();
+	}
+
+	/**
+	 * Gets the WC order ID from the invoice ID.
+	 *
+	 * @param string $invoice_id The invoice ID.
+	 * @return int The order ID.
+	 */
+	public static function get_order_id_by_invoice_id( string $invoice_id ) {
+		global $wpdb;
+
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"
+				SELECT pm.post_id
+				FROM {$wpdb->prefix}postmeta AS pm
+				INNER JOIN {$wpdb->prefix}posts AS p ON pm.post_id = p.ID
+				WHERE pm.meta_key = %s AND pm.meta_value = %s
+				",
+				self::ORDER_INVOICE_ID_KEY,
+				$invoice_id
+			)
+		);
+	}
+}

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -22,12 +22,31 @@ class WC_Payments_Subscriptions {
 	private static $product_service;
 
 	/**
+	 * Instance of WC_Payments_Tax_Service, created in init function.
+	 *
+	 * @var WC_Payments_Tax_Service
+	 */
+	private static $tax_service;
+
+	/**
+	 * Instance of WC_Payments_Invoice_Service, created in init function.
+	 *
+	 * @var WC_Payments_Invoice_Service
+	 */
+	private static $invoice_service;
+
+	/**
 	 * Initialize WooCommerce Payments subscriptions. (Stripe Billing)
 	 *
 	 * @param WC_Payments_API_Client $api_client WCPay API client.
 	 */
 	public static function init( WC_Payments_API_Client $api_client ) {
 		include_once __DIR__ . '/class-wc-payments-product-service.php';
+		include_once __DIR__ . '/class-wc-payments-invoice-service.php';
+
 		self::$product_service = new WC_Payments_Product_Service( $api_client );
+		self::$tax_service     = null;
+		self::$invoice_service = new WC_Payments_Invoice_Service( $api_client, self::$tax_service );
+
 	}
 }

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -20,8 +20,9 @@ class WC_Payments_API_Client {
 	const ENDPOINT_SITE_FRAGMENT = 'sites/%s';
 	const ENDPOINT_REST_BASE     = 'wcpay';
 
-	const POST = 'POST';
-	const GET  = 'GET';
+	const POST   = 'POST';
+	const GET    = 'GET';
+	const DELETE = 'DELETE';
 
 	const API_TIMEOUT_SECONDS = 70;
 
@@ -46,6 +47,7 @@ class WC_Payments_API_Client {
 	const PRICES_API          = 'products/prices';
 	const SUBSCRIPTIONS_API   = 'subscriptions';
 	const INVOICES_API        = 'invoices';
+	const INVOICE_ITEMS_API   = '/invoice/items';
 
 	/**
 	 * Common keys in API requests/responses that we might want to redact.
@@ -1030,6 +1032,55 @@ class WC_Payments_API_Client {
 			$price_data,
 			self::PRICES_API . '/' . $price_id,
 			self::POST
+		);
+	}
+
+	/**
+	 * Charges an invoice.
+	 *
+	 * Calling this function charges the customer. Pass the param 'paid_out_of_band' => true to mark the invoice as paid without charging the customer.
+	 *
+	 * @param string $invoice_id ID of the invoice to charge.
+	 * @param array  $data       Parameters to send to the invoice /pay endpoint. Optional. Default is an empty array.
+	 * @return array
+	 *
+	 * @throws API_Exception Error charging the invoice.
+	 */
+	public function charge_invoice( string $invoice_id, array $data = [] ) {
+		return $this->request(
+			$data,
+			self::INVOICES_API . '/' . $invoice_id . '/pay',
+			self::POST
+		);
+	}
+
+	/**
+	 * Creates an invoice item.
+	 *
+	 * @param array $invoice_item_data The invoice item data.
+	 *
+	 * @throws API_Exception Error creating the invoice item.
+	 */
+	public function create_invoice_item( $invoice_item_data ) {
+		return $this->request(
+			$invoice_item_data,
+			self::INVOICE_ITEMS_API,
+			self::POST
+		);
+	}
+
+	/**
+	 * Deletes an invoice item.
+	 *
+	 * @param string $invoice_item_id ID of the invoice item to delete.
+	 *
+	 * @throws API_Exception Error deleting the invoice item.
+	 */
+	public function delete_invoice_item( $invoice_item_id ) {
+		return $this->request(
+			[],
+			self::INVOICE_ITEMS_API . '/' . $invoice_item_id,
+			self::DELETE
 		);
 	}
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -138,4 +138,17 @@
       <code>WC_Subscriptions_Base_Plugin</code>
     </UndefinedClass>
   </file>
+  <file src="includes/subscriptions/class-wc-payments-invoice-service.php">
+    <UndefinedClass occurrences="6">
+      <code>WC_Subscription</code>
+      <code>WC_Subscription</code>
+      <code>WC_Subscription</code>
+      <code>WC_Subscription</code>
+      <code>WC_Subscription</code>
+      <code>WC_Subscription</code>
+    </UndefinedClass>
+    <UndefinedFunction occurrences="1">
+      <code>wcs_order_contains_subscription( $order_id, 'parent' )</code>
+    </UndefinedFunction>
+  </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -148,7 +148,7 @@
       <code>WC_Subscription</code>
     </UndefinedClass>
     <UndefinedFunction occurrences="1">
-      <code>wcs_order_contains_subscription( $order_id, 'parent' )</code>
+      <code>wcs_order_contains_subscription( $order, 'parent' )</code>
     </UndefinedFunction>
   </file>
 </files>

--- a/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * Class WC_Payments_Invoice_Service_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Exceptions\API_Exception;
+
+/**
+ * WC_Payments_Invoice_Service_Test unit tests.
+ */
+class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
+
+	const PENDING_INVOICE_ID_KEY = '_wcpay_pending_invoice_id';
+	const ORDER_INVOICE_ID_KEY   = '_wcpay_billing_invoice_id';
+
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_API_Client|MockObject
+	 */
+	private $mock_api_client;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->mock_api_client = $this->createMock( WC_Payments_API_Client::class );
+		$this->invoice_service = new WC_Payments_Invoice_Service( $this->mock_api_client, null );
+	}
+
+	/**
+	 * Tests for WC_Payments_Invoice_Service::mark_pending_invoice_for_subscription()
+	 */
+	public function test_mark_pending_invoice_for_subscription() {
+		$mock_subscription = new WC_Subscription();
+		$invoice_id        = 'in_123abc';
+
+		$this->invoice_service->mark_pending_invoice_for_subscription( $mock_subscription, $invoice_id );
+		$this->assertEquals( $invoice_id, $mock_subscription->get_meta( self::PENDING_INVOICE_ID_KEY, true ) );
+	}
+
+	/**
+	 * Tests for WC_Payments_Invoice_Service::mark_pending_invoice_paid_for_subscription()
+	 */
+	public function test_mark_pending_invoice_paid_for_subscription() {
+		$mock_subscription = new WC_Subscription();
+
+		$this->invoice_service->mark_pending_invoice_paid_for_subscription( $mock_subscription );
+		$this->assertEquals( '', $mock_subscription->get_meta( self::PENDING_INVOICE_ID_KEY, true ) );
+	}
+
+	/**
+	 * Tests for WC_Payments_Invoice_Service::delete_invoice_items()
+	 */
+	public function test_delete_invoice_items() {
+		$invoice_ids = [ 'in_foo', 'in_bar', 'in_baz' ];
+
+		$this->mock_api_client->expects( $this->exactly( 3 ) )
+			->method( 'delete_invoice_item' )
+			->withConsecutive(
+				[ $this->equalTo( 'in_foo' ) ],
+				[ $this->equalTo( 'in_bar' ) ],
+				[ $this->equalTo( 'in_baz' ) ]
+			);
+
+		$this->invoice_service->delete_invoice_items( $invoice_ids );
+	}
+
+	/**
+	 * Tests for WC_Payments_Invoice_Service::format_invoice_item_data()
+	 */
+	public function test_format_invoice_item_data() {
+		$result = PHPUnit_Utils::call_method(
+			$this->invoice_service,
+			'format_invoice_item_data',
+			[ 10, 'USD', 'foobar' ]
+		);
+
+		$this->assertEquals(
+			[
+				'amount'      => (float) 1000,
+				'currency'    => 'USD',
+				'description' => 'foobar',
+				'tax_rates'   => [],
+			],
+			$result
+		);
+	}
+
+	/**
+	 * Tests for WC_Payments_Invoice_Service::get_pending_invoice_id()
+	 */
+	public function test_get_pending_invoice_id() {
+		$mock_subscription = new WC_Subscription();
+
+		$this->assertEquals( '', $this->invoice_service->get_pending_invoice_id( $mock_subscription ) );
+
+		$mock_subscription->update_meta_data( self::PENDING_INVOICE_ID_KEY, 'in_test123' );
+		$this->assertEquals( 'in_test123', $this->invoice_service->get_pending_invoice_id( $mock_subscription ) );
+	}
+
+	/**
+	 * Tests for WC_Payments_Invoice_Service::set_pending_invoice_id()
+	 */
+	public function test_set_pending_invoice_id() {
+		$mock_subscription = new WC_Subscription();
+
+		PHPUnit_Utils::call_method(
+			$this->invoice_service,
+			'set_pending_invoice_id',
+			[ $mock_subscription, 'in_test_abc' ]
+		);
+		$this->assertEquals( 'in_test_abc', $mock_subscription->get_meta( self::PENDING_INVOICE_ID_KEY, true ) );
+	}
+
+	/**
+	 * Tests for WC_Payments_Invoice_Service::get_order_invoice_id()
+	 */
+	public function test_get_order_invoice_id() {
+		$mock_order = WC_Helper_Order::create_order();
+
+		$this->assertEquals( '', $this->invoice_service->get_order_invoice_id( $mock_order ) );
+
+		$mock_order->update_meta_data( self::ORDER_INVOICE_ID_KEY, 'in_foo' );
+		$this->assertEquals( 'in_foo', $this->invoice_service->get_order_invoice_id( $mock_order ) );
+	}
+
+	/**
+	 * Tests for WC_Payments_Invoice_Service::set_order_invoice_id()
+	 */
+	public function test_set_order_invoice_id() {
+		$mock_order = WC_Helper_Order::create_order();
+
+		$this->invoice_service->set_order_invoice_id( $mock_order, 'in_bar' );
+		$this->assertEquals( 'in_bar', $mock_order->get_meta( self::ORDER_INVOICE_ID_KEY, true ) );
+	}
+
+	/**
+	 * Tests for WC_Payments_Invoice_Service::get_order_id_by_invoice_id()
+	 */
+	public function test_get_order_id_by_invoice_id() {
+		$mock_order = WC_Helper_Order::create_order();
+
+		$mock_order->update_meta_data( self::ORDER_INVOICE_ID_KEY, 'in_invoice123' );
+		$mock_order->save();
+
+		$this->assertEquals( $mock_order->get_id(), $this->invoice_service->get_order_id_by_invoice_id( 'in_invoice123' ) );
+		$this->assertEquals( 0, $this->invoice_service->get_order_id_by_invoice_id( 'invalid_invoice_id' ) );
+	}
+
+	/**
+	 * Tests for WC_Payments_Invoice_Service::prepare_invoice_item_data()
+	 */
+	public function test_prepare_invoice_item_data() {
+		$mock_order        = WC_Helper_Order::create_order();
+		$mock_subscription = new WC_Subscription();
+
+		$mock_subscription->set_parent( $mock_order );
+		$mock_order->set_discount_total( 20 );
+
+		$result = PHPUnit_Utils::call_method(
+			$this->invoice_service,
+			'prepare_invoice_item_data',
+			[ $mock_subscription ]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertContainsOnly( 'array', $result );
+		$this->assertEquals( 2, count( $result ) );
+
+		foreach ( $result as $item_data ) {
+			foreach ( [ 'amount', 'currency', 'description', 'tax_rates' ] as $key ) {
+				$this->assertArrayHasKey( $key, $item_data );
+			}
+		}
+	}
+
+	/**
+	 * Tests for WC_Payments_Invoice_Service::create_invoice_items_for_subscription()
+	 */
+	public function test_create_invoice_items_for_subscription() {
+		$wcpay_subscription_id = 'sub_test123';
+		$wcpay_customer_id     = 'cus_test123';
+
+		$mock_order        = WC_Helper_Order::create_order();
+		$mock_subscription = new WC_Subscription();
+
+		$mock_subscription->set_parent( $mock_order );
+
+		// The mock order comes with a $10 flat rate shipping so the expected invoice items are the following.
+		$expected_args = [
+			'amount'       => 1000,
+			'currency'     => 'USD',
+			'description'  => 'Flat rate shipping',
+			'tax_rates'    => [],
+			'customer'     => $wcpay_customer_id,
+			'subscription' => $wcpay_subscription_id,
+		];
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'create_invoice_item' )
+			->with( $expected_args );
+
+		$this->invoice_service->create_invoice_items_for_subscription( $mock_subscription, $wcpay_customer_id, $wcpay_subscription_id );
+	}
+
+	/**
+	 * Tests for WC_Payments_Invoice_Service::maybe_record_first_invoice_payment()
+	 */
+	public function test_maybe_record_first_invoice_payment() {
+		$invoice_id = 'in_foo123';
+		$mock_order = WC_Helper_Order::create_order();
+
+		$this->mock_wcs_order_contains_subscription( true );
+		$mock_order->update_meta_data( self::ORDER_INVOICE_ID_KEY, $invoice_id );
+		$mock_order->save();
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'charge_invoice' )
+			->with( $invoice_id, [ 'paid_out_of_band' => 'true' ] );
+
+		$this->invoice_service->maybe_record_first_invoice_payment( $mock_order->get_id(), 'pending', 'processing' );
+	}
+
+	/**
+	 * Mocks the wcs_order_contains_subscription function return.
+	 *
+	 * @param bool The value to return to wcs_order_contains_subscription() calls.
+	 */
+	private function mock_wcs_order_contains_subscription( $value ) {
+		WC_Subscriptions::set_wcs_order_contains_subscription(
+			function ( $order ) use ( $value ) {
+				return $value;
+			}
+		);
+	}
+}


### PR DESCRIPTION
See pb0GrA-1g9-p2

#### Changes proposed in this Pull Request

This PR adds the subscription invoice service class that facilitates the generating of invoice item data, the processing of the first invoice on sign up and storing invoice IDs on subscriptions and orders. 

Because of the nature of this class as a pure service object, it isn't put to use until it's plugged into a subscription service object that will come in the following PRs.

#### Testing instructions

Because the functions in this class don't do anything on their own, there aren't steps to really test this yet. Having said that, I've added unit tests to test every function being introduced. 


-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
