### PR TITLE
Fix Survey Submission Error with default survey answer

### DIFF
--- a/client/settings/survey-modal/provider.js
+++ b/client/settings/survey-modal/provider.js
@@ -8,12 +8,16 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import WcPaySurveyContext from './context';
+import { wcPaySurveys } from './questions';
 import { NAMESPACE } from '../../data/constants';
 
 const WcPaySurveyContextProvider = ( { children } ) => {
 	const [ isSurveySubmitted, setSurveySubmitted ] = useState( false );
 	const [ status, setStatus ] = useState( 'resolved' );
-	const [ surveyAnswers, setSurveyAnswers ] = useState( {} );
+	// set a default answer since the survey form has a default value.
+	const [ surveyAnswers, setSurveyAnswers ] = useState(
+		wcPaySurveys[ 0 ].defaultAnswer
+	);
 
 	const submitSurvey = useCallback( () => {
 		setStatus( 'pending' );

--- a/client/settings/survey-modal/questions.js
+++ b/client/settings/survey-modal/questions.js
@@ -5,6 +5,7 @@
 export const wcPaySurveys = [
 	{
 		key: 'wcpay-upe-disable-early-access',
+		defaultAnswer: { 'why-disable': 'slow-buggy' },
 		questions: {
 			'why-disable': {
 				'slow-buggy': 'It is slow or buggy',

--- a/client/settings/survey-modal/test/index.test.js
+++ b/client/settings/survey-modal/test/index.test.js
@@ -58,7 +58,7 @@ describe( 'WcPaySurveyContextProvider', () => {
 			isSurveySubmitted: false,
 			submitSurvey: expect.any( Function ),
 			status: 'resolved',
-			surveyAnswers: {},
+			surveyAnswers: { 'why-disable': 'slow-buggy' },
 			setSurveyAnswers: expect.any( Function ),
 		} );
 		expect( apiFetch ).not.toHaveBeenCalled();


### PR DESCRIPTION
The UPE Feedback form has a default value specified within the RadioControl component. The `change` handler is hooked up to functions created by `WcPaySurveyContext`, however, the survey answer will be an empty object by default. This means that if you submit the form without changing any of the answers, you'll get an error because you haven't triggered the RadioControl component's `onChange()` function.

This sets a default answer within the provider itself and adds a new `defaultAnswer` property to a question array item to help avoid some hard-coding.

#### Testing instructions

- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments
- Click the Hamburger menu on the top-right of the **Payment Methods** card, select **Provide Feedback**
- Submit the form without changing the answer(you could add a comment to make it easier to filter out test submissions).
- Verify that it submits with a positive toast notification.

- [x] Covered with tests (or have a good reason not to test in description ☝️)