### PR TITLE
Support plurals in renewal attempted failed string

### DIFF
--- a/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
@@ -161,7 +161,7 @@ class WC_Payments_Subscriptions_Event_Handler {
 		}
 
 		// Translators: %d Number of failed renewal attempts.
-		$subscription->add_order_note( sprintf( __( 'WCPay subscription renewal attempt %d failed.', 'woocommerce-payments' ), $attempts ) );
+		$subscription->add_order_note( sprintf( _n( 'WCPay subscription renewal attempt %d failed.', 'WCPay subscription renewal attempt %d failed.', $attempts, 'woocommerce-payments' ), $attempts ) );
 
 		if ( self::MAX_RETRIES > $attempts ) {
 			remove_action( 'woocommerce_subscription_status_on-hold', [ $this->subscription_service, 'suspend_subscription' ] );


### PR DESCRIPTION
Fixes #3152

#### Changes proposed in this Pull Request

We add the order note `WCPay subscription renewal attempt %d failed.` when the `invoice.payment_failed` webhook is received. To improve translation quality, this PR allows the message to be translated conditionally on whether the attempt number is singular or plural.

#### Testing instructions

* Enable Billing Clocks for testing purposes.
* With WCPay Subscriptions enabled and WooCommerce Subscriptions disabled, make a new subscription purchase as a customer.
* As an admin, go to **WooCommerce > Subscriptions** and click on the subscription ID. Under "Schedule", enable "Dev Testing Mode" and trigger the upcoming invoice webhook. Then trigger the payment failed webhook.
* Refresh the page and verify that you still see the correct order note, e.g. "WCPay subscription renewal attempt 1 failed."

<img width="298" alt="Screen Shot 2021-10-19 at 5 19 04 PM" src="https://user-images.githubusercontent.com/16066224/137993173-1525bad5-146a-4952-8d27-771440a4f847.png">

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
