### PR TITLE
Enable the WCPay Subscriptions feature on eligible stores

### DIFF
--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -95,7 +95,15 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_wcpay_subscriptions_enabled() {
-		return '1' === get_option( self::WCPAY_SUBSCRIPTIONS_FLAG_NAME, '0' );
+		$enabled = get_option( self::WCPAY_SUBSCRIPTIONS_FLAG_NAME, null );
+
+		// Enable the feature by default for stores that are eligible.
+		if ( null === $enabled && function_exists( 'wc_get_base_location' ) && self::is_wcpay_subscriptions_eligible() ) {
+			$enabled = '1';
+			update_option( self::WCPAY_SUBSCRIPTIONS_FLAG_NAME, $enabled );
+		}
+
+		return '1' === $enabled;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3087

#### Changes proposed in this Pull Request

This PR switches on WCPay Subscriptions by default for eligible stores. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* From your database, delete any `_wcpay_feature_subscriptions` option you had previously set. 
* Reloading any page on your site should either:
   * If your store is located in the US it will set the option back to `'1'` - the feature is enabled.
   * If your store is located outside the US it won't be enabled - no option set at all.
* Change your site's eligibility by changing the store's country in **WooCommerce > Settings** to confirm the expected outcome. 
* If your store is eligible and the feature is turned on, you can go to **WooCommerce > Settings > Payments** and under the advanced settings, turn off WC Pay Subscriptions. That will set the option to `'0'` and the feature will be disabled. 

----
 
**Note:** because we load subscriptions functionality on the WC Payments main plugin file load, when we do that WooCommerce hasn't loaded yet and so we can always check the base store's location on every `is_wcpay_subscriptions_enabled()` call. We need to wait for the `wc_get_base_location()` function to be available. 

**What does this mean?** 
 
The feature will be switched on by default for eligible stores on the first load after installing or upgrading to WC Payments 3.2. However, the WooCommerce > Subscriptions menu item won't appear until the next page load since it couldn't be switched on early enough.

We also cannot delay when WC Pay initialises Subscriptions functionality because waiting until WC has loaded, is too late.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
