### PR TITLE
Add 'type' to the 'payments/terminal/locations' update route args

### DIFF
--- a/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
+++ b/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
@@ -52,8 +52,12 @@ class WC_REST_Payments_Terminal_Locations_Controller extends WC_Payments_REST_Co
 				'callback'            => [ $this, 'update_location' ],
 				'permission_callback' => [ $this, 'check_permission' ],
 				'args'                => [
-					'display_name',
-					'address',
+					'display_name' => [
+						'type' => 'string',
+					],
+					'address'      => [
+						'type' => 'object',
+					],
 				],
 			]
 		);


### PR DESCRIPTION
This prevents a PHP warning that shows up because the items of 'args' are expected to be arrays instead of strings.

Fixes #3049 

#### Changes proposed in this Pull Request

Adding a schema containing the type for the args of the "payments/terminal/locations" route. Minor change to prevent the PHP warning from happening.

#### Testing instructions

* The UPDATE endpoint should continue to work as described in the [original PR](https://github.com/Automattic/woocommerce-payments/pull/3013)
* No PHP warning should be displayed nor logged when going to a WCPay page

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
