### PR TITLE
Trigger an event to init the tokenization-form.js script

### DIFF
--- a/client/checkout/classic/index.js
+++ b/client/checkout/classic/index.js
@@ -212,6 +212,17 @@ jQuery( function ( $ ) {
 		if ( $( '#wcpay-sepa-element' ).length ) {
 			sepaElement.mount( '#wcpay-sepa-element' );
 		}
+
+		/*
+		 * Trigger this event to ensure the tokenization-form.js init
+		 * is executed.
+		 *
+		 * This script handles the radio input interaction when toggling
+		 * between the user's saved card / entering new card details.
+		 *
+		 * Ref: https://github.com/woocommerce/woocommerce/blob/2429498/assets/js/frontend/tokenization-form.js#L109
+		 */
+		$( document.body ).trigger( 'wc-credit-card-form-init' );
 	}
 
 	// Update the validation state based on the element's state.

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -249,6 +249,17 @@ jQuery( function ( $ ) {
 			return;
 		}
 
+		/*
+		 * Trigger this event to ensure the tokenization-form.js init
+		 * is executed.
+		 *
+		 * This script handles the radio input interaction when toggling
+		 * between the user's saved card / entering new card details.
+		 *
+		 * Ref: https://github.com/woocommerce/woocommerce/blob/2429498/assets/js/frontend/tokenization-form.js#L109
+		 */
+		$( document.body ).trigger( 'wc-credit-card-form-init' );
+
 		// If paying from order, we need to create Payment Intent from order not cart.
 		const isOrderPay = getConfig( 'isOrderPay' );
 		const isCheckout = getConfig( 'isCheckout' );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -627,7 +627,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		wp_register_script(
 			'WCPAY_CHECKOUT',
 			plugins_url( 'dist/checkout.js', WCPAY_PLUGIN_FILE ),
-			[ 'stripe', 'wc-checkout' ],
+			[ 'stripe', 'wc-checkout', 'woocommerce-tokenization-form' ],
 			WC_Payments::get_file_version( 'dist/checkout.js' ),
 			true
 		);

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -109,7 +109,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		wp_register_script(
 			'wcpay-upe-checkout',
 			plugins_url( 'dist/upe_checkout.js', WCPAY_PLUGIN_FILE ),
-			[ 'stripe', 'wc-checkout' ],
+			[ 'stripe', 'wc-checkout', 'woocommerce-tokenization-form' ],
 			WC_Payments::get_file_version( 'dist/upe_checkout.js' ),
 			true
 		);


### PR DESCRIPTION
Fixes #2931 

#### Changes proposed in this Pull Request

This PR fires the `wc-credit-card-form-init` event on the `document.body` element to initialize the `tokenization-form.js` script in WC Core.

Ref: https://github.com/woocommerce/woocommerce/blob/2429498/assets/js/frontend/tokenization-form.js#L109

This **was not** happening which caused a small issue where the credit card form was visible on the subscription "Change payment method" page regardless of which radio button is selected in the "Credit card / debit card" box.

Screencast of the bug - https://d.pr/v/UyTaBD

With the fix in place, we can observe the expected behaviour - https://d.pr/v/fHD2J5

**Question:** I haven't tested just yet but it seems like this bug might also affect WC Subscriptions. So far, I have only tested with WCPay Subscriptions. If that's the case, it seems like we should probably move this fix to the subscriptions base to ensure it fixes the issue across both WCPay Subscriptions and WC Subscriptions?

Keen to hear some ideas or feedback about this.

#### Testing instructions

1. Create a subscription product and publish it.
2. As a shopper, purchase the subscription product from the store.
3. Navigate to My Account → Subscriptions.
4. Click the "View" button on the subscription you just purchased.
5. Click the "Change payment" button.
6. Scroll down the page to the "Credit card / debit card" box.
7. Ensure the credit card form is hidden by default if a saved card is selected.
8. Select the "Use a new payment method" radio input, observe the credit card form is visible.
9. Select a saved card radio input, observe the credit card form is hidden.

This should work regardless of whether UPE is enabled or disabled.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
