### PR TITLE
Update the composer.lock to pull the latest WCS Core 1.0.0 changes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,21 +8,21 @@
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
-            "version": "v1.4.6",
+            "version": "v1.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-a8c-mc-stats.git",
-                "reference": "68d100cf6c55ce01d57ab587241780ce8cb5ea76"
+                "reference": "adb8738d08ae88c16a0dda0a3fc8285b60c0d96f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-a8c-mc-stats/zipball/68d100cf6c55ce01d57ab587241780ce8cb5ea76",
-                "reference": "68d100cf6c55ce01d57ab587241780ce8cb5ea76",
+                "url": "https://api.github.com/repos/Automattic/jetpack-a8c-mc-stats/zipball/adb8738d08ae88c16a0dda0a3fc8285b60c0d96f",
+                "reference": "adb8738d08ae88c16a0dda0a3fc8285b60c0d96f",
                 "shasum": ""
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^2.0",
-                "yoast/phpunit-polyfills": "1.0.1"
+                "automattic/jetpack-changelogger": "^3.0",
+                "yoast/phpunit-polyfills": "1.0.2"
             },
             "type": "library",
             "extra": {
@@ -46,31 +46,31 @@
             ],
             "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-a8c-mc-stats/tree/v1.4.6"
+                "source": "https://github.com/Automattic/jetpack-a8c-mc-stats/tree/v1.4.8"
             },
-            "time": "2021-09-28T18:19:29+00:00"
+            "time": "2021-10-13T17:10:46+00:00"
         },
         {
             "name": "automattic/jetpack-assets",
-            "version": "v1.11.7",
+            "version": "v1.11.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-assets.git",
-                "reference": "d109f5d135d0cef2a42642d20b9bc4a13bab3197"
+                "reference": "7e2fc169af1b3dfce5ea70e0b225aaf6ad49b77a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-assets/zipball/d109f5d135d0cef2a42642d20b9bc4a13bab3197",
-                "reference": "d109f5d135d0cef2a42642d20b9bc4a13bab3197",
+                "url": "https://api.github.com/repos/Automattic/jetpack-assets/zipball/7e2fc169af1b3dfce5ea70e0b225aaf6ad49b77a",
+                "reference": "7e2fc169af1b3dfce5ea70e0b225aaf6ad49b77a",
                 "shasum": ""
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^2.0",
+                "automattic/jetpack-changelogger": "^3.0",
                 "brain/monkey": "2.6.0",
-                "yoast/phpunit-polyfills": "1.0.1"
+                "yoast/phpunit-polyfills": "1.0.2"
             },
             "type": "library",
             "extra": {
@@ -94,9 +94,9 @@
             ],
             "description": "Asset management utilities for Jetpack ecosystem packages",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-assets/tree/v1.11.7"
+                "source": "https://github.com/Automattic/jetpack-assets/tree/v1.11.9"
             },
-            "time": "2021-09-28T18:19:47+00:00"
+            "time": "2021-10-13T17:11:16+00:00"
         },
         {
             "name": "automattic/jetpack-autoloader",
@@ -236,22 +236,22 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "v1.6.7",
+            "version": "v1.6.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-constants.git",
-                "reference": "464173d25c5923d92131fedde2232063587b7ecd"
+                "reference": "b4764b5050367692f173d62220cf1e69f4f7af0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/464173d25c5923d92131fedde2232063587b7ecd",
-                "reference": "464173d25c5923d92131fedde2232063587b7ecd",
+                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/b4764b5050367692f173d62220cf1e69f4f7af0b",
+                "reference": "b4764b5050367692f173d62220cf1e69f4f7af0b",
                 "shasum": ""
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^2.0",
+                "automattic/jetpack-changelogger": "^3.0",
                 "brain/monkey": "2.6.0",
-                "yoast/phpunit-polyfills": "1.0.1"
+                "yoast/phpunit-polyfills": "1.0.2"
             },
             "type": "library",
             "extra": {
@@ -275,22 +275,22 @@
             ],
             "description": "A wrapper for defining constants in a more testable way.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-constants/tree/v1.6.7"
