### PR TITLE
Change fee breakdown when there's only a base fee

### DIFF
--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -163,6 +163,20 @@ const isFXEvent = ( event = {} ) => {
 	);
 };
 
+/**
+ * Returns a boolean indicating whether only fee applied is the base fee
+ *
+ * @param {Object} event Event object
+ *
+ * @return {boolean} true if the only applied fee is the base fee
+ */
+const isBaseFeeOnly = ( event ) => {
+	if ( ! event.fee_rates ) return false;
+
+	const history = event.fee_rates.history;
+	return 1 === history?.length && 'base' === history[ 0 ].type;
+};
+
 const composeNetString = ( event ) => {
 	if ( ! isFXEvent( event ) ) {
 		return formatExplicitCurrency(
@@ -201,11 +215,13 @@ const composeFeeString = ( event ) => {
 	}
 
 	return sprintf(
-		/* translators: %1$s is the total fee amount, %2$f%% is the fee percentage, and %3$s is the fixed fee amount. */
-		__( 'Fee (%2$f%% + %3$s): %1$s', 'woocommerce-payments' ),
+		/* translators: %1$s is the total fee amount, %2$f%% is the fee percentage, %3$s is the fixed fee amount
+		 * and %4%s is the fee label  */
+		__( '%4$s (%2$f%% + %3$s): %1$s', 'woocommerce-payments' ),
 		formatCurrency( -feeAmount, feeCurrency ),
 		formatFee( percentage ),
-		formatCurrency( fixed, fixedCurrency )
+		formatCurrency( fixed, fixedCurrency ),
+		isBaseFeeOnly( event ) ? 'Base fee' : 'Fee'
 	);
 };
 
@@ -330,7 +346,11 @@ const feeBreakdown = ( event ) => {
 		);
 	} );
 
-	return <ul className="fee-breakdown-list">{ feeHistoryList }</ul>;
+	return (
+		<ul className="fee-breakdown-list">
+			{ isBaseFeeOnly( event ) ? [] : feeHistoryList }
+		</ul>
+	);
 };
 
 /**

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -541,6 +541,57 @@ Array [
 ]
 `;
 
+exports[`mapTimelineEvents single currency events formats captured events with just the base fee 1`] = `
+Array [
+  Object {
+    "body": Array [],
+    "date": 2020-04-01T14:37:54.000Z,
+    "headline": "Payment status changed to Paid.",
+    "icon": <t
+      className=""
+      icon="sync"
+      size={24}
+    />,
+  },
+  Object {
+    "body": Array [],
+    "date": 2020-04-01T14:37:54.000Z,
+    "headline": <React.Fragment>
+      $59.50 USD was added to your 
+      <Link
+        href="admin.php?page=wc-admin&path=%2Fpayments%2Fdeposits%2Fdetails&id=dummy_po_5eaada696b281"
+        type="wc-admin"
+      >
+        Apr 2, 2020 deposit
+      </Link>
+      .
+    </React.Fragment>,
+    "icon": <t
+      className=""
+      icon="plus"
+      size={24}
+    />,
+  },
+  Object {
+    "body": Array [
+      undefined,
+      "Base fee (1.95% + $0.15): $-3.50",
+      <ul
+        className="fee-breakdown-list"
+      />,
+      "Net deposit: $59.50 USD",
+    ],
+    "date": 2020-04-01T14:37:54.000Z,
+    "headline": "A payment of $63.00 USD was successfully charged.",
+    "icon": <t
+      className="is-success"
+      icon="checkmark"
+      size={24}
+    />,
+  },
+]
+`;
+
 exports[`mapTimelineEvents single currency events formats captured events without fee details 1`] = `
 Array [
   Object {

--- a/client/payment-details/timeline/test/map-events.js
+++ b/client/payment-details/timeline/test/map-events.js
@@ -214,6 +214,37 @@ describe( 'mapTimelineEvents', () => {
 			).toMatchSnapshot();
 		} );
 
+		test( 'formats captured events with just the base fee', () => {
+			expect(
+				mapTimelineEvents( [
+					{
+						amount: 6300,
+						currency: 'USD',
+						datetime: 1585751874,
+						deposit: {
+							arrival_date: 1585838274,
+							id: 'dummy_po_5eaada696b281',
+						},
+						fee: 350,
+						fee_rates: {
+							percentage: 0.0195,
+							fixed: 15,
+							fixed_currency: 'USD',
+							history: [
+								{
+									type: 'base',
+									percentage_rate: 0.014,
+									fixed_rate: 20,
+									currency: 'gbp',
+								},
+							],
+						},
+						type: 'captured',
+					},
+				] )
+			).toMatchSnapshot();
+		} );
+
 		test( 'formats dispute_needs_response events', () => {
 			expect(
 				mapTimelineEvents( [


### PR DESCRIPTION
Fixes #2905 

#### Changes proposed in this Pull Request
As mentioned in #2905, fee breakdown is displayed on transaction details page even if only base fee is applied

Following changes are proposed here,
1. Hide the fee breakdown when only a base fee is applied to the transaction
2. Change fee title from "Fee" to "Base fee"
3. Add a test case to cover single base fee scenario

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
When there's only a base fee
![Screen Shot 2021-09-16 at 10 12 07 AM](https://user-images.githubusercontent.com/6216000/133638262-556eb180-171d-45d2-9ba6-d202e4a3a3a0.png)

With additional fees (Should be same as before)
![Screen Shot 2021-09-16 at 10 12 21 AM](https://user-images.githubusercontent.com/6216000/133638297-32d4f695-8f38-4dda-8637-e6949b919a61.png)


#### Testing instructions

**To test transactions with just the base fee**
1. Make a purchase.
2. Go to transaction details page.
3. See fee breakdown with a single item.

**To test transactions with multiple fees**
This flow should stay unchanged with the changes proposed here.
1. Make a purchase with a different currency than store's currency
    i. Set store currency to US
    ii. Enable giropay and/or Sofort from Payments -> Settings -> Add Payment Method 
    iii. In checkout page as a buyer, change the currency to EUR and make a purchase 
2. See that fee breakdown is still visible and fee label shows as "Fee"
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
