### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'type: bug'
+assignees: ''
+
+---
+
+### Describe the bug
+<!-- A clear and concise description of what the bug is. Please be as descriptive as possible. -->
+
+### To Reproduce
+<!-- Describe the steps to reproduce the behavior.-->
+
+1. Go to '…'
+2. Click on '…'
+3. Scroll down to …'
+4. See error
+
+### Actual behavior:
+<!-- A clear and concise description of what actually happens. -->
+
+### Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+### Desktop (please complete the following information):
+
+* OS: [e.g. iOS]
+* Browser [e.g. chrome, safari]
+* Version [e.g. 22]
+
+### Smartphone (please complete the following information):
+
+* Device: [e.g. iPhone6]
+* OS: [e.g. iOS8.1]
+* Browser [e.g. stock browser, safari]
+* Version [e.g. 22]
+
+### Additional context
+<!--Any additional context or details you think might be helpful.-->
+<!--Ticket numbers/links, plugin versions, system statuses etc.-->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,14 +11,14 @@ assignees: ''
 <!-- A clear and concise description of what the bug is. Please be as descriptive as possible. -->
 
 ### To Reproduce
-<!-- Describe the steps to reproduce the behavior.-->
+<!-- Describe the steps to reproduce the behavior. -->
 
 1. Go to '…'
 2. Click on '…'
 3. Scroll down to …'
 4. See error
 
-### Actual behavior:
+### Actual behavior
 <!-- A clear and concise description of what actually happens. -->
 
 ### Screenshots
@@ -41,5 +41,5 @@ assignees: ''
 * Version [e.g. 22]
 
 ### Additional context
-<!--Any additional context or details you think might be helpful.-->
-<!--Ticket numbers/links, plugin versions, system statuses etc.-->
+<!-- Any additional context or details you think might be helpful. -->
+<!-- Ticket numbers/links, plugin versions, system statuses etc. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -13,11 +13,21 @@ assignees: ''
 ### Acceptance criteria
 <!-- A list of predefined requirements that must be met in order to mark the issue as complete. -->
 
+* First requirement
+* Second requirement
+* Third requirement
+* etc.
+
 ### Designs
 <!-- If applicable, add screenshots or links to the UI design for this feature. -->
 
 ### Testing instructions
 <!-- If applicable, a list of instructions that will aid in confirming that the new feature or improvement is working as expected. -->
+
+1. Go to '…'
+2. Click on '…'
+3. Scroll down to '…'
+4. Observe expected behaviour
 
 ### Dev notes
 <!-- If applicable, additional technical or implementation details that will help when developing this feature or improvement. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,27 @@
+---
+name: Feature
+about: A new feature or improvement
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Description
+<!-- A clear and concise description of what the new feature or improvement is. -->
+
+### Acceptance criteria
+<!-- A list of predefined requirements that must be met in order to mark the issue as complete. -->
+
+### Designs
+<!-- If applicable, add screenshots or links to the UI design for this feature. -->
+
+### Testing instructions
+<!-- If applicable, a list of instructions that will aid in confirming that the new feature or improvement is working as expected. -->
+
+### Dev notes
+<!-- If applicable, additional technical or implementation details that will help when developing this feature or improvement. -->
+
+### Additional context
+<!-- Any additional context or details you think might be helpful. -->
+<!-- Ticket numbers/links, P2s, project threads, etc. -->


### PR DESCRIPTION
Fixes #2780

This PR introduces "Bug report" and "Feature" GitHub issue templates as proposed here - paJDYF-2dR-p2

**Testing instructions**
- Review the proposed templates.
- View the [rendered bug report template](https://github.com/Automattic/woocommerce-payments/blob/add/2780-github-issue-templates/.github/ISSUE_TEMPLATE/bug_report.md).
- View the [rendered feature template](https://github.com/Automattic/woocommerce-payments/blob/add/2780-github-issue-templates/.github/ISSUE_TEMPLATE/feature.md).

Please feel free to suggest changes or other issue types.