### PR TITLE
Add disount functionality and validation on invoice.upcoming

### DIFF
--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -168,81 +168,32 @@ class WC_Payments_Invoice_Service {
 	/**
 	 * Validates a WCPay invoice.
 	 *
-	 * @param array           $wcpay_items     The WCPay invoice items.
-	 * @param array           $wcpay_discounts The WCPay invoice discounts.
-	 * @param WC_Subscription $subscription    The WC Subscription object.
+	 * @param array           $wcpay_item_data     The WCPay invoice items.
+	 * @param array           $wcpay_discount_data The WCPay invoice discounts.
+	 * @param WC_Subscription $subscription        The WC Subscription object.
 	 *
-	 * @throws Rest_Request_Exception WCPay invoice items do not match WC subscription items.
+	 * @throws API_Exception          If updating the WCPay subscription or items fails.
+	 * @throws Rest_Request_Exception If WCPay invoice items do not match WC subscription items.
 	 */
-	public function validate_invoice_items( array $wcpay_items, array $wcpay_discounts, WC_Subscription $subscription ) {
-		$wcpay_item_data = [];
+	public function validate_invoice( array $wcpay_item_data, array $wcpay_discount_data, WC_Subscription $subscription ) {
+		$item_data = $this->get_repair_data_for_wcpay_items( $wcpay_item_data, $subscription );
 
-		foreach ( $wcpay_items as $item ) {
-			$wcpay_subscription_item_id = $item['subscription_item'];
-
-			$wcpay_item_data[ $wcpay_subscription_item_id ] = [
-				'amount'    => $item['amount'],
-				'quantity'  => $item['quantity'],
-				'tax_rates' => array_column( $item['tax_rates'], 'percentage' ),
-			];
-		}
-
-		foreach ( $subscription->get_items( [ 'line_item', 'fee', 'shipping' ] ) as $item ) {
-			$subscription_item_id = WC_Payments_Subscription_Service::get_wcpay_subscription_item_id( $item );
-
-			if ( ! $subscription_item_id ) {
-				continue;
-			}
-
-			if ( ! in_array( $subscription_item_id, array_keys( $wcpay_item_data ), true ) ) {
-				$message = __( 'The WCPay invoice items do not match WC subscription items', 'woocommerce-payments' );
-				Logger::error( $message );
-				throw new Rest_Request_Exception( $message );
-			}
-
-			$item_data   = $wcpay_item_data[ $subscription_item_id ];
-			$repair_data = [];
-
-			if ( (int) $item->get_total() * 100 !== $item_data['amount'] ) {
-				if ( $item->is_type( 'line_item' ) ) {
-					$product              = $item->get_product();
-					$repair_data['price'] = $this->product_service->get_wcpay_price_id( $product );
-				} else {
-					$repair_data['price_data'] = WC_Payments_Subscription_Service::format_item_price_data(
-						$subscription->get_currency(),
-						$this->product_service->get_stripe_product_id_for_item( $item->get_type() ),
-						$item->get_total(),
-						$subscription->get_billing_period(),
-						$subscription->get_billing_interval()
-					);
-				}
-			}
-
-			if ( $item->get_quantity() !== $item_data['quantity'] ) {
-				$repair_data['quantity'] = $item->get_quantity();
-			}
-
-			if ( ! empty( $item->get_taxes() ) ) {
-				$tax_rate_ids = array_keys( $item->get_taxes()['total'] );
-
-				if ( count( $tax_rate_ids ) !== count( $item_data['tax_rates'] ) ) {
-					$repair_data['tax_rates'] = WC_Payments_Subscription_Service::get_tax_rates_for_item( $item, $subscription );
-				} else {
-					foreach ( $subscription->get_taxes() as $tax ) {
-						if ( in_array( $tax->get_rate_id(), $tax_rate_ids, true ) && ! in_array( (int) $tax->get_rate_percent(), $item_data['tax_rates'], true ) ) {
-							$repair_data['tax_rates'] = WC_Payments_Subscription_Service::get_tax_rates_for_item( $item, $subscription );
-							break;
-						}
-					}
-				}
-			}
-
-			if ( ! empty( $repair_data ) ) {
-				$this->payments_api_client->update_subscription_item( $subscription_item_id, $repair_data );
+		if ( ! empty( $item_data ) ) {
+			foreach ( $item_data as $id => $data ) {
+				$this->payments_api_client->update_subscription_item( $id, $data );
 			}
 		}
 
-		// TODO: Handle discounts.
+		$discount_data = $this->get_repair_data_for_wcpay_discounts( $wcpay_discount_data, $subscription );
+
+		if ( ! empty( $discount_data ) ) {
+			$response = $this->payments_api_client->update_subscription(
+				WC_Payments_Subscription_Service::get_wcpay_subscription_id( $subscription ),
+				[ 'discounts' => $discount_data ]
+			);
+
+			WC_Payments_Subscription_Service::set_wcpay_discount_ids( $subscription, $response['discounts'] );
+		}
 	}
 
 	/**
@@ -276,5 +227,110 @@ class WC_Payments_Invoice_Service {
 	private function set_pending_invoice_id( $subscription, string $invoice_id ) {
 		$subscription->update_meta_data( self::PENDING_INVOICE_ID_KEY, $invoice_id );
 		$subscription->save();
+	}
+
+	/**
+	 * Gets repair data for WCPay invoice items.
+	 *
+	 * @param array           $wcpay_item_data The WCPay invoice items.
+	 * @param WC_Subscription $subscription    The WC Subscription object.
+	 *
+	 * @return array Repair data.
+	 *
+	 * @throws Rest_Request_Exception WCPay invoice items do not match WC subscription items.
+	 */
+	private function get_repair_data_for_wcpay_items( array $wcpay_item_data, WC_Subscription $subscription ) : array {
+		$repair_data = [];
+		$wcpay_items = [];
+
+		foreach ( $wcpay_item_data as $item ) {
+			$wcpay_subscription_item_id = $item['subscription_item'];
+
+			$wcpay_items[ $wcpay_subscription_item_id ] = [
+				'amount'    => $item['amount'],
+				'quantity'  => $item['quantity'],
+				'tax_rates' => array_column( $item['tax_rates'], 'percentage' ),
+			];
+		}
+
+		foreach ( $subscription->get_items( [ 'line_item', 'fee', 'shipping' ] ) as $item ) {
+			$subscription_item_id = WC_Payments_Subscription_Service::get_wcpay_subscription_item_id( $item );
+
+			if ( ! $subscription_item_id ) {
+				continue;
+			}
+
+			if ( ! in_array( $subscription_item_id, array_keys( $wcpay_items ), true ) ) {
+				$message = __( 'The WCPay invoice items do not match WC subscription items', 'woocommerce-payments' );
+				Logger::error( $message );
+				throw new Rest_Request_Exception( $message );
+			}
+
+			$item_data = $wcpay_items[ $subscription_item_id ];
+
+			if ( (int) $item->get_total() * 100 !== $item_data['amount'] ) {
+				if ( $item->is_type( 'line_item' ) ) {
+					$product                                       = $item->get_product();
+					$repair_data[ $subscription_item_id ]['price'] = $this->product_service->get_wcpay_price_id( $product );
+				} else {
+					$repair_data[ $subscription_item_id ]['price_data'] = WC_Payments_Subscription_Service::format_item_price_data(
+						$subscription->get_currency(),
+						$this->product_service->get_stripe_product_id_for_item( $item->get_type() ),
+						$item->get_total(),
+						$subscription->get_billing_period(),
+						$subscription->get_billing_interval()
+					);
+				}
+			}
+
+			if ( $item->get_quantity() !== $item_data['quantity'] ) {
+				$repair_data[ $subscription_item_id ]['quantity'] = $item->get_quantity();
+			}
+
+			if ( ! empty( $item->get_taxes() ) ) {
+				$tax_rate_ids = array_keys( $item->get_taxes()['total'] );
+
+				if ( count( $tax_rate_ids ) !== count( $item_data['tax_rates'] ) ) {
+					$repair_data[ $subscription_item_id ]['tax_rates'] = WC_Payments_Subscription_Service::get_tax_rates_for_item( $item, $subscription );
+				} else {
+					foreach ( $subscription->get_taxes() as $tax ) {
+						if ( in_array( $tax->get_rate_id(), $tax_rate_ids, true ) && ! in_array( (int) $tax->get_rate_percent(), $item_data['tax_rates'], true ) ) {
+							$repair_data[ $subscription_item_id ]['tax_rates'] = WC_Payments_Subscription_Service::get_tax_rates_for_item( $item, $subscription );
+							break;
+						}
+					}
+				}
+			}
+		}
+
+		return $repair_data;
+	}
+
+	/**
+	 * Gets repair data for WCPay invoice discounts.
+	 *
+	 * @param array           $wcpay_discount_data The WCPay disounts.
+	 * @param WC_Subscription $subscription        The WC Subscription object.
+	 *
+	 * @return array
+	 */
+	private function get_repair_data_for_wcpay_discounts( array $wcpay_discount_data, WC_Subscription $subscription ) : array {
+		$repair_data               = [];
+		$subscription_discount_ids = WC_Payments_Subscription_Service::get_wcpay_discount_ids( $subscription );
+
+		if ( ! empty( $subscription_discount_ids ) || ! empty( $wcpay_discount_data ) ) {
+			if ( count( $subscription_discount_ids ) !== count( $wcpay_discount_data ) ) {
+				$repair_data = WC_Payments_Subscription_Service::get_discount_item_data_for_subscription( $subscription );
+			} else {
+				foreach ( $subscription_discount_ids as $discount_id ) {
+					if ( ! in_array( $discount_id, $wcpay_discount_data, true ) ) {
+						$repair_data = WC_Payments_Subscription_Service::get_discount_item_data_for_subscription( $subscription );
+						break;
+					}
+				}
+			}
+		}
+
+		return $repair_data;
 	}
 }

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -186,7 +186,7 @@ class WC_Payments_Invoice_Service {
 
 		$discount_data = $this->get_repair_data_for_wcpay_discounts( $wcpay_discount_data, $subscription );
 
-		if ( ! empty( $discount_data ) ) {
+		if ( isset( $discount_data ) ) {
 			$response = $this->payments_api_client->update_subscription(
 				WC_Payments_Subscription_Service::get_wcpay_subscription_id( $subscription ),
 				[ 'discounts' => $discount_data ]
@@ -312,10 +312,10 @@ class WC_Payments_Invoice_Service {
 	 * @param array           $wcpay_discount_data The WCPay disounts.
 	 * @param WC_Subscription $subscription        The WC Subscription object.
 	 *
-	 * @return array
+	 * @return mixed
 	 */
-	private function get_repair_data_for_wcpay_discounts( array $wcpay_discount_data, WC_Subscription $subscription ) : array {
-		$repair_data               = [];
+	private function get_repair_data_for_wcpay_discounts( array $wcpay_discount_data, WC_Subscription $subscription ) {
+		$repair_data               = null;
 		$subscription_discount_ids = WC_Payments_Subscription_Service::get_wcpay_discount_ids( $subscription );
 
 		if ( ! empty( $subscription_discount_ids ) || ! empty( $wcpay_discount_data ) ) {

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -605,7 +605,7 @@ class WC_Payments_Subscription_Service {
 	private function prepare_wcpay_subscription_data( string $wcpay_customer_id, WC_Subscription $subscription ) {
 		$recurring_items = $this->get_recurring_item_data_for_subscription( $subscription );
 		$one_time_items  = $this->get_one_time_item_data_for_subscription( $subscription );
-		$discount_items  = $this->get_discount_item_data_for_subscription( $subscription, true );
+		$discount_items  = self::get_discount_item_data_for_subscription( $subscription, true );
 		$data            = [
 			'customer' => $wcpay_customer_id,
 			'items'    => $recurring_items,

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -318,7 +318,7 @@ class WC_Payments_Subscription_Service {
 			$coupon   = new WC_Coupon( $code );
 			$duration = in_array( $coupon->get_discount_type(), [ 'recurring_fee', 'recurring_percent' ], true ) ? 'forever' : 'once';
 			$data[]   = [
-				'amount_off' => $coupon->get_amount() * 100,
+				'amount_off' => $item->get_discount() * 100,
 				'currency'   => $subscription->get_currency(),
 				'duration'   => $duration,
 				// Translators: %s Coupon code.

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -37,6 +37,13 @@ class WC_Payments_Subscription_Service {
 	const SUBSCRIPTION_ITEM_ID_META_KEY = '_wcpay_subscription_item_id';
 
 	/**
+	 * Subscription discounts meta key used to store WCPay subscription discount IDs.
+	 *
+	 * @const string
+	 */
+	const SUBSCRIPTION_DISCOUNT_IDS_META_KEY = '_wcpay_subscription_discount_ids';
+
+	/**
 	 * WC Payments API Client
 	 *
 	 * @var WC_Payments_API_Client
@@ -196,6 +203,30 @@ class WC_Payments_Subscription_Service {
 	}
 
 	/**
+	 * Gets the WCPay subscription discount IDs from a WC subscription.
+	 *
+	 * @param WC_Subscription $subscription WC Subscription.
+	 *
+	 * @return array
+	 */
+	public static function get_wcpay_discount_ids( WC_Subscription $subscription ) {
+		return $subscription->get_meta( self::SUBSCRIPTION_DISCOUNT_IDS_META_KEY, true );
+	}
+
+	/**
+	 * Sets Stripe discount ids on WC subscription.
+	 *
+	 * @param WC_Subscription $subscription The WC Subscription object.
+	 * @param array           $discounts    The WCPay discount data.
+	 *
+	 * @return void
+	 */
+	public static function set_wcpay_discount_ids( WC_Subscription $subscription, array $discounts ) {
+		$subscription->update_meta_data( self::SUBSCRIPTION_DISCOUNT_IDS_META_KEY, $discounts );
+		$subscription->save();
+	}
+
+	/**
 	 * Determines if a given WC subscription is a WCPay subscription.
 	 *
 	 * @param WC_Subscription $subscription WC Subscription object.
@@ -271,6 +302,34 @@ class WC_Payments_Subscription_Service {
 	}
 
 	/**
+	 * Prepares discount data used to create a WCPay subscription.
+	 *
+	 * @param WC_Subscription $subscription The WC subscription used to create the subscription on server.
+	 * @param bool            $parent       Whether to get data from subscription parent.
+	 *
+	 * @return array WCPay discount item data.
+	 */
+	public static function get_discount_item_data_for_subscription( WC_Subscription $subscription, bool $parent = false ) : array {
+		$data  = [];
+		$items = $parent ? $subscription->get_parent()->get_items( 'coupon' ) : $subscription->get_items( 'coupon' );
+
+		foreach ( $items as $item ) {
+			$code     = $item->get_code();
+			$coupon   = new WC_Coupon( $code );
+			$duration = in_array( $coupon->get_discount_type(), [ 'recurring_fee', 'recurring_percent' ], true ) ? 'forever' : 'once';
+			$data[]   = [
+				'amount_off' => $coupon->get_amount() * 100,
+				'currency'   => $subscription->get_currency(),
+				'duration'   => $duration,
+				// Translators: %s Coupon code.
+				'name'       => sprintf( __( 'Coupon - %s', 'woocommerce-payments' ), $code ),
+			];
+		}
+
+		return $data;
+	}
+
+	/**
 	 * Gets a WCPay subscription from a WC subscription object.
 	 *
 	 * @param WC_Subscription $subscription The WC subscription to get from server.
@@ -315,6 +374,11 @@ class WC_Payments_Subscription_Service {
 
 			$this->set_wcpay_subscription_id( $subscription, $response['id'] );
 			$this->set_wcpay_subscription_item_ids( $subscription, $response['items']['data'] );
+
+			if ( isset( $response['discounts'] ) ) {
+				$this->set_wcpay_discount_ids( $subscription, $response['discounts'] );
+			}
+
 			$this->invoice_service->set_subscription_invoice_id( $subscription, $response['latest_invoice'] );
 		} catch ( API_Exception $e ) {
 			Logger::log( sprintf( 'There was a problem creating the WCPay subscription %s', $e->getMessage() ) );
@@ -506,35 +570,6 @@ class WC_Payments_Subscription_Service {
 	}
 
 	/**
-	 * Sets Stripe subscription item ids on WC order items.
-	 *
-	 * @param WC_Subscription $subscription       The WC Subscription object.
-	 * @param array           $subscription_items The Stripe Subscription data.
-	 *
-	 * @return void
-	 */
-	public function set_wcpay_subscription_item_ids( WC_Subscription $subscription, array $subscription_items ) {
-		foreach ( $subscription_items as $item ) {
-			$wcpay_subscription_item_id = $item['id'];
-			$subscription_item_id       = isset( $item['metadata']['wc_item_id'] ) ? $item['metadata']['wc_item_id'] : false;
-
-			if ( $subscription_item_id ) {
-				$subscription_item = $subscription->get_item( $subscription_item_id );
-				$subscription_item->update_meta_data( self::SUBSCRIPTION_ITEM_ID_META_KEY, $wcpay_subscription_item_id );
-				$subscription_item->save();
-			} else {
-				Logger::log(
-					sprintf(
-						// Translators: %s Stripe subscription item ID.
-						__( 'Unable to set subscription item ID meta for WCPay subscription item %s.', 'woocommerce-payments' ),
-						$wcpay_subscription_item_id
-					)
-				);
-			}
-		}
-	}
-
-	/**
 	 * Updates a subscription's next payment date to match the WCPay subscription's payment date.
 	 *
 	 * @param array           $wcpay_subscription The WCPay Subscription data.
@@ -570,7 +605,7 @@ class WC_Payments_Subscription_Service {
 	private function prepare_wcpay_subscription_data( string $wcpay_customer_id, WC_Subscription $subscription ) {
 		$recurring_items = $this->get_recurring_item_data_for_subscription( $subscription );
 		$one_time_items  = $this->get_one_time_item_data_for_subscription( $subscription );
-		$discount_items  = $this->get_discount_item_data_for_subscription( $subscription );
+		$discount_items  = $this->get_discount_item_data_for_subscription( $subscription, true );
 		$data            = [
 			'customer' => $wcpay_customer_id,
 			'items'    => $recurring_items,
@@ -685,31 +720,6 @@ class WC_Payments_Subscription_Service {
 	}
 
 	/**
-	 * Prepares discount data used to create a WCPay subscription.
-	 *
-	 * @param WC_Subscription $subscription The WC subscription used to create the subscription on server.
-	 *
-	 * @return array WCPay discount item data.
-	 */
-	private function get_discount_item_data_for_subscription( WC_Subscription $subscription ) : array {
-		$data = [];
-
-		foreach ( $subscription->get_parent()->get_items( 'coupon' ) as $item ) {
-			$code     = $item->get_code();
-			$coupon   = new WC_Coupon( $code );
-			$duration = in_array( $coupon->get_discount_type(), [ 'recurring_fee', 'recurring_percent' ], true ) ? 'forever' : 'once';
-			$data[]   = [
-				'amount_off' => $coupon->get_amount() * 100,
-				'currency'   => $subscription->get_currency(),
-				'duration'   => $duration,
-				'name'       => 'Coupon - ' . $code,
-			];
-		}
-
-		return $data;
-	}
-
-	/**
 	 * Updates a WCPay subscription.
 	 *
 	 * @param WC_Subscription $subscription The WC subscription that relates to the WCPay subscription that needs updating.
@@ -758,6 +768,35 @@ class WC_Payments_Subscription_Service {
 	private function set_wcpay_subscription_id( WC_Subscription $subscription, string $value ) {
 		$subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, $value );
 		$subscription->save();
+	}
+
+	/**
+	 * Sets Stripe subscription item ids on WC order items.
+	 *
+	 * @param WC_Subscription $subscription       The WC Subscription object.
+	 * @param array           $subscription_items The WCPay Subscription data.
+	 *
+	 * @return void
+	 */
+	private function set_wcpay_subscription_item_ids( WC_Subscription $subscription, array $subscription_items ) {
+		foreach ( $subscription_items as $item ) {
+			$wcpay_subscription_item_id = $item['id'];
+			$subscription_item_id       = isset( $item['metadata']['wc_item_id'] ) ? $item['metadata']['wc_item_id'] : false;
+
+			if ( $subscription_item_id ) {
+				$subscription_item = $subscription->get_item( $subscription_item_id );
+				$subscription_item->update_meta_data( self::SUBSCRIPTION_ITEM_ID_META_KEY, $wcpay_subscription_item_id );
+				$subscription_item->save();
+			} else {
+				Logger::log(
+					sprintf(
+						// Translators: %s Stripe subscription item ID.
+						__( 'Unable to set subscription item ID meta for WCPay subscription item %s.', 'woocommerce-payments' ),
+						$wcpay_subscription_item_id
+					)
+				);
+			}
+		}
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
@@ -78,7 +78,7 @@ class WC_Payments_Subscriptions_Event_Handler {
 			$subscription->add_order_note( sprintf( __( 'Next automatic payment scheduled for %s.', 'woocommerce-payments' ), get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $wcpay_subscription['current_period_end'] ), wc_date_format() . ' ' . wc_time_format() ) ) );
 
 			$this->subscription_service->update_dates_to_match_wcpay_subscription( $wcpay_subscription, $subscription );
-			$this->invoice_service->validate_invoice_items( $wcpay_lines, $wcpay_discounts, $subscription );
+			$this->invoice_service->validate_invoice( $wcpay_lines, $wcpay_discounts ? $wcpay_discounts : [], $subscription );
 		}
 	}
 

--- a/tests/unit/helpers/class-wc-helper-subscription.php
+++ b/tests/unit/helpers/class-wc-helper-subscription.php
@@ -142,8 +142,8 @@ class WC_Subscription extends WC_Mock_WC_Data {
 		return ! empty( $this->parent_order ) ? $this->parent_order : false;
 	}
 
-	public function get_items() {
-		return ! empty( $this->parent_order ) ? $this->parent_order->get_items() : [];
+	public function get_items( $type = 'line_item' ) {
+		return ! empty( $this->parent_order ) ? $this->parent_order->get_items( $type ) : [];
 	}
 
 	public function get_fees() {

--- a/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
@@ -275,7 +275,7 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 			);
 
 		$this->invoice_service->validate_invoice( $mock_item_data, $mock_discount_data, $mock_subscription );
-		$this->assertEquals( [], $mock_subscription->get_meta( self::SUBSCRIPTION_DISCOUNT_IDS_META_KEY, true ) );
+		$this->assertSame( [], $mock_subscription->get_meta( self::SUBSCRIPTION_DISCOUNT_IDS_META_KEY, true ) );
 	}
 	/**
 	 * Mocks the wcs_order_contains_subscription function return.

--- a/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
@@ -13,10 +13,12 @@ use WCPay\Exceptions\API_Exception;
  */
 class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 
-	const PENDING_INVOICE_ID_KEY        = '_wcpay_pending_invoice_id';
-	const ORDER_INVOICE_ID_KEY          = '_wcpay_billing_invoice_id';
-	const SUBSCRIPTION_ITEM_ID_META_KEY = '_wcpay_subscription_item_id';
-	const PRICE_ID_KEY                  = '_wcpay_product_price_id';
+	const PRICE_ID_KEY                       = '_wcpay_product_price_id';
+	const PENDING_INVOICE_ID_KEY             = '_wcpay_pending_invoice_id';
+	const ORDER_INVOICE_ID_KEY               = '_wcpay_billing_invoice_id';
+	const SUBSCRIPTION_ID_META_KEY           = '_wcpay_subscription_id';
+	const SUBSCRIPTION_ITEM_ID_META_KEY      = '_wcpay_subscription_item_id';
+	const SUBSCRIPTION_DISCOUNT_IDS_META_KEY = '_wcpay_subscription_discount_ids';
 
 	/**
 	 * Mock WC_Payments_API_Client.
@@ -177,12 +179,56 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests for WC_Payments_Invoice_Service::validate_invoice()
+	 * Tests for WC_Payments_Invoice_Service::validate_invoice() with valid data.
 	 */
-	public function test_validate_invoice() {
+	public function test_validate_invoice_with_valid_data() {
 		$mock_order        = WC_Helper_Order::create_order();
 		$mock_subscription = new WC_Subscription();
 		$mock_subscription->set_parent( $mock_order );
+		$mock_subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, [ 'sub_test123' ] );
+		$mock_subscription->update_meta_data( self::SUBSCRIPTION_DISCOUNT_IDS_META_KEY, [ 'di_test123' ] );
+
+		foreach ( $mock_order->get_items( 'line_item', 'fee', 'shipping' ) as $item ) {
+			$item->update_meta_data( self::SUBSCRIPTION_ITEM_ID_META_KEY, 'si_test123' );
+		}
+
+		$mock_item_data = [
+			[
+				'subscription_item' => 'si_test123',
+				'amount'            => 4000,
+				'quantity'          => 4,
+				'tax_rates'         => [],
+			],
+			[
+				'subscription_item' => 'si_test123',
+				'amount'            => 4000,
+				'quantity'          => 4,
+				'tax_rates'         => [],
+			],
+		];
+
+		$mock_discount_data = [ 'di_test123' ];
+
+		$this->mock_api_client
+			->expects( $this->never() )
+			->method( 'update_subscription_item' );
+
+		$this->mock_api_client
+			->expects( $this->never() )
+			->method( 'update_subscription' );
+
+		$this->invoice_service->validate_invoice( $mock_item_data, $mock_discount_data, $mock_subscription );
+	}
+
+	/**
+	 * Tests for WC_Payments_Invoice_Service::validate_invoice() with invalid data.
+	 */
+	public function test_validate_invoice_with_invalid_data() {
+		$mock_order        = WC_Helper_Order::create_order();
+		$mock_subscription = new WC_Subscription();
+		$mock_subscription->set_parent( $mock_order );
+		$mock_subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, 'sub_test123' );
+		$mock_subscription->update_meta_data( self::SUBSCRIPTION_DISCOUNT_IDS_META_KEY, [ 'di_test123' ] );
 
 		foreach ( $mock_order->get_items( 'line_item', 'fee', 'shipping' ) as $item ) {
 			$item->update_meta_data( self::SUBSCRIPTION_ITEM_ID_META_KEY, 'si_test123' );
@@ -197,7 +243,7 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 			],
 		];
 
-		$mock_discount_data = [];
+		$mock_discount_data = [ 'di_test456' ];
 
 		$this->mock_product_service
 			->expects( $this->once() )
@@ -215,9 +261,22 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 				]
 			);
 
-		$this->invoice_service->validate_invoice( $mock_item_data, $mock_discount_data, $mock_subscription );
-	}
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'update_subscription' )
+			->with(
+				'sub_test123',
+				[
+					'discounts' => [],
+				]
+			)
+			->willReturn(
+				[ 'discounts' => [] ]
+			);
 
+		$this->invoice_service->validate_invoice( $mock_item_data, $mock_discount_data, $mock_subscription );
+		$this->assertEquals( [], $mock_subscription->get_meta( self::SUBSCRIPTION_DISCOUNT_IDS_META_KEY, true ) );
+	}
 	/**
 	 * Mocks the wcs_order_contains_subscription function return.
 	 *

--- a/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
@@ -177,9 +177,9 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests for WC_Payments_Invoice_Service::validate_invoice_items()
+	 * Tests for WC_Payments_Invoice_Service::validate_invoice()
 	 */
-	public function test_validate_invoice_items() {
+	public function test_validate_invoice() {
 		$mock_order        = WC_Helper_Order::create_order();
 		$mock_subscription = new WC_Subscription();
 		$mock_subscription->set_parent( $mock_order );
@@ -188,7 +188,7 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 			$item->update_meta_data( self::SUBSCRIPTION_ITEM_ID_META_KEY, 'si_test123' );
 		}
 
-		$mock_items = [
+		$mock_item_data = [
 			[
 				'subscription_item' => 'si_test123',
 				'amount'            => 1000,
@@ -197,7 +197,7 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 			],
 		];
 
-		$mock_discounts = [];
+		$mock_discount_data = [];
 
 		$this->mock_product_service
 			->expects( $this->once() )
@@ -215,7 +215,7 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 				]
 			);
 
-		$this->invoice_service->validate_invoice_items( $mock_items, $mock_discounts, $mock_subscription );
+		$this->invoice_service->validate_invoice( $mock_item_data, $mock_discount_data, $mock_subscription );
 	}
 
 	/**

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -331,15 +331,18 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 		$mock_subscription            = new WC_Subscription();
 		$mock_subscription->trial_end = 0;
 		$mock_subscription_product    = new WC_Subscriptions_Product();
-		$mock_subscription_product->save(); // Calling get_items on orders returns false unless we save.
+		$mock_subscription_product->save();
 		$mock_order         = WC_Helper_Order::create_order( 1, 50, $mock_subscription_product );
 		$mock_line_item     = array_values( $mock_order->get_items() )[0];
 		$mock_shipping_item = array_values( $mock_order->get_items( 'shipping' ) )[0];
-		$mock_coupon        = new WC_Coupon();
-		$mock_coupon->set_code( 'test_coupon' );
-		$mock_coupon->set_amount( 10.0 );
-		$mock_coupon->save();
-		$mock_order->apply_coupon( $mock_coupon );
+		$mock_coupon_item   = new WC_Order_Item_Coupon();
+		$mock_coupon_item->set_props(
+			[
+				'code'     => 'test_coupon',
+				'discount' => 5,
+			]
+		);
+		$mock_order->add_item( $mock_coupon_item );
 		$mock_subscription->set_parent( $mock_order );
 
 		$mock_wcpay_subscription_id = 'wcpay_prepare_sub12345';
@@ -359,7 +362,7 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 			'customer'  => $mock_wcpay_customer_id,
 			'discounts' => [
 				[
-					'amount_off' => 1000,
+					'amount_off' => 500,
 					'currency'   => 'USD',
 					'duration'   => 'once',
 					'name'       => 'Coupon - test_coupon',


### PR DESCRIPTION
Fixes #2977 

#### Changes proposed in this Pull Request

This applies coupon discounts to subscriptions on creation and adds validation for subscription discount data on `invoice.upcoming`

Note this PR depends on the following server PR: 1192-gh-Automattic/woocommerce-payments-server

#### Testing instructions

##### Applying coupons

- Add a subscription with a signup fee to cart
- Apply a recurring and a signup fee coupon
- Checkout
- Verify coupons appear for the subscription and initial invoice in Stripe dashboard:
  - https://cloudup.com/cmDxF_E_SSA
  - https://cloudup.com/csszYjnboij

##### Coupon validation
- Enable Billing Clock via WCPay Dev Tools for this subscription in WP-Admin
- Via Stripe dashboard, update the billing clock subscription by removing the coupon: https://cloudup.com/crUT4UJAk1U
- Verify the recurring coupon is no longer added to the subscription
- Go back to WP-Admin and trigger `invoice.upcoming`
- Verify the recurring coupon has been re-added to the subscription

Note: When adding multiple RECURRING coupons to a subscription, these are correctly added to the subscription in Stripe, but it is not possible to edit coupons in Stripe in these cases. Probably because adding multiple coupons is a beta feature.

-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)