### PR TITLE
Fixed payment method name on success page for saved cards #3027

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@
 * Add - Add subscriptions functionality via Stripe Billing and WC Subscriptions core.
 * Fix - Prevent currency switcher to show when enabled currencies list is empty.
 * Fix - Show currency switcher notice until customer explicitly dismisses it.
-* Fix - Show correct payment method name during checkout using upe methods
+* Fix - Show correct payment method name during checkout using upe methods.
 
 = 3.1.0 - 2021-10-06 =
 * Fix - Issue affecting analytics for Multi-Currency orders made with a zero-decimal to non-zero decimal conversion.

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Add - Add subscriptions functionality via Stripe Billing and WC Subscriptions core.
 * Fix - Prevent currency switcher to show when enabled currencies list is empty.
 * Fix - Show currency switcher notice until customer explicitly dismisses it.
+* Fix - Show correct payment method name during checkout using upe methods
 
 = 3.1.0 - 2021-10-06 =
 * Fix - Issue affecting analytics for Multi-Currency orders made with a zero-decimal to non-zero decimal conversion.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -966,6 +966,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$order->add_order_note( $note );
 			}
 
+			$order->set_payment_method_title( __( 'Credit / Debit Card', 'woocommerce-payments' ) );
+			$order->save();
+
 			return [
 				'result'   => 'success',
 				'redirect' => $this->get_return_url( $order ),
@@ -1071,10 +1074,33 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$cart->empty_cart();
 		}
 
+		if ( $payment_needed ) {
+			$payment_method_details = $intent->get_payment_method_details();
+			$payment_method_type    = $payment_method_details ? $payment_method_details['type'] : null;
+		} else {
+			$payment_method_details = false;
+			$payment_method_options = array_keys( $intent['payment_method_options'] );
+			$payment_method_type    = $payment_method_options ? $payment_method_options[0] : null;
+		}
+
+		$this->set_payment_method_title_for_order( $order, $payment_method_type, $payment_method_details );
+
 		return [
 			'result'   => 'success',
 			'redirect' => $this->get_return_url( $order ),
 		];
+	}
+
+	/**
+	 * By default this function does not do anything. But it can be overriden by child classes.
+	 * It is used to set a formatted readable payment method title for order,
+	 * using payment method details from accompanying charge.
+	 *
+	 * @param WC_Order   $order WC Order being processed.
+	 * @param string     $payment_method_type Stripe payment method key.
+	 * @param array|bool $payment_method_details Array of payment method details from charge or false.
+	 */
+	public function set_payment_method_title_for_order( $order, $payment_method_type, $payment_method_details ) {
 	}
 
 	/**

--- a/tests/e2e/specs/shopper/shopper-myaccount-save-card-and-checkout-upe.spec.js
+++ b/tests/e2e/specs/shopper/shopper-myaccount-save-card-and-checkout-upe.spec.js
@@ -8,7 +8,7 @@ const { shopper, merchant } = require( '@woocommerce/e2e-utils' );
 /**
  * Internal dependencies
  */
