### PR TITLE
Do not show payment request / express checkout buttons for subscription products.

### DIFF
--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -476,8 +476,8 @@ class WC_Payments_Payment_Request_Button_Handler {
 				return false;
 			}
 
-			// Trial subscriptions with shipping are not supported.
-			if ( class_exists( 'WC_Subscriptions_Product' ) && WC_Subscriptions_Product::is_subscription( $_product ) && $_product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $_product ) > 0 ) {
+			// Subscriptions products are not supported.
+			if ( class_exists( 'WC_Subscriptions_Product' ) && WC_Subscriptions_Product::is_subscription( $_product ) ) {
 				return false;
 			}
 		}
@@ -689,8 +689,8 @@ class WC_Payments_Payment_Request_Button_Handler {
 			return false;
 		}
 
-		// Trial subscriptions with shipping are not supported.
-		if ( class_exists( 'WC_Subscriptions_Product' ) && $product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $product ) > 0 ) {
+		// Subscriptions products are not supported.
+		if ( class_exists( 'WC_Subscriptions_Product' ) && WC_Subscriptions_Product::is_subscription( $product ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #3094

#### Changes proposed in this Pull Request

Make subscriptions product in general as not supported by express checkout / payment request buttons.

#### Testing instructions

1. Make sure you can see express checkout buttons. Here are the requirements:
  - You have connected to a Stripe account.
  - Under Admin > Payments > Settings, 'Enable express checkouts' option is enabled and 'Show express checkouts on' shows on Checkout, Product page, and Cart.
  - Your store is on HTTPs (I suggest to use ngrok or Jurrasic Tube) or dev mode.
  - Using Chrome with a Google account that has saved payment. Check chrome://settings/payments.

2. Create a simple (non-subscription) product and a subscription product.

3. Open both product pages.
  - With base branch, expect to see express checkout buttons on both product pages.
  - With head branch, expect to see express checkout buttons only on the simple product page.

4. Testing cart page:
  - With base branch, expect express checkout buttons to show up even when subscription product is in the cart.
  - With head branch, express checkout buttons shouldn't show on cart page when there is subscription product in the cart.

5. Testing checkout page:
  - With base branch, expect express checkout buttons to show up even when subscription product is in the cart.
  - With head branch, express checkout buttons shouldn't show on cart page when there is subscription product in the cart.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
