### PR TITLE
Fix 2 E2E tests Shopper Checkout Failures/Subscriptions Purchasing

### DIFF
--- a/tests/e2e/specs/merchant/merchant-subscriptions-purchase-no-sign-up.spec.js
+++ b/tests/e2e/specs/merchant/merchant-subscriptions-purchase-no-sign-up.spec.js
@@ -28,7 +28,11 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 			await merchant.login();
 
 			// Create subscription product without signup fee
-			await merchantWCP.createSubscriptionProduct( productName, false );
+			await merchantWCP.createSubscriptionProduct(
+				productName,
+				'month',
+				false
+			);
 
 			await merchant.logout();
 		} );

--- a/tests/e2e/specs/merchant/merchant-subscriptions-purchase-sign-up-fee.spec.js
+++ b/tests/e2e/specs/merchant/merchant-subscriptions-purchase-sign-up-fee.spec.js
@@ -28,7 +28,11 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 			await merchant.login();
 
 			// Create subscription product with signup fee
-			await merchantWCP.createSubscriptionProduct( productName, true );
+			await merchantWCP.createSubscriptionProduct(
+				productName,
+				'month',
+				true
+			);
 
 			await merchant.logout();
 

--- a/tests/e2e/specs/merchant/merchant-subscriptions-renew-action-scheduler.spec.js
+++ b/tests/e2e/specs/merchant/merchant-subscriptions-renew-action-scheduler.spec.js
@@ -31,7 +31,11 @@ describeif( RUN_SUBSCRIPTIONS_TESTS, RUN_ACTION_SCHEDULER_TESTS )(
 			await merchant.login();
 
 			// Create subscription product with signup fee
-			await merchantWCP.createSubscriptionProduct( productName, true );
+			await merchantWCP.createSubscriptionProduct(
+				productName,
+				'month',
+				true
+			);
 
 			await merchant.logout();
 

--- a/tests/e2e/specs/merchant/merchant-subscriptions-renew-subscription.spec.js
+++ b/tests/e2e/specs/merchant/merchant-subscriptions-renew-subscription.spec.js
@@ -29,7 +29,11 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 			await merchant.login();
 
 			// Create subscription product with signup fee
-			await merchantWCP.createSubscriptionProduct( productName, true );
+			await merchantWCP.createSubscriptionProduct(
+				productName,
+				'month',
+				true
+			);
 
 			await merchant.logout();
 

--- a/tests/e2e/specs/shopper/shopper-checkout-failures.spec.js
+++ b/tests/e2e/specs/shopper/shopper-checkout-failures.spec.js
@@ -30,8 +30,7 @@ describe( 'Shopper > Checkout > Failures with various cards', () => {
 		// Reload the page after every test so there are no messages
 		await page.reload();
 		await page.waitForSelector( '.blockUI' );
-		await uiUnblocked();
-		await page.waitForSelector( '.__PrivateStripeElement' );
+		await page.waitFor( 3000 );
 	} );
 
 	afterAll( async () => {

--- a/tests/e2e/specs/shopper/shopper-checkout-failures.spec.js
+++ b/tests/e2e/specs/shopper/shopper-checkout-failures.spec.js
@@ -29,8 +29,9 @@ describe( 'Shopper > Checkout > Failures with various cards', () => {
 	afterEach( async () => {
 		// Reload the page after every test so there are no messages
 		await page.reload();
+		await page.waitForSelector( '.blockUI' );
 		await uiUnblocked();
-		await page.waitFor( 2000 );
+		await page.waitForSelector( '.__PrivateStripeElement' );
 	} );
 
 	afterAll( async () => {

--- a/tests/e2e/specs/shopper/shopper-myaccount-renew-subscription.spec.js
+++ b/tests/e2e/specs/shopper/shopper-myaccount-renew-subscription.spec.js
@@ -28,7 +28,11 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 			await merchant.login();
 
 			// Create subscription product with signup fee
-			await merchantWCP.createSubscriptionProduct( productName, true );
+			await merchantWCP.createSubscriptionProduct(
+				productName,
+				'month',
+				true
+			);
 
 			await merchant.logout();
 		} );

--- a/tests/e2e/specs/shopper/shopper-subscriptions-change-payment-method.spec.js
+++ b/tests/e2e/specs/shopper/shopper-subscriptions-change-payment-method.spec.js
@@ -54,7 +54,8 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 		beforeAll( async () => {
 			await merchant.login();
 			productId = await merchantWCP.createSubscriptionProduct(
-				productName
+				productName,
+				'month'
 			);
 			await merchant.logout();
 

--- a/tests/e2e/specs/shopper/shopper-subscriptions-free-trial.spec.js
+++ b/tests/e2e/specs/shopper/shopper-subscriptions-free-trial.spec.js
@@ -40,6 +40,7 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 			// Create subscription product without signup fee
 			await merchantWCP.createSubscriptionProduct(
 				productName,
+				'month',
 				false,
 				true
 			);

--- a/tests/e2e/specs/shopper/shopper-subscriptions-manage-payments.spec.js
+++ b/tests/e2e/specs/shopper/shopper-subscriptions-manage-payments.spec.js
@@ -32,7 +32,11 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 		beforeAll( async () => {
 			// Create subscription product
 			await merchant.login();
-			await merchantWCP.createSubscriptionProduct( productName, false );
+			await merchantWCP.createSubscriptionProduct(
+				productName,
+				'month',
+				false
+			);
 			await merchant.logout();
 		} );
 

--- a/tests/e2e/specs/shopper/shopper-subscriptions-purchase-multiple-subscriptions.spec.js
+++ b/tests/e2e/specs/shopper/shopper-subscriptions-purchase-multiple-subscriptions.spec.js
@@ -32,7 +32,8 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 
 			for ( const productName of productNames ) {
 				const productId = await merchantWCP.createSubscriptionProduct(
-					productName
+					productName,
+					'month'
 				);
 				productIds.push( productId );
 			}

--- a/tests/e2e/specs/shopper/shopper-subscriptions-purchase-subscription-product.spec.js
+++ b/tests/e2e/specs/shopper/shopper-subscriptions-purchase-subscription-product.spec.js
@@ -18,7 +18,7 @@ const getNextPaymentDate = ( subscriptionStartDateLocal ) => {
 	const formatter = new Intl.DateTimeFormat( 'en-US', {
 		dateStyle: 'long',
 	} );
-	const nextPaymentDate = nowUTC.setDate( nowUTC.getDate() + 30 );
+	const nextPaymentDate = nowUTC.setUTCDate( nowUTC.getDate() + 30 );
 	return formatter.format( nextPaymentDate );
 };
 

--- a/tests/e2e/specs/shopper/shopper-subscriptions-purchase-subscription-product.spec.js
+++ b/tests/e2e/specs/shopper/shopper-subscriptions-purchase-subscription-product.spec.js
@@ -9,22 +9,10 @@ import { RUN_SUBSCRIPTIONS_TESTS, describeif, merchantWCP } from '../../utils';
 
 import { fillCardDetails, setupCheckout } from '../../utils/payments';
 
-const getNextPaymentDate = ( subscriptionStartDateLocal ) => {
-	const nowUTC = new Date(
-		subscriptionStartDateLocal.getUTCFullYear(),
-		subscriptionStartDateLocal.getUTCMonth(),
-		subscriptionStartDateLocal.getUTCDate()
-	);
-	const formatter = new Intl.DateTimeFormat( 'en-US', {
-		dateStyle: 'long',
-	} );
-	const nextPaymentDate = nowUTC.setUTCDate( nowUTC.getDate() + 30 );
-	return formatter.format( nextPaymentDate );
-};
-
 const nowLocal = new Date();
-const nextPayDateFormatted = getNextPaymentDate( nowLocal );
+const nextPayDate = 'In 7 days';
 const productName = `Subscription product ${ nowLocal.getTime() }`;
+const periodTime = 'week';
 const customerBilling = config.get( 'addresses.customer.billing' );
 const card = config.get( 'cards.basic' );
 const baseUrl = config.get( 'url' );
@@ -41,7 +29,8 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 		beforeAll( async () => {
 			await merchant.login();
 			productId = await merchantWCP.createSubscriptionProduct(
-				productName
+				productName,
+				periodTime
 			);
 			await merchant.logout();
 		} );
@@ -82,7 +71,7 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 			await expect( page ).toMatchElement(
 				'td.subscription-next-payment',
 				{
-					text: `${ nextPayDateFormatted }`,
+					text: `${ nextPayDate }`,
 				}
 			);
 			await expect( page ).toMatchElement( 'td.subscription-total', {
@@ -120,12 +109,12 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 				'table.subscription_details'
 			);
 			await expect( subDetailsTable ).toMatch( 'Active' );
-			await expect( subDetailsTable ).toMatch( nextPayDateFormatted );
+			await expect( subDetailsTable ).toMatch( nextPayDate );
 
 			// Verify that all details in the 'Subscription totals' table are correct.
 			const subTotalsTable = await page.$( 'table.order_details' );
 			await expect( subTotalsTable ).toMatch( productName );
-			await expect( subTotalsTable ).toMatch( '$9.99 / month' );
+			await expect( subTotalsTable ).toMatch( '$9.99 / week' );
 
 			// Verify that all details in 'Related orders' table are correct.
 			await expect( page ).toMatchElement( 'td.order-number', {

--- a/tests/e2e/specs/shopper/shopper-subscriptions-purchase-subscription-product.spec.js
+++ b/tests/e2e/specs/shopper/shopper-subscriptions-purchase-subscription-product.spec.js
@@ -12,7 +12,6 @@ import { fillCardDetails, setupCheckout } from '../../utils/payments';
 const nowLocal = new Date();
 const nextPayDate = 'In 7 days';
 const productName = `Subscription product ${ nowLocal.getTime() }`;
-const periodTime = 'week';
 const customerBilling = config.get( 'addresses.customer.billing' );
 const card = config.get( 'cards.basic' );
 const baseUrl = config.get( 'url' );
@@ -30,7 +29,7 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 			await merchant.login();
 			productId = await merchantWCP.createSubscriptionProduct(
 				productName,
-				periodTime
+				'week'
 			);
 			await merchant.logout();
 		} );

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -226,6 +226,7 @@ export const merchantWCP = {
 	 * Create a subscription product with an optional signup fee
 	 *
 	 * @param productName
+	 * @param periodTime defaults to `month`
 	 * @param includeSignupFee defaults to `false`
 	 * @param includeFreeTrial defaults to `false`
 	 * @return id of the created subscription product
@@ -234,6 +235,7 @@ export const merchantWCP = {
 
 	createSubscriptionProduct: async (
 		productName,
+		periodTime = 'month',
 		includeSignupFee = false,
 		includeFreeTrial = false
 	) => {
@@ -245,6 +247,7 @@ export const merchantWCP = {
 		await expect( page ).toFill( '#title', productName );
 		await expect( page ).toSelect( '#product-type', 'Simple subscription' );
 		await expect( page ).toFill( '#_subscription_price', '9.99' );
+		await expect( page ).toSelect( '#_subscription_period', periodTime );
 
 		if ( includeSignupFee ) {
 			await expect( page ).toFill( '#_subscription_sign_up_fee', '1.99' );

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -226,7 +226,7 @@ export const merchantWCP = {
 	 * Create a subscription product with an optional signup fee
 	 *
 	 * @param productName
-	 * @param periodTime defaults to `month`
+	 * @param periodTime can be `day`, `week`, `month` or `year`
 	 * @param includeSignupFee defaults to `false`
 	 * @param includeFreeTrial defaults to `false`
 	 * @return id of the created subscription product
@@ -235,7 +235,7 @@ export const merchantWCP = {
 
 	createSubscriptionProduct: async (
 		productName,
-		periodTime = 'month',
+		periodTime,
 		includeSignupFee = false,
 		includeFreeTrial = false
 	) => {

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -7,6 +7,7 @@ const { shopper, uiUnblocked } = require( '@woocommerce/e2e-utils' );
 
 // WooCommerce Checkout
 export async function fillCardDetails( page, card ) {
+	await page.waitForSelector( '.__PrivateStripeElement' );
 	const frameHandle = await page.waitForSelector(
 		'#payment #wcpay-card-element iframe[name^="__privateStripeFrame"]'
 	);
@@ -31,6 +32,7 @@ export async function fillCardDetails( page, card ) {
 
 // WooCommerce Blocks Checkout
 export async function fillCardDetailsWCB( page, card ) {
+	await page.waitForSelector( '.__PrivateStripeElement' );
 	const frameHandle = await page.waitForSelector(
 		'#payment-method .wcpay-card-mounted iframe[name^="__privateStripeFrame"]'
 	);


### PR DESCRIPTION
Fixes issue with 2 E2E tests:
Shopper > Subscriptions > Purchase subscription product
Shopper > Checkout Failures

I have improved the logic of the function `createSubscriptionProduct` so now we can decide whether we want monthly or weekly or something else. Updated test accordingly.

Please run them locally:
(assuming you have WC Subscriptions plugin installed already)
- npm run test:e2e ./tests/e2e/specs/shopper/shopper-subscriptions-purchase-subscription-product.spec.js
- npm run test:e2e ./tests/e2e/specs/shopper/shopper-checkout-failures.spec.js
