### PR TITLE
Add in person text for US based stores

### DIFF
--- a/client/connect-account-page/index.js
+++ b/client/connect-account-page/index.js
@@ -149,7 +149,9 @@ const ConnectPageOnboarding = () => {
 		<>
 			<h2>{ strings.onboarding.heading }</h2>
 			<p>
-				{ strings.onboarding.description }
+				{ 'US' === country
+					? strings.onboarding.descriptionUS
+					: strings.onboarding.description }
 				<br />
 				<LearnMore />
 			</p>

--- a/client/connect-account-page/strings.js
+++ b/client/connect-account-page/strings.js
@@ -21,6 +21,10 @@ export default {
 			'With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store’s dashboard - with no setup costs or monthly fees.',
 			'woocommerce-payments'
 		),
+		descriptionUS: __(
+			'With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies – with no setup costs or monthly fees – and you can now accept in-person payments with the Woo mobile app.',
+			'woocommerce-payments'
+		),
 	},
 
 	paymentMethodsHeading: __(

--- a/client/connect-account-page/test/__snapshots__/index.js.snap
+++ b/client/connect-account-page/test/__snapshots__/index.js.snap
@@ -107,7 +107,7 @@ exports[`ConnectAccountPage should render correctly 1`] = `
               Finish setup to enable credit card payments
             </h2>
             <p>
-              With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store’s dashboard - with no setup costs or monthly fees.
+              With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies – with no setup costs or monthly fees – and you can now accept in-person payments with the Woo mobile app.
               <br />
               <a
                 href="https://woocommerce.com/payments/"


### PR DESCRIPTION
Related - https://github.com/woocommerce/woocommerce-admin/pull/7830

#### Changes proposed in this Pull Request

Adds "in-person" text to the setup card for stores based in the US.

##### Non-US
<img width="763" alt="Screen Shot 2021-10-21 at 4 22 00 PM" src="https://user-images.githubusercontent.com/10561050/138352238-9b39330f-60e2-43ac-b731-1bbef7ce98d6.png">

##### US

<img width="763" alt="Screen Shot 2021-10-21 at 4 20 48 PM" src="https://user-images.githubusercontent.com/10561050/138352257-b696356c-6696-4c9b-a7b7-e5e1b50b1b36.png">


#### Testing instructions

1. Don't set up WC Pay
2. Set your store to a US based location
3. Visit `wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect`
4. Make sure the "in-person" text is in the description
5. Change the store to a non-US supported country
6. Check that the "in-person" description is not used