### PR TITLE
Add provision to display the capped fee in the breakdown

### DIFF
--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -205,6 +205,7 @@ const composeFeeString = ( event ) => {
 		percentage,
 		fixed,
 		fixed_currency: fixedCurrency,
+		history,
 	} = event.fee_rates;
 	let feeAmount = event.fee;
 	let feeCurrency = event.currency;
@@ -214,11 +215,22 @@ const composeFeeString = ( event ) => {
 		feeCurrency = event.transaction_details.store_currency;
 	}
 
+	const baseFeeLabel = isBaseFeeOnly( event )
+		? __( 'Base fee', 'woocommerce-payments' )
+		: __( 'Fee', 'woocommerce-payments' );
+
+	if ( isBaseFeeOnly( event ) && history[ 0 ].capped ) {
+		return sprintf(
+			'%1$s (capped at %2$s): %3$s',
+			baseFeeLabel,
+			formatCurrency( fixed, fixedCurrency ),
+			formatCurrency( -feeAmount, feeCurrency )
+		);
+	}
+
 	return sprintf(
 		'%1$s (%2$f%% + %3$s): %4$s',
-		isBaseFeeOnly( event )
-			? __( 'Base fee', 'woocommerce-payments' )
-			: __( 'Fee', 'woocommerce-payments' ),
+		baseFeeLabel,
 		formatFee( percentage ),
 		formatCurrency( fixed, fixedCurrency ),
 		formatCurrency( -feeAmount, feeCurrency )

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -219,7 +219,7 @@ const composeFeeString = ( event ) => {
 		? __( 'Base fee', 'woocommerce-payments' )
 		: __( 'Fee', 'woocommerce-payments' );
 
-	if ( isBaseFeeOnly( event ) && history[ 0 ].capped ) {
+	if ( isBaseFeeOnly( event ) && history[ 0 ]?.capped ) {
 		return sprintf(
 			'%1$s (capped at %2$s): %3$s',
 			baseFeeLabel,

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -267,34 +267,43 @@ const feeBreakdown = ( event ) => {
 		fee_rates: { history },
 	} = event;
 
-	const feeLabelMapping = ( fixedRate ) => ( {
-		base:
-			0 !== fixedRate
-				? /* translators: %1$s% is the fee amount and %2$s is the fixed rate */
-				  __( 'Base fee: %1$s%% + %2$s', 'woocommerce-payments' )
-				: /* translators: %1$s% is the fee amount */
-				  __( 'Base fee: %1$s%%', 'woocommerce-payments' ),
+	const feeLabelMapping = ( fixedRate, capped ) => ( {
+		base: ( () => {
+			if ( capped ) {
+				/* translators: %2$s is the capped fee */
+				return __( 'Base fee: capped at %2$s', 'woocommerce-payments' );
+			}
+
+			if ( 0 !== fixedRate ) {
+				/* translators: %1$s% is the fee percentage and %2$s is the fixed rate */
+				return __( 'Base fee: %1$s%% + %2$s', 'woocommerce-payments' );
+			}
+
+			/* translators: %1$s% is the fee percentage */
+			return __( 'Base fee: %1$s%%', 'woocommerce-payments' );
+		} )(),
+
 		'additional-international':
 			0 !== fixedRate
 				? __(
-						/* translators: %1$s% is the fee amount and %2$s is the fixed rate */
+						/* translators: %1$s% is the fee percentage and %2$s is the fixed rate */
 						'International card fee: %1$s%% + %2$s',
 						'woocommerce-payments'
 				  )
 				: __(
-						/* translators: %1$s% is the fee amount */
+						/* translators: %1$s% is the fee percentage */
 						'International card fee: %1$s%%',
 						'woocommerce-payments'
 				  ),
 		'additional-fx':
 			0 !== fixedRate
 				? __(
-						/* translators: %1$s% is the fee amount and %2$s is the fixed rate */
+						/* translators: %1$s% is the fee percentage and %2$s is the fixed rate */
 						'Foreign exchange fee: %1$s%% + %2$s',
 						'woocommerce-payments'
 				  )
 				: __(
-						/* translators: %1$s% is the fee amount */
+						/* translators: %1$s% is the fee percentage */
 						'Foreign exchange fee: %1$s%%',
 						'woocommerce-payments'
 				  ),
@@ -329,6 +338,7 @@ const feeBreakdown = ( event ) => {
 			percentage_rate: percentageRate,
 			fixed_rate: fixedRate,
 			currency,
+			capped,
 		} = fee;
 
 		const percentageRateFormatted = formatFee( percentageRate );
@@ -337,7 +347,7 @@ const feeBreakdown = ( event ) => {
 		return (
 			<li key={ labelKey }>
 				{ sprintf(
-					feeLabelMapping( fixedRate )[ labelKey ],
+					feeLabelMapping( fixedRate, capped )[ labelKey ],
 					percentageRateFormatted,
 					fixedRateFormatted
 				) }

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -279,9 +279,9 @@ const feeBreakdown = ( event ) => {
 		fee_rates: { history },
 	} = event;
 
-	const feeLabelMapping = ( fixedRate, capped ) => ( {
+	const feeLabelMapping = ( fixedRate, isCapped ) => ( {
 		base: ( () => {
-			if ( capped ) {
+			if ( isCapped ) {
 				/* translators: %2$s is the capped fee */
 				return __( 'Base fee: capped at %2$s', 'woocommerce-payments' );
 			}
@@ -350,7 +350,7 @@ const feeBreakdown = ( event ) => {
 			percentage_rate: percentageRate,
 			fixed_rate: fixedRate,
 			currency,
-			capped,
+			capped: isCapped,
 		} = fee;
 
 		const percentageRateFormatted = formatFee( percentageRate );
@@ -359,7 +359,7 @@ const feeBreakdown = ( event ) => {
 		return (
 			<li key={ labelKey }>
 				{ sprintf(
-					feeLabelMapping( fixedRate, capped )[ labelKey ],
+					feeLabelMapping( fixedRate, isCapped )[ labelKey ],
 					percentageRateFormatted,
 					fixedRateFormatted
 				) }


### PR DESCRIPTION
Fixes #3111 

#### Changes proposed in this Pull Request
Added provision to display the capped fee in payments timeline for SEPA.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- See testing instructions for 1224-gh-Automattic/woocommerce-payments-server

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)