### PR TITLE
Fix discounts by sending the product line item subtotal (post discount amount)

### DIFF
--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -740,7 +740,7 @@ class WC_Payments_Subscription_Service {
 				'price_data' => $this->format_item_price_data(
 					$subscription->get_currency(),
 					$this->product_service->get_wcpay_product_id( $product ),
-					$item->get_total() / $item->get_quantity(),
+					$item->get_subtotal() / $item->get_quantity(),
 					$subscription->get_billing_period(),
 					$subscription->get_billing_interval()
 				),


### PR DESCRIPTION
Fixes #3180

#### Changes proposed in this Pull Request

When sending price data to create the WCPay Subscription we were previously sending the line item's total, however, that was causing issues with coupons because the line item's subtotal includes the post discount amount, given we're sending discount data, we need to send the pre-discounted amount (obtainable by `get_subtotal()`).

<img width="418.5" alt="Screen Shot 2021-10-21 at 8 25 16 pm" src="https://user-images.githubusercontent.com/8490476/138259878-8ad1ea36-0eb1-4077-b1ca-dd4a4603dccb.png">


#### Set up

* Disable taxes as they will be borked until #3177 is merged.
* Create a recurring x% coupon. https://d.pr/i/qCo6EF
* Create a flat $x recurring coupon. https://d.pr/i/AARCo3 

#### Testing instructions

1. Place a subscription product in the cart.
2. Add one or both of the two coupons to the cart.
3. Purchase the subscription with WCPay. 
4. Compare the WC and WCPay subscription totals. 
     - On `develop` the totals will be incorrect. (WC total - $91.40, Stripe total - $81.80) 
     - On this branch, the totals will be right 

<img width="543.5" alt="Screen Shot 2021-10-21 at 8 16 00 pm" src="https://user-images.githubusercontent.com/8490476/138260781-1aa58a3b-0281-49ce-974d-243de783ac77.png">

<img width="712" alt="Screen Shot 2021-10-21 at 8 14 51 pm" src="https://user-images.githubusercontent.com/8490476/138260745-d2ab1120-47f1-48a0-94f7-0c4d6fadc038.png">


^^ on `develop`


<img width="1435" alt=" " src="https://user-images.githubusercontent.com/8490476/138262266-ccb97d51-4667-41a5-b8a0-557b571613f7.png">

^^ on this branch.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
