### PR TITLE
Attach the payment intent data to renewal orders

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -331,7 +331,7 @@ class WC_Payments {
 		// Load WCPay Subscriptions.
 		if ( WC_Payments_Features::is_wcpay_subscriptions_enabled() ) {
 			include_once WCPAY_ABSPATH . '/includes/subscriptions/class-wc-payments-subscriptions.php';
-			WC_Payments_Subscriptions::init( self::$api_client, self::$customer_service );
+			WC_Payments_Subscriptions::init( self::$api_client, self::$customer_service, self::$card_gateway );
 		}
 
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -98,7 +98,6 @@ class WC_Payments_Subscription_Service {
 	 * @param WC_Payments_Customer_Service $customer_service WC payments customer serivce.
 	 * @param WC_Payments_Product_Service  $product_service  WC payments Products service.
 	 * @param WC_Payments_Invoice_Service  $invoice_service  WC payments Invoice service.
-	 * @param WC_Payment_Gateway_WCPay     $card_gateway     WC payments Payment Gateway.
 	 *
 	 * @return void
 	 */
@@ -106,14 +105,12 @@ class WC_Payments_Subscription_Service {
 		WC_Payments_API_Client $api_client,
 		WC_Payments_Customer_Service $customer_service,
 		WC_Payments_Product_Service $product_service,
-		WC_Payments_Invoice_Service $invoice_service,
-		WC_Payment_Gateway_WCPay $card_gateway
+		WC_Payments_Invoice_Service $invoice_service
 	) {
 		$this->payments_api_client = $api_client;
 		$this->customer_service    = $customer_service;
 		$this->product_service     = $product_service;
 		$this->invoice_service     = $invoice_service;
-		$this->card_gateway        = $card_gateway;
 
 		if ( ! $this->is_subscriptions_plugin_active() ) {
 			add_action( 'woocommerce_checkout_subscription_created', [ $this, 'create_subscription' ] );
@@ -595,31 +592,6 @@ class WC_Payments_Subscription_Service {
 
 		// Remove the 'subscription_date_changes' exception.
 		$this->clear_feature_support_exception( $subscription, 'subscription_date_changes' );
-	}
-
-	/**
-	 * Retrieves the intent object and adds its data to the order.
-	 *
-	 * @param WC_Order $order The order to update.
-	 * @param string   $intent_id The intent ID.
-	 */
-	public function get_and_attach_intent_info_to_order( $order, $intent_id ) {
-		try {
-			$intent_object = $this->payments_api_client->get_intent( $intent_id );
-		} catch ( API_Exception $e ) {
-			$order->add_order_note( __( 'The payment info couldn\'t be added to the order.', 'woocommerce-payments' ) );
-			return;
-		}
-
-		$this->card_gateway->attach_intent_info_to_order(
-			$order,
-			$intent_id,
-			$intent_object->get_status(),
-			$intent_object->get_payment_method_id(),
-			$intent_object->get_customer_id(),
-			$intent_object->get_charge_id(),
-			$intent_object->get_currency()
-		);
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
@@ -94,6 +94,7 @@ class WC_Payments_Subscriptions_Event_Handler {
 		$event_object          = $this->get_event_property( $event_data, 'object' );
 		$wcpay_subscription_id = $this->get_event_property( $event_object, 'subscription' );
 		$wcpay_invoice_id      = $this->get_event_property( $event_object, 'id' );
+		$wcpay_intent_id       = $this->get_event_property( $event_object, 'payment_intent' );
 		$subscription          = WC_Payments_Subscription_Service::get_subscription_from_wcpay_subscription_id( $wcpay_subscription_id );
 
 		if ( ! $subscription ) {
@@ -120,6 +121,9 @@ class WC_Payments_Subscriptions_Event_Handler {
 		if ( $order->needs_payment() ) {
 			$order->payment_complete();
 		}
+
+		// Add the payment intent data to the order.
+		$this->subscription_service->get_and_attach_intent_info_to_order( $order, $wcpay_intent_id );
 
 		// Remove pending invoice ID in case one was recorded for previous failed renewal attempts.
 		$this->invoice_service->mark_pending_invoice_paid_for_subscription( $subscription );

--- a/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
@@ -123,7 +123,7 @@ class WC_Payments_Subscriptions_Event_Handler {
 		}
 
 		// Add the payment intent data to the order.
-		$this->subscription_service->get_and_attach_intent_info_to_order( $order, $wcpay_intent_id );
+		$this->invoice_service->get_and_attach_intent_info_to_order( $order, $wcpay_intent_id );
 
 		// Remove pending invoice ID in case one was recorded for previous failed renewal attempts.
 		$this->invoice_service->mark_pending_invoice_paid_for_subscription( $subscription );

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -57,8 +57,8 @@ class WC_Payments_Subscriptions {
 		include_once __DIR__ . '/class-wc-payments-subscription-change-payment-method-handler.php';
 
 		self::$product_service      = new WC_Payments_Product_Service( $api_client );
-		self::$invoice_service      = new WC_Payments_Invoice_Service( $api_client, self::$product_service );
-		self::$subscription_service = new WC_Payments_Subscription_Service( $api_client, $customer_service, self::$product_service, self::$invoice_service, $card_gateway );
+		self::$invoice_service      = new WC_Payments_Invoice_Service( $api_client, self::$product_service, $card_gateway );
+		self::$subscription_service = new WC_Payments_Subscription_Service( $api_client, $customer_service, self::$product_service, self::$invoice_service );
 
 		// Load the subscription and invoice incoming event handler.
 		include_once __DIR__ . '/class-wc-payments-subscriptions-event-handler.php';

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -47,8 +47,9 @@ class WC_Payments_Subscriptions {
 	 *
 	 * @param WC_Payments_API_Client       $api_client       WCPay API client.
 	 * @param WC_Payments_Customer_Service $customer_service WCPay Customer Service.
+	 * @param WC_Payment_Gateway_WCPay     $card_gateway     WCPay Payment Gateway.
 	 */
-	public static function init( WC_Payments_API_Client $api_client, WC_Payments_Customer_Service $customer_service ) {
+	public static function init( WC_Payments_API_Client $api_client, WC_Payments_Customer_Service $customer_service, WC_Payment_Gateway_WCPay $card_gateway ) {
 		// Load Services.
 		include_once __DIR__ . '/class-wc-payments-product-service.php';
 		include_once __DIR__ . '/class-wc-payments-invoice-service.php';
@@ -57,7 +58,7 @@ class WC_Payments_Subscriptions {
 
 		self::$product_service      = new WC_Payments_Product_Service( $api_client );
 		self::$invoice_service      = new WC_Payments_Invoice_Service( $api_client, self::$product_service );
-		self::$subscription_service = new WC_Payments_Subscription_Service( $api_client, $customer_service, self::$product_service, self::$invoice_service );
+		self::$subscription_service = new WC_Payments_Subscription_Service( $api_client, $customer_service, self::$product_service, self::$invoice_service, $card_gateway );
 
 		// Load the subscription and invoice incoming event handler.
 		include_once __DIR__ . '/class-wc-payments-subscriptions-event-handler.php';

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -47,9 +47,9 @@ class WC_Payments_Subscriptions {
 	 *
 	 * @param WC_Payments_API_Client       $api_client       WCPay API client.
 	 * @param WC_Payments_Customer_Service $customer_service WCPay Customer Service.
-	 * @param WC_Payment_Gateway_WCPay     $card_gateway     WCPay Payment Gateway.
+	 * @param WC_Payment_Gateway_WCPay     $gateway          WCPay Payment Gateway.
 	 */
-	public static function init( WC_Payments_API_Client $api_client, WC_Payments_Customer_Service $customer_service, WC_Payment_Gateway_WCPay $card_gateway ) {
+	public static function init( WC_Payments_API_Client $api_client, WC_Payments_Customer_Service $customer_service, WC_Payment_Gateway_WCPay $gateway ) {
 		// Load Services.
 		include_once __DIR__ . '/class-wc-payments-product-service.php';
 		include_once __DIR__ . '/class-wc-payments-invoice-service.php';
@@ -57,7 +57,7 @@ class WC_Payments_Subscriptions {
 		include_once __DIR__ . '/class-wc-payments-subscription-change-payment-method-handler.php';
 
 		self::$product_service      = new WC_Payments_Product_Service( $api_client );
-		self::$invoice_service      = new WC_Payments_Invoice_Service( $api_client, self::$product_service, $card_gateway );
+		self::$invoice_service      = new WC_Payments_Invoice_Service( $api_client, self::$product_service, $gateway );
 		self::$subscription_service = new WC_Payments_Subscription_Service( $api_client, $customer_service, self::$product_service, self::$invoice_service );
 
 		// Load the subscription and invoice incoming event handler.

--- a/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
@@ -281,7 +281,7 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 			new DateTime(),
 			'succeeded', // Intent status.
 			'charge_id',
-			'client_secret',
+			'client_secret'
 		);
 
 		$this->mock_api_client

--- a/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
@@ -264,6 +264,61 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 		$this->invoice_service->validate_invoice( $mock_item_data, $mock_discount_data, $mock_subscription );
 		$this->assertSame( [], $mock_subscription->get_meta( self::SUBSCRIPTION_DISCOUNT_IDS_META_KEY, true ) );
 	}
+
+	/**
+	 * Tests WC_Payments_Invoice_Service::get_and_attach_intent_info_to_order() with a valid Intention object.
+	 */
+	public function test_get_and_attach_intent_info_to_order() {
+		$mock_order = WC_Helper_Order::create_order();
+		$intent_id  = 'pi_paymentIntentID';
+
+		$intent = new WC_Payments_API_Intention(
+			$intent_id,
+			'10',
+			'USD',
+			'customer_id',
+			'payment_method_id',
+			new DateTime(),
+			'succeeded', // Intent status.
+			'charge_id',
+			'client_secret',
+		);
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->with( $intent_id )
+			->willReturn( $intent );
+
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'attach_intent_info_to_order' )
+			->willReturn( null );
+
+		$this->invoice_service->get_and_attach_intent_info_to_order( $mock_order, $intent_id );
+	}
+
+	/**
+	 * Tests WC_Payments_Invoice_Service::get_and_attach_intent_info_to_order() with a thrown exception when retrieving the PaymentIntent.
+	 */
+	public function test_get_and_attach_intent_info_to_order_with_exception() {
+		$mock_order = WC_Helper_Order::create_order();
+		$intent_id  = 'pi_paymentIntentID';
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->with( $intent_id )
+			->will( $this->throwException( new API_Exception( 'whoops', 'mock_error', 403 ) ) );
+
+		$this->mock_gateway
+			->expects( $this->never() )
+			->method( 'attach_intent_info_to_order' )
+			->willReturn( null );
+
+		$this->invoice_service->get_and_attach_intent_info_to_order( $mock_order, $intent_id );
+	}
+
 	/**
 	 * Mocks the wcs_order_contains_subscription function return.
 	 *

--- a/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
@@ -42,7 +42,8 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 
 		$this->mock_api_client      = $this->createMock( WC_Payments_API_Client::class );
 		$this->mock_product_service = $this->createMock( WC_Payments_Product_Service::class );
-		$this->invoice_service      = new WC_Payments_Invoice_Service( $this->mock_api_client, $this->mock_product_service );
+		$this->mock_gateway         = $this->createMock( WC_Payment_Gateway_WCPay::class );
+		$this->invoice_service      = new WC_Payments_Invoice_Service( $this->mock_api_client, $this->mock_product_service, $this->mock_gateway );
 	}
 
 	/**

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions-event-handler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions-event-handler.php
@@ -163,7 +163,7 @@ class WC_Payments_Subscriptions_Event_Handler_Test extends WP_UnitTestCase {
 	 * Test handle_invoice_paid when the incoming webhook belongs to a subscription that doesn't exist.
 	 */
 	public function test_handle_invoice_paid_exception() {
-		$test_body = $this->get_mock_test_body( 'sub_ID_no_invoice_paid', 'cus_test1234', 'ii_testInvoiceID' );
+		$test_body = $this->get_mock_test_body( 'sub_ID_no_invoice_paid', 'cus_test1234', 'ii_testInvoiceID', 'payment_intent' );
 
 		$this->expectException( Rest_Request_Exception::class );
 		$this->expectExceptionMessage( 'Cannot find subscription for the incoming "invoice.paid" event.' );
@@ -331,14 +331,15 @@ class WC_Payments_Subscriptions_Event_Handler_Test extends WP_UnitTestCase {
 		return [
 			'data' => [
 				'object' => [
-					'attempt_count' => $attempt_count,
-					'customer'      => $customer_id,
-					'discounts'     => [],
-					'id'            => $invoice_id,
-					'lines'         => [
+					'attempt_count'  => $attempt_count,
+					'customer'       => $customer_id,
+					'discounts'      => [],
+					'id'             => $invoice_id,
+					'payment_intent' => 'pi_xxxx',
+					'lines'          => [
 						'data' => [],
 					],
-					'subscription'  => $subscription_id,
+					'subscription'   => $subscription_id,
 				],
 			],
 		];


### PR DESCRIPTION
Fixes #3085 

#### Changes proposed in this Pull Request

Add the payment intent data to renewal orders.

* Pass an instance of `WC_Payment_Gateway_WCPay` to the `WC_Payments_Subscription_Service` and `WC_Payments_Subscriptions`  class constructors
* Retrieve the related payment intent object when `invoice.paid` webhook is triggered
* Add the payment intent data to the order using [WC_Payment_Gateway_WCPay::attach_intent_info_to_order()](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payment-gateway-wcpay.php#L1165)

Besides adding the charge ID as a meta to the order (which would alone solve the linked issue), this PR also adds the other paymentIntent data as meta to the order and adds a note with its parsed information, as it happens with regular orders. 

Another approach was simply adding the charge ID as a meta to the order [here](https://github.com/Automattic/woocommerce-payments/compare/fix/order-id-missing-in-renewal-transactions?expand=1#diff-bf0178a8a5666e52202affc2f2e1acad3006584ce361f2d55241fa1193dbcf28L123), which would link the transaction and the order and solve the linked issue, instead of calling `get_and_attach_intent_info_to_order()`, but this approach seemed more complete. We could also mimic `WC_Payment_Gateway_WCPay::attach_intent_info_to_order()` instead of having to pass an instance of `WC_Payment_Gateway_WCPay` just for this method. Lmk what you think, glad to adjust it.

The tests are pending but I wanted to check the approach with you before getting into it.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

* Checkout develop branch and pull down WCPay Dev tools latest trunk (to test billing clocks)
* Make sure WC Subscriptions extension is disabled to use WCPay Subscriptions
* Purchase a subscription product with WC Payments
* Enable dev testing mode on the subscription to use billing clocks (https://d.pr/i/vETbae)
* Fast-forward the subscriptions billing clock to process a successful renewal order
* Once the renewal order is created, visit the Payments > Transactions page 
* Opposite to what the linked issue described, now you should see the ID under the `Order #` column for the newly added transaction
* When editing the related order, you should also see an order note with the payment details and a link to the details page of the related transaction

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
