### PR TITLE
Switch the charge ID and the paymentIntent ID in the copy of a couple screens

### DIFF
--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -173,7 +173,9 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 									'Payment ID',
 									'woocommerce-payments'
 								) }: ` }
-								{ charge.payment_intent }
+								{ charge.payment_intent
+									? charge.payment_intent
+									: charge.id }
 							</Loadable>
 						</div>
 					</div>

--- a/client/payment-details/summary/index.js
+++ b/client/payment-details/summary/index.js
@@ -167,13 +167,13 @@ const PaymentDetailsSummary = ( { charge = {}, isLoading } ) => {
 						<div className="payment-details-summary__id">
 							<Loadable
 								isLoading={ isLoading }
-								placeholder="Payment ID: ch_xxxxxxxxxxxxxxxxxxxxxxxx"
+								placeholder="Payment ID: pi_xxxxxxxxxxxxxxxxxxxxxxxx"
 							>
 								{ `${ __(
 									'Payment ID',
 									'woocommerce-payments'
 								) }: ` }
-								{ charge.id }
+								{ charge.payment_intent }
 							</Loadable>
 						</div>
 					</div>

--- a/client/payment-details/summary/test/__snapshots__/index.js.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.js.snap
@@ -674,7 +674,7 @@ exports[`PaymentDetailsSummary renders loading state 1`] = `
               aria-busy="true"
               class="is-loadable-placeholder"
             >
-              Payment ID: ch_xxxxxxxxxxxxxxxxxxxxxxxx
+              Payment ID: pi_xxxxxxxxxxxxxxxxxxxxxxxx
             </span>
           </div>
         </div>

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1154,7 +1154,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 							]
 						),
 						WC_Payments_Explicit_Price_Formatter::get_explicit_price( wc_price( $amount, [ 'currency' => $currency ] ), $order ),
-						$intent_id
+						$charge_id
 					);
 					$order->add_order_note( $note );
 				}
@@ -1884,7 +1884,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 								]
 							),
 							WC_Payments_Explicit_Price_Formatter::get_explicit_price( wc_price( $amount, [ 'currency' => $order->get_currency() ] ), $order ),
-							$intent_id
+							$intent->get_charge_id()
 						);
 						$order->add_order_note( $note );
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -231,10 +231,10 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->method( 'add_order_note' )
 			->with(
 				$this->callback(
-					function( $note ) use ( $intent_id, $total ) {
+					function( $note ) use ( $charge_id, $total ) {
 						return (
 						strpos( $note, 'successfully charged' )
-						&& strpos( $note, $intent_id )
+						&& strpos( $note, $charge_id )
 						&& strpos( $note, strval( $total ) )
 						);
 					}


### PR DESCRIPTION
Fixes #540 (partially)

#### Changes proposed in this Pull Request

Switch the charge ID and the paymentIntent ID in the copy of a couple screens for consistency.

* In the order notes of a successfully paid order, we're now displaying the associated charge ID instead of the paymentIntent ID.
* In the top card of the Transaction Details screen, we're now displaying the paymentIntent ID instead of the charge ID under "Payment ID". 

Only the copy was updated. This shouldn't be a high-impact change. I've updated the associated tests.


#### Testing instructions

1. Purchase a product with a card via WCPay
2. Go edit the order. In the order notes, where it says "A payment of xx was successfully charged", the charge ID should be displayed as the anchor text to go to the Transaction Details page, instead of the paymentIntent ID
Before/After for the order notes
![image](https://user-images.githubusercontent.com/41606954/133791505-5dc0a868-0f5b-41ab-be39-6ad7ac176656.png)

3. Follow that link to go to the Transaction Details page
4. In the top card, it should display the paymentIntent ID instead of the charge ID
Before/After for the Transaction Details page
![image](https://user-images.githubusercontent.com/41606954/133791386-03334e5f-8329-4d6c-97c0-3b3ac9eb8a07.png)


-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
