### PR TITLE
Add checks for get_*_currencies methods in Multi-Currency

### DIFF
--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -497,12 +497,12 @@ class MultiCurrency {
 	}
 
 	/**
-	 * Gets the currencies available.
+	 * Gets the currencies available. Initializes it if needed.
 	 *
 	 * @return Currency[] Array of Currency objects.
 	 */
 	public function get_available_currencies(): array {
-		if ( $this->available_currencies ) {
+		if ( null !== $this->available_currencies ) {
 			return $this->available_currencies;
 		}
 		$this->init();
@@ -510,12 +510,12 @@ class MultiCurrency {
 	}
 
 	/**
-	 * Gets the store base currency.
+	 * Gets the store base currency. Initializes it if needed.
 	 *
 	 * @return Currency The store base currency.
 	 */
 	public function get_default_currency(): Currency {
-		if ( $this->default_currency ) {
+		if ( null !== $this->default_currency ) {
 			return $this->default_currency;
 		}
 		$this->init();
@@ -523,12 +523,12 @@ class MultiCurrency {
 	}
 
 	/**
-	 * Gets the currently enabled currencies.
+	 * Gets the currently enabled currencies. Initializes it if needed.
 	 *
 	 * @return Currency[] Array of Currency objects.
 	 */
 	public function get_enabled_currencies(): array {
-		if ( $this->enabled_currencies ) {
+		if ( null !== $this->enabled_currencies ) {
 			return $this->enabled_currencies;
 		}
 		$this->init();

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -122,7 +122,7 @@ class MultiCurrency {
 	 *
 	 * @var bool
 	 */
-	protected $available_currencies_initialized = false;
+	protected $are_available_currencies_initialized = false;
 
 	/**
 	 * The default currency.
@@ -136,7 +136,7 @@ class MultiCurrency {
 	 *
 	 * @var bool
 	 */
-	protected $default_currency_initialized = false;
+	protected $is_default_currency_initialized = false;
 
 	/**
 	 * The enabled currencies.
@@ -150,7 +150,7 @@ class MultiCurrency {
 	 *
 	 * @var bool
 	 */
-	protected $enabled_currencies_initialized = false;
+	protected $are_enabled_currencies_initialized = false;
 
 	/**
 	 * Client for making requests to the WooCommerce Payments API
@@ -427,38 +427,14 @@ class MultiCurrency {
 	}
 
 	/**
-	 * Return if available currencies are initialized.
-	 *
-	 * @return bool
-	 */
-	private function is_available_currencies_initialized(): bool {
-		return $this->available_currencies_initialized;
-	}
-
-	/**
-	 * Return whether the default currency is initialized.
-	 *
-	 * @return bool
-	 */
-	private function is_default_currency_initialized(): bool {
-		return $this->default_currency_initialized;
-	}
-
-	/**
-	 * Return if enabled currencies are initialized.
-	 *
-	 * @return bool
-	 */
-	private function is_enabled_currencies_initialized(): bool {
-		return $this->enabled_currencies_initialized;
-	}
-
-	/**
 	 * Sets up the available currencies, which are alphabetical by name.
 	 *
 	 * @return void
 	 */
 	private function initialize_available_currencies() {
+		if ( ! $this->are_available_currencies_initialized ) {
+			return;
+		}
 		// Add default store currency with a rate of 1.0.
 		$woocommerce_currency                                = get_woocommerce_currency();
 		$this->available_currencies[ $woocommerce_currency ] = new Currency( $woocommerce_currency, 1.0 );
@@ -483,7 +459,7 @@ class MultiCurrency {
 			$this->available_currencies[ $currency->get_code() ] = $currency;
 		}
 
-		$this->available_currencies_initialized = true;
+		$this->are_available_currencies_initialized = true;
 	}
 
 	/**
@@ -492,6 +468,10 @@ class MultiCurrency {
 	 * @return void
 	 */
 	private function initialize_enabled_currencies() {
+		if ( ! $this->are_enabled_currencies_initialized ) {
+			return;
+		}
+
 		$available_currencies     = $this->get_available_currencies();
 		$enabled_currency_codes   = get_option( $this->id . '_enabled_currencies', [] );
 		$enabled_currency_codes   = is_array( $enabled_currency_codes ) ? $enabled_currency_codes : [];
@@ -532,7 +512,7 @@ class MultiCurrency {
 		unset( $this->enabled_currencies[ $default_code ] );
 		$this->enabled_currencies = array_merge( $default, $this->enabled_currencies );
 
-		$this->enabled_currencies_initialized = true;
+		$this->are_enabled_currencies_initialized = true;
 	}
 
 	/**
@@ -541,10 +521,13 @@ class MultiCurrency {
 	 * @return void
 	 */
 	private function set_default_currency() {
+		if ( ! $this->is_default_currency_initialized ) {
+			return;
+		}
 		$available_currencies   = $this->get_available_currencies();
 		$this->default_currency = $available_currencies[ get_woocommerce_currency() ] ?? null;
 
-		$this->default_currency_initialized = true;
+		$this->is_default_currency_initialized = true;
 	}
 
 	/**
@@ -553,7 +536,7 @@ class MultiCurrency {
 	 * @return Currency[] Array of Currency objects.
 	 */
 	public function get_available_currencies(): array {
-		if ( ! $this->is_available_currencies_initialized() ) {
+		if ( ! $this->are_available_currencies_initialized ) {
 			$this->initialize_available_currencies();
 		}
 		return $this->available_currencies;
@@ -565,7 +548,7 @@ class MultiCurrency {
 	 * @return Currency The store base currency.
 	 */
 	public function get_default_currency(): Currency {
-		if ( ! $this->is_default_currency_initialized() ) {
+		if ( ! $this->is_default_currency_initialized ) {
 			$this->set_default_currency();
 		}
 		return $this->default_currency;
@@ -577,7 +560,7 @@ class MultiCurrency {
 	 * @return Currency[] Array of Currency objects.
 	 */
 	public function get_enabled_currencies(): array {
-		if ( ! $this->is_enabled_currencies_initialized() ) {
+		if ( ! $this->are_enabled_currencies_initialized ) {
 			$this->initialize_enabled_currencies();
 		}
 		return $this->enabled_currencies;

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -489,7 +489,8 @@ class MultiCurrency {
 	 * @return void
 	 */
 	private function set_default_currency() {
-		$this->default_currency = $this->available_currencies[ get_woocommerce_currency() ] ?? null;
+		$available_currencies   = $this->get_available_currencies();
+		$this->default_currency = $available_currencies[ get_woocommerce_currency() ] ?? null;
 	}
 
 	/**
@@ -498,6 +499,9 @@ class MultiCurrency {
 	 * @return Currency[] Array of Currency objects.
 	 */
 	public function get_available_currencies(): array {
+		if ( ! self::is_initialized() ) {
+			$this->initialize_available_currencies();
+		}
 		return $this->available_currencies;
 	}
 
@@ -507,6 +511,9 @@ class MultiCurrency {
 	 * @return Currency The store base currency.
 	 */
 	public function get_default_currency(): Currency {
+		if ( ! self::is_initialized() ) {
+			$this->set_default_currency();
+		}
 		return $this->default_currency;
 	}
 
@@ -516,6 +523,9 @@ class MultiCurrency {
 	 * @return Currency[] Array of Currency objects.
 	 */
 	public function get_enabled_currencies(): array {
+		if ( ! self::is_initialized() ) {
+			$this->initialize_enabled_currencies();
+		}
 		return $this->enabled_currencies;
 	}
 

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -489,8 +489,7 @@ class MultiCurrency {
 	 * @return void
 	 */
 	private function set_default_currency() {
-		$available_currencies   = $this->get_available_currencies();
-		$this->default_currency = $available_currencies[ get_woocommerce_currency() ] ?? null;
+		$this->default_currency = $this->get_available_currencies()[ get_woocommerce_currency() ] ?? null;
 	}
 
 	/**
@@ -500,7 +499,7 @@ class MultiCurrency {
 	 */
 	public function get_available_currencies(): array {
 		if ( ! self::is_initialized() ) {
-			$this->initialize_available_currencies();
+			$this->init();
 		}
 		return $this->available_currencies;
 	}
@@ -512,7 +511,7 @@ class MultiCurrency {
 	 */
 	public function get_default_currency(): Currency {
 		if ( ! self::is_initialized() ) {
-			$this->set_default_currency();
+			$this->init();
 		}
 		return $this->default_currency;
 	}
@@ -524,7 +523,7 @@ class MultiCurrency {
 	 */
 	public function get_enabled_currencies(): array {
 		if ( ! self::is_initialized() ) {
-			$this->initialize_enabled_currencies();
+			$this->init();
 		}
 		return $this->enabled_currencies;
 	}

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -505,7 +505,7 @@ class MultiCurrency {
 		if ( $this->available_currencies ) {
 			return $this->available_currencies;
 		}
-		$this->initialize_available_currencies();
+		$this->init();
 		return $this->available_currencies;
 	}
 
@@ -518,7 +518,7 @@ class MultiCurrency {
 		if ( $this->default_currency ) {
 			return $this->default_currency;
 		}
-		$this->set_default_currency();
+		$this->init();
 		return $this->default_currency;
 	}
 
@@ -531,7 +531,7 @@ class MultiCurrency {
 		if ( $this->enabled_currencies ) {
 			return $this->enabled_currencies;
 		}
-		$this->initialize_enabled_currencies();
+		$this->init();
 		return $this->enabled_currencies;
 	}
 

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -432,9 +432,6 @@ class MultiCurrency {
 	 * @return void
 	 */
 	private function initialize_available_currencies() {
-		if ( ! $this->are_available_currencies_initialized ) {
-			return;
-		}
 		// Add default store currency with a rate of 1.0.
 		$woocommerce_currency                                = get_woocommerce_currency();
 		$this->available_currencies[ $woocommerce_currency ] = new Currency( $woocommerce_currency, 1.0 );
@@ -468,10 +465,6 @@ class MultiCurrency {
 	 * @return void
 	 */
 	private function initialize_enabled_currencies() {
-		if ( ! $this->are_enabled_currencies_initialized ) {
-			return;
-		}
-
 		$available_currencies     = $this->get_available_currencies();
 		$enabled_currency_codes   = get_option( $this->id . '_enabled_currencies', [] );
 		$enabled_currency_codes   = is_array( $enabled_currency_codes ) ? $enabled_currency_codes : [];
@@ -521,9 +514,6 @@ class MultiCurrency {
 	 * @return void
 	 */
 	private function set_default_currency() {
-		if ( ! $this->is_default_currency_initialized ) {
-			return;
-		}
 		$available_currencies   = $this->get_available_currencies();
 		$this->default_currency = $available_currencies[ get_woocommerce_currency() ] ?? null;
 

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -118,6 +118,13 @@ class MultiCurrency {
 	protected $available_currencies = [];
 
 	/**
+	 * Flag whether the available currencies initialized.
+	 *
+	 * @var bool
+	 */
+	protected $available_currencies_initialized = false;
+
+	/**
 	 * The default currency.
 	 *
 	 * @var Currency
@@ -125,11 +132,25 @@ class MultiCurrency {
 	protected $default_currency;
 
 	/**
+	 * Flag whether the default currency is initialized.
+	 *
+	 * @var bool
+	 */
+	protected $default_currency_initialized = false;
+
+	/**
 	 * The enabled currencies.
 	 *
 	 * @var array
 	 */
 	protected $enabled_currencies = [];
+
+	/**
+	 * Flag whether the enabled currencies initialized.
+	 *
+	 * @var bool
+	 */
+	protected $enabled_currencies_initialized = false;
 
 	/**
 	 * Client for making requests to the WooCommerce Payments API
@@ -406,6 +427,33 @@ class MultiCurrency {
 	}
 
 	/**
+	 * Return if available currencies are initialized.
+	 *
+	 * @return bool
+	 */
+	private function is_available_currencies_initialized(): bool {
+		return $this->available_currencies_initialized;
+	}
+
+	/**
+	 * Return whether the default currency is initialized.
+	 *
+	 * @return bool
+	 */
+	private function is_default_currency_initialized(): bool {
+		return $this->default_currency_initialized;
+	}
+
+	/**
+	 * Return if enabled currencies are initialized.
+	 *
+	 * @return bool
+	 */
+	private function is_enabled_currencies_initialized(): bool {
+		return $this->enabled_currencies_initialized;
+	}
+
+	/**
 	 * Sets up the available currencies, which are alphabetical by name.
 	 *
 	 * @return void
@@ -434,6 +482,8 @@ class MultiCurrency {
 		foreach ( $available_currencies as $currency ) {
 			$this->available_currencies[ $currency->get_code() ] = $currency;
 		}
+
+		$this->available_currencies_initialized = true;
 	}
 
 	/**
@@ -481,6 +531,8 @@ class MultiCurrency {
 		$default[ $default_code ] = $this->enabled_currencies[ $default_code ];
 		unset( $this->enabled_currencies[ $default_code ] );
 		$this->enabled_currencies = array_merge( $default, $this->enabled_currencies );
+
+		$this->enabled_currencies_initialized = true;
 	}
 
 	/**
@@ -489,7 +541,10 @@ class MultiCurrency {
 	 * @return void
 	 */
 	private function set_default_currency() {
-		$this->default_currency = $this->available_currencies[ get_woocommerce_currency() ] ?? null;
+		$available_currencies   = $this->get_available_currencies();
+		$this->default_currency = $available_currencies[ get_woocommerce_currency() ] ?? null;
+
+		$this->default_currency_initialized = true;
 	}
 
 	/**
@@ -498,8 +553,8 @@ class MultiCurrency {
 	 * @return Currency[] Array of Currency objects.
 	 */
 	public function get_available_currencies(): array {
-		if ( ! self::is_initialized() ) {
-			$this->init();
+		if ( ! $this->is_available_currencies_initialized() ) {
+			$this->initialize_available_currencies();
 		}
 		return $this->available_currencies;
 	}
@@ -510,8 +565,8 @@ class MultiCurrency {
 	 * @return Currency The store base currency.
 	 */
 	public function get_default_currency(): Currency {
-		if ( ! self::is_initialized() ) {
-			$this->init();
+		if ( ! $this->is_default_currency_initialized() ) {
+			$this->set_default_currency();
 		}
 		return $this->default_currency;
 	}
@@ -522,8 +577,8 @@ class MultiCurrency {
 	 * @return Currency[] Array of Currency objects.
 	 */
 	public function get_enabled_currencies(): array {
-		if ( ! self::is_initialized() ) {
-			$this->init();
+		if ( ! $this->is_enabled_currencies_initialized() ) {
+			$this->initialize_enabled_currencies();
 		}
 		return $this->enabled_currencies;
 	}

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -489,7 +489,7 @@ class MultiCurrency {
 	 * @return void
 	 */
 	private function set_default_currency() {
-		$this->default_currency = $this->get_available_currencies()[ get_woocommerce_currency() ] ?? null;
+		$this->default_currency = $this->available_currencies[ get_woocommerce_currency() ] ?? null;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2724 

#### Changes proposed in this Pull Request

Added flags for lazy initialization for such methods:
- `get_available_currencies`
- `get_default_currency`
- `get_enabled_currencies`

I also tried just call `$this->init()` inside every method it if the `$is_initialized` flag is `false`, but that not worked. It goes to recursion since the flag becomes `true` only at the end of `init` method.

Did not add tests since the changes are pretty simple. I did not write setter methods on purpose to keep it simple.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Observe there are no errors on any page of the site that is related to multi-currency: like WooCommerce > Settings > Multi-Currency in admin, Merchant's shop/cart/checkout etc

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
