### PR TITLE
Move changelog entry from 3.1.0 to 3.2.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Add - UPE track on upgrade and on setting toggle.
 * Fix - Prevent currency switcher to show when enabled currencies list is empty.
 * Fix - Show currency switcher notice until customer explicitly dismisses it.
+* Fix - Track 'wcpay_payment_request_settings_change' for when updating the Payment Requests setting not being recorded.
 * Update - Fee breakdown when there's only a base fee
 * Fix - Inconsistent shipping options in Payment Request popup.
 
@@ -17,7 +18,6 @@
 * Add - Currency deletion confirmation modal for currencies that are bound to an UPE method.
 * Fix - Currency switcher does not affect order confirmation screen prices.
 * Fix - Error when attempting to change the payment method for a subscription with UPE enabled.
-* Fix - Track for when updating the Payment Requests setting not being recorded.
 * Add - Multi-Currency track currency added.
 * Fix - Fill missing order_intent_info even if an exception occurs.
 * Fix - Authorize and capture payments later with new credit cards.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Move changelog entry from 3.1.0 to 3.2.0.

Move the changelog entry added in [this PR](https://github.com/Automattic/woocommerce-payments/pull/3039/files) to the version it would actually be introduced. I created the PR while working on 3.1.0, but missed updating the changelog when merging it.

#### Testing instructions

Nothing to test. Not sure if this even needs a review?
