### PR TITLE
Fix fatal error when WooCommerce is not active

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -407,6 +407,7 @@ class WC_Payments {
 			);
 
 			if ( current_user_can( 'install_plugins' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/plugin.php'; // Load this file for the `validate_plugin` function.
 				if ( is_wp_error( validate_plugin( 'woocommerce/woocommerce.php' ) ) ) {
 					// WooCommerce is not installed.
 					$activate_url  = wp_nonce_url( admin_url( 'update.php?action=install-plugin&plugin=woocommerce' ), 'install-plugin_woocommerce' );


### PR DESCRIPTION
Regression of #3010. 
Internal discussion p1633406431202600-slack-CGGCLBN58

#### To replicate the issue 

- Use https://github.com/Automattic/woocommerce-payments/releases/download/3.1.0-test-3/woocommerce-payments.zip
- Go to a site without WooCommerce.
- Upload/install WCPay.
- Activate WCPay. 
- Get this fatal error: 

```
[05-Oct-2021 05:48:25 UTC] PHP Fatal error:  Uncaught Error: Call to undefined function validate_plugin() in /var/www/html/wp-content/plugins/woocommerce-payments/includes/class-wc-payments.php:410
Stack trace:
#0 /var/www/html/wp-content/plugins/woocommerce-payments/includes/class-wc-payments.php(160): WC_Payments::check_plugin_dependencies()
#1 /var/www/html/wp-content/plugins/woocommerce-payments/woocommerce-payments.php(94): WC_Payments::init()
#2 /var/www/html/wp-includes/class-wp-hook.php(303): wcpay_init('')
#3 /var/www/html/wp-includes/class-wp-hook.php(327): WP_Hook->apply_filters(NULL, Array)
#4 /var/www/html/wp-includes/plugin.php(470): WP_Hook->do_action(Array)
#5 /var/www/html/wp-settings.php(441): do_action('plugins_loaded')
#6 /var/www/html/wp-config.php(254): require_once('/var/www/html/w...')
#7 /var/www/html/wp-load.php(50): require_once('/var/www/html/w...')
#8 /var/www/html/wp-admin/admin.php(34): require_once('/var/www/html/w...')
#9 /var/www/html/wp-admin/plugins.php(10): require_once('/var/www/html/w...')
#10 {main}
  thrown in /var/www/html/wp-content/plugins/woocommerce-payments/includes/class-wc-payments.php on line 410
``` 

#### Changes proposed in this Pull Request

- Load file `wp-admin/includes/plugin.php` for so that we can use `validate_plugin`function at this stage. 


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

* Follow steps `To replicate the issue`.
* Expectation: There is no fatal error, AND a messagea asking for installing WooCommerce.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)