### PR TITLE
Only allow Renovate to run at the weekends

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,8 @@
   },
   "pin": {
     "automerge": true
-  }
+  },
+  "schedule": [
+    "every weekend"
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,6 @@
     "automerge": true
   },
   "schedule": [
-    "every weekend"
+    "before 3am on Sunday"
   ]
 }


### PR DESCRIPTION
Renovate can be quite noisy, especially if we get behind on handling the PRs it opens. It will often rebase branches triggering CI builds and notifications.

Let's experiment with only letting it run at the weekend, this will still give us plenty of time to get things merged ahead of releases.

Renovate scheduling documentation: https://docs.renovatebot.com/noise-reduction/#scheduling-renovate

I will monitor Renovate's PRs after this is merged to make sure it's behaving as expected.
