### PR TITLE
Enable automatic refunds for WCPay Subscriptions renewals

### DIFF
--- a/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-event-handler.php
@@ -114,9 +114,8 @@ class WC_Payments_Subscriptions_Event_Handler {
 			if ( is_wp_error( $order ) ) {
 				throw new Rest_Request_Exception( __( 'Unable to generate renewal order for subscription on the "invoice.paid" event.', 'woocommerce-payments' ) );
 			} else {
-				$this->invoice_service->set_order_invoice_id( $order, $wcpay_invoice_id );
 				$order->set_payment_method( WC_Payment_Gateway_WCPay::GATEWAY_ID );
-				$order->save();
+				$this->invoice_service->set_order_invoice_id( $order, $wcpay_invoice_id );
 			}
 		}
 
@@ -158,6 +157,7 @@ class WC_Payments_Subscriptions_Event_Handler {
 			if ( is_wp_error( $order ) ) {
 				throw new Rest_Request_Exception( __( 'Unable to generate renewal order for subscription to record the incoming "invoice.payment_failed" event.', 'woocommerce-payments' ) );
 			} else {
+				$order->set_payment_method( WC_Payment_Gateway_WCPay::GATEWAY_ID );
 				$this->invoice_service->set_order_invoice_id( $order, $wcpay_invoice_id );
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
- Allow processing automatic refunds on WCPay Subscription renewal orders

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

After processing a WCPay Subscription renewal order, I noticed I could only process a manual refund for this order:

![image](https://user-images.githubusercontent.com/2275145/138636244-f0fa0c6e-7f91-4d6b-bddb-6260d55435d1.png)

After doing some digging, I found out this is caused by our renewal orders having no `_payment_method` metadata set on them (this meta isn't copied from the subscription when we call `wcs_create_renewal_order( $subscription )`

This PR enables automatic renewal orders by updating our `handle_invoice_paid()` webhook handler to also attach the payment method on the order after creating it.

After making these changes I have tested partial and full refunds of WCPay Subscription renewal errors and it's all working as expected.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before testing this PR, you'll need:
 - Billing Clocks set up
 - WooCommerce Subscriptions extension deactivated
 - WooCommerce Payments gateway enabled

To test these changes:

1. Purchase a Subscription product with WC Payments
2. Visit the Edit Subscription page and advance the billing clock until you've processed the first renewal order
3. Visit the Edit Order page for the new renewal and click on the refund button
4. On `develop` you'll see "Refund x manually"
5. Checkout this branch
6. Go back to the subscription and process another renewal order
7. Visit  the Edit Order page for this renewal and click on the refund button
8. You should now see "Refund x via WooCommerce Payments"
9. Try process a partial or full refund
10. Check invoice/transaction in Stripe to confirm the refund was processed
