### PR TITLE
Remove the styles overwrite done by Gutenberg in some WCPay pages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Add - Add subscriptions functionality via Stripe Billing and WC Subscriptions core.
 * Fix - Prevent currency switcher to show when enabled currencies list is empty.
 * Fix - Show currency switcher notice until customer explicitly dismisses it.
+* Fix - Prevent Gutenberg's style overwrite on WCPay's settings and "Add new payment methods" screens
 
 = 3.1.0 - 2021-10-06 =
 * Fix - Issue affecting analytics for Multi-Currency orders made with a zero-decimal to non-zero decimal conversion.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -69,9 +69,7 @@ class WC_Payments_Admin {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_payments_scripts' ] );
 		add_action( 'woocommerce_admin_field_payment_gateways', [ $this, 'payment_gateways_container' ] );
 
-		// This function was introduced in Gutenberg in 1.5.0.
-		// It should be safe to rely on it.
-		if ( function_exists( 'gutenberg_pre_init' ) ) {
+		if ( function_exists( 'gutenberg_register_packages_styles' ) ) {
 			// Remove the style overwrite Gutenberg does.
 			add_action( 'wp_default_styles', [ $this, 'remove_gutenberg_styles_overwrite' ], 9 );
 		}


### PR DESCRIPTION
Fixes #3033 

#### Changes proposed in this Pull Request

Remove the styles overwrite done by Gutenberg in some WCPay pages

This removes the action that makes Gutenberg overwrite the wp-components style from WP in the screens where the VisuallyHidden component is used. This overwrite breaks that component appearance by displaying it when it should be hidden.

Not adding tests as no functionality was added/updated.

Before:
![image](https://user-images.githubusercontent.com/41606954/136562522-783e2329-4906-444f-88f6-80e61ecba8aa.png)

With the fix:
![image](https://user-images.githubusercontent.com/41606954/136562307-a5d6fe86-c815-4742-adbd-cdc32368d66b.png)

#### Testing instructions

* Go to /wp-admin/admin.php?page=wc-admin&task=woocommerce-payments--additional-payment-methods and enable the new checkout experience (step 1)
* When step 2 is displayed, notice things look fine
* Install and activate Gutenberg
* Go to /wp-admin/admin.php?page=wc-admin&task=woocommerce-payments--additional-payment-methods again, and notice the UI is broken. The "Information about the payment method" text shouldn't be visible.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
