### PR TITLE
E2E test for "Shopper / Subscriptions / Purchase subscription product" flow

### DIFF
--- a/tests/e2e/specs/shopper/shopper-subscriptions-purchase-subscription-product.spec.js
+++ b/tests/e2e/specs/shopper/shopper-subscriptions-purchase-subscription-product.spec.js
@@ -1,0 +1,139 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+
+const { merchant, shopper, withRestApi } = require( '@woocommerce/e2e-utils' );
+
+import { RUN_SUBSCRIPTIONS_TESTS, describeif, merchantWCP } from '../../utils';
+
+import { fillCardDetails, setupCheckout } from '../../utils/payments';
+
+const getNextPaymentDate = ( subscriptionStartDateLocal ) => {
+	const nowUTC = new Date(
+		subscriptionStartDateLocal.getUTCFullYear(),
+		subscriptionStartDateLocal.getUTCMonth(),
+		subscriptionStartDateLocal.getUTCDate()
+	);
+	const formatter = new Intl.DateTimeFormat( 'en-US', {
+		dateStyle: 'long',
+	} );
+	const nextPaymentDate = nowUTC.setDate( nowUTC.getDate() + 30 );
+	return formatter.format( nextPaymentDate );
+};
+
+const nowLocal = new Date();
+const nextPayDateFormatted = getNextPaymentDate( nowLocal );
+const productName = `Subscription product ${ nowLocal.getTime() }`;
+const customerBilling = config.get( 'addresses.customer.billing' );
+const card = config.get( 'cards.basic' );
+const baseUrl = config.get( 'url' );
+
+let productId;
+let orderId;
+let subscriptionId;
+
+describeif( RUN_SUBSCRIPTIONS_TESTS )(
+	'Subscriptions > Purchase subscription product',
+	() => {
+		// Setup the subscription product.
+		// Take note of the the product ID.
+		beforeAll( async () => {
+			await merchant.login();
+			productId = await merchantWCP.createSubscriptionProduct(
+				productName
+			);
+			await merchant.logout();
+		} );
+
+		afterAll( async () => {
+			// Delete the user created with the subscription
+			await withRestApi.deleteCustomerByEmail( customerBilling.email );
+		} );
+
+		it( 'should be able to purchase the subscription product', async () => {
+			// As a Shopper purchase the product using a test card.
+			await shopper.goToProduct( productId );
+			await shopper.addToCart();
+			await setupCheckout( customerBilling );
+			await fillCardDetails( page, card );
+			await shopper.placeOrder();
+
+			// Take note of the the order ID
+			const orderIdField = await page.$(
+				'.woocommerce-order-overview__order.order > strong'
+			);
+			orderId = await orderIdField.evaluate( ( el ) => el.innerText );
+			subscriptionId = parseInt( orderId, 10 ) + 1;
+
+			// Open to the order.
+			const orderUrl = baseUrl + `my-account/view-order/${ orderId }/`;
+			await page.goto( orderUrl, {
+				waitUntil: 'networkidle0',
+			} );
+
+			// Ensure the new subscription is listed there
+			await expect( page ).toMatchElement( 'td.subscription-id', {
+				text: `#${ subscriptionId }`,
+			} );
+			await expect( page ).toMatchElement( 'td.subscription-status', {
+				text: 'Active',
+			} );
+			await expect( page ).toMatchElement(
+				'td.subscription-next-payment',
+				{
+					text: `${ nextPayDateFormatted }`,
+				}
+			);
+			await expect( page ).toMatchElement( 'td.subscription-total', {
+				text: '$9.99',
+			} );
+
+			// Ensure 'Subscription' link and 'View' button are opening.
+			const subscriptionLink = await page.$( 'td.subscription-id a' );
+			const actualSubHref = await subscriptionLink.evaluate( ( el ) =>
+				el.getAttribute( 'href' )
+			);
+			expect( actualSubHref ).toContain(
+				`/view-subscription/${ subscriptionId }`
+			);
+
+			const viewButton = await page.$( 'td.subscription-actions a' );
+			const viewButtonHref = await viewButton.evaluate( ( el ) =>
+				el.getAttribute( 'href' )
+			);
+			expect( viewButtonHref ).toContain(
+				`/view-subscription/${ subscriptionId }`
+			);
+
+			// Navigate to the Subscription details page.
+			await expect( page ).toClick( 'td.subscription-actions a', {
+				text: 'View',
+			} );
+			await page.waitForNavigation( { waitUntil: 'networkidle0' } );
+			await expect( page ).toMatchElement( 'h1.entry-title', {
+				text: `Subscription #${ subscriptionId }`,
+			} );
+
+			// Verify that all details in the Subscription Details table are correct.
+			const subDetailsTable = await page.$(
+				'table.subscription_details'
+			);
+			await expect( subDetailsTable ).toMatch( 'Active' );
+			await expect( subDetailsTable ).toMatch( nextPayDateFormatted );
+
+			// Verify that all details in the 'Subscription totals' table are correct.
+			const subTotalsTable = await page.$( 'table.order_details' );
+			await expect( subTotalsTable ).toMatch( productName );
+			await expect( subTotalsTable ).toMatch( '$9.99 / month' );
+
+			// Verify that all details in 'Related orders' table are correct.
+			await expect( page ).toMatchElement( 'td.order-number', {
+				text: `#${ orderId }`,
+			} );
+			await expect( page ).toMatchElement( 'td.order-total', {
+				text: '$9.99',
+			} );
+		} );
+	}
+);

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -187,7 +187,16 @@ export const merchantWCP = {
 		await expect( page ).toMatchElement( 'h1', { text: 'Subscriptions' } );
 	},
 
-	// Create a subscription product with an optional signup fee
+	/**
+	 * Create a subscription product with an optional signup fee
+	 *
+	 * @param productName
+	 * @param includeSignupFee defaults to `false`
+	 * @param includeFreeTrial defaults to `false`
+	 * @return id of the created subscription product
+	 *
+	 */
+
 	createSubscriptionProduct: async (
 		productName,
 		includeSignupFee = false,
@@ -211,6 +220,11 @@ export const merchantWCP = {
 		}
 
 		await verifyAndPublish();
+
+		// Return the id of this subscription product
+		const postSubstring = page.url().match( /post=\d+/ )[ 0 ];
+		const productId = postSubstring.replace( 'post=', '' );
+		return productId;
 	},
 
 	openDisputes: async () => {


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-payments/issues/2220.

#### Changes proposed in this Pull Request

Title: E2E test for "Shopper / Subscriptions / Purchase subscription product" flow

Description: This PR adds an e2e test that covers the "Shopper / Subscriptions / Purchase subscription product" flow. Steps here are consistent with the ones listed in the [testing instructions](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows#purchase-subscription-product).

#### Testing instructions

1. Setup the e2e environment on your local machine.
2. Run the newly added test:
    ```
    npm run test:e2e tests/e2e/specs/shopper/shopper-subscriptions-purchase-subscription-product.spec.js
    ```
3. The test should pass, like so:
    <img width="726" alt="Screen Shot 2021-09-02 at 8 41 56 PM" src="https://user-images.githubusercontent.com/4509348/131848326-1f677d7d-02e6-42d8-ae59-48de57b79ceb.png">
4. Run all the other tests. None of the existing tests should fail.

