### PR TITLE
Fix - error while checking out with UPE when fields are hidden

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 2.9.1 - 2021-xx-xx =
+* Fix - error while checking out with UPE when fields are hidden.
+
 = 2.9.0 - 2021-08-25 =
 * Add - Split discount line in timeline into variable fee and fixed fee.
 * Add - Order status validation for payments/orders/{order_id}/create_customer API.

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -497,7 +497,9 @@ jQuery( function ( $ ) {
 		blockUI( $form );
 		// Create object where keys are form field names and keys are form field values
 		const formFields = $form.serializeArray().reduce( ( obj, field ) => {
-			obj[ field.name ] = field.value;
+			if ( '' !== field.value ) {
+				obj[ field.name ] = field.value;
+			}
 			return obj;
 		}, {} );
 		try {

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -116,11 +116,9 @@ jQuery( function ( $ ) {
 	const hiddenBillingFields = {
 		name: 'never',
 		email: 'never',
-		phone: 'never',
 		address: {
 			country: 'never',
 			line1: 'never',
-			line2: 'never',
 			city: 'never',
 			state: 'never',
 			postalCode: 'never',

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -116,9 +116,11 @@ jQuery( function ( $ ) {
 	const hiddenBillingFields = {
 		name: 'never',
 		email: 'never',
+		phone: 'never',
 		address: {
 			country: 'never',
 			line1: 'never',
+			line2: 'never',
 			city: 'never',
 			state: 'never',
 			postalCode: 'never',
@@ -220,16 +222,18 @@ jQuery( function ( $ ) {
 	 */
 	const getBillingDetails = ( fields ) => {
 		return {
-			name: `${ fields.billing_first_name } ${ fields.billing_last_name }`.trim(),
+			name:
+				`${ fields.billing_first_name } ${ fields.billing_last_name }`.trim() ||
+				'-',
 			email: fields.billing_email,
-			phone: fields.billing_phone,
+			phone: fields.billing_phone || '-',
 			address: {
 				country: fields.billing_country,
 				line1: fields.billing_address_1,
-				line2: fields.billing_address_2,
-				city: fields.billing_city,
-				state: fields.billing_state,
-				postal_code: fields.billing_postcode,
+				line2: fields.billing_address_2 || '-',
+				city: fields.billing_city || '-',
+				state: fields.billing_state || '-',
+				postal_code: fields.billing_postcode || '-',
 			},
 		};
 	};
@@ -497,9 +501,7 @@ jQuery( function ( $ ) {
 		blockUI( $form );
 		// Create object where keys are form field names and keys are form field values
 		const formFields = $form.serializeArray().reduce( ( obj, field ) => {
-			if ( '' !== field.value ) {
-				obj[ field.name ] = field.value;
-			}
+			obj[ field.name ] = field.value;
 			return obj;
 		}, {} );
 		try {

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -225,11 +225,11 @@ jQuery( function ( $ ) {
 			name:
 				`${ fields.billing_first_name } ${ fields.billing_last_name }`.trim() ||
 				'-',
-			email: fields.billing_email,
+			email: fields.billing_email || '-',
 			phone: fields.billing_phone || '-',
 			address: {
-				country: fields.billing_country,
-				line1: fields.billing_address_1,
+				country: fields.billing_country || '-',
+				line1: fields.billing_address_1 || '-',
 				line2: fields.billing_address_2 || '-',
 				city: fields.billing_city || '-',
 				state: fields.billing_state || '-',

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,9 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 2.9.1 - 2021-xx-xx =
+* Fix - error while checking out with UPE when fields are hidden.
+
 = 2.9.0 - 2021-08-25 =
 * Add - Split discount line in timeline into variable fee and fixed fee.
 * Add - Order status validation for payments/orders/{order_id}/create_customer API.


### PR DESCRIPTION
Fixes #2743  #2688 #2785 

#### Changes proposed in this Pull Request

- Passing a truthy `-` as value for the fields in case they are undefined or empty.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions 1

- Install [checkout field editor](https://github.com/woocommerce/woocommerce-checkout-field-editor).
- goto WooCommerce => Checkout fields.
- Hide `billing_phone` or/and `billing_address_2` fields.
- Try checking out with UPE.
- Order should pass through, no errors observed.

#### Testing instructions 2
- Install [checkout field editor](https://github.com/woocommerce/woocommerce-checkout-field-editor).
- goto WooCommerce => Checkout fields.
- Keep `billing_phone` or/and `billing_address_2` fields but do not mark them as required.
- Try checking out with UPE.
- Order should pass through, no errors observed.

#### Testing instructions 3
- Install [checkout field editor](https://github.com/woocommerce/woocommerce-checkout-field-editor).
- goto WooCommerce => Checkout fields.
- Keep `billing_phone` or/and `billing_address_2` fields and mark them as required.
- Try checking out with UPE.
- Order should pass through, no errors observed.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
