### PR TITLE
Pass parameters in query string for DELETE requests.

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -23,7 +23,6 @@ class WC_Payments_API_Client {
 	const POST   = 'POST';
 	const GET    = 'GET';
 	const DELETE = 'DELETE';
-	const PUT    = 'PUT';
 
 	const API_TIMEOUT_SECONDS = 70;
 
@@ -1372,8 +1371,12 @@ class WC_Payments_API_Client {
 
 		$body = null;
 
+		$redacted_params = WC_Payments_Utils::redact_array( $params, self::API_KEYS_TO_REDACT );
+		$redacted_url    = $url;
+
 		if ( in_array( $method, [ self::GET, self::DELETE ], true ) ) {
-			$url .= '?' . http_build_query( $params );
+			$url          .= '?' . http_build_query( $params );
+			$redacted_url .= '?' . http_build_query( $redacted_params );
 		} else {
 			// Encode the request body as JSON.
 			$body = wp_json_encode( $params );
@@ -1391,11 +1394,11 @@ class WC_Payments_API_Client {
 		$headers['Content-Type'] = 'application/json; charset=utf-8';
 		$headers['User-Agent']   = $this->user_agent;
 
-		Logger::log( "REQUEST $method $url" );
-		if ( in_array( $method, [ self::POST, self::PUT ], true ) ) {
+		Logger::log( "REQUEST $method $redacted_url" );
+		if ( null !== $body ) {
 			Logger::log(
 				'BODY: '
-				. var_export( WC_Payments_Utils::redact_array( $params, self::API_KEYS_TO_REDACT ), true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+				. var_export( $redacted_params, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 			);
 		}
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1155,7 +1155,9 @@ class WC_Payments_API_Client {
 		return $this->request(
 			[],
 			self::SUBSCRIPTIONS_API . '/' . $wcpay_subscription_id,
-			self::DELETE
+			self::DELETE,
+			true,
+			true
 		);
 	}
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -23,6 +23,7 @@ class WC_Payments_API_Client {
 	const POST   = 'POST';
 	const GET    = 'GET';
 	const DELETE = 'DELETE';
+	const PUT    = 'PUT';
 
 	const API_TIMEOUT_SECONDS = 70;
 
@@ -1155,9 +1156,7 @@ class WC_Payments_API_Client {
 		return $this->request(
 			[],
 			self::SUBSCRIPTIONS_API . '/' . $wcpay_subscription_id,
-			self::DELETE,
-			true,
-			true
+			self::DELETE
 		);
 	}
 
@@ -1373,7 +1372,7 @@ class WC_Payments_API_Client {
 
 		$body = null;
 
-		if ( self::GET === $method ) {
+		if ( in_array( $method, [ self::GET, self::DELETE ], true ) ) {
 			$url .= '?' . http_build_query( $params );
 		} else {
 			// Encode the request body as JSON.
@@ -1393,7 +1392,7 @@ class WC_Payments_API_Client {
 		$headers['User-Agent']   = $this->user_agent;
 
 		Logger::log( "REQUEST $method $url" );
-		if ( 'POST' === $method || 'PUT' === $method ) {
+		if ( in_array( $method, [ self::POST, self::PUT ], true ) ) {
 			Logger::log(
 				'BODY: '
 				. var_export( WC_Payments_Utils::redact_array( $params, self::API_KEYS_TO_REDACT ), true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -188,46 +188,46 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 
 		// Mock the HTTP client manually to assert we are sending the correct args.
 		$this->mock_http_client
-		->expects( $this->once() )
-		->method( 'remote_request' )
-		->with(
-			[
-				'url'             => 'https://public-api.wordpress.com/wpcom/v2/sites/%s/wcpay/setup_intents',
-				'method'          => 'POST',
-				'headers'         => [
-					'Content-Type' => 'application/json; charset=utf-8',
-					'User-Agent'   => 'Unit Test Agent/0.1.0',
-				],
-				'timeout'         => 70,
-				'connect_timeout' => 70,
-			],
-			wp_json_encode(
+			->expects( $this->once() )
+			->method( 'remote_request' )
+			->with(
 				[
-					'test_mode'            => false,
-					'customer'             => $customer_id,
-					'confirm'              => 'false',
-					'payment_method_types' => $payment_method_types,
-				]
-			),
-			true,
-			false
-		)
-		->will(
-			$this->returnValue(
-				[
-					'body'     => wp_json_encode(
-						[
-							'id'     => 'seti_mock',
-							'object' => 'setup_intent',
-						]
-					),
-					'response' => [
-						'code'    => 200,
-						'message' => 'OK',
+					'url'             => 'https://public-api.wordpress.com/wpcom/v2/sites/%s/wcpay/setup_intents',
+					'method'          => 'POST',
+					'headers'         => [
+						'Content-Type' => 'application/json; charset=utf-8',
+						'User-Agent'   => 'Unit Test Agent/0.1.0',
 					],
-				]
+					'timeout'         => 70,
+					'connect_timeout' => 70,
+				],
+				wp_json_encode(
+					[
+						'test_mode'            => false,
+						'customer'             => $customer_id,
+						'confirm'              => 'false',
+						'payment_method_types' => $payment_method_types,
+					]
+				),
+				true,
+				false
 			)
-		);
+			->will(
+				$this->returnValue(
+					[
+						'body'     => wp_json_encode(
+							[
+								'id'     => 'seti_mock',
+								'object' => 'setup_intent',
+							]
+						),
+						'response' => [
+							'code'    => 200,
+							'message' => 'OK',
+						],
+					]
+				)
+			);
 
 		$result = $this->payments_api_client->create_setup_intention( $customer_id, $payment_method_types );
 
@@ -257,49 +257,49 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 
 		// Mock the HTTP client manually to assert we are adding mandate data.
 		$this->mock_http_client
-		->expects( $this->once() )
-		->method( 'remote_request' )
-		->with(
-			[
-				'url'             => 'https://public-api.wordpress.com/wpcom/v2/sites/%s/wcpay/setup_intents',
-				'method'          => 'POST',
-				'headers'         => [
-					'Content-Type' => 'application/json; charset=utf-8',
-					'User-Agent'   => 'Unit Test Agent/0.1.0',
-				],
-				'timeout'         => 70,
-				'connect_timeout' => 70,
-			],
-			wp_json_encode(
+			->expects( $this->once() )
+			->method( 'remote_request' )
+			->with(
 				[
-					'test_mode'            => false,
-					'payment_method'       => $payment_method_id,
-					'customer'             => $customer_id,
-					'confirm'              => 'true',
-					'payment_method_types' => $payment_method_types,
-					'mandate_data'         => $mandate_data,
-				]
-			),
-			true,
-			false
-		)
-		->will(
-			$this->returnValue(
-				[
-					'body'     => wp_json_encode(
-						[
-							'id'             => 'seti_mock',
-							'object'         => 'setup_intent',
-							'payment_method' => $payment_method_id,
-						]
-					),
-					'response' => [
-						'code'    => 200,
-						'message' => 'OK',
+					'url'             => 'https://public-api.wordpress.com/wpcom/v2/sites/%s/wcpay/setup_intents',
+					'method'          => 'POST',
+					'headers'         => [
+						'Content-Type' => 'application/json; charset=utf-8',
+						'User-Agent'   => 'Unit Test Agent/0.1.0',
 					],
-				]
+					'timeout'         => 70,
+					'connect_timeout' => 70,
+				],
+				wp_json_encode(
+					[
+						'test_mode'            => false,
+						'payment_method'       => $payment_method_id,
+						'customer'             => $customer_id,
+						'confirm'              => 'true',
+						'payment_method_types' => $payment_method_types,
+						'mandate_data'         => $mandate_data,
+					]
+				),
+				true,
+				false
 			)
-		);
+			->will(
+				$this->returnValue(
+					[
+						'body'     => wp_json_encode(
+							[
+								'id'             => 'seti_mock',
+								'object'         => 'setup_intent',
+								'payment_method' => $payment_method_id,
+							]
+						),
+						'response' => [
+							'code'    => 200,
+							'message' => 'OK',
+						],
+					]
+				)
+			);
 
 		$result = $this->payments_api_client->create_and_confirm_setup_intent( $payment_method_id, $customer_id );
 
@@ -1131,6 +1131,52 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 				'Online Payment for Order #100 for example.org blog_id 999',
 			],
 		];
+	}
+
+	/**
+	 * Test a successful call to cancel subscription.
+	 *
+	 * @throws Exception - In the event of test failure.
+	 */
+	public function test_cancel_subscription() {
+		$this->mock_http_client
+			->expects( $this->once() )
+			->method( 'remote_request' )
+			->with(
+				[
+					'url'             => 'https://public-api.wordpress.com/wpcom/v2/sites/%s/wcpay/subscriptions/sub_test?test_mode=0',
+					'method'          => 'DELETE',
+					'headers'         => [
+						'Content-Type' => 'application/json; charset=utf-8',
+						'User-Agent'   => 'Unit Test Agent/0.1.0',
+					],
+					'timeout'         => 70,
+					'connect_timeout' => 70,
+				],
+				null,
+				true,
+				false
+			)
+			->will(
+				$this->returnValue(
+					[
+						'response' => [
+							'code'    => 200,
+							'message' => 'OK',
+						],
+						'body'     => wp_json_encode(
+							[
+								'id'     => 'sub_test',
+								'object' => 'subscription',
+							]
+						),
+					]
+				)
+			);
+
+		$result = $this->payments_api_client->cancel_subscription( 'sub_test' );
+		$this->assertEquals( 'sub_test', $result['id'] );
+		$this->assertEquals( 'subscription', $result['object'] );
 	}
 
 	/**

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -1175,8 +1175,8 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 			);
 
 		$result = $this->payments_api_client->cancel_subscription( 'sub_test' );
-		$this->assertEquals( 'sub_test', $result['id'] );
-		$this->assertEquals( 'subscription', $result['object'] );
+		$this->assertSame( 'sub_test', $result['id'] );
+		$this->assertSame( 'subscription', $result['object'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2925

#### Changes proposed in this Pull Request

- Make sure parameters is passed as query string for DELETE requests.
- Fix some indentitation.
- Introduce constant for PUT.

#### Testing instructions

- Purchase a subscription in WooCommerce on the JN store: p1631763567328100/1631758836.323500-slack-C02BW3Z8SHK.
- Confirm the subscription in Stripe dashboard is created.
- Cancel the subscription in Woo (set the status to Cancelled on the Edit Subscription page).
- Confirm the subscription in Stripe dashboard is cancelled (check Subscriptions > Cancelled tab).

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)