### PR TITLE
Create WC Pay customer on subscription creation

### DIFF
--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -148,7 +148,7 @@ class WC_Payments_Subscription_Service {
 	 * @throws Exception Throws an exception to stop checkout processing and display message to customer.
 	 */
 	public function create_subscription( WC_Subscription $subscription ) {
-		$checkout_error_message = __( 'There was a problem creating your subscription. Please try again or use an alternative payment method.', 'woocommerce-payments' );
+		$checkout_error_message = __( 'There was a problem creating your subscription. Please try again or contact us for assistance.', 'woocommerce-payments' );
 		$user                   = $subscription->get_user();
 		$wcpay_customer_id      = $user instanceof WP_User ? $this->customer_service->get_customer_id_by_user_id( $user->ID ) : null;
 

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -149,8 +149,7 @@ class WC_Payments_Subscription_Service {
 	 */
 	public function create_subscription( WC_Subscription $subscription ) {
 		$checkout_error_message = __( 'There was a problem creating your subscription. Please try again or contact us for assistance.', 'woocommerce-payments' );
-		$user                   = $subscription->get_user();
-		$wcpay_customer_id      = $user instanceof WP_User ? $this->customer_service->get_customer_id_by_user_id( $user->ID ) : null;
+		$wcpay_customer_id      = $this->customer_service->get_customer_id_for_order( $subscription );
 
 		if ( ! $wcpay_customer_id ) {
 			Logger::error( 'There was a problem creating the WCPay subscription. WCPay customer ID missing.' );

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -102,7 +102,7 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 
 		$mock_wcpay_subscription_id = 'wcpay_subscription_test12345';
 		$mock_subscription_data     = [
-			'customer'           => '1',
+			'customer'           => 'wcpay_cus_test12345',
 			'items'              => [ 'not empty subscription data' ],
 			'proration_behavior' => 'none',
 			'payment_behavior'   => 'default_incomplete',
@@ -111,9 +111,9 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 		$this->assertNotEquals( $mock_subscription->get_meta( self::SUBSCRIPTION_ID_META_KEY ), $mock_wcpay_subscription_id );
 
 		$this->mock_customer_service->expects( $this->once() )
-			->method( 'get_customer_id_by_user_id' )
-			->with( '1' )
-			->willReturn( 1 );
+			->method( 'get_customer_id_for_order' )
+			->with( $mock_subscription )
+			->willReturn( $mock_subscription_data['customer'] );
 
 		$this->mock_product_service->expects( $this->once() )
 			->method( 'get_product_data_for_subscription' )


### PR DESCRIPTION
Fixes #2869

#### Changes proposed in this Pull Request

Create the WC Payments Customer object on subscription creation if the customer doesn't already have one. Prior to this PR we assumed the customer would have already been created. This changed though when we moved subscription creation to occur before order payment. 

This fixes this error on checkout for new customers:

<img width="845" alt="Screen Shot 2021-09-08 at 11 33 06 am" src="https://user-images.githubusercontent.com/8490476/132434024-42e2ffb4-475a-413a-be8f-ddcb31ab194a.png">

Because WC Payments will be the only payment method for WC Pay Subscriptions stores, I replaced the suggestion in the error notice above to use an alternative payment method. 

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the latest `feature/subscription_services` development branch.
2. Create a subscription product if you don't already have one.
3. In an incognito or alternative browser attempt to purchase the product via the checkout while not logged in - as a new customer.
4. See the error
5. Check out this branch. 
6. Reattampt to purchase the subscription. On this branch, it should be successful.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
