### PR TITLE
unit tests - remove add_token_to_order mock

### DIFF
--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -135,7 +135,6 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 					'get_return_url',
 					'mark_payment_complete_for_order',
 					'get_level3_data_from_order', // To avoid needing to mock the order items.
-					'add_token_to_order',
 				]
 			)
 			->getMock();
@@ -163,6 +162,9 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 
 		$this->mock_wcs_order_contains_subscription( true );
 
+		$subscriptions = [ WC_Helper_Order::create_order( self::USER_ID ) ];
+		$this->mock_wcs_get_subscriptions_for_order( $subscriptions );
+
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_and_confirm_intention' )
@@ -175,20 +177,20 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 			->with( self::PAYMENT_METHOD_ID, $order->get_user() )
 			->willReturn( $this->token );
 
-		// Expect add token to order to be called, so it can be reused in renewals.
-		$this->mock_wcpay_gateway
-			->expects( $this->once() )
-			->method( 'add_token_to_order' )
-			->with(
-				$this->callback( $this->match_order_id( $order->get_id() ) ),
-				$this->token
-			);
-
 		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
 		$result_order = wc_get_order( $order->get_id() );
 
 		$this->assertEquals( 'processing', $result_order->get_status() );
 		$this->assertEquals( 'success', $result['result'] );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		// This is an integration test, different scenarios for add_token_to_order method
+		// are tested in WC_Payment_Gateway_WCPay_Subscriptions_Test.
+		$orders = array_merge( [ $order ], $subscriptions );
+		foreach ( $orders as $order ) {
+			$payment_tokens = $order->get_payment_tokens();
+			$this->assertEquals( $this->token->get_id(), end( $payment_tokens ) );
+		}
 	}
 
 	public function test_new_card_zero_dollar_subscription() {
@@ -196,6 +198,9 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 
 		$this->mock_wcs_order_contains_subscription( true );
 
+		$subscriptions = [ WC_Helper_Order::create_order( self::USER_ID ) ];
+		$this->mock_wcs_get_subscriptions_for_order( $subscriptions );
+
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_and_confirm_setup_intent' )
@@ -208,20 +213,20 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 			->with( self::PAYMENT_METHOD_ID, $order->get_user() )
 			->willReturn( $this->token );
 
-		// Expect add token to order to be called, so it can be reused in renewals.
-		$this->mock_wcpay_gateway
-			->expects( $this->once() )
-			->method( 'add_token_to_order' )
-			->with(
-				$this->callback( $this->match_order_id( $order->get_id() ) ),
-				$this->token
-			);
-
 		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
 		$result_order = wc_get_order( $order->get_id() );
 
 		$this->assertEquals( 'processing', $result_order->get_status() );
 		$this->assertEquals( 'success', $result['result'] );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		// This is an integration test, different scenarios for add_token_to_order method
+		// are tested in WC_Payment_Gateway_WCPay_Subscriptions_Test.
+		$orders = array_merge( [ $order ], $subscriptions );
+		foreach ( $orders as $order ) {
+			$payment_tokens = $order->get_payment_tokens();
+			$this->assertEquals( $this->token->get_id(), end( $payment_tokens ) );
+		}
 	}
 
 	public function test_new_card_is_added_before_status_update() {
@@ -229,6 +234,9 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 
 		$this->mock_wcs_order_contains_subscription( true );
 
+		$subscriptions = [ WC_Helper_Order::create_order( self::USER_ID ) ];
+		$this->mock_wcs_get_subscriptions_for_order( $subscriptions );
+
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_and_confirm_setup_intent' )
@@ -241,19 +249,16 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 			->with( self::PAYMENT_METHOD_ID, $order->get_user() )
 			->willReturn( $this->token );
 
-		// Expect add token to order to be called, so it can be reused in renewals.
-		$this->mock_wcpay_gateway
-			->expects( $this->once() )
-			->method( 'add_token_to_order' )
-			->with(
-				$this->logicalAnd(
-					$this->callback( $this->match_order_id( $order->get_id() ) ),
-					$this->callback( $this->match_order_status( 'pending' ) )
-				),
-				$this->token
-			);
-
 		$result = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		// This is an integration test, different scenarios for add_token_to_order method
+		// are tested in WC_Payment_Gateway_WCPay_Subscriptions_Test.
+		$orders = array_merge( [ $order ], $subscriptions );
+		foreach ( $orders as $order ) {
+			$payment_tokens = $order->get_payment_tokens();
+			$this->assertEquals( $this->token->get_id(), end( $payment_tokens ) );
+		}
 	}
 
 	public function test_saved_card_subscription() {
@@ -266,6 +271,9 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 
 		$this->mock_wcs_order_contains_subscription( true );
 
+		$subscriptions = [ WC_Helper_Order::create_order( self::USER_ID ) ];
+		$this->mock_wcs_get_subscriptions_for_order( $subscriptions );
+
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_and_confirm_intention' )
@@ -276,20 +284,20 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 			->expects( $this->never() )
 			->method( 'add_payment_method_to_user' );
 
-		// Expect add token to order to be called, so it can be reused in renewals.
-		$this->mock_wcpay_gateway
-			->expects( $this->once() )
-			->method( 'add_token_to_order' )
-			->with(
-				$this->callback( $this->match_order_id( $order->get_id() ) ),
-				$this->token
-			);
-
 		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
 		$result_order = wc_get_order( $order->get_id() );
 
 		$this->assertEquals( 'processing', $result_order->get_status() );
 		$this->assertEquals( 'success', $result['result'] );
+
+		// Expect add token to order to be called, so it can be reused in renewals.
+		// This is an integration test, different scenarios for add_token_to_order method
+		// are tested in WC_Payment_Gateway_WCPay_Subscriptions_Test.
+		$orders = array_merge( [ $order ], $subscriptions );
+		foreach ( $orders as $order ) {
+			$payment_tokens = $order->get_payment_tokens();
+			$this->assertEquals( $this->token->get_id(), end( $payment_tokens ) );
+		}
 	}
 
 	public function test_saved_card_zero_dollar_subscription() {
@@ -313,17 +321,25 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 			->expects( $this->never() )
 			->method( 'add_payment_method_to_user' );
 
-		// We do need to add the payment method to the order so we can charge it when it's time to
-		// renew the order or when the free trial is over.
-		$this->mock_wcpay_gateway
-			->expects( $this->once() )
-			->method( 'add_token_to_order' );
+		$subscriptions = [ WC_Helper_Order::create_order( self::USER_ID ) ];
+		$this->mock_wcs_get_subscriptions_for_order( $subscriptions );
 
 		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
 		$result_order = wc_get_order( $order->get_id() );
 
 		$this->assertEquals( 'processing', $result_order->get_status() );
 		$this->assertEquals( 'success', $result['result'] );
+
+		// We do need to add the payment method to the order so we can charge it when it's time to
+		// renew the order or when the free trial is over.
+		// This is an integration test, different scenarios for add_token_to_order method
+		// are tested in WC_Payment_Gateway_WCPay_Subscriptions_Test.
+		$orders = array_merge( [ $order ], $subscriptions );
+		foreach ( $orders as $order ) {
+			$payment_tokens = $order->get_payment_tokens();
+			$this->assertEquals( $this->token->get_id(), end( $payment_tokens ) );
+		}
+
 	}
 
 	public function test_card_is_saved_when_updating_subscription_payment_method() {
@@ -339,6 +355,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 			}
 		);
 
