### PR TITLE
Clear selected currencies when closing modal for adding currencies

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 3.0.0 - 2021-xx-xx =
 * Add - Download deposits report in CSV.
 * Fix - Use store currency on analytics leaderboard when Multi-Currency is enabled.
+* Fix - Clear the list of selected currencies after closing the modal for adding currencies.
 
 = 2.9.0 - 2021-08-25 =
 * Add - Split discount line in timeline into variable fee and fixed fee.

--- a/client/multi-currency/enabled-currencies-list/modal.js
+++ b/client/multi-currency/enabled-currencies-list/modal.js
@@ -57,13 +57,17 @@ const EnabledCurrenciesModal = ( { className } ) => {
 				);
 		  } );
 
-	useEffect( () => {
+	const setInitialSelectedCurrencies = useCallback( () => {
 		setSelectedCurrencies(
 			availableCurrencyCodes.reduce( ( acc, value ) => {
 				acc[ value ] = enabledCurrencyCodes.includes( value );
 				return acc;
 			}, {} )
 		);
+	}, [ enabledCurrencyCodes, availableCurrencyCodes ] );
+
+	useEffect( () => {
+		setInitialSelectedCurrencies();
 		/* eslint-disable react-hooks/exhaustive-deps */
 	}, [
 		JSON.stringify( availableCurrencyCodes ),
@@ -99,7 +103,8 @@ const EnabledCurrenciesModal = ( { className } ) => {
 		setIsEnabledCurrenciesModalOpen( false );
 		setCurrenciesListWidth( false );
 		setSearchText( '' );
-	}, [ setIsEnabledCurrenciesModalOpen ] );
+		setInitialSelectedCurrencies();
+	}, [ setIsEnabledCurrenciesModalOpen, setInitialSelectedCurrencies ] );
 
 	const handleAddSelectedClick = () => {
 		setIsEnabledCurrenciesModalOpen( false );

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,7 @@ Please note that our support for the checkout block is still experimental and th
 = 3.0.0 - 2021-xx-xx =
 * Add - Download deposits report in CSV.
 * Fix - Use store currency on analytics leaderboard when Multi-Currency is enabled.
+* Fix - Clear the list of selected currencies after closing the modal for adding currencies.
 
 = 2.9.0 - 2021-08-25 =
 * Add - Split discount line in timeline into variable fee and fixed fee.


### PR DESCRIPTION
Fixes #2362 

#### Changes proposed in this Pull Request

Clear selected currencies when closing modal for adding currencies

The state that keeps track of the selected currencies was not properly resetted when closing the modal.

See video in #2362.

This PR resets the state to the initial with only the enabled currencies when closing the modal without saving the selection.

#### Testing instructions

- Go to Payment->Setting->Multi-currency.
- Click on "Add Currencies" button.
- Select some currencies and click on "Close/Cancel" button.
- Again click on "Add Currencies" button.
- Observe that selected currencies clear upon clicking "Close/Cancel" button.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
