### PR TITLE
Bump Preview Mode Experiment Version to v4

### DIFF
--- a/client/deposits/index.js
+++ b/client/deposits/index.js
@@ -39,7 +39,7 @@ const DepositsPage = () => {
 	return (
 		<Page>
 			<Experiment
-				name="wcpay_empty_state_preview_mode_v2"
+				name="wcpay_empty_state_preview_mode_v4"
 				treatmentExperience={ treatmentExperience }
 				defaultExperience={ defaultExperience }
 			/>

--- a/client/transactions/index.tsx
+++ b/client/transactions/index.tsx
@@ -38,7 +38,7 @@ export const TransactionsPage = (): JSX.Element => {
 	return (
 		<Page>
 			<Experiment
-				name="wcpay_empty_state_preview_mode_v2"
+				name="wcpay_empty_state_preview_mode_v4"
 				treatmentExperience={ treatmentExperience }
 				defaultExperience={ defaultExperience }
 			/>

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -616,7 +616,7 @@ class WC_Payments_Admin {
 			'yes' === get_option( 'woocommerce_allow_tracking' )
 		);
 
-		return 'treatment' === $abtest->get_variation( 'wcpay_empty_state_preview_mode_v2' );
+		return 'treatment' === $abtest->get_variation( 'wcpay_empty_state_preview_mode_v4' );
 	}
 
 	/**


### PR DESCRIPTION
This bumps the Preview Mode ExPlat experiment version. Version 3 is skipped because it has geo-targeting for US-stores.

The v4 experiment has no geo-targeting per new requirements.

### Testing Instructions

See that PHP and E2E checks pass.

Note: it is not possible to manually test this. This PR will enable manual testing of PR https://github.com/Automattic/woocommerce-payments/pull/2557.