+		$this->mock_wcs_get_subscriptions_for_order( [] );
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_and_confirm_setup_intent' )
@@ -351,20 +368,16 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 			->with( self::PAYMENT_METHOD_ID, $order->get_user() )
 			->willReturn( $this->token );
 
-		// Expect add token to order to be called, so it can be reused in renewals.
-		$this->mock_wcpay_gateway
-			->expects( $this->once() )
-			->method( 'add_token_to_order' )
-			->with(
-				$this->callback( $this->match_order_id( $order->get_id() ) ),
-				$this->token
-			);
-
 		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
 		$result_order = wc_get_order( $order->get_id() );
 
 		$this->assertEquals( 'processing', $result_order->get_status() );
 		$this->assertEquals( 'success', $result['result'] );
+		// Expect add token to order to be called, so it can be reused in renewals.
+		// This is an integration test, different scenarios for add_token_to_order method
+		// are tested in WC_Payment_Gateway_WCPay_Subscriptions_Test.
+		$payment_tokens = $order->get_payment_tokens();
+		$this->assertEquals( $this->token->get_id(), end( $payment_tokens ) );
 	}
 
 	public function test_card_is_saved_when_updating_subscription_using_saved_payment_method() {
@@ -383,6 +396,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 				return true;
 			}
 		);
+		$this->mock_wcs_get_subscriptions_for_order( [] );
 
 		$this->mock_api_client
 			->expects( $this->never() )
@@ -392,26 +406,30 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 			->expects( $this->never() )
 			->method( 'add_payment_method_to_user' );
 
-		// Expect add token to order to be called, so it can be reused in renewals.
-		$this->mock_wcpay_gateway
-			->expects( $this->once() )
-			->method( 'add_token_to_order' )
-			->with(
-				$this->callback( $this->match_order_id( $order->get_id() ) ),
-				$this->token
-			);
-
 		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
 		$result_order = wc_get_order( $order->get_id() );
 
 		$this->assertEquals( 'processing', $result_order->get_status() );
 		$this->assertEquals( 'success', $result['result'] );
+		// Expect add token to order to be called, so it can be reused in renewals.
+		// This is an integration test, different scenarios for add_token_to_order method
+		// are tested in WC_Payment_Gateway_WCPay_Subscriptions_Test.
+		$payment_tokens = $order->get_payment_tokens();
+		$this->assertEquals( $this->token->get_id(), end( $payment_tokens ) );
 	}
 
 	private function mock_wcs_order_contains_subscription( $value ) {
 		WC_Subscriptions::set_wcs_order_contains_subscription(
 			function ( $order ) use ( $value ) {
 				return $value;
+			}
+		);
+	}
+
+	private function mock_wcs_get_subscriptions_for_order( $subscriptions ) {
+		WC_Subscriptions::set_wcs_get_subscriptions_for_order(
+			function ( $order ) use ( $subscriptions ) {
+				return $subscriptions;
 			}
 		);
 	}


### PR DESCRIPTION
Fixes [#920](https://app.zenhub.com/workspaces/team-gamma-60365838efc796001bb2d4b8/issues/automattic/woocommerce-payments/920)

#### Changes proposed in this Pull Request

**Unit tests - remove mocking for add_token_to_order**

`add_token_to_order` - does not make any API requests, and the tests can be made without mocking it. Since there is another class that tests the `add_token_to_order`, I changed the tests in order to test only the basic scenario - if the method was called, by checking if the token was added to the order.

#### Testing instructions

* Run PHPUnit tests.

-------------------

- [x] Added changelog entry (or does not apply) _n/a_
- [x] Covered with tests (or have a good reason not to test in description ☝️)  _n/a_
- [x] Tested on mobile (or does not apply) _n/a_

**Post merge**

- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply) _n/a_