+                "source": "https://github.com/Automattic/jetpack-constants/tree/v1.6.9"
             },
-            "time": "2021-09-28T18:19:36+00:00"
+            "time": "2021-10-13T17:10:57+00:00"
         },
         {
             "name": "automattic/jetpack-heartbeat",
-            "version": "v1.3.11",
+            "version": "v1.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-heartbeat.git",
-                "reference": "f01a06c569c9ded649c1c5336568683af0181682"
+                "reference": "89aa8de4786cebea1d153fe11de6c4c45007e508"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-heartbeat/zipball/f01a06c569c9ded649c1c5336568683af0181682",
-                "reference": "f01a06c569c9ded649c1c5336568683af0181682",
+                "url": "https://api.github.com/repos/Automattic/jetpack-heartbeat/zipball/89aa8de4786cebea1d153fe11de6c4c45007e508",
+                "reference": "89aa8de4786cebea1d153fe11de6c4c45007e508",
                 "shasum": ""
             },
             "require": {
@@ -298,7 +298,7 @@
                 "automattic/jetpack-options": "^1.13"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^2.0"
+                "automattic/jetpack-changelogger": "^3.0"
             },
             "type": "library",
             "extra": {
@@ -322,30 +322,30 @@
             ],
             "description": "This adds a cronjob that sends a batch of internal automattic stats to wp.com once a day",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-heartbeat/tree/v1.3.11"
+                "source": "https://github.com/Automattic/jetpack-heartbeat/tree/v1.3.12"
             },
-            "time": "2021-09-28T18:19:54+00:00"
+            "time": "2021-10-13T17:11:24+00:00"
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "v1.13.2",
+            "version": "v1.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-options.git",
-                "reference": "4aa5869657d234f55b5417d78041759744c84906"
+                "reference": "aa021e07d60b978f8631de1aa564af80b46eede5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/4aa5869657d234f55b5417d78041759744c84906",
-                "reference": "4aa5869657d234f55b5417d78041759744c84906",
+                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/aa021e07d60b978f8631de1aa564af80b46eede5",
+                "reference": "aa021e07d60b978f8631de1aa564af80b46eede5",
                 "shasum": ""
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^2.0",
-                "yoast/phpunit-polyfills": "1.0.1"
+                "automattic/jetpack-changelogger": "^3.0",
+                "yoast/phpunit-polyfills": "1.0.2"
             },
             "type": "library",
             "extra": {
@@ -369,31 +369,31 @@
             ],
             "description": "A wrapper for wp-options to manage specific Jetpack options.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-options/tree/v1.13.2"
+                "source": "https://github.com/Automattic/jetpack-options/tree/v1.13.4"
             },
-            "time": "2021-09-28T18:19:48+00:00"
+            "time": "2021-10-13T17:11:18+00:00"
         },
         {
             "name": "automattic/jetpack-redirect",
-            "version": "v1.7.2",
+            "version": "v1.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-redirect.git",
-                "reference": "bb99b8e046f6161dcfaed39e483b28af23885a29"
+                "reference": "c3e64db200272f3ab7a5fb0381b0c3a5b89a624f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-redirect/zipball/bb99b8e046f6161dcfaed39e483b28af23885a29",
-                "reference": "bb99b8e046f6161dcfaed39e483b28af23885a29",
+                "url": "https://api.github.com/repos/Automattic/jetpack-redirect/zipball/c3e64db200272f3ab7a5fb0381b0c3a5b89a624f",
+                "reference": "c3e64db200272f3ab7a5fb0381b0c3a5b89a624f",
                 "shasum": ""
             },
             "require": {
                 "automattic/jetpack-status": "^1.8"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^2.0",
+                "automattic/jetpack-changelogger": "^3.0",
                 "brain/monkey": "2.6.0",
-                "yoast/phpunit-polyfills": "1.0.1"
+                "yoast/phpunit-polyfills": "1.0.2"
             },
             "type": "library",
             "extra": {
@@ -417,28 +417,28 @@
             ],
             "description": "Utilities to build URLs to the jetpack.com/redirect/ service",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-redirect/tree/v1.7.2"
