### PR TITLE
Adds WCPay Subscriptions event/webhook handling code

### DIFF
--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -131,13 +131,13 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 					$this->process_webhook_payment_intent_succeeded( $body );
 					break;
 				case 'invoice.upcoming':
-					$this->handle_invoice_upcoming( $body );
+					WC_Payments_Subscriptions::get_event_handler()->handle_invoice_upcoming( $body );
 					break;
 				case 'invoice.paid':
-					$this->handle_invoice_paid( $body );
+					WC_Payments_Subscriptions::get_event_handler()->handle_invoice_paid( $body );
 					break;
 				case 'invoice.payment_failed':
-					$this->handle_invoice_payment_failed( $body );
+					WC_Payments_Subscriptions::get_event_handler()->handle_invoice_payment_failed( $body );
 					break;
 			}
 
@@ -298,41 +298,5 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 			);
 		}
 		return $array[ $key ];
-	}
-
-	/**
-	 * Adds fee, discount, and shipping related invoice items to Stripe subscription.
-	 *
-	 * @param array $event_body The event that triggered the webhook.
-	 *
-	 * @throws Rest_Request_Exception Required parameters not found.
-	 */
-	private function handle_invoice_upcoming( array $event_body ) {
-		// Stub.
-		Logger::debug( 'Invoice upcoming!' );
-	}
-
-	/**
-	 * Renews a subscription associated with paid invoice.
-	 *
-	 * @param array $event_body The event that triggered the webhook.
-	 *
-	 * @throws Rest_Request_Exception Required parameters not found.
-	 */
-	private function handle_invoice_paid( array $event_body ) {
-		// Stub.
-		Logger::debug( 'Invoice paid!' );
-	}
-
-	/**
-	 * Marks a subscription payment associated with invoice as failed.
-	 *
-	 * @param array $event_body The event that triggered the webhook.
-	 *
-	 * @throws Rest_Request_Exception Required parameters not found.
-	 */
-	private function handle_invoice_payment_failed( array $event_body ) {
-		// Stub.
-		Logger::debug( 'Invoice payment failed :(' );
 	}
 }

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -486,6 +486,9 @@ class WC_Payments_Subscription_Service {
 		$next_payment_date = gmdate( 'Y-m-d H:i:s', $wcpay_subscription['current_period_end'] );
 		$subscription->update_dates( [ 'next_payment' => $next_payment_date ] );
 
+		// Translators: %s Scheduled/upcoming payment date in Y-m-d H:i:s format.
+		$subscription->add_order_note( sprintf( __( 'Next automatic payment scheduled for %s. Subscription dates have been updated to match.', 'woocommerce-payments' ), get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $wcpay_subscription['current_period_end'] ), wc_date_format() . ' ' . wc_time_format() ) ) );
+
 		// Remove the 'subscription_date_changes' exception.
 		$this->clear_feature_support_exception( $subscription, 'subscription_date_changes' );
 	}

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -486,8 +486,11 @@ class WC_Payments_Subscription_Service {
 		$next_payment_date = gmdate( 'Y-m-d H:i:s', $wcpay_subscription['current_period_end'] );
 		$subscription->update_dates( [ 'next_payment' => $next_payment_date ] );
 
-		// Translators: %s Scheduled/upcoming payment date in Y-m-d H:i:s format.
-		$subscription->add_order_note( sprintf( __( 'Next automatic payment scheduled for %s. Subscription dates have been updated to match.', 'woocommerce-payments' ), get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $wcpay_subscription['current_period_end'] ), wc_date_format() . ' ' . wc_time_format() ) ) );
+		$next_payment_time_difference = absint( $wcpay_subscription['current_period_end'] - $subscription->get_time( 'next_payment' ) );
+
+		if ( $next_payment_time_difference > 0 && $next_payment_time_difference >= 12 * HOURS_IN_SECONDS ) {
+			$subscription->add_order_note( __( 'The subscription\'s next payment date has been updated to match WCPay server.', 'woocommerce-payments' ) );
+		}
 
 		// Remove the 'subscription_date_changes' exception.
 		$this->clear_feature_support_exception( $subscription, 'subscription_date_changes' );

