### PR TITLE
Always get the discounts from the subscription, not the parent order

### DIFF
--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -329,25 +329,27 @@ class WC_Payments_Subscription_Service {
 	 * Prepares discount data used to create a WCPay subscription.
 	 *
 	 * @param WC_Subscription $subscription The WC subscription used to create the subscription on server.
-	 * @param bool            $parent       Whether to get data from subscription parent.
 	 *
 	 * @return array WCPay discount item data.
 	 */
-	public static function get_discount_item_data_for_subscription( WC_Subscription $subscription, bool $parent = false ) : array {
-		$data  = [];
-		$items = $parent ? $subscription->get_parent()->get_items( 'coupon' ) : $subscription->get_items( 'coupon' );
+	public static function get_discount_item_data_for_subscription( WC_Subscription $subscription ) : array {
+		$data = [];
 
-		foreach ( $items as $item ) {
+		foreach ( $subscription->get_items( 'coupon' ) as $item ) {
 			$code     = $item->get_code();
 			$coupon   = new WC_Coupon( $code );
 			$duration = in_array( $coupon->get_discount_type(), [ 'recurring_fee', 'recurring_percent' ], true ) ? 'forever' : 'once';
-			$data[]   = [
-				'amount_off' => $item->get_discount() * 100,
-				'currency'   => $subscription->get_currency(),
-				'duration'   => $duration,
-				// Translators: %s Coupon code.
-				'name'       => sprintf( __( 'Coupon - %s', 'woocommerce-payments' ), $code ),
-			];
+			$discount = $item->get_discount();
+
+			if ( $discount ) {
+				$data[] = [
+					'amount_off' => $discount * 100,
+					'currency'   => $subscription->get_currency(),
+					'duration'   => $duration,
+					// Translators: %s Coupon code.
+					'name'       => sprintf( __( 'Coupon - %s', 'woocommerce-payments' ), $code ),
+				];
+			}
 		}
 
 		return $data;
@@ -671,7 +673,7 @@ class WC_Payments_Subscription_Service {
 	private function prepare_wcpay_subscription_data( string $wcpay_customer_id, WC_Subscription $subscription ) {
 		$recurring_items = $this->get_recurring_item_data_for_subscription( $subscription );
 		$one_time_items  = $this->get_one_time_item_data_for_subscription( $subscription );
-		$discount_items  = self::get_discount_item_data_for_subscription( $subscription, (bool) $subscription->get_parent_id() );
+		$discount_items  = self::get_discount_item_data_for_subscription( $subscription );
 		$data            = [
 			'customer' => $wcpay_customer_id,
 			'items'    => $recurring_items,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Prior to this PR, when generating the discount items that get sent to create the WCPay subscription, we would get the coupons from the parent order. This leads to issues however when you have a mixed checkout (weekly and monthly products), where a coupon only applies to one of those products.

This PR fixes those scenarios by always getting the coupons from the subscription itself, rather than the parent order that may have coupons which apply to different subscriptions. This PR also fixes a issue if you have a coupon line item that has no discount. Previously that would lead to this error:

```
...
  'discounts' => 
  array (
    0 => 
    array (
      'amount_off' => 0,
      'currency' => 'USD',
      'duration' => 'forever',
      'name' => '(redacted)',
    ),
  ),
)
ERROR This value must be greater than or equal to 1. (parameter_invalid_integer)
INFO There was a problem creating the WCPay subscription Error: This value must be greater than or equal to 1.
```


#### Set up

- Disable taxes as they will be borked until #3177 is merged.
- Create a $x / week and a $y / month product. 
- Create a recurring coupon that applies to a specific product (in my case the weekly product). https://d.pr/i/y12IiS, https://d.pr/i/OVICDL

#### Testing Instructions

**Note!** the totals will be incorrect when viewing the subscription in Stripe. It's because of the issue being fixed in #3184.

1. Place the weekly and monthly product in the cart.
2. Place the add your weekly only coupon. 
   - **Note:** the weekly coupon discounts the initial payment but only the weekly subscription (https://d.pr/i/GWZmGT)
4. Place the order using WCPay
5. Check the subscription in Stripe.
   - On `develop` both the subscriptions (weekly and monthly) will contain the coupon 
   - On this branch on the weekly subscription has the coupon. 
   
---

The previous approach of using the parent order could lead to pretty dramatic issues too. Imagine you have a $100 yearly product and a $10 weekly one. A 20% coupon gets applied and reduces the initial payment by $22. The monthly WCPay subscription gets created and the coupons get copied from the parent order. The monthly subscription would be free ($10 - $22) and the yearly subscription would be $78 ($100-$22). This PR also fixes that issue that too.

![image](https://user-images.githubusercontent.com/8490476/138268566-83f29eb1-1cfd-469a-827a-454f2ed98082.png)

<img width="360" alt="Screen Shot 2021-10-21 at 9 32 10 pm" src="https://user-images.githubusercontent.com/8490476/138268775-55dd363a-41b6-431b-8340-1ab1e38460d5.png">

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
