### PR TITLE
Fix missing argument descriptions in terminal locations API

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Payments Changelog ***
 
 = 3.2.0 - 2021-xx-xx =
-* 
+* Fix - PHP warning at the bottom of WooCommerce Payments admin pages
 
 = 3.1.0 - 2021-10-06 =
 * Fix - Issue affecting analytics for Multi-Currency orders made with a zero-decimal to non-zero decimal conversion.

--- a/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
+++ b/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
@@ -52,8 +52,14 @@ class WC_REST_Payments_Terminal_Locations_Controller extends WC_Payments_REST_Co
 				'callback'            => [ $this, 'update_location' ],
 				'permission_callback' => [ $this, 'check_permission' ],
 				'args'                => [
-					'display_name',
-					'address',
+					'display_name' => [
+						'type'     => 'string',
+						'required' => false,
+					],
+					'address'      => [
+						'type'     => 'object',
+						'required' => false,
+					],
 				],
 			]
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -99,7 +99,7 @@ Please note that our support for the checkout block is still experimental and th
 == Changelog ==
 
 = 3.2.0 - 2021-xx-xx =
-* 
+* Fix - PHP warning at the bottom of WooCommerce Payments admin pages
 
 = 3.1.0 - 2021-10-06 =
 * Fix - Issue affecting analytics for Multi-Currency orders made with a zero-decimal to non-zero decimal conversion.


### PR DESCRIPTION
Fixes an error in the WooCommerce Payments admin screens:

```
Warning: array_intersect_key(): Expected parameter 1 to be an array, string given in /var/www/html/wp-includes/rest-api/class-wp-rest-server.php on line 1436

Call Stack:
    0.0002     409912   1. {main}() /var/www/html/wp-admin/admin.php:0
    3.9651   17375976   2. require_once('/var/www/html/wp-admin/admin-footer.php') /var/www/html/wp-admin/admin.php:297
    4.0048   17444832   3. do_action() /var/www/html/wp-admin/admin-footer.php:95
    4.0048   17445208   4. WP_Hook->do_action() /var/www/html/wp-includes/plugin.php:470
    4.0048   17445208   5. WP_Hook->apply_filters() /var/www/html/wp-includes/class-wp-hook.php:327
    4.0048   17446336   6. Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry->enqueue_asset_data() /var/www/html/wp-includes/class-wp-hook.php:303
    4.0059   17454584   7. Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry->initialize_core_data() /var/www/html/wp-content/plugins/woo-gutenberg-products-block/src/Assets/AssetDataRegistry.php:333
    4.0059   17454584   8. apply_filters() /var/www/html/wp-content/plugins/woo-gutenberg-products-block/src/Assets/AssetDataRegistry.php:200
    4.0059   17454984   9. WP_Hook->apply_filters() /var/www/html/wp-includes/plugin.php:189
    4.0059   17456488  10. Automattic\WooCommerce\Admin\Loader::add_component_settings() /var/www/html/wp-includes/class-wp-hook.php:303
    4.0082   17460648  11. array_reduce() /var/www/html/wp-content/plugins/woocommerce/packages/woocommerce-admin/src/Loader.php:1043
    4.0082   17460648  12. rest_preload_api_request() /var/www/html/wp-content/plugins/woocommerce/packages/woocommerce-admin/src/Loader.php:1043
    4.0082   17461248  13. rest_do_request() /var/www/html/wp-includes/rest-api.php:2832
    6.1339   25127576  14. WP_REST_Server->dispatch() /var/www/html/wp-includes/rest-api.php:495
    6.1441   25130208  15. WP_REST_Server->respond_to_request() /var/www/html/wp-includes/rest-api/class-wp-rest-server.php:987
    6.1442   25130960  16. WP_REST_Server->get_namespace_index() /var/www/html/wp-includes/rest-api/class-wp-rest-server.php:1140
    6.1743   25381048  17. WP_REST_Server->get_data_for_routes() /var/www/html/wp-includes/rest-api/class-wp-rest-server.php:1323
    6.1825   25453608  18. WP_REST_Server->get_data_for_route() /var/www/html/wp-includes/rest-api/class-wp-rest-server.php:1358
    6.1879   25458456  19. array_intersect_key() /var/www/html/wp-includes/rest-api/class-wp-rest-server.php:1436
```

#### Changes proposed in this Pull Request

Provide argument descriptions to terminal locations API update endpoint

#### Testing instructions

 * Open WooCommerce Payments admin page without the fix. Notice the error like above appearing at the bottom of the page.
 * Checkout the branch and load page again. Error should go away.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
