### PR TITLE
Update MC tracking to include single currency settings usage.

### DIFF
--- a/includes/multi-currency/Tracking.php
+++ b/includes/multi-currency/Tracking.php
@@ -55,10 +55,40 @@ class Tracking {
 	 * @return array Assoc array with the Currency data.
 	 */
 	private function get_currency_data_array( Currency $currency ): array {
-		return [
+		$data = [
 			'code' => $currency->get_code(),
 			'name' => html_entity_decode( $currency->get_name() ),
 		];
+
+		// Return early if it's the default currency.
+		if ( $currency->get_code() === $this->multi_currency->get_default_currency()->get_code() ) {
+			return $data;
+		}
+
+		// Is it a zero decimal currency?
+		$is_zero_decimal = $currency->get_is_zero_decimal();
+
+		// Is it using a custom or automatic rate?
+		$rate_type = get_option( $this->multi_currency->id . '_exchange_rate_' . $currency->get_id(), 'automatic' );
+		$rate_type = 'automatic' === $rate_type ? $rate_type . ' (default)' : $rate_type;
+
+		// What is the price rounding setting?
+		$price_rounding_default = $is_zero_decimal ? '100' : '1.00';
+		$price_rounding         = $currency->get_rounding();
+		$price_rounding         = $price_rounding_default === $price_rounding ? $price_rounding . ' (default)' : $price_rounding;
+
+		// What is the price charm setting?
+		$price_charm = $currency->get_charm();
+		$price_charm = 0.00 === $price_charm ? '0.00 (default)' : $price_charm;
+
+		$additional_data = [
+			'is_zero_decimal' => $is_zero_decimal,
+			'rate_type'       => $rate_type,
+			'price_rounding'  => $price_rounding,
+			'price_charm'     => $price_charm,
+		];
+
+		return array_merge( $data, $additional_data );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2764

#### Requested data

* Count of merchants using automatic rates
* Count of merchants using custom rate
* Count of merchants using default formatting settings (auto rounding, no price charm)
* Count of merchants using custom formatting settings (changes to either the rounding amount and or price charm)

#### Changes proposed in this Pull Request

* Update `get_currency_data_array` method to return additional data, including the exchange rate type, price rounding, price charm, and if it's a zero decimal currency.
* Updated data will return similar to the below array, adding `(default)` if the setting is default. This is mainly done to zero decimal currencies have differing defaults from other currencies.
  * If the currency has been added and no settings have been added, the default settings are returned, as that's what MC uses.
* Changelog not updated due to there are multiple tracking updates happening and adding only a single entry should suffice.

```
    [wcpay_multi_currency] => Array
        (
            [enabled_currencies] => Array
                (
                    [BIF] => Array
                        (
                            [code] => BIF
                            [name] => Burundian franc
                            [is_zero_decimal] => 1
                            [rate_type] => manual
                            [price_rounding] => 50
                            [price_charm] => -1
                        )

                    [CAD] => Array
                        (
                            [code] => CAD
                            [name] => Canadian dollar
                            [is_zero_decimal] => 
                            [rate_type] => manual
                            [price_rounding] => 0.50
                            [price_charm] => -0.01
                        )

                    [CLP] => Array
                        (
                            [code] => CLP
                            [name] => Chilean peso
                            [is_zero_decimal] => 1
                            [rate_type] => automatic (default)
                            [price_rounding] => 100 (default)
                            [price_charm] => 0.00 (default)
                        )

                    [EUR] => Array
                        (
                            [code] => EUR
                            [name] => Euro
                            [is_zero_decimal] => 
                            [rate_type] => automatic (default)
                            [price_rounding] => 1.00 (default)
                            [price_charm] => 0.00 (default)
                        )

                    [JPY] => Array
                        (
                            [code] => JPY
                            [name] => Japanese yen
                            [is_zero_decimal] => 1
                            [rate_type] => automatic (default)
                            [price_rounding] => 100 (default)
                            [price_charm] => 0.00 (default)
                        )

                    [GBP] => Array
                        (
                            [code] => GBP
                            [name] => Pound sterling
                            [is_zero_decimal] => 
                            [rate_type] => automatic (default)
                            [price_rounding] => 1.00 (default)
                            [price_charm] => 0.00 (default)
                        )

                )

            [default_currency] => Array
                (
                    [code] => USD
                    [name] => United States (US) dollar
                )

            [order_count] => 399
        )
```

#### Testing instructions

* It's recommended to remove all enabled currencies under WooCommerce > Settings > Multi-Currency, this allows for a clean slate to work with.
* 3 standard (CAD, EUR, GBP) and 3 zero decimal currencies (BIF, CLP, JPY) should be used, recommendations in parenthesis.
* Update one of each type of currency (BIF, CAD) to have non-default settings.
* Update one of each type of currency (CLP, EUR) to have default settings, meaning go into the edit page and just click save.
* Do not modify the last two currencies (JPY, GBP).
* Make sure you have `WP_DEBUG` and `WP_DEBUG_LOG` set to `true`.
* Add the below snippets either in your `functions.php` file, or via the Code Snippets plugin.
* Go to WooCommerce > Settings > Advanced > WooCommerce.com and _Enable tracking_.
* From here you must trigger the tracking cron in one of two ways:
  * CLI command: `wp cron event run woocommerce_tracker_send_event`, or
  * Use the WP Crontrol plugin, which has the events under Tools > Cron events
* The last snippet will cause the full data sent to WC Tracker to be logged to your `debug.log`, and the last part of the data should be in the same format as the array mentioned above. 


```
add_filter( 'woocommerce_tracker_send_override', '__return_false' );
add_filter( 'woocommerce_tracker_last_send_time', '__return_false' );

add_filter(
	'woocommerce_tracker_data',
	function( $data ) {
		error_log( __FILE__ . ':' . __LINE__ . ":\n" . '$data: ' . print_r( $data, true ) );
		return $data;
	},
	999
);
```

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
