### PR TITLE
E2E test for "Merchant / Order / Manual capture" flow

### DIFF
--- a/tests/e2e/specs/merchant/merchant-orders-manual-capture.spec.js
+++ b/tests/e2e/specs/merchant/merchant-orders-manual-capture.spec.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+const {
+	merchant,
+	shopper,
+	setCheckbox,
+	unsetCheckbox,
+	selectOrderAction,
+} = require( '@woocommerce/e2e-utils' );
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import { merchantWCP } from '../../utils';
+import { fillCardDetails, setupProductCheckout } from '../../utils/payments';
+
+const chkboxCaptureLaterOption = '#inspector-checkbox-control-7';
+let orderId;
+
+describe( 'Order > Manual Capture', () => {
+	beforeAll( async () => {
+		// As the merchant, Enable the "Issue an authorization on checkout, and capture later" option in the Payment Settings page
+		await merchant.login();
+		await merchantWCP.openWCPSettings();
+		await setCheckbox( chkboxCaptureLaterOption );
+		await expect( page ).toFill( '#inspector-text-control-0', 'E2E Store' );
+		await merchantWCP.wcpSettingsSaveChanges();
+
+		// As the shopper, place an order as usual.
+		// Remember the order id
+		await setupProductCheckout(
+			config.get( 'addresses.customer.billing' )
+		);
+		const card = config.get( 'cards.basic' );
+		await fillCardDetails( page, card );
+		await shopper.placeOrder();
+		await expect( page ).toMatch( 'Order received' );
+		const orderIdField = await page.$(
+			'.woocommerce-order-overview__order.order > strong'
+		);
+		orderId = await orderIdField.evaluate( ( el ) => el.innerText );
+	} );
+
+	it( 'should create an order with status "On Hold"', async () => {
+		await merchant.goToOrder( orderId );
+
+		await expect( page ).toMatchElement(
+			'#select2-order_status-container',
+			{ text: 'On hold' }
+		);
+	} );
+
+	it( 'should create an order note saying that payment was authorized ', async () => {
+		await expect( page ).toMatchElement( '.system-note', {
+			text: /A payment of \$\d+\.\d{2}.* was authorized/,
+		} );
+	} );
+
+	it( 'should successfully capture charge', async () => {
+		// Capture the charge
+		await selectOrderAction( 'capture_charge' );
+
+		// Verify that the order status is now "Processing"
+		await expect( page ).toMatchElement(
+			'#select2-order_status-container',
+			{ text: 'Processing' }
+		);
+
+		// Verify that a system note about the capture was generated
+		await expect( page ).toMatchElement( '.system-note', {
+			text: /A payment of \$\d+\.\d{2}.* was successfully captured/,
+		} );
+	} );
+
+	afterAll( async () => {
+		await merchantWCP.openWCPSettings();
+		await unsetCheckbox( chkboxCaptureLaterOption );
+		await merchantWCP.wcpSettingsSaveChanges();
+	} );
+} );

--- a/tests/e2e/specs/merchant/merchant-orders-manual-capture.spec.js
+++ b/tests/e2e/specs/merchant/merchant-orders-manual-capture.spec.js
@@ -21,7 +21,7 @@ let orderId;
 
 describe( 'Order > Manual Capture', () => {
 	beforeAll( async () => {
-		// As the merchant, Enable the "Issue an authorization on checkout, and capture later" option in the Payment Settings page
+		// As the merchant, enable the "Issue an authorization on checkout, and capture later" option in the Payment Settings page
 		await merchant.login();
 		await merchantWCP.openWCPSettings();
 		await setCheckbox( chkboxCaptureLaterOption );
@@ -41,6 +41,14 @@ describe( 'Order > Manual Capture', () => {
 			'.woocommerce-order-overview__order.order > strong'
 		);
 		orderId = await orderIdField.evaluate( ( el ) => el.innerText );
+	} );
+
+	afterAll( async () => {
+		// Disable the "Issue an authorization on checkout, and capture later" option
+		await merchantWCP.openWCPSettings();
+		await unsetCheckbox( chkboxCaptureLaterOption );
+		await merchantWCP.wcpSettingsSaveChanges();
+		await merchant.logout();
 	} );
 
 	it( 'should create an order with status "On Hold"', async () => {
@@ -72,11 +80,5 @@ describe( 'Order > Manual Capture', () => {
 		await expect( page ).toMatchElement( '.system-note', {
 			text: /A payment of \$\d+\.\d{2}.* was successfully captured/,
 		} );
-	} );
-
-	afterAll( async () => {
-		await merchantWCP.openWCPSettings();
-		await unsetCheckbox( chkboxCaptureLaterOption );
-		await merchantWCP.wcpSettingsSaveChanges();
 	} );
 } );

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -239,4 +239,15 @@ export const merchantWCP = {
 			waitUntil: 'networkidle0',
 		} );
 	},
+
+	openWCPSettings: async () => {
+		await merchant.openSettings( 'checkout', 'woocommerce_payments' );
+	},
+
+	wcpSettingsSaveChanges: async () => {
+		await expect( page ).toClick( '.save-settings-section button' );
+		await expect( page ).toClick( '.components-snackbar', {
+			timeout: 30000,
+		} );
+	},
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-payments/issues/2211

#### Changes proposed in this Pull Request

Title: E2E Test for the flow "Merchant / Order / Manual capture"

Description: This PR adds an E2E test that covers the "Merchant / Order / Manual capture" flow. The steps in this test are consistent with the testing instructions in https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#manual-capture.

#### Testing instructions

1. Setup the E2E testing environment.
2. Run this new e2e test:
    ```
    npm run test:e2e ./tests/e2e/specs/merchant/merchant-orders-manual-capture.spec.js
    ```
3. You should see the test pass, like so:
    <img width="574" alt="Screen Shot 2021-08-22 at 7 03 58 PM" src="https://user-images.githubusercontent.com/4509348/130352919-f5ba2552-2250-453e-bf9f-8c807de747bd.png">


