### PR TITLE
Fix track 'wcpay_payment_request_settings_change' not being recorded

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Add - Currency deletion confirmation modal for currencies that are bound to an UPE method.
 * Fix - Currency switcher does not affect order confirmation screen prices.
 * Fix - Error when attempting to change the payment method for a subscription with UPE enabled.
+* Fix - Track for when updating the Payment Requests setting not being recorded.
 * Add - Multi-Currency track currency added.
 * Fix - Fill missing order_intent_info even if an exception occurs.
 * Add - Gutenberg Block Widget for Multi-Currency.

--- a/client/additional-methods-setup/methods-selector/add-payment-methods-task.js
+++ b/client/additional-methods-setup/methods-selector/add-payment-methods-task.js
@@ -27,6 +27,7 @@ import {
 	useSettings,
 	usePaymentRequestEnabledSettings,
 } from '../../data';
+import wcpayTracks from '../../tracks';
 import './add-payment-methods-task.scss';
 import CurrencyInformationForMethods from '../../components/currency-information-for-methods';
 import { upeMethods } from '../constants';
@@ -132,6 +133,16 @@ const AddPaymentMethodsTask = () => {
 				setIsPaymentRequestEnabled( initialIsPaymentRequestEnabled );
 				updateEnabledPaymentMethodIds( initialEnabledPaymentMethodIds );
 				return;
+			}
+
+			// Record the track event when the setting is updated.
+			if ( initialIsPaymentRequestEnabled !== isPaymentRequestChecked ) {
+				wcpayTracks.recordEvent(
+					wcpayTracks.events.PAYMENT_REQUEST_SETTINGS_CHANGE,
+					{
+						enabled: isPaymentRequestChecked ? 'yes' : 'no',
+					}
+				);
 			}
 
 			setCompleted( true, 'setup-complete' );

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -26,6 +26,7 @@ const SaveSettingsSection = () => {
 
 	if (
 		null === initialIsPaymentRequestEnabled &&
+		settings &&
 		'undefined' !== typeof settings.is_payment_request_enabled
 	) {
 		setInitialIsPaymentRequestEnabled(

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -10,11 +10,52 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useSettings } from '../../data';
+import wcpayTracks from '../../tracks';
 import SettingsSection from '../settings-section';
 import './style.scss';
 
 const SaveSettingsSection = () => {
-	const { saveSettings, isSaving, isLoading } = useSettings();
+	const { saveSettings, isSaving, isLoading, settings } = useSettings();
+
+	// Keep the inital value of is_payment_request_enabled
+	// in state for recording its track on change.
+	const [
+		initialIsPaymentRequestEnabled,
+		setInitialIsPaymentRequestEnabled,
+	] = useState( null );
+
+	if (
+		null === initialIsPaymentRequestEnabled &&
+		'undefined' !== typeof settings.is_payment_request_enabled
+	) {
+		setInitialIsPaymentRequestEnabled(
+			settings.is_payment_request_enabled
+		);
+	}
+
+	const saveOnClick = async () => {
+		const isSuccess = await saveSettings();
+
+		// Track the event when the value changed and the
+		// settings were successfully saved.
+		if (
+			isSuccess &&
+			initialIsPaymentRequestEnabled !==
+				settings.is_payment_request_enabled
+		) {
+			wcpayTracks.recordEvent(
+				wcpayTracks.events.PAYMENT_REQUEST_SETTINGS_CHANGE,
+				{
+					enabled: settings.is_payment_request_enabled ? 'yes' : 'no',
+				}
+			);
+
+			// Update the "initial" value to properly track consecutive saves.
+			setInitialIsPaymentRequestEnabled(
+				settings.is_payment_request_enabled
+			);
+		}
+	};
 
 	return (
 		<SettingsSection className="save-settings-section">
@@ -22,7 +63,7 @@ const SaveSettingsSection = () => {
 				isPrimary
 				isBusy={ isSaving }
 				disabled={ isSaving || isLoading }
-				onClick={ saveSettings }
+				onClick={ saveOnClick }
 			>
 				{ __( 'Save changes', 'woocommerce-payments' ) }
 			</Button>

--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -37,6 +37,7 @@ const events = {
 		'wcpay_deposits_summary_empty_state_click',
 	MULTI_CURRENCY_ENABLED_CURRENCIES_UPDATED:
 		'wcpay_multi_currency_enabled_currencies_updated',
+	PAYMENT_REQUEST_SETTINGS_CHANGE: 'wcpay_payment_request_settings_change',
 };
 
 export default {

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -14,7 +14,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use WCPay\Logger;
-use WCPay\Tracker;
 
 /**
  * WC_Payments_Payment_Request_Button_Handler class.
@@ -53,9 +52,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 * @return  void
 	 */
 	public function init() {
-		// Add Track event on settings change.
-		add_action( 'update_option_woocommerce_woocommerce_payments_settings', [ $this, 'track_payment_request_settings_change' ], 10, 2 );
-
 		// Checks if WCPay is enabled.
 		if ( ! $this->gateway->is_enabled() ) {
 			return;
@@ -101,26 +97,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 		// will be used to calculate it whenever the option value is retrieved instead.
 		// It's used for displaying inbox notifications.
 		add_filter( 'pre_option_wcpay_is_apple_pay_enabled', [ $this, 'get_option_is_apple_pay_enabled' ], 10, 1 );
-	}
-
-	/**
-	 * Track Payment Request settings activation/deactivation.
-	 *
-	 * @param array $prev_settings Settings before update.
-	 * @param array $settings      Settings after update.
-	 */
-	public function track_payment_request_settings_change( $prev_settings, $settings ) {
-		$prev_payment_request_enabled = 'yes' === ( $prev_settings['payment_request'] ?? 'no' );
-		$payment_request_enabled      = 'yes' === ( $settings['payment_request'] ?? 'no' );
-
-		if ( $prev_payment_request_enabled !== $payment_request_enabled ) {
-			Tracker::track_admin(
-				'wcpay_payment_request_settings_change',
-				[
-					'enabled' => $payment_request_enabled,
-				]
-			);
-		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2995

#### Changes proposed in this Pull Request

Record the track  "wcpay_payment_request_settings_change" on the client-side instead of the server-side.

This PR removes the code for tracking "wcpay_payment_request_settings_change" on the server-side because it's not being recorded this way, as explained in the related issue. This seems to be happening because WC_Tracks isn't loaded when saving WCPay settings.

It also introduces recording this same event on the client-side when saving WCPay settings and the value of the "is_payment_request_enabled" setting changes.

#### Testing instructions

For when updating the setting via WCPay settings:
* On your install, go to Payments -> Settings
* Scroll to the "Express checkouts" section
* Check "Enable express checkouts" so it's enabled (or disable it if it was enabled) and save your changes
* Search "wcpay_payment_request_settings_change" on tracks and open the Live view
* Wait ~5 minutes and, opposite to what's described in the issue. notice the event does show up

For when updating it via tasks:
I didn't see how this would show up in the regular flow. It requires UPE preview to be disabled (which is enabled by default and has to be disabled by updating either the code or the value in the database), and other combinations of things that I didn't find possible to set up without touching the code. I added the track in case that's introduced into the regular flow again.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
