### PR TITLE
Adds the WCPay subscriptions service class

### DIFF
--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -363,4 +363,30 @@ class WC_Payments_Customer_Service {
 			}
 		}
 	}
+
+	/**
+	 * Get the WCPay customer ID associated with an order, or create one if none found.
+	 *
+	 * @param WC_Order $order WC Order object.
+	 *
+	 * @return string WCPay customer ID.
+	 *
+	 * @throws API_Exception If there's an error creating customer.
+	 */
+	public function get_customer_id_for_order( $order ) {
+		$customer_id = null;
+		$user        = $order->get_user();
+
+		if ( false !== $user ) {
+			// Determine the customer making the payment, create one if we don't have one already.
+			$customer_id = $this->get_customer_id_by_user_id( $user->ID );
+
+			if ( null === $customer_id ) {
+				$customer_data = self::map_customer_data( $order, new WC_Customer( $user->ID ) );
+				$customer_id   = $this->create_customer_for_user( $user, $customer_data );
+			}
+		}
+
+		return $customer_id;
+	}
 }

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -297,7 +297,7 @@ class WC_Payments {
 
 		// Load subscriptions (Stripe Billing).
 		include_once WCPAY_ABSPATH . '/includes/subscriptions/class-wc-payments-subscriptions.php';
-		WC_Payments_Subscriptions::init( self::$api_client );
+		WC_Payments_Subscriptions::init( self::$api_client, self::$customer_service );
 
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ __CLASS__, 'set_plugin_activation_timestamp' ] );

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -286,6 +286,17 @@ class WC_Payments_Invoice_Service {
 	}
 
 	/**
+	 * Sets the subscription's last invoice ID meta for WC subscription.
+	 *
+	 * @param WC_Subscription $subscription      The subscription.
+	 * @param string          $parent_invoice_id The parent order invoice ID.
+	 */
+	public function set_subscription_invoice_id( WC_Subscription $subscription, string $parent_invoice_id ) {
+		$subscription->update_meta_data( self::ORDER_INVOICE_ID_KEY, $parent_invoice_id );
+		$subscription->save();
+	}
+
+	/**
 	 * Gets the WC order ID from the invoice ID.
 	 *
 	 * @param string $invoice_id The invoice ID.

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -97,7 +97,7 @@ class WC_Payments_Invoice_Service {
 
 		if ( $needed_payment && $order_completed ) {
 			foreach ( wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'parent' ] ) as $subscription ) {
-				$invoice_id = self::get_order_invoice_id( $subscription );
+				$invoice_id = self::get_subscription_invoice_id( $subscription );
 
 				if ( ! $invoice_id ) {
 					continue;
@@ -285,6 +285,17 @@ class WC_Payments_Invoice_Service {
 	public function set_order_invoice_id( WC_Order $order, string $invoice_id ) {
 		$order->update_meta_data( self::ORDER_INVOICE_ID_KEY, $invoice_id );
 		$order->save();
+	}
+
+	/**
+	 * Gets the invoice ID from a WC subscription.
+	 *
+	 * @param WC_Subscription $subscription The subscription.
+	 *
+	 * @return string Invoice ID.
+	 */
+	public static function get_subscription_invoice_id( WC_Subscription $subscription ) {
+		return $subscription->get_meta( self::ORDER_INVOICE_ID_KEY, true );
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -92,18 +92,20 @@ class WC_Payments_Invoice_Service {
 			return;
 		}
 
-		$invoice_id = self::get_order_invoice_id( $order );
-
-		if ( ! $invoice_id || ! wcs_order_contains_subscription( $order, 'parent' ) ) {
-			return;
-		}
-
 		$needed_payment  = in_array( $old_status, apply_filters( 'woocommerce_valid_order_statuses_for_payment', [ 'pending', 'on-hold', 'failed' ], $order ), true );
 		$order_completed = in_array( $new_status, [ apply_filters( 'woocommerce_payment_complete_order_status', 'processing', $order_id, $order ), 'processing', 'completed' ], true );
 
 		if ( $needed_payment && $order_completed ) {
-			// Update the status of the invoice to paid but don't charge the customer by using paid_out_of_band parameter.
-			$this->payments_api_client->charge_invoice( $invoice_id, [ 'paid_out_of_band' => 'true' ] );
+			foreach ( wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'parent' ] ) as $subscription ) {
+				$invoice_id = self::get_order_invoice_id( $subscription );
+
+				if ( ! $invoice_id ) {
+					continue;
+				}
+
+				// Update the status of the invoice to paid but don't charge the customer by using paid_out_of_band parameter.
+				$this->payments_api_client->charge_invoice( $invoice_id, [ 'paid_out_of_band' => 'true' ] );
+			}
 		}
 	}
 

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -351,6 +351,40 @@ class WC_Payments_Product_Service {
 	}
 
 	/**
+	 * Gets product data from a subscription needed to create a WCPay subscription.
+	 *
+	 * @param WC_Subscription $subscription The WC subscription to fetch product data from.
+	 *
+	 * @return array|null WCPay Product data or null on error.
+	 */
+	public function get_product_data_for_subscription( WC_Subscription $subscription ) {
+		$product_data = [];
+
+		foreach ( $subscription->get_items() as $item ) {
+			$product = $item->get_product();
+
+			if ( ! WC_Subscriptions_Product::is_subscription( $product ) ) {
+				continue;
+			}
+
+			try {
+				// TODO: Use the tax service get_tax_rates_for_item() once implemented.
+				$tax_rates = [];
+			} catch ( API_Exception $e ) {
+				return null;
+			}
+
+			$product_data[] = [
+				'price'     => $this->get_stripe_price_id( $product ),
+				'quantity'  => $item->get_quantity(),
+				'tax_rates' => $tax_rates,
+			];
+		}
+
+		return $product_data;
+	}
+
+	/**
 	 * Gets product data relevant to Stripe from a WC product.
 	 *
 	 * @param WC_Product $product The product to get data from.

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -1,0 +1,523 @@
+<?php
+/**
+ * Class WC_Payments_Subscription_Service
+ *
+ * @package WooCommerce\Payments
+ */
+
+use WCPay\Exceptions\API_Exception;
+use WCPay\Logger;
+
+/**
+ * Subscriptions logic for WCPay Subscriptions
+ */
+class WC_Payments_Subscription_Service {
+
+	/**
+	 * WCPay subscriptions endpoint on server.
+	 *
+	 * @const string
+	 */
+	const SUBSCRIPTION_API_PATH = '/subscriptions';
+
+	/**
+	 * Subscription meta key used to store WCPay subscription's ID.
+	 *
+	 * @const string
+	 */
+	const SUBSCRIPTION_ID_META_KEY = '_wcpay_subscription_id';
+
+	/**
+	 * WC Payments API Client
+	 *
+	 * @var WC_Payments_API_Client
+	 */
+	private $payments_api_client;
+
+	/**
+	 * Customer Service
+	 *
+	 * @var WC_Payments_Customer_Service
+	 */
+	private $customer_service;
+
+	/**
+	 * Tax Service
+	 *
+	 * @var null (Not yet implemented)
+	 */
+	private $tax_service;
+
+	/**
+	 * Product Service
+	 *
+	 * @var WC_Payments_Product_Service
+	 */
+	private $product_service;
+
+	/**
+	 * Invoice Service
+	 *
+	 * @var null (Not yet implemented)
+	 */
+	private $invoice_service;
+
+	/**
+	 * The features WCPay Subscriptions Support.
+	 *
+	 * @var array
+	 */
+	private $supports = [
+		'gateway_scheduled_payments',
+		'subscriptions',
+		'subscription_suspension',
+		'subscription_reactivation',
+		'subscription_cancellation',
+	];
+
+	/**
+	 * A set of temporary exceptions to the limited feature support.
+	 *
+	 * @var array
+	 */
+	private $feature_support_exceptions = [];
+
+	/**
+	 * WC Payments Subscriptions Constructor
+	 *
+	 * @param WC_Payments_API_Client       $api_client       WC payments API Client.
+	 * @param WC_Payments_Customer_Service $customer_service WC payments customer serivce.
+	 * @param null                         $tax_service      WC payments tax service.
+	 * @param WC_Payments_Product_Service  $product_service  WC payments Products service.
+	 * @param null                         $invoice_service  WC payments Invoice service.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		WC_Payments_API_Client $api_client,
+		WC_Payments_Customer_Service $customer_service,
+		$tax_service,
+		WC_Payments_Product_Service $product_service,
+		$invoice_service
+	) {
+		$this->payments_api_client = $api_client;
+		$this->customer_service    = $customer_service;
+		$this->tax_service         = $tax_service;
+		$this->product_service     = $product_service;
+		$this->invoice_service     = $invoice_service;
+
+		add_action( 'woocommerce_checkout_create_subscription', [ $this, 'create_subscription' ] );
+		add_action( 'woocommerce_subscription_status_cancelled', [ $this, 'cancel_subscription' ] );
+		add_action( 'woocommerce_subscription_status_expired', [ $this, 'cancel_subscription' ] );
+		add_action( 'woocommerce_subscription_status_on-hold', [ $this, 'suspend_subscription' ] );
+		add_action( 'woocommerce_subscription_status_pending-cancel', [ $this, 'set_pending_cancel_for_subscription' ] );
+		add_action( 'woocommerce_subscription_status_pending-cancel_to_active', [ $this, 'reactivate_subscription' ] );
+		add_action( 'woocommerce_subscription_status_on-hold_to_active', [ $this, 'reactivate_subscription' ] );
+		add_action( 'save_post_shop_subscription', [ $this, 'maybe_update_date_for_subscription' ] );
+
+		// Save the new token on the WCPay subscription when it's added to a WC subscription.
+		add_action( 'woocommerce_payment_token_added_to_order', [ $this, 'update_wcpay_subscription_payment_method' ], 10, 3 );
+		add_filter( 'woocommerce_subscription_payment_gateway_supports', [ $this, 'prevent_wcpay_subscription_changes' ], 10, 3 );
+	}
+
+	/**
+	 * Gets a WCPay subscription from a WC subscription object.
+	 *
+	 * @param WC_Subscription $subscription The WC subscription to get from server.
+	 *
+	 * @return array|bool WCPay subscription data, otherwise false.
+	 */
+	public function get_wcpay_subscription( WC_Subscription $subscription ) {
+		$wcpay_subscription_id = self::get_wcpay_subscription_id( $subscription );
+
+		if ( ! $wcpay_subscription_id ) {
+			return false;
+		}
+
+		try {
+			return $this->payments_api_client->get_subscription( $wcpay_subscription_id );
+		} catch ( API_Exception $e ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Creates a WCPay subscription.
+	 *
+	 * @param WC_Subscription $subscription The WC subscription used to create a subscription on server.
+	 *
+	 * @return void
+	 *
+	 * @throws Exception Throws an exception to stop checkout processing and display message to customer.
+	 */
+	public function create_subscription( WC_Subscription $subscription ) {
+		$wcpay_customer_id      = $this->customer_service->get_customer_id_for_order( $subscription );
+		$subscription_data      = $this->prepare_wcpay_subscription_data( $wcpay_customer_id, $subscription );
+		$checkout_error_message = __( 'There was a problem creating your subscription. Please try again or use an alternative payment method.', 'woocommerce-payments' );
+
+		if ( ! $wcpay_customer_id || ! $subscription_data ) {
+			Logger::error( sprintf( 'There was a problem creating the subscription on WCPay server. Invalid customer ID: %s', $wcpay_customer_id ) );
+			throw new Exception( $checkout_error_message );
+		}
+
+		try {
+			$response = $this->payments_api_client->create_subscription( $subscription_data );
+
+			$this->set_wcpay_subscription_id( $subscription, $response['id'] );
+			// TODO: Uncomment this line once invoice service has been added.
+			/*$this->invoice_service->set_order_invoice_id( $subscription->get_parent(), $result['latest_invoice'] );*/ // PHPCS:ignore Squiz.PHP.CommentedOutCode.Found
+		} catch ( API_Exception $e ) {
+			Logger::log( sprintf( 'There was a problem creating the subscription on WCPay server: %s', $e->getMessage() ) );
+			throw new Exception( $checkout_error_message );
+		}
+	}
+
+	/**
+	 * Cancels the WCPay subscription when it's cancelled in WC.
+	 *
+	 * @param WC_Subscription $subscription The WC subscription that was canceled.
+	 *
+	 * @return void
+	 */
+	public function cancel_subscription( WC_Subscription $subscription ) {
+		$wcpay_subscription_id = self::get_wcpay_subscription_id( $subscription );
+
+		if ( ! $wcpay_subscription_id ) {
+			return;
+		}
+
+		try {
+			$this->payments_api_client->cancel_subscription( $wcpay_subscription_id );
+		} catch ( API_Exception $e ) {
+			Logger::log( sprintf( 'There was a problem canceling the subscription on WCPay server: %s.', $e->getMessage() ) );
+		}
+	}
+
+	/**
+	 * Suspends the WCPay subscription when a WC subscription is put on-hold.
+	 *
+	 * @param WC_Subscription $subscription The WC subscription that was suspended.
+	 *
+	 * @return void
+	 */
+	public function suspend_subscription( WC_Subscription $subscription ) {
+		$this->update_subscription( $subscription, [ 'pause_collection' => [ 'behavior' => 'void' ] ] );
+	}
+
+	/**
+	 * Reactivates the WCPay subscription when the WC subscription is activated.
+	 * This is done by making a request to server to unset the "cancellation at end of period" value for the WCPay subscription.
+	 *
+	 * @param WC_Subscription $subscription The WC subscription that was activated.
+	 *
+	 * @return void
+	 */
+	public function reactivate_subscription( WC_Subscription $subscription ) {
+		$this->update_subscription(
+			$subscription,
+			[
+				'cancel_at_period_end' => 'false',
+				'pause_collection'     => '',
+			]
+		);
+	}
+
+	/**
+	 * Marks the WCPay subscription as pending-cancel by setting the "cancellation at end of period" on the WCPay subscription.
+	 *
+	 * @param WC_Subscription $subscription The subscription that was set as pending cancel.
+	 *
+	 * @return void
+	 */
+	public function set_pending_cancel_for_subscription( WC_Subscription $subscription ) {
+		$this->update_subscription( $subscription, [ 'cancel_at_period_end' => 'true' ] );
+	}
+
+	/**
+	 * When a WC Subscription's payment method has been updated make sure we attach
+	 * the new payment method ID to the WCPay subscription.
+	 *
+	 * If the WCPay subscription's payment method was updated while there's a failed invoice, trigger a retry.
+	 *
+	 * @param int              $post_id  Post ID (WC subscription ID) that had its payment method updated.
+	 * @param int              $token_id Payment Token post ID stored in DB.
+	 * @param WC_Payment_Token $token    Payment Token object.
+	 *
+	 * @return void
+	 */
+	public function update_wcpay_subscription_payment_method( int $post_id, int $token_id, WC_Payment_Token $token ) {
+		$subscription = wcs_get_subscription( $post_id );
+
+		if ( $subscription ) {
+			$wcpay_subscription_id   = $this->get_wcpay_subscription_id( $subscription );
+			$wcpay_payment_method_id = $token->get_token();
+
+			if ( $wcpay_subscription_id && $wcpay_payment_method_id ) {
+				try {
+					$this->update_subscription( $subscription, [ 'default_payment_method' => $wcpay_payment_method_id ] );
+				} catch ( API_Exception $e ) {
+					Logger::error( sprintf( 'There was a problem updating the WCPay subscription\'s default payment method on server: %s.', $e->getMessage() ) );
+					return;
+				}
+
+				// now that we have a new payment method, retry the latest failed invoice (if there is one).
+				$this->maybe_attempt_payment_for_subscription( $subscription );
+			}
+		}
+	}
+
+	/**
+	 * Updates the next payment or trial end dates for a WCPay Subscription.
+	 *
+	 * @param int $post_id WC Subscription ID.
+	 *
+	 * @return void
+	 */
+	public function maybe_update_date_for_subscription( int $post_id ) {
+		if ( empty( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( wc_clean( wp_unslash( $_POST['woocommerce_meta_nonce'] ) ), 'woocommerce_save_data' ) ) {
+			return;
+		}
+
+		$subscription = wcs_get_subscription( $post_id );
+
+		// Check for new trial end date.
+		if ( array_key_exists( 'trial_end_timestamp_utc', $_POST ) && (int) $_POST['trial_end_timestamp_utc'] !== $subscription->get_time( 'trial_end' ) ) {
+			$timestamp = empty( $_POST['trial_end_timestamp_utc'] ) ? 'now' : (int) $_POST['trial_end_timestamp_utc'];
+			$this->set_trial_end_for_subscription( $subscription, $timestamp );
+			return; // Trial end should be equal to next payment, so we can return early.
+		}
+
+		// Check for new next payment date.
+		if ( array_key_exists( 'next_payment_timestamp_utc', $_POST ) && (int) $_POST['next_payment_timestamp_utc'] !== $subscription->get_time( 'next_payment' ) ) {
+			$timestamp = empty( $_POST['next_payment_timestamp_utc'] ) ? 'now' : (int) $_POST['next_payment_timestamp_utc'];
+			$this->set_trial_end_for_subscription( $subscription, $timestamp );
+		}
+	}
+
+	/**
+	 * Prepares data used to create a WCPay subscription.
+	 *
+	 * @param string          $wcpay_customer_id WCPay Customer ID to create the subscription for.
+	 * @param WC_Subscription $subscription      The WC subscription used to create the subscription on server.
+	 *
+	 * @return array WCPay subscription data
+	 */
+	private function prepare_wcpay_subscription_data( string $wcpay_customer_id, WC_Subscription $subscription ) {
+		$items = $this->product_service->get_product_data_for_subscription( $subscription );
+
+		if ( is_wp_error( $items ) ) {
+			return [];
+		}
+
+		$data = [
+			'customer'           => $wcpay_customer_id,
+			'items'              => $items,
+			'proration_behavior' => 'none',
+			'payment_behavior'   => 'default_incomplete', // creates an incomplete/pending wcpay subscription while still processing the payment on checkout.
+		];
+
+		if ( self::has_delayed_payment( $subscription ) ) {
+			$data['trial_end'] = max( $subscription->get_time( 'trial_end' ), $subscription->get_time( 'next_payment' ) );
+		}
+
+		return apply_filters( 'wcpay_subscriptions_prepare_subscription_data', $data );
+	}
+
+	/**
+	 * Updates a WCPay subscription.
+	 *
+	 * @param WC_Subscription $subscription The WC subscription that relates to the WCPay subscription that needs updating.
+	 * @param array           $data         Data to update.
+	 *
+	 * @return array|null Updated wcpay subscription or null if there was an error.
+	 */
+	private function update_subscription( WC_Subscription $subscription, array $data ) {
+		$wcpay_subscription_id = $this->get_wcpay_subscription_id( $subscription );
+		$response              = null;
+
+		if ( ! $wcpay_subscription_id ) {
+			Logger::log( 'There was a problem updating the WCPay subscription in: Subscription does not contain a valid subscription ID.' );
+			return;
+		}
+
+		try {
+			$response = $this->payments_api_client->update_subscription( $wcpay_subscription_id, $data );
+		} catch ( API_Exception $e ) {
+			Logger::log( sprintf( 'There was a problem updating the WCPay subscription on server: %s', $e->getMessage() ) );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Set the trial end date for the WCPay subscription (this updates both trial end as well as next payment).
+	 *
+	 * @param WC_Subscription $subscription WC subscription linked to the WCPay subscription that needs updating.
+	 * @param int             $timestamp    Next payment or trial end timestamp in UTC.
+	 *
+	 * @return void
+	 */
+	private function set_trial_end_for_subscription( WC_Subscription $subscription, int $timestamp ) {
+		$this->update_subscription( $subscription, [ 'trial_end' => $timestamp ] );
+	}
+
+	/**
+	 * Attempts payment for WCPay subscription if needed.
+	 *
+	 * @param WC_Subscription $subscription WC subscription linked to the WCPay subscription that maybe needs to retry payment.
+	 *
+	 * @return void
+	 */
+	private function maybe_attempt_payment_for_subscription( WC_Subscription $subscription ) {
+		$wcpay_invoice_id = WC_Payments_Invoice_Service::get_wcpay_pending_invoice_id( $subscription );
+
+		if ( $wcpay_invoice_id ) {
+			$this->invoice_service->pay_invoice( $wcpay_invoice_id );
+		}
+	}
+
+	/**
+	 * Whether the subscription supports a given feature.
+	 *
+	 * @param bool            $supported    Is feature supported.
+	 * @param string          $feature      Feature flag.
+	 * @param WC_Subscription $subscription WC Subscription to check if feature is supported against.
+	 *
+	 * @return bool
+	 */
+	public function prevent_wcpay_subscription_changes( bool $supported, string $feature, WC_Subscription $subscription ) {
+
+		if ( ! self::is_wcpay_subscription( $subscription ) ) {
+			return $supported;
+		}
+
+		return in_array( $feature, $this->supports, true ) || isset( $this->feature_support_exceptions[ $subscription->get_id() ][ $feature ] );
+	}
+
+	/**
+	 * Checks if the WC subscription has a first payment date that is in the future.
+	 *
+	 * @param WC_Subscription $subscription WC subscription to check if first payment is now or delayed.
+	 *
+	 * @return bool Whether the first payment is delayed.
+	 */
+	public static function has_delayed_payment( WC_Subscription $subscription ) {
+		$trial_end = $subscription->get_time( 'trial_end' );
+		$has_sync  = false;
+
+		// TODO: Check if there is a better way to see if sync date is today.
+		if ( WC_Subscriptions_Synchroniser::is_syncing_enabled() && WC_Subscriptions_Synchroniser::subscription_contains_synced_product( $subscription ) ) {
+			$has_sync = true;
+
+			foreach ( $subscription->get_items( 'line_item' ) as $item ) {
+				if ( WC_Subscriptions_Synchroniser::is_payment_upfront( $item->get_product() ) ) {
+					$has_sync = false;
+					break;
+				}
+			}
+		}
+
+		return $has_sync || $trial_end > time();
+	}
+
+	/**
+	 * Gets the WC subscription associated with a WCPay subscription ID.
+	 *
+	 * @param string $wcpay_subscription_id WCPay subscription ID.
+	 *
+	 * @return WC_Subscription|bool The WC subscription or false if it can't be found.
+	 */
+	public static function get_subscription_from_wcpay_subscription_id( string $wcpay_subscription_id ) {
+		global $wpdb;
+
+		$subscription_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT post_id FROM {$wpdb->prefix}postmeta
+				WHERE meta_key = %s
+				AND meta_value = %s",
+				self::SUBSCRIPTION_ID_META_KEY,
+				$wcpay_subscription_id
+			)
+		);
+
+		return wcs_get_subscription( $subscription_id );
+	}
+
+	/**
+	 * Gets the WCPay subscription ID from a WC subscription.
+	 *
+	 * @param WC_Subscription $subscription WC Subscription.
+	 *
+	 * @return string
+	 */
+	public static function get_wcpay_subscription_id( WC_Subscription $subscription ) {
+		return $subscription->get_meta( self::SUBSCRIPTION_ID_META_KEY, true );
+	}
+
+	/**
+	 * Sets the WCPay subscription ID meta for WC subscription.
+	 *
+	 * @param WC_Subscription $subscription WC Subscription to store meta against.
+	 * @param string          $value        WCPay subscription ID meta value.
+	 *
+	 * @return void
+	 */
+	private function set_wcpay_subscription_id( WC_Subscription $subscription, string $value ) {
+		$subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $value );
+		$subscription->save();
+	}
+
+	/**
+	 * Determines if a given WC subscription is a WCPay subscription.
+	 *
+	 * @param WC_Subscription $subscription WC Subscription object.
+	 *
+	 * @return bool
+	 */
+	public static function is_wcpay_subscription( WC_Subscription $subscription ) : bool {
+		return WC_Payment_Gateway_WCPay::GATEWAY_ID === $subscription->get_payment_method() && (bool) self::get_wcpay_subscription_id( $subscription );
+	}
+
+	/**
+	 * Updates a subscription's next payment date to match the WCPay subscription's payment date.
+	 *
+	 * @param array           $wcpay_subscription The WCPay Subscription data.
+	 * @param WC_Subscription $subscription       The WC Subscription object.
+	 *
+	 * @return void
+	 */
+	public function update_dates_to_match_wcpay_subscription( array $wcpay_subscription, WC_Subscription $subscription ) {
+		// Temporarily allow date changes when we're updating dates to match the dates on the WCPay subscription.
+		$this->set_feature_support_exception( $subscription, 'subscription_date_changes' );
+
+		$next_payment_date = gmdate( 'Y-m-d H:i:s', $wcpay_subscription['current_period_end'] );
+		$subscription->update_dates( [ 'next_payment' => $next_payment_date ] );
+
+		// Remove the 'subscription_date_changes' exception.
+		$this->clear_feature_support_exception( $subscription, 'subscription_date_changes' );
+	}
+
+	/**
+	 * Temporarily allows a subscription to bypass a payment gateway feature support flag.
+	 *
+	 * Use @see WC_Payments_Subscription_Service::clear_feature_support_exception() to clear it.
+	 *
+	 * @param WC_Subscription $subscription The subscription to set the exception for.
+	 * @param string          $feature      The feature to allow.
+	 */
+	private function set_feature_support_exception( WC_Subscription $subscription, string $feature ) {
+		$this->feature_support_exceptions[ $subscription->get_id() ][ $feature ] = true;
+	}
+
+	/**
+	 * Clears a gateway support flag exception.
+	 *
+	 * Use @see WC_Payments_Subscription_Service::set_feature_support_exception() to set one.
+	 *
+	 * @param WC_Subscription $subscription The subscription to remove the exception for.
+	 * @param string          $feature      The feature.
+	 */
+	private function clear_feature_support_exception( WC_Subscription $subscription, string $feature ) {
+		unset( $this->feature_support_exceptions[ $subscription->get_id() ][ $feature ] );
+	}
+}

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -13,6 +13,8 @@ use WCPay\Logger;
  */
 class WC_Payments_Subscription_Service {
 
+	use WC_Payments_Subscriptions_Utilities;
+
 	/**
 	 * WCPay subscriptions endpoint on server.
 	 *
@@ -106,7 +108,10 @@ class WC_Payments_Subscription_Service {
 		$this->product_service     = $product_service;
 		$this->invoice_service     = $invoice_service;
 
-		add_action( 'woocommerce_checkout_subscription_created', [ $this, 'create_subscription' ] );
+		if ( ! $this->is_subscriptions_plugin_active() ) {
+			add_action( 'woocommerce_checkout_subscription_created', [ $this, 'create_subscription' ] );
+		}
+
 		add_action( 'woocommerce_subscription_status_cancelled', [ $this, 'cancel_subscription' ] );
 		add_action( 'woocommerce_subscription_status_expired', [ $this, 'cancel_subscription' ] );
 		add_action( 'woocommerce_subscription_status_on-hold', [ $this, 'suspend_subscription' ] );

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -53,7 +53,6 @@ class WC_Payments_Subscriptions {
 		include_once __DIR__ . '/class-wc-payments-invoice-service.php';
 		include_once __DIR__ . '/class-wc-payments-subscription-service.php';
 
-		
 		self::$product_service      = new WC_Payments_Product_Service( $api_client );
 		self::$tax_service          = null; // TODO: create instance of tax service once implemented.
 		self::$invoice_service      = new WC_Payments_Invoice_Service( $api_client, self::$tax_service );

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -36,17 +36,27 @@ class WC_Payments_Subscriptions {
 	private static $invoice_service;
 
 	/**
+	 * Instance of WC_Payments_Subscription_Service, created in init function.
+	 *
+	 * @var WC_Payments_Subscription_Service
+	 */
+	private static $subscription_service;
+
+	/**
 	 * Initialize WooCommerce Payments subscriptions. (Stripe Billing)
 	 *
-	 * @param WC_Payments_API_Client $api_client WCPay API client.
+	 * @param WC_Payments_API_Client       $api_client       WCPay API client.
+	 * @param WC_Payments_Customer_Service $customer_service WCPay Customer Service.
 	 */
-	public static function init( WC_Payments_API_Client $api_client ) {
+	public static function init( WC_Payments_API_Client $api_client, WC_Payments_Customer_Service $customer_service ) {
 		include_once __DIR__ . '/class-wc-payments-product-service.php';
 		include_once __DIR__ . '/class-wc-payments-invoice-service.php';
+		include_once __DIR__ . '/class-wc-payments-subscription-service.php';
 
-		self::$product_service = new WC_Payments_Product_Service( $api_client );
-		self::$tax_service     = null;
-		self::$invoice_service = new WC_Payments_Invoice_Service( $api_client, self::$tax_service );
-
+		
+		self::$product_service      = new WC_Payments_Product_Service( $api_client );
+		self::$tax_service          = null; // TODO: create instance of tax service once implemented.
+		self::$invoice_service      = new WC_Payments_Invoice_Service( $api_client, self::$tax_service );
+		self::$subscription_service = new WC_Payments_Subscription_Service( $api_client, $customer_service, self::$tax_service, self::$product_service, self::$invoice_service );
 	}
 }

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1085,6 +1085,75 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Fetch a WCPay subscription.
+	 *
+	 * @param string $wcpay_subscription_id Data used to create subscription.
+	 *
+	 * @return array The WCPay subscription.
+	 *
+	 * @throws API_Exception If fetching the subscription fails.
+	 */
+	public function get_subscription( string $wcpay_subscription_id ) {
+		return $this->request(
+			[],
+			self::SUBSCRIPTIONS_API . '/' . $wcpay_subscription_id,
+			self::GET
+		);
+	}
+
+	/**
+	 * Create a WCPay subscription.
+	 *
+	 * @param array $data Data used to create subscription.
+	 *
+	 * @return array New WCPay subscription.
+	 *
+	 * @throws API_Exception If creating the subscription fails.
+	 */
+	public function create_subscription( array $data = [] ) {
+		return $this->request(
+			$data,
+			self::SUBSCRIPTIONS_API,
+			self::POST
+		);
+	}
+
+	/**
+	 * Update a WCPay subscription.
+	 *
+	 * @param string $wcpay_subscription_id WCPay subscription ID.
+	 * @param array  $data                  Update subscription data.
+	 *
+	 * @return array Updated WCPay subscription response from server.
+	 *
+	 * @throws API_Exception If updating the WCPay subscription fails.
+	 */
+	public function update_subscription( $wcpay_subscription_id, $data ) {
+		return $this->request(
+			$data,
+			self::SUBSCRIPTIONS_API . '/' . $wcpay_subscription_id,
+			self::POST
+		);
+	}
+
+	/**
+	 * Cancel a WC Pay subscription.
+	 *
+	 * @param string $wcpay_subscription_id WCPay subscription ID.
+	 *
+	 * @return array Canceled subscription.
+	 *
+	 * @throws API_Exception If canceling the subscription fails.
+	 */
+	public function cancel_subscription( string $wcpay_subscription_id ) {
+		return $this->request(
+			[],
+			self::SUBSCRIPTIONS_API . '/' . $wcpay_subscription_id,
+			self::DELETE
+		);
+	}
+
+	/**
 	 * Get payment method details.
 	 *
 	 * @param string $payment_method_id Payment method ID.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1049,7 +1049,7 @@ class WC_Payments_API_Client {
 	public function charge_invoice( string $invoice_id, array $data = [] ) {
 		return $this->request(
 			$data,
-			self::INVOICES_API . '/' . $invoice_id . '/pay',
+			self::INVOICES_API . '/pay/' . $invoice_id,
 			self::POST
 		);
 	}

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -121,8 +121,13 @@
       <code>wcs_is_subscription( wc_clean( wp_unslash( $_GET['change_payment_method'] ) ) )</code>
     </UndefinedFunction>
   </file>
+  <file src="includes/subscriptions/class-wc-payments-subscriptions.php">
+    <UndefinedDocblockClass occurrences="1">
+      <code>WC_Payments_Tax_Service</code>
+    </UndefinedDocblockClass>
+  </file>
   <file src="includes/subscriptions/class-wc-payments-product-service.php">
-    <UndefinedClass occurrences="5">
+    <UndefinedClass occurrences="6">
       <code>WC_Subscriptions_Product</code>
     </UndefinedClass>
   </file>
@@ -139,7 +144,12 @@
     </UndefinedClass>
   </file>
   <file src="includes/subscriptions/class-wc-payments-invoice-service.php">
-    <UndefinedClass occurrences="6">
+    <UndefinedDocblockClass occurrences="2">
+      <code>WC_Payments_Tax_Service</code>
+      <code>WC_Payments_Tax_Service</code>
+    </UndefinedDocblockClass>
+    <UndefinedClass occurrences="8">
+      <code>WC_Subscription</code>
       <code>WC_Subscription</code>
       <code>WC_Subscription</code>
       <code>WC_Subscription</code>
@@ -149,6 +159,17 @@
     </UndefinedClass>
     <UndefinedFunction occurrences="1">
       <code>wcs_order_contains_subscription( $order, 'parent' )</code>
+    </UndefinedFunction>
+  </file>
+  <file src="includes/subscriptions/class-wc-payments-subscription-service.php">
+    <UndefinedClass occurrences="18">
+      <code>WC_Subscription</code>
+    </UndefinedClass>
+    <UndefinedDocblockClass occurrences="2">
+      <code>WC_Subscription|bool</code>
+    </UndefinedDocblockClass>
+    <UndefinedFunction occurrences="3">
+      <code>wcs_get_subscription</code>
     </UndefinedFunction>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -158,7 +158,7 @@
       <code>WC_Subscription</code>
     </UndefinedClass>
     <UndefinedFunction occurrences="1">
-      <code>wcs_order_contains_subscription( $order, 'parent' )</code>
+      <code>wcs_get_subscriptions_for_order( $order, [ 'order_type' =&gt; 'parent' ] )</code>
     </UndefinedFunction>
   </file>
   <file src="includes/subscriptions/class-wc-payments-subscription-service.php">

--- a/tests/unit/helpers/class-wc-helper-subscription.php
+++ b/tests/unit/helpers/class-wc-helper-subscription.php
@@ -51,6 +51,20 @@ class WC_Subscription extends WC_Mock_WC_Data {
 	public $payment_method_title;
 
 	/**
+	 * Trial End timestamp
+	 *
+	 * @var int
+	 */
+	public $trial_end;
+
+	/**
+	 * Next Payment timestamp
+	 *
+	 * @var int
+	 */
+	public $next_payment;
+
+	/**
 	 * A helper function for handling function calls not yet implimented on this helper.
 	 *
 	 * Attempts to get the value by checking if it has been set as an object property.
@@ -116,5 +130,15 @@ class WC_Subscription extends WC_Mock_WC_Data {
 
 	public function get_payment_method_title() {
 		return $this->payment_method_title;
+	}
+
+	public function get_time( $time ) {
+		return $this->{$time};
+	}
+
+	public function update_dates( $dates = [] ) {
+		foreach ( $dates as $date_type => $date_string ) {
+			$this->{$date_type} = strtotime( $date_string );
+		}
 	}
 }

--- a/tests/unit/helpers/class-wc-helper-subscriptions-product.php
+++ b/tests/unit/helpers/class-wc-helper-subscriptions-product.php
@@ -26,6 +26,13 @@ class WC_Subscriptions_Product {
 	public static $subscription_product_interval = null;
 
 	/**
+	 * Is a subscription product.
+	 *
+	 * @var bool
+	 */
+	public static $is_subscription = true;
+
+	/**
 	 * Mock for static get_period.
 	 *
 	 * @param Product $product WC Product.
@@ -67,7 +74,7 @@ class WC_Subscriptions_Product {
 	 * @param Product $product WC Product.
 	 */
 	public static function is_subscription( $product ) {
-		return true;
+		return self::$is_subscription;
 	}
 
 	/**

--- a/tests/unit/helpers/class-wc-helper-subscriptions-synchroniser.php
+++ b/tests/unit/helpers/class-wc-helper-subscriptions-synchroniser.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Subscription WC_Subscriptions_Product helper.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * Class WC_Subscriptions_Product.
+ *
+ * This helper class should ONLY be used for unit tests!.
+ */
+class WC_Subscriptions_Synchroniser {
+
+	/**
+	 * Is syncing enabled setter.
+	 *
+	 * @var bool
+	 */
+	public static $is_syncing_enabled = false;
+
+	/**
+	 * Subscriptions contains synced product setter.
+	 *
+	 * @var bool
+	 */
+	public static $subscription_contains_synced_product = false;
+
+	public static function is_syncing_enabled() {
+		return self::$is_syncing_enabled;
+	}
+
+	public static function subscription_contains_synced_product( $subscription ) {
+		return self::$subscription_contains_synced_product;
+	}
+}

--- a/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
@@ -169,7 +169,7 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 			[ $mock_subscription ]
 		);
 
-		$this->assertIsArray( $result );
+		$this->assertTrue( is_array( $result ) );
 		$this->assertContainsOnly( 'array', $result );
 		$this->assertEquals( 2, count( $result ) );
 

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -95,6 +95,9 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 		$this->assertTrue( true );
 		$mock_subscription            = new WC_Subscription();
 		$mock_subscription->trial_end = 0;
+		$order                        = WC_Helper_Order::create_order();
+
+		$mock_subscription->set_parent( $order );
 
 		WC_Subscriptions_Synchroniser::$is_syncing_enabled = false;
 

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -92,7 +92,6 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 	 * Test WC_Payments_Subscription_Service->create_subscription()
 	 */
 	public function test_create_subscription() {
-		$this->assertTrue( true );
 		$mock_subscription            = new WC_Subscription();
 		$mock_subscription->trial_end = 0;
 		$order                        = WC_Helper_Order::create_order();
@@ -112,8 +111,8 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 		$this->assertNotEquals( $mock_subscription->get_meta( self::SUBSCRIPTION_ID_META_KEY ), $mock_wcpay_subscription_id );
 
 		$this->mock_customer_service->expects( $this->once() )
-			->method( 'get_customer_id_for_order' )
-			->with( $mock_subscription )
+			->method( 'get_customer_id_by_user_id' )
+			->with( '1' )
 			->willReturn( 1 );
 
 		$this->mock_product_service->expects( $this->once() )

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -1,0 +1,484 @@
+<?php
+/**
+ * Class WC_Payments_Subscription_Service_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * WC_Payments_Subscription_Service_Test unit tests.
+ */
+class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
+
+	/**
+	 * Subscription meta key used to store WCPay subscription's ID.
+	 *
+	 * @const string
+	 */
+	const SUBSCRIPTION_ID_META_KEY = '_wcpay_subscription_id';
+
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_API_Client|MockObject
+	 */
+	private $mock_api_client;
+
+	/**
+	 * Mock WC_Payments_Customer_Service.
+	 *
+	 * @var WC_Payments_Customer_Service|MockObject
+	 */
+	private $mock_customer_service;
+
+	/**
+	 * Mock WC_Payments_Product_Service.
+	 *
+	 * @var WC_Payments_Product_Service|MockObject
+	 */
+	private $mock_product_service;
+
+	/**
+	 * Mock WC_Payments_Invoice_Service.
+	 *
+	 * @var WC_Payments_Invoice_Service|MockObject
+	 */
+	private $mock_invoice_service;
+
+	/**
+	 * Mock WC_Payments_Subscription_Service
+	 *
+	 * @var WC_Payments_Subscription_Service
+	 */
+	private $subscription_service;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->mock_api_client       = $this->createMock( WC_Payments_API_Client::class );
+		$this->mock_customer_service = $this->createMock( WC_Payments_Customer_Service::class );
+		$this->mock_product_service  = $this->createMock( WC_Payments_Product_Service::class );
+		$this->mock_invoice_service  = $this->createMock( WC_Payments_Invoice_Service::class );
+
+		$this->subscription_service = new WC_Payments_Subscription_Service( $this->mock_api_client, $this->mock_customer_service, null, $this->mock_product_service, $this->mock_invoice_service );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->get_wcpay_subscription().
+	 */
+	public function test_get_wcpay_subscription() {
+		$mock_subscription          = new WC_Subscription();
+		$mock_wcpay_subscription_id = 'wcpay_subscription_id_12345';
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'get_subscription' )
+			->with( $mock_wcpay_subscription_id )
+			->willReturn( [ 'subscription_id' => $mock_wcpay_subscription_id ] );
+
+		// Check subscription that isn't a WCPay Subscription.
+		$this->assertEquals( $this->subscription_service->get_wcpay_subscription( $mock_subscription ), false );
+
+		// set WCPay Subscription ID.
+		$mock_subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $mock_wcpay_subscription_id );
+		$this->assertEquals( $this->subscription_service->get_wcpay_subscription( $mock_subscription ), [ 'subscription_id' => $mock_wcpay_subscription_id ] );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->create_subscription()
+	 */
+	public function test_create_subscription() {
+		$this->assertTrue( true );
+		$mock_subscription            = new WC_Subscription();
+		$mock_subscription->trial_end = 0;
+
+		WC_Subscriptions_Synchroniser::$is_syncing_enabled = false;
+
+		$mock_wcpay_subscription_id = 'wcpay_subscription_test12345';
+		$mock_subscription_data     = [
+			'customer'           => '1',
+			'items'              => [ 'not empty subscription data' ],
+			'proration_behavior' => 'none',
+			'payment_behavior'   => 'default_incomplete',
+		];
+
+		$this->assertNotEquals( $mock_subscription->get_meta( self::SUBSCRIPTION_ID_META_KEY ), $mock_wcpay_subscription_id );
+
+		$this->mock_customer_service->expects( $this->once() )
+			->method( 'get_customer_id_for_order' )
+			->with( $mock_subscription )
+			->willReturn( 1 );
+
+		$this->mock_product_service->expects( $this->once() )
+			->method( 'get_product_data_for_subscription' )
+			->with( $mock_subscription )
+			->willReturn( [ 'not empty subscription data' ] );
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'create_subscription' )
+			->with( $mock_subscription_data )
+			->willReturn(
+				[
+					'id'             => $mock_wcpay_subscription_id,
+					'latest_invoice' => 'mock_wcpay_invoice_id',
+				]
+			);
+
+		$this->subscription_service->create_subscription( $mock_subscription );
+
+		// check the subscription was created and the create_subscription() correctly stored the wcpay subscription ID on the subscription.
+		$this->assertEquals( $mock_subscription->get_meta( self::SUBSCRIPTION_ID_META_KEY ), $mock_wcpay_subscription_id );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->cancel_subscription()
+	 */
+	public function test_cancel_subscription() {
+		$mock_subscription          = new WC_Subscription();
+		$mock_wcpay_subscription_id = 'wcpay_canceled_test12345';
+
+		$mock_subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $mock_wcpay_subscription_id );
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'cancel_subscription' )
+			->with( $mock_wcpay_subscription_id )
+			->willReturn( [ 'id' => $mock_wcpay_subscription_id ] );
+
+		$this->subscription_service->cancel_subscription( $mock_subscription );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->suspend_subscription()
+	 */
+	public function test_suspend_subscription() {
+		$mock_subscription          = new WC_Subscription();
+		$mock_wcpay_subscription_id = 'wcpay_suspended_test12345';
+		$input_data                 = [ 'pause_collection' => [ 'behavior' => 'void' ] ];
+
+		$mock_subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $mock_wcpay_subscription_id );
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'update_subscription' )
+			->with( $mock_wcpay_subscription_id, $input_data )
+			->willReturn( [ 'id' => $mock_wcpay_subscription_id ] );
+
+		$this->subscription_service->suspend_subscription( $mock_subscription );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->reactivate_subscription()
+	 */
+	public function test_reactivate_subscription() {
+		$mock_subscription          = new WC_Subscription();
+		$mock_wcpay_subscription_id = 'wcpay_activated_test12345';
+		$input_data                 = [
+			'cancel_at_period_end' => 'false',
+			'pause_collection'     => '',
+		];
+
+		$mock_subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $mock_wcpay_subscription_id );
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'update_subscription' )
+			->with( $mock_wcpay_subscription_id, $input_data )
+			->willReturn( [ 'id' => $mock_wcpay_subscription_id ] );
+
+		$this->subscription_service->reactivate_subscription( $mock_subscription );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->set_pending_cancel_for_subscription()
+	 */
+	public function test_set_pending_cancel_for_subscription() {
+		$mock_subscription          = new WC_Subscription();
+		$mock_wcpay_subscription_id = 'wcpay_pending_canceled_test12345';
+		$input_data                 = [ 'cancel_at_period_end' => 'true' ];
+
+		$mock_subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $mock_wcpay_subscription_id );
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'update_subscription' )
+			->with( $mock_wcpay_subscription_id, $input_data )
+			->willReturn( [ 'id' => $mock_wcpay_subscription_id ] );
+
+		$this->subscription_service->set_pending_cancel_for_subscription( $mock_subscription );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->update_wcpay_subscription_payment_method()
+	 */
+	public function test_update_wcpay_subscription_payment_method() {
+		$subscription               = new WC_Subscription();
+		$mock_wcpay_subscription_id = 'wcpay_subscription_test12345';
+		$mock_wcpay_token_id        = 'wcpay_test_token1234';
+		$token                      = WC_Helper_Token::create_token( $mock_wcpay_token_id, 1 );
+
+		$subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $mock_wcpay_subscription_id );
+
+		WC_Subscriptions::set_wcs_get_subscription(
+			function ( $id ) use ( $subscription ) {
+				return $subscription;
+			}
+		);
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'update_subscription' )
+			->with( $mock_wcpay_subscription_id, [ 'default_payment_method' => $mock_wcpay_token_id ] )
+			->willReturn( [ 'id' => $mock_wcpay_subscription_id ] );
+
+		$this->subscription_service->update_wcpay_subscription_payment_method( 1, $token->get_id(), $token );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->maybe_update_date_for_subscription()
+	 */
+	public function test_maybe_update_date_for_subscription() {
+		$this->assertTrue( true );
+		$subscription               = new WC_Subscription();
+		$mock_subscription_id       = 1;
+		$mock_wcpay_subscription_id = 'wcpay_update_date_test12345';
+		$subscription->trial_end    = 0;
+
+		$subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $mock_wcpay_subscription_id );
+
+		$_POST['woocommerce_meta_nonce']  = wp_create_nonce( 'woocommerce_save_data' );
+		$_POST['trial_end_timestamp_utc'] = time();
+
+		WC_Subscriptions::set_wcs_get_subscription(
+			function ( $id ) use ( $subscription ) {
+				return $subscription;
+			}
+		);
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'update_subscription' )
+			->with( $mock_wcpay_subscription_id, [ 'trial_end' => $_POST['trial_end_timestamp_utc'] ] ) //PHPCS:ignore WordPress.Security
+			->willReturn( [ 'id' => $mock_wcpay_subscription_id ] );
+
+		$this->subscription_service->maybe_update_date_for_subscription( $mock_subscription_id );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->prepare_wcpay_subscription_data()
+	 */
+	public function test_prepare_wcpay_subscription_data() {
+		$mock_subscription            = new WC_Subscription();
+		$mock_wcpay_subscription_id   = 'wcpay_prepare_sub12345';
+		$mock_wcpay_customer_id       = 'wcpay_prepare_cus12345';
+		$mock_subscription->trial_end = 0;
+
+		update_user_option( 1, WC_Payments_Customer_Service::WCPAY_LIVE_CUSTOMER_ID_OPTION, $mock_wcpay_customer_id );
+
+		$this->mock_product_service->expects( $this->once() )
+			->method( 'get_product_data_for_subscription' )
+			->with( $mock_subscription )
+			->willReturn( [ 'item1' => 'item1_data' ] );
+
+		$expected_result = [
+			'customer'           => $mock_wcpay_customer_id,
+			'items'              => [ 'item1' => 'item1_data' ],
+			'proration_behavior' => 'none',
+			'payment_behavior'   => 'default_incomplete',
+		];
+
+		$actual_result = PHPUnit_Utils::call_method(
+			$this->subscription_service,
+			'prepare_wcpay_subscription_data',
+			[ $mock_wcpay_customer_id, $mock_subscription ]
+		);
+
+		$this->assertEquals( $expected_result, $actual_result );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->update_subscription()
+	 */
+	public function test_update_subscription() {
+		$mock_subscription          = new WC_Subscription();
+		$mock_wcpay_subscription_id = 'wcpay_update_subscription_test12345';
+
+		$mock_subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $mock_wcpay_subscription_id );
+		$mock_data = [ 'trial_end' => 0 ];
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'update_subscription' )
+			->with( $mock_wcpay_subscription_id, $mock_data )
+			->willReturn( [ 'updated' => $mock_wcpay_subscription_id ] );
+
+		$actual_result = PHPUnit_Utils::call_method(
+			$this->subscription_service,
+			'update_subscription',
+			[ $mock_subscription, $mock_data ]
+		);
+
+		$this->assertEquals( [ 'updated' => $mock_wcpay_subscription_id ], $actual_result );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->set_trial_end_for_subscription()
+	 */
+	public function test_set_trial_end_for_subscription() {
+		$mock_subscription          = new WC_Subscription();
+		$mock_wcpay_subscription_id = 'wcpay_set_trial12345';
+		$mock_trial_end             = time();
+
+		$mock_subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $mock_wcpay_subscription_id );
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'update_subscription' )
+			->with( $mock_wcpay_subscription_id, [ 'trial_end' => $mock_trial_end ] )
+			->willReturn( [ 'updated_trial_end' => $mock_trial_end ] );
+
+		PHPUnit_Utils::call_method(
+			$this->subscription_service,
+			'set_trial_end_for_subscription',
+			[ $mock_subscription, $mock_trial_end ]
+		);
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->maybe_attempt_payment_for_subscription()
+	 */
+	public function test_maybe_attempt_payment_for_subscription() {
+		$mock_subscription       = new WC_Subscription();
+		$mock_pending_invoice_id = 'wcpay_pending_invoice_idtest123';
+
+		$mock_subscription->update_meta_data( WC_Payments_Invoice_Service_Test::PENDING_INVOICE_ID_KEY, $mock_pending_invoice_id );
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'charge_invoice' )
+			->with( $mock_pending_invoice_id )
+			->willReturn( [ 'invoice_paid' ] );
+
+			PHPUnit_Utils::call_method(
+				$this->subscription_service,
+				'maybe_attempt_payment_for_subscription',
+				[ $mock_subscription ]
+			);
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->prevent_wcpay_subscription_changes()
+	 */
+	public function test_prevent_wcpay_subscription_changes() {
+		$mock_subscription          = new WC_Subscription();
+		$mock_wcpay_subscription_id = 'wcpay_prevent_changes12345';
+
+		$this->assertTrue( $this->subscription_service->prevent_wcpay_subscription_changes( true, 'random_feature', $mock_subscription ) );
+
+		$mock_subscription->payment_method = 'woocommerce_payments';
+		$mock_subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $mock_wcpay_subscription_id );
+
+		$this->assertFalse( $this->subscription_service->prevent_wcpay_subscription_changes( true, 'random_feature', $mock_subscription ) );
+
+		$this->assertTrue( $this->subscription_service->prevent_wcpay_subscription_changes( false, 'subscriptions', $mock_subscription ) );
+		$this->assertTrue( $this->subscription_service->prevent_wcpay_subscription_changes( true, 'subscriptions', $mock_subscription ) );
+
+		$this->assertTrue( $this->subscription_service->prevent_wcpay_subscription_changes( false, 'gateway_scheduled_payments', $mock_subscription ) );
+		$this->assertTrue( $this->subscription_service->prevent_wcpay_subscription_changes( true, 'gateway_scheduled_payments', $mock_subscription ) );
+
+		$this->assertTrue( $this->subscription_service->prevent_wcpay_subscription_changes( false, 'subscriptions', $mock_subscription ) );
+		$this->assertTrue( $this->subscription_service->prevent_wcpay_subscription_changes( true, 'subscriptions', $mock_subscription ) );
+
+		$this->assertTrue( $this->subscription_service->prevent_wcpay_subscription_changes( false, 'subscription_suspension', $mock_subscription ) );
+		$this->assertTrue( $this->subscription_service->prevent_wcpay_subscription_changes( true, 'subscription_suspension', $mock_subscription ) );
+
+		$this->assertTrue( $this->subscription_service->prevent_wcpay_subscription_changes( false, 'subscription_reactivation', $mock_subscription ) );
+		$this->assertTrue( $this->subscription_service->prevent_wcpay_subscription_changes( true, 'subscription_reactivation', $mock_subscription ) );
+
+		$this->assertTrue( $this->subscription_service->prevent_wcpay_subscription_changes( false, 'subscription_cancellation', $mock_subscription ) );
+		$this->assertTrue( $this->subscription_service->prevent_wcpay_subscription_changes( true, 'subscription_cancellation', $mock_subscription ) );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->has_delayed_payment()
+	 */
+	public function test_has_delayed_payment() {
+		$mock_subscription = new WC_Subscription();
+		$order             = WC_Helper_Order::create_order();
+
+		$mock_subscription->set_parent( $order );
+		$mock_subscription->trial_end = 0;
+
+		$this->assertFalse( WC_Payments_Subscription_Service::has_delayed_payment( $mock_subscription ) );
+
+		$mock_subscription->trial_end = time() + 1000;
+
+		$this->assertTrue( WC_Payments_Subscription_Service::has_delayed_payment( $mock_subscription ) );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->get_wcpay_subscription_id()
+	 */
+	public function test_get_wcpay_subscription_id() {
+		$subscription               = new WC_Subscription();
+		$mock_wcpay_subscription_id = 'wcpay_subscription_test111';
+
+		$this->assertEquals( '', WC_Payments_Subscription_Service::get_wcpay_subscription_id( $subscription ) );
+
+		$subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $mock_wcpay_subscription_id );
+
+		$this->assertEquals( $mock_wcpay_subscription_id, WC_Payments_Subscription_Service::get_wcpay_subscription_id( $subscription ) );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->set_wcpay_subscription_id()
+	 */
+	public function test_set_wcpay_subscription_id() {
+		$subscription                 = new WC_Subscription();
+		$mock_wcpay_subscription_id_1 = 'wcpay_subscription_test1';
+		$mock_wcpay_subscription_id_2 = 'wcpay_subscription_test2';
+
+		// Test a subscription with no WCPay subscription ID is set.
+		$this->assertNotEquals( $mock_wcpay_subscription_id_1, $subscription->get_meta( self::SUBSCRIPTION_ID_META_KEY ) );
+
+		PHPUnit_Utils::call_method(
+			$this->subscription_service,
+			'set_wcpay_subscription_id',
+			[ $subscription, $mock_wcpay_subscription_id_1 ]
+		);
+
+		$this->assertEquals( $mock_wcpay_subscription_id_1, $subscription->get_meta( self::SUBSCRIPTION_ID_META_KEY ) );
+
+		// Test overriding an existing WCPay Subscription ID.
+		PHPUnit_Utils::call_method(
+			$this->subscription_service,
+			'set_wcpay_subscription_id',
+			[ $subscription, $mock_wcpay_subscription_id_2 ]
+		);
+
+		$this->assertEquals( $mock_wcpay_subscription_id_2, $subscription->get_meta( self::SUBSCRIPTION_ID_META_KEY ) );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->is_wcpay_subscription().
+	 */
+	public function test_is_wcpay_subscription() {
+		$subscription = new WC_Subscription();
+		$this->assertFalse( WC_Payments_Subscription_Service::is_wcpay_subscription( $subscription ) );
+
+		$subscription->payment_method = 'woocommerce_payments';
+		$this->assertFalse( WC_Payments_Subscription_Service::is_wcpay_subscription( $subscription ) );
+
+		$subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, 'test_is_wcpay_subscription' );
+
+		$this->assertTrue( WC_Payments_Subscription_Service::is_wcpay_subscription( $subscription ) );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->update_dates_to_match_wcpay_subscription().
+	 */
+	public function test_update_dates_to_match_wcpay_subscription() {
+		$subscription      = new WC_Subscription();
+		$next_payment_time = time() + 10000;
+		$wcpay_dates       = [ 'current_period_end' => $next_payment_time ];
+
+		$this->subscription_service->update_dates_to_match_wcpay_subscription( $wcpay_dates, $subscription );
+
+		$this->assertEquals( $next_payment_time, $subscription->get_time( 'next_payment' ) );
+	}
+}

--- a/tests/unit/test-class-wc-payments-customer-service.php
+++ b/tests/unit/test-class-wc-payments-customer-service.php
@@ -572,4 +572,55 @@ class WC_Payments_Customer_Service_Test extends WP_UnitTestCase {
 			$overrides
 		);
 	}
