### PR TITLE
Add order data to Multi-Currency tracking.

### DIFF
--- a/includes/multi-currency/Tracking.php
+++ b/includes/multi-currency/Tracking.php
@@ -110,15 +110,12 @@ class Tracking {
 	}
 
 	/**
-	 * Queries the postmeta table to see how many orders have been made using Multi-Currency.
+	 * Queries the database to see how many orders have been made using Multi-Currency.
 	 *
 	 * @return array Result count.
 	 */
 	private function get_mc_order_count(): array {
 		global $wpdb;
-
-		$results = $wpdb->get_results( "SELECT post_id FROM {$wpdb->prefix}postmeta WHERE meta_key = '_wcpay_multi_currency_order_exchange_rate'" );
-		$total   = is_array( $results ) ? count( $results ) : 0;
 
 		$orders_by_currency = $wpdb->get_results(
 			"
@@ -127,16 +124,19 @@ class Tracking {
 			FROM (
 				SELECT
 					orders.id AS order_id,
-					MAX(CASE WHEN meta_key = '_payment_method' THEN meta_value END) gateway,
-					MAX(CASE WHEN meta_key = '_order_total' THEN meta_value END) total,
-					MAX(CASE WHEN meta_key = '_order_currency' THEN meta_value END) currency
+					MAX(CASE WHEN order_meta.meta_key = '_payment_method' THEN order_meta.meta_value END) gateway,
+					MAX(CASE WHEN order_meta.meta_key = '_order_total' THEN order_meta.meta_value END) total,
+					MAX(CASE WHEN order_meta.meta_key = '_order_currency' THEN order_meta.meta_value END) currency
 				FROM
 					{$wpdb->prefix}posts orders
 				LEFT JOIN
 					{$wpdb->prefix}postmeta order_meta ON order_meta.post_id = orders.id
+                INNER JOIN
+					{$wpdb->prefix}postmeta mc_meta ON mc_meta.post_id = orders.id 
+                    AND mc_meta.meta_key = '_wcpay_multi_currency_order_exchange_rate'
 				WHERE orders.post_type = 'shop_order'
 					AND orders.post_status in ( 'wc-completed', 'wc-processing', 'wc-refunded' )
-					AND meta_key in ( '_payment_method', '_order_total', '_order_currency', '_wcpay_multi_currency_order_exchange_rate' )
+					AND order_meta.meta_key in ( '_payment_method', '_order_total', '_order_currency' )
 				GROUP BY orders.id
 			) order_gateways
 			GROUP BY currency, gateway
@@ -144,29 +144,32 @@ class Tracking {
 		);
 
 		$currencies  = [];
-		$added_total = 0;
+		$total_count = 0;
 		foreach ( $orders_by_currency as $group ) {
+			// Get current counts and totals.
 			$counts = $currencies[ $group->currency ]['counts'] ?? 0;
 			$totals = $currencies[ $group->currency ]['totals'] ?? 0;
 
-			$currencies[ $group->currency ] = [
-				'counts'   => $counts + $group->counts,
-				'totals'   => $totals + $group->totals,
-				'gateways' => [
-					$group->gateway => [
-						'counts' => $group->counts,
-						'totals' => $group->totals,
-					],
-				],
+			// Update the counts and totals for the currency.
+			$currencies[ $group->currency ]['counts'] = $counts + $group->counts;
+			$currencies[ $group->currency ]['totals'] = $totals + $group->totals;
+
+			// If something provides a 100% discount, the payment method is null. This could be coupons, gift cards, etc.
+			$gateway = $group->gateway ?? 'unknown';
+
+			// Update the counts and totals per gateway for the currency.
+			$currencies[ $group->currency ]['gateways'][ $gateway ] = [
+				'counts' => $group->counts,
+				'totals' => $group->totals,
 			];
 
-			$added_total += $group->counts;
+			// Update the total count.
+			$total_count += $group->counts;
 		}
 
 		return [
-			'total'       => $total,
-			'added_total' => $added_total,
-			'currencies'  => $currencies,
+			'counts'     => $total_count,
+			'currencies' => $currencies,
 		];
 	}
 }


### PR DESCRIPTION
Fixes #2762

#### Requested data

1. Weekly active merchants by default currency
   1. The sum should match weekly active merchants – however it will provide a breakdown of their default currencies. IE, on any given week if there are 300 active merchants, 200 have a default currency of USD, 150 have a default currency of GBP, and 50 have default currency of EUR. Plotted as a stacked bar chart
1. Active customer currencies
   1. Provide a count of active merchants using each customer currency plotted as a line chart. To Provides insight into the most used customer currencies,
1. Count of successful charge transactions by currency type
   1. Track if the charge was completed with a default currency or a customer currency. (Only customer currencies set by wcpay multi-currency) This will give us a high level overview of whether or not customers are using the feature, and can be used to track revenue for the feature by backing out fees associated with the transactions. 

#### Changes proposed in this Pull Request

The data in 1 and 2 is provided by the data being added by #2852.

* Update `get_mc_order_count` to return an array of data rather than just an int. Data returned includes:
  * Total order count for orders that have the statuses of `wc-completed`, `wc-processing`, or `wc-refunded`, and have the meta key `_wcpay_multi_currency_order_exchange_rate`. This means it returns completed orders that have had the exchange rate set by MC.
  * Currencies from the orders, with their total order count and order totals. It also then breaks down the order data by gateway.
  * Noting that the gateway will show as `unknown` if the gateway is not set, which happens if a 100% coupon or something similar is used.
* Changelog not updated due to there are multiple tracking updates happening and adding only a single entry should suffice.

```
    [wcpay_multi_currency] => Array
        (
            [enabled_currencies] => Array
                (
                    [BIF] => Array
                        (
                            [code] => BIF
                            [name] => Burundian franc
                            [is_zero_decimal] => 1
                            [rate_type] => manual
                            [price_rounding] => 50
                            [price_charm] => -1
                        )

                    [CAD] => Array
                        (
                            [code] => CAD
                            [name] => Canadian dollar
                            [is_zero_decimal] => 
                            [rate_type] => manual
                            [price_rounding] => 0.50
                            [price_charm] => -0.01
                        )

                    [CLP] => Array
                        (
                            [code] => CLP
                            [name] => Chilean peso
                            [is_zero_decimal] => 1
                            [rate_type] => automatic (default)
                            [price_rounding] => 100 (default)
                            [price_charm] => 0.00 (default)
                        )

                    [EUR] => Array
                        (
                            [code] => EUR
                            [name] => Euro
                            [is_zero_decimal] => 
                            [rate_type] => automatic (default)
                            [price_rounding] => 1.00 (default)
                            [price_charm] => 0.00 (default)
                        )

                    [JPY] => Array
                        (
                            [code] => JPY
                            [name] => Japanese yen
                            [is_zero_decimal] => 1
                            [rate_type] => automatic (default)
                            [price_rounding] => 100 (default)
                            [price_charm] => 0.00 (default)
                        )

                    [GBP] => Array
                        (
                            [code] => GBP
                            [name] => Pound sterling
                            [is_zero_decimal] => 
                            [rate_type] => automatic (default)
                            [price_rounding] => 1.00 (default)
                            [price_charm] => 0.00 (default)
                        )
                )

            [default_currency] => Array
                (
                    [code] => USD
                    [name] => United States (US) dollar
                )

            [order_counts] => Array
                (
                    [counts] => 360
                    [currencies] => Array
                        (
                            [BIF] => Array
                                (
                                    [counts] => 1
                                    [totals] => 32571
                                    [gateways] => Array
                                        (
                                            [woocommerce_payments] => Array
                                                (
                                                    [counts] => 1
                                                    [totals] => 32571
                                                )
                                        )
                                )

                            [CAD] => Array
                                (
                                    [counts] => 340
                                    [totals] => 12258.49
                                    [gateways] => Array
                                        (
                                            [unknown] => Array
                                                (
                                                    [counts] => 4
                                                    [totals] => 0
                                                )
                                            [stripe] => Array
                                                (
                                                    [counts] => 2
                                                    [totals] => 26.240000000000002
                                                )
                                            [woocommerce_payments] => Array
                                                (
                                                    [counts] => 334
                                                    [totals] => 12232.250000000002
                                                )
                                        )
                                )

                            [EUR] => Array
                                (
                                    [counts] => 17
                                    [totals] => 768.94
                                    [gateways] => Array
                                        (
                                            [stripe] => Array
                                                (
                                                    [counts] => 1
                                                    [totals] => 9.28
                                                )
                                            [woocommerce_payments] => Array
                                                (
                                                    [counts] => 16
                                                    [totals] => 759.6599999999999
                                                )
                                        )
                                )

                            [GBP] => Array
                                (
                                    [counts] => 2
                                    [totals] => 86.92
                                    [gateways] => Array
                                        (
                                            [woocommerce_payments] => Array
                                                (
                                                    [counts] => 2
                                                    [totals] => 86.92
                                                )
                                        )
                                )
                        )
                )
        )
```

#### Testing instructions

* If you do not have at least 1 additional currency, go to WooCommerce > Settings > Multi-Currency and add an additional currency.
* Go to your store and select an additional currency and purchase an item.
* Go to Marketing > Coupons and create a _Percentage discount_ coupon  with an about of 100 (for 100% off).
* Go to your store and purchase an item with the coupon.
* Make sure you have `WP_DEBUG` and `WP_DEBUG_LOG` set to `true`.
* Add the below snippets either in your `functions.php` file, or via the Code Snippets plugin.
* Go to WooCommerce > Settings > Advanced > WooCommerce.com and _Enable tracking_.
* From here you must trigger the tracking cron in one of two ways:
  * CLI command: `wp cron event run woocommerce_tracker_send_event`, or
  * Use the WP Crontrol plugin, which has the events under Tools > Cron events
* The last snippet will cause the full data sent to WC Tracker to be logged to your `debug.log`, and the last part of the data should be in the same format as the array mentioned above. 


```
add_filter( 'woocommerce_tracker_send_override', '__return_false' );
add_filter( 'woocommerce_tracker_last_send_time', '__return_false' );

add_filter(
	'woocommerce_tracker_data',
	function( $data ) {
		error_log( __FILE__ . ':' . __LINE__ . ":\n" . '$data: ' . print_r( $data, true ) );
		return $data;
	},
	999
);
```

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
