### PR TITLE
Fix Shipping Cost not updating in Google Pay' payment sheet when changing payment method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@
 * Fix - Fill missing order_intent_info even if an exception occurs.
 * Add - Gutenberg Block Widget for Multi-Currency.
 * Update - WCPay logo
+* Fix - Update shipping cost in payment sheet when changing payment method.
 
 = 3.0.0 - 2021-09-16 =
 * Add - Download deposits report in CSV.

--- a/client/payment-request/event-handlers.js
+++ b/client/payment-request/event-handlers.js
@@ -22,7 +22,9 @@ export const shippingAddressChangeHandler = async ( api, event ) => {
 };
 
 export const shippingOptionChangeHandler = async ( api, event ) => {
-	const response = await api.paymentRequestUpdateShippingDetails( event );
+	const response = await api.paymentRequestUpdateShippingDetails(
+		event.shippingOption
+	);
 
 	if ( 'success' === response.result ) {
 		event.updateWith( {

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Fill missing order_intent_info even if an exception occurs.
 * Add - Gutenberg Block Widget for Multi-Currency.
 * Update - WCPay logo
+* Fix - Update shipping cost in payment sheet when changing payment method.
 
 = 3.0.0 - 2021-09-16 =
 * Add - Download deposits report in CSV.


### PR DESCRIPTION
Fixes #2971

#### Changes proposed in this Pull Request
Fixes an issue where Shipping cost (and total) didn't update correctly in the payment sheet when user changed between shipping options.

#### Testing instructions
First of all you'll need at least two shipping methods for at least one shipping zone.

- Go to WooCommerce > Settings > Shipping.
- Click "Locations not covered by your other zones".
- Click "Add shipping method" -> Select "Flat rate" in dropdown then click "Add shipping method".
- Click "Add shipping method" -> Select "Free shipping" in dropdown then click "Add shipping method".
- Mouse over "Flat rate" then click "Edit". set "Cost" to 20. Click "Save changes".
- Create a simple product. Set price to 20.
- Go to the product's page.
- Click "Buy now" button
- "Shipping" should cost $0 so far. Total should be $20.
- Enter/chose a shipping address.
- Notice "Shipping" costs $20 now. Total should be $40.
- In Shipping Method, chose "Free shipping"
- Shipping now should costs $0. Total should be $0.