### PR TITLE
Add a command to toggle xdebug extension in WordPress container

### DIFF
--- a/bin/xdebug-toggle.sh
+++ b/bin/xdebug-toggle.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+XDEBUG_OVERRIDE_FILE=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
+if test -f "$XDEBUG_OVERRIDE_FILE"; then
+
+	# Get the status from the override file.
+	XDEBUG_STATUS_CONTENTS=$(cat "$XDEBUG_OVERRIDE_FILE")
+	XDEBUG_STATUS=${XDEBUG_STATUS_CONTENTS: 1}
+	if [ $XDEBUG_STATUS -eq '0' ]; then
+		echo 'Enabling XDebug...';
+		echo 'zend_extension=xdebug' > $XDEBUG_OVERRIDE_FILE
+	else
+		echo 'Disabling XDebug...';
+		echo '# zend_extension=xdebug' > $XDEBUG_OVERRIDE_FILE
+	fi
+else
+	# Disable it, it's currently enabled.
+	echo 'Disabling XDebug...';
+	echo '# zend_extension=xdebug' > $XDEBUG_OVERRIDE_FILE
+fi
+
+# Restart the apache service.
+service apache2 restart

--- a/bin/xdebug-toggle.sh
+++ b/bin/xdebug-toggle.sh
@@ -8,8 +8,9 @@ if test -f "$XDEBUG_OVERRIDE_FILE"; then
 
 	# Get the status from the override file.
 	XDEBUG_STATUS_CONTENTS=$(cat "$XDEBUG_OVERRIDE_FILE")
-	XDEBUG_STATUS=${XDEBUG_STATUS_CONTENTS: 1}
-	if [ $XDEBUG_STATUS -eq '0' ]; then
+	XDEBUG_STATUS=${XDEBUG_STATUS_CONTENTS:0:1}
+
+	if [[ "$XDEBUG_STATUS" == '#' ]]; then
 		echo 'Enabling XDebug...';
 		echo 'zend_extension=xdebug' > $XDEBUG_OVERRIDE_FILE
 	else
@@ -23,4 +24,4 @@ else
 fi
 
 # Restart the apache service.
-service apache2 restart
+service apache2 force-reload

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "tube:setup": "./bin/jurassic-tube-setup.sh",
     "tube:start": "./docker/bin/jt/tunnel.sh",
     "tube:stop": "./docker/bin/jt/tunnel.sh break",
-    "psalm": "./bin/run-psalm.sh"
+    "psalm": "./bin/run-psalm.sh",
+    "xdebug:toggle": "docker-compose exec -u root wordpress /var/www/html/wp-content/plugins/woocommerce-payments/bin/xdebug-toggle.sh"
   },
   "dependencies": {
     "@stripe/react-stripe-js": "1.4.1",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds `npm run xdebug:toggle` command which disables/enables the xdebug extension on the WordPress container, by commenting in or out the `zend_extension=xdebug` line in `docker-php-ext-xdebug.ini` file, and restarting `Apache httpd` service.


<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- run `npm run xdebug:toggle` on the root folder of the project
- the action will be displayed as `Enabling XDebug...` or `Disabling XDebug` and then you'll see the web server restarting.
- Attach a shell to the container, and run `php -v` inside it, you should see XDebug line and version when XDebug is enabled, and when it's disabled, you shouldn't see that.
- If you want, a third step, try debugging the code with xdebug disabled, and enable it afterwards seeing it not stopping the execution, then enable it and see if it stops and displays debug information on the breakpoint hit.

Below checkboxes are all (or does not apply).

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
