### PR TITLE
Include critical fields in the stripe element if they are hidden in checkout

### DIFF
--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -20,6 +20,7 @@ jQuery( function ( $ ) {
 	const publishableKey = getConfig( 'publishableKey' );
 	const isUPEEnabled = getConfig( 'isUPEEnabled' );
 	const paymentMethodsConfig = getConfig( 'paymentMethodsConfig' );
+	const enabledBillingFields = getConfig( 'enabledBillingFields' );
 
 	if ( ! publishableKey ) {
 		// If no configuration is present, probably this is not the checkout page.
@@ -114,16 +115,36 @@ jQuery( function ( $ ) {
 	let paymentIntentId = null;
 	let isUPEComplete = false;
 	const hiddenBillingFields = {
-		name: 'never',
-		email: 'never',
-		phone: 'never',
+		name:
+			enabledBillingFields.includes( 'billing_first_name' ) ||
+			enabledBillingFields.includes( 'billing_last_name' )
+				? 'never'
+				: 'auto',
+		email: enabledBillingFields.includes( 'billing_email' )
+			? 'never'
+			: 'auto',
+		phone: enabledBillingFields.includes( 'billing_phone' )
+			? 'never'
+			: 'auto',
 		address: {
-			country: 'never',
-			line1: 'never',
-			line2: 'never',
-			city: 'never',
-			state: 'never',
-			postalCode: 'never',
+			country: enabledBillingFields.includes( 'billing_country' )
+				? 'never'
+				: 'auto',
+			line1: enabledBillingFields.includes( 'billing_address_1' )
+				? 'never'
+				: 'auto',
+			line2: enabledBillingFields.includes( 'billing_address_2' )
+				? 'never'
+				: 'auto',
+			city: enabledBillingFields.includes( 'billing_city' )
+				? 'never'
+				: 'auto',
+			state: enabledBillingFields.includes( 'billing_state' )
+				? 'never'
+				: 'auto',
+			postalCode: enabledBillingFields.includes( 'billing_postcode' )
+				? 'never'
+				: 'auto',
 		},
 	};
 

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -573,6 +573,14 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		$payment_fields['checkoutTitle']            = $this->checkout_title;
 		$payment_fields['cartContainsSubscription'] = $this->is_subscription_item_in_cart();
 
+		$enabled_billing_fields = [];
+		foreach ( WC()->checkout()->get_checkout_fields( 'billing' ) as $billing_field => $billing_field_options ) {
+			if ( ! isset( $billing_field_options['enabled'] ) || $billing_field_options['enabled'] ) {
+				$enabled_billing_fields[] = $billing_field;
+			}
+		}
+		$payment_fields['enabledBillingFields'] = $enabled_billing_fields;
+
 		if ( is_wc_endpoint_url( 'order-pay' ) ) {
 			if ( $this->is_subscriptions_enabled() && $this->is_changing_payment_method_for_subscription() ) {
 				$payment_fields['isChangingPayment']   = true;


### PR DESCRIPTION
This is backporting a fix from the [stripe plugin](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1795/commits/e205416fd1f0c57c2934591fff911470536a4653)

In the rare cases when merchants hide essential fields such as postal code from the checkout, this change set hidden fields as automattic so stripe UPE can choose to show them if they are required for the customer's location and chosen payment method.

#### Testing instructions

* hide postal code using checkout fields editor
* try to checkout with UPE enabled
* Postal code should appear below CC fields in the stripe element

![image](https://user-images.githubusercontent.com/1534605/132728397-07c4cc2d-e71a-4d68-9cee-28166ff8de7b.png)


-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
