### PR TITLE
Use price_data exclusively when creating WCPay subscriptions

### DIFF
--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -105,7 +105,7 @@ class WC_Payments_Product_Service {
 	 *
 	 * @return string             The WC Pay product ID or an empty string.
 	 */
-	public static function get_wcpay_product_id( WC_Product $product, $test_mode = null ) : string {
+	public function get_wcpay_product_id( WC_Product $product, $test_mode = null ) : string {
 		// If the subscription product doesn't have a WC Pay product ID, create one.
 		if ( ! self::has_wcpay_product_id( $product, $test_mode ) && WC_Subscriptions_Product::is_subscription( $product ) ) {
 			$is_current_environment = null === $test_mode || WC_Payments::get_gateway()->is_in_test_mode() === $test_mode;

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -716,38 +716,21 @@ class WC_Payments_Subscription_Service {
 
 			$item_data = [
 				'metadata'  => [ 'wc_item_id' => $item->get_id() ],
-				'price'     => $this->product_service->get_wcpay_price_id( $product ),
 				'quantity'  => $item->get_quantity(),
 				'tax_rates' => $this->get_tax_rates_for_item( $item, $subscription ),
 			];
 
-			$product_price         = (float) $product->get_price();
-			$product_interval      = (int) WC_Subscriptions_Product::get_interval( $product );
-			$product_period        = WC_Subscriptions_Product::get_period( $product );
-			$inclusive_taxes       = $subscription->get_prices_include_tax() ? array_sum( $item->get_taxes()['total'] ) : 0;
-			$item_total            = floatval( $item->get_total() + $inclusive_taxes ) / $item->get_quantity();
-			$subscription_interval = (int) $subscription->get_billing_interval();
-			$subscription_period   = $subscription->get_billing_period();
-
-			if (
-				$product_price !== $item_total ||
-				$product_interval !== $subscription_interval ||
-				$product_period !== $subscription_period
-			) {
-				unset( $item_data['price'] );
-
-				$item_data['price_data'] = $this->format_item_price_data(
-					$subscription->get_currency(),
-					$this->product_service->get_wcpay_product_id( $product ),
-					$item->get_total() / $item->get_quantity(),
-					$subscription_period,
-					$subscription_interval
-				);
-
-				foreach ( $item_data['tax_rates'] as $index => $tax_data ) {
-					$item_data['tax_rates'][ $index ]['inclusive'] = false;
-				}
+			foreach ( $item_data['tax_rates'] as $index => $tax_data ) {
+				$item_data['tax_rates'][ $index ]['inclusive'] = false;
 			}
+
+			$item_data['price_data'] = $this->format_item_price_data(
+				$subscription->get_currency(),
+				$this->product_service->get_wcpay_product_id( $product ),
+				$item->get_total() / $item->get_quantity(),
+				$subscription->get_billing_period(),
+				$subscription->get_billing_interval()
+			);
 
 			$data[] = $item_data;
 		}

--- a/tests/unit/subscriptions/test-class-wc-payments-product-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-product-service.php
@@ -290,7 +290,7 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 		$mock_product_id = 'prod_123_wcpay_test_product_id';
 		$this->mock_product->update_meta_data( WC_Payments_Product_Service::LIVE_PRODUCT_ID_KEY, $mock_product_id );
 
-		$this->assertSame( $mock_product_id, WC_Payments_Product_Service::get_wcpay_product_id( $this->mock_product ) );
+		$this->assertSame( $mock_product_id, $this->product_service->get_wcpay_product_id( $this->mock_product ) );
 
 		// Test that deleting the price will cause the product to be created.
 		$this->mock_product->delete_meta_data( WC_Payments_Product_Service::LIVE_PRODUCT_ID_KEY );
@@ -307,7 +307,7 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 		$this->mock_get_period( 'month' );
 		$this->mock_get_interval( 3 );
 
-		$this->assertSame( $mock_product_id, WC_Payments_Product_Service::get_wcpay_product_id( $this->mock_product ) );
+		$this->assertSame( $mock_product_id, $this->product_service->get_wcpay_product_id( $this->mock_product ) );
 	}
 
 	/**

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-service.php
@@ -117,11 +117,15 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 	 * Test WC_Payments_Subscription_Service->create_subscription()
 	 */
 	public function test_create_subscription() {
-		$mock_subscription            = new WC_Subscription();
-		$mock_subscription->trial_end = 0;
-		$mock_subscription_product    = new WC_Subscriptions_Product();
+		$mock_subscription_product = new WC_Subscriptions_Product();
 		$this->mock_get_period( 'month' );
 		$this->mock_get_interval( 1 );
+		$mock_subscription_product->set_props(
+			[
+				'regular_price' => 10,
+				'price'         => 10,
+			]
+		);
 		$mock_subscription_product->save();
 		$mock_order         = WC_Helper_Order::create_order( 1, 50, $mock_subscription_product );
 		$mock_line_item     = array_values( $mock_order->get_items() )[0];
@@ -129,19 +133,26 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 		$mock_subscription  = new WC_Subscription();
 		$mock_subscription->set_parent( $mock_order );
 		$mock_wcpay_product_id           = 'wcpay_prod_test123';
-		$mock_wcpay_price_id             = 'wcpay_price_test123';
 		$mock_wcpay_subscription_id      = 'wcpay_subscription_test12345';
 		$mock_wcpay_subscription_item_id = 'wcpay_subscription_item_test12345';
 		$mock_subscription_data          = [
 			'customer' => '1',
 			'items'    => [
 				[
-					'price'     => $mock_wcpay_price_id,
-					'quantity'  => 4,
-					'metadata'  => [
+					'quantity'   => 4,
+					'metadata'   => [
 						'wc_item_id' => $mock_line_item->get_id(),
 					],
-					'tax_rates' => [],
+					'tax_rates'  => [],
+					'price_data' => [
+						'currency'            => 'USD',
+						'product'             => '',
+						'unit_amount_decimal' => 1000.0,
+						'recurring'           => [
+							'interval'       => 'month',
+							'interval_count' => 1,
+						],
+					],
 				],
 				[
 					'price_data' => [
@@ -167,10 +178,6 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 			->method( 'get_customer_id_for_order' )
 			->with( $mock_subscription )
 			->willReturn( $mock_subscription_data['customer'] );
-
-		$this->mock_product_service->expects( $this->once() )
-			->method( 'get_wcpay_price_id' )
-			->willReturn( $mock_wcpay_price_id );
 
 		$this->mock_product_service->expects( $this->once() )
 			->method( 'get_wcpay_product_id_for_item' )
@@ -234,10 +241,6 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 			->method( 'get_customer_id_for_order' )
 			->with( $mock_subscription )
 			->willReturn( 'wcpay_cus_test123' );
-
-		$this->mock_product_service->expects( $this->once() )
-			->method( 'get_wcpay_price_id' )
-			->willReturn( 'wcpay_price_test123' );
 
 		$this->mock_product_service->expects( $this->once() )
 			->method( 'get_wcpay_product_id_for_item' )
@@ -429,6 +432,12 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 		$mock_subscription_product    = new WC_Subscriptions_Product();
 		$this->mock_get_period( 'month' );
 		$this->mock_get_interval( 1 );
+		$mock_subscription_product->set_props(
+			[
+				'regular_price' => 10,
+				'price'         => 10,
+			]
+		);
 		$mock_subscription_product->save();
 		$mock_order         = WC_Helper_Order::create_order( 1, 50, $mock_subscription_product );
 		$mock_line_item     = array_values( $mock_order->get_items() )[0];
@@ -449,10 +458,6 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 		update_user_option( 1, WC_Payments_Customer_Service::WCPAY_LIVE_CUSTOMER_ID_OPTION, $mock_wcpay_customer_id );
 
 		$this->mock_product_service->expects( $this->once() )
-			->method( 'get_wcpay_price_id' )
-			->willReturn( 'wcpay_price_test123' );
-
-		$this->mock_product_service->expects( $this->once() )
 			->method( 'get_wcpay_product_id_for_item' )
 			->willReturn( 'wcpay_prod_test123' );
 
@@ -468,12 +473,20 @@ class WC_Payments_Subscription_Service_Test extends WP_UnitTestCase {
 			],
 			'items'     => [
 				[
-					'metadata'  => [
+					'metadata'   => [
 						'wc_item_id' => $mock_line_item->get_id(),
 					],
-					'price'     => 'wcpay_price_test123',
-					'quantity'  => 4,
-					'tax_rates' => [],
+					'quantity'   => 4,
+					'tax_rates'  => [],
+					'price_data' => [
+						'currency'            => 'USD',
+						'product'             => '',
+						'unit_amount_decimal' => 1000.0,
+						'recurring'           => [
+							'interval'       => 'month',
+							'interval_count' => 1,
+						],
+					],
 				],
 				[
 					'price_data' => [


### PR DESCRIPTION
Fixes #3155

#### Changes proposed in this Pull Request

This PR modifies the way we attach price details to subscriptions when creating new subscriptions.

Prior to this PR, we would use both the [`price`](https://stripe.com/docs/api/subscription_items/create#create_subscription_item-price) and [`price_data` ](https://stripe.com/docs/api/subscription_items/create#create_subscription_item-price_data) parameters when creating a subscription.

This PR moves away from using `price` and instead uses `price_data` in all scenarios.

#### Testing instructions

**Prerequisites**
* Create a simple subscription product (e.g. $10 per week).

**Create a subscription from an existing manual renewal subscription**

* Create a new order from WP admin, **WooCommerce → Orders → Add order**
* The new order should have the following attributes:
	* Status: Completed
	* Customer: [Add existing customer]
	* Line items: [The subscription product you created above]
* Create a new subscription from WP admin, **WooCommerce → Subscriptions → Add Subscription**
* The new subscription should have the following attributes:
	* Customer: [The same customer you added to the order]
	* Subscription status: Active
	* Parent order: [The order you created above]
	* Line items: [The subscription product you added in the order above]
* In the "Schedule" metabox, ensure the "Payment" fields align with the subscription product schedule. i.e. if the subscription product was created with a weekly renewal schedule, then the "Payment" fields should reflect this.
* Add a "Next Payment" date sometime in the future, e.g. +1 week from the current date/time.
* As a shopper, navigate to **My account → Subscriptions**
* Observe the newly created subscription, click the "View" button.
* Navigate to the "Action" section and click the "Add payment" button.
* Enter new credit card details in the provided form and click the "Add payment method" button.
* Observe the "Payment method added." success notice.
* Navigate to the Stripe dashboard for your connected account.
* Navigate to "Subscriptions".
* Observe the newly created subscription, click it to view the subscription details.
* On this page, observe the following items:
	* The "Started" date should be today.
	* The "Next invoice" section should contain the correct price and date (i.e. as per the "Next Payment" date you added when creating the subscription in WP admin)
	* The "Payment method" should reflect the card you previously added.
	* The "Pricing" section should reflect the subscription product you added with the correct price and billing schedule.
* Click the 3 dot menu found to the right of the item inside the "Pricing" section and click "View price details".
* Observe there should be an "Archived" badge next to the price name on this page.

**Create a subscription via the checkout flow**

* Navigate to the store and locate the subscription product you created earlier.
* Add the product to your cart.
* Navigate to the checkout and complete the checkout.
* Observe you are redirected to the "Order received" page on successful checkout.
* Navigate to the Stripe dashboard for your connected account.
* Navigate to "Subscriptions".
* Observe the newly created subscription, click it to view the subscription details.
* On this page, observe the following items:
	* The "Started" date should be today.
	* The "Next invoice" section should contain the correct price and date (i.e. as per the "Next Payment" date you added when creating the subscription in WP admin)
	* The "Payment method" should reflect the card you previously added.
	* The "Pricing" section should reflect the subscription product you added with the correct price and billing schedule.
* Click the 3 dot menu found to the right of the item inside the "Pricing" section and click "View price details".
* Observe there should be an "Archived" badge next to the price name on this page.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
