### PR TITLE
Fixed problem that would not allow to resume paused subscription

### DIFF
--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -482,7 +482,10 @@ class WC_Payments_Subscription_Service {
 			$subscription,
 			[
 				'cancel_at_period_end' => 'false',
-				'pause_collection'     => '',
+				'pause_collection'     => [
+					'behavior'   => 'void',
+					'resumes_at' => time(),
+				],
 			]
 		);
 	}


### PR DESCRIPTION
Fixes #3169

#### Changes proposed in this Pull Request
When resuming a paused subscription sending empty values to pause_collection does not work. Now we send a resume_at timestamp to start charging again

#### Testing instructions

- As a shopper buy any subscriptions product
- As a merchant Go to WooCommerce > Subscriptions
- Suspend the subscription
- Resume the subscription
- Copy you account id from Dev Tools
- Go to Stripe dashboard
- Search for your account
- Click on subscriptions
- Subscription should not be marked as paused
- Suspend the subscription again on wp-admin
- Check on stripe if the subscription is suspended