### PR TITLE
Add Terminal Locations REST API

### DIFF
--- a/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
+++ b/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
@@ -7,6 +7,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use WCPay\Exceptions\API_Exception;
 /**
  * REST controller for account details and status.
  */
@@ -44,39 +45,43 @@ class WC_REST_Payments_Terminal_Locations_Controller extends WC_Payments_REST_Co
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_store_location( $request ) {
-		$name    = get_bloginfo();
-		$address = [
-			'city'        => WC()->countries->get_base_city(),
-			'country'     => WC()->countries->get_base_country(),
-			'line1'       => WC()->countries->get_base_address(),
-			'line2'       => WC()->countries->get_base_address_2(),
-			'postal_code' => WC()->countries->get_base_postcode(),
-			'state'       => WC()->countries->get_base_state(),
-		];
+		try {
+			$name    = get_bloginfo();
+			$address = [
+				'city'        => WC()->countries->get_base_city(),
+				'country'     => WC()->countries->get_base_country(),
+				'line1'       => WC()->countries->get_base_address(),
+				'line2'       => WC()->countries->get_base_address_2(),
+				'postal_code' => WC()->countries->get_base_postcode(),
+				'state'       => WC()->countries->get_base_state(),
+			];
 
-		// Load the cached locations or retrieve them from the API.
-		$locations = get_transient( static::STORE_LOCATIONS_TRANSIENT_KEY );
-		if ( ! $locations ) {
-			$locations = $this->api_client->get_terminal_locations();
-			set_transient( static::STORE_LOCATIONS_TRANSIENT_KEY, $locations, DAY_IN_SECONDS );
-		}
-
-		// Check the existing locations to see if one of them matches the store.
-		foreach ( $locations as $location ) {
-			if (
-				$location['display_name'] === $name
-				&& count( array_intersect( $location['address'], $address ) ) === count( $address )
-			) {
-				return $this->format_location_response( $location );
+			// Load the cached locations or retrieve them from the API.
+			$locations = get_transient( static::STORE_LOCATIONS_TRANSIENT_KEY );
+			if ( ! $locations ) {
+				$locations = $this->api_client->get_terminal_locations();
+				set_transient( static::STORE_LOCATIONS_TRANSIENT_KEY, $locations, DAY_IN_SECONDS );
 			}
+
+			// Check the existing locations to see if one of them matches the store.
+			foreach ( $locations as $location ) {
+				if (
+					$location['display_name'] === $name
+					&& count( array_intersect( $location['address'], $address ) ) === count( $address )
+				) {
+					return $this->format_location_response( $location );
+				}
+			}
+
+			// Create a new location, and add it to the cached list.
+			$location    = $this->api_client->create_terminal_location( $name, $address );
+			$locations[] = $location;
+			set_transient( static::STORE_LOCATIONS_TRANSIENT_KEY, $locations, DAY_IN_SECONDS );
+
+			return $this->format_location_response( $location );
+		} catch ( API_Exception $e ) {
+			return rest_ensure_response( new WP_Error( $e->get_error_code(), $e->getMessage() ) );
 		}
-
-		// Create a new location, and add it to the cached list.
-		$location    = $this->api_client->create_terminal_location( $name, $address );
-		$locations[] = $location;
-		set_transient( static::STORE_LOCATIONS_TRANSIENT_KEY, $locations, DAY_IN_SECONDS );
-
-		return $this->format_location_response( $location );
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
+++ b/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Class WC_REST_Payments_Terminal_Locations_Controller
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST controller for account details and status.
+ */
+class WC_REST_Payments_Terminal_Locations_Controller extends WC_Payments_REST_Controller {
+
+	const STORE_LOCATIONS_TRANSIENT_KEY = 'wcpay_store_terminal_locations';
+
+	/**
+	 * Endpoint path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'payments/terminal/locations';
+
+	/**
+	 * Configure REST API routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/store',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_store_location' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+	}
+
+	/**
+	 * Get store terminal location.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_store_location( $request ) {
+		$name    = get_bloginfo();
+		$address = [
+			'city'        => WC()->countries->get_base_city(),
+			'country'     => WC()->countries->get_base_country(),
+			'line1'       => WC()->countries->get_base_address(),
+			'line2'       => WC()->countries->get_base_address_2(),
+			'postal_code' => WC()->countries->get_base_postcode(),
+			'state'       => WC()->countries->get_base_state(),
+		];
+
+		// Load the cached locations or retrieve them from the API.
+		$locations = get_transient( static::STORE_LOCATIONS_TRANSIENT_KEY );
+		if ( ! $locations ) {
+			$locations = $this->api_client->get_terminal_locations();
+			set_transient( static::STORE_LOCATIONS_TRANSIENT_KEY, $locations, DAY_IN_SECONDS );
+		}
+
+		// Check the existing locations to see if one of them matches the store.
+		foreach ( $locations as $location ) {
+			if (
+				$location['display_name'] === $name
+				&& count( array_intersect( $location['address'], $address ) ) === count( $address )
+			) {
+				return $this->format_location_response( $location );
+			}
+		}
+
+		// Create a new location, and add it to the cached list.
+		$location    = $this->api_client->create_terminal_location( $name, $address );
+		$locations[] = $location;
+		set_transient( static::STORE_LOCATIONS_TRANSIENT_KEY, $locations, DAY_IN_SECONDS );
+
+		return $this->format_location_response( $location );
+	}
+
+	/**
+	 * Formats a Stripe terminal location object into a correct response.
+	 *
+	 * @param array $location The location.
+	 * @return WP_REST_Response
+	 */
+	private function format_location_response( $location ) {
+		return rest_ensure_response(
+			[
+				'id'           => $location['id'],
+				'address'      => $location['address'],
+				'display_name' => $location['display_name'],
+				'livemode'     => $location['livemode'],
+			]
+		);
+	}
+}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -752,6 +752,10 @@ class WC_Payments {
 		$tos_controller = new WC_REST_Payments_Tos_Controller( self::$api_client, self::$card_gateway, self::$account );
 		$tos_controller->register_routes();
 
+		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-terminal-locations-controller.php';
+		$accounts_controller = new WC_REST_Payments_Terminal_Locations_Controller( self::$api_client );
+		$accounts_controller->register_routes();
+
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-fraud-controller.php';
 		$fraud_controller = new WC_REST_Payments_Fraud_Controller( self::$api_client );
 		$fraud_controller->register_routes();

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -25,23 +25,24 @@ class WC_Payments_API_Client {
 
 	const API_TIMEOUT_SECONDS = 70;
 
-	const ACCOUNTS_API        = 'accounts';
-	const APPLE_PAY_API       = 'apple_pay';
-	const CHARGES_API         = 'charges';
-	const CONN_TOKENS_API     = 'terminal/connection_tokens';
-	const CUSTOMERS_API       = 'customers';
-	const CURRENCY_API        = 'currency';
-	const INTENTIONS_API      = 'intentions';
-	const REFUNDS_API         = 'refunds';
-	const DEPOSITS_API        = 'deposits';
-	const TRANSACTIONS_API    = 'transactions';
-	const DISPUTES_API        = 'disputes';
-	const FILES_API           = 'files';
-	const OAUTH_API           = 'oauth';
-	const TIMELINE_API        = 'timeline';
-	const PAYMENT_METHODS_API = 'payment_methods';
-	const SETUP_INTENTS_API   = 'setup_intents';
-	const TRACKING_API        = 'tracking';
+	const ACCOUNTS_API           = 'accounts';
+	const APPLE_PAY_API          = 'apple_pay';
+	const CHARGES_API            = 'charges';
+	const CONN_TOKENS_API        = 'terminal/connection_tokens';
+	const TERMINAL_LOCATIONS_API = 'terminal/locations';
+	const CUSTOMERS_API          = 'customers';
+	const CURRENCY_API           = 'currency';
+	const INTENTIONS_API         = 'intentions';
+	const REFUNDS_API            = 'refunds';
+	const DEPOSITS_API           = 'deposits';
+	const TRANSACTIONS_API       = 'transactions';
+	const DISPUTES_API           = 'disputes';
+	const FILES_API              = 'files';
+	const OAUTH_API              = 'oauth';
+	const TIMELINE_API           = 'timeline';
+	const PAYMENT_METHODS_API    = 'payment_methods';
+	const SETUP_INTENTS_API      = 'setup_intents';
+	const TRACKING_API           = 'tracking';
 
 	/**
 	 * Common keys in API requests/responses that we might want to redact.
@@ -1144,6 +1145,60 @@ class WC_Payments_API_Client {
 				'domain_name' => $domain_name,
 			],
 			self::APPLE_PAY_API . '/domains',
+			self::POST
+		);
+	}
+
+	/**
+	 * Retrieves a store's terminal locations.
+	 *
+	 * @return array[] Stripe terminal location objects.
+	 * @see https://stripe.com/docs/api/terminal/locations/object
+	 *
+	 * @throws API_Exception If an error occurs.
+	 */
+	public function get_terminal_locations() {
+		return $this->request( [], self::TERMINAL_LOCATIONS_API, self::GET );
+	}
+
+	/**
+	 * Creates a new terminal location.
+	 *
+	 * @param string  $display_name The display name of the terminal location.
+	 * @param array   $address {
+	 *     Address partials.
+	 *
+	 *     @type string $country     Two-letter country code.
+	 *     @type string $line1       Address line 1.
+	 *     @type string $line2       Optional. Address line 2.
+	 *     @type string $city        Optional. City, district, suburb, town, or village.
+	 *     @type int    $postal_code Optional. ZIP or postal code.
+	 *     @type string $state       Optional. State, county, province, or region.
+	 * }
+	 * @param mixed[] $metadata Optional. Metadata for the location.
+	 *
+	 * @return array A Stripe terminal location object.
+	 * @see https://stripe.com/docs/api/terminal/locations/object
+	 *
+	 * @throws API_Exception If an error occurs.
+	 */
+	public function create_terminal_location( $display_name, $address, $metadata = null ) {
+		if ( ! is_array( $address ) || ! isset( $address['country'] ) || ! isset( $address['line1'] ) ) {
+			throw new API_Exception(
+				__( 'Address country and line 1 are required.', 'woocommerce-payments' ),
+				'wcpay_invalid_terminal_location_request',
+				0
+			);
+		}
+
+		$request = [
+			'display_name' => $display_name,
+			'address'      => $address,
+		];
+
+		return $this->request(
+			$request,
+			self::TERMINAL_LOCATIONS_API,
 			self::POST
 		);
 	}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1182,18 +1182,19 @@ class WC_Payments_API_Client {
 	 *
 	 * @throws API_Exception If an error occurs.
 	 */
-	public function create_terminal_location( $display_name, $address, $metadata = null ) {
-		if ( ! is_array( $address ) || ! isset( $address['country'] ) || ! isset( $address['line1'] ) ) {
+	public function create_terminal_location( $display_name, $address, $metadata = [] ) {
+		if ( ! isset( $address['country'], $address['line1'] ) ) {
 			throw new API_Exception(
 				__( 'Address country and line 1 are required.', 'woocommerce-payments' ),
 				'wcpay_invalid_terminal_location_request',
-				0
+				400
 			);
 		}
 
 		$request = [
 			'display_name' => $display_name,
 			'address'      => $address,
+			'metadata'     => $metadata,
 		];
 
 		return $this->request(

--- a/tests/unit/admin/test-class-wc-rest-payments-terminal-locations-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-terminal-locations-controller.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Class WC_REST_Payments_Terminal_Locations_Controller_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_REST_Payments_Terminal_Locations_Controller as Controller;
+
+/**
+ * WC_REST_Payments_Tos_Controller unit tests.
+ */
+class WC_REST_Payments_Terminal_Locations_Controller_Test extends WP_UnitTestCase {
+
+	/**
+	 * The system under test.
+	 *
+	 * @var WC_REST_Payments_Terminal_Locations_Controller
+	 */
+	private $controller;
+
+	/**
+	 * An API client mock.
+	 *
+	 * @var WC_Payments_API_Client|MockObject
+	 */
+	private $mock_api_client;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Set the user so that we can pass the authentication.
+		wp_set_current_user( 1 );
+
+		$this->mock_api_client = $this->getMockBuilder( WC_Payments_API_Client::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->controller = new WC_REST_Payments_Terminal_Locations_Controller( $this->mock_api_client );
+
+		// Setup a test request.
+		$this->request = new WP_REST_Request(
+			'GET',
+			'/wc/v3/payments/terminal/locations'
+		);
+
+		$this->request->set_header( 'Content-Type', 'application/json' );
+
+		$this->location = [
+			'id'           => 'tml_XXXXXX',
+			'livemode'     => true,
+			'display_name' => get_bloginfo(),
+			'address'      => [
+				'city'        => WC()->countries->get_base_city(),
+				'country'     => WC()->countries->get_base_country(),
+				'line1'       => WC()->countries->get_base_address(),
+				'line2'       => WC()->countries->get_base_address_2(),
+				'postal_code' => WC()->countries->get_base_postcode(),
+				'state'       => WC()->countries->get_base_state(),
+			],
+		];
+	}
+
+	public function test_creates_location_from_scatch() {
+		delete_transient( Controller::STORE_LOCATIONS_TRANSIENT_KEY );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_terminal_locations' )
+			->willReturn( [] );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'create_terminal_location' )
+			->with( $this->location['display_name'], $this->location['address'] )
+			->willReturn(
+				$this->location,
+			);
+
+		$result = $this->controller->get_store_location( $this->request );
+
+		$this->assertSame( [ $this->location ], get_transient( Controller::STORE_LOCATIONS_TRANSIENT_KEY ) );
+		$this->assertEquals( $this->location, $result->get_data() );
+	}
+
+	public function test_creates_location_upon_mismatch() {
+		// This location will have a slight change compared to the current settings.
+		$mismatched_location = array_merge(
+			$this->location,
+			[
+				'display_name' => 'Example',
+			]
+		);
+
+		set_transient(
+			Controller::STORE_LOCATIONS_TRANSIENT_KEY,
+			[ $mismatched_location ],
+			DAY_IN_SECONDS
+		);
+
+		$this->mock_api_client
+			->expects( $this->never() )
+			->method( 'get_terminal_locations' );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'create_terminal_location' )
+			->with( $this->location['display_name'], $this->location['address'] )
+			->willReturn(
+				$this->location,
+			);
+
+		$result = $this->controller->get_store_location( $this->request );
+
+		$this->assertSame(
+			[
+				$mismatched_location,
+				$this->location,
+			],
+			get_transient( Controller::STORE_LOCATIONS_TRANSIENT_KEY )
+		);
+		$this->assertEquals( $this->location, $result->get_data() );
+	}
+
+	public function test_uses_existing_location_without_cache() {
+		delete_transient( Controller::STORE_LOCATIONS_TRANSIENT_KEY );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_terminal_locations' )
+			->willReturn( [ $this->location ] );
+
+		$this->mock_api_client
+			->expects( $this->never() )
+			->method( 'create_terminal_location' );
+
+		$result = $this->controller->get_store_location( $this->request );
+		$this->assertEquals( $this->location, $result->get_data() );
+		$this->assertEquals(
+			[ $this->location ],
+			get_transient( Controller::STORE_LOCATIONS_TRANSIENT_KEY )
+		);
+	}
+
+	public function test_uses_existing_location_with_cache() {
+		set_transient(
+			Controller::STORE_LOCATIONS_TRANSIENT_KEY,
+			[ $this->location ]
+		);
+
+		$this->mock_api_client
+			->expects( $this->never() )
+			->method( 'get_terminal_locations' );
+
+		$this->mock_api_client
+			->expects( $this->never() )
+			->method( 'create_terminal_location' );
+
+		$result = $this->controller->get_store_location( $this->request );
+		$this->assertEquals( $this->location, $result->get_data() );
+	}
+}

--- a/tests/unit/admin/test-class-wc-rest-payments-terminal-locations-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-terminal-locations-controller.php
@@ -77,9 +77,7 @@ class WC_REST_Payments_Terminal_Locations_Controller_Test extends WP_UnitTestCas
 			->expects( $this->once() )
 			->method( 'create_terminal_location' )
 			->with( $this->location['display_name'], $this->location['address'] )
-			->willReturn(
-				$this->location,
-			);
+			->willReturn( $this->location );
 
 		$result = $this->controller->get_store_location( $this->request );
 
@@ -110,9 +108,7 @@ class WC_REST_Payments_Terminal_Locations_Controller_Test extends WP_UnitTestCas
 			->expects( $this->once() )
 			->method( 'create_terminal_location' )
 			->with( $this->location['display_name'], $this->location['address'] )
-			->willReturn(
-				$this->location,
-			);
+			->willReturn( $this->location );
 
 		$result = $this->controller->get_store_location( $this->request );
 

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -66,6 +66,7 @@ function _manually_load_plugin() {
 	require_once $_plugin_dir . 'includes/admin/class-wc-rest-payments-accounts-controller.php';
 	require_once $_plugin_dir . 'includes/admin/class-wc-rest-payments-orders-controller.php';
 	require_once $_plugin_dir . 'includes/admin/class-wc-rest-payments-webhook-controller.php';
+	require_once $_plugin_dir . 'includes/admin/class-wc-rest-payments-terminal-locations-controller.php';
 	require_once $_plugin_dir . 'includes/admin/class-wc-rest-payments-tos-controller.php';
 	require_once $_plugin_dir . 'includes/admin/class-wc-rest-payments-settings-controller.php';
 	require_once $_plugin_dir . 'includes/admin/class-wc-rest-upe-flag-toggle-controller.php';

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -1049,6 +1049,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 				'country' => 'US',
 				'line1'   => 'Some Str. 2',
 			],
+			'metadata'     => [],
 		];
 
 		$this->mock_http_client
@@ -1081,6 +1082,8 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 			);
 
 		$result = $this->payments_api_client->create_terminal_location( $location['display_name'], $location['address'] );
+		// The returned value is an object, even though Stripe specifies an array.
+		$result['metadata'] = (array) $result['metadata'];
 		$this->assertSame( $location, $result );
 	}
 


### PR DESCRIPTION
Fixes #2784
Requires 1145-gh-Automattic/woocommerce-payments-server

#### Changes proposed in this Pull Request

A new `terminal/locations/store` endpoint, which utilizes the `/wcpay/terminal/locations` GET and POST server endoints.

This endpoint does not simply forward the request to Stripe, instead it ensures that a correct singular location is always return based on the settings of the particular shop.

To accomplish this, the store settings are prepared upon each call, and an existing location is returned only whenever it completely matches them. If any of the following settings changes, this will require a new location to be created:

- Blog/store name
- City
- Country
- Address line 1
- Address line 2
- Postal code
- State

A transient is used to cache all existing locations for a day, in order to avoid redundant API calls. Note that only the existing locations are cached, not only the one for the store. This ensures that if settings get changed, a new location will be generated, without using excessive resources.

![image](https://user-images.githubusercontent.com/5311119/131808350-7da05d5d-e8e8-45a7-ade7-19c8bacc8a3e.png)

#### Testing instructions

0. Run unit tests and make sure that they are sound.
1. Make sure your WCPay account (in the local server) has the `card_present_enabled` meta set to `'1'`.
2. Call the new endpoint and make sure that the response contains the correct data for the current store.
3. Call the endpoint again and verify that the same location is returned, instead of generating a new one.
4. (Optionally) Clear all transients and call the endpoint once more.

-------------------

- [ ] Added changelog entry: **Does a changelog entry make sense for this PR, considering that it only makes sense for merchants who are eligible for card present?**
- [x] Covered with tests
- [x] Tested on mobile (does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)