### PR TITLE
Allow payment_intent_succeeded webhook to handle orders without intent_id attached

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Update - Remove unused "wcpay_deposits_summary_empty_state_click" track.
 * Fix - Applied sentence case on all strings
 * Fix - Missing customer information after guest checkout via Checkout Block
+* Fix - Allow payment_intent_succeeded webhook to handle orders without intent_id attached.
 
 = 3.1.0 - 2021-10-06 =
 * Fix - Issue affecting analytics for Multi-Currency orders made with a zero-decimal to non-zero decimal conversion.

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -262,6 +262,15 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 
 		// Look up the order related to this charge.
 		$order = $this->wcpay_db->order_from_intent_id( $intent_id );
+
+		if ( ! $order ) {
+			// Retrieving order with order_id in case intent_id was not properly set.
+			Logger::debug( 'intent_id not found, using order_id to retrieve order' );
+			$metadata = $this->read_rest_property( $event_object, 'metadata' );
+			$order_id = $metadata['order_id'];
+			$order    = wc_get_order( ( $order_id ) );
+		}
+
 		if ( ! $order ) {
 			throw new Invalid_Payment_Method_Exception(
 				sprintf(

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -268,7 +268,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 			Logger::debug( 'intent_id not found, using order_id to retrieve order' );
 			$metadata = $this->read_rest_property( $event_object, 'metadata' );
 			$order_id = $metadata['order_id'];
-			$order    = wc_get_order( ( $order_id ) );
+			$order    = $this->wcpay_db->order_from_order_id( $order_id );
 		}
 
 		if ( ! $order ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1031,6 +1031,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$next_action   = $intent['next_action'];
 		}
 
+		$this->attach_intent_info_to_order( $order, $intent_id, $status, $payment_method, $customer_id, $charge_id, $currency );
+		$this->attach_exchange_info_to_order( $order, $charge_id );
+
 		if ( ! empty( $intent ) ) {
 			if ( ! in_array( $status, self::SUCCESSFUL_INTENT_STATUS, true ) ) {
 				$intent_failed = true;
@@ -1075,9 +1078,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				}
 			}
 		}
-
-		$this->attach_intent_info_to_order( $order, $intent_id, $status, $payment_method, $customer_id, $charge_id, $currency );
-		$this->attach_exchange_info_to_order( $order, $charge_id );
 
 		if ( isset( $response ) ) {
 			return $response;

--- a/includes/class-wc-payments-db.php
+++ b/includes/class-wc-payments-db.php
@@ -67,4 +67,15 @@ class WC_Payments_DB {
 		);
 		return $order_id;
 	}
+
+	/**
+	 * Retrieve an order using order ID.
+	 *
+	 * @param string $order_id       WC Order Id.
+	 *
+	 * @return null|WC_Order
+	 */
+	public function order_from_order_id( $order_id ) {
+		return wc_get_order( ( $order_id ) );
+	}
 }

--- a/includes/class-wc-payments-db.php
+++ b/includes/class-wc-payments-db.php
@@ -25,7 +25,7 @@ class WC_Payments_DB {
 		$order_id = $this->order_id_from_meta_key_value( self::META_KEY_CHARGE_ID, $charge_id );
 
 		if ( $order_id ) {
-			return wc_get_order( $order_id );
+			return $this->order_from_order_id( $order_id );
 		}
 		return false;
 	}