--- a/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
@@ -13,6 +13,13 @@ use WCPay\Exceptions\Rest_Request_Exception;
 class WC_Payments_Subscriptions_Event_Handler {
 
 	/**
+	 * Maximum amount of payment retries to handle before cancelling the subscription.
+	 *
+	 * @var int
+	 */
+	const MAX_RETRIES = 4;
+
+	/**
 	 * Invoice Service.
 	 *
 	 * @var WC_Payments_Invoice_Service
@@ -155,7 +162,7 @@ class WC_Payments_Subscriptions_Event_Handler {
 		// Translators: %d Number of failed renewal attempts.
 		$subscription->add_order_note( sprintf( __( 'WCPay subscription renewal attempt %d failed.', 'woocommerce-payments' ), $attempts ) );
 
-		if ( 4 > $attempts ) {
+		if ( self::MAX_RETRIES > $attempts ) {
 			remove_action( 'woocommerce_subscription_status_on-hold', [ $this->subscription_service, 'suspend_subscription' ] );
 			$subscription->payment_failed();
 			add_action( 'woocommerce_subscription_status_on-hold', [ $this->subscription_service, 'suspend_subscription' ] );

--- a/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
@@ -96,7 +96,7 @@ class WC_Payments_Subscriptions_Event_Handler {
 		$subscription          = WC_Payments_Subscription_Service::get_subscription_from_wcpay_subscription_id( $wcpay_subscription_id );
 
 		if ( ! $subscription ) {
-			throw new Rest_Request_Exception( __( 'Cannot find subscription for the incoming "invoice.upcoming" event.', 'woocommerce-payments' ) );
+			throw new Rest_Request_Exception( __( 'Cannot find subscription for the incoming "invoice.paid" event.', 'woocommerce-payments' ) );
 		}
 
 		// This incoming invoice.paid event is linked to the subscription parent invoice and can be ignored.

--- a/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
@@ -73,6 +73,9 @@ class WC_Payments_Subscriptions_Event_Handler {
 				$this->subscription_service->suspend_subscription( $subscription );
 			}
 		} else {
+			// Translators: %s Scheduled/upcoming payment date in Y-m-d H:i:s format.
+			$subscription->add_order_note( sprintf( __( 'Next automatic payment scheduled for %s.', 'woocommerce-payments' ), get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $wcpay_subscription['current_period_end'] ), wc_date_format() . ' ' . wc_time_format() ) ) );
+
 			// Update the subscription in WC to match the WCPay Subscription's next payment date.
 			$this->subscription_service->update_dates_to_match_wcpay_subscription( $wcpay_subscription, $subscription );
 

--- a/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Class WC_Payments_Subscriptions_Event_Handler
+ *
+ * @package WooCommerce\Payments
+ */
+
+use WCPay\Exceptions\Rest_Request_Exception;
+
+/**
+ * Subscriptions Event/Webhook Handler class
+ */
+class WC_Payments_Subscriptions_Event_Handler {
+
+	/**
+	 * Invoice Service.
+	 *
+	 * @var WC_Payments_Invoice_Service
+	 */
+	private $invoice_service;
+
+	/**
+	 * Subscription Service.
+	 *
+	 * @var WC_Payments_Subscription_Service
+	 */
+	private $subscription_service;
+
+	/**
+	 * Subscriptions event handler constructor.
+	 *
+	 * @param WC_Payments_Invoice_Service      $invoice_service      Invoice service.
+	 * @param WC_Payments_Subscription_Service $subscription_service Subscription service.
+	 */
+	public function __construct( WC_Payments_Invoice_Service $invoice_service, WC_Payments_Subscription_Service $subscription_service ) {
+		$this->invoice_service      = $invoice_service;
+		$this->subscription_service = $subscription_service;
+	}
+
+	/**
+	 * Adds fee, discount, and shipping related invoice items to WCPay subscription.
+	 *
+	 * @param array $body The event body that triggered the webhook.
+	 *
+	 * @throws Rest_Request_Exception Required parameters not found.
+	 */
+	public function handle_invoice_upcoming( array $body ) {
+		$event_data            = $this->get_event_property( $body, 'data' );
+		$event_object          = $this->get_event_property( $event_data, 'object' );
+		$wcpay_subscription_id = $this->get_event_property( $event_object, 'subscription' );
+		$wcpay_customer_id     = $this->get_event_property( $event_object, 'customer' );
+		$subscription          = WC_Payments_Subscription_Service::get_subscription_from_wcpay_subscription_id( $wcpay_subscription_id );
+
+		if ( ! $subscription ) {
+			throw new Rest_Request_Exception( __( 'Cannot find subscription to handle the "invoice.upcoming" event.', 'woocommerce-payments' ) );
+		}
+
+		$wcpay_subscription = $this->subscription_service->get_wcpay_subscription( $subscription );
+
+		// Suspend or cancel subscription if we didn't expect a next payment.
+		if ( 0 === $subscription->get_time( 'next_payment' ) ) {
+			if ( ! $subscription->has_status( 'on-hold' ) && 0 !== $subscription->get_time( 'end' ) ) {
+				$this->subscription_service->cancel_subscription( $subscription );
+				$subscription->add_order_note( __( 'There was an upcoming payment event however the subscription is due to end in WooCommerce. The subscription has been cancelled.', 'woocommerce-payments' ) );
+			} else {
+				$this->subscription_service->suspend_subscription( $subscription );
+				$subscription->add_order_note( __( 'There was an upcoming payment event however the subscription is on-hold. The subscription has been suspended.', 'woocommerce-payments' ) );
+			}
+		} else {
+			// Update the subscription in WC to match the WCPay Subscription's next payment date.
+			$this->subscription_service->update_dates_to_match_wcpay_subscription( $wcpay_subscription, $subscription );
+			// Translators: %s Scheduled/upcoming payment date in Y-m-d H:i:s format.
+			$subscription->add_order_note( sprintf( __( "There's an upcoming invoice which will automatically attempt payment on %s. The subscription's next payment date has been updated to match.", 'woocommerce-payments' ), get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $wcpay_subscription['current_period_end'] ), wc_date_format() . ' ' . wc_time_format() ) ) );
+
+			$response = $this->invoice_service->create_invoice_items_for_subscription( $subscription, $wcpay_customer_id, $wcpay_subscription_id );
+
+			if ( is_wp_error( $response ) ) {
+				throw new Rest_Request_Exception( $response->get_error_message() );
+			}
+		}
+	}
+
+	/**
+	 * Renews a subscription associated with paid invoice.
+	 *
+	 * @param array $body The event body that triggered the webhook.
+	 *
+	 * @throws Rest_Request_Exception Required parameters not found.
+	 */
+	public function handle_invoice_paid( array $body ) {
+		$event_data            = $this->get_event_property( $body, 'data' );
+		$event_object          = $this->get_event_property( $event_data, 'object' );
+		$wcpay_subscription_id = $this->get_event_property( $event_object, 'subscription' );
+		$wcpay_invoice_id      = $this->get_event_property( $event_object, 'id' );
+		$subscription          = WC_Payments_Subscription_Service::get_subscription_from_wcpay_subscription_id( $wcpay_subscription_id );
+
+		if ( ! $subscription ) {
+			throw new Rest_Request_Exception( __( 'Cannot find subscription for the incoming "invoice.upcoming" event.', 'woocommerce-payments' ) );
+		}
+
+		// This incoming invoice.paid event is linked to the subscription parent invoice and can be ignored.
+		if ( WC_Payments_Invoice_Service::get_subscription_invoice_id( $subscription ) === $wcpay_invoice_id ) {
+			return;
+		}
+
+		$order_id = WC_Payments_Invoice_Service::get_order_id_by_invoice_id( $wcpay_invoice_id );
+		$order    = $order_id ? wc_get_order( $order_id ) : false;
+
+		if ( ! $order ) {
+			$subscription->update_status( 'on-hold', __( 'Processing WCPay subscription renewal', 'woocommerce-payments' ) );
+			$order = wcs_create_renewal_order( $subscription );
+
+			if ( is_wp_error( $order ) ) {
+				throw new Rest_Request_Exception( __( 'Unable to generate renewal order for subscription on the "invoice.paid" event.', 'woocommerce-payments' ) );
+			} else {
+				$this->invoice_service->set_order_invoice_id( $order, $wcpay_invoice_id );
+				$order->payment_complete();
+			}
+		}
+
+		// Remove pending invoice ID in case one was recorded for previous failed renewal attempts.
+		$this->invoice_service->mark_pending_invoice_paid_for_subscription( $subscription );
+	}
+
+	/**
+	 * Marks a subscription payment associated with invoice as failed.
+	 *
+	 * @param array $body The event body that triggered the webhook.
+	 *
+	 * @throws Rest_Request_Exception Required parameters not found.
+	 */
+	public function handle_invoice_payment_failed( array $body ) {
+		$event_data            = $this->get_event_property( $body, 'data' );
+		$event_object          = $this->get_event_property( $event_data, 'object' );
+		$wcpay_subscription_id = $this->get_event_property( $event_object, 'subscription' );
+		$wcpay_invoice_id      = $this->get_event_property( $event_object, 'id' );
+		$attempts              = (int) $this->get_event_property( $event_object, 'attempt_count' );
+		$subscription          = WC_Payments_Subscription_Service::get_subscription_from_wcpay_subscription_id( $wcpay_subscription_id );
+
+		if ( ! $subscription ) {
+			throw new Rest_Request_Exception( __( 'Cannot find subscription for the incoming "invoice.upcoming" event.', 'woocommerce-payments' ) );
+		}
+
+		$order_id = WC_Payments_Invoice_Service::get_order_id_by_invoice_id( $wcpay_invoice_id );
+		$order    = $order_id ? wc_get_order( $order_id ) : false;
+
+		if ( ! $order ) {
+			$order = wcs_create_renewal_order( $subscription );
+
+			if ( is_wp_error( $order ) ) {
+				throw new Rest_Request_Exception( __( 'Unable to generate renewal order for subscription to record the incoming "invoice.payment_failed" event.', 'woocommerce-payments' ) );
+			} else {
+				$this->invoice_service->set_order_invoice_id( $order, $wcpay_invoice_id );
+			}
+		}
+
+		// Translators: %d Number of failed renewal attempts.
+		$subscription->add_order_note( sprintf( __( 'WCPay subscription renewal attempt %d failed.', 'woocommerce-payments' ), $attempts ) );
+
+		if ( 4 > $attempts ) {
+			$subscription->payment_failed();
+		} else {
+			$subscription->payment_failed( 'cancelled' );
+		}
+
+		// Record invoice ID so we can trigger repayment on payment method update.
+		$this->invoice_service->mark_pending_invoice_for_subscription( $subscription, $wcpay_invoice_id );
+	}
+
+	/**
+	 * Gets the event data by property.
+	 *
+	 * @param array  $event_data Event data.
+	 * @param string $key        Requested key.
+	 *
+	 * @return string
+	 *
+	 * @throws Rest_Request_Exception Event data not found by key.
+	 */
+	private function get_event_property( array $event_data, string $key ) {
+		if ( ! isset( $event_data[ $key ] ) ) {
+			// Translators: %s Property name not found in event data array.
+			throw new Rest_Request_Exception( sprintf( __( '%s not found in array', 'woocommerce-payments' ), $key ) );
+		}
+
+		return $event_data[ $key ];
+	}
+}

