### PR TITLE
Fix currency formatter fallback exception on Safari < 14.1.2

### DIFF
--- a/client/multi-currency/index.js
+++ b/client/multi-currency/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -86,6 +86,10 @@ const rounding = document.querySelector(
 	'[name^=wcpay_multi_currency_price_rounding_]'
 );
 
+const isZeroDecimal = document.querySelector(
+	'[name^=wcpay_multi_currency_is_zero_decimal_]'
+);
+
 const charm = document.querySelector(
 	'[name^=wcpay_multi_currency_price_charm_]'
 );
@@ -119,14 +123,22 @@ function updatePreview() {
 		return;
 	}
 
-	previewDisplay.innerHTML = total.toLocaleString(
-		undefined, // Use the default locale for the given currency.
-		{
-			style: 'currency',
-			currency: currencyCode,
-			currencyDisplay: 'narrowSymbol',
-		}
-	);
+	try {
+		previewDisplay.innerHTML = total.toLocaleString(
+			undefined, // Use the default locale for the given currency.
+			{
+				style: 'currency',
+				currency: currencyCode,
+				currencyDisplay: 'narrowSymbol',
+			}
+		);
+	} catch ( error ) {
+		return sprintf(
+			isZeroDecimal ? '%s %i' : '%s %.2f',
+			currencyCode.toUpperCase(),
+			total
+		);
+	}
 }
 
 const hideShowManualField = ( show ) => {

--- a/client/utils/currency/index.js
+++ b/client/utils/currency/index.js
@@ -239,11 +239,11 @@ function composeFallbackCurrency( amount, currencyCode, isZeroDecimal ) {
 			dummy: isZeroDecimal,
 		} );
 	} catch ( error ) {
-	return sprintf(
-		isZeroDecimal ? '%s %i' : '%s %.2f',
-		currencyCode.toUpperCase(),
-		amount
-	);
+		return sprintf(
+			isZeroDecimal ? '%s %i' : '%s %.2f',
+			currencyCode.toUpperCase(),
+			amount
+		);
 	}
 }
 

--- a/client/utils/currency/index.js
+++ b/client/utils/currency/index.js
@@ -230,13 +230,20 @@ function removeCurrencySymbol( formatted ) {
 }
 
 function composeFallbackCurrency( amount, currencyCode, isZeroDecimal ) {
-	// Fallback for unsupported currencies: currency code and amount
-	return amount.toLocaleString( undefined, {
-		style: 'currency',
-		currency: currencyCode,
-		currencyDisplay: 'narrowSymbol',
-		dummy: isZeroDecimal,
-	} );
+	try {
+		// Fallback for unsupported currencies: currency code and amount
+		return amount.toLocaleString( undefined, {
+			style: 'currency',
+			currency: currencyCode,
+			currencyDisplay: 'narrowSymbol',
+			dummy: isZeroDecimal,
+		} );
+	} catch ( error ) {
+		if ( ! isZeroDecimal ) {
+			return sprintf( '%.02f %s', amount, currencyCode );
+		}
+		return sprintf( '%s %s', amount, currencyCode );
+	}
 }
 
 function trimEndingZeroes( formattedCurrencyAmount = '' ) {

--- a/client/utils/currency/index.js
+++ b/client/utils/currency/index.js
@@ -239,10 +239,11 @@ function composeFallbackCurrency( amount, currencyCode, isZeroDecimal ) {
 			dummy: isZeroDecimal,
 		} );
 	} catch ( error ) {
-		if ( ! isZeroDecimal ) {
-			return sprintf( '%.02f %s', amount, currencyCode );
-		}
-		return sprintf( '%s %s', amount, currencyCode );
+	return sprintf(
+		isZeroDecimal ? '%s %i' : '%s %.2f',
+		currencyCode.toUpperCase(),
+		amount
+	);
 	}
 }
 

--- a/includes/multi-currency/Settings.php
+++ b/includes/multi-currency/Settings.php
@@ -236,6 +236,10 @@ class Settings extends \WC_Settings_Page {
 					<span style="display:inline-block;"></span>
 				</div>
 				<input type="hidden"
+					name="<?php echo esc_attr( $this->id . '_is_zero_decimal' ); ?>"
+					value="<?php echo esc_attr( $available_currencies[ $currency->get_code() ]->get_is_zero_decimal() ); ?>"
+				/>
+				<input type="hidden"
 					name="<?php echo esc_attr( $this->id . '_automatic_exchange_rate' ); ?>"
 					value="<?php echo esc_attr( $available_currencies[ $currency->get_code() ]->get_rate() ); ?>"
 				/>


### PR DESCRIPTION
Fixes #2791

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

Safari versions prior than 14.1.2 and Safari Mobile versions prior than 14.5 doesn't support `narrowSymbol` as a value of `currencyDisplay` in `toLocaleString` function, this PR catches all errors that's related with `toLocaleString` formatter, and falls back to `sprintf`'ing the amount and the currency code (as it was before we applied the `Intl` formatter.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create and pay an order with DKK currency
* Sync the transaction
* On a Safari < 14.1.2 browser, (you can also use a BrowserStack browser with tunneling your local site with Jurassic Tube) navigate to `Payments > Transactions` page
* See if the page renders correctly.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
