### PR TITLE
Remove redundant args from the create subscription request

### DIFF
--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -299,12 +299,9 @@ class WC_Payments_Subscription_Service {
 	 */
 	private function prepare_wcpay_subscription_data( string $wcpay_customer_id, WC_Subscription $subscription ) {
 		$items = $this->product_service->get_product_data_for_subscription( $subscription );
-
-		$data = [
-			'customer'           => $wcpay_customer_id,
-			'items'              => $items,
-			'proration_behavior' => 'none',
-			'payment_behavior'   => 'default_incomplete', // creates an incomplete/pending wcpay subscription while still processing the payment on checkout.
+		$data  = [
+			'customer' => $wcpay_customer_id,
+			'items'    => $items,
 		];
 
 		if ( self::has_delayed_payment( $subscription ) ) {

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -102,10 +102,8 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 
 		$mock_wcpay_subscription_id = 'wcpay_subscription_test12345';
 		$mock_subscription_data     = [
-			'customer'           => 'wcpay_cus_test12345',
-			'items'              => [ 'not empty subscription data' ],
-			'proration_behavior' => 'none',
-			'payment_behavior'   => 'default_incomplete',
+			'customer' => 'wcpay_cus_test12345',
+			'items'    => [ 'not empty subscription data' ],
 		];
 
 		$this->assertNotEquals( $mock_subscription->get_meta( self::SUBSCRIPTION_ID_META_KEY ), $mock_wcpay_subscription_id );
@@ -281,10 +279,8 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 			->willReturn( [ 'item1' => 'item1_data' ] );
 
 		$expected_result = [
-			'customer'           => $mock_wcpay_customer_id,
-			'items'              => [ 'item1' => 'item1_data' ],
-			'proration_behavior' => 'none',
-			'payment_behavior'   => 'default_incomplete',
+			'customer' => $mock_wcpay_customer_id,
+			'items'    => [ 'item1' => 'item1_data' ],
 		];
 
 		$actual_result = PHPUnit_Utils::call_method(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When forming the create subscription request we would include two hardcoded args.

```php
'proration_behavior' => 'none',
'payment_behavior'   => 'default_incomplete'
```

These args aren't necessary because they are hardcoded on the server and aren't [declared as accepted args](https://git.io/JzJCA). 

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the WC Subscriptions plugin is deactivated.
* Check out this branch.
* Purchase a subscription product. 
* Check your merchant dashboard in Stripe and note that the subscription is created correctly. 
* If you check the initial subscription request (see screenshots below), you'll notice these args are still being sent.

<img width="1444" alt="Screen Shot 2021-09-17 at 4 30 58 pm" src="https://user-images.githubusercontent.com/8490476/133735518-2ad89a92-2eac-4691-bf6c-a12eadff35a1.png">
 
<img width="700" alt="Screen Shot 2021-09-17 at 4 31 15 pm" src="https://user-images.githubusercontent.com/8490476/133735520-03fa9dbb-48e9-4154-ac5e-053b4fe5f453.png">

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)