### PR TITLE
MC Onboarding: Enabled currencies missing currency bug

### DIFF
--- a/client/multi-currency-setup/tasks/add-currencies-task/test/utils.test.js
+++ b/client/multi-currency-setup/tasks/add-currencies-task/test/utils.test.js
@@ -1,0 +1,172 @@
+/**
+ * Internal dependencies
+ */
+import {
+	ConcatenateCurrencyStrings,
+	StringRepresentationOfCurrency,
+} from '../utils';
+
+const availableCurrencies = {
+	USD: {
+		code: 'USD',
+		rate: 1,
+		name: 'United States (US) dollar',
+		id: 'usd',
+		is_default: true,
+		flag: '🇺🇸',
+		symbol: '$',
+	},
+	CAD: {
+		code: 'CAD',
+		rate: '1.206823',
+		name: 'Canadian dollar',
+		id: 'cad',
+		is_default: false,
+		flag: '🇨🇦',
+		symbol: '$',
+	},
+	GBP: {
+		code: 'GBP',
+		rate: '0.708099',
+		name: 'Pound sterling',
+		id: 'gbp',
+		is_default: false,
+		flag: '🇬🇧',
+		symbol: '£',
+	},
+	EUR: {
+		code: 'EUR',
+		rate: '0.826381',
+		name: 'Euro',
+		id: 'eur',
+		is_default: false,
+		flag: '🇪🇺',
+		symbol: '€',
+	},
+	AED: {
+		code: 'AED',
+		rate: '3.6732',
+		name: 'United Arab Emirates dirham',
+		id: 'aed',
+		is_default: false,
+		flag: '🇦🇪',
+		symbol: 'د.إ',
+	},
+	CDF: {
+		code: 'CDF',
+		rate: '2000',
+		name: 'Congolese franc',
+		id: 'cdf',
+		is_default: false,
+		flag: '🇨🇩',
+		symbol: 'Fr',
+	},
+	AUD: {
+		code: 'AUD',
+		rate: 1.79,
+		name: 'Australian dollar',
+		id: 'aud',
+		is_default: false,
+		flag: '🇦🇺',
+		symbol: '$',
+	},
+	JPY: {
+		code: 'JPY',
+		rate: 1,
+		name: 'Japanese yen',
+		id: 'jpy',
+		is_default: false,
+		flag: '🇯🇵',
+		symbol: '¥',
+	},
+	INR: {
+		code: 'INR',
+		rate: 1,
+		name: 'Indian rupee',
+		id: 'inr',
+		is_default: false,
+		flag: '🇮🇳',
+		symbol: '₹',
+		is_zero_decimal: false,
+		last_updated: 1630070442,
+	},
+	DKK: {
+		code: 'DKK',
+		rate: '6.144615',
+		name: 'Danish krone',
+		id: 'dkk',
+		is_default: false,
+		flag: '🇩🇰',
+		symbol: 'DKK',
+	},
+	BIF: {
+		code: 'BIF',
+		rate: '1974',
+		name: 'Burundian franc',
+		id: 'bif',
+		is_default: false,
+		flag: '🇧🇮',
+		symbol: 'Fr',
+	},
+	CLP: {
+		code: 'CLP',
+		rate: '706.8',
+		name: 'Chilean peso',
+		id: 'clp',
+		is_default: false,
+		flag: '🇨🇱',
+		symbol: '$',
+	},
+};
+
+describe( 'Multi-currency setup utility functions', () => {
+	it( 'should represent the currencies correctly', () => {
+		const expectationMap = {
+			USD: 'United States (US) dollar ($ USD)',
+			JPY: 'Japanese yen (¥ JPY)',
+			DKK: 'Danish krone (DKK)',
+			EUR: 'Euro (€ EUR)',
+			CLP: 'Chilean peso ($ CLP)',
+			XXX: '',
+			undefined: '',
+			false: '',
+		};
+		Object.keys( expectationMap ).forEach( ( currency ) => {
+			expect(
+				StringRepresentationOfCurrency(
+					availableCurrencies[ currency ]
+				)
+			).toEqual( expectationMap[ currency ] );
+		} );
+	} );
+
+	it( 'should concatenate the string representations right', () => {
+		const availableCurrenciesCopy = Object.assign(
+			{},
+			availableCurrencies
+		);
+		const results = [];
+		for ( let runCount = 0; 5 > runCount; runCount++ ) {
+			results.push(
+				ConcatenateCurrencyStrings(
+					Object.keys( availableCurrencies ).slice( 0, runCount ),
+					'GBP',
+					availableCurrencies
+				)
+			);
+			expect( availableCurrenciesCopy ).toEqual( availableCurrencies );
+		}
+		expect( results[ 0 ] ).toEqual( '' );
+		expect( results[ 1 ] ).toEqual( 'United States (US) dollar ($ USD)' );
+		expect( results[ 2 ] ).toEqual(
+			'United States (US) dollar ($ USD) and Canadian dollar ($ CAD)'
+		);
+		// Should skip GBP as it's the except key
+		expect( results[ 3 ] ).toEqual(
+			'United States (US) dollar ($ USD) and Canadian dollar ($ CAD)'
+		);
+		expect( results[ 4 ] ).toEqual(
+			'United States (US) dollar ($ USD), Canadian dollar ($ CAD), and Euro (€ EUR)'
+		);
+	} );
+} );

