### PR TITLE
Fix checkout: Missing available payment metohds

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2438,7 +2438,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				&& $this->payment_methods[ $payment_method_id ]->is_enabled_at_checkout( $order_id )
 				&& ( is_admin() || $this->payment_methods[ $payment_method_id ]->is_currency_valid() )
 				&& isset( $active_payment_methods[ $payment_method_capability_key ] )
-				&& 'active' === $active_payment_methods[ $payment_method_capability_key ] ) {
+				&& 'active' === $active_payment_methods[ $payment_method_capability_key ]['status']
+			) {
 				$enabled_payment_methods[] = $payment_method_id;
 			}
 		}

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -233,7 +233,13 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->expects( $this->any() )
 			->method( 'get_upe_enabled_payment_method_statuses' )
 			->will(
-				$this->returnValue( [ 'card_payments' => 'active' ] )
+				$this->returnValue(
+					[
+						'card_payments' => [
+							'status' => 'active',
+						],
+					]
+				)
 			);
 
 		// Arrange: Define a $_POST array which includes the payment method,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a bug, introduced in https://github.com/Automattic/woocommerce-payments/pull/3157 where the returned value of `get_upe_enabled_payment_method_statuses` got changed into a two-dimensional array from a single-dimensional one.

`get_upe_enabled_at_checkout_payment_method_ids` performed this check:

```
'active' === $active_payment_methods[ $payment_method_capability_key ]
```

but `$active_payment_methods[ $payment_method_capability_key ]` is now an array, which contains a `status` property.

This caused `wcpay_config.paymentMethodsConfig` during checkout to be an empty array, which broke the checkout payment section.

The content of this PR simply adds `['status']` to the end of that line.

#### Testing instructions

Apply this fix, and make sure that fields are rendered on the checkout page.

-------------------

- [x] Covered with tests (fixed the existing tests, the original PR broke them)