### PR TITLE
Fix duplicate account onboarding requests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Fix - User order currency format on admin refund button.
 * Fix - Clear the list of selected currencies after closing the modal for adding currencies.
 * Fix - Fix subscription change payment method errors after entering a payment method that fails.
+* Fix - Prevent duplicate account onboarding requests.
 
 = 2.9.1 - 2021-09-07 =
 * Fix - Error while checking out with UPE when fields are hidden.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -23,6 +23,7 @@ class WC_Payments_Account {
 	const ACCOUNT_OPTION                 = 'wcpay_account_data';
 	const ACCOUNT_RETRIEVAL_ERROR        = 'ERROR';
 	const ON_BOARDING_DISABLED_TRANSIENT = 'wcpay_on_boarding_disabled';
+	const ON_BOARDING_STATUS_TRANSIENT   = 'wcpay_on_boarding_status';
 	const ERROR_MESSAGE_TRANSIENT        = 'wcpay_error_message';
 
 	/**
@@ -539,6 +540,16 @@ class WC_Payments_Account {
 	 * @param string $wcpay_connect_from - where the user should be returned to after connecting.
 	 */
 	private function init_stripe_oauth( $wcpay_connect_from ) {
+		if ( get_transient( self::ON_BOARDING_STATUS_TRANSIENT ) ) {
+			$this->redirect_to_onboarding_page(
+				__( 'There was a duplicate attempt to redirect you to Stripe. Please wait a few seconds and try again.', 'woocommerce-payments' )
+			);
+			return;
+		}
+
+		// Set a quickly expiring transient to save the current onboarding state and avoid duplicate requests.
+		set_transient( self::ON_BOARDING_STATUS_TRANSIENT, 1, 10 );
+
 		// Clear account transient when generating Stripe's oauth data.
 		$this->clear_cache();
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -542,7 +542,7 @@ class WC_Payments_Account {
 	private function init_stripe_oauth( $wcpay_connect_from ) {
 		if ( get_transient( self::ON_BOARDING_STARTED_TRANSIENT ) ) {
 			$this->redirect_to_onboarding_page(
-				__( 'There was a duplicate attempt to redirect you to Stripe. Please wait a few seconds and try again.', 'woocommerce-payments' )
+				__( 'There was a duplicate attempt to initiate account setup. Please wait a few seconds and try again.', 'woocommerce-payments' )
 			);
 			return;
 		}
@@ -574,6 +574,8 @@ class WC_Payments_Account {
 			],
 			$this->get_actioned_notes()
 		);
+
+		delete_transient( self::ON_BOARDING_STARTED_TRANSIENT );
 
 		// If an account already exists for this site, we're done.
 		if ( false === $oauth_data['url'] ) {

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -23,7 +23,7 @@ class WC_Payments_Account {
 	const ACCOUNT_OPTION                 = 'wcpay_account_data';
 	const ACCOUNT_RETRIEVAL_ERROR        = 'ERROR';
 	const ON_BOARDING_DISABLED_TRANSIENT = 'wcpay_on_boarding_disabled';
-	const ON_BOARDING_STATUS_TRANSIENT   = 'wcpay_on_boarding_status';
+	const ON_BOARDING_STARTED_TRANSIENT  = 'wcpay_on_boarding_started';
 	const ERROR_MESSAGE_TRANSIENT        = 'wcpay_error_message';
 
 	/**
@@ -540,7 +540,7 @@ class WC_Payments_Account {
 	 * @param string $wcpay_connect_from - where the user should be returned to after connecting.
 	 */
 	private function init_stripe_oauth( $wcpay_connect_from ) {
-		if ( get_transient( self::ON_BOARDING_STATUS_TRANSIENT ) ) {
+		if ( get_transient( self::ON_BOARDING_STARTED_TRANSIENT ) ) {
 			$this->redirect_to_onboarding_page(
 				__( 'There was a duplicate attempt to redirect you to Stripe. Please wait a few seconds and try again.', 'woocommerce-payments' )
 			);
@@ -548,7 +548,7 @@ class WC_Payments_Account {
 		}
 
 		// Set a quickly expiring transient to save the current onboarding state and avoid duplicate requests.
-		set_transient( self::ON_BOARDING_STATUS_TRANSIENT, 1, 10 );
+		set_transient( self::ON_BOARDING_STARTED_TRANSIENT, true, 10 );
 
 		// Clear account transient when generating Stripe's oauth data.
 		$this->clear_cache();

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - User order currency format on admin refund button.
 * Fix - Clear the list of selected currencies after closing the modal for adding currencies.
 * Fix - Fix subscription change payment method errors after entering a payment method that fails.
+* Fix - Prevent duplicate account onboarding requests.
 
 = 2.9.1 - 2021-09-07 =
 * Fix - Error while checking out with UPE when fields are hidden.


### PR DESCRIPTION
Fixes #2825

#### Changes proposed in this Pull Request

Disabling the "Finish setup" button isn't enough to prevent multiple onboarding requests, as we've been seeing in production (1143-gh-Automattic/woocommerce-payments-server).

This PR adds a quickly expiring transient to create an "onboarding started" state and avoid simultaneous onboarding requests.

A different approach of switching the onboarding request from `GET` to `POST` was considered, but we wouldn't be able to redirect from Jetpack to Stripe's KYC directly without the user triggering another `POST`. Unless we need to submit other data from the onboarding page to Stripe's KYC, I think the transient approach is better for the time being.

#### Testing instructions

1. Make sure you're not onboarded in WCPay.
2. In the onboarding page, open the "Finish setup" link in a new tab and then click it in the current tab.
3. Notice you can't get redirected more than once in 10 seconds.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)