### PR TITLE
Add stub WP_UnitTestCase

### DIFF
--- a/tests/WP_UnitTestCase.php
+++ b/tests/WP_UnitTestCase.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Class WP_UnitTestCase
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * This stub assists IDE in recognizing PHPUnit tests.
+ *
+ * Class WP_UnitTestCase
+ */
+class WP_UnitTestCase extends \PHPUnit\Framework\TestCase {
+
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adding this stub class `WP_UnitTestCase` so that IDEs can recognize PHPUnit tests. 

| Before  | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/10045087/131958456-a9e1a059-2bd2-461b-bbfb-a3469b679ef4.png)  | ![after](https://user-images.githubusercontent.com/10045087/131958485-37a55525-ba4a-437d-931c-8804f59a743f.png)  |

Note: I am not going to add a changelog here as it seems not really a feature/fix. It's more a developer experience issue. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

* Open PHPStorm and see before and after above. 

-------------------

- [x] ~Added changelog entry~ (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [x] ~Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions)~ (or does not apply)