@@ -41,7 +41,7 @@ class WC_Payments_DB {
 		$order_id = $this->order_id_from_meta_key_value( self::META_KEY_INTENT_ID, $intent_id );
 
 		if ( $order_id ) {
-			return wc_get_order( $order_id );
+			return $this->order_from_order_id( $order_id );
 		}
 		return false;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ Please note that our support for the checkout block is still experimental and th
 * Update - Fee breakdown when there's only a base fee
 * Fix - Inconsistent shipping options in Payment Request popup.
 * Fix - Missing customer information after guest checkout via Checkout Block
+* Fix - Allow payment_intent_succeeded webhook to handle orders without intent_id attached.
 
 = 3.1.0 - 2021-10-06 =
 * Fix - Issue affecting analytics for Multi-Currency orders made with a zero-decimal to non-zero decimal conversion.

--- a/tests/unit/admin/test-class-wc-rest-payments-webhook.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-webhook.php
@@ -58,7 +58,7 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 
 		$this->mock_db_wrapper = $this->getMockBuilder( WC_Payments_DB::class )
 			->disableOriginalConstructor()
-			->setMethods( [ 'order_from_charge_id', 'order_from_intent_id' ] )
+			->setMethods( [ 'order_from_charge_id', 'order_from_intent_id', 'order_from_order_id' ] )
 			->getMock();
 
 		$this->mock_remote_note_service = $this->createMock( WC_Payments_Remote_Note_Service::class );
@@ -550,6 +550,56 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'order_from_intent_id' )
 			->with( 'pi_123123123123123' )
+			->willReturn( $mock_order );
+
+		// Run the test.
+		$response = $this->controller->handle_webhook( $this->request );
+
+		// Check the response.
+		$response_data = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( [ 'result' => 'success' ], $response_data );
+	}
+
+	/**
+	 * Tests that a payment_intent.succeeded event will complete the order even if the intent was not properly attached into the order.
+	 */
+	public function test_payment_intent_successful_and_completes_order_without_intent_id() {
+		$this->request_body['type']           = 'payment_intent.succeeded';
+		$this->request_body['data']['object'] = [
+			'id'       => 'pi_123123123123123', // payment_intent's ID.
+			'object'   => 'payment_intent',
+			'amount'   => 1500,
+			'charges'  => [],
+			'currency' => 'eur',
+			'metadata' => [ 'order_id' => 'id_1323' ], // Using order_id inside of the intent metadata to find the order.
+		];
+
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
+
+		$mock_order = $this->createMock( WC_Order::class );
+
+		$mock_order
+			->expects( $this->once() )
+			->method( 'has_status' )
+			->with( [ 'processing', 'completed' ] )
+			->willReturn( false );
+
+		$mock_order
+			->expects( $this->once() )
+			->method( 'payment_complete' );
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_intent_id' )
+			->with( 'pi_123123123123123' )
+			->willReturn( null );
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_order_id' )
+			->with( 'id_1323' )
 			->willReturn( $mock_order );
 
 		// Run the test.


### PR DESCRIPTION
Fixes 1202-gh-Automattic/woocommerce-payments-server

#### Changes proposed in this Pull Request

There has been a lot of reports in different merchants about a situation where an order was successfully paid in Stripe side, but canceled in WooCommerce (because of `woocommerce_hold_stock_minutes`).

Find more about it and its investigation in the shared links here 1202-gh-Automattic/woocommerce-payments-server

This PR allows the webhook to obtain an order using the attached `order_id` in the metadata of the object, in case the intent_id was not properly attached into the order because of any racing condition.

@dmallory42 has also contributed moving `attach_intent_info_to_order` and `attach_exchange_info_to_order` higher in the execution to try to mitigate the racing condition as we spoke here p1634210077172300-slack-C0208C3BXHP

#### Testing instructions

* Run the tests, I've added a new one that gets an order when one is not found using intent_id.
* To test it manually, go to this line https://github.com/Automattic/woocommerce-payments/blob/38dade9f92d20c715aedc89ffdf744f787884066/includes/admin/class-wc-rest-payments-webhook-controller.php#L264 and change it for 
`$order = $this->wcpay_db->order_from_intent_id( "anything" );` in order to simulate getting an intent_id that we had no record of.
* Make a purchase
* See in the logs `intent_id not found, using order_id to retrieve order`, that indicates the webhook has gone into the new added logic.
* Check the order is successfully marked as `payment_complete` after the order was successfully retrieved using the webhook metadata.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)