### PR TITLE
Terminal locations: tweak error response, so settings url supplied as message

### DIFF
--- a/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
+++ b/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
@@ -63,18 +63,15 @@ class WC_REST_Payments_Terminal_Locations_Controller extends WC_Payments_REST_Co
 			return rest_ensure_response(
 				new \WP_Error(
 					'store_address_is_incomplete',
-					__( 'The store address is incomplete, please update your settings.', 'woocommerce-payments' ),
-					[
-						'url' => admin_url(
-							add_query_arg(
-								[
-									'page' => 'wc-settings',
-									'tab'  => 'general',
-								],
-								'admin.php'
-							)
-						),
-					]
+					admin_url(
+						add_query_arg(
+							[
+								'page' => 'wc-settings',
+								'tab'  => 'general',
+							],
+							'admin.php'
+						)
+					)
 				)
 			);
 		}

--- a/tests/unit/admin/test-class-wc-rest-payments-terminal-locations-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-terminal-locations-controller.php
@@ -88,7 +88,7 @@ class WC_REST_Payments_Terminal_Locations_Controller_Test extends WP_UnitTestCas
 		$result = $this->controller->get_store_location( $this->request );
 
 		$this->assertSame( 'store_address_is_incomplete', $result->get_error_code() );
-		$this->assertStringEndsWith( '/admin.php?page=wc-settings&tab=general', $result->get_error_data()['url'] );
+		$this->assertStringEndsWith( '/admin.php?page=wc-settings&tab=general', $result->get_error_message() );
 	}
 
 	public function test_creates_location_from_scratch() {


### PR DESCRIPTION
Following up on p1634045497370800/1633927391.348800-slack-CGGCLBN58: the PR cherry-picks changes from https://github.com/Automattic/woocommerce-payments/pull/3096