### PR TITLE
Add callback to create new wcpay subscription on manual renewal

### DIFF
--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -157,6 +157,12 @@ class WC_Payments_Invoice_Service {
 
 			// Update the status of the invoice to paid but don't charge the customer by using paid_out_of_band parameter.
 			$this->payments_api_client->charge_invoice( $invoice_id, [ 'paid_out_of_band' => 'true' ] );
+
+			if ( $subscription->is_manual() ) {
+				$subscription->set_requires_manual_renewal( false );
+				$subscription->set_payment_method( WC_Payment_Gateway_WCPay::GATEWAY_ID );
+				$subscription->save();
+			}
 		}
 	}
 

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -152,7 +152,9 @@ class WC_Payments_Invoice_Service {
 		$order_completed = in_array( $new_status, [ apply_filters( 'woocommerce_payment_complete_order_status', 'processing', $order_id, $order ), 'processing', 'completed' ], true );
 
 		if ( $needed_payment && $order_completed ) {
-			foreach ( wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'parent' ] ) as $subscription ) {
+			$subscriptions = wcs_get_subscriptions_for_order( $order, [ 'order_type' => [ 'parent', 'renewal' ] ] );
+
+			foreach ( $subscriptions as $subscription ) {
 				$invoice_id = self::get_subscription_invoice_id( $subscription );
 
 				if ( ! $invoice_id ) {

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -161,6 +161,9 @@ class WC_Payments_Invoice_Service {
 			if ( $subscription->is_manual() ) {
 				$subscription->set_requires_manual_renewal( false );
 				$subscription->set_payment_method( WC_Payment_Gateway_WCPay::GATEWAY_ID );
+
+				// Copy the payment token used to pay for the order to the subscription.
+				WC_Payments::get_gateway()->update_failing_payment_method( $subscription, $order );
 				$subscription->save();
 			}
 		}

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -144,7 +144,7 @@ class WC_Payments_Invoice_Service {
 	public function maybe_record_invoice_payment( int $order_id ) {
 		$order = wc_get_order( $order_id );
 
-		if ( ! $order ) {
+		if ( ! $order || self::get_order_invoice_id( $order ) ) {
 			return;
 		}
 

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -114,6 +114,7 @@ class WC_Payments_Subscription_Service {
 
 		if ( ! $this->is_subscriptions_plugin_active() ) {
 			add_action( 'woocommerce_checkout_subscription_created', [ $this, 'create_subscription' ] );
+			add_action( 'woocommerce_renewal_order_payment_complete', [ $this, 'create_subscription_for_manual_renewal' ] );
 		}
 
 		add_action( 'woocommerce_subscription_status_cancelled', [ $this, 'cancel_subscription' ] );
@@ -129,7 +130,6 @@ class WC_Payments_Subscription_Service {
 		add_filter( 'woocommerce_subscription_payment_gateway_supports', [ $this, 'prevent_wcpay_subscription_changes' ], 10, 3 );
 
 		add_action( 'woocommerce_payments_changed_subscription_payment_method', [ $this, 'maybe_attempt_payment_for_subscription' ], 10, 2 );
-		add_action( 'woocommerce_renewal_order_payment_complete', [ $this, 'create_subscription_for_manual_renewal' ] );
 	}
 
 	/**

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -163,7 +163,7 @@
     </UndefinedDocblockClass>
     <UndefinedFunction occurrences="4">
       <code>wcs_get_subscription</code>
-      <code>wcs_get_subscriptions_for_order( $order_id )</code>
+      <code>wcs_get_subscriptions_for_renewal_order( $order_id )</code>
     </UndefinedFunction>
   </file>
   <file src="includes/subscriptions/class-wc-payments-subscriptions-event-handler.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -151,7 +151,7 @@
       <code>WC_Subscription</code>
     </UndefinedClass>
     <UndefinedFunction occurrences="1">
-      <code>wcs_get_subscriptions_for_order( $order, [ 'order_type' =&gt; 'parent' ] )</code>
+      <code>wcs_get_subscriptions_for_order( $order, [ 'order_type' =&gt; [ 'parent', 'renewal' ] ] )</code>
     </UndefinedFunction>
   </file>
   <file src="includes/subscriptions/class-wc-payments-subscription-service.php">
@@ -161,8 +161,9 @@
     <UndefinedDocblockClass occurrences="2">
       <code>WC_Subscription|bool</code>
     </UndefinedDocblockClass>
-    <UndefinedFunction occurrences="3">
+    <UndefinedFunction occurrences="4">
       <code>wcs_get_subscription</code>
+      <code>wcs_get_subscriptions_for_order( $order_id )</code>
     </UndefinedFunction>
   </file>
   <file src="includes/subscriptions/class-wc-payments-subscriptions-event-handler.php">

--- a/tests/unit/helpers/class-wc-helper-subscription.php
+++ b/tests/unit/helpers/class-wc-helper-subscription.php
@@ -239,7 +239,7 @@ class WC_Subscription extends WC_Mock_WC_Data {
 		return $this->manual;
 	}
 
-	public function set_manual( $bool ) {
+	public function set_requires_manual_renewal( $bool ) {
 		$this->manual = $bool;
 	}
 }

--- a/tests/unit/helpers/class-wc-helper-subscription.php
+++ b/tests/unit/helpers/class-wc-helper-subscription.php
@@ -79,6 +79,13 @@ class WC_Subscription extends WC_Mock_WC_Data {
 	public $status;
 
 	/**
+	 * Helper variable for mocking the subscription manual check.
+	 *
+	 * @var bool
+	 */
+	public $manual;
+
+	/**
 	 * Currency.
 	 *
 	 * @var string
@@ -130,16 +137,16 @@ class WC_Subscription extends WC_Mock_WC_Data {
 		throw new Exception( "Call to undefined method WC_Subscription::{$name}()" );
 	}
 
-	public function set_parent( $parent_order ) {
-		$this->parent_order = $parent_order;
-	}
-
 	public function get_parent_id() {
 		return ! empty( $this->parent_order ) ? $this->parent_order->get_id() : 0;
 	}
 
 	public function get_parent() {
 		return ! empty( $this->parent_order ) ? $this->parent_order : false;
+	}
+
+	public function set_parent( $parent_order ) {
+		$this->parent_order = $parent_order;
 	}
 
 	public function get_items( $type = 'line_item' ) {
@@ -226,5 +233,13 @@ class WC_Subscription extends WC_Mock_WC_Data {
 
 	public function has_status( $status ) {
 		return ( is_array( $status ) && in_array( $this->get_status(), $status, true ) ) || $this->get_status() === $status;
+	}
+
+	public function is_manual() {
+		return $this->manual;
+	}
+
+	public function set_manual( $bool ) {
+		$this->manual = $bool;
 	}
 }

--- a/tests/unit/helpers/class-wc-helper-subscriptions.php
+++ b/tests/unit/helpers/class-wc-helper-subscriptions.php
@@ -20,6 +20,13 @@ function wcs_get_subscriptions_for_order( $order ) {
 	return ( WC_Subscriptions::$wcs_get_subscriptions_for_order )( $order );
 }
 
+function wcs_get_subscriptions_for_renewal_order( $order ) {
+	if ( ! WC_Subscriptions::$wcs_get_subscriptions_for_renewal_order ) {
+		return;
+	}
+	return ( WC_Subscriptions::$wcs_get_subscriptions_for_renewal_order )( $order );
+}
+
 function wcs_is_subscription( $order ) {
 	if ( ! WC_Subscriptions::$wcs_is_subscription ) {
 		return;
@@ -90,6 +97,13 @@ class WC_Subscriptions {
 	public static $wcs_get_subscriptions_for_order = null;
 
 	/**
+	 * wcs_get_subscriptions_for_renewal_order mock.
+	 *
+	 * @var function
+	 */
+	public static $wcs_get_subscriptions_for_renewal_order = null;
+
+	/**
 	 * wcs_is_subscription mock.
 	 *
 	 * @var function
@@ -137,6 +151,10 @@ class WC_Subscriptions {
 
 	public static function set_wcs_get_subscriptions_for_order( $function ) {
 		self::$wcs_get_subscriptions_for_order = $function;
+	}
+
+	public static function set_wcs_get_subscriptions_for_renewal_order( $function ) {
+		self::$wcs_get_subscriptions_for_renewal_order = $function;
 	}
 
 	public static function set_wcs_is_subscription( $function ) {

--- a/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
@@ -128,54 +128,37 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests for WC_Payments_Invoice_Service::maybe_record_first_invoice_payment()
+	 * Tests for WC_Payments_Invoice_Service::maybe_record_invoice_payment()
 	 */
-	public function test_maybe_record_first_invoice_payment() {
+	public function test_maybe_record_invoice_payment() {
 		$invoice_id        = 'in_foo123';
 		$mock_order        = WC_Helper_Order::create_order();
 		$mock_subscription = new WC_Subscription();
 
 		// With the following calls to `maybe_record_first_invoice_payment()`, we only expect 2 calls (see Positive Cases) to result in an API call.
-		$this->mock_api_client->expects( $this->exactly( 6 ) )
+		$this->mock_api_client->expects( $this->once() )
 			->method( 'charge_invoice' )
 			->with( $invoice_id, [ 'paid_out_of_band' => 'true' ] );
 
+		// Negative Cases.
 		// Mock an empty list of subscriptions.
 		$this->mock_wcs_get_subscriptions_for_order( [] );
 
-		// Negative Cases.
 		// Order isn't related to a subscription.
-		$this->invoice_service->maybe_record_first_invoice_payment( $mock_order->get_id(), 'pending', 'processing' );
+		$this->invoice_service->maybe_record_invoice_payment( $mock_order->get_id() );
 
-		$subscriptions = [ $mock_subscription ];
+		// Invalid order ID.
+		$this->invoice_service->maybe_record_invoice_payment( 0 );
 
 		// Mock the get subscriptions from order call.
-		$this->mock_wcs_get_subscriptions_for_order( $subscriptions );
-
-		// Order doesn't have a pending invoice.
-		$this->invoice_service->maybe_record_first_invoice_payment( $mock_order->get_id(), 'pending', 'processing' );
+		$this->mock_wcs_get_subscriptions_for_order( [ $mock_subscription ] );
 
 		// Mock the order having a invoice ID stored in meta.
 		$mock_subscription->update_meta_data( self::ORDER_INVOICE_ID_KEY, $invoice_id );
 		$mock_subscription->save();
 
-		// Invalid order ID.
-		$this->invoice_service->maybe_record_first_invoice_payment( 0, 'pending', 'processing' );
-
-		// An already completed order.
-		$this->invoice_service->maybe_record_first_invoice_payment( $mock_order->get_id(), 'processing', 'completed' );
-
-		// A failed order.
-		$this->invoice_service->maybe_record_first_invoice_payment( $mock_order->get_id(), 'pending', 'failed' );
-
-		// Positive Cases.
-		// Successful calls - Subscription parent order, with an invoice, transitioning to a paid status (processing or completed) from an unpaid status (pending, on-hold, failed).
-		$this->invoice_service->maybe_record_first_invoice_payment( $mock_order->get_id(), 'pending', 'processing' );
-		$this->invoice_service->maybe_record_first_invoice_payment( $mock_order->get_id(), 'on-hold', 'processing' );
-		$this->invoice_service->maybe_record_first_invoice_payment( $mock_order->get_id(), 'failed', 'processing' );
-		$this->invoice_service->maybe_record_first_invoice_payment( $mock_order->get_id(), 'pending', 'completed' );
-		$this->invoice_service->maybe_record_first_invoice_payment( $mock_order->get_id(), 'on-hold', 'completed' );
-		$this->invoice_service->maybe_record_first_invoice_payment( $mock_order->get_id(), 'failed', 'completed' );
+		// Positive Case.
+		$this->invoice_service->maybe_record_invoice_payment( $mock_order->get_id() );
 	}
 
 	/**

--- a/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
@@ -140,24 +140,22 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 			->method( 'charge_invoice' )
 			->with( $invoice_id, [ 'paid_out_of_band' => 'true' ] );
 
-		// Negative Cases.
-		// Mock an empty list of subscriptions.
-		$this->mock_wcs_get_subscriptions_for_order( [] );
-
-		// Order isn't related to a subscription.
-		$this->invoice_service->maybe_record_invoice_payment( $mock_order->get_id() );
-
-		// Invalid order ID.
-		$this->invoice_service->maybe_record_invoice_payment( 0 );
-
-		// Mock the get subscriptions from order call.
-		$this->mock_wcs_get_subscriptions_for_order( [ $mock_subscription ] );
-
-		// Mock the order having a invoice ID stored in meta.
 		$mock_subscription->update_meta_data( self::ORDER_INVOICE_ID_KEY, $invoice_id );
 		$mock_subscription->save();
 
 		// Positive Case.
+		$this->mock_wcs_get_subscriptions_for_order( [ $mock_subscription ] );
+		$this->invoice_service->maybe_record_invoice_payment( $mock_order->get_id() );
+
+		// Negative Cases.
+		// Invalid order ID.
+		$this->invoice_service->maybe_record_invoice_payment( 0 );
+		// Order isn't related to a subscription.
+		$this->mock_wcs_get_subscriptions_for_order( [] );
+		$this->invoice_service->maybe_record_invoice_payment( $mock_order->get_id() );
+		// Order contains invoice ID meta.
+		$mock_order->update_meta_data( self::ORDER_INVOICE_ID_KEY, $invoice_id );
+		$mock_order->save();
 		$this->invoice_service->maybe_record_invoice_payment( $mock_order->get_id() );
 	}
 

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -199,7 +199,7 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 		$mock_subscription_product->save();
 		$mock_order        = WC_Helper_Order::create_order( 1, 50, $mock_subscription_product );
 		$mock_subscription = new WC_Subscription();
-		$mock_subscription->set_manual( true );
+		$mock_subscription->set_requires_manual_renewal( true );
 		$mock_subscription->set_parent( $mock_order );
 
 		WC_Subscriptions::set_wcs_get_subscriptions_for_renewal_order(
@@ -242,7 +242,7 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 	public function test_create_subscription_for_manual_renewal_on_existing_wcpay_subscription() {
 		$mock_order        = WC_Helper_Order::create_order();
 		$mock_subscription = new WC_Subscription();
-		$mock_subscription->set_manual( true );
+		$mock_subscription->set_requires_manual_renewal( true );
 		$mock_subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, 'sub_test123' );
 		$mock_subscription->set_parent( $mock_order );
 

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -99,17 +99,13 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 	 * Test WC_Payments_Subscription_Service->create_subscription()
 	 */
 	public function test_create_subscription() {
-		$mock_subscription            = new WC_Subscription();
-		$mock_subscription->trial_end = 0;
-		$mock_subscription_product    = new WC_Subscriptions_Product();
+		$mock_subscription_product = new WC_Subscriptions_Product();
 		$mock_subscription_product->save();
 		$mock_order         = WC_Helper_Order::create_order( 1, 50, $mock_subscription_product );
 		$mock_line_item     = array_values( $mock_order->get_items() )[0];
 		$mock_shipping_item = array_values( $mock_order->get_items( 'shipping' ) )[0];
+		$mock_subscription  = new WC_Subscription();
 		$mock_subscription->set_parent( $mock_order );
-
-		WC_Subscriptions_Synchroniser::$is_syncing_enabled = false;
-
 		$mock_wcpay_product_id           = 'wcpay_prod_test123';
 		$mock_wcpay_price_id             = 'wcpay_price_test123';
 		$mock_wcpay_subscription_id      = 'wcpay_subscription_test12345';
@@ -193,6 +189,132 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 		foreach ( $mock_order->get_items( 'line_item', 'shipping' ) as $item ) {
 			$this->assertEquals( $item->get_meta( self::SUBSCRIPTION_ITEM_ID_META_KEY ), $mock_wcpay_subscription_item_id );
 		}
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->create_subscription_for_manual_renewal()
+	 */
+	public function test_create_subscription_for_manual_renewal() {
+		$mock_subscription_product = new WC_Subscriptions_Product();
+		$mock_subscription_product->save();
+		$mock_order         = WC_Helper_Order::create_order( 1, 50, $mock_subscription_product );
+		$mock_line_item     = array_values( $mock_order->get_items() )[0];
+		$mock_shipping_item = array_values( $mock_order->get_items( 'shipping' ) )[0];
+		$mock_subscription  = new WC_Subscription();
+		$mock_subscription->set_manual( true );
+		$mock_subscription->set_parent( $mock_order );
+		$mock_wcpay_product_id           = 'wcpay_prod_test123';
+		$mock_wcpay_price_id             = 'wcpay_price_test123';
+		$mock_wcpay_subscription_id      = 'wcpay_subscription_test12345';
+		$mock_wcpay_subscription_item_id = 'wcpay_subscription_item_test12345';
+		$mock_subscription_data          = [
+			'customer' => '1',
+			'items'    => [
+				[
+					'price'     => $mock_wcpay_price_id,
+					'quantity'  => 4,
+					'metadata'  => [
+						'wc_item_id' => $mock_line_item->get_id(),
+					],
+					'tax_rates' => [],
+				],
+				[
+					'price_data' => [
+						'product'     => $mock_wcpay_product_id,
+						'currency'    => 'USD',
+						'unit_amount' => 1000,
+						'recurring'   => [
+							'interval'       => 'month',
+							'interval_count' => 1,
+						],
+					],
+					'metadata'   => [
+						'wc_item_id' => $mock_shipping_item->get_id(),
+					],
+					'tax_rates'  => [],
+				],
+			],
+		];
+
+		WC_Subscriptions::set_wcs_get_subscriptions_for_renewal_order(
+			function ( $id ) use ( $mock_subscription ) {
+				return [ '1' => $mock_subscription ];
+			}
+		);
+
+		$this->assertNotEquals( $mock_subscription->get_meta( self::SUBSCRIPTION_ID_META_KEY ), $mock_wcpay_subscription_id );
+
+		$this->mock_customer_service->expects( $this->once() )
+			->method( 'get_customer_id_for_order' )
+			->with( $mock_subscription )
+			->willReturn( $mock_subscription_data['customer'] );
+
+		$this->mock_product_service->expects( $this->once() )
+			->method( 'get_wcpay_price_id' )
+			->willReturn( $mock_wcpay_price_id );
+
+		$this->mock_product_service->expects( $this->once() )
+			->method( 'get_stripe_product_id_for_item' )
+			->willReturn( $mock_wcpay_product_id );
+
+		$this->mock_api_client->expects( $this->once() )
+			->method( 'create_subscription' )
+			->with( $mock_subscription_data )
+			->willReturn(
+				[
+					'id'             => $mock_wcpay_subscription_id,
+					'latest_invoice' => 'mock_wcpay_invoice_id',
+					'items'          => [
+						'data' => [
+							[
+								'id'       => $mock_wcpay_subscription_item_id,
+								'metadata' => [
+									'wc_item_id' => $mock_line_item->get_id(),
+								],
+							],
+							[
+								'id'       => $mock_wcpay_subscription_item_id,
+								'metadata' => [
+									'wc_item_id' => $mock_shipping_item->get_id(),
+								],
+							],
+						],
+					],
+				]
+			);
+
+		$this->subscription_service->create_subscription_for_manual_renewal( $mock_order->get_id() );
+	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service->create_subscription_for_manual_renewal() run on existing WCPay subscription.
+	 */
+	public function test_create_subscription_for_manual_renewal_on_existing_wcpay_subscription() {
+		$mock_order        = WC_Helper_Order::create_order();
+		$mock_subscription = new WC_Subscription();
+		$mock_subscription->set_manual( true );
+		$mock_subscription->update_meta_data( self::SUBSCRIPTION_ID_META_KEY, 'sub_test123' );
+		$mock_subscription->set_parent( $mock_order );
+
+		WC_Subscriptions::set_wcs_get_subscriptions_for_renewal_order(
+			function ( $id ) use ( $mock_subscription ) {
+				return [ '1' => $mock_subscription ];
+			}
+		);
+
+		$this->mock_customer_service->expects( $this->never() )
+			->method( 'get_customer_id_for_order' );
+
+		$this->mock_product_service->expects( $this->never() )
+			->method( 'get_wcpay_price_id' );
+
+		$this->mock_product_service->expects( $this->never() )
+			->method( 'get_stripe_product_id_for_item' );
+
+		$this->mock_api_client->expects( $this->never() )
+			->method( 'create_subscription' );
+
+		$this->subscription_service->create_subscription_for_manual_renewal( $mock_order->get_id() );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2960 

#### Changes proposed in this Pull Request

This adds callbacks to the `woocommerce_renewal_order_payment_complete` hook that create a new WCPay subscription when a manual renewal order is paid for an order in which the associated WC subscription doesn't have a corresponding Stripe subscription.

#### Testing instructions

- Create a few manual subscriptions following step 1 outlined in #2960 
- Make sure WC Subscriptions is disabled before proceeding
- As the merchant, create a pending renewal order for one of the subscriptions created above
- As the customer, access the `my account` page, find the pending renewal order, and select the pay button
- As the customer, pay for the order with WCPay payment gateway
- Confirm a new subscription has been created in the Stripe dashboard for the connected account
- Confirm the details of the Stripe subscription match the details of the WC subscription
- After testing the main flow above, go through standard renewal flows to ensure there are no side effects

-------------------

- [ ] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
