### PR TITLE
Disable payment country in dev mode

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -300,7 +300,8 @@ class WC_Payments_API_Client {
 			// Only update the payment_method_types if we have a reference to the payment type the customer selected.
 			$request['payment_method_types'] = [ $selected_upe_payment_type ];
 		}
-		if ( $payment_country ) {
+		if ( $payment_country && ! WC_Payments::get_gateway()->is_in_dev_mode() ) {
+			// Do not update on dev mode, Stripe tests cards don't return the appropriate country.
 			$request['payment_country'] = $payment_country;
 		}
 		if ( $customer_id ) {


### PR DESCRIPTION
Fixes #3160

#### Changes proposed in this Pull Request

Stripe test cards don't return the appropriate country, to prevent any falsy issue we should disable it on dev mode. I don't like to use different implementations for dev and production. But I think in this case makes sense, being this solution temporary and due to the Stripe test cards behaviour.

#### Testing instructions

- With a store in $US.
- Make a purchase using a new card `4242 4242 4242 4242` (which return GB as country).
- Confirm that the applied fees are correct, they should match the transaction details.

#### Screenshots (After / Before)
<img width="639" alt="Screenshot 2021-10-21 at 10 47 36" src="https://user-images.githubusercontent.com/7670276/138244388-ed55fec3-5485-404b-8f63-cd50b4f2cbbb.png">

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**
- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
