### PR TITLE
Fix payment method checkbox mobile view

### DIFF
--- a/client/additional-methods-setup/upe-preview-methods-selector/index.scss
+++ b/client/additional-methods-setup/upe-preview-methods-selector/index.scss
@@ -1,5 +1,5 @@
 .upe-preview-methods-selector {
 	max-width: 700px;
-	min-width: 510px;
+	min-width: 320px;
 	margin: 0 auto;
 }

--- a/client/components/confirmation-modal/styles.scss
+++ b/client/components/confirmation-modal/styles.scss
@@ -2,7 +2,6 @@
 	// increasing the specificity of the styles, to ensure it is honored
 	&#{&} {
 		max-width: 600px;
-		min-width: 400px;
 	}
 
 	// to ensure that the separator extends all the way, even with different versions of Gutenberg

--- a/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
+++ b/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
@@ -30,3 +30,11 @@
 		}
 	}
 }
+
+.woocommerce-payments__payment-method-icon {
+	@include breakpoint( '<660px' ) {
+		svg {
+			display: none;
+		}
+	}
+}

--- a/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
+++ b/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
@@ -1,8 +1,15 @@
 .payment-method-checkbox {
 	display: flex;
+	flex-wrap: nowrap;
 	justify-content: space-between;
 	align-items: center;
 	width: 100%;
+
+	@include breakpoint( '<660px' ) {
+		flex-wrap: wrap;
+		justify-content: flex-start;
+		row-gap: 5px;
+	}
 
 	margin-bottom: $grid-unit-20;
 	&:last-child {
@@ -11,6 +18,10 @@
 
 	& > * {
 		margin: 0 3px;
+
+		@include breakpoint( '<660px' ) {
+			flex-basis: 100%;
+		}
 	}
 
 	.components-base-control__field {
@@ -21,6 +32,10 @@
 		margin-left: auto;
 		margin-right: 3px;
 		text-transform: uppercase;
+
+		@include breakpoint( '<660px' ) {
+			margin-left: 40px;
+		}
 	}
 
 	&__info {


### PR DESCRIPTION
Fixes #2466

#### Overview
The issue describes that the checkboxes of payment methods look distorted in the mobile view. This issue is not reproducible anymore. However, in the issue, there is a design improvement suggestion for mobile view in [this comment](https://github.com/Automattic/woocommerce-payments/issues/2466#issuecomment-889318144). The mobile view of checkboxes for payment methods in this PR has been improved as per the design suggestion.

#### Changes proposed in this Pull Request
- Hiding the payment method icon in the mobile view. Targeting the Icon's SVG in the checkbox and hiding the display for mobile view.  
- Showing checkbox items are split into two lines. Making the first element of the flex container a full-width element to send the others in the second line if in mobile view.

The desktop view should be the same as before
![Desktop View](https://user-images.githubusercontent.com/33387139/130210938-5e122afc-3131-4a5f-974d-6981a47a4df1.png)

The mobile view would be changed as following:
![Mobile View](https://user-images.githubusercontent.com/33387139/130213771-3dbfece1-de73-4356-949a-408fcc4f1747.png)

#### Testing instructions

- Check `Enable UPE Checkout` in the `WCPay Dev Utils`.  Go to `WooCommerce -> Settings -> Payments -> WooCommerce Payments` and click `Add payment method`. The desktop view should be unchanged, the mobile view should reflect the changes mentioned above.
- Uncheck `Enable UPE Checkout` in the `WCPay Dev Utils`. Go to Onboarding Task in `WooCommerce -> Home`. Check the `Boost your sales with payment methods` section. The desktop view should be unchanged, the mobile view should reflect the changes mentioned above.

#### QA Checklist

- [ ] Desktop view is unchanged
- [ ] Mobile view does not show the payment method icon
- [ ] Mobile view has payment method name in one line and the other elements in the second line

-------------------

- [x] Changelog entry does not apply)
- [x] Test coverage is not needed
- [x] Tested on mobile