### PR TITLE
gitignore docker compose override file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ docker/data
 docker/wordpress
 docker/logs
 
+# Local machine docker override
+docker-compose.override.yml
+
 # Tunneling scripts
 /docker/bin/jt
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Tiny wee dev-quality-of-life tweak. 

- [`docker-compose.override.yml` file allows you to tweak the docker config](https://docs.docker.com/compose/reference/). For example, you can mount extra folders in the container. I want to do this so I can mount other plugin repos as needed.
- The override file is typically used as a per-machine/per-user override, so it's not useful to commit to the repo, so should be ignored. 

#### Testing instructions
* Add a `docker-compose.override.yml` file to the root of your repo clone.
* Add some other settings or overrides, optionally restart your docker to test them out:
   - `npm run up` automatically picks up the override file via `docker-compose up` built-in behaviour.
   - Note when you relaunch container you'll need to restart localhost tunnel e.g. `npm run tube:start`.
   - See below for an example mounting another woo plugin.
* Check your git client, there should be no dirty files, and it should be hard to accidentally commit the compose override file.

```yml
# docker-compose.override.yml
version: '3'

# I have woo subs repo cloned alongside woo payments, and I want to mount it as another WP plugin:
services:
  wordpress:
    volumes:
      - ../woocommerce-subscriptions:/var/www/html/wp-content/plugins/woocommerce-subscriptions
```

-------------------

- [ ] Added changelog entry (or does not apply) _n/a_
- [ ] Covered with tests (or have a good reason not to test in description ☝️) _n/a, zero impact dev tooling tweak_ 
- [ ] Tested on mobile (or does not apply) _n/a_

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply) _n/a_
