### PR TITLE
Adding Debug Logs to Multi-Currency

### DIFF
--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -24,6 +24,14 @@ class Analytics {
 
 	const SUPPORTED_CONTEXTS = [ 'orders', 'products', 'variations', 'categories', 'coupons', 'taxes' ];
 
+
+	/**
+	 * SQL string replacements made by the analytics multi-currency extension.
+	 *
+	 * @var array
+	 */
+	protected $sql_replacements = [];
+
 	/**
 	 * Instance of MultiCurrency.
 	 *
@@ -213,15 +221,6 @@ class Analytics {
 	}
 
 	/**
-	 * Get the SQL replacements variable.
-	 *
-	 * @return array
-	 */
-	private function get_sql_replacements(): array {
-		return $this->sql_replacements;
-	}
-
-	/**
 	 * Check to see whether we should convert an order to store in the order stats table.
 	 *
 	 * @param WC_Order|WC_Order_Refund $order The order.
@@ -307,6 +306,16 @@ class Analytics {
 	private function generate_case_when( string $variable, string $then, string $else ): string {
 		return "CASE WHEN {$variable} IS NOT NULL THEN {$then} ELSE {$else} END";
 	}
+
+	/**
+	 * Get the SQL replacements variable.
+	 *
+	 * @return array
+	 */
+	private function get_sql_replacements(): array {
+		return $this->sql_replacements;
+	}
+
 	/**
 	 * Set the SQL replacements variable.
 	 *

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -9,9 +9,11 @@ namespace WCPay\MultiCurrency;
 
 use WC_Payments;
 use WC_Payments_Account;
+use WC_Payments_Utils;
 use WC_Payments_API_Client;
 use WC_Payments_Localization_Service;
 use WCPay\Exceptions\API_Exception;
+use WCPay\Logger;
 use WCPay\MultiCurrency\Notes\NoteMultiCurrencyAvailable;
 
 defined( 'ABSPATH' ) || exit;
@@ -113,7 +115,7 @@ class MultiCurrency {
 	/**
 	 * The available currencies.
 	 *
-	 * @var array
+	 * @var Currency[]
 	 */
 	protected $available_currencies = [];
 
@@ -127,7 +129,7 @@ class MultiCurrency {
 	/**
 	 * The enabled currencies.
 	 *
-	 * @var array
+	 * @var Currency[]
 	 */
 	protected $enabled_currencies = [];
 
@@ -307,6 +309,7 @@ class MultiCurrency {
 	 * @return void
 	 */
 	public function clear_cache() {
+		Logger::debug( 'Clearing the cache to force new rates to be fetched from the server.' );
 		delete_option( self::CURRENCY_CACHE_OPTION );
 	}
 
@@ -534,6 +537,11 @@ class MultiCurrency {
 			// Update the enabled currencies and reinitialize.
 			update_option( $this->id . '_enabled_currencies', $currencies );
 			$this->initialize_enabled_currencies();
+
+			Logger::debug(
+				'Enabled currencies updated: '
+				. var_export( $currencies, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+			);
 
 			// Now remove the removed currencies settings.
 			$this->remove_currencies_settings( $removed_currencies );
@@ -838,6 +846,7 @@ class MultiCurrency {
 			'updated'    => $updated,
 		];
 
+		Logger::debug( 'Saved currencies fetched from the server to the cache. Expiry: ' . gmdate( 'Y-m-d H:i:s', time() + $expiration ) );
 		return update_option( self::CURRENCY_CACHE_OPTION, $currency_cache, 'no' );
 	}
 

--- a/includes/multi-currency/Settings.php
+++ b/includes/multi-currency/Settings.php
@@ -7,6 +7,7 @@
 
 namespace WCPay\MultiCurrency;
 
+use WCPay\Logger;
 use WCPay\MultiCurrency\Currency;
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -827,6 +827,8 @@ class WC_Payments_API_Client {
 	 * @param ?array $currencies_to - An array of the currencies we want to convert into. If left empty, will get all supported currencies.
 	 *
 	 * @return array
+	 *
+	 * @throws API_Exception - Error contacting the API.
 	 */
 	public function get_currency_rates( string $currency_from, $currencies_to = null ) {
 		$query_body = [ 'currency_from' => $currency_from ];


### PR DESCRIPTION
Fixes #2690

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- Adds some debug logs when certain actions are triggered in multi currency.
- Also a fix for an issue where a variable was not defined in the `Analytics` class (this was not causing any errors because it was getting declared before it was ever used, but it should have been initialised on class initial creation).
- It would be good to get some thoughts on any further logs that would also be useful. I didn't add a log to the call to fetch the currencies from the server, as this is logged by the WC_Payments_API_Client.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Perform some multi-currency updates (e.g. change your store default currency in `Settings > General` to force a fetch from the server, then add/remove some enabled currencies.
* Go to Dev Tools then click `View Latest Logs`
* Check the logs to ensure the actions performed were logged.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

#### Notes

I kept the logs pretty basic initially to avoid the plugin creating too many logs, if there are any other logs we think are important, please let me know and i'm happy to add them in.

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
