### PR TITLE
Only update the order status on failure outside of change payment requests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Enabled currencies modal UI.
 * Fix - User order currency format on admin refund button.
 * Fix - Clear the list of selected currencies after closing the modal for adding currencies.
+* Fix - Fix subscription change payment method errors after entering a payment method that fails.
 
 = 2.9.1 - 2021-09-07 =
 * Fix - Error while checking out with UPE when fields are hidden.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -810,7 +810,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			wc_add_notice( $error_message, 'error' );
 
-			$order->update_status( 'failed' );
+			if ( empty( $payment_information ) || ! $payment_information->is_changing_payment_method_for_subscription() ) {
+				$order->update_status( 'failed' );
+			}
 
 			if ( $e instanceof API_Exception && $e->get_error_code() === 'card_declined' ) {
 				$this->failed_transaction_rate_limiter->bump();


### PR DESCRIPTION
Fixes #2841 

#### Changes proposed in this Pull Request

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

When changing a subscription's payment method, if you enter a new card that fails (eg `4000000000000069`) the error occurs and the subscription is set to `failed`. Because subscriptions don't use failed statuses, this falls back to pending and the subscription is effectively broken (cannot be reactivated etc). This PR fixes that.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Purchase any subscription product. 
2. Go to **My Account > My Subscription(s)** and view the subscription. 
3. Click the **Change payment** button.
4. Enter a new card and put in `4000000000000069`.
5. **Submit**. 
6. Eventually the page will load with an error specific to your card failure (your card has expired) in addition:
     - On `trunk` or `develop` the error is followed by a "you cannot change that subscription" error. If you go back to the subscription page, you'll notice the subscription is now pending and cannot be interacted with anymore.
     - On this branch, you remain on the change payment method form.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
