### PR TITLE
Add DownloadButton component

### DIFF
--- a/client/components/download-button/index.js
+++ b/client/components/download-button/index.js
@@ -15,7 +15,6 @@ import './style.scss';
 
 const DownloadButton = ( { isDisabled, onClick } ) => (
 	<Button
-		key="download"
 		className="woocommerce-table__download-button"
 		disabled={ isDisabled }
 		onClick={ onClick }

--- a/client/components/download-button/index.js
+++ b/client/components/download-button/index.js
@@ -1,0 +1,30 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const DownloadButton = ( { isDisabled, onClick } ) => (
+	<Button
+		key="download"
+		className="woocommerce-table__download-button"
+		disabled={ isDisabled }
+		onClick={ onClick }
+	>
+		<Gridicon icon={ 'cloud-download' } />
+		<span className="woocommerce-table__download-button__label">
+			{ __( 'Download', 'woocommerce-payments' ) }
+		</span>
+	</Button>
+);
+
+export default DownloadButton;

--- a/client/components/download-button/style.scss
+++ b/client/components/download-button/style.scss
@@ -1,0 +1,59 @@
+$gap-small: 12px;
+$gap-smaller: 8px;
+
+.woocommerce-report-table {
+	&.has-compare,
+	&.has-search {
+		@include breakpoint( '<960px' ) {
+			.woocommerce-card__action {
+				.woocommerce-table__download-button {
+					grid-area: 1 / 2 / 2 / 3;
+					justify-self: end;
+					margin: -6px 0;
+					position: absolute;
+				}
+			}
+		}
+
+		&.has-search:not( .has-compare ) {
+			.woocommerce-card__action {
+				.woocommerce-table__download-button {
+					align-self: center;
+					grid-column-start: 2;
+					grid-column-end: 3;
+				}
+			}
+
+			@include breakpoint( '<960px' ) {
+				.woocommerce-card__action {
+					.woocommerce-table__download-button {
+						grid-area: 1 / 2 / 2 / 3;
+					}
+				}
+			}
+		}
+	}
+}
+
+button.woocommerce-table__download-button {
+	padding: 6px $gap-small;
+	color: $studio-black;
+	text-decoration: none;
+	align-items: center;
+
+	svg {
+		margin-right: $gap-smaller;
+		height: 24px;
+		width: 24px;
+	}
+
+	@include breakpoint( '<960px' ) {
+		svg {
+			margin-right: 0;
+		}
+
+		.woocommerce-table__download-button__label {
+			display: none;
+		}
+	}
+}

--- a/client/components/download-button/test/__snapshots__/index.js.snap
+++ b/client/components/download-button/test/__snapshots__/index.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DownloadButton renders a disabled button 1`] = `
+<div>
+  <button
+    class="components-button woocommerce-table__download-button"
+    disabled=""
+    type="button"
+  >
+    <svg
+      class="gridicon gridicons-cloud-download"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g>
+        <path
+          d="M18 9c-.01 0-.017.002-.025.003C17.72 5.646 14.922 3 11.5 3 7.91 3 5 5.91 5 9.5c0 .524.07 1.03.186 1.52C5.123 11.015 5.064 11 5 11c-2.21 0-4 1.79-4 4 0 1.202.54 2.267 1.38 3h18.593C22.196 17.09 23 15.643 23 14c0-2.76-2.24-5-5-5zm-6 7l-4-5h3V8h2v3h3l-4 5z"
+        />
+      </g>
+    </svg>
+    <span
+      class="woocommerce-table__download-button__label"
+    >
+      Download
+    </span>
+  </button>
+</div>
+`;
+
+exports[`DownloadButton renders an active button 1`] = `
+<div>
+  <button
+    class="components-button woocommerce-table__download-button"
+    type="button"
+  >
+    <svg
+      class="gridicon gridicons-cloud-download"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g>
+        <path
+          d="M18 9c-.01 0-.017.002-.025.003C17.72 5.646 14.922 3 11.5 3 7.91 3 5 5.91 5 9.5c0 .524.07 1.03.186 1.52C5.123 11.015 5.064 11 5 11c-2.21 0-4 1.79-4 4 0 1.202.54 2.267 1.38 3h18.593C22.196 17.09 23 15.643 23 14c0-2.76-2.24-5-5-5zm-6 7l-4-5h3V8h2v3h3l-4 5z"
+        />
+      </g>
+    </svg>
+    <span
+      class="woocommerce-table__download-button__label"
+    >
+      Download
+    </span>
+  </button>
+</div>
+`;

--- a/client/components/download-button/test/index.js
+++ b/client/components/download-button/test/index.js
@@ -1,0 +1,50 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { render, fireEvent, getByRole } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import DownloadButton from '../';
+
+describe( 'DownloadButton', () => {
+	test( 'renders an active button', () => {
+		const onDownload = jest.fn();
+		const { container: button } = renderDownloadButton( false, onDownload );
+
+		fireEvent(
+			getByRole( button, 'button' ),
+			new MouseEvent( 'click', {
+				bubbles: true,
+				cancelable: true,
+			} )
+		);
+
+		expect( onDownload.mock.calls.length ).toBe( 1 );
+		expect( button ).toMatchSnapshot();
+	} );
+
+	test( 'renders a disabled button', () => {
+		const onDownload = jest.fn();
+		const { container: button } = renderDownloadButton( true, onDownload );
+
+		fireEvent(
+			getByRole( button, 'button' ),
+			new MouseEvent( 'click', {
+				bubbles: true,
+				cancelable: true,
+			} )
+		);
+
+		expect( onDownload.mock.calls.length ).toBe( 0 );
+		expect( button ).toMatchSnapshot();
+	} );
+
+	function renderDownloadButton( isDisabled, onClick ) {
+		return render(
+			<DownloadButton isDisabled={ isDisabled } onClick={ onClick } />
+		);
+	}
+} );

--- a/client/deposits/list/index.js
+++ b/client/deposits/list/index.js
@@ -235,6 +235,7 @@ export const DepositsList = () => {
 				actions={ [
 					downloadable && (
 						<DownloadButton
+							key="download"
 							isDisabled={ isLoading }
 							onClick={ onDownload }
 						/>

--- a/client/deposits/list/index.js
+++ b/client/deposits/list/index.js
@@ -8,14 +8,12 @@ import { dateI18n } from '@wordpress/date';
 import { __, _n } from '@wordpress/i18n';
 import moment from 'moment';
 import { TableCard, Link } from '@woocommerce/components';
-import { Button } from '@wordpress/components';
 import { onQueryChange, getQuery } from '@woocommerce/navigation';
 import {
 	downloadCSVFile,
 	generateCSVDataFromTable,
 	generateCSVFileName,
 } from '@woocommerce/csv-export';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies.
@@ -28,6 +26,7 @@ import DetailsLink, { getDetailsURL } from 'components/details-link';
 import ClickableCell from 'components/clickable-cell';
 import Page from '../../components/page';
 import DepositsFilters from '../filters';
+import DownloadButton from '../../components/download-button';
 
 import './style.scss';
 
@@ -235,17 +234,10 @@ export const DepositsList = () => {
 				onQueryChange={ onQueryChange }
 				actions={ [
 					downloadable && (
-						<Button
-							key="download"
-							className="woocommerce-table__download-button"
-							disabled={ isLoading }
+						<DownloadButton
+							isDisabled={ isLoading }
 							onClick={ onDownload }
-						>
-							<Gridicon icon={ 'cloud-download' } />
-							<span className="woocommerce-table__download-button__label">
-								{ __( 'Download', 'woocommerce-payments' ) }
-							</span>
-						</Button>
+						/>
 					),
 				] }
 			/>

--- a/client/deposits/list/index.js
+++ b/client/deposits/list/index.js
@@ -26,7 +26,7 @@ import DetailsLink, { getDetailsURL } from 'components/details-link';
 import ClickableCell from 'components/clickable-cell';
 import Page from '../../components/page';
 import DepositsFilters from '../filters';
-import DownloadButton from '../../components/download-button';
+import DownloadButton from 'components/download-button';
 
 import './style.scss';
 

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -15,7 +15,6 @@ import {
 	Link,
 	TableCardColumn,
 } from '@woocommerce/components';
-import { Button } from '@wordpress/components';
 import {
 	onQueryChange,
 	getQuery,
@@ -26,7 +25,6 @@ import {
 	generateCSVDataFromTable,
 	generateCSVFileName,
 } from '@woocommerce/csv-export';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -46,6 +44,7 @@ import './style.scss';
 import TransactionsFilters from '../filters';
 import Page from '../../components/page';
 import wcpayTracks from 'tracks';
+import DownloadButton from '../../components/download-button';
 
 interface TransactionsListProps {
 	depositId?: string;
@@ -482,17 +481,10 @@ export const TransactionsList = (
 						autocompleter={ autocompleter }
 					/>,
 					downloadable && (
-						<Button
-							key="download"
-							className="woocommerce-table__download-button"
-							disabled={ isLoading }
+						<DownloadButton
+							isDisabled={ isLoading }
 							onClick={ onDownload }
-						>
-							<Gridicon icon={ 'cloud-download' } />
-							<span className="woocommerce-table__download-button__label">
-								{ __( 'Download', 'woocommerce-payments' ) }
-							</span>
-						</Button>
+						/>
 					),
 				] }
 			/>

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -482,6 +482,7 @@ export const TransactionsList = (
 					/>,
 					downloadable && (
 						<DownloadButton
+							key="download"
 							isDisabled={ isLoading }
 							onClick={ onDownload }
 						/>

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -44,7 +44,7 @@ import './style.scss';
 import TransactionsFilters from '../filters';
 import Page from '../../components/page';
 import wcpayTracks from 'tracks';
-import DownloadButton from '../../components/download-button';
+import DownloadButton from 'components/download-button';
 
 interface TransactionsListProps {
 	depositId?: string;

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -35,7 +35,6 @@ $space-header-item: 12px;
 */
 $gap: 16px;
 $gap-small: 12px;
-$gap-smaller: 8px;
 .woocommerce-report-table {
 	.woocommerce-search {
 		flex-grow: 1;
@@ -73,13 +72,6 @@ $gap-smaller: 8px;
 					grid-area: 2 / 2 / 3 / 4;
 					margin-right: 0;
 				}
-
-				.woocommerce-table__download-button {
-					grid-area: 1 / 2 / 2 / 3;
-					justify-self: end;
-					margin: -6px 0;
-					position: absolute;
-				}
 			}
 		}
 
@@ -92,12 +84,6 @@ $gap-smaller: 8px;
 					grid-column-start: 1;
 					grid-column-end: 2;
 				}
-
-				.woocommerce-table__download-button {
-					align-self: center;
-					grid-column-start: 2;
-					grid-column-end: 3;
-				}
 			}
 
 			@include breakpoint( '<960px' ) {
@@ -107,10 +93,6 @@ $gap-smaller: 8px;
 					.woocommerce-search {
 						grid-area: 2 / 1 / 3 / 4;
 						margin-left: 0;
-					}
-
-					.woocommerce-table__download-button {
-						grid-area: 1 / 2 / 2 / 3;
 					}
 				}
 			}
@@ -127,29 +109,6 @@ $gap-smaller: 8px;
 		.woocommerce-compare-button {
 			padding: 3px $gap-small;
 			height: auto;
-		}
-	}
-}
-
-button.woocommerce-table__download-button {
-	padding: 6px $gap-small;
-	color: $studio-black;
-	text-decoration: none;
-	align-items: center;
-
-	svg {
-		margin-right: $gap-smaller;
-		height: 24px;
-		width: 24px;
-	}
-
-	@include breakpoint( '<960px' ) {
-		svg {
-			margin-right: 0;
-		}
-
-		.woocommerce-table__download-button__label {
-			display: none;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2794 

#### Changes proposed in this Pull Request

This PR aims to extract the download button currently embedded inside `TransactionsList` and `DepositsList` components (export to CSV functionality) in its own separate component to make our code DRY.

![Annotation on 2021-08-25 at 11-18-50](https://user-images.githubusercontent.com/1288616/130733589-0d60a56f-142a-4c1e-ab95-57e40cb7a280.png)

#### Testing instructions

1. Visit the Transactions page and verify if the Download button (upper-right) still works the same.
2. Visit the Deposits page and verify if the Download button (upper-right) still works the same.

-------------------

- [x] Added changelog entry (does not apply)
- [x] Covered with tests
- [x] Tested on mobile
