### PR TITLE
Pass parameters to the wc_get_template() function in the correct order

### DIFF
--- a/includes/subscriptions/class-wc-payments-subscriptions-plugin-notice-manager.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-plugin-notice-manager.php
@@ -73,7 +73,7 @@ class WC_Payments_Subscriptions_Plugin_Notice_Manager {
 	 */
 	public function output_notice_template() {
 		if ( $this->is_admin_plugins_screen() ) {
-			wc_get_template( 'html-subscriptions-plugin-notice.php', '', [], dirname( __DIR__ ) . '/subscriptions/templates/' );
+			wc_get_template( 'html-subscriptions-plugin-notice.php', [], '', dirname( __DIR__ ) . '/subscriptions/templates/' );
 		}
 	}
 }


### PR DESCRIPTION
Fixes #3137 

#### Changes proposed in this Pull Request

This PR fixes an error on the WP plugins screen caused by passing the parameters to the `wc_get_template()` function in the incorrect order. 

#### Testing instructions

- Checkout the `develop` branch.
- go to the WP Plugins screen. 
- You should get the following error.
- This branch fixes that error.

```
PHP Notice:  Array to string conversion in /Users/jamesallan/local-dev/wcsstripebilling/app/public/wp-content/plugins/woocommerce/includes/wc-core-functions.php on line 297
PHP Stack trace:
PHP   1. {main}() /Users/jamesallan/local-dev/wcsstripebilling/app/public/wp-admin/plugins.php:0
PHP   2. require_once() /Users/jamesallan/local-dev/wcsstripebilling/app/public/wp-admin/plugins.php:782
PHP   3. do_action() /Users/jamesallan/local-dev/wcsstripebilling/app/public/wp-admin/admin-footer.php:78
PHP   4. WP_Hook->do_action() /Users/jamesallan/local-dev/wcsstripebilling/app/public/wp-includes/plugin.php:470
PHP   5. WP_Hook->apply_filters() /Users/jamesallan/local-dev/wcsstripebilling/app/public/wp-includes/class-wp-hook.php:327
PHP   6. WC_Payments_Subscriptions_Plugin_Notice_Manager->output_notice_template() /Users/jamesallan/local-dev/wcsstripebilling/app/public/wp-includes/class-wp-hook.php:303
PHP   7. wc_get_template() /Users/jamesallan/local-dev/wcsstripebilling/app/public/wp-content/plugins/woocommerce-payments/includes/subscriptions/class-wc-payments-subscriptions-plugin-notice-manager.php:76
PHP   8. implode() /Users/jamesallan/local-dev/wcsstripebilling/app/public/wp-content/plugins/woocommerce/includes/wc-core-functions.php:297
```

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