--- a/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
@@ -70,8 +70,6 @@ class WC_Payments_Subscriptions_Event_Handler {
 		} else {
 			// Update the subscription in WC to match the WCPay Subscription's next payment date.
 			$this->subscription_service->update_dates_to_match_wcpay_subscription( $wcpay_subscription, $subscription );
-			// Translators: %s Scheduled/upcoming payment date in Y-m-d H:i:s format.
-			$subscription->add_order_note( sprintf( __( "There's an upcoming invoice which will automatically attempt payment on %s. The subscription's next payment date has been updated to match.", 'woocommerce-payments' ), get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $wcpay_subscription['current_period_end'] ), wc_date_format() . ' ' . wc_time_format() ) ) );
 
 			$response = $this->invoice_service->create_invoice_items_for_subscription( $subscription, $wcpay_customer_id, $wcpay_subscription_id );
 

--- a/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
@@ -69,10 +69,8 @@ class WC_Payments_Subscriptions_Event_Handler {
 			// TODO: Add error handling to these {cancel/suspend}_subscription calls i.e. add a subscription order note if the WCPay subscription wasn't cancelled.
 			if ( ! $subscription->has_status( 'on-hold' ) && 0 !== $subscription->get_time( 'end' ) ) {
 				$this->subscription_service->cancel_subscription( $subscription );
-				$subscription->add_order_note( __( 'There was an upcoming payment event however the subscription is due to end in WooCommerce. The subscription has been cancelled.', 'woocommerce-payments' ) );
 			} else {
 				$this->subscription_service->suspend_subscription( $subscription );
-				$subscription->add_order_note( __( 'There was an upcoming payment event however the subscription is on-hold. The subscription has been suspended.', 'woocommerce-payments' ) );
 			}
 		} else {
 			// Update the subscription in WC to match the WCPay Subscription's next payment date.
@@ -109,8 +107,7 @@ class WC_Payments_Subscriptions_Event_Handler {
 			return;
 		}
 
-		$order_id = WC_Payments_Invoice_Service::get_order_id_by_invoice_id( $wcpay_invoice_id );
-		$order    = $order_id ? wc_get_order( $order_id ) : false;
+		$order = wc_get_order( WC_Payments_Invoice_Service::get_order_id_by_invoice_id( $wcpay_invoice_id ) );
 
 		if ( ! $order ) {
 			$order = wcs_create_renewal_order( $subscription );
@@ -146,8 +143,7 @@ class WC_Payments_Subscriptions_Event_Handler {
 			throw new Rest_Request_Exception( __( 'Cannot find subscription for the incoming "invoice.upcoming" event.', 'woocommerce-payments' ) );
 		}
 
-		$order_id = WC_Payments_Invoice_Service::get_order_id_by_invoice_id( $wcpay_invoice_id );
-		$order    = $order_id ? wc_get_order( $order_id ) : false;
+		$order = wc_get_order( WC_Payments_Invoice_Service::get_order_id_by_invoice_id( $wcpay_invoice_id ) );
 
 		if ( ! $order ) {
 			$order = wcs_create_renewal_order( $subscription );

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -36,12 +36,20 @@ class WC_Payments_Subscriptions {
 	private static $subscription_service;
 
 	/**
+	 * Instance of WC_Payments_Subscriptions_Event_Handler, created in init function.
+	 *
+	 * @var WC_Payments_Subscriptions_Event_Handler
+	 */
+	private static $event_handler;
+
+	/**
 	 * Initialize WooCommerce Payments subscriptions. (Stripe Billing)
 	 *
 	 * @param WC_Payments_API_Client       $api_client       WCPay API client.
 	 * @param WC_Payments_Customer_Service $customer_service WCPay Customer Service.
 	 */
 	public static function init( WC_Payments_API_Client $api_client, WC_Payments_Customer_Service $customer_service ) {
+		// Load Services.
 		include_once __DIR__ . '/class-wc-payments-product-service.php';
 		include_once __DIR__ . '/class-wc-payments-invoice-service.php';
 		include_once __DIR__ . '/class-wc-payments-subscription-service.php';
@@ -49,6 +57,19 @@ class WC_Payments_Subscriptions {
 		self::$product_service      = new WC_Payments_Product_Service( $api_client );
 		self::$invoice_service      = new WC_Payments_Invoice_Service( $api_client, self::$product_service );
 		self::$subscription_service = new WC_Payments_Subscription_Service( $api_client, $customer_service, self::$product_service, self::$invoice_service );
+
+		// Load the subscription and invoice incoming event handler.
+		include_once __DIR__ . '/class-wc-payments-subscriptions-event-handler.php';
+		self::$event_handler = new WC_Payments_Subscriptions_Event_Handler( self::$invoice_service, self::$subscription_service );
+	}
+
+	/**
+	 * Get the Event Handler class instance.
+	 *
+	 * @return WC_Payments_Subscriptions_Event_Handler
+	 */
+	public static function get_event_handler() {
+		return self::$event_handler;
 	}
 
 	/**

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -172,4 +172,12 @@
       <code>wcs_get_subscription</code>
     </UndefinedFunction>
   </file>
+  <file src="includes/subscriptions/class-wc-payments-subscriptions-event-handler.php">
+    <UndefinedDocblockClass occurrences="9">
+      <code>WC_Subscription</code>
+    </UndefinedDocblockClass>
+    <UndefinedFunction occurrences="2">
+      <code>wcs_create_renewal_order( $subscription )</code>
+    </UndefinedFunction>
+  </file>
 </files>

--- a/tests/unit/helpers/class-wc-helper-subscription.php
+++ b/tests/unit/helpers/class-wc-helper-subscription.php
@@ -163,4 +163,8 @@ class WC_Subscription extends WC_Mock_WC_Data {
 	public function add_order_note( $note = '' ) {
 		// do nothing.
 	}
+
+	public function payment_failed( $new_status = 'on-hold' ) {
+		$this->set_status( $new_status );
+	}
 }

--- a/tests/unit/helpers/class-wc-helper-subscription.php
+++ b/tests/unit/helpers/class-wc-helper-subscription.php
@@ -65,6 +65,13 @@ class WC_Subscription extends WC_Mock_WC_Data {
 	public $next_payment;
 
 	/**
+	 * End timestamp
+	 *
+	 * @var int
+	 */
+	public $end;
+
+	/**
 	 * Taxes.
 	 *
 	 * @var array
@@ -151,5 +158,9 @@ class WC_Subscription extends WC_Mock_WC_Data {
 
 	public function get_taxes() {
 		return $this->taxes;
+	}
+
+	public function add_order_note( $note = '' ) {
+		// do nothing.
 	}
 }

--- a/tests/unit/helpers/class-wc-helper-subscriptions.php
+++ b/tests/unit/helpers/class-wc-helper-subscriptions.php
@@ -55,6 +55,13 @@ function wcs_cart_contains_resubscribe() {
 	return ( WC_Subscriptions::$wcs_cart_contains_resubscribe )();
 }
 
+function wcs_create_renewal_order( $subscription ) {
+	if ( ! WC_Subscriptions::$wcs_create_renewal_order ) {
+		return;
+	}
+	return ( WC_Subscriptions::$wcs_create_renewal_order )( $subscription );
+}
+
 /**
  * Class WC_Subscriptions.
  *
@@ -117,6 +124,13 @@ class WC_Subscriptions {
 	 */
 	public static $wcs_cart_contains_resubscribe = null;
 
+	/**
+	 * wcs_create_renewal_order mock.
+	 *
+	 * @var function
+	 */
+	public static $wcs_create_renewal_order = null;
+
 	public static function set_wcs_order_contains_subscription( $function ) {
 		self::$wcs_order_contains_subscription = $function;
 	}
@@ -143,5 +157,9 @@ class WC_Subscriptions {
 
 	public static function wcs_cart_contains_resubscribe( $function ) {
 		self::$wcs_cart_contains_resubscribe = $function;
+	}
+
+	public static function wcs_create_renewal_order( $function ) {
+		self::$wcs_create_renewal_order = $function;
 	}
 }

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions-event-handler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions-event-handler.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Class WC_Payments_Subscriptions_Event_Handler
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\Exceptions\Rest_Request_Exception;
+
+/**
+ * WC_Payments_Subscriptions_Event_Handler unit tests.
+ */
+class WC_Payments_Subscriptions_Event_Handler_Test extends WP_UnitTestCase {
+
+	/**
+	 * Subscription meta key used to store WCPay subscription's ID.
+	 *
+	 * @const string
+	 */
+	const SUBSCRIPTION_ID_META_KEY = '_wcpay_subscription_id';
+
+	/**
+	 * Order Invoice meta key used to store WCPay invoice ID.
+	 *
+	 * @const string
+	 */
+	const ORDER_INVOICE_ID_KEY = '_wcpay_billing_invoice_id';
+
+	/**
+	 * Mock WC_Payments_Invoice_Service.
+	 *
+	 * @var WC_Payments_Invoice_Service|MockObject
+	 */
+	private $mock_invoice_service;
+
+	/**
+	 * Mock WC_Payments_Subscription_Service
+	 *
+	 * @var WC_Payments_Subscription_Service
+	 */
+	private $mock_subscription_service;
+
+	/**
+	 * Mock WC_Payments_Subscriptions_Event_Handler.
+	 *
+	 * @var WC_Payments_Subscriptions_Event_Handler
+	 */
+	private $subscriptions_event_handler;
+
+	/**
+	 * Pre-test setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->mock_invoice_service      = $this->createMock( WC_Payments_Invoice_Service::class );
+		$this->mock_subscription_service = $this->createMock( WC_Payments_Subscription_Service::class );
+
+		$this->subscriptions_event_handler = new WC_Payments_Subscriptions_Event_Handler( $this->mock_invoice_service, $this->mock_subscription_service );
+
+		WC_Subscriptions::set_wcs_get_subscription(
+			function ( $id ) {
+				return false;
+			}
+		);
+	}
+
+	/**
+	 * Test exception thrown during get_event_property.
+	 */
+	public function test_get_event_property_exception() {
+		$this->expectException( Rest_Request_Exception::class );
+		$this->expectExceptionMessage( 'garbage not found in array' );
+
+		PHPUnit_Utils::call_method(
+			$this->subscriptions_event_handler,
+			'get_event_property',
+			[ [ 'non_empty_key' => 'non_empty_value' ], 'garbage' ]
+		);
+	}
+
+	/**
+	 * Test exception thrown during handle_invoice_upcoming.
+	 */
+	public function test_handle_invoice_upcoming_exception() {
+		$test_body = [
+			'data' => [
+				'object' => [
+					'subscription' => 'sub_ID_not_exists',
+					'customer'     => 'cus_test1234',
+				],
+			],
+		];
+
+		$this->expectException( Rest_Request_Exception::class );
+		$this->expectExceptionMessage( 'Cannot find subscription to handle the "invoice.upcoming" event.' );
+
+		$this->subscriptions_event_handler->handle_invoice_upcoming( $test_body );
+	}
+
+	/**
+	 * Test handle_invoice_upcoming when subscription is active.
+	 */
+	public function test_handle_invoice_upcoming_active() {
+		$wcpay_subscription_id = 'sub_invoiceUpcoming';
+		$wcpay_customer_id     = 'cus_test1234';
+		$test_body             = [
+			'data' => [
+				'object' => [
+					'subscription' => $wcpay_subscription_id,
+					'customer'     => $wcpay_customer_id,
+				],
+			],
+		];
+
+		$mock_subscription = new WC_Subscription();
+		$mock_subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $wcpay_subscription_id );
+		$mock_subscription->next_payment = time();
+
+		$mock_wcpay_subscription = [
+			'subscription'       => $wcpay_subscription_id,
+			'current_period_end' => time() + 10000,
+		];
+
+		WC_Subscriptions::set_wcs_get_subscription(
+			function ( $id ) use ( $mock_subscription ) {
+				return $mock_subscription;
+			}
+		);
+
+		$this->mock_subscription_service->expects( $this->once() )
+			->method( 'get_wcpay_subscription' )
+			->with( $mock_subscription )
+			->willReturn( $mock_wcpay_subscription );
+
+		$this->mock_subscription_service->expects( $this->once() )
+			->method( 'update_dates_to_match_wcpay_subscription' )
+			->with( $mock_wcpay_subscription, $mock_subscription )
+			->willReturn( null );
+
+		$this->mock_invoice_service->expects( $this->once() )
+			->method( 'create_invoice_items_for_subscription' )
+			->with( $mock_subscription, $wcpay_customer_id, $wcpay_subscription_id )
+			->willReturn( [ 'response' ] );
+
+		$this->subscriptions_event_handler->handle_invoice_upcoming( $test_body );
+	}
+
+	/**
+	 * Test handle_invoice_upcoming when subscription is suspended.
+	 */
+	public function test_handle_invoice_upcoming_suspended() {
+		$wcpay_subscription_id = 'sub_invoiceUpcomingSuspended';
+		$wcpay_customer_id     = 'cus_test4321';
+		$test_body             = [
+			'data' => [
+				'object' => [
+					'subscription' => $wcpay_subscription_id,
+					'customer'     => $wcpay_customer_id,
+				],
+			],
+		];
+
+		$mock_order        = WC_Helper_Order::create_order();
+		$mock_subscription = new WC_Subscription();
+		$mock_subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $wcpay_subscription_id );
+		$mock_subscription->next_payment = 0;
+		$mock_subscription->end          = 0;
+		$mock_subscription->set_parent( $mock_order );
+
+		$mock_wcpay_subscription = [
+			'subscription'       => $wcpay_subscription_id,
+			'current_period_end' => time() + 10000,
+		];
+
+		WC_Subscriptions::set_wcs_get_subscription(
+			function ( $id ) use ( $mock_subscription ) {
+				return $mock_subscription;
+			}
+		);
+
+		$this->mock_subscription_service->expects( $this->once() )
+			->method( 'suspend_subscription' )
+			->with( $mock_subscription )
+			->willReturn( null );
+
+		$this->subscriptions_event_handler->handle_invoice_upcoming( $test_body );
+	}
+
+	/**
+	 * Test handle_invoice_paid when the incoming webhook belongs to a subscription that doesn't exist.
+	 */
+	public function test_handle_invoice_paid_exception() {
+		$test_body = [
+			'data' => [
+				'object' => [
+					'subscription' => 'sub_ID_no_invoice_paid',
+					'customer'     => 'cus_test1234',
+					'id'           => 'ii_testInvoiceID',
+				],
+			],
+		];
+
+		$this->expectException( Rest_Request_Exception::class );
+		$this->expectExceptionMessage( 'Cannot find subscription for the incoming "invoice.paid" event.' );
+
+		$this->subscriptions_event_handler->handle_invoice_paid( $test_body );
+	}
+
+	/**
+	 * Test handle_invoice_paid
+	 */
+	public function test_handle_invoice_paid_parent_order() {
+		$wcpay_subscription_id = 'sub_invoiceUpcoming';
+		$wcpay_customer_id     = 'cus_test1234';
+		$wcpay_invoiceid       = 'ii_testInvoiceID';
+		$test_body             = [
+			'data' => [
+				'object' => [
+					'subscription' => $wcpay_subscription_id,
+					'customer'     => $wcpay_customer_id,
+					'id'           => $wcpay_invoiceid,
+				],
+			],
+		];
+
+		$mock_subscription = new WC_Subscription();
+		$mock_subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $wcpay_subscription_id );
+		$mock_subscription->next_payment = time();
+
+		$this->expectException( Rest_Request_Exception::class );
+		$this->expectExceptionMessage( 'Cannot find subscription for the incoming "invoice.paid" event.' );
+
+		$this->subscriptions_event_handler->handle_invoice_paid( $test_body );
+	}
+
+	/**
+	 * Test handle_invoice_paid
+	 */
+	public function test_handle_invoice_paid() {
+		$wcpay_subscription_id = 'sub_invoiceUpcoming';
+		$wcpay_customer_id     = 'cus_test1234';
+		$wcpay_invoiceid       = 'ii_testInvoiceID';
+		$test_body             = [
+			'data' => [
+				'object' => [
+					'subscription' => $wcpay_subscription_id,
+					'customer'     => $wcpay_customer_id,
+					'id'           => $wcpay_invoiceid,
+				],
+			],
+		];
+
+		$mock_renewal_order = WC_Helper_Order::create_order();
+		$mock_subscription  = new WC_Subscription();
+
+		WC_Subscriptions::set_wcs_get_subscription(
+			function ( $id ) use ( $mock_subscription ) {
+				return $mock_subscription;
+			}
+		);
+
+		WC_Subscriptions::wcs_create_renewal_order(
+			function ( $subscription ) use ( $mock_renewal_order ) {
+				return $mock_renewal_order;
+			}
+		);
+
+		$this->mock_invoice_service->expects( $this->once() )
+			->method( 'set_order_invoice_id' )
+			->with( $mock_renewal_order, $wcpay_invoiceid )
+			->willReturn( null );
+
+		$this->mock_invoice_service->expects( $this->once() )
+			->method( 'mark_pending_invoice_paid_for_subscription' )
+			->with( $mock_subscription )
+			->willReturn( null );
+
+		$this->subscriptions_event_handler->handle_invoice_paid( $test_body );
+	}
+}

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions.php
@@ -30,4 +30,11 @@ class WC_Payments_Subscriptions_Test extends WP_UnitTestCase {
 	public function test_get_subscription_service() {
 		$this->assertInstanceOf( 'WC_Payments_Subscription_Service', WC_Payments_Subscriptions::get_subscription_service() );
 	}
+
+	/**
+	 * Tests WC_Payments_Subscriptions::get_subscription_service().
+	 */
+	public function test_get_event_handler() {
+		$this->assertInstanceOf( 'WC_Payments_Subscriptions_Event_Handler', WC_Payments_Subscriptions::get_event_handler() );
+	}
 }


### PR DESCRIPTION
Internal p2: pb0GrA-1g9-p2

---

#### Changes proposed in this Pull Request

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR adds WCPay Subscriptions event handling for the following webhooks sent from Stripe:
 - `invoice.upcoming` - This webhook is sent up to 7 days before the scheduled renewal will happen on Stripe's end. At this point in time, we want to:
   - confirm whether the WC Subscription expects an upcoming payment (i.e. make sure it's not suspended/cancelled in Woo)
   - update the invoice line items in Stripe to make sure it matches the latest Subscription data
 - `invoice.paid` - Stripe sends this webhook immediately when a recurring payment is taken. When we receive this webhook, we need to:
   - create a renewal order and mark the order's payment as completed
   - make sure the WC subscription doesn't have any record of a pending invoice associated with it
 - `invoice.payment_failed` - This webhook is sent when Stripe fails to make the renewal payment (usually due to the card being declined). Stripe has their own retry handling, however, on Woo's side, when we receive this webhook we:
   - Create a renewal order and mark the subscription as failed payment
   - Set a flag on the subscription to say that the latest invoice failed. This flag allows customers to update their payment method attached to the subscription and immediately retry the payment.

In the PR, I removed the stubbed methods that were added in https://github.com/Automattic/woocommerce-payments/pull/2738 and moved them into their own Subscriptions event handling class. This might be more of a personal preference thing, but I kinda like having all WCPay Subscriptions code within `woocommerce-payments/includes/subscriptions`. Let me know if this is okay with everyone else 😄 


#### Testing instructions

Before testing this PR, you'll need:
* The latest changes on WCPay server (https://git.io/JEsEF)
* The stripe billing clocks testing/dev tool changes (https://git.io/JEXwn)
* Setup your local env to listen and redirect webhooks to your dev store

---

1. Create a new subscription to test event handling (add a subscription product to the cart and complete the payment)
2. Visit the Edit Subscription page and in the list of actions click "Set up custom billing clock" (https://d.pr/i/xi1xO4)
3. Once you have set up a billing clock for this subscription, use the subscriptions actions dropdown to step through the Stripe subscription's billing cycle. First choose "Trigger upcoming invoice"
4. You shouldn't see any changes to the WC Subscriptions (this event is when we update the invoice on Stripe)
5. Run the "Trigger invoice created" action. We don't have any handling on this event
6. After this, run the "Process latest order" action to trigger the "invoice.paid" event to be sent
7. Confirm a new renewal order is created in Woo and the subscription remains active
8. Go through this process once again and instead of choosing "Process latest order", click "Fail latest order" to trigger a failed renewal.
9. Confirm there's a new failed renewal order and subscription is on-hold
