### PR TITLE
Fix Multi-Currency not showing converted prices with admin as referer

### DIFF
--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -46,7 +46,7 @@ class FrontendCurrencies {
 		$this->multi_currency       = $multi_currency;
 		$this->localization_service = $localization_service;
 
-		if ( ! is_admin() && ! defined( 'DOING_CRON' ) && ! Utils::is_admin_request() ) {
+		if ( ! is_admin() && ! defined( 'DOING_CRON' ) && ! Utils::is_admin_api_request() ) {
 			// Currency hooks.
 			add_filter( 'woocommerce_currency', [ $this, 'get_woocommerce_currency' ], 50 );
 			add_filter( 'wc_get_price_decimals', [ $this, 'get_price_decimals' ], 50 );

--- a/includes/multi-currency/FrontendPrices.php
+++ b/includes/multi-currency/FrontendPrices.php
@@ -39,7 +39,7 @@ class FrontendPrices {
 		$this->multi_currency = $multi_currency;
 		$this->compatibility  = $compatibility;
 
-		if ( ! is_admin() && ! defined( 'DOING_CRON' ) && ! Utils::is_admin_request() ) {
+		if ( ! is_admin() && ! defined( 'DOING_CRON' ) && ! Utils::is_admin_api_request() ) {
 			// Simple product price hooks.
 			add_filter( 'woocommerce_product_get_price', [ $this, 'get_product_price' ], 50, 2 );
 			add_filter( 'woocommerce_product_get_regular_price', [ $this, 'get_product_price' ], 50, 2 );

--- a/includes/multi-currency/Utils.php
+++ b/includes/multi-currency/Utils.php
@@ -31,11 +31,11 @@ class Utils {
 	}
 
 	/**
-	 * Checks if HTTP referer matches admin url.
+	 * Checks if is a REST API request and the HTTP referer matches admin url.
 	 *
 	 * @return boolean
 	 */
-	public static function is_admin_request(): bool {
-		return 0 === stripos( wp_get_referer(), admin_url() );
+	public static function is_admin_api_request(): bool {
+		return 0 === stripos( wp_get_referer(), admin_url() ) && WC()->is_rest_api_request();
 	}
 }

--- a/tests/unit/multi-currency/test-class-utils.php
+++ b/tests/unit/multi-currency/test-class-utils.php
@@ -33,13 +33,15 @@ class WCPay_Multi_Currency_Utils_Tests extends WP_UnitTestCase {
 		$this->assertTrue( $this->utils->is_call_in_backtrace( [ 'WCPay_Multi_Currency_Utils_Tests->test_is_call_in_backtrace_return_true' ] ) );
 	}
 
-	public function test_is_admin_request_returns_false() {
+	public function test_is_admin_api_request_returns_false() {
 		$_SERVER['HTTP_REFERER'] = 'http://example.org/';
-		$this->assertFalse( $this->utils->is_admin_request() );
+		$_SERVER['REQUEST_URI']  = trailingslashit( rest_get_url_prefix() );
+		$this->assertFalse( $this->utils->is_admin_api_request() );
 	}
 
-	public function test_is_admin_request_returns_true() {
+	public function test_is_admin_api_request_returns_true() {
 		$_SERVER['HTTP_REFERER'] = 'http://example.org/wp-admin/';
-		$this->assertTrue( $this->utils->is_admin_request() );
+		$_SERVER['REQUEST_URI']  = trailingslashit( rest_get_url_prefix() );
+		$this->assertTrue( $this->utils->is_admin_api_request() );
 	}
 }


### PR DESCRIPTION
Fixes #2900

#### Changes proposed in this Pull Request
Rename `is_admin_request` to `is_admin_api_request` checking also if the request is an api request. This function was added to check if the request comes from an admin url to prevent converting currencies on admin analytics leaderboard. But this caused a new bug when you visit the store with an admin url as referer.

We want to convert currencies on frontend api request, because for example the checkout blocks use them. But we should prevent it on admin ones, to avoid any issues like the analytics leaderboard.

#### Testing instructions
- Having the store in one currency (ex USD), choose another with a different symbol on the store fronted (ex EUR).
- Access the store through `Visit Store` in the upper left corner of your admin are, when you move the cursor over your site name. The products prices should use the selected currency.
- Go to **Analytics > Overview** and ensure that the **Leaderboards** use the store currency and not the frontend one.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**
- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
