### PR TITLE
Only rebase Renovate PRs when they become conflicted

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "pin": {
     "automerge": true
   },
+  "rebaseWhen": "conflicted",
   "schedule": [
     "before 3am on Sunday"
   ]


### PR DESCRIPTION
The default behaviour is "auto" which, due to our GitHub config, will rebase Renovate PRs after every new commit to the develop branch. Docs: https://docs.renovatebot.com/configuration-options/#rebasewhen

According to these the scheduling [docs](https://docs.renovatebot.com/noise-reduction/):

> Any of the above reasons can lead to a Renovate branch being considered "stale" and then Renovate needs to rebase it off the base branch before you can test and merge again, and Renovate won't do this until it's back in schedule.

Which suggests to me that https://github.com/Automattic/woocommerce-payments/pull/3120 should have stopped Renovate from rebasing PRs everytime we have a new commit on develop. Perhaps it'll only apply it to PRs created after our scheduling change?

Anyway, for now we can try this change to the `rebaseWhen` option.