### PR TITLE
Set plugin version to match tag name

### DIFF
--- a/.github/workflows/pre-release-publish-on-tag.yaml
+++ b/.github/workflows/pre-release-publish-on-tag.yaml
@@ -89,7 +89,11 @@ jobs:
           coverage: none
 
       - name: Build release
+        env:
+          TAG: ${{ steps.get_tag.outputs.TAG_REF }}
         run: |
+          # Change the 'Version' header in woocommerce-payments.php:14 to 2.4.0-test-2
+          sed -i "s/^ \* Version: .*$/ * Version: ${TAG}/" woocommerce-payments.php
           npm ci
           npm run build
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Tweak GitHub workflow to update plugin version to match tag when creating a pre-release package.

#### Testing instructions

 * Checkout the branch
 * Push a new tag while in a branch, e.g.

```bash
git tag -a -m 'Test tag' test-tag && git push origin test-tag
```

 * Wait for an action to complete.
 * Check [Releases](https://github.com/Automattic/woocommerce-payments/releases) page and find one corresponding to created tag.
 * Download `woocommerce-payments.zip` from the assets section.
 * Open the archive and check that `Version` header in the `woocommerce-payments.php` matches tag name, e.g.

```
 * Version: test-tag
 ```

 * Delete test tag by running:

```bash
git tag --delete test-tag && git push origin --delete test-tag
```

 * Reload the [Releases](https://github.com/Automattic/woocommerce-payments/releases) page, see that release has been converted to draft.
 * Open release draft and discard it.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
