### PR TITLE
fixed appearance of upload buttons inside challenge dispute

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@
 * Update - Bump minimum supported version of WooCommerce from 5.4 to 5.5.
 * Update - Bump minimum required version of WooCommerce from 4.0 to 4.4.
 * Fix - Add credit card on My Account using other payment gateways does not show "Your card number is incomplete" error
+* Fix - Appearance of upload file buttons inside challenge dispute page
 
 = 3.0.0 - 2021-09-16 =
 * Add - Download deposits report in CSV.

--- a/client/disputes/evidence/file-upload.js
+++ b/client/disputes/evidence/file-upload.js
@@ -51,7 +51,7 @@ export const FileUploadControl = ( props ) => {
 				<FormFileUpload
 					id={ `form-file-upload-${ field.key }` }
 					className={ isDone && ! hasError ? 'is-success' : null }
-					isPrimary
+					isSecondary
 					isDestructive={ hasError }
 					isBusy={ isLoading }
 					disabled={ disabled || isLoading }

--- a/client/disputes/evidence/test/__snapshots__/file-upload.js.snap
+++ b/client/disputes/evidence/test/__snapshots__/file-upload.js.snap
@@ -28,7 +28,7 @@ exports[`FileUploadControl renders default file upload control 1`] = `
           class="components-form-file-upload"
         >
           <button
-            class="components-button is-primary has-text has-icon"
+            class="components-button is-secondary has-text has-icon"
             id="form-file-upload-field_key"
             type="button"
           >
@@ -90,7 +90,7 @@ exports[`FileUploadControl renders disabled state 1`] = `
           class="components-form-file-upload"
         >
           <button
-            class="components-button is-success is-primary has-text has-icon"
+            class="components-button is-success is-secondary has-text has-icon"
             disabled=""
             id="form-file-upload-field_key"
             type="button"
@@ -155,7 +155,7 @@ exports[`FileUploadControl renders loading state 1`] = `
           class="components-form-file-upload"
         >
           <button
-            class="components-button is-primary is-busy has-text has-icon"
+            class="components-button is-secondary is-busy has-text has-icon"
             disabled=""
             id="form-file-upload-field_key"
             type="button"
@@ -218,7 +218,7 @@ exports[`FileUploadControl renders upload done state 1`] = `
           class="components-form-file-upload"
         >
           <button
-            class="components-button is-success is-primary has-text has-icon"
+            class="components-button is-success is-secondary has-text has-icon"
             id="form-file-upload-field_key"
             type="button"
           >
@@ -301,7 +301,7 @@ exports[`FileUploadControl renders upload failed state 1`] = `
           class="components-form-file-upload"
         >
           <button
-            class="components-button is-primary is-destructive has-text has-icon"
+            class="components-button is-secondary is-destructive has-text has-icon"
             id="form-file-upload-field_key"
             type="button"
           >

--- a/client/disputes/evidence/test/__snapshots__/index.js.snap
+++ b/client/disputes/evidence/test/__snapshots__/index.js.snap
@@ -78,7 +78,7 @@ exports[`Dispute evidence form needing response, renders correctly 1`] = `
               class="components-form-file-upload"
             >
               <button
-                class="components-button is-primary has-text has-icon"
+                class="components-button is-secondary has-text has-icon"
                 id="form-file-upload-customer_signature"
                 type="button"
               >
@@ -255,7 +255,7 @@ exports[`Dispute evidence form not needing response, renders correctly 1`] = `
               class="components-form-file-upload"
             >
               <button
-                class="components-button is-primary has-text has-icon"
+                class="components-button is-secondary has-text has-icon"
                 disabled=""
                 id="form-file-upload-customer_signature"
                 type="button"

--- a/client/disputes/style.scss
+++ b/client/disputes/style.scss
@@ -65,14 +65,14 @@
 		align-items: center;
 
 		// Selector here is super specific to ensure styles are overwritten.
-		.components-button.is-primary:not( :disabled ):not( [aria-disabled='true'] ) {
+		.components-button.is-secondary:not( :disabled ):not( [aria-disabled='true'] ) {
 			&.is-success {
-				background-color: $studio-green;
-				border-color: $studio-green;
+				box-shadow: inset 0 0 0 1px $studio-green;
+				color: $studio-green;
 
 				&:hover {
-					background-color: $studio-green-60;
-					border-color: $studio-green-60;
+					box-shadow: inset 0 0 0 1px $studio-green-60;
+					color: $studio-green-60;
 				}
 			}
 


### PR DESCRIPTION
Fixes #523 

This PR fixes the appearance of the upload file buttons inside challenge dispute page. 

Before: 
<img width="241" alt="Screen Shot 2021-10-01 at 11 44 42 AM" src="https://user-images.githubusercontent.com/6342964/135639681-5d0176c8-cdb1-44a9-bcbe-6731ae540f53.png">

After:
<img width="260" alt="Screen Shot 2021-10-01 at 11 30 33 AM" src="https://user-images.githubusercontent.com/6342964/135639734-5b8f4aee-c9c2-45f9-aa17-e9834a45b48d.png">

#### Testing instructions

- Go to wp-admin >  Payments > Disputes > Challenge dispute
- Check if the button has the proper appearance according to image above


-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
