### PR TITLE
Use order abstract object instead of order object

### DIFF
--- a/includes/class-wc-payments-explicit-price-formatter.php
+++ b/includes/class-wc-payments-explicit-price-formatter.php
@@ -118,8 +118,8 @@ class WC_Payments_Explicit_Price_Formatter {
 	/**
 	 * Returns the price suffixed with the appropriate currency code, if not already.
 	 *
-	 * @param string        $price The price.
-	 * @param WC_Order|null $order The order.
+	 * @param string                 $price The price.
+	 * @param WC_Abstract_Order|null $order The order.
 	 *
 	 * @return string
 	 */


### PR DESCRIPTION
#### Changes proposed in this Pull Request
- In the `get_explicit_price` function,  change the 2nd parameter from `WC_Order` to `WC_Abstract_Order` so that WooCommerce Payments does not crash when retrieving order totals for **other order types** such as **Refund Orders**.

https://github.com/Automattic/woocommerce-payments/blob/5db15876a393b339b8b0f7f0e65f6ea99d4f4bbd/includes/class-wc-payments-explicit-price-formatter.php#L126

This is the error from our customers using our PDF Invoices plugin to generate a **Credit Note** (basically the Invoice for Refund Orders):

`Fatal error: Argument 2 passed to WC_Payments_Explicit_Price_Formatter::get_explicit_price() must be an instance of WC_Order or null, instance of Automattic\WooCommerce\Admin\Overrides\OrderRefund given, called in /var/www/vhosts/container-selisch.de/httpdocs/wp-includes/class-wp-hook.php on line 303`

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

Using an order refund

```php
$refund->get_order_item_totals()
```