### PR TITLE
Store separate WCPay Product and Price IDs and hashes metadata for test and live mode

### DIFF
--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -14,33 +14,62 @@ defined( 'ABSPATH' ) || exit;
  * Class handling any subscription product functionality
  */
 class WC_Payments_Product_Service {
-	/**
-	 * The product meta key used to store the product data we last sent to WC Pay as a hash. Used to compare current WC product data with WC Pay data.
-	 *
-	 * @const string
-	 */
-	const PRODUCT_HASH_KEY = '_wcpay_product_hash';
 
 	/**
-	 * The product meta key used to store the product's ID in WC Pay.
+	 * The product meta key used to store the live product data we last sent to WC Pay as a hash. Used to compare current WC product data with live WC Pay data.
 	 *
 	 * @const string
 	 */
-	const PRODUCT_ID_KEY = '_wcpay_product_id';
+	const LIVE_PRODUCT_HASH_KEY = '_wcpay_product_hash_live';
 
 	/**
-	 * The product price meta key used to store the price data we last sent to WC Pay as a hash. Used to compare current WC product price data with WC Pay data.
+	 * The product meta key used to store the testmode product data we last sent to WC Pay as a hash. Used to compare current WC product data with WC Pay data.
 	 *
 	 * @const string
 	 */
-	const PRICE_HASH_KEY = '_wcpay_product_price_hash';
+	const TEST_PRODUCT_HASH_KEY = '_wcpay_product_hash_test';
 
 	/**
-	 * The product meta key used to store the product's WC Pay Price object ID.
+	 * The live product meta key used to store the product's ID in WC Pay.
 	 *
 	 * @const string
 	 */
-	const PRICE_ID_KEY = '_wcpay_product_price_id';
+	const LIVE_PRODUCT_ID_KEY = '_wcpay_product_id_live';
+
+	/**
+	 * The testmode product meta key used to store the product's ID in WC Pay.
+	 *
+	 * @const string
+	 */
+	const TEST_PRODUCT_ID_KEY = '_wcpay_product_id_test';
+
+	/**
+	 * The product price meta key used to store the live price data we last sent to WC Pay as a hash. Used to compare current WC product price data with live WC Pay data.
+	 *
+	 * @const string
+	 */
+	const LIVE_PRICE_HASH_KEY = '_wcpay_product_price_hash_live';
+
+	/**
+	 * The product price meta key used to store the testmode price data we last sent to WC Pay as a hash. Used to compare current WC product price data with testmode WC Pay data.
+	 *
+	 * @const string
+	 */
+	const TEST_PRICE_HASH_KEY = '_wcpay_product_price_hash_test';
+
+	/**
+	 * The product meta key used to store the live product's WC Pay Price object ID.
+	 *
+	 * @const string
+	 */
+	const LIVE_PRICE_ID_KEY = '_wcpay_product_price_id_live';
+
+	/**
+	 * The product meta key used to store the testmode product's WC Pay Price object ID.
+	 *
+	 * @const string
+	 */
+	const TEST_PRICE_ID_KEY = '_wcpay_product_price_id_test';
 
 	/**
 	 * Client for making requests to the WooCommerce Payments API
@@ -78,7 +107,7 @@ class WC_Payments_Product_Service {
 	 * @return string             The product's hash or an empty string.
 	 */
 	public static function get_wcpay_product_hash( WC_Product $product ) : string {
-		return $product->get_meta( self::PRODUCT_HASH_KEY, true );
+		return $product->get_meta( self::get_wcpay_product_hash_option(), true );
 	}
 
 	/**
@@ -94,7 +123,7 @@ class WC_Payments_Product_Service {
 			WC_Payments_Subscriptions::get_product_service()->create_product( $product );
 		}
 
-		return $product->get_meta( self::PRODUCT_ID_KEY, true );
+		return $product->get_meta( self::get_wcpay_product_id_option(), true );
 	}
 
 	/**
@@ -104,7 +133,7 @@ class WC_Payments_Product_Service {
 	 * @return string             The product's price hash or an empty string.
 	 */
 	public static function get_wcpay_price_hash( WC_Product $product ) : string {
-		return $product->get_meta( self::PRICE_HASH_KEY, true );
+		return $product->get_meta( self::get_wcpay_price_hash_option(), true );
 	}
 
 	/**
@@ -114,12 +143,12 @@ class WC_Payments_Product_Service {
 	 * @return string             The product's WC Pay price ID or an empty string.
 	 */
 	public function get_wcpay_price_id( WC_Product $product ) : string {
-		$price_id = $product->get_meta( self::PRICE_ID_KEY, true );
+		$price_id = $product->get_meta( self::get_wcpay_price_id_option(), true );
 
 		// If the subscription product doesn't have a WC Pay price ID, create one now.
 		if ( empty( $price_id ) && WC_Subscriptions_Product::is_subscription( $product ) ) {
 			WC_Payments_Subscriptions::get_product_service()->create_product( $product );
-			$price_id = $product->get_meta( self::PRICE_ID_KEY, true );
+			$price_id = $product->get_meta( self::get_wcpay_price_id_option(), true );
 		}
 
 		return $price_id;
@@ -132,11 +161,11 @@ class WC_Payments_Product_Service {
 	 * return string       The item's WCPay product id.
 	 */
 	public function get_stripe_product_id_for_item( string $type ) : string {
-		if ( ! get_option( self::PRODUCT_ID_KEY . '_' . $type ) ) {
+		if ( ! get_option( self::get_wcpay_product_id_option() . '_' . $type ) ) {
 			$this->create_product_for_item_type( $type );
 		}
 
-		return get_option( self::PRODUCT_ID_KEY . '_' . $type );
+		return get_option( self::get_wcpay_product_id_option() . '_' . $type );
 	}
 
 	/**
@@ -146,7 +175,7 @@ class WC_Payments_Product_Service {
 	 * @return string             The WC Pay product ID or an empty string.
 	 */
 	public static function has_wcpay_product_id( WC_Product $product ) : string {
-		return (bool) $product->get_meta( self::PRODUCT_ID_KEY, true );
+		return (bool) $product->get_meta( self::get_wcpay_product_id_option(), true );
 	}
 
 	/**
@@ -235,7 +264,7 @@ class WC_Payments_Product_Service {
 				]
 			);
 
-			update_option( self::PRODUCT_ID_KEY . '_' . $type, $wcpay_product['wcpay_product_id'] );
+			update_option( self::get_wcpay_product_id_option() . '_' . $type, $wcpay_product['wcpay_product_id'] );
 		} catch ( API_Exception $e ) {
 			Logger::log( 'There was a problem creating the product on WCPay Server: ' . $e->getMessage() );
 		}
@@ -552,7 +581,7 @@ class WC_Payments_Product_Service {
 	 * @param string     $value   The WC Pay product hash.
 	 */
 	private function set_wcpay_product_hash( WC_Product $product, string $value ) {
-		$product->update_meta_data( self::PRODUCT_HASH_KEY, $value );
+		$product->update_meta_data( self::get_wcpay_product_hash_option(), $value );
 		$product->save();
 	}
 
@@ -563,7 +592,7 @@ class WC_Payments_Product_Service {
 	 * @param string     $value   The WC Pay product ID.
 	 */
 	private function set_wcpay_product_id( WC_Product $product, string $value ) {
-		$product->update_meta_data( self::PRODUCT_ID_KEY, $value );
+		$product->update_meta_data( self::get_wcpay_product_id_option(), $value );
 		$product->save();
 	}
 
@@ -574,7 +603,7 @@ class WC_Payments_Product_Service {
 	 * @param string     $value   The WC Pay product hash.
 	 */
 	private function set_wcpay_price_hash( WC_Product $product, string $value ) {
-		$product->update_meta_data( self::PRICE_HASH_KEY, $value );
+		$product->update_meta_data( self::get_wcpay_price_hash_option(), $value );
 		$product->save();
 	}
 
@@ -585,7 +614,43 @@ class WC_Payments_Product_Service {
 	 * @param string     $value   The WC Pay price ID.
 	 */
 	private function set_wcpay_price_id( WC_Product $product, string $value ) {
-		$product->update_meta_data( self::PRICE_ID_KEY, $value );
+		$product->update_meta_data( self::get_wcpay_price_id_option(), $value );
 		$product->save();
+	}
+
+	/**
+	 * Returns the name of the product hash option meta, taking test mode into account.
+	 *
+	 * @return string The price hash option name.
+	 */
+	public static function get_wcpay_product_hash_option() : string {
+		return WC_Payments::get_gateway()->is_in_test_mode() ? self::TEST_PRODUCT_HASH_KEY : self::LIVE_PRODUCT_HASH_KEY;
+	}
+
+	/**
+	 * Returns the name of the product id option meta, taking test mode into account.
+	 *
+	 * @return string The price hash option name.
+	 */
+	public static function get_wcpay_product_id_option() : string {
+		return WC_Payments::get_gateway()->is_in_test_mode() ? self::TEST_PRODUCT_ID_KEY : self::LIVE_PRODUCT_ID_KEY;
+	}
+
+	/**
+	 * Returns the name of the price hash option meta, taking test mode into account.
+	 *
+	 * @return string The price hash option name.
+	 */
+	public static function get_wcpay_price_hash_option() : string {
+		return WC_Payments::get_gateway()->is_in_test_mode() ? self::TEST_PRICE_HASH_KEY : self::LIVE_PRICE_HASH_KEY;
+	}
+
+	/**
+	 * Returns the name of the price id option meta, taking test mode into account.
+	 *
+	 * @return string The price hash option name.
+	 */
+	public static function get_wcpay_price_id_option() : string {
+		return WC_Payments::get_gateway()->is_in_test_mode() ? self::TEST_PRICE_ID_KEY : self::LIVE_PRICE_ID_KEY;
 	}
 }

--- a/tests/unit/subscriptions/test-class-wc-payments-product-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-product-service.php
@@ -13,9 +13,8 @@ use WCPay\Exceptions\API_Exception;
  */
 class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 
-	const PRODUCT_HASH_KEY = '_wcpay_product_hash';
-	const PRODUCT_ID_KEY   = '_wcpay_product_id';
-	const PRICE_ID_KEY     = '_wcpay_product_price_id';
+	const LIVE_PRODUCT_ID_KEY = '_wcpay_product_id_live';
+	const LIVE_PRICE_ID_KEY   = '_wcpay_product_price_id_live';
 
 	/**
 	 * System under test.
@@ -59,15 +58,15 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 		$this->mock_get_period( 'month' );
 		$this->mock_get_interval( 3 );
 		$this->product_service->create_product( $this->mock_product );
-		$this->assertEquals( 'prod_test123', $this->mock_product->get_meta( self::PRODUCT_ID_KEY, true ) );
-		$this->assertEquals( 'price_test123', $this->mock_product->get_meta( self::PRICE_ID_KEY, true ) );
+		$this->assertEquals( 'prod_test123', $this->mock_product->get_meta( self::LIVE_PRODUCT_ID_KEY, true ) );
+		$this->assertEquals( 'price_test123', $this->mock_product->get_meta( self::LIVE_PRICE_ID_KEY, true ) );
 	}
 
 	/**
 	 * Test update product.
 	 */
 	public function test_update_product() {
-		$this->mock_product->update_meta_data( self::PRODUCT_ID_KEY, 'prod_test123' );
+		$this->mock_product->update_meta_data( self::LIVE_PRODUCT_ID_KEY, 'prod_test123' );
 		$this->mock_product->save();
 
 		$this->mock_api_client->expects( $this->once() )
@@ -94,8 +93,8 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 	 * Note: This also tests unarchive_product
 	 */
 	public function test_archive_product() {
-		$this->mock_product->update_meta_data( self::PRODUCT_ID_KEY, 'prod_test123' );
-		$this->mock_product->update_meta_data( self::PRICE_ID_KEY, 'price_test123' );
+		$this->mock_product->update_meta_data( self::LIVE_PRODUCT_ID_KEY, 'prod_test123' );
+		$this->mock_product->update_meta_data( self::LIVE_PRICE_ID_KEY, 'price_test123' );
 		$this->mock_product->save();
 
 		$this->mock_api_client->expects( $this->once() )
@@ -212,12 +211,12 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 		$ref->setValue( null, $this->product_service );
 
 		$mock_price_id = 'wcpay_test_price_id';
-		$this->mock_product->update_meta_data( WC_Payments_Product_Service::PRICE_ID_KEY, $mock_price_id );
+		$this->mock_product->update_meta_data( WC_Payments_Product_Service::LIVE_PRICE_ID_KEY, $mock_price_id );
 
 		$this->assertSame( $mock_price_id, $this->product_service->get_wcpay_price_id( $this->mock_product ) );
 
 		// Test that deleting the price will cause the product to be created.
-		$this->mock_product->delete_meta_data( WC_Payments_Product_Service::PRICE_ID_KEY );
+		$this->mock_product->delete_meta_data( WC_Payments_Product_Service::LIVE_PRICE_ID_KEY );
 		$this->mock_api_client->expects( $this->once() )
 			->method( 'create_product' )
 			->with( $this->get_mock_product_data() )
@@ -246,12 +245,12 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 		$ref->setValue( null, $this->product_service );
 
 		$mock_prodict_id = 'prod_123_wcpay_test_product_id';
-		$this->mock_product->update_meta_data( WC_Payments_Product_Service::PRODUCT_ID_KEY, $mock_prodict_id );
+		$this->mock_product->update_meta_data( WC_Payments_Product_Service::LIVE_PRODUCT_ID_KEY, $mock_prodict_id );
 
 		$this->assertSame( $mock_prodict_id, WC_Payments_Product_Service::get_wcpay_product_id( $this->mock_product ) );
 
 		// Test that deleting the price will cause the product to be created.
-		$this->mock_product->delete_meta_data( WC_Payments_Product_Service::PRODUCT_ID_KEY );
+		$this->mock_product->delete_meta_data( WC_Payments_Product_Service::LIVE_PRODUCT_ID_KEY );
 		$this->mock_api_client->expects( $this->once() )
 			->method( 'create_product' )
 			->with( $this->get_mock_product_data() )

--- a/tests/unit/subscriptions/test-class-wc-payments-product-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-product-service.php
@@ -39,6 +39,8 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 		$this->mock_product    = $this->get_mock_product();
 		$this->mock_api_client = $this->createMock( WC_Payments_API_Client::class );
 		$this->product_service = new WC_Payments_Product_Service( $this->mock_api_client );
+
+		WC_Payments::get_gateway()->update_option( 'test_mode', 'no' );
 	}
 
 	/**
@@ -265,5 +267,49 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 		$this->mock_get_interval( 3 );
 
 		$this->assertSame( $mock_prodict_id, WC_Payments_Product_Service::get_wcpay_product_id( $this->mock_product ) );
+	}
+
+	/**
+	 * Tests for WC_Payments_Product_Service::get_wcpay_product_hash_option()
+	 */
+	public function test_get_wcpay_product_hash_option() {
+		$this->assertSame( '_wcpay_product_hash_live', WC_Payments_Product_Service::get_wcpay_product_hash_option() );
+
+		// set to testmode.
+		WC_Payments::get_gateway()->update_option( 'test_mode', 'yes' );
+		$this->assertSame( '_wcpay_product_hash_test', WC_Payments_Product_Service::get_wcpay_product_hash_option() );
+	}
+
+	/**
+	 * Tests for WC_Payments_Product_Service::get_wcpay_product_id_option()
+	 */
+	public function test_get_wcpay_product_id_option() {
+		$this->assertSame( '_wcpay_product_id_live', WC_Payments_Product_Service::get_wcpay_product_id_option() );
+
+		// set to testmode.
+		WC_Payments::get_gateway()->update_option( 'test_mode', 'yes' );
+		$this->assertSame( '_wcpay_product_id_test', WC_Payments_Product_Service::get_wcpay_product_id_option() );
+	}
+
+	/**
+	 * Tests for WC_Payments_Product_Service::get_wcpay_price_hash_option()
+	 */
+	public function test_get_wcpay_price_hash_option() {
+		$this->assertSame( '_wcpay_product_price_hash_live', WC_Payments_Product_Service::get_wcpay_price_hash_option() );
+
+		// set to testmode.
+		WC_Payments::get_gateway()->update_option( 'test_mode', 'yes' );
+		$this->assertSame( '_wcpay_product_price_hash_test', WC_Payments_Product_Service::get_wcpay_price_hash_option() );
+	}
+
+	/**
+	 * Tests for WC_Payments_Product_Service::get_wcpay_price_id_option()
+	 */
+	public function test_get_wcpay_price_id_option() {
+		$this->assertSame( '_wcpay_product_price_id_live', WC_Payments_Product_Service::get_wcpay_price_id_option() );
+
+		// set to testmode.
+		WC_Payments::get_gateway()->update_option( 'test_mode', 'yes' );
+		$this->assertSame( '_wcpay_product_price_id_test', WC_Payments_Product_Service::get_wcpay_price_id_option() );
 	}
 }


### PR DESCRIPTION
Fixes #2943 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
 - Store WCPay Product/Price IDs and hashes in postmeta with `_test` and `_live` suffixes 

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

With our WCPay Subscriptions integration with Stripe Billing, when a product in WC is created/updated we store and update the following postmeta on products:
 - `_wcpay_product_id`
 - `_wcpay_product_price_id`
 - `_wcpay_product_hash`
 - `_wcpay_product_price_hash`

The product and price IDs are then passed to sever when attempting to a WCPay Subscriptions. There's an issue when a store switches from test mode to live mode of WC Payments because the `_wcpay_product_id` we created in test mode, doesn't exist in live mode.

This PR stores the above meta data with `_test` and `_live` so that we're storing all product and price data for both test/live environments.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I'm not able to flick my WC Pay dev site between live and test mode however these testing instructions assume you can.

1. Deactivate WC Subscriptions extension if you have it
2. Checkout `develop` branch
3. Enable WCPay Subscriptions from the WC Pay dev tools page
4. Set WC Payments gateway to test mode
4. Create a new Subscription product
5. Confirm the product is created on Stripes dashboard
5. Purchase this new subscription product
6. Switch your gateway to live mode (if you can)
7. Try to purchase this subscription product again
8. You should see an error on the checkout (this is caused by the `_wcpay_product_/price_id` not existing)
9. Checkout this branch `fix/issue-2943`
10. Try to purchase this subscription again
11. Checkout should work
12. You should also notice in your DB that product/price meta is stored with _test and _live (https://d.pr/i/RbacYN)

-------------------

Closes #2943 