### PR TITLE
Fix multi currency analytics leaderboard wrong currency

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 3.0.0 - 2021-xx-xx =
 * Add - Download deposits report in CSV.
+* Fix - Use store currency on analytics leaderboard when Multi-Currency is enabled.
 
 = 2.9.0 - 2021-08-25 =
 * Add - Split discount line in timeline into variable fee and fixed fee.

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -46,7 +46,10 @@ class FrontendCurrencies {
 		$this->multi_currency       = $multi_currency;
 		$this->localization_service = $localization_service;
 
-		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
+		// We should avoid affecting admin API requests.
+		$is_admin_request = 0 === stripos( wp_get_referer(), admin_url() );
+
+		if ( ! is_admin() && ! defined( 'DOING_CRON' ) && ! $is_admin_request ) {
 			// Currency hooks.
 			add_filter( 'woocommerce_currency', [ $this, 'get_woocommerce_currency' ], 50 );
 			add_filter( 'wc_get_price_decimals', [ $this, 'get_price_decimals' ], 50 );

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -46,10 +46,7 @@ class FrontendCurrencies {
 		$this->multi_currency       = $multi_currency;
 		$this->localization_service = $localization_service;
 
-		// We should avoid affecting admin API requests.
-		$is_admin_request = 0 === stripos( wp_get_referer(), admin_url() );
-
-		if ( ! is_admin() && ! defined( 'DOING_CRON' ) && ! $is_admin_request ) {
+		if ( ! is_admin() && ! defined( 'DOING_CRON' ) && ! Utils::is_admin_request() ) {
 			// Currency hooks.
 			add_filter( 'woocommerce_currency', [ $this, 'get_woocommerce_currency' ], 50 );
 			add_filter( 'wc_get_price_decimals', [ $this, 'get_price_decimals' ], 50 );

--- a/includes/multi-currency/FrontendPrices.php
+++ b/includes/multi-currency/FrontendPrices.php
@@ -39,10 +39,7 @@ class FrontendPrices {
 		$this->multi_currency = $multi_currency;
 		$this->compatibility  = $compatibility;
 
-		// We should avoid affecting admin API requests.
-		$is_admin_request = 0 === stripos( wp_get_referer(), admin_url() );
-
-		if ( ! is_admin() && ! defined( 'DOING_CRON' ) && ! $is_admin_request ) {
+		if ( ! is_admin() && ! defined( 'DOING_CRON' ) && ! Utils::is_admin_request() ) {
 			// Simple product price hooks.
 			add_filter( 'woocommerce_product_get_price', [ $this, 'get_product_price' ], 50, 2 );
 			add_filter( 'woocommerce_product_get_regular_price', [ $this, 'get_product_price' ], 50, 2 );

--- a/includes/multi-currency/FrontendPrices.php
+++ b/includes/multi-currency/FrontendPrices.php
@@ -39,7 +39,10 @@ class FrontendPrices {
 		$this->multi_currency = $multi_currency;
 		$this->compatibility  = $compatibility;
 
-		if ( ! is_admin() && ! defined( 'DOING_CRON' ) ) {
+		// We should avoid affecting admin API requests.
+		$is_admin_request = 0 === stripos( wp_get_referer(), admin_url() );
+
+		if ( ! is_admin() && ! defined( 'DOING_CRON' ) && ! $is_admin_request ) {
 			// Simple product price hooks.
 			add_filter( 'woocommerce_product_get_price', [ $this, 'get_product_price' ], 50, 2 );
 			add_filter( 'woocommerce_product_get_regular_price', [ $this, 'get_product_price' ], 50, 2 );

--- a/includes/multi-currency/Utils.php
+++ b/includes/multi-currency/Utils.php
@@ -29,4 +29,13 @@ class Utils {
 		}
 		return false;
 	}
+
+	/**
+	 * Checks if HTTP referer matches admin url.
+	 *
+	 * @return boolean
+	 */
+	public static function is_admin_request(): bool {
+		return 0 === stripos( wp_get_referer(), admin_url() );
+	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 3.0.0 - 2021-xx-xx =
 * Add - Download deposits report in CSV.
+* Fix - Use store currency on analytics leaderboard when Multi-Currency is enabled.
 
 = 2.9.0 - 2021-08-25 =
 * Add - Split discount line in timeline into variable fee and fixed fee.

--- a/tests/unit/multi-currency/test-class-utils.php
+++ b/tests/unit/multi-currency/test-class-utils.php
@@ -32,4 +32,14 @@ class WCPay_Multi_Currency_Utils_Tests extends WP_UnitTestCase {
 	public function test_is_call_in_backtrace_return_true() {
 		$this->assertTrue( $this->utils->is_call_in_backtrace( [ 'WCPay_Multi_Currency_Utils_Tests->test_is_call_in_backtrace_return_true' ] ) );
 	}
+
+	public function test_is_admin_request_returns_false() {
+		$_SERVER['HTTP_REFERER'] = 'http://example.org/';
+		$this->assertFalse( $this->utils->is_admin_request() );
+	}
+
+	public function test_is_admin_request_returns_true() {
+		$_SERVER['HTTP_REFERER'] = 'http://example.org/wp-admin/';
+		$this->assertTrue( $this->utils->is_admin_request() );
+	}
 }


### PR DESCRIPTION
Fixes #2582 

#### Changes proposed in this Pull Request
Prevent `FrontendCurrencies` to filter `woocommerce_currency` on API requests made from admin.

This issue is not related with https://github.com/woocommerce/woocommerce-admin/issues/5154. That happens when you want to see the analytics in another currency. But #2582 is a bug caused by us filtering `woocommerce_currency` on API requests, that results in the leaderboard showing the currency selected on the fronted. Because woocommerce-admin uses `wc_price` to format the amounts.

#### Testing instructions
- Leaderboards on **Analytics > Overview** should use store currency.
- Choose another currency on the frontend and check that the leaderboard keep using the store currency rather than the selected one.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
