### PR TITLE
Adds Tax calculations to WCPay Subscriptions and Invoices

### DIFF
--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -112,9 +112,9 @@ class WC_Payments_Invoice_Service {
 	/**
 	 * Creates invoice items for discounts, fees, and shipping if applicable.
 	 *
-	 * @param WC_Subscription $subscription           The WC Subscription object.
-	 * @param string          $customer_id            The WCPay Customer ID.
-	 * @param string          $wcpay_subscription_id  The WCPay Billing subscription ID.
+	 * @param WC_Subscription $subscription          The WC Subscription object.
+	 * @param string          $customer_id           The WCPay Customer ID.
+	 * @param string          $wcpay_subscription_id The WCPay Billing subscription ID.
 	 *
 	 * @throws API_Exception When there's an error creating the invoice items on server.
 	 *

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -39,7 +39,7 @@ class WC_Payments_Invoice_Service {
 	/**
 	 * Tax Service.
 	 *
-	 * @var WC_Payments_Product_Service Add the tax service class.
+	 * @var WC_Payments_Product_Service Add the product service class
 	 */
 	private $product_service;
 
@@ -171,7 +171,7 @@ class WC_Payments_Invoice_Service {
 	 *
 	 * @return array Invoice item data.
 	 */
-	private function prepare_invoice_item_data( WC_Subscription $subscription ) {
+	private function prepare_invoice_item_data( WC_Subscription $subscription ) : array {
 		$data     = [];
 		$discount = $subscription->get_total_discount( false );
 		$currency = $subscription->get_currency();

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -398,7 +398,7 @@ class WC_Payments_Product_Service {
 			return $tax_rates;
 		}
 
-		$tax_inclusive = wc_prices_include_tax() ? 'true' : 'false';
+		$tax_inclusive = wc_prices_include_tax();
 
 		foreach ( $subscription->get_taxes() as $tax ) {
 			if ( in_array( $tax->get_rate_id(), $tax_rate_ids, true ) ) {

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -367,21 +367,50 @@ class WC_Payments_Product_Service {
 				continue;
 			}
 
-			try {
-				// TODO: Use the tax service get_tax_rates_for_item() once implemented.
-				$tax_rates = [];
-			} catch ( API_Exception $e ) {
-				return null;
-			}
-
 			$product_data[] = [
 				'price'     => $this->get_stripe_price_id( $product ),
 				'quantity'  => $item->get_quantity(),
-				'tax_rates' => $tax_rates,
+				'tax_rates' => $this->get_tax_rates_for_item( $item, $subscription ),
 			];
 		}
 
 		return $product_data;
+	}
+
+	/**
+	 * Prepare tax rates for a subscription item.
+	 *
+	 * @param WC_Order_Item   $item         Subscription order item.
+	 * @param WC_Subscription $subscription A Subscription to get tax rate information from.
+	 *
+	 * @return array
+	 */
+	public function get_tax_rates_for_item( WC_Order_Item $item, WC_Subscription $subscription ) {
+		$tax_rates = [];
+
+		if ( ! wc_tax_enabled() || ! $item->get_taxes() ) {
+			return $tax_rates;
+		}
+
+		$tax_rate_ids = array_keys( $item->get_taxes()['total'] );
+
+		if ( ! $tax_rate_ids ) {
+			return $tax_rates;
+		}
+
+		$tax_inclusive = wc_prices_include_tax() ? 'true' : 'false';
+
+		foreach ( $subscription->get_taxes() as $tax ) {
+			if ( in_array( $tax->get_rate_id(), $tax_rate_ids, true ) ) {
+				$tax_rates[] = [
+					'display_name' => $tax->get_name(),
+					'inclusive'    => $tax_inclusive,
+					'percentage'   => $tax->get_rate_percent(),
+				];
+			}
+		}
+
+		return $tax_rates;
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -44,13 +44,6 @@ class WC_Payments_Subscription_Service {
 	private $customer_service;
 
 	/**
-	 * Tax Service
-	 *
-	 * @var null (Not yet implemented)
-	 */
-	private $tax_service;
-
-	/**
 	 * Product Service
 	 *
 	 * @var WC_Payments_Product_Service
@@ -89,7 +82,6 @@ class WC_Payments_Subscription_Service {
 	 *
 	 * @param WC_Payments_API_Client       $api_client       WC payments API Client.
 	 * @param WC_Payments_Customer_Service $customer_service WC payments customer serivce.
-	 * @param null                         $tax_service      WC payments tax service.
 	 * @param WC_Payments_Product_Service  $product_service  WC payments Products service.
 	 * @param WC_Payments_Invoice_Service  $invoice_service  WC payments Invoice service.
 	 *
@@ -98,13 +90,11 @@ class WC_Payments_Subscription_Service {
 	public function __construct(
 		WC_Payments_API_Client $api_client,
 		WC_Payments_Customer_Service $customer_service,
-		$tax_service,
 		WC_Payments_Product_Service $product_service,
 		WC_Payments_Invoice_Service $invoice_service
 	) {
 		$this->payments_api_client = $api_client;
 		$this->customer_service    = $customer_service;
-		$this->tax_service         = $tax_service;
 		$this->product_service     = $product_service;
 		$this->invoice_service     = $invoice_service;
 

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -156,6 +156,8 @@ class WC_Payments_Subscription_Service {
 		}
 
 		try {
+			$this->invoice_service->create_invoice_items_for_subscription( $subscription, $wcpay_customer_id );
+
 			$subscription_data = $this->prepare_wcpay_subscription_data( $wcpay_customer_id, $subscription );
 			$response          = $this->payments_api_client->create_subscription( $subscription_data );
 

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -310,10 +310,6 @@ class WC_Payments_Subscription_Service {
 	private function prepare_wcpay_subscription_data( string $wcpay_customer_id, WC_Subscription $subscription ) {
 		$items = $this->product_service->get_product_data_for_subscription( $subscription );
 
-		if ( is_wp_error( $items ) ) {
-			return [];
-		}
-
 		$data = [
 			'customer'           => $wcpay_customer_id,
 			'items'              => $items,

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -22,13 +22,6 @@ class WC_Payments_Subscriptions {
 	private static $product_service;
 
 	/**
-	 * Instance of WC_Payments_Tax_Service, created in init function.
-	 *
-	 * @var WC_Payments_Tax_Service
-	 */
-	private static $tax_service;
-
-	/**
 	 * Instance of WC_Payments_Invoice_Service, created in init function.
 	 *
 	 * @var WC_Payments_Invoice_Service
@@ -55,7 +48,7 @@ class WC_Payments_Subscriptions {
 
 		self::$product_service      = new WC_Payments_Product_Service( $api_client );
 		self::$invoice_service      = new WC_Payments_Invoice_Service( $api_client, self::$product_service );
-		self::$subscription_service = new WC_Payments_Subscription_Service( $api_client, $customer_service, self::$tax_service, self::$product_service, self::$invoice_service );
+		self::$subscription_service = new WC_Payments_Subscription_Service( $api_client, $customer_service, self::$product_service, self::$invoice_service );
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -54,8 +54,7 @@ class WC_Payments_Subscriptions {
 		include_once __DIR__ . '/class-wc-payments-subscription-service.php';
 
 		self::$product_service      = new WC_Payments_Product_Service( $api_client );
-		self::$tax_service          = null; // TODO: create instance of tax service once implemented.
-		self::$invoice_service      = new WC_Payments_Invoice_Service( $api_client, self::$tax_service );
+		self::$invoice_service      = new WC_Payments_Invoice_Service( $api_client, self::$product_service );
 		self::$subscription_service = new WC_Payments_Subscription_Service( $api_client, $customer_service, self::$tax_service, self::$product_service, self::$invoice_service );
 	}
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -47,7 +47,7 @@ class WC_Payments_API_Client {
 	const PRICES_API          = 'products/prices';
 	const SUBSCRIPTIONS_API   = 'subscriptions';
 	const INVOICES_API        = 'invoices';
-	const INVOICE_ITEMS_API   = '/invoice/items';
+	const INVOICE_ITEMS_API   = 'invoices/items';
 
 	/**
 	 * Common keys in API requests/responses that we might want to redact.
@@ -1055,13 +1055,13 @@ class WC_Payments_API_Client {
 	}
 
 	/**
-	 * Creates an invoice item.
+	 * Creates invoice items.
 	 *
 	 * @param array $invoice_item_data The invoice item data.
 	 *
 	 * @throws API_Exception Error creating the invoice item.
 	 */
-	public function create_invoice_item( $invoice_item_data ) {
+	public function create_invoice_items( $invoice_item_data ) {
 		return $this->request(
 			$invoice_item_data,
 			self::INVOICE_ITEMS_API,

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1063,7 +1063,7 @@ class WC_Payments_API_Client {
 	 */
 	public function create_invoice_items( $invoice_item_data ) {
 		return $this->request(
-			$invoice_item_data,
+			[ 'invoiceitems' => $invoice_item_data ],
 			self::INVOICE_ITEMS_API,
 			self::POST
 		);

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -127,7 +127,7 @@
     </UndefinedDocblockClass>
   </file>
   <file src="includes/subscriptions/class-wc-payments-product-service.php">
-    <UndefinedClass occurrences="6">
+    <UndefinedClass occurrences="7">
       <code>WC_Subscriptions_Product</code>
     </UndefinedClass>
   </file>

--- a/tests/unit/helpers/class-wc-helper-subscription.php
+++ b/tests/unit/helpers/class-wc-helper-subscription.php
@@ -65,6 +65,13 @@ class WC_Subscription extends WC_Mock_WC_Data {
 	public $next_payment;
 
 	/**
+	 * Taxes.
+	 *
+	 * @var array
+	 */
+	public $taxes = [];
+
+	/**
 	 * A helper function for handling function calls not yet implimented on this helper.
 	 *
 	 * Attempts to get the value by checking if it has been set as an object property.
@@ -140,5 +147,9 @@ class WC_Subscription extends WC_Mock_WC_Data {
 		foreach ( $dates as $date_type => $date_string ) {
 			$this->{$date_type} = strtotime( $date_string );
 		}
+	}
+
+	public function get_taxes() {
+		return $this->taxes;
 	}
 }

--- a/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
@@ -164,11 +164,13 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 	/**
 	 * Tests for WC_Payments_Invoice_Service::prepare_invoice_item_data()
 	 */
-	public function test_prepare_invoice_item_data() {
-		$mock_order        = WC_Helper_Order::create_order();
-		$mock_subscription = new WC_Subscription();
-		$mock_items        = $mock_order->get_shipping_methods();
-		$mock_order_item   = array_pop( $mock_items );
+	public function test_prepare_invoice_item_data_with_subscription_id() {
+		$mock_order                 = WC_Helper_Order::create_order();
+		$mock_subscription          = new WC_Subscription();
+		$mock_items                 = $mock_order->get_shipping_methods();
+		$mock_order_item            = array_pop( $mock_items );
+		$mock_wcpay_subscription_id = 'si_testSubscriptionID';
+		$mock_wcpay_customer_id     = 'cust_testCustomerID';
 
 		$mock_subscription->set_parent( $mock_order );
 		$mock_order->set_discount_total( 20 );
@@ -181,7 +183,7 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 		$result = PHPUnit_Utils::call_method(
 			$this->invoice_service,
 			'prepare_invoice_item_data',
-			[ $mock_subscription ]
+			[ $mock_subscription, $mock_wcpay_customer_id, $mock_wcpay_subscription_id ]
 		);
 
 		$this->assertTrue( is_array( $result ) );
@@ -189,9 +191,46 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 		$this->assertEquals( 2, count( $result ) );
 
 		foreach ( $result as $item_data ) {
-			foreach ( [ 'amount', 'currency', 'description', 'tax_rates' ] as $key ) {
+			foreach ( [ 'amount', 'currency', 'description', 'tax_rates', 'customer', 'subscription' ] as $key ) {
 				$this->assertArrayHasKey( $key, $item_data );
 			}
+		}
+	}
+
+	/**
+	 * Tests for WC_Payments_Invoice_Service::prepare_invoice_item_data()
+	 */
+	public function test_prepare_invoice_item_data_without_subscription_id() {
+		$mock_order             = WC_Helper_Order::create_order();
+		$mock_subscription      = new WC_Subscription();
+		$mock_items             = $mock_order->get_shipping_methods();
+		$mock_order_item        = array_pop( $mock_items );
+		$mock_wcpay_customer_id = 'cust_testCustomerID';
+
+		$mock_subscription->set_parent( $mock_order );
+		$mock_order->set_discount_total( 20 );
+
+		$this->mock_product_service->expects( $this->once() )
+			->method( 'get_tax_rates_for_item' )
+			->with( $mock_order_item, $mock_subscription )
+			->willReturn( [] );
+
+		$result = PHPUnit_Utils::call_method(
+			$this->invoice_service,
+			'prepare_invoice_item_data',
+			[ $mock_subscription, $mock_wcpay_customer_id, '' ]
+		);
+
+		$this->assertTrue( is_array( $result ) );
+		$this->assertContainsOnly( 'array', $result );
+		$this->assertEquals( 2, count( $result ) );
+
+		foreach ( $result as $item_data ) {
+			foreach ( [ 'amount', 'currency', 'description', 'tax_rates', 'customer' ] as $key ) {
+				$this->assertArrayHasKey( $key, $item_data );
+			}
+
+			$this->assertArrayNotHasKey( 'subscription', $item_data );
 		}
 	}
 
@@ -216,21 +255,20 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 
 		// The mock order comes with a $10 flat rate shipping so the expected invoice items are the following.
 		$expected_args = [
-			'invoiceitems' => [
-				[
-					'amount'       => 1000,
-					'currency'     => 'USD',
-					'description'  => 'Flat rate shipping',
-					'tax_rates'    => [],
-					'customer'     => $wcpay_customer_id,
-					'subscription' => $wcpay_subscription_id,
-				],
+			[
+				'amount'       => 1000,
+				'currency'     => 'USD',
+				'description'  => 'Flat rate shipping',
+				'tax_rates'    => [],
+				'customer'     => $wcpay_customer_id,
+				'subscription' => $wcpay_subscription_id,
 			],
 		];
 
 		$this->mock_api_client->expects( $this->once() )
 			->method( 'create_invoice_items' )
-			->with( $expected_args );
+			->with( $expected_args )
+			->willReturn( [ 'mockNewInvoiceID' ] );
 
 		$this->invoice_service->create_invoice_items_for_subscription( $mock_subscription, $wcpay_customer_id, $wcpay_subscription_id );
 	}

--- a/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
@@ -216,16 +216,20 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 
 		// The mock order comes with a $10 flat rate shipping so the expected invoice items are the following.
 		$expected_args = [
-			'amount'       => 1000,
-			'currency'     => 'USD',
-			'description'  => 'Flat rate shipping',
-			'tax_rates'    => [],
-			'customer'     => $wcpay_customer_id,
-			'subscription' => $wcpay_subscription_id,
+			'invoiceitems' => [
+				[
+					'amount'       => 1000,
+					'currency'     => 'USD',
+					'description'  => 'Flat rate shipping',
+					'tax_rates'    => [],
+					'customer'     => $wcpay_customer_id,
+					'subscription' => $wcpay_subscription_id,
+				],
+			],
 		];
 
 		$this->mock_api_client->expects( $this->once() )
-			->method( 'create_invoice_item' )
+			->method( 'create_invoice_items' )
 			->with( $expected_args );
 
 		$this->invoice_service->create_invoice_items_for_subscription( $mock_subscription, $wcpay_customer_id, $wcpay_subscription_id );

--- a/tests/unit/subscriptions/test-class-wc-payments-product-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-product-service.php
@@ -242,20 +242,10 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test $product_service->get_tax_rates_for_item().
+	 * Test $product_service->get_tax_rates_for_item() with tax data attached to subscription items.
 	 */
-	public function test_get_tax_rates_for_item() {
-		$mock_order        = WC_Helper_Order::create_order();
+	public function test_get_tax_rates_for_items_with_tax_data() {
 		$mock_subscription = new WC_Subscription();
-		$mock_subscription->get_parent( $mock_order );
-
-		$mock_items      = $mock_order->get_shipping_methods();
-		$mock_order_item = array_pop( $mock_items );
-
-		update_option( 'woocommerce_calc_taxes', 'no' );
-
-		$this->assertSame( [], $this->product_service->get_tax_rates_for_item( $mock_order_item, $mock_subscription ) );
-
 		// Setup the tax item.
 		$mock_tax_item = $this->getMockBuilder( WC_Order_Item_Tax::class )
 			->disableOriginalConstructor()
@@ -291,7 +281,9 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 			->will( $this->returnValue( $mock_line_item_taxes ) );
 
 		$mock_subscription->taxes = $mock_order_taxes;
+
 		update_option( 'woocommerce_calc_taxes', 'yes' );
+
 		$expected_result = [
 			[
 				'display_name' => 'Test Tax Rate',
@@ -301,5 +293,28 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 		];
 
 		$this->assertSame( $expected_result, $this->product_service->get_tax_rates_for_item( $mock_item, $mock_subscription ) );
+
+		update_option( 'woocommerce_calc_taxes', 'no' );
+		$this->assertSame( [], $this->product_service->get_tax_rates_for_item( $mock_item, $mock_subscription ) );
+	}
+
+	/**
+	 * Test $product_service->get_tax_rates_for_item() without any tax data on the subscription.
+	 */
+	public function test_get_tax_rates_for_items_with_no_tax_data() {
+		$mock_order        = WC_Helper_Order::create_order();
+		$mock_subscription = new WC_Subscription();
+		$mock_subscription->get_parent( $mock_order );
+
+		$mock_items      = $mock_order->get_shipping_methods();
+		$mock_order_item = array_pop( $mock_items );
+
+		update_option( 'woocommerce_calc_taxes', 'no' );
+
+		$this->assertSame( [], $this->product_service->get_tax_rates_for_item( $mock_order_item, $mock_subscription ) );
+
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+
+		$this->assertSame( [], $this->product_service->get_tax_rates_for_item( $mock_order_item, $mock_subscription ) );
 	}
 }

--- a/tests/unit/subscriptions/test-class-wc-payments-product-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-product-service.php
@@ -240,4 +240,20 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 		];
 		$this->assertEquals( $this->product_service->get_product_data_for_subscription( $subscription ), $expected_result );
 	}
+
+	/**
+	 * Test $product_service->get_tax_rates_for_item().
+	 */
+	public function test_get_tax_rates_for_item() {
+		$mock_order        = WC_Helper_Order::create_order();
+		$mock_subscription = new WC_Subscription();
+		$mock_subscription->get_parent( $mock_order );
+
+		$mock_items      = $mock_order->get_shipping_methods();
+		$mock_order_item = array_pop( $mock_items );
+
+		update_option( 'woocommerce_calc_taxes', 'no' );
+
+		$this->assertEquals( [], $this->product_service->get_tax_rates_for_item( $mock_order_item, $mock_subscription ) );
+	}
 }

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -65,7 +65,7 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 		$this->mock_product_service  = $this->createMock( WC_Payments_Product_Service::class );
 		$this->mock_invoice_service  = $this->createMock( WC_Payments_Invoice_Service::class );
 
-		$this->subscription_service = new WC_Payments_Subscription_Service( $this->mock_api_client, $this->mock_customer_service, null, $this->mock_product_service, $this->mock_invoice_service );
+		$this->subscription_service = new WC_Payments_Subscription_Service( $this->mock_api_client, $this->mock_customer_service, $this->mock_product_service, $this->mock_invoice_service );
 	}
 
 	/**


### PR DESCRIPTION
Internal p2: https://wp.me/pb0GrA-1g9

---

### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
#### Set item tax rates data to WCPay server when creating subscriptions and setting invoice items.

In this PR we're now sending tax information to server to create WCPay tax rate IDs. The information sent to server is in an array with:
 - Display name
 - Tax rate percentage
 - Inclusive (`'true'` or `'false'`)

On another PR (https://github.com/Automattic/woocommerce-payments/pull/2758#issuecomment-902481006) we discussed storing WCPay tax rate IDs on the actual subscription order items, but I didn't implement that as I didn't actually see a need for this.

I assumed we originally thought we needed to store the WCPay tax rate IDs on the order items in case we needed to update/archive them but since we're not allowing this (at least not in v1), I decided not to store this information.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

Before testing, before sure to have the latest changes from: 1005-gh-Automattic/woocommerce-payments-server

1. Make sure you have WC taxes enabled with a valid tax rate for your test customers location
2. Go through the checkout flow and sign up for a subscription product
3. Confirm the new tax rate is created in the stripe dashboard (Products > Tax Rates)
4. Go through the checkout with the same or different subscription product
5. Confirm the existing WCPay Tax rate is used and a new tax rate is not created