+                "source": "https://github.com/Automattic/jetpack-redirect/tree/v1.7.4"
             },
-            "time": "2021-09-28T18:19:50+00:00"
+            "time": "2021-10-13T17:11:20+00:00"
         },
         {
             "name": "automattic/jetpack-roles",
-            "version": "v1.4.7",
+            "version": "v1.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-roles.git",
-                "reference": "c52f1904fe10597410231c23f3300b2923b816a3"
+                "reference": "75d466da1c421d071d09051eddfd570a7c950f59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/c52f1904fe10597410231c23f3300b2923b816a3",
-                "reference": "c52f1904fe10597410231c23f3300b2923b816a3",
+                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/75d466da1c421d071d09051eddfd570a7c950f59",
+                "reference": "75d466da1c421d071d09051eddfd570a7c950f59",
                 "shasum": ""
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^2.0",
+                "automattic/jetpack-changelogger": "^3.0",
                 "brain/monkey": "2.6.0",
-                "yoast/phpunit-polyfills": "1.0.1"
+                "yoast/phpunit-polyfills": "1.0.2"
             },
             "type": "library",
             "extra": {
@@ -462,28 +462,28 @@
             ],
             "description": "Utilities, related with user roles and capabilities.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-roles/tree/v1.4.7"
+                "source": "https://github.com/Automattic/jetpack-roles/tree/v1.4.9"
             },
-            "time": "2021-09-28T18:19:43+00:00"
+            "time": "2021-10-13T17:11:07+00:00"
         },
         {
             "name": "automattic/jetpack-status",
-            "version": "v1.8.2",
+            "version": "v1.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-status.git",
-                "reference": "5dca669c94578f87594921d7bfb221835908fdf8"
+                "reference": "da3d0a44586f5a168d7c8d930ce21539db30ae47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/5dca669c94578f87594921d7bfb221835908fdf8",
-                "reference": "5dca669c94578f87594921d7bfb221835908fdf8",
+                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/da3d0a44586f5a168d7c8d930ce21539db30ae47",
+                "reference": "da3d0a44586f5a168d7c8d930ce21539db30ae47",
                 "shasum": ""
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^2.0",
+                "automattic/jetpack-changelogger": "^3.0",
                 "brain/monkey": "2.6.0",
-                "yoast/phpunit-polyfills": "1.0.1"
+                "yoast/phpunit-polyfills": "1.0.2"
             },
             "type": "library",
             "extra": {
@@ -507,22 +507,22 @@
             ],
             "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-status/tree/v1.8.2"
+                "source": "https://github.com/Automattic/jetpack-status/tree/v1.8.4"
             },
-            "time": "2021-09-28T18:19:44+00:00"
+            "time": "2021-10-13T17:11:09+00:00"
         },
         {
             "name": "automattic/jetpack-terms-of-service",
-            "version": "v1.9.10",
+            "version": "v1.9.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-terms-of-service.git",
-                "reference": "3d6c41678d837bb103be70876e3a7e79fcbc8387"
+                "reference": "4c7cf21695503750be136d1e431a3c0f4c2d737d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-terms-of-service/zipball/3d6c41678d837bb103be70876e3a7e79fcbc8387",
-                "reference": "3d6c41678d837bb103be70876e3a7e79fcbc8387",
+                "url": "https://api.github.com/repos/Automattic/jetpack-terms-of-service/zipball/4c7cf21695503750be136d1e431a3c0f4c2d737d",
+                "reference": "4c7cf21695503750be136d1e431a3c0f4c2d737d",
                 "shasum": ""
             },
             "require": {
@@ -530,9 +530,9 @@
                 "automattic/jetpack-status": "^1.8"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^2.0",
+                "automattic/jetpack-changelogger": "^3.0",
                 "brain/monkey": "2.6.0",
-                "yoast/phpunit-polyfills": "1.0.1"
+                "yoast/phpunit-polyfills": "1.0.2"
             },
             "type": "library",
             "extra": {
@@ -556,22 +556,22 @@
             ],
             "description": "Everything need to manage the terms of service state",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-terms-of-service/tree/v1.9.10"
