### PR TITLE
Disable Bancontact, iDEAL, and P24 as UPE payment methods.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,6 @@
 *** WooCommerce Payments Changelog ***
 
 = 2.9.0 - 2021-xx-xx =
-* Add - *Early access*: allow your store to collect payments with Bancontact, iDEAL, and Przelewy24 (P24). Enable the feature in settings!
 * Add - Split discount line in timeline into variable fee and fixed fee.
 * Fix - Align table items according to design correctly.
 * Fix - Fatal error if wcpay_multi_currency_enabled_currencies is a string.

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -736,10 +736,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	public function get_upe_available_payment_methods() {
 		$methods = parent::get_upe_available_payment_methods();
 
-		$methods[] = 'bancontact';
 		$methods[] = 'giropay';
-		$methods[] = 'ideal';
-		$methods[] = 'p24';
 		$methods[] = 'sofort';
 
 		return array_values(

--- a/readme.txt
+++ b/readme.txt
@@ -99,7 +99,6 @@ Please note that our support for the checkout block is still experimental and th
 == Changelog ==
 
 = 2.9.0 - 2021-xx-xx =
-* Add - *Early access*: allow your store to collect payments with Bancontact, iDEAL, and Przelewy24 (P24). Enable the feature in settings!
 * Add - Split discount line in timeline into variable fee and fixed fee.
 * Fix - Align table items according to design correctly.
 * Fix - Fatal error if wcpay_multi_currency_enabled_currencies is a string.

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -131,7 +131,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WP_UnitTestCase {
 		$enabled_method_ids = $response->get_data()['available_payment_method_ids'];
 
 		$this->assertEquals(
-			[ 'card', 'bancontact', 'giropay', 'ideal', 'p24', 'sofort' ],
+			[ 'card', 'giropay', 'sofort' ],
 			$enabled_method_ids
 		);
 	}


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Remove ability for merchants to add Bancontact, iDEAL, and P24 as UPE methods.

#### Testing instructions

* Go to Payments > Settings
* You should not see Bancontact, iDEAL, or P24 as able to be added as UPE methods.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)

Actually removed testing instructions:
<details>
## Test iDEAL payment method

iDEAL is the most used payment method in Netherlands.

This feature adds iDEAL as an available payment method when using UPE.
- Adds the method into the UPE payment gateway
- Adds all the different places in the client where is used, to enable the method, transactions info, checkout...

![image](https://user-images.githubusercontent.com/2612426/128512804-05d688c4-d6db-4335-8b73-bbee96202b23.png)

![image](https://user-images.githubusercontent.com/2612426/128513147-2c14c32b-31d2-403d-aa3f-519b65b5a6a2.png)

**Testing instructions**

* Enable "grouped settings", "UPE checkout" and "UPE additional payment methods" in the WCPay Dev Utils
* Add iDEAL as a payment method in "Payments accepted on checkout" in **WooCommerce → Settings**.
* Choose Euro as a currency
* Buy something
* In the checkout you can select iDEAL and any bank to test
* Test both succeeding and failing cases

## Test P24 payment method

This feature adds the P24 payment method as a UPE provider to WooCommerce Payments. P24 is the most popular payment method in Poland, it supports PLN and EUR as payment currencies, also from their website, they support:

- Card transaction processing on the merchant's website, the option of adapting the card form to the website/store layout,
- One Click Payment - payment with a single click - with no need for the buyer to create an account in the payment service provider's system,
- Supporting transactions in 50 currencies with no currency conversion fees - 1 to 1 payment,
- DCC (Dynamic Currency Conversion) - this solution allows customers to make transactions in foreign currencies. A foreign card-holder may choose the currency for a given transaction but is charged the amount in his native currency. When this type of payment is made, the merchant receives a bonus - a refund of up to 1% of the transaction value,
- Recurring payments which guarantee timely settlements with merchants who offer subscriptions, passes, etc.,
- Card payments over the phone - IVR
- Transfer of risk in case of fraud.

After the implementation, these screens now contain P24 elements:

##### Add Payment Method Modal
<img width="571" alt="Add Payment Methods" src="https://user-images.githubusercontent.com/3295/128630812-0b78e8cf-df74-4bea-8d78-c0692e13d1ba.png">

##### Enabled Payment Methods List
<img width="677" alt="Enabled Payment Methods" src="https://user-images.githubusercontent.com/3295/128630814-0bc56d0b-d4ee-4877-9088-9ebc2a5ac7c7.png">

##### Payment Screen
<img width="264" alt="Payment Screen" src="https://user-images.githubusercontent.com/3295/128630816-5c02f5f4-6a98-4e5c-9772-90ebe47de2fe.png">

**Testing instructions**

* Enable "grouped settings", "UPE checkout" and "UPE additional payment methods" in the WCPay Dev Utils
* Go to **WooCommerce > Settings > Payments** And on this screen, find **Payment Methods** metabox
* Check if you can see the P24 icon on the right of the **Add Payment Method** button.
* Click the **Add Payment Method** button, select **Przelewy24 (P24)** and click **Add selected**.
* Check if **Przelewy24 (P24)** is added to the **Payment Methods** list.
* Go to your store and select your customer currency to EUR. Or if you don't have customer multi-currency, set your store currency to EUR from **WooCommerce > Settings > General** page.
* Add some items to the cart, and proceed to checkout. 
* On the checkout page, select **Use a different payment method** radio button and wait for the UPE iframe to render.
* Check if you can see Przelewy24 (P24) on the available payment methods list in the iframe.
* Select P24 and on the new form below, select a bank.
* Click **Place Order** button to complete the payment.
* This should redirect you to Stripe's P24 test transaction page.

## Test Bancontact payment method

![Markup 2021-08-13 at 15 13 27](https://user-images.githubusercontent.com/4634416/129402497-60086233-5a89-4fa2-942e-f93e56316460.png)
![Markup 2021-08-13 at 15 14 22](https://user-images.githubusercontent.com/4634416/129402512-6acf24a0-c8d4-41bd-b455-409f2b710321.png)

**Testing instructions**

* Under dev tools the boxes for _Enable grouped settings_, _Enable UPE checkout_, and _Add UPE additional payment methods_ need to be checked.
* If EUR is your default currency, navigate to WooCommerce > Settings > General and change the currency to USD.
* If EUR is an enabled currency in your store, navigate to WooCommerce > Settings > Multi-Currency and remove EUR as a currency.
* Navigate to Payments > Settings.
* Click _Add payment method_, verify Bancontact is in the modal, along with its icon.
* Select Bancontact, a notice should appear stating that Euros are being added to your store. Click _Add selected_, then scroll to the bottom and click _Save changes_.
* Verify Bancontact and its logo are now in the _Payment methods_ area.
* Navigate to WooCommerce > Settings > Multi-Currency and verify EUR is now an enabled currency in your store.
* On the frontend, add an item to your cart, and go to checkout.
* Verify your currency *is not* EUR, payment method should show as _Credit card / debit card_ and when selecting _Use a new payment method_, Bancontact should not appear.
* Switch your currency to EUR, payment method should show as _Popular payment methods_ and when selecting _Use a new payment method_, Bancontact should appear.
* Select Bancontact.
* Complete checkout/place order.
* You will be taken to a Stripe test confirmation page, choose _Authorize test payment_.
* Once order is received, navigate to WooCommerce > Orders in the admin.
* Find your order and select it.
* Click _Refund_, and then increase a line item in your order to 1.
* Click _Refund via WooCommerce Payments_, verify your refund completed.
* Navigate to Payments > Transactions, you should see your _Payment_ and _Payment refund_ listed for your order, verify both have the Bancontact logo.
* Click on the Payment, then verify the _Payment method_ both at the top and bottom are correctly formatting (they will have default test info).
* Do the same for the Payment refund.
* Navigate to Payments > Settings, then click the trash can icon to delete Bancontact. Verify the name and the logo in the modal are correct, then click _Remove_, scroll to the bottom and _Save changes_.
* Verify Bancontact is no longer in the list of _Payment methods_.
</details>