### PR TITLE
Make sure new the payment method radio is selected when adding new payment method in e2e tests

### DIFF
--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -127,6 +127,13 @@ export const shopperWCP = {
 		await page.waitForNavigation( {
 			waitUntil: 'networkidle0',
 		} );
+
+		if ( null !== page.$( '#wc-woocommerce_payments-payment-token-new' ) ) {
+			await expect( page ).toClick(
+				'#wc-woocommerce_payments-payment-token-new'
+			);
+		}
+
 		await fillCardDetails( page, card );
 		await expect( page ).toClick( 'button', {
 			text: 'Add payment method',

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -12,6 +12,7 @@ const {
 	evalAndClick,
 	uiUnblocked,
 	clearAndFillInput,
+	setCheckbox,
 } = require( '@woocommerce/e2e-utils' );
 const {
 	fillCardDetails,
@@ -129,9 +130,7 @@ export const shopperWCP = {
 		} );
 
 		if ( null !== page.$( '#wc-woocommerce_payments-payment-token-new' ) ) {
-			await expect( page ).toClick(
-				'#wc-woocommerce_payments-payment-token-new'
-			);
+			await setCheckbox( '#wc-woocommerce_payments-payment-token-new' );
 		}
 
 		await fillCardDetails( page, card );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes the failing `tests/e2e/specs/shopper/shopper-subscriptions-change-payment-method.spec.js` e2e tests in `feature/stripe_billing`.

It looks like after our changes, when we attempt to [add a new payment method](https://github.com/Automattic/woocommerce-payments/blob/1190780ec0c655045f89aef04c3d101864b84864/tests/e2e/specs/shopper/shopper-subscriptions-change-payment-method.spec.js#L74), the test expects there to be no saved method. 

But with the changes in our feature branch, there are, which causes this particular test to timeout since its unable to fill out new card info with a saved payment method selected.

This ensures the new payment method radio is selected prior to filling out card details when adding a new payment method via the e2e addNewPaymentMethod helper function.

#### Testing instructions

Run the e2e test on `feature/stripe_billing`, and on this branch:

```
npm run test:e2e-dev ./tests/e2e/specs/shopper/shopper-subscriptions-change-payment-method.spec.js
```

You should see failures as a result of the described behavior above on the feature branch, and none on this one.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