+                "source": "https://github.com/Automattic/jetpack-terms-of-service/tree/v1.9.12"
             },
-            "time": "2021-09-28T18:19:57+00:00"
+            "time": "2021-10-13T17:11:28+00:00"
         },
         {
             "name": "automattic/jetpack-tracking",
-            "version": "v1.13.11",
+            "version": "v1.13.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-tracking.git",
-                "reference": "ed8ce7054fd04d1c75e2bdd87683e17d4b852295"
+                "reference": "f49360abb3b9c1072f6f7b336fbd2324a477f2ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-tracking/zipball/ed8ce7054fd04d1c75e2bdd87683e17d4b852295",
-                "reference": "ed8ce7054fd04d1c75e2bdd87683e17d4b852295",
+                "url": "https://api.github.com/repos/Automattic/jetpack-tracking/zipball/f49360abb3b9c1072f6f7b336fbd2324a477f2ae",
+                "reference": "f49360abb3b9c1072f6f7b336fbd2324a477f2ae",
                 "shasum": ""
             },
             "require": {
@@ -581,9 +581,9 @@
                 "automattic/jetpack-terms-of-service": "^1.9"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^2.0",
+                "automattic/jetpack-changelogger": "^3.0",
                 "brain/monkey": "2.6.0",
-                "yoast/phpunit-polyfills": "1.0.1"
+                "yoast/phpunit-polyfills": "1.0.2"
             },
             "type": "library",
             "extra": {
@@ -608,9 +608,9 @@
             ],
             "description": "Tracking for Jetpack",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-tracking/tree/v1.13.11"
+                "source": "https://github.com/Automattic/jetpack-tracking/tree/v1.13.13"
             },
-            "time": "2021-09-30T18:26:36+00:00"
+            "time": "2021-10-13T17:11:30+00:00"
         },
         {
             "name": "composer/installers",
@@ -826,12 +826,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "7c449346727113e652c5e6cc2071cf23712ff3f3"
+                "reference": "c54970df24cb40f2d0c5ffa0fadc97e949324923"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/7c449346727113e652c5e6cc2071cf23712ff3f3",
-                "reference": "7c449346727113e652c5e6cc2071cf23712ff3f3",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/c54970df24cb40f2d0c5ffa0fadc97e949324923",
+                "reference": "c54970df24cb40f2d0c5ffa0fadc97e949324923",
                 "shasum": ""
             },
             "require": {
@@ -864,7 +864,7 @@
                 "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/1.0.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2021-10-07T01:50:38+00:00"
+            "time": "2021-10-18T06:45:29+00:00"
         }
     ],
     "packages-dev": [
@@ -3491,6 +3491,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-11-30T07:30:19+00:00"
         },
         {
@@ -3542,16 +3543,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.0",
+            "version": "3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e",
                 "shasum": ""
             },
             "require": {
@@ -3594,7 +3595,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-04-09T00:54:41+00:00"
+            "time": "2021-10-11T04:00:11+00:00"
         },
         {
             "name": "symfony/console",


### PR DESCRIPTION
We've just re-tagged our 1.0.0 of Subscriptions Core so this PR is updating the `composer.lock` to make sure everyone is pulling the correct version of WCS Core.

Before WC Pay 3.2 release we'll be doing an official 1.0.1 release of Subscriptions Core

#### Testing instructions

1. Checking out this branch should run `composer install` but you may need to run this manually.
2. Check you have the latest WCS Core changes (look at the changelog in `/vendor/woocommerce/subscriptions-core to confirm you see the following: https://d.pr/i/Wh0zEM)