### PR TITLE
POC Hide payment gateway title on page load

### DIFF
--- a/client/checkout/classic/index.js
+++ b/client/checkout/classic/index.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import './style.scss';
+import './upe.scss';
 import {
 	PAYMENT_METHOD_NAME_CARD,
 	PAYMENT_METHOD_NAME_GIROPAY,

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import './style.scss';
+import './upe.scss';
 import {
 	PAYMENT_METHOD_NAME_CARD,
 	PAYMENT_METHOD_NAME_UPE,
@@ -326,9 +326,9 @@ jQuery( function ( $ ) {
 	};
 
 	const renameGatewayTitle = () =>
-		$( 'label[for=payment_method_woocommerce_payments]' ).text(
-			getCustomGatewayTitle( paymentMethodsConfig )
-		);
+		$( 'label[for=payment_method_woocommerce_payments]' )
+			.text( getCustomGatewayTitle( paymentMethodsConfig ) )
+			.addClass( 'visible' );
 
 	// Only attempt to mount the card element once that section of the page has loaded. We can use the updated_checkout
 	// event for this. This part of the page can also reload based on changes to checkout details, so we call unmount

--- a/client/checkout/classic/upe.scss
+++ b/client/checkout/classic/upe.scss
@@ -1,0 +1,48 @@
+#payment
+	.payment_methods
+	li
+	.payment_box.payment_method_woocommerce_payments
+	fieldset {
+	padding: 0;
+}
+
+#payment .payment_method_woocommerce_payments > fieldset > legend {
+	padding-top: 0;
+}
+
+#payment .payment_method_woocommerce_payments .testmode-info {
+	margin-bottom: 0.5em;
+}
+
+#payment .payment_method_woocommerce_payments .woocommerce-error {
+	margin: 1em 0 0;
+}
+
+#wcpay-card-element,
+#wcpay-sepa-element {
+	border: 1px solid #ddd;
+	padding: 5px 7px;
+	min-height: 29px;
+}
+
+#wcpay-upe-element {
+	padding: 7px 7px;
+	margin-bottom: 0.5em;
+
+	&.processing {
+		min-height: 70px;
+	}
+}
+
+.wcpay-card-mounted,
+.wcpay-upe-mounted,
+.wcpay-sepa-mounted {
+	background-color: #fff;
+}
+
+li.payment_method_woocommerce_payments label {
+	opacity: 0;
+}
+li.payment_method_woocommerce_payments label.visible {
+	opacity: 1;
+}

--- a/client/checkout/classic/upe.scss
+++ b/client/checkout/classic/upe.scss
@@ -40,9 +40,11 @@
 	background-color: #fff;
 }
 
-li.payment_method_woocommerce_payments label {
+li.payment_method_woocommerce_payments
+	label[for='payment_method_woocommerce_payments'] {
 	opacity: 0;
 }
-li.payment_method_woocommerce_payments label.visible {
+li.payment_method_woocommerce_payments
+	label[for='payment_method_woocommerce_payments'].visible {
 	opacity: 1;
 }


### PR DESCRIPTION
Fixes #2891 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
# Use CSS to hide default, yet incorrect, payment gateway title while gateway is loading

Please see description of #2891 for more details of this issue. This is a POC branch that shows how CSS can be used to hide the title of the gateway, before it's correct title can be set, depending on the number of enabled payment methods. 

This SCSS file must only be loaded when the UPE is enabled, _not_ when the legacy payment gateway is present. This PR adds the SCSS for both gateways, because of how webpack is configured to load stylesheets. That is why this PR is incomplete and should not be merged in this state.

Below is an example of how this looks with the changes in this PR.

![Hiding gateway title](https://cdn-std.droplr.net/files/acc_1104206/li8lJl)
_Using CSS to hide gateway title while preloading_

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
1. Enable UPE and visit checkout.
2. Notice that while payment gateway is in preloading state, while initial payment intent is being created, gateway is NOT titled "WooCommerce Payments". Title should be hidden during preloading.
3. Disable UPE and visit checkout. Gateway title should not be hidden at any time.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