-import { shopperWCP } from '../../utils/flows';
+import { merchantWCP, shopperWCP } from '../../utils/flows';
 import {
 	confirmCardAuthentication,
 	setupProductCheckout,
@@ -19,71 +19,14 @@ const cards = [
 	[ '3DS2', config.get( 'cards.3ds2' ) ],
 ];
 
-const WCPAY_DEV_TOOLS = `${ config.get(
-	'url'
-) }wp-admin/admin.php?page=wcpaydev`;
-
-async function activateUpe() {
-	await page.goto( WCPAY_DEV_TOOLS, {
-		waitUntil: 'networkidle0',
-	} );
-
-	if ( ! ( await page.$( '#_wcpay_feature_upe:checked' ) ) ) {
-		await expect( page ).toClick( 'label', {
-			text: 'Enable UPE checkout',
-		} );
-	}
-
-	const isAdditionalPaymentsActive = await page.$(
-		'#_wcpay_feature_upe_additional_payment_methods:checked'
-	);
-
-	if ( ! isAdditionalPaymentsActive ) {
-		await expect( page ).toClick( 'label', {
-			text: 'Add UPE additional payment methods',
-		} );
-	}
-
-	await expect( page ).toClick( 'input[type="submit"]' );
-	await page.waitForNavigation( {
-		waitUntil: 'networkidle0',
-	} );
-}
-
-async function deactivateUpe() {
-	await page.goto( WCPAY_DEV_TOOLS, {
-		waitUntil: 'networkidle0',
-	} );
-
-	if ( await page.$( '#_wcpay_feature_upe:checked' ) ) {
-		await expect( page ).toClick( 'label', {
-			text: 'Enable UPE checkout',
-		} );
-	}
-
-	const isAdditionalPaymentsActive = await page.$(
-		'#_wcpay_feature_upe_additional_payment_methods:checked'
-	);
-
-	if ( isAdditionalPaymentsActive ) {
-		await expect( page ).toClick( 'label', {
-			text: 'Add UPE additional payment methods',
-		} );
-	}
-
-	await expect( page ).toClick( 'input[type="submit"]' );
-	await page.waitForNavigation( {
-		waitUntil: 'networkidle0',
-	} );
-}
-
 describe( 'Saved cards ', () => {
 	describe.each( cards )(
 		'when using a %s card added through my account',
 		( cardType, card ) => {
 			beforeAll( async () => {
 				await merchant.login();
-				await activateUpe();
+				await merchantWCP.activateUpe();
+				await merchantWCP.deactivateUpe();
 				await merchant.logout();
 
 				await shopper.login();
@@ -92,7 +35,7 @@ describe( 'Saved cards ', () => {
 			afterAll( async () => {
 				await shopperWCP.logout();
 				await merchant.login();
-				await deactivateUpe();
+				await merchantWCP.deactivateUpe();
 				await merchant.logout();
 			} );
 

--- a/tests/e2e/specs/shopper/shopper-myaccount-save-card-and-checkout-upe.spec.js
+++ b/tests/e2e/specs/shopper/shopper-myaccount-save-card-and-checkout-upe.spec.js
@@ -1,0 +1,139 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+
+const { shopper, merchant } = require( '@woocommerce/e2e-utils' );
+
+/**
+ * Internal dependencies
+ */
+import { shopperWCP } from '../../utils/flows';
+import {
+	confirmCardAuthentication,
+	setupProductCheckout,
+} from '../../utils/payments';
+
+const cards = [
+	[ 'basic', config.get( 'cards.basic' ) ],
+	[ '3DS2', config.get( 'cards.3ds2' ) ],
+];
+
+const WCPAY_DEV_TOOLS = `${ config.get(
+	'url'
+) }wp-admin/admin.php?page=wcpaydev`;
+
+async function activateUpe() {
+	await page.goto( WCPAY_DEV_TOOLS, {
+		waitUntil: 'networkidle0',
+	} );
+
+	if ( ! ( await page.$( '#_wcpay_feature_upe:checked' ) ) ) {
+		await expect( page ).toClick( 'label', {
+			text: 'Enable UPE checkout',
+		} );
+	}
+
+	const isAdditionalPaymentsActive = await page.$(
+		'#_wcpay_feature_upe_additional_payment_methods:checked'
+	);
+
+	if ( ! isAdditionalPaymentsActive ) {
+		await expect( page ).toClick( 'label', {
+			text: 'Add UPE additional payment methods',
+		} );
+	}
+
+	await expect( page ).toClick( 'input[type="submit"]' );
+	await page.waitForNavigation( {
+		waitUntil: 'networkidle0',
+	} );
+}
+
+async function deactivateUpe() {
+	await page.goto( WCPAY_DEV_TOOLS, {
+		waitUntil: 'networkidle0',
+	} );
+
+	if ( await page.$( '#_wcpay_feature_upe:checked' ) ) {
+		await expect( page ).toClick( 'label', {
+			text: 'Enable UPE checkout',
+		} );
+	}
+
+	const isAdditionalPaymentsActive = await page.$(
+		'#_wcpay_feature_upe_additional_payment_methods:checked'
+	);
+
+	if ( isAdditionalPaymentsActive ) {
+		await expect( page ).toClick( 'label', {
+			text: 'Add UPE additional payment methods',
+		} );
+	}
+
+	await expect( page ).toClick( 'input[type="submit"]' );
+	await page.waitForNavigation( {
+		waitUntil: 'networkidle0',
+	} );
+}
+
+describe( 'Saved cards ', () => {
+	describe.each( cards )(
+		'when using a %s card added through my account',
+		( cardType, card ) => {
+			beforeAll( async () => {
+				await merchant.login();
+				await activateUpe();
+				await merchant.logout();
+
+				await shopper.login();
+			} );
+
+			afterAll( async () => {
+				await shopperWCP.logout();
+				await merchant.login();
+				await deactivateUpe();
+				await merchant.logout();
+			} );
+
+			it( 'should save the card', async () => {
+				await shopperWCP.goToPaymentMethods();
+				await shopperWCP.addNewPaymentMethod( cardType, card );
+				await expect( page ).toMatch(
+					'Payment method successfully added'
+				);
+			} );
+
+			it( 'should process a payment with the saved card', async () => {
+				await setupProductCheckout(
+					config.get( 'addresses.customer.billing' )
+				);
+				await shopperWCP.selectSavedPaymentMethod(
+					`${ card.label } (expires ${ card.expires.month }/${ card.expires.year })`
+				);
+
+				if ( 'basic' === cardType ) {
+					await shopper.placeOrder();
+				} else {
+					await expect( page ).toClick( '#place_order' );
+					await confirmCardAuthentication( page, cardType );
+					await page.waitForNavigation( {
+						waitUntil: 'networkidle0',
+					} );
+				}
+
+				await expect( page ).toMatch( 'Order received' );
+				await expect( page ).toMatchElement(
+					'.woocommerce-order-overview__payment-method',
+					'Visa credit card'
+				);
+			} );
+
+			it( 'should delete the card', async () => {
+				await shopperWCP.goToPaymentMethods();
+				await shopperWCP.deleteSavedPaymentMethod( card.label );
+				await expect( page ).toMatch( 'Payment method deleted' );
+			} );
+		}
+	);
+} );

--- a/tests/e2e/specs/shopper/shopper-myaccount-save-card-and-checkout-upe.spec.js
+++ b/tests/e2e/specs/shopper/shopper-myaccount-save-card-and-checkout-upe.spec.js
@@ -26,9 +26,7 @@ describe( 'Saved cards ', () => {
 			beforeAll( async () => {
 				await merchant.login();
 				await merchantWCP.activateUpe();
-				await merchantWCP.deactivateUpe();
 				await merchant.logout();
-
 				await shopper.login();
 			} );
 

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -117,24 +117,27 @@ export const shopperWCP = {
 	 * @param {*} card Card object that you want to add as the new payment method.
 	 */
 	addNewPaymentMethod: async ( cardType, card ) => {
-		const cardIs3DS =
-			cardType.toUpperCase().includes( '3DS' ) &&
-			! cardType.toLowerCase().includes( 'declined' );
-
 		await expect( page ).toClick( 'a', {
 			text: 'Add payment method',
 		} );
 		await page.waitForNavigation( {
 			waitUntil: 'networkidle0',
 		} );
+
 		await fillCardDetails( page, card );
+
 		await expect( page ).toClick( 'button', {
 			text: 'Add payment method',
 		} );
 
+		const cardIs3DS =
+			cardType.toUpperCase().includes( '3DS' ) &&
+			! cardType.toLowerCase().includes( 'declined' );
+
 		if ( cardIs3DS ) {
 			await confirmCardAuthentication( page, cardType );
 		}
+
 		await page.waitForNavigation( {
 			waitUntil: 'networkidle0',
 		} );

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -38,6 +38,9 @@ const WC_SUBSCRIPTIONS_PAGE =
 const ACTION_SCHEDULER = baseUrl + 'wp-admin/tools.php?page=action-scheduler';
 const WP_ADMIN_PAGES = baseUrl + 'wp-admin/edit.php?post_type=page';
 const WCB_CHECKOUT = baseUrl + 'checkout-wcb/';
+const WCPAY_DEV_TOOLS = `${ config.get(
+	'url'
+) }wp-admin/admin.php?page=wcpaydev`;
 
 export const RUN_SUBSCRIPTIONS_TESTS =
 	'1' !== process.env.SKIP_WC_SUBSCRIPTIONS_TESTS;
@@ -198,6 +201,60 @@ export const shopperWCP = {
 // The generic flows will be moved to their own package soon (more details in p7bje6-2gV-p2), so we're
 // keeping our customizations grouped here so it's easier to extend the flows once the move happens.
 export const merchantWCP = {
+	activateUpe: async () => {
+		await page.goto( WCPAY_DEV_TOOLS, {
+			waitUntil: 'networkidle0',
+		} );
+
+		if ( ! ( await page.$( '#_wcpay_feature_upe:checked' ) ) ) {
+			await expect( page ).toClick( 'label', {
+				text: 'Enable UPE checkout',
+			} );
+		}
+
+		const isAdditionalPaymentsActive = await page.$(
+			'#_wcpay_feature_upe_additional_payment_methods:checked'
+		);
+
+		if ( ! isAdditionalPaymentsActive ) {
+			await expect( page ).toClick( 'label', {
+				text: 'Add UPE additional payment methods',
+			} );
+		}
+
+		await expect( page ).toClick( 'input[type="submit"]' );
+		await page.waitForNavigation( {
+			waitUntil: 'networkidle0',
+		} );
+	},
+
+	deactivateUpe: async () => {
+		await page.goto( WCPAY_DEV_TOOLS, {
+			waitUntil: 'networkidle0',
+		} );
+
+		if ( await page.$( '#_wcpay_feature_upe:checked' ) ) {
+			await expect( page ).toClick( 'label', {
+				text: 'Enable UPE checkout',
+			} );
+		}
+
+		const isAdditionalPaymentsActive = await page.$(
+			'#_wcpay_feature_upe_additional_payment_methods:checked'
+		);
+
+		if ( isAdditionalPaymentsActive ) {
+			await expect( page ).toClick( 'label', {
+				text: 'Add UPE additional payment methods',
+			} );
+		}
+
+		await expect( page ).toClick( 'input[type="submit"]' );
+		await page.waitForNavigation( {
+			waitUntil: 'networkidle0',
+		} );
+	},
+
 	openDisputeDetails: async ( disputeDetailsLink ) => {
 		await Promise.all( [
 			page.goto( WC_ADMIN_BASE_URL + disputeDetailsLink, {

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -7,27 +7,58 @@ const { shopper, uiUnblocked } = require( '@woocommerce/e2e-utils' );
 
 // WooCommerce Checkout
 export async function fillCardDetails( page, card ) {
-	await page.waitForSelector( '.__PrivateStripeElement' );
-	const frameHandle = await page.waitForSelector(
-		'#payment #wcpay-card-element iframe[name^="__privateStripeFrame"]'
-	);
-	const stripeFrame = await frameHandle.contentFrame();
+	if ( await page.$( '#payment #wcpay-upe-element' ) ) {
+		const frameHandle = await page.waitForSelector(
+			'#payment #wcpay-upe-element iframe'
+		);
 
-	const cardNumberInput = await stripeFrame.waitForSelector(
-		'[name="cardnumber"]',
-		{ timeout: 30000 }
-	);
-	await cardNumberInput.type( card.number, { delay: 20 } );
+		const stripeFrame = await frameHandle.contentFrame();
 
-	const cardDateInput = await stripeFrame.waitForSelector(
-		'[name="exp-date"]'
-	);
-	await cardDateInput.type( card.expires.month + card.expires.year, {
-		delay: 20,
-	} );
+		const cardNumberInput = await stripeFrame.waitForSelector(
+			'[name="number"]',
+			{ timeout: 30000 }
+		);
 
-	const cardCvcInput = await stripeFrame.waitForSelector( '[name="cvc"]' );
-	await cardCvcInput.type( card.cvc, { delay: 20 } );
+		await cardNumberInput.type( card.number, { delay: 20 } );
+
+		const cardDateInput = await stripeFrame.waitForSelector(
+			'[name="expiry"]'
+		);
+
+		await cardDateInput.type( card.expires.month + card.expires.year, {
+			delay: 20,
+		} );
+
+		const cardCvcInput = await stripeFrame.waitForSelector(
+			'[name="cvc"]'
+		);
+		await cardCvcInput.type( card.cvc, { delay: 20 } );
+	} else {
+		await page.waitForSelector( '.__PrivateStripeElement' );
+		const frameHandle = await page.waitForSelector(
+			'#payment #wcpay-card-element iframe[name^="__privateStripeFrame"]'
+		);
+		const stripeFrame = await frameHandle.contentFrame();
+
+		const cardNumberInput = await stripeFrame.waitForSelector(
+			'[name="cardnumber"]',
+			{ timeout: 30000 }
+		);
+		await cardNumberInput.type( card.number, { delay: 20 } );
+
+		const cardDateInput = await stripeFrame.waitForSelector(
+			'[name="exp-date"]'
+		);
+
+		await cardDateInput.type( card.expires.month + card.expires.year, {
+			delay: 20,
+		} );
+
+		const cardCvcInput = await stripeFrame.waitForSelector(
+			'[name="cvc"]'
+		);
+		await cardCvcInput.type( card.cvc, { delay: 20 } );
+	}
 }
 
 // WooCommerce Blocks Checkout


### PR DESCRIPTION
Fixes #3027

#### Changes proposed in this Pull Request
This PR changes how the name of a payment method is set during checkout. To make sure the proper name is set instead of just showing WooCommerce Payments on the success page

#### Testing instructions
- As a merchant activate upe checkout
- As a shopper go to My account > Payment methods > Add Payment Method and add the credit card ```4242 4242 4242 4242```
- Buy any product and checkout using the saved product
- The payment method should be set to "Vista credit card" on the success page

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)

**Post merge**
- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
