### PR TITLE
Fix rounded shipping value

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,8 +9,9 @@
 * Update - Fee breakdown when there's only a base fee
 * Fix - Inconsistent shipping options in Payment Request popup.
 * Update - Remove unused "wcpay_deposits_summary_empty_state_click" track.
-* Fix - Applied sentence case on all strings
-* Fix - Missing customer information after guest checkout via Checkout Block
+* Fix - Applied sentence case on all strings.
+* Fix - Missing customer information after guest checkout via Checkout Block.
+* Fix - Rounding error on shipment value.
 
 = 3.1.0 - 2021-10-06 =
 * Fix - Issue affecting analytics for Multi-Currency orders made with a zero-decimal to non-zero decimal conversion.

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -250,9 +250,9 @@ class WC_Payments_Subscription_Service {
 	 */
 	public static function format_item_price_data( string $currency, string $wcpay_product_id, float $unit_amount, string $interval = '', int $interval_count = 0 ) : array {
 		$data = [
-			'currency'    => $currency,
-			'product'     => $wcpay_product_id,
-			'unit_amount' => WC_Payments_Utils::prepare_amount( $unit_amount, $currency ),
+			'currency'            => $currency,
+			'product'             => $wcpay_product_id,
+			'unit_amount_decimal' => $unit_amount * 100,
 		];
 
 		if ( $interval && $interval_count ) {

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -252,7 +252,7 @@ class WC_Payments_Subscription_Service {
 		$data = [
 			'currency'    => $currency,
 			'product'     => $wcpay_product_id,
-			'unit_amount' => (int) $unit_amount * 100,
+			'unit_amount' => WC_Payments_Utils::prepare_amount( $unit_amount, $currency ),
 		];
 
 		if ( $interval && $interval_count ) {

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -597,4 +597,19 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $next_payment_time, $subscription->get_time( 'next_payment' ) );
 	}
+
+	/**
+	 * Test WC_Payments_Subscription_Service::format_item_price_data().
+	 */
+	public function test_format_item_price_data() {
+		$expected = [
+			'currency'            => 'USD',
+			'product'             => '',
+			'unit_amount_decimal' => 1033.33,
+		];
+
+		$actual = WC_Payments_Subscription_Service::format_item_price_data( 'USD', '', 10.3333 );
+
+		$this->assertEquals( $expected, $actual );
+	}
 }

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -127,10 +127,10 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 				],
 				[
 					'price_data' => [
-						'product'     => $mock_wcpay_product_id,
-						'currency'    => 'USD',
-						'unit_amount' => 1000,
-						'recurring'   => [
+						'product'             => $mock_wcpay_product_id,
+						'currency'            => 'USD',
+						'unit_amount_decimal' => 1000.0,
+						'recurring'           => [
 							'interval'       => 'month',
 							'interval_count' => 1,
 						],
@@ -379,10 +379,10 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 				],
 				[
 					'price_data' => [
-						'product'     => 'wcpay_prod_test123',
-						'currency'    => 'USD',
-						'unit_amount' => 1000,
-						'recurring'   => [
+						'product'             => 'wcpay_prod_test123',
+						'currency'            => 'USD',
+						'unit_amount_decimal' => 1000.0,
+						'recurring'           => [
 							'interval'       => 'month',
 							'interval_count' => 1,
 						],


### PR DESCRIPTION
Fixes #3110 

#### Changes proposed in this Pull Request
This PR fixes the rounding error that would occur when a shipment had a decimal price

#### Testing instructions

1. Deactivate the WC Subscriptions extension. 
2. Enable the **WCPay Subscriptions feature** via the feature flag (WCPay Dev tools has a setting for this)
3. Create a flat rate shipping method that includes cents $20.10. 
4. Purchase a subscription. 
5. Note the subscription total (https://d.pr/i/fo69Fw)
6. View the subscription in the Stripe dashboard. 
7. Note shipping amount match. 

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
