### PR TITLE
Fix inconsistent shipping options in Google Pay payment sheet

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@
 * Fix - Translations in transaction/deposit exports
 * Fix - Update shipping cost in payment sheet when changing payment method.
 * Fix - Transaction search with translated terms
+* Fix - Inconsistent shipping options in Payment Request popup
 
 = 3.0.0 - 2021-09-16 =
 * Add - Download deposits report in CSV.

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -283,7 +283,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 			];
 		}
 
-		if ( wc_shipping_enabled() && $product->needs_shipping() ) {
+		if ( wc_shipping_enabled() && 0 !== wc_get_shipping_method_count( true ) && $product->needs_shipping() ) {
 			$items[] = [
 				'label'   => __( 'Shipping', 'woocommerce-payments' ),
 				'amount'  => 0,
@@ -305,7 +305,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 			'pending' => true,
 		];
 
-		$data['needs_shipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );
+		$data['needs_shipping'] = ( wc_shipping_enabled() && 0 !== wc_get_shipping_method_count( true ) && $product->needs_shipping() );
 		$data['currency']       = strtolower( get_woocommerce_currency() );
 		$data['country_code']   = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
 

--- a/readme.txt
+++ b/readme.txt
@@ -114,6 +114,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Translations in transaction/deposit exports
 * Fix - Update shipping cost in payment sheet when changing payment method.
 * Fix - Transaction search with translated terms
+* Fix - Inconsistent shipping options in Payment Request popup
 
 = 3.0.0 - 2021-09-16 =
 * Add - Download deposits report in CSV.


### PR DESCRIPTION
Fixes #1926 

#### Changes proposed in this Pull Request
When a shipping method is not set, Google Pay payments popup works differently on the product page and checkout page. Checkout page allows the purchase when a shipping method is absent while the product page payment sheet does not.

When checking out through the checkout page, `WC() ->cart->needs_shipping()` is being called which checks for the [presence of shipping methods](https://github.com/woocommerce/woocommerce/blob/trunk/includes/class-wc-cart.php#L1526). Changes proposed here introduces the same check when checking out in the product page

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to WooCommerce > Settings > Shipping.
* Create a shipping zone for United States but don't add a shipping method
* Add some products.
* Enable Express Checkouts for Checkout and Product Page from Payment->Settings.
* Visit any Product page on Google Chrome.
* Click on Google Pay button.
* Ensure that user is allowed to checkout.


- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
