### PR TITLE
Add hash to return url to trigger UPE validation errors

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Fix - Currency switcher does not affect order confirmation screen prices.
 * Fix - Error when attempting to change the payment method for a subscription with UPE enabled.
 * Add - Multi-Currency track currency added.
+* Fix - Form validation in UPE when no fields were interacted with.
 
 = 3.0.0 - 2021-09-16 =
 * Add - Download deposits report in CSV.

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -415,7 +415,7 @@ jQuery( function ( $ ) {
 			const { error } = await api.getStripe().confirmPayment( {
 				element: upeElement,
 				confirmParams: {
-					return_url: '',
+					return_url: '#',
 				},
 			} );
 			$form.removeClass( 'processing' ).unblock();


### PR DESCRIPTION
This issue was discovered in the Stripe plugin implementation of UPE: https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1940 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
Fix UPE Form Validation

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

With UPE, the field validation doesn't occur until something has been entered in to one of the fields. To capture instances where a user may not have interacted with all the fields and instead just hit submit, we run a sort of "mock" `confirmPayment` call to trigger the validation. We only run this when we have not received an `event.complete` from the UPE element. That event only fires once all required fields have been filled in.

There may have been a change the Stripe API that now requires a non-empty value for the `confirmParams.return_url`. Previously with that value empty the confirm would work and trigger validation, but now it throws an error. This PR adds a hash to that parameter to now avoid the error. This should be a safe workaround as we already know at this point that the confirmation will fail due to the fact that not all fields have been provided.


<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- Start with this branch and UPE enabled with at least CC enabled within UPE.
- Make sure to the JS has been rebuilt with this change from the PR.
- As a customer, add a product to the cart and go to checkout. Confirm UPE loads.
- Without entering any payment information, click the Place Order button.
- Confirm that error messages are displayed for the invalid fields.
- Refresh the checkout page.
- Enter a full CC number, but do not enter any expiration or CVV and click Place Order.
- Confirm that error messages are displayed for the invalid fields and no console errors are shown.
- Complete all payment fields and click Place Order.
- Confirm that the order was successfully placed.
- Next as a logged in customer visit the My Account > Payment Methods page.
- Click Add Payment Method button.
- Run through some of the same tests listed above with empty/partially filled/then fully filled fields and confirm that the proper error messages are displayed and no console errors are shown.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
