### PR TITLE
Add API to expose Multi-Currency widget to theme/plugin developers for easy integration

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 3.0.0 - 2021-xx-xx =
 * Add - Download deposits report in CSV.
 * Fix - Use store currency on analytics leaderboard when Multi-Currency is enabled.
+* Add - Add API to expose Multi-Currency widget to theme/plugin developers for easy integration.
 
 = 2.9.0 - 2021-08-25 =
 * Add - Split discount line in timeline into variable fee and fixed fee.

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -409,6 +409,30 @@ class MultiCurrency {
 	}
 
 	/**
+	 * Generates the switcher widget markup.
+	 *
+	 * @param array $instance The widget's instance settings.
+	 * @param array $args     The widget's arguments.
+	 *
+	 * @return string The widget markup.
+	 */
+	public function get_switcher_widget_markup( array $instance = [], array $args = [] ): string {
+		/**
+		 * The spl_object_hash function is used here due to we register the widget with an instance of the widget and
+		 * not the class name of the widget. WordPress core takes the instance and passes it through spl_object_hash
+		 * to get a hash and adds that as the widget's name in the $wp_widget_factory->widgets[] array. In order to
+		 * call the_widget, you need to have the name of the widget, so we get the instance and hash to use.
+		 */
+		ob_start();
+		the_widget(
+			spl_object_hash( $this->get_currency_switcher_widget() ),
+			apply_filters( $this->id . '_theme_widget_instance', $instance ),
+			apply_filters( $this->id . '_theme_widget_args', $args )
+		);
+		return ob_get_clean();
+	}
+
+	/**
 	 * Sets up the available currencies, which are alphabetical by name.
 	 *
 	 * @return void

--- a/includes/multi-currency/StorefrontIntegration.php
+++ b/includes/multi-currency/StorefrontIntegration.php
@@ -94,35 +94,6 @@ class StorefrontIntegration {
 	}
 
 	/**
-	 * Generates the switcher widget markup.
-	 *
-	 * @return string The widget markup.
-	 */
-	public function switcher_widget_markup(): string {
-		/**
-		 * The spl_object_hash function is used here due to we register the widget with an instance of the widget and
-		 * not the class name of the widget. WordPress core takes the instance and passes it through spl_object_hash
-		 * to get a hash and adds that as the widget's name in the $wp_widget_factory->widgets[] array. In order to
-		 * call the_widget, you need to have the name of the widget, so we get the instance and hash to use.
-		 */
-		ob_start();
-		the_widget(
-			spl_object_hash( $this->multi_currency->get_currency_switcher_widget() ),
-			null,
-			apply_filters(
-				$this->id . '_storefront_widget_args',
-				[
-					'before_widget' => '<div id="woocommerce-payments-multi-currency-storefront-widget" class="woocommerce-breadcrumb">',
-					'after_widget'  => '</div>',
-				]
-			)
-		);
-		return ob_get_clean();
-	}
-
-
-
-	/**
 	 * This modifies the breadcrumb defaults for us to be able to place the widget.
 	 *
 	 * @param array $defaults The defaults breadcrumb properties.
@@ -130,11 +101,21 @@ class StorefrontIntegration {
 	 * @return array The modified defaults properties.
 	 */
 	public function modify_breadcrumb_defaults( array $defaults ): array {
+		// Set the instance and args arrays for the widget.
+		$instance = apply_filters( $this->id . '_storefront_widget_instance', [] );
+		$args     = apply_filters(
+			$this->id . '_storefront_widget_args',
+			[
+				'before_widget' => '<div id="woocommerce-payments-multi-currency-storefront-widget" class="woocommerce-breadcrumb">',
+				'after_widget'  => '</div>',
+			]
+		);
+
 		/**
-		 * Some storefront child themes uses different wrappers and styles. We need to place the widget before
+		 * Some storefront child themes use different wrappers and styles. We need to place the widget before
 		 * the <nav> to display it properly.
 		 */
-		$defaults['wrap_before'] = str_replace( '<nav', $this->switcher_widget_markup() . '<nav', $defaults['wrap_before'] );
+		$defaults['wrap_before'] = str_replace( '<nav', $this->multi_currency->get_switcher_widget_markup( $instance, $args ) . '<nav', $defaults['wrap_before'] );
 
 		return $defaults;
 	}

