### PR TITLE
Fix currency format in admin refund button 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Add - Download deposits report in CSV.
 * Fix - Use store currency on analytics leaderboard when Multi-Currency is enabled.
 * Fix - Enabled currencies modal UI.
+* Fix - User order currency format on admin refund button.
 
 = 2.9.1 - 2021-09-07 =
 * Fix - Error while checking out with UPE when fields are hidden.

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -1021,6 +1021,8 @@ class MultiCurrency {
 	/**
 	 * Apply client order currency format and reduces the rounding precision to 2.
 	 *
+	 * @psalm-suppress InvalidGlobal
+	 *
 	 * @return  void
 	 */
 	public function set_client_format_and_rounding_precision() {

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Download deposits report in CSV.
 * Fix - Use store currency on analytics leaderboard when Multi-Currency is enabled.
 * Fix - Enabled currencies modal UI.
+* Fix - User order currency format on admin refund button.
 
 = 2.9.1 - 2021-09-07 =
 * Fix - Error while checking out with UPE when fields are hidden.


### PR DESCRIPTION
Fixes #2722 

#### Changes proposed in this Pull Request
Update `admin_head` hook `set_client_rounding_precision` to also apply currency format based on order currency.
Apart from the already included `rounding_precision` property of `woocommerce_admin_meta_boxes`, it injects now the following:
- `currency_format_num_decimals`
- `currency_format_decimal_sep`
- `currency_format_thousand_sep`
- `currency_format`

This will ensure that the refund button show the currency in the expected format.

I thought of different ways of fixing this, but we're quite limited here, because the code that format the currency after the inputs are modified is on the JS side here: https://github.com/woocommerce/woocommerce/blob/2d005836eb613e9fdfface73d13301263295d9a9/includes/admin/class-wc-admin-assets.php#L363-L367
So there are no hooks we can use to override the format, and we also need to get the order currency to use the right format.

On the other hand, I opted to update `set_client_rounding_precision` to avoid adding another hook that will check for the same conditions on `get_current_screen()`.

#### Screenshots
| Before | After |
| - | - |
|<img width="290" alt="Screenshot 2021-09-03 at 14 09 06" src="https://user-images.githubusercontent.com/7670276/132002894-fb3f8f40-01e9-446f-b544-f24809e9cd2b.png">|<img width="294" alt="Screenshot 2021-09-03 at 14 05 01" src="https://user-images.githubusercontent.com/7670276/132002751-ea13a622-da36-4bdb-a0dd-10cb0f5ac5d4.png">|
|<img width="297" alt="Screenshot 2021-09-03 at 14 05 21" src="https://user-images.githubusercontent.com/7670276/132002750-26a571f6-8e97-4e8f-b0a0-bdfc3c87820e.png">|<img width="279" alt="Screenshot 2021-09-03 at 14 05 52" src="https://user-images.githubusercontent.com/7670276/132002745-9738fd4e-7274-4e26-8218-dddc0f4bd5e7.png">|

#### Testing instructions
- With the store currency in **USD**.
- Edit an order in **EUR**
- Click on refund and change any item **QTY** to show an amount greater than zero on the button.
- Currency format should match the screenshot above.
- You can do the same with **JPY**.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**
- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