+
+	/**
+	 * Test $customer_service->get_customer_id_for_order( $order ).
+	 */
+	public function test_get_customer_id_for_order() {
+		// order with no customer.
+		$order = WC_Helper_Order::create_order();
+		$order->set_customer_id( 0 );
+
+		$this->assertEquals( $this->customer_service->get_customer_id_for_order( $order ), null );
+
+		// reset order to belong to customer 1.
+		$order->set_customer_id( 1 );
+
+		// test fetching and existing WCPay customer ID from and order.
+		update_user_option( 1, self::CUSTOMER_LIVE_META_KEY, 'wcpay_cus_12345' );
+		$this->assertEquals( $this->customer_service->get_customer_id_for_order( $order ), 'wcpay_cus_12345' );
+
+		// test creating a new WCPay customer ID if the order customer doesn't have one.
+		delete_user_option( 1, self::CUSTOMER_LIVE_META_KEY );
+		$mock_customer_data = [
+			'name'        => 'Jeroen Sormani',
+			'description' => 'Name: Jeroen Sormani, Username: admin',
+			'email'       => 'admin@example.org',
+			'phone'       => '555-32123',
+			'address'     => [
+				'line1'       => 'WooAddress',
+				'line2'       => '',
+				'postal_code' => '12345',
+				'city'        => 'WooCity',
+				'state'       => 'NY',
+				'country'     => 'US',
+			],
+		];
+
+		$this->mock_account
+			->method( 'get_fraud_services_config' )
+			->willReturn( [ 'sift' => [ 'session_id' => 'woo_session_id' ] ] );
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'create_customer' )
+			->with(
+				array_merge(
+					$mock_customer_data,
+					[ 'session_id' => 'woo_session_id' ]
+				)
+			)
+			->willReturn( 'wcpay_cus_test12345' );
+
+		$this->assertEquals( $this->customer_service->get_customer_id_for_order( $order ), 'wcpay_cus_test12345' );
+	}
 }


### PR DESCRIPTION
Internal link: https://wp.me/pb0GrA-1g9

### Changes proposed in this Pull Request

This PR adds the WCPay subscription service class which handles all things related to: subscription creation, status and date changes, changing payment method and triggering Stripe to retry payment, and storing wcpay subscription IDs on subscriptions.

**Note - New tax rates handling hasn't been implemented yet**

For the most part, I've left out dealing with tax rates while we still figure out where that code will live.

I believe the invoice and subscription service will need to use the same tax rates code so I'd prefer to get this PR merged into the WIP feature branch beforehand, then the tax rates changes can be implemented with all existing code in mind.

### Testing instructions

No testing instructions as there are missing pieces to this code.

The plan is to test this as a complete feature and as such, this is being merged into the WIP feature branch `feature/subscription_services`