### PR TITLE
Fix for warnings and notices in Unit Tests

### DIFF
--- a/client/multi-currency/blocks/currency-switcher.js
+++ b/client/multi-currency/blocks/currency-switcher.js
@@ -20,6 +20,7 @@ import {
 	InspectorControls,
 	useBlockProps,
 } from '@wordpress/block-editor';
+
 registerBlockType( 'woocommerce-payments/multi-currency-switcher', {
 	apiVersion: 2,
 	title: __( 'Currency Switcher Block', 'woocommerce-payments' ),

--- a/includes/multi-currency/CurrencySwitcherBlock.php
+++ b/includes/multi-currency/CurrencySwitcherBlock.php
@@ -52,7 +52,13 @@ class CurrencySwitcherBlock {
 	 */
 	public function init_block_widget() {
 		// Automatically load dependencies and version.
-		$asset_file = include WCPAY_ABSPATH . 'dist/multi-currency-switcher-block.asset.php';
+		$asset_file_path = WCPAY_ABSPATH . 'dist/multi-currency-switcher-block.asset.php';
+		$asset_file      = file_exists( $asset_file_path )
+			? require_once $asset_file_path
+			: [
+				'dependencies' => [],
+				'version'      => false,
+			];
 
 		wp_register_script(
 			'woocommerce-payments/multi-currency-switcher',


### PR DESCRIPTION

Fixes: #3002

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- Adds a check for whether the `multi-currency-switcher-block.asset.php` file.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that unit tests pass without warnings and notices (check the "WC compatibility (5.5.0, latest, 7.4)" test in the runner and examine the logs for the issues mentioned in the linked issue, they should not be present.
* Do a quick smoke test of the multi currency block widget to make sure it is working as expected, see https://github.com/Automattic/woocommerce-payments/pull/2883 for more information on how to test this.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)