### PR TITLE
Fix Merchant Partial Refund E2E Test

### DIFF
--- a/tests/e2e/specs/merchant/merchant-orders-partial-refund.spec.js
+++ b/tests/e2e/specs/merchant/merchant-orders-partial-refund.spec.js
@@ -49,7 +49,7 @@ const dataTable = [
 ];
 
 describe.each( dataTable )(
-	'Order > Partial refund',
+	'Order > Partial Refund',
 	( testName, { lineItems, refundInputs } ) => {
 		let orderId;
 		let orderTotal;
@@ -189,7 +189,7 @@ describe.each( dataTable )(
 					text: `$${ refundTotalString } USD will be deducted from a future deposit.`,
 				} ),
 				expect( page ).toMatchElement( 'li.woocommerce-timeline-item', {
-					text: 'Payment status changed to partial refund.',
+					text: 'Payment status changed to Partial Refund.',
 				} ),
 			] );
 		} );


### PR DESCRIPTION
I fixed merchant-orders-partial-refund E2E test. This is more like maintenance because the text has changed in Woo Pay to `Partial Refund` from `partial refund`.

Make sure the checks are passing or run the specific test locally:
- npm run test:e2e-dev ./tests/e2e/specs/merchant/merchant-orders-partial-refund.spec.js