--- a/client/multi-currency-setup/tasks/add-currencies-task/utils.js
+++ b/client/multi-currency-setup/tasks/add-currencies-task/utils.js
@@ -31,22 +31,23 @@ export const ConcatenateCurrencyStrings = (
 	except,
 	currenciesData
 ) => {
-	if ( currencies.includes( except ) )
-		currencies.splice( currencies.indexOf( except ), 1 );
-	if ( 0 === currencies.length ) return '';
-	if ( 1 === currencies.length )
+	const currenciesCopy = [ ...currencies ];
+	if ( currenciesCopy.includes( except ) )
+		currenciesCopy.splice( currenciesCopy.indexOf( except ), 1 );
+	if ( 0 === currenciesCopy.length ) return '';
+	if ( 1 === currenciesCopy.length )
 		return StringRepresentationOfCurrency(
-			currenciesData[ currencies[ 0 ] ]
+			currenciesData[ currenciesCopy[ 0 ] ]
 		);
-	if ( 2 === currencies.length )
-		return currencies
+	if ( 2 === currenciesCopy.length )
+		return currenciesCopy
 			.map( ( d ) => currenciesData[ d ] )
 			.map( StringRepresentationOfCurrency )
 			.join( __( ' and ' ) );
 
-	const lastCurrency = currenciesData[ currencies.pop() ];
+	const lastCurrency = currenciesData[ currenciesCopy.pop() ];
 	return (
-		currencies
+		currenciesCopy
 			.map( ( d ) => currenciesData[ d ] )
 			.map( StringRepresentationOfCurrency )
 			.join( ', ' ) +

--- a/client/multi-currency-setup/tasks/add-currencies-task/utils.js
+++ b/client/multi-currency-setup/tasks/add-currencies-task/utils.js
@@ -31,23 +31,21 @@ export const ConcatenateCurrencyStrings = (
 	except,
 	currenciesData
 ) => {
-	const currenciesCopy = [ ...currencies ];
-	if ( currenciesCopy.includes( except ) )
-		currenciesCopy.splice( currenciesCopy.indexOf( except ), 1 );
-	if ( 0 === currenciesCopy.length ) return '';
-	if ( 1 === currenciesCopy.length )
+	const currenciesToList = currencies.filter( ( code ) => code !== except );
+	if ( 0 === currenciesToList.length ) return '';
+	if ( 1 === currenciesToList.length )
 		return StringRepresentationOfCurrency(
-			currenciesData[ currenciesCopy[ 0 ] ]
+			currenciesData[ currenciesToList[ 0 ] ]
 		);
-	if ( 2 === currenciesCopy.length )
-		return currenciesCopy
+	if ( 2 === currenciesToList.length )
+		return currenciesToList
 			.map( ( d ) => currenciesData[ d ] )
 			.map( StringRepresentationOfCurrency )
 			.join( __( ' and ' ) );
 
-	const lastCurrency = currenciesData[ currenciesCopy.pop() ];
+	const lastCurrency = currenciesData[ currenciesToList.pop() ];
 	return (
-		currenciesCopy
+		currenciesToList
 			.map( ( d ) => currenciesData[ d ] )
 			.map( StringRepresentationOfCurrency )
 			.join( ', ' ) +

--- a/client/multi-currency-setup/tasks/add-currencies-task/utils.js
+++ b/client/multi-currency-setup/tasks/add-currencies-task/utils.js
@@ -10,12 +10,15 @@ import { sprintf, __ } from '@wordpress/i18n';
  * @return {string} The string representation of the currency object.
  */
 export const StringRepresentationOfCurrency = ( currency ) => {
-	const name = currency.name;
-	const hintText =
-		currency.code === currency.symbol
-			? currency.code
-			: sprintf( '%s %s', currency.symbol, currency.code );
-	return sprintf( '%s (%s)', name, hintText );
+	if ( currency && currency.name && currency.symbol && currency.code ) {
+		const name = currency.name;
+		const hintText =
+			currency.code === currency.symbol
+				? currency.code
+				: sprintf( '%s %s', currency.symbol, currency.code );
+		return sprintf( '%s (%s)', name, hintText );
+	}
+	return '';
 };
 
 /**
@@ -31,27 +34,19 @@ export const ConcatenateCurrencyStrings = (
 	except,
 	currenciesData
 ) => {
-	const currenciesToList = currencies.filter( ( code ) => code !== except );
-	if ( 0 === currenciesToList.length ) return '';
-	if ( 1 === currenciesToList.length )
-		return StringRepresentationOfCurrency(
-			currenciesData[ currenciesToList[ 0 ] ]
-		);
-	if ( 2 === currenciesToList.length )
-		return currenciesToList
-			.map( ( d ) => currenciesData[ d ] )
-			.map( StringRepresentationOfCurrency )
-			.join( __( ' and ' ) );
-
-	const lastCurrency = currenciesData[ currenciesToList.pop() ];
-	return (
-		currenciesToList
-			.map( ( d ) => currenciesData[ d ] )
-			.map( StringRepresentationOfCurrency )
-			.join( ', ' ) +
-		', ' +
-		__( 'and', 'woocommerce-payments' ) +
-		' ' +
-		StringRepresentationOfCurrency( lastCurrency )
+	const filteredCurrencies = currencies.filter(
+		( code ) => code !== except && currenciesData[ code ]
 	);
+	const __and = __( 'and', 'woocommerce-payments' );
+	return filteredCurrencies
+		.map( ( code ) =>
+			StringRepresentationOfCurrency( currenciesData[ code ] )
+		)
+		.join( ', ' )
+		.replace(
+			/, ([^,]+)$/,
+			2 === filteredCurrencies.length
+				? ' ' + __and + ' $1'
+				: ', ' + __and + ' $1'
+		);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

**Note:** This is a follow-up PR to solve a problem in the MC onboarding code (#2786), which I didn't realize before.

The function responsible for creating concatenated strings about previously enabled currencies were editing the enabled currencies array, and it caused missing enabled currencies when submitted.

The utility is used like this: 

```jsx
<strong>
	{ ConcatenateCurrencyStrings(
		enabledCurrencyCodes,
		defaultCurrencyCode,
		availableCurrencies
	) }
</strong>
```

And `ConcatenateCurrencyStrings` had this statement inside:


```js
export const ConcatenateCurrencyStrings = (
	currencies,
	except,
	currenciesData
) => {
	if ( currencies.includes( except ) )
		currencies.splice( currencies.indexOf( except ), 1 );
```

Which altered the original array, and caused problems like missing currencies on the enabled list. This PR fixes that.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I don't have a concrete scenario for this but I've observed this multiple times with the previous version:

* Set your store currency something different than USD.
* Go to the onboarding screen by clicking the MC note on WCPay home screen.
* Add some currencies (including USD) and make it to the next step.
* Refresh the page and return back to step 1.
* Select another currency and save it again.
* In the previous version, you'd have USD missing from the enabled list and available back for selection again, I don't know why.
* In the current version, you shouldn't be losing any data when something like this occurs.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
