### PR TITLE
Adds logging for checkout errors while using UPE

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@
 * Update - Continue loading WCPay if the account is connected.
 * Add - Message to suggest using the previous version of WooCommerce Payments for old Woo core versions.
 * Fix - Appearance of upload file buttons inside challenge dispute page
+* Fix - Enable logging for UPE checkout errors.
 
 = 3.0.0 - 2021-09-16 =
 * Add - Download deposits report in CSV.

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -545,4 +545,23 @@ export default class WCPayAPI {
 			...paymentData,
 		} );
 	}
+
+	/**
+	 * Log Payment Errors via Ajax.
+	 *
+	 * @param {string} chargeId Stripe Charge ID
+	 * @return {boolean} Returns true irrespective of result.
+	 */
+	logPaymentError( chargeId ) {
+		return this.request(
+			buildAjaxURL( getConfig( 'wcAjaxUrl' ), 'log_payment_error' ),
+			{
+				charge_id: chargeId,
+				_ajax_nonce: getConfig( 'logPaymentErrorNonce' ),
+			}
+		).then( () => {
+			// There is not any action to take or harm caused by a failed update, so just returning true.
+			return true;
+		} );
+	}
 }

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -556,7 +556,11 @@ jQuery( function ( $ ) {
 				( { error } = await api.getStripe().confirmSetup( upeConfig ) );
 			}
 			if ( error ) {
-				throw error;
+				// Log payment errors on charge and then throw the error.
+				const logError = await api.logPaymentError( error.charge );
+				if ( logError ) {
+					throw error;
+				}
 			}
 		} catch ( error ) {
 			$form.removeClass( 'processing' ).unblock();

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -904,6 +904,9 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 				throw new Exception( 'Order not found. Unable to log error.' );
 			}
 
+			$order_amount  = WC_Payments_Explicit_Price_Formatter::get_explicit_price( wc_price( $order->get_total(), [ 'currency' => $order->get_currency() ] ), $order );
+			$error_message = esc_html( rtrim( $get_charge_data['failure_message'], '.' ) );
+
 			$order_note = sprintf(
 				WC_Payments_Utils::esc_interpolated_html(
 				/* translators: %1: the failed payment amount, %2: error message  */
@@ -916,8 +919,8 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 						'code'   => '<code>',
 					]
 				),
-				WC_Payments_Explicit_Price_Formatter::get_explicit_price( wc_price( $order->get_total(), [ 'currency' => $order->get_currency() ] ), $order ),
-				esc_html( rtrim( $get_charge_data['failure_message'], '.' ) )
+				$order_amount,
+				$error_message
 			);
 
 			// Set order as failed and add the order note.

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,7 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Bump minimum required version of WooCommerce from 4.0 to 4.4.
 * Update - Continue loading WCPay if the account is connected.
 * Add - Message to suggest using the previous version of WooCommerce Payments for old Woo core versions.
+* Fix - Enable logging for UPE checkout errors.
 
 = 3.0.0 - 2021-09-16 =
 * Add - Download deposits report in CSV.


### PR DESCRIPTION
Fixes #2702 

## Changes proposed in this Pull Request

At the moment, if an error occurs while charging a UPE not logged on the order. Additionally the order status is not updated to Failed and instead remain as Pending Payment.

This PR adds error logging for UPE Payments. The changes doesn't break any of the existing flows. Even if any error occurs while logging the error, it is ignored so the checkout works as expected.

## Testing instructions

* Enable UPE Checkout.
* Follow instructions on #2702 to replicate the error.
* Switch branch to `fix/issue_2702` and try checkout again.
* Confirm that the order status is changed to `Failed` and the error message is logged to Order Note.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
