### PR TITLE
Remove "Automatic Recurring Payments" tooltip when WC Subscriptions i…

### DIFF
--- a/includes/subscriptions/subscriptions-base/assets/css/admin.css
+++ b/includes/subscriptions/subscriptions-base/assets/css/admin.css
@@ -720,7 +720,8 @@ table.wp-list-table .subscription_renewal_order:after {
 	color: #a46497;
 }
 
-table.wc_gateways .renewals .tips {
+table.wc_gateways .renewals .tips,
+table.wc_gateways .renewals .renewals-enabled-icon {
 	margin: 0 0.2em;
 	display: inline-block;
 }

--- a/includes/subscriptions/subscriptions-base/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/subscriptions/subscriptions-base/includes/admin/class-wc-subscriptions-admin.php
@@ -1667,7 +1667,7 @@ class WC_Subscriptions_Admin {
 	public static function payment_gateways_renewal_support( $gateway ) {
 		echo '<td class="renewals">';
 		if ( ( is_array( $gateway->supports ) && in_array( 'subscriptions', $gateway->supports ) ) || $gateway->id == 'paypal' ) {
-			$status_html = '<span class="status-enabled tips" data-tip="' . esc_attr__( 'Supports automatic renewal payments with the WooCommerce Subscriptions extension.', 'woocommerce-subscriptions' ) . '">' . esc_html__( 'Yes', 'woocommerce-subscriptions' ) . '</span>';
+			$status_html = '<span class="status-enabled renewals-enabled-icon">' . esc_html__( 'Yes', 'woocommerce-subscriptions' ) . '</span>';
 		} else {
 			$status_html = '-';
 		}


### PR DESCRIPTION
…s not installed

Fixes #2988

#### Changes proposed in this Pull Request

Removing the "Automatic Recurring Payments" tooltip when the WooCommerce Subscriptions extension is not installed because the tooltip text is incorrect in such a case.

<img width="1068" alt="134604955-913f1566-4cfb-45ea-975a-82eaa4a2ead7" src="https://user-images.githubusercontent.com/8667118/135420646-d37850b4-aa98-4557-a601-db18a463d5d4.png">

#### Testing instructions

**Scenario 1 - WooCommerce Subscriptions is not installed**

- Ensure WooCommerce Subscriptions is not installed.
- Navigate to WooCommerce → Settings → Payments.
- Hover the checkmark icon in the "Automatic Recurring Payments" column next to WooCommerce Payments.
- Observe no tooltip is shown.

**Scenario 2 - WooCommerce Subscriptions is installed and active**

- Ensure WooCommerce Subscriptions is installed and active.
- Navigate to WooCommerce → Settings → Payments.
- Hover the checkmark icon in the "Automatic Recurring Payments" column next to WooCommerce Payments.
- Observe a tooltip is visible and reads "Supports automatic renewal payments with the WooCommerce Subscriptions extension."

*

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)