### PR TITLE
Don't copy product ID when duplicating subscription product

### DIFF
--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -157,8 +157,7 @@ class WC_Payments_Product_Service {
 	 * @return array Keys to exclude.
 	 */
 	public static function exclude_meta_wcpay_product( $meta_keys ) {
-		array_push( $meta_keys, self::PRODUCT_ID_KEY, self::PRODUCT_HASH_KEY, self::PRICE_ID_KEY, self::PRICE_HASH_KEY );
-		return $meta_keys;
+		return array_merge( $meta_keys, [ self::PRODUCT_ID_KEY, self::PRODUCT_HASH_KEY, self::PRICE_ID_KEY, self::PRICE_HASH_KEY ] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2944

#### Changes proposed in this Pull Request

Previously, duplicating a subscription product would retain the same `_wcpay_product_id`, which meant one product on Stripe would be linked to two products in WooCommerce. Editing one of the products would invalidate the price on the other product and lead to an error during purchase ("There was a problem creating your subscription. Please try again or contact us for assistance.") This PR fixes this by excluding the meta field `_wcpay_product_id` from being copied during duplication.

#### Testing instructions

* Create a new subscription product. Check the database to see what the product's `_wcpay_product_id` value is in the `wp_postmeta` table.
* On the **Products > All Products** admin screen, click "Duplicate" beneath the original subscription product. Change the subscription price and click "Update."
* Check the database again and notice that both products should have different `_wcpay_product_id` values.
* Check the Stripe dashboard, note that both products should be listed there: one for the original product, and one for the duplicate.
* Make a sample purchase for either  subscription product and verify that the correct price is charged and "Sign up now" doesn't trigger an error.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
