### PR TITLE
Add a class to handle updating the payment method after a billing invoice failure

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -972,6 +972,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					$payment_information->get_payment_token()->get_last4()
 				);
 				$order->add_order_note( $note );
+
+				do_action( 'woocommerce_payments_changed_subscription_payment_method', $order, $payment_information->get_payment_token() );
 			}
 
 			return [

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -217,7 +217,7 @@ class WC_Payments_Invoice_Service {
 	 *
 	 * @return string Invoice ID.
 	 */
-	public static function get_pending_invoice_id( WC_Subscription $subscription ) : string {
+	public static function get_pending_invoice_id( $subscription ) : string {
 		return $subscription->get_meta( self::PENDING_INVOICE_ID_KEY, true );
 	}
 
@@ -227,7 +227,7 @@ class WC_Payments_Invoice_Service {
 	 * @param WC_Subscription $subscription The subscription.
 	 * @param string          $invoice_id   The invoice ID.
 	 */
-	private function set_pending_invoice_id( WC_Subscription $subscription, string $invoice_id ) {
+	private function set_pending_invoice_id( $subscription, string $invoice_id ) {
 		$subscription->update_meta_data( self::PENDING_INVOICE_ID_KEY, $invoice_id );
 		$subscription->save();
 	}

--- a/includes/subscriptions/class-wc-payments-subscription-change-payment-method-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscription-change-payment-method-handler.php
@@ -29,6 +29,8 @@ class WC_Payments_Subscription_Change_Payment_Method_Handler {
 
 		// Fallback to redirecting all pay for order pages for WCPay billing invoices to the update card page.
 		add_action( 'template_redirect', [ $this, 'redirect_pay_for_order_to_update_payment_method' ] );
+
+		add_filter( 'woocommerce_change_payment_button_text', [ $this, 'change_payment_method_form_submit_text' ] );
 	}
 
 	/**
@@ -194,5 +196,24 @@ class WC_Payments_Subscription_Change_Payment_Method_Handler {
 			],
 			$subscription->get_checkout_payment_url()
 		);
+	}
+
+	/**
+	 * Modifies the change payment method form submit button to include language about retrying payment if there's a failed order.
+	 *
+	 * @param string $button_text The change subscription payment method button text.
+	 * @return string The change subscription payment method button text.
+	 */
+	public function change_payment_method_form_submit_text( $button_text ) {
+
+		if ( isset( $_GET['change_payment_method'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$subscription = wcs_get_subscription( wc_clean( wp_unslash( $_GET['change_payment_method'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
+
+			if ( $subscription && $this->does_subscription_need_payment_updated( $subscription ) ) {
+				$button_text = __( 'Update and retry payment', 'woocommerce-payments' );
+			}
+		}
+
+		return $button_text;
 	}
 }

--- a/includes/subscriptions/class-wc-payments-subscription-change-payment-method-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscription-change-payment-method-handler.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Class WC_Payments_Subscription_Change_Payment_Method
+ *
+ * @package WooCommerce\Payments
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class handling any WCPay subscription change payment method functionality
+ */
+class WC_Payments_Subscription_Change_Payment_Method_Handler {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		// Add an "Update card" action to all stripe billing subscriptions with a failed renewal order.
+		add_filter( 'wcs_view_subscription_actions', [ $this, 'update_subscription_change_payment_button' ], 15, 2 );
+		add_filter( 'woocommerce_can_subscription_be_updated_to_new-payment-method', [ $this, 'can_update_payment_method' ], 15, 2 );
+
+		// Override the pay for order link on the order to redirect to a change payment method page.
+		add_filter( 'woocommerce_my_account_my_orders_actions', [ $this, 'update_order_pay_button' ], 15, 2 );
+
+		// Filter elements/messaging on the "Change payment method" page to reflect updating a Stripe billing card.
+		add_filter( 'woocommerce_subscriptions_change_payment_method_page_title', [ $this, 'change_payment_method_page_title' ], 10, 2 );
+		add_filter( 'woocommerce_subscriptions_change_payment_method_page_notice_message', [ $this, 'change_payment_method_page_notice' ], 10, 2 );
+
+		// Fallback to redirecting all pay for order pages for stripe billing invoices to the update card page.
+		add_action( 'template_redirect', [ $this, 'redirect_pay_for_order_to_update_payment_method' ] );
+	}
+
+	/**
+	 * Replaces the default change payment method action for WC Pay subscriptions when the subscription needs a new payment method after a failed attempt.
+	 *
+	 * @param array           $actions The My Account > View Subscription actions.
+	 * @param WC_Subscription $subscription The subscription object.
+	 *
+	 * @return array The subscription actions.
+	 */
+	public function update_subscription_change_payment_button( $actions, $subscription ) {
+		if ( $this->does_subscription_need_payment_updated( $subscription ) ) {
+			// Override any existing button on $actions['change_payment_method'] to show "Update Card" button.
+			$actions['change_payment_method'] = [
+				'url'  => $this->get_subscription_update_payment_url( $subscription ),
+				'name' => __( 'Update Card', 'woocommerce-payments' ),
+			];
+		}
+
+		return $actions;
+	}
+
+	/**
+	 * Updates the 'Pay' link displayed on the My Account > Orders or from a subscriptions related orders table, to make sure customers are directed to update their card.
+	 *
+	 * @param array    $actions Order actions.
+	 * @param WC_Order $order   The WC Order object.
+	 *
+	 * @return array The order actions.
+	 */
+	public function update_order_pay_button( $actions, $order ) {
+		// If the order isn't payable, there's nothing to update.
+		if ( ! isset( $actions['pay'] ) ) {
+			return $actions;
+		}
+
+		$invoice_id         = WC_Payments_Invoice_Service::get_order_invoice_id( $order );
+		$updated_pay_action = false;
+
+		// Don't show the default pay link for any WC Pay Subscription order because we don't want customer paying for them.
+		if ( $invoice_id ) {
+			$subscriptions = wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'any' ] );
+
+			if ( ! empty( $subscriptions ) ) {
+				$subscription = array_pop( $subscriptions );
+
+				if ( $subscription && WC_Payments_Invoice_Service::get_pending_invoice_id( $subscription ) ) {
+					$actions['pay']['url'] = $this->get_subscription_update_payment_url( $subscription );
+					$updated_pay_action    = true;
+				}
+			}
+
+			if ( ! $updated_pay_action ) {
+				unset( $actions['pay'] );
+			}
+		}
+
+		return $actions;
+	}
+
+	/**
+	 * Filters subscription `can_be_updated_to( 'new-payment-method' )` calls to allow customers to update their subscription's payment method.
+	 *
+	 * @param bool            $can_update   Whether the subscription's payment method can be updated.
+	 * @param WC_Subscription $subscription The WC Subscription object.
+	 *
+	 * @return bool Whether the subscription's payment method can be updated.
+	 */
+	public function can_update_payment_method( bool $can_update, WC_Subscription $subscription ) {
+		return $this->does_subscription_need_payment_updated( $subscription ) ? true : $can_update;
+	}
+
+	/**
+	 * Redirects customers to update their payment method rather than pay for a WC Pay Subscription's failed order.
+	 */
+	public function redirect_pay_for_order_to_update_payment_method() {
+		global $wp;
+
+		if ( isset( $_GET['pay_for_order'], $_GET['key'], $_GET['order_id'], $wp->query_vars['order-pay'] ) && empty( $_GET['change_payment_method'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// Check if the order is linked to a stripe billing invoice.
+			$order_id = ( isset( $wp->query_vars['order-pay'] ) ) ? absint( $wp->query_vars['order-pay'] ) : absint( $_GET['order_id'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$order    = wc_get_order( $order_id );
+
+			if ( $order && $order instanceof WC_Order ) {
+				$stripe_invoice_id = WC_Payments_Invoice_Service::get_order_invoice_id( $order );
+
+				if ( $stripe_invoice_id ) {
+					$subscriptions = wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'any' ] );
+
+					if ( ! empty( $subscriptions ) ) {
+						$subscription = array_pop( $subscriptions );
+
+						if ( $subscription && WC_Payments_Invoice_Service::get_pending_invoice_id( $subscription ) ) {
+							wp_safe_redirect( $this->get_subscription_update_payment_url( $subscription ) );
+							exit;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Modifies the change payment method page title (and page breadcrumbs) when updating card details for WC Pay subscriptions.
+	 *
+	 * @param string          $title        The default page title.
+	 * @param WC_Subscription $subscription The WC Subscription object.
+	 *
+	 * @return string The page title.
+	 */
+	public function change_payment_method_page_title( string $title, WC_Subscription $subscription ) {
+		if ( $this->does_subscription_need_payment_updated( $subscription ) ) {
+			$title = __( 'Update Card Details', 'woocommerce-payments' );
+		}
+
+		return $title;
+	}
+
+	/**
+	 * Checks if a subscription needs to update it's WCPay payment method.
+	 *
+	 * @param WC_Subscription $subscription The WC Subscription object.
+	 * @return bool Whether the subscription's last order failed and needs a new updated payment method.
+	 */
+	private function does_subscription_need_payment_updated( $subscription ) {
+		// We're only interested in WC Pay subscriptions that are on hold due to a failed payment.
+		if ( ! $subscription->has_status( 'on-hold' ) || ! WC_Payments_Subscription_Service::get_wcpay_subscription_id( $subscription ) ) {
+			return false;
+		}
+
+		$last_order = $subscription->get_last_order( 'all', 'any' );
+
+		return $last_order && $last_order->has_status( 'failed' );
+	}
+
+	/**
+	 * Generates the URL for the WC Pay Subscription's update payment method screen.
+	 *
+	 * @param WC_Subscription $subscription The WC Subscription object.
+	 * @return string The update payment method
+	 */
+	private function get_subscription_update_payment_url( $subscription ) {
+		return wp_nonce_url( add_query_arg( [ 'change_payment_method' => $subscription->get_id() ], $subscription->get_checkout_payment_url() ) );
+	}
+}

--- a/includes/subscriptions/class-wc-payments-subscription-change-payment-method-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscription-change-payment-method-handler.php
@@ -157,7 +157,7 @@ class WC_Payments_Subscription_Change_Payment_Method_Handler {
 	 */
 	public function change_payment_method_page_notice( string $message, WC_Subscription $subscription ) {
 		if ( $this->does_subscription_need_payment_updated( $subscription ) ) {
-			$message = __( "Your subscription's latest renewal failed payment. Please update your payment details so we can reattempt payment.", 'woocommerce-payments' );
+			$message = __( "Your subscription's last renewal failed payment. Please update your payment details so we can reattempt payment.", 'woocommerce-payments' );
 		}
 
 		return $message;

--- a/includes/subscriptions/class-wc-payments-subscription-change-payment-method-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscription-change-payment-method-handler.php
@@ -44,7 +44,7 @@ class WC_Payments_Subscription_Change_Payment_Method_Handler {
 			// Override any existing button on $actions['change_payment_method'] to show "Update Card" button.
 			$actions['change_payment_method'] = [
 				'url'  => $this->get_subscription_update_payment_url( $subscription ),
-				'name' => __( 'Update card', 'woocommerce-payments' ),
+				'name' => __( 'Update payment method', 'woocommerce-payments' ),
 			];
 		}
 

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -371,12 +371,8 @@ class WC_Payments_Subscription_Service {
 
 		$response = $this->payments_api_client->charge_invoice( $wcpay_invoice_id );
 
-		if ( ! $response ) {
-			return;
-		}
-
 		// Rather than wait for the Stripe webhook to be received, complete the order now if it was successfully paid.
-		if ( isset( $response['status'] ) && 'paid' === $response['status'] ) {
+		if ( $response && isset( $response['status'] ) && 'paid' === $response['status'] ) {
 			$order_id = WC_Payments_Invoice_Service::get_order_id_by_invoice_id( $wcpay_invoice_id );
 			$order    = $order_id ? wc_get_order( $order_id ) : false;
 

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -361,7 +361,12 @@ class WC_Payments_Subscription_Service {
 	 *
 	 * @return void
 	 */
-	public function maybe_attempt_payment_for_subscription( WC_Subscription $subscription, WC_Payment_Token $token ) {
+	public function maybe_attempt_payment_for_subscription( $subscription, WC_Payment_Token $token ) {
+
+		if ( ! wcs_is_subscription( $subscription ) ) {
+			return;
+		}
+
 		$wcpay_invoice_id = WC_Payments_Invoice_Service::get_pending_invoice_id( $subscription );
 
 		if ( ! $wcpay_invoice_id ) {

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -387,6 +387,7 @@ class WC_Payments_Subscription_Service {
 
 				// Reinstate the "is request to change payment method" flag.
 				WC_Subscriptions_Change_Payment_Gateway::$is_request_to_change_payment = $is_change_payment_request;
+				wc_add_notice( __( "We've successully collected payment for your subscription using your new payment method.", 'woocommerce-payments' ) );
 			}
 
 			// Remove pending invoice ID in case one was recorded for previous failed renewal attempts.

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -113,6 +113,8 @@ class WC_Payments_Subscription_Service {
 		// Save the new token on the WCPay subscription when it's added to a WC subscription.
 		add_action( 'woocommerce_payment_token_added_to_order', [ $this, 'update_wcpay_subscription_payment_method' ], 10, 3 );
 		add_filter( 'woocommerce_subscription_payment_gateway_supports', [ $this, 'prevent_wcpay_subscription_changes' ], 10, 3 );
+
+		add_action( 'woocommerce_payments_changed_subscription_payment_method', [ $this, 'maybe_attempt_payment_for_subscription' ], 10, 2 );
 	}
 
 	/**
@@ -256,9 +258,6 @@ class WC_Payments_Subscription_Service {
 					Logger::error( sprintf( 'There was a problem updating the WCPay subscription\'s default payment method on server: %s.', $e->getMessage() ) );
 					return;
 				}
-
-				// now that we have a new payment method, retry the latest failed invoice (if there is one).
-				$this->maybe_attempt_payment_for_subscription( $subscription, $token );
 			}
 		}
 	}
@@ -362,7 +361,7 @@ class WC_Payments_Subscription_Service {
 	 *
 	 * @return void
 	 */
-	private function maybe_attempt_payment_for_subscription( WC_Subscription $subscription, WC_Payment_Token $token ) {
+	public function maybe_attempt_payment_for_subscription( WC_Subscription $subscription, WC_Payment_Token $token ) {
 		$wcpay_invoice_id = WC_Payments_Invoice_Service::get_pending_invoice_id( $subscription );
 
 		if ( ! $wcpay_invoice_id ) {
@@ -373,11 +372,14 @@ class WC_Payments_Subscription_Service {
 
 		// Rather than wait for the Stripe webhook to be received, complete the order now if it was successfully paid.
 		if ( $response && isset( $response['status'] ) && 'paid' === $response['status'] ) {
+			// Remove the pending invoice ID now that we know it has been paid.
+			$this->invoice_service->mark_pending_invoice_paid_for_subscription( $subscription );
+
 			$order_id = WC_Payments_Invoice_Service::get_order_id_by_invoice_id( $wcpay_invoice_id );
 			$order    = $order_id ? wc_get_order( $order_id ) : false;
 
 			if ( $order && $order->needs_payment() ) {
-				// We're about to record a successful payment, temporarily remove the "is request to change payment method" flag as it prevents us from activating the subscrption.
+				// We're about to record a successful payment, temporarily remove the "is request to change payment method" flag as it prevents us from activating the subscrption via WC_Subscription::payment_complete().
 				$is_change_payment_request = WC_Subscriptions_Change_Payment_Gateway::$is_request_to_change_payment;
 				WC_Subscriptions_Change_Payment_Gateway::$is_request_to_change_payment = false;
 
@@ -389,9 +391,6 @@ class WC_Payments_Subscription_Service {
 				WC_Subscriptions_Change_Payment_Gateway::$is_request_to_change_payment = $is_change_payment_request;
 				wc_add_notice( __( "We've successully collected payment for your subscription using your new payment method.", 'woocommerce-payments' ) );
 			}
-
-			// Remove pending invoice ID in case one was recorded for previous failed renewal attempts.
-			$this->invoice_service->mark_pending_invoice_paid_for_subscription( $subscription );
 		}
 	}
 

--- a/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
@@ -119,9 +119,10 @@ class WC_Payments_Subscriptions_Event_Handler {
 				throw new Rest_Request_Exception( __( 'Unable to generate renewal order for subscription on the "invoice.paid" event.', 'woocommerce-payments' ) );
 			} else {
 				$this->invoice_service->set_order_invoice_id( $order, $wcpay_invoice_id );
-				$order->payment_complete();
 			}
 		}
+
+		$order->payment_complete();
 
 		// Remove pending invoice ID in case one was recorded for previous failed renewal attempts.
 		$this->invoice_service->mark_pending_invoice_paid_for_subscription( $subscription );

--- a/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
@@ -122,7 +122,9 @@ class WC_Payments_Subscriptions_Event_Handler {
 			}
 		}
 
-		$order->payment_complete();
+		if ( $order->needs_payment() ) {
+			$order->payment_complete();
+		}
 
 		// Remove pending invoice ID in case one was recorded for previous failed renewal attempts.
 		$this->invoice_service->mark_pending_invoice_paid_for_subscription( $subscription );

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -53,6 +53,7 @@ class WC_Payments_Subscriptions {
 		include_once __DIR__ . '/class-wc-payments-product-service.php';
 		include_once __DIR__ . '/class-wc-payments-invoice-service.php';
 		include_once __DIR__ . '/class-wc-payments-subscription-service.php';
+		include_once __DIR__ . '/class-wc-payments-subscription-change-payment-method-handler.php';
 
 		self::$product_service      = new WC_Payments_Product_Service( $api_client );
 		self::$invoice_service      = new WC_Payments_Invoice_Service( $api_client, self::$product_service );
@@ -61,6 +62,8 @@ class WC_Payments_Subscriptions {
 		// Load the subscription and invoice incoming event handler.
 		include_once __DIR__ . '/class-wc-payments-subscriptions-event-handler.php';
 		self::$event_handler = new WC_Payments_Subscriptions_Event_Handler( self::$invoice_service, self::$subscription_service );
+
+		new WC_Payments_Subscription_Change_Payment_Method_Handler();
 	}
 
 	/**

--- a/includes/subscriptions/subscriptions-base/includes/class-wc-subscriptions-cart.php
+++ b/includes/subscriptions/subscriptions-base/includes/class-wc-subscriptions-cart.php
@@ -442,8 +442,12 @@ class WC_Subscriptions_Cart {
 	 * @return boolean
 	 */
 	public static function cart_needs_shipping_address( $needs_shipping_address ) {
-		if ( self::cart_contains_subscription() ) {
-			$needs_shipping_address = $needs_shipping_address || self::cart_contains_subscriptions_needing_shipping();
+		if ( $needs_shipping_address ) {
+			return $needs_shipping_address;
+		}
+
+		if ( ! wc_ship_to_billing_address_only() && self::cart_contains_subscription() ) {
+			$needs_shipping_address = self::cart_contains_subscriptions_needing_shipping();
 		}
 
 		return $needs_shipping_address;

--- a/includes/subscriptions/subscriptions-base/includes/class-wc-subscriptions-change-payment-gateway.php
+++ b/includes/subscriptions/subscriptions-base/includes/class-wc-subscriptions-change-payment-gateway.php
@@ -208,7 +208,7 @@ class WC_Subscriptions_Change_Payment_Gateway {
 				}
 
 				// translators: placeholder is either empty or "Next payment is due..."
-				wc_print_notice( sprintf( __( 'Choose a new payment method.%s', 'woocommerce-subscriptions' ), $next_payment_string ), 'notice' );
+				wc_print_notice( apply_filters( 'woocommerce_subscriptions_change_payment_method_page_notice_message', sprintf( __( 'Choose a new payment method.%s', 'woocommerce-subscriptions' ), $next_payment_string ), $subscription ), 'notice' );
 
 				// Set the customer location to subscription billing location
 				foreach ( array( 'country', 'state', 'postcode' ) as $address_property ) {
@@ -729,13 +729,7 @@ class WC_Subscriptions_Change_Payment_Gateway {
 			return $title;
 		}
 
-		if ( $subscription->has_payment_gateway() ) {
-			$title = _x( 'Change payment method', 'the page title of the change payment method form', 'woocommerce-subscriptions' );
-		} else {
-			$title = _x( 'Add payment method', 'the page title of the add payment method form', 'woocommerce-subscriptions' );
-		}
-
-		return $title;
+		return self::get_change_payment_method_page_title( $subscription );
 	}
 
 	/**
@@ -766,20 +760,30 @@ class WC_Subscriptions_Change_Payment_Gateway {
 				esc_url( $subscription->get_view_order_url() ),
 			);
 
-			if ( $subscription->has_payment_gateway() ) {
-				$crumbs[3] = array(
-					_x( 'Change payment method', 'the page title of the change payment method form', 'woocommerce-subscriptions' ),
-					'',
-				);
-			} else {
-				$crumbs[3] = array(
-					_x( 'Add payment method', 'the page title of the add payment method form', 'woocommerce-subscriptions' ),
-					'',
-				);
-			}
+			$crumbs[3] = array(
+				self::get_change_payment_method_page_title( $subscription ),
+				'',
+			);
 		}
 
 		return $crumbs;
+	}
+
+	/**
+	 * Get the Change Payment Method page title (also used for the page breadcrumb)
+	 *
+	 * @since 4.0.0
+	 * @param WC_Subscription $subscription
+	 * @return string
+	 */
+	public static function get_change_payment_method_page_title( $subscription ) {
+		if ( $subscription->has_payment_gateway() ) {
+			$title = _x( 'Change payment method', 'the page title of the change payment method form', 'woocommerce-subscriptions' );
+		} else {
+			$title = _x( 'Add payment method', 'the page title of the add payment method form', 'woocommerce-subscriptions' );
+		}
+
+		return apply_filters( 'woocommerce_subscriptions_change_payment_method_page_title', $title, $subscription );
 	}
 
 	/**

--- a/includes/subscriptions/subscriptions-base/includes/class-wc-subscriptions-coupon.php
+++ b/includes/subscriptions/subscriptions-base/includes/class-wc-subscriptions-coupon.php
@@ -230,14 +230,24 @@ class WC_Subscriptions_Coupon {
 					$apply_initial_percent_coupon = true;
 				}
 
-				// Get the sign-up fee including tax.
-				$signup_fee = wc_get_price_including_tax(
-					$cart_item['data'],
-					array(
-						'qty'   => 1,
-						'price' => WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] ),
-					)
-				);
+				// Get the sign up fee amount depending on the store's tax inclusivity.
+				if ( wc_prices_include_tax() ) {
+					$signup_fee = wc_get_price_including_tax(
+						$cart_item['data'],
+						array(
+							'qty'   => 1,
+							'price' => WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] ),
+						)
+					);
+				} else {
+					$signup_fee = wc_get_price_excluding_tax(
+						$cart_item['data'],
+						array(
+							'qty'   => 1,
+							'price' => WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] ),
+						)
+					);
+				}
 
 				// Only Sign up fee coupons apply to sign up fees, adjust the discounting_amount accordingly
 				if ( in_array( $coupon_type, array( 'sign_up_fee', 'sign_up_fee_percent' ) ) ) {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -180,8 +180,9 @@
     <UndefinedClass occurrences="3">
       <code>WC_Subscription</code>
     </UndefinedClass>
-    <UndefinedFunction occurrences="2">
+    <UndefinedFunction occurrences="3">
       <code>wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'any' ] )</code>
+      <code>wcs_get_subscription( wc_clean( wp_unslash( $_GET['change_payment_method'] ) ) )</code>
     </UndefinedFunction>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -146,15 +146,8 @@
   <file src="includes/subscriptions/class-wc-payments-invoice-service.php">
     <UndefinedDocblockClass occurrences="2">
       <code>WC_Payments_Tax_Service</code>
-      <code>WC_Payments_Tax_Service</code>
     </UndefinedDocblockClass>
-    <UndefinedClass occurrences="8">
-      <code>WC_Subscription</code>
-      <code>WC_Subscription</code>
-      <code>WC_Subscription</code>
-      <code>WC_Subscription</code>
-      <code>WC_Subscription</code>
-      <code>WC_Subscription</code>
+    <UndefinedClass occurrences="9">
       <code>WC_Subscription</code>
     </UndefinedClass>
     <UndefinedFunction occurrences="1">
@@ -180,4 +173,16 @@
       <code>wcs_create_renewal_order( $subscription )</code>
     </UndefinedFunction>
   </file>
+  <file src="includes/subscriptions/class-wc-payments-subscription-change-payment-method-handler.php">
+    <UndefinedDocblockClass occurrences="3">
+      <code>WC_Subscription</code>
+    </UndefinedDocblockClass>
+    <UndefinedClass occurrences="3">
+      <code>WC_Subscription</code>
+    </UndefinedClass>
+    <UndefinedFunction occurrences="2">
+      <code>wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'any' ] )</code>
+    </UndefinedFunction>
+  </file>
 </files>
+

--- a/tests/unit/helpers/class-wc-helper-subscription.php
+++ b/tests/unit/helpers/class-wc-helper-subscription.php
@@ -171,16 +171,15 @@ class WC_Subscription extends WC_Mock_WC_Data {
 		// do nothing.
 	}
 
-<<<<<<< HEAD
 	public function payment_failed( $new_status = 'on-hold' ) {
-		$this->set_status( $new_status );
-=======
+		$this->status = $new_status;
+	}
+
 	public function get_status() {
 		return $this->status;
 	}
 
 	public function has_status( $status ) {
 		return ( is_array( $status ) && in_array( $this->get_status(), $status, true ) ) || $this->get_status() === $status;
->>>>>>> b9af3f7c (Add unit tests for the WC_Payments_Subscription_Change_Payment_Method_Handler class)
 	}
 }

--- a/tests/unit/helpers/class-wc-helper-subscription.php
+++ b/tests/unit/helpers/class-wc-helper-subscription.php
@@ -72,6 +72,13 @@ class WC_Subscription extends WC_Mock_WC_Data {
 	public $end;
 
 	/**
+	 * Helper variable for mocking the subscription's status.
+	 *
+	 * @var string
+	 */
+	public $status;
+
+	/**
 	 * Taxes.
 	 *
 	 * @var array
@@ -164,7 +171,16 @@ class WC_Subscription extends WC_Mock_WC_Data {
 		// do nothing.
 	}
 
+<<<<<<< HEAD
 	public function payment_failed( $new_status = 'on-hold' ) {
 		$this->set_status( $new_status );
+=======
+	public function get_status() {
+		return $this->status;
+	}
+
+	public function has_status( $status ) {
+		return ( is_array( $status ) && in_array( $this->get_status(), $status, true ) ) || $this->get_status() === $status;
+>>>>>>> b9af3f7c (Add unit tests for the WC_Payments_Subscription_Change_Payment_Method_Handler class)
 	}
 }

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-change-payment-method.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-change-payment-method.php
@@ -73,7 +73,7 @@ class WC_Payments_Subscription_Change_Payment_Method_Test extends WP_UnitTestCas
 		$this->assertArrayHasKey( 'name', $result['change_payment_method'] );
 
 		// Confirm the function changed the button name and URL.
-		$this->assertEquals( 'Update Card', $result['change_payment_method']['name'] );
+		$this->assertEquals( 'Update card', $result['change_payment_method']['name'] );
 		$this->assertStringContainsString( 'change_payment_method=', $result['change_payment_method']['url'] );
 		$this->assertStringContainsString( '_wpnonce=', $result['change_payment_method']['url'] );
 	}
@@ -174,7 +174,7 @@ class WC_Payments_Subscription_Change_Payment_Method_Test extends WP_UnitTestCas
 		// Set up the positive case - last order is failed.
 		$mock_order->set_status( 'failed' );
 		$mock_order->save();
-		$this->assertEquals( 'Update Card Details', $this->change_payment_method_handler->change_payment_method_page_title( $default_title, $mock_subscription ) );
+		$this->assertEquals( 'Update payment details', $this->change_payment_method_handler->change_payment_method_page_title( $default_title, $mock_subscription ) );
 	}
 
 	/**

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-change-payment-method.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-change-payment-method.php
@@ -36,7 +36,7 @@ class WC_Payments_Subscription_Change_Payment_Method_Test extends WP_UnitTestCas
 		$mock_subscription = new WC_Subscription();
 
 		// Test the false case - no change to input.
-		$this->assertEquals( [], $this->change_payment_method_handler->update_subscription_change_payment_button( [], $mock_subscription ) );
+		$this->assertSame( [], $this->change_payment_method_handler->update_subscription_change_payment_button( [], $mock_subscription ) );
 
 		// Set up a subscriotion with a failed last payment to test the positive/true case.
 		$mock_subscription->status     = 'on-hold';
@@ -61,19 +61,19 @@ class WC_Payments_Subscription_Change_Payment_Method_Test extends WP_UnitTestCas
 
 		$result = $this->change_payment_method_handler->update_subscription_change_payment_button( $default_actions, $mock_subscription );
 
-		$this->assertTrue( is_array( $result ) );
+		$this->assertIsArray( $result );
 		$this->assertContainsOnly( 'array', $result );
-		$this->assertEquals( 2, count( $result ) );
+		$this->assertCount( 2, $result );
 
 		$this->assertArrayHasKey( 'change_payment_method', $result );
 
 		// Confirm the change payment method element format.
-		$this->assertEquals( 2, count( $result['change_payment_method'] ) );
+		$this->assertCount( 2, $result['change_payment_method'] );
 		$this->assertArrayHasKey( 'url', $result['change_payment_method'] );
 		$this->assertArrayHasKey( 'name', $result['change_payment_method'] );
 
 		// Confirm the function changed the button name and URL.
-		$this->assertEquals( 'Update card', $result['change_payment_method']['name'] );
+		$this->assertSame( 'Update card', $result['change_payment_method']['name'] );
 		$this->assertRegExp( '/change_payment_method=/', $result['change_payment_method']['url'] );
 		$this->assertRegExp( '/_wpnonce=/', $result['change_payment_method']['url'] );
 	}
@@ -93,12 +93,12 @@ class WC_Payments_Subscription_Change_Payment_Method_Test extends WP_UnitTestCas
 		$mock_subscription->set_parent( $mock_order );
 
 		// Without a 'pay' key element, the array input should remain unchanged.
-		$this->assertEquals( [], $this->change_payment_method_handler->update_order_pay_button( [], $mock_order ) );
-		$this->assertEquals( $test_actions, $this->change_payment_method_handler->update_order_pay_button( $test_actions, $mock_order ) );
+		$this->assertSame( [], $this->change_payment_method_handler->update_order_pay_button( [], $mock_order ) );
+		$this->assertSame( $test_actions, $this->change_payment_method_handler->update_order_pay_button( $test_actions, $mock_order ) );
 
 		// Add the 'pay' element.
 		$test_actions['pay']['url'] = 'example.com?pay=123';
-		$this->assertEquals( $test_actions, $this->change_payment_method_handler->update_order_pay_button( $test_actions, $mock_order ) );
+		$this->assertSame( $test_actions, $this->change_payment_method_handler->update_order_pay_button( $test_actions, $mock_order ) );
 
 		// Set up the positive/true case.
 		$mock_order->update_meta_data( WC_Payments_Invoice_Service::ORDER_INVOICE_ID_KEY, 'in_test123' );
@@ -112,7 +112,7 @@ class WC_Payments_Subscription_Change_Payment_Method_Test extends WP_UnitTestCas
 
 		// Confirm the order actions format.
 		$this->assertContainsOnly( 'array', $result );
-		$this->assertEquals( count( $test_actions ), count( $result ) );
+		$this->assertSame( count( $test_actions ), count( $result ) );
 
 		$this->assertArrayHasKey( 'cancel', $test_actions );
 		$this->assertArrayHasKey( 'pay', $test_actions );
@@ -159,22 +159,22 @@ class WC_Payments_Subscription_Change_Payment_Method_Test extends WP_UnitTestCas
 		$default_title     = 'Test Title';
 
 		// Confirm the input is unchanged on the negative case.
-		$this->assertEquals( $default_title, $this->change_payment_method_handler->change_payment_method_page_title( $default_title, $mock_subscription ) );
+		$this->assertSame( $default_title, $this->change_payment_method_handler->change_payment_method_page_title( $default_title, $mock_subscription ) );
 
 		$mock_subscription->last_order = $mock_order;
 		$mock_subscription->update_meta_data( WC_Payments_Subscription_Service::SUBSCRIPTION_ID_META_KEY, 'sub_test123' );
 		$mock_subscription->save();
 
 		// Confirm the input is unchanged on the negative case.
-		$this->assertEquals( $default_title, $this->change_payment_method_handler->change_payment_method_page_title( $default_title, $mock_subscription ) );
+		$this->assertSame( $default_title, $this->change_payment_method_handler->change_payment_method_page_title( $default_title, $mock_subscription ) );
 
 		$mock_subscription->status = 'on-hold';
-		$this->assertEquals( $default_title, $this->change_payment_method_handler->change_payment_method_page_title( $default_title, $mock_subscription ) );
+		$this->assertSame( $default_title, $this->change_payment_method_handler->change_payment_method_page_title( $default_title, $mock_subscription ) );
 
 		// Set up the positive case - last order is failed.
 		$mock_order->set_status( 'failed' );
 		$mock_order->save();
-		$this->assertEquals( 'Update payment details', $this->change_payment_method_handler->change_payment_method_page_title( $default_title, $mock_subscription ) );
+		$this->assertSame( 'Update payment details', $this->change_payment_method_handler->change_payment_method_page_title( $default_title, $mock_subscription ) );
 	}
 
 	/**

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-change-payment-method.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-change-payment-method.php
@@ -61,7 +61,7 @@ class WC_Payments_Subscription_Change_Payment_Method_Test extends WP_UnitTestCas
 
 		$result = $this->change_payment_method_handler->update_subscription_change_payment_button( $default_actions, $mock_subscription );
 
-		$this->assertIsArray( $result );
+		$this->assertTrue( is_array( $result ) );
 		$this->assertContainsOnly( 'array', $result );
 		$this->assertCount( 2, $result );
 

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-change-payment-method.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-change-payment-method.php
@@ -73,7 +73,7 @@ class WC_Payments_Subscription_Change_Payment_Method_Test extends WP_UnitTestCas
 		$this->assertArrayHasKey( 'name', $result['change_payment_method'] );
 
 		// Confirm the function changed the button name and URL.
-		$this->assertSame( 'Update card', $result['change_payment_method']['name'] );
+		$this->assertSame( 'Update payment method', $result['change_payment_method']['name'] );
 		$this->assertRegExp( '/change_payment_method=/', $result['change_payment_method']['url'] );
 		$this->assertRegExp( '/_wpnonce=/', $result['change_payment_method']['url'] );
 	}

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-change-payment-method.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-change-payment-method.php
@@ -74,8 +74,8 @@ class WC_Payments_Subscription_Change_Payment_Method_Test extends WP_UnitTestCas
 
 		// Confirm the function changed the button name and URL.
 		$this->assertEquals( 'Update card', $result['change_payment_method']['name'] );
-		$this->assertStringContainsString( 'change_payment_method=', $result['change_payment_method']['url'] );
-		$this->assertStringContainsString( '_wpnonce=', $result['change_payment_method']['url'] );
+		$this->assertRegExp( '/change_payment_method=/', $result['change_payment_method']['url'] );
+		$this->assertRegExp( '/_wpnonce=/', $result['change_payment_method']['url'] );
 	}
 
 	/**
@@ -118,9 +118,9 @@ class WC_Payments_Subscription_Change_Payment_Method_Test extends WP_UnitTestCas
 		$this->assertArrayHasKey( 'pay', $test_actions );
 
 		// Confirm the pay url has been updated to include the change payment method flag.
-		$this->assertStringContainsString( 'order-pay=', $result['pay']['url'] );
-		$this->assertStringContainsString( 'pay_for_order=', $result['pay']['url'] );
-		$this->assertStringContainsString( 'change_payment_method=', $result['pay']['url'] );
+		$this->assertRegExp( '/order-pay=/', $result['pay']['url'] );
+		$this->assertRegExp( '/pay_for_order=/', $result['pay']['url'] );
+		$this->assertRegExp( '/change_payment_method=/', $result['pay']['url'] );
 	}
 
 	/**

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-change-payment-method.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-change-payment-method.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Class WC_Payments_Invoice_Service_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Exceptions\API_Exception;
+
+/**
+ * WC_Payments_Invoice_Service_Test unit tests.
+ */
+class WC_Payments_Subscription_Change_Payment_Method_Test extends WP_UnitTestCase {
+
+	/**
+	 * System under test.
+	 *
+	 * @var WC_Payments_Product_Service
+	 */
+	private $change_payment_method_handler;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->change_payment_method_handler = new WC_Payments_Subscription_Change_Payment_Method_Handler();
+	}
+
+	/**
+	 * Tests for WC_Payments_Subscription_Change_Payment_Method_Handler::update_subscription_change_payment_button().
+	 */
+	public function test_update_subscription_change_payment_button() {
+		$mock_subscription = new WC_Subscription();
+
+		// Test the false case - no change to input.
+		$this->assertEquals( [], $this->change_payment_method_handler->update_subscription_change_payment_button( [], $mock_subscription ) );
+
+		// Set up a subscriotion with a failed last payment to test the positive/true case.
+		$mock_subscription->status     = 'on-hold';
+		$mock_subscription->last_order = WC_Helper_Order::create_order();
+		$mock_subscription->last_order->set_status( 'failed' );
+
+		// The update_subscription_change_payment_button function attempts to call WC_Subscription->get_checkout_payment_url(). To avoid errors mock that function's return.
+		$mock_subscription->checkout_payment_url = 'example.com';
+		$mock_subscription->update_meta_data( WC_Payments_Subscription_Service::SUBSCRIPTION_ID_META_KEY, 'sub_test123' );
+		$mock_subscription->save();
+
+		$default_actions = [
+			'suspend'               => [
+				'name' => 'suspend',
+				'url'  => 'example.com',
+			],
+			'change_payment_method' => [
+				'name' => 'Change payment',
+				'url'  => 'example.com',
+			],
+		];
+
+		$result = $this->change_payment_method_handler->update_subscription_change_payment_button( $default_actions, $mock_subscription );
+
+		$this->assertTrue( is_array( $result ) );
+		$this->assertContainsOnly( 'array', $result );
+		$this->assertEquals( 2, count( $result ) );
+
+		$this->assertArrayHasKey( 'change_payment_method', $result );
+
+		// Confirm the change payment method element format.
+		$this->assertEquals( 2, count( $result['change_payment_method'] ) );
+		$this->assertArrayHasKey( 'url', $result['change_payment_method'] );
+		$this->assertArrayHasKey( 'name', $result['change_payment_method'] );
+
+		// Confirm the function changed the button name and URL.
+		$this->assertEquals( 'Update Card', $result['change_payment_method']['name'] );
+		$this->assertStringContainsString( 'change_payment_method=', $result['change_payment_method']['url'] );
+		$this->assertStringContainsString( '_wpnonce=', $result['change_payment_method']['url'] );
+	}
+
+	/**
+	 * Tests for WC_Payments_Subscription_Change_Payment_Method_Handler::update_order_pay_button().
+	 */
+	public function test_update_order_pay_button() {
+		$mock_subscription = new WC_Subscription();
+		$mock_order        = WC_Helper_Order::create_order();
+		$test_actions      = [
+			'cancel' => [
+				'url' => 'example.com',
+			],
+		];
+
+		$mock_subscription->set_parent( $mock_order );
+
+		// Without a 'pay' key element, the array input should remain unchanged.
+		$this->assertEquals( [], $this->change_payment_method_handler->update_order_pay_button( [], $mock_order ) );
+		$this->assertEquals( $test_actions, $this->change_payment_method_handler->update_order_pay_button( $test_actions, $mock_order ) );
+
+		// Add the 'pay' element.
+		$test_actions['pay']['url'] = 'example.com?pay=123';
+		$this->assertEquals( $test_actions, $this->change_payment_method_handler->update_order_pay_button( $test_actions, $mock_order ) );
+
+		// Set up the positive/true case.
+		$mock_order->update_meta_data( WC_Payments_Invoice_Service::ORDER_INVOICE_ID_KEY, 'in_test123' );
+		$mock_order->save();
+
+		$mock_subscription->update_meta_data( WC_Payments_Invoice_Service::PENDING_INVOICE_ID_KEY, 'in_test123' );
+		$mock_subscription->save();
+		$this->mock_wcs_get_subscriptions_for_order( [ $mock_subscription ] );
+
+		$result = $this->change_payment_method_handler->update_order_pay_button( $test_actions, $mock_order );
+
+		// Confirm the order actions format.
+		$this->assertContainsOnly( 'array', $result );
+		$this->assertEquals( count( $test_actions ), count( $result ) );
+
+		$this->assertArrayHasKey( 'cancel', $test_actions );
+		$this->assertArrayHasKey( 'pay', $test_actions );
+
+		// Confirm the pay url has been updated to include the change payment method flag.
+		$this->assertStringContainsString( 'order-pay=', $result['pay']['url'] );
+		$this->assertStringContainsString( 'pay_for_order=', $result['pay']['url'] );
+		$this->assertStringContainsString( 'change_payment_method=', $result['pay']['url'] );
+	}
+
+	/**
+	 * Tests for WC_Payments_Subscription_Change_Payment_Method_Handler::can_update_payment_method().
+	 */
+	public function test_can_update_payment_method() {
+		$mock_subscription = new WC_Subscription();
+		$mock_order        = WC_Helper_Order::create_order();
+
+		$mock_subscription->last_order = $mock_order;
+		$mock_subscription->update_meta_data( WC_Payments_Subscription_Service::SUBSCRIPTION_ID_META_KEY, 'sub_test123' );
+		$mock_subscription->save();
+
+		// Confirm the input is unchanged on the negative case.
+		foreach ( [ false, true ] as $input ) {
+			$this->assertEquals( $input, $this->change_payment_method_handler->can_update_payment_method( $input, $mock_subscription ) );
+		}
+
+		$mock_subscription->status = 'on-hold';
+		$this->assertFalse( $this->change_payment_method_handler->can_update_payment_method( false, $mock_subscription ) );
+		$this->assertTrue( $this->change_payment_method_handler->can_update_payment_method( true, $mock_subscription ) );
+
+		// Set up the positive case - last order is failed.
+		$mock_order->set_status( 'failed' );
+		$mock_order->save();
+		$this->assertTrue( $this->change_payment_method_handler->can_update_payment_method( true, $mock_subscription ) );
+		$this->assertTrue( $this->change_payment_method_handler->can_update_payment_method( false, $mock_subscription ) );
+	}
+
+	/**
+	 * Tests for WC_Payments_Subscription_Change_Payment_Method_Handler::change_payment_method_page_title().
+	 */
+	public function test_change_payment_method_page_title() {
+		$mock_subscription = new WC_Subscription();
+		$mock_order        = WC_Helper_Order::create_order();
+		$default_title     = 'Test Title';
+
+		// Confirm the input is unchanged on the negative case.
+		$this->assertEquals( $default_title, $this->change_payment_method_handler->change_payment_method_page_title( $default_title, $mock_subscription ) );
+
+		$mock_subscription->last_order = $mock_order;
+		$mock_subscription->update_meta_data( WC_Payments_Subscription_Service::SUBSCRIPTION_ID_META_KEY, 'sub_test123' );
+		$mock_subscription->save();
+
+		// Confirm the input is unchanged on the negative case.
+		$this->assertEquals( $default_title, $this->change_payment_method_handler->change_payment_method_page_title( $default_title, $mock_subscription ) );
+
+		$mock_subscription->status = 'on-hold';
+		$this->assertEquals( $default_title, $this->change_payment_method_handler->change_payment_method_page_title( $default_title, $mock_subscription ) );
+
+		// Set up the positive case - last order is failed.
+		$mock_order->set_status( 'failed' );
+		$mock_order->save();
+		$this->assertEquals( 'Update Card Details', $this->change_payment_method_handler->change_payment_method_page_title( $default_title, $mock_subscription ) );
+	}
+
+	/**
+	 * Mocks the wcs_get_subscriptions_for_order function return.
+	 *
+	 * @param WC_Subscription[] $subscriptions The subscriptions to return to wcs_get_subscriptions_for_order calls.
+	 */
+	private function mock_wcs_get_subscriptions_for_order( $subscriptions ) {
+		WC_Subscriptions::set_wcs_get_subscriptions_for_order(
+			function ( $order ) use ( $subscriptions ) {
+				return $subscriptions;
+			}
+		);
+	}
+}

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -351,6 +351,12 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 
 		$mock_subscription->update_meta_data( WC_Payments_Invoice_Service_Test::PENDING_INVOICE_ID_KEY, $mock_pending_invoice_id );
 
+		WC_Subscriptions::set_wcs_is_subscription(
+			function ( $subscription ) {
+				return true;
+			}
+		);
+
 		$this->mock_api_client->expects( $this->once() )
 			->method( 'charge_invoice' )
 			->with( $mock_pending_invoice_id )

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -356,11 +356,11 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 			->with( $mock_pending_invoice_id )
 			->willReturn( [ 'invoice_paid' ] );
 
-			PHPUnit_Utils::call_method(
-				$this->subscription_service,
-				'maybe_attempt_payment_for_subscription',
-				[ $mock_subscription ]
-			);
+		PHPUnit_Utils::call_method(
+			$this->subscription_service,
+			'maybe_attempt_payment_for_subscription',
+			[ $mock_subscription, new WC_Payment_Token_CC() ]
+		);
 	}
 
 	/**


### PR DESCRIPTION
#### 🛑 Blocked status 🛑 

This PR is blocked by the following PRs:

- [x] #2811 
- [x] #2843
- [ ] Requires 26-gh-Automattic/woocommerce-payments-dev-tools for testing.

------
#### Changes proposed in this Pull Request

This PR is porting over the _change payment method class_ developed in our prototype for Stripe Billing. It adds the following functionality.

When a subscription is a WC Pay billing subscription with a failed renewal order we:

1. Override the default 'change payment' method button on the **My Account > Subscriptions > View Subscription** so customers are prompted to update their card details instead.
2. Replace the 'pay' link next to the failed order. This is to prevent customers from trying to pay for the order instead of updating their details. The link now directs the customer to the 'update payment method' page.
3. Redirect customers who manage to land on a pay for order page for an order linked to a WC pay billed subscription redirecting them through the update payment method page flow instead. This catches customers who may have received a link via email for instance. 
4. Changes the change payment method page's title, breadcrumbs and notice content for a more appropriate message. 
 
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Set up:**
1. Install the https://github.com/Automattic/woocommerce-payments-dev-tools plugin
2. Check out the 26-gh-Automattic/woocommerce-payments-dev-tools PR. 
3. Enable the billing clocks functionality following [these steps](https://github.com/Automattic/woocommerce-payments-dev-tools/blob/a21c7093051e3efeb8a5f92af7ba0044b36dcfb0/README.md#billing-clocks).
4. Your site will need to be receiving webhooks from Stripe. https://github.com/Automattic/woocommerce-payments-server/tree/trunk/local#5-listen-to-webhooks

----

1. Purchase a subscription
2. Go to the **WooCommerce > Subscriptions > Edit Subscription** screen on the admin dashboard.
3. Go to the subscription actions dropdown and select **"Set up custom billing clock"**. https://d.pr/i/cFv62X
4. **Save**. 
5. This will set up the billing clock enabled subscription with a new user etc.
6. From the Subscriptions actions dropdown (https://d.pr/i/tLjGQ8) select **`Trigger upcoming invoice`**, **`Trigger invoice created`**,  and **`Fail the next invoice`** in that order, submitting the form each time. _**Note: if the correct action doesn't appear at any stage, refresh the page as there may be some lag time between receiving the response from Stripe.**_
7. In an incognito browser log in as the customer using the instructions found in the updated readme [here](https://github.com/Automattic/woocommerce-payments-dev-tools/blob/a21c7093051e3efeb8a5f92af7ba0044b36dcfb0/README.md#to-pay-for-failed-renewals).
8.  Go to **My Account > My Subscription.** 
    - Here you should find an on-hold subscription with an **'Update payment method'** button option. 
    - If you scroll down there will be a failed renewal with a **'Pay'** link https://d.pr/i/TYNp56
    - Click either the  **'Update payment method'** or **'Pay'** link. They both go to the same page.
    - You should land on a page that looks like a pay for order/change payment method page. https://d.pr/i/02gwnF
    - Enter a new method or choose an existing saved method.  
    - If you entered a successful payment method, the payment should be reattempted and the subscription activated. 
        - The subscription's payment method will also update to the successful card.
        -  You can also verify the subscription's payment method updates by clicking the `sub_xyz` link on the edit subscription screen. https://d.pr/i/OowOIp
        - This [0341](https://d.pr/i/8qqlxd) (failing card number) will be updated to the new card.
    - If you entered a failing payment method, the error will be displayed on the change payment method form and you'll be prompted to try again.

-------------------
 
**Notes**

- This PR also includes an update to the `subscriptions-base` to include the latest changes. This was particularly necessary to test this PR because it includes new actions/filters for changing some Change payment method page titles, and notices.  See: 4162-gh-woocommerce/woocommerce-subscriptions

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)