### PR TITLE
Fix Add enabled currencies modal UI bug

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@
 = 3.0.0 - 2021-xx-xx =
 * Add - Download deposits report in CSV.
 * Fix - Use store currency on analytics leaderboard when Multi-Currency is enabled.
-* Fix - Add enabled currencies modal UI.
+* Fix - Enabled currencies modal UI.
 
 = 2.9.0 - 2021-08-25 =
 * Add - Split discount line in timeline into variable fee and fixed fee.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 3.0.0 - 2021-xx-xx =
 * Add - Download deposits report in CSV.
 * Fix - Use store currency on analytics leaderboard when Multi-Currency is enabled.
+* Fix - Add enabled currencies modal UI.
 
 = 2.9.0 - 2021-08-25 =
 * Add - Split discount line in timeline into variable fee and fixed fee.

--- a/client/components/confirmation-modal/styles.scss
+++ b/client/components/confirmation-modal/styles.scss
@@ -12,6 +12,7 @@
 	.components-modal__header {
 		margin: 0 -#{$grid-unit-30} $grid-unit-30;
 		padding: 0 $grid-unit-30;
+		left: auto;
 	}
 
 	&__separator {

--- a/client/multi-currency/enabled-currencies-list/style.scss
+++ b/client/multi-currency/enabled-currencies-list/style.scss
@@ -144,12 +144,6 @@
 				vertical-align: bottom;
 			}
 		}
-		.components-checkbox-control__input {
-			margin: 0 4px 0 4px;
-		}
-		.components-checkbox-control__checked {
-			left: 2px;
-		}
 
 		&__code {
 			color: $studio-gray-30;
@@ -168,6 +162,7 @@
 		display: flex;
 		flex-direction: column;
 		margin: 0 -#{$grid-unit-30} -#{$grid-unit-30} 0;
+		padding-left: 4px;
 	}
 
 	&__search {
@@ -188,11 +183,6 @@
 			max-height: none;
 			min-height: 0;
 			flex: 1;
-		}
-		.enabled-currency-checkbox {
-			.components-checkbox-control__checked {
-				left: 4px;
-			}
 		}
 	}
 }

--- a/client/multi-currency/enabled-currencies-list/style.scss
+++ b/client/multi-currency/enabled-currencies-list/style.scss
@@ -189,5 +189,10 @@
 			min-height: 0;
 			flex: 1;
 		}
+		.enabled-currency-checkbox {
+			.components-checkbox-control__checked {
+				left: 4px;
+			}
+		}
 	}
 }

--- a/client/multi-currency/enabled-currencies-list/style.scss
+++ b/client/multi-currency/enabled-currencies-list/style.scss
@@ -144,6 +144,12 @@
 				vertical-align: bottom;
 			}
 		}
+		.components-checkbox-control__input {
+			margin: 0 4px 0 4px;
+		}
+		.components-checkbox-control__checked {
+			left: 2px;
+		}
 
 		&__code {
 			color: $studio-gray-30;

--- a/readme.txt
+++ b/readme.txt
@@ -101,7 +101,7 @@ Please note that our support for the checkout block is still experimental and th
 = 3.0.0 - 2021-xx-xx =
 * Add - Download deposits report in CSV.
 * Fix - Use store currency on analytics leaderboard when Multi-Currency is enabled.
-* Fix - Add enabled currencies modal UI.
+* Fix - Enabled currencies modal UI.
 
 = 2.9.0 - 2021-08-25 =
 * Add - Split discount line in timeline into variable fee and fixed fee.

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,7 @@ Please note that our support for the checkout block is still experimental and th
 = 3.0.0 - 2021-xx-xx =
 * Add - Download deposits report in CSV.
 * Fix - Use store currency on analytics leaderboard when Multi-Currency is enabled.
+* Fix - Add enabled currencies modal UI.
 
 = 2.9.0 - 2021-08-25 =
 * Add - Split discount line in timeline into variable fee and fixed fee.


### PR DESCRIPTION
Fixes #2731 

#### Changes proposed in this Pull Request

Fixed bugs with UI modal:
- Fixed styling of the header _Add enabled currencies_ by overriding `left: auto`. In Gutenberg plugin there is a `left: 0` by default.
- Fixed margin of the checkbox (`.components-checkbox-control__input`) from `margin: 0 4px 0 0` to `margin: 0 4px 0 4px`. It allows the `box-shadow` to become visible.
- Fixed svg `left` value from `-2px` to `2px` on desktop and `4px` on mobile due to margin fix in the previous stage.

#### Screenshots

After fix (with activated Gutenberg plugin) - Desktop
![image](https://user-images.githubusercontent.com/79862886/131908988-9f0a9157-dcd5-47d6-a09d-0c321c26ffe8.png)

Mobile
![image](https://user-images.githubusercontent.com/79862886/131980199-69deb5d1-d2e4-4b61-8a8a-ad1d56aebe0c.png)

#### Testing instructions

* Enable the Gutenberg plugin
* Check that enabled currencies modal looks according to the screenshot (or the connected issue)
* Disable the Gutenberg plugin
* Check that enabled currencies modal still looks according to the screenshot (or the connected issue)

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
