### PR TITLE
Add changelog entries for `automattic/jetpack-connection` update

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@
 * Add - Message to suggest using the previous version of WooCommerce Payments for old Woo core versions.
 * Fix - Appearance of upload file buttons inside challenge dispute page
 * Fix - Enable logging for UPE checkout errors.
+* Update - Composer package `automattic/jetpack-connection` from v1.20.0 to v1.30.5.
 
 = 3.0.0 - 2021-09-16 =
 * Add - Download deposits report in CSV.

--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,7 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Continue loading WCPay if the account is connected.
 * Add - Message to suggest using the previous version of WooCommerce Payments for old Woo core versions.
 * Fix - Enable logging for UPE checkout errors.
+* Update - Composer package `automattic/jetpack-connection` from v1.20.0 to v1.30.5.
 
 = 3.0.0 - 2021-09-16 =
 * Add - Download deposits report in CSV.


### PR DESCRIPTION
Adds missing changelog entry for https://github.com/Automattic/woocommerce-payments/pull/1217 to readme.txt and changelog.txt files.