--- a/includes/multi-currency/wc-payments-multi-currency.php
+++ b/includes/multi-currency/wc-payments-multi-currency.php
@@ -26,3 +26,15 @@ register_deactivation_hook( WCPAY_PLUGIN_FILE, 'wcpay_multi_currency_deactivated
 function wcpay_multi_currency_deactivated() {
 	WCPay\MultiCurrency\MultiCurrency::remove_woo_admin_notes();
 }
+
+/**
+ * Gets the switcher widget markup.
+ *
+ * @param array $instance The widget's instance settings.
+ * @param array $args     The widget's arguments.
+ *
+ * @return string The widget markup.
+ */
+function get_wcpay_multi_currency_widget_markup( array $instance = [], array $args = [] ): string {
+	return WC_Payments_Multi_Currency()->switcher_widget_markup( $instance, $args );
+}

--- a/includes/multi-currency/wc-payments-multi-currency.php
+++ b/includes/multi-currency/wc-payments-multi-currency.php
@@ -36,5 +36,5 @@ function wcpay_multi_currency_deactivated() {
  * @return string The widget markup.
  */
 function get_wcpay_multi_currency_widget_markup( array $instance = [], array $args = [] ): string {
-	return WC_Payments_Multi_Currency()->switcher_widget_markup( $instance, $args );
+	return WC_Payments_Multi_Currency()->get_switcher_widget_markup( $instance, $args );
 }

--- a/includes/multi-currency/wc-payments-multi-currency.php
+++ b/includes/multi-currency/wc-payments-multi-currency.php
@@ -27,14 +27,16 @@ function wcpay_multi_currency_deactivated() {
 	WCPay\MultiCurrency\MultiCurrency::remove_woo_admin_notes();
 }
 
-/**
- * Gets the switcher widget markup.
- *
- * @param array $instance The widget's instance settings.
- * @param array $args     The widget's arguments.
- *
- * @return string The widget markup.
- */
-function get_wcpay_multi_currency_widget_markup( array $instance = [], array $args = [] ): string {
-	return WC_Payments_Multi_Currency()->get_switcher_widget_markup( $instance, $args );
+if ( ! function_exists( 'wc_get_currency_switcher_markup' ) ) {
+	/**
+	 * Gets the switcher widget markup.
+	 *
+	 * @param array $instance The widget's instance settings.
+	 * @param array $args     The widget's arguments.
+	 *
+	 * @return string The widget markup.
+	 */
+	function wc_get_currency_switcher_markup( array $instance = [], array $args = [] ): string {
+		return WC_Payments_Multi_Currency()->get_switcher_widget_markup( $instance, $args );
+	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,7 @@ Please note that our support for the checkout block is still experimental and th
 = 3.0.0 - 2021-xx-xx =
 * Add - Download deposits report in CSV.
 * Fix - Use store currency on analytics leaderboard when Multi-Currency is enabled.
+* Add - Add API to expose Multi-Currency widget to theme/plugin developers for easy integration.
 
 = 2.9.0 - 2021-08-25 =
 * Add - Split discount line in timeline into variable fee and fixed fee.

--- a/tests/unit/multi-currency/test-class-compatibility.php
+++ b/tests/unit/multi-currency/test-class-compatibility.php
@@ -52,6 +52,15 @@ class WCPay_Multi_Currency_Compatibility_Tests extends WP_UnitTestCase {
 		$this->mock_coupon = $this->createMock( \WC_Coupon::class );
 	}
 
+	public function tearDown() {
+		// Reset cart checks so future tests can pass.
+		$this->mock_wcs_cart_contains_renewal( false );
+		$this->mock_wcs_cart_contains_resubscribe( false );
+		$this->mock_wcs_get_order_type_cart_items( false );
+
+		parent::tearDown();
+	}
+
 	/**
 	 * @dataProvider woocommerce_filter_provider
 	 */

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -795,8 +795,8 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		);
 
 		$this->multi_currency = new MultiCurrency( $mock_api_client ?? $this->mock_api_client, $this->mock_account, $this->mock_localization_service );
-		$this->multi_currency->init();
 		$this->multi_currency->init_widgets();
+		$this->multi_currency->init();
 	}
 
 	private function mock_theme( $theme ) {

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -728,6 +728,20 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $this->multi_currency->get_available_currencies() );
 	}
 
+	public function test_get_switcher_widget_markup() {
+		$expected = '<div class="widget ">		<form>
+						<select
+				name="currency"
+				aria-label=""
+				onchange="this.form.submit()"
+			>
+				<option value="USD" selected>&#36; USD</option><option value="BIF">Fr BIF</option><option value="CAD">&#36; CAD</option><option value="GBP">&pound; GBP</option>			</select>
+		</form>
+		</div>';
+
+		$this->assertEquals( $expected, $this->multi_currency->get_switcher_widget_markup() );
+	}
+
 	public function get_price_provider() {
 		return [
 			[ '5.2499', '0.00', 5.2499 ],
@@ -782,6 +796,7 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 
 		$this->multi_currency = new MultiCurrency( $mock_api_client ?? $this->mock_api_client, $this->mock_account, $this->mock_localization_service );
 		$this->multi_currency->init();
+		$this->multi_currency->init_widgets();
 	}
 
 	private function mock_theme( $theme ) {


### PR DESCRIPTION
Fixes #2746 

#### Changes proposed in this Pull Request

* Move `switcher_widget_markup` from `StorefrontIntegration` to `MultiCurrency`, along with renaming it to `get_switcher_widget_markup`.
* Add `$instance` and `$args` parameters to the method to allow for modifying the widget.
* Add filters for the widget instance and args. `wcpay_multi_currency_theme_widget_instance` and `wcpay_multi_currency_theme_widget_args`
* Update `modify_breadcrumb_defaults` in `StorefrontIntegration` to allow for its filters, and then to call `get_switcher_widget_markup` to get the widget markup.
* Create the function `get_wcpay_multi_currency_widget_markup` that can be used to get the widget markup for output in themes or other plugins.

#### Testing instructions

* Make sure unit tests pass.
* Can be tested by adding the below snippet directly to `functions.php` of theme, or through Code Snippets plugin.
* The snippet will add the switcher widget to the beginning of any sidebar/widget area.


```
add_action( 'dynamic_sidebar_before', function( $index ) {
	if ( is_admin() ) {
		return;
	}
	$instance = [
		'symbol' => true,
		'flag'   => true,
	];
	echo wc_get_currency_switcher_markup( $instance, [] );
});
```

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
