### PR TITLE
Fix blank connect page when in treatment mode

### DIFF
--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -136,7 +136,18 @@ class WC_Payments_Admin {
 
 		wc_admin_register_page( $this->admin_child_pages['wc-payments-deposits'] );
 		wc_admin_register_page( $this->admin_child_pages['wc-payments-transactions'] );
-
+		wc_admin_register_page(
+			[
+				'id'       => 'wc-payments-connect',
+				'title'    => __( 'Connect', 'woocommerce-payments' ),
+				'parent'   => 'wc-payments',
+				'path'     => '/payments/connect',
+				'nav_args' => [
+					'parent' => 'wc-payments',
+					'order'  => 10,
+				],
+			]
+		);
 		wp_enqueue_style(
 			'wcpay-admin-css',
 			plugins_url( 'assets/css/admin.css', WCPAY_PLUGIN_FILE ),


### PR DESCRIPTION
Fixes #2833 

This PR registers `/payments/conenct`  to fix the blank page issue when a user is in treatment mode for `wcpay_empty_state_preview_mode_v4` experiment.


#### Testing instructions

We need to hack code a bit to test since `wcpay_empty_state_preview_mode_v4` experiment has been disabled at the moment.

1. Start with a fresh site.
2. Open `includes/admin/class-wc-payments-admin.php and` add `return true` in `is_in_treatment_mode` method to force treatment mode.
3. Open `client/deposits/index.js` and assign `treatmentExperience` to `defaultExperience` so that we get the treatment page on the front end.

```
	return (
		<Page>
			<Experiment
				name="wcpay_empty_state_preview_mode_v4"
				treatmentExperience={ treatmentExperience }
				defaultExperience={ treatmentExperience }
			/>
		</Page>
	);
```
4. Run `npm start` 
5. Navigate to WordPress admin and confirm `Payments` menu has been rendered.
6. Confirm `Payments` menu has three sub-menus -- Deposits, Transactions, and Connect
7. Click `Deposits`
8. Click the "Finish setup" button.
9. Finish the onboarding process.

