### PR TITLE
fixed test that would fail because of wrong case #3143

### DIFF
--- a/tests/e2e/specs/merchant/merchant-orders-partial-refund.spec.js
+++ b/tests/e2e/specs/merchant/merchant-orders-partial-refund.spec.js
@@ -76,7 +76,7 @@ describe.each( dataTable )(
 
 			// Login as merchant
 			await merchant.login();
-		}, 120000 );
+		}, 200000 );
 
 		afterAll( async () => {
 			await merchant.logout();
@@ -189,7 +189,7 @@ describe.each( dataTable )(
 					text: `$${ refundTotalString } USD will be deducted from a future deposit.`,
 				} ),
 				expect( page ).toMatchElement( 'li.woocommerce-timeline-item', {
-					text: 'Payment status changed to partial refund.',
+					text: 'Payment status changed to Partial refund.',
 				} ),
 			] );
 		} );


### PR DESCRIPTION
Fixes #3143 Partially

#### Changes proposed in this Pull Request

Fix the case of the message that the test(tests/e2e/specs/merchant/merchant-orders-partial-refund.spec.js) searches for on the transaction page and increased the timeout.

#### Testing instructions

- execute the test tests/e2e/specs/merchant/merchant-orders-partial-refund.spec.js
- It should pass.

#### Observations
**tests/e2e/specs/merchant/merchant-a-onboarding-setup.spec.js**
Fail -> Timeout [low here](https://github.com/Automattic/woocommerce-payments/blob/develop/tests/e2e/setup/jest-setup.js#L158). But I am not very comfortable with increasing it too much. Should we split the completeOnboardingWizard function into smaller functions? Or that timeout is not very important and could be removed/increased?

**tests/e2e/specs/merchant/merchant-a-onboarding-task-list.spec.js**
Pass

**tests/e2e/specs/merchant/merchant-orders-partial-refund.spec.js**
Fail -> Wrong case on expected message and timeout. Fixed by changing the case on this message

**tests/e2e/specs/shopper/shopper-wc-blocks-checkout-failures.spec.js**
Pass
tests/e2e/specs/shopper/shopper-wc-blocks-checkout-purchase.spec.js
Pass