### PR TITLE
Changelog entries for 3.3.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,6 @@
 *** WooCommerce Payments Changelog ***
 
 = 3.3.0 - 2021-xx-xx =
-
 * Update - Updated @woocommerce/components to remove ' from negative numbers on csv files
 
 = 3.2.0 - 2021-xx-xx =

--- a/readme.txt
+++ b/readme.txt
@@ -99,7 +99,6 @@ Please note that our support for the checkout block is still experimental and th
 == Changelog ==
 
 = 3.3.0 - 2021-xx-xx =
-
 * Update - Updated @woocommerce/components to remove ' from negative numbers on csv files
 
 = 3.2.0 - 2021-xx-xx =


### PR DESCRIPTION
Created changelog entry for 3.3.0, since 3.2.0 is now frozen.

changes

- Created changelog headers for 3.3.0
- Move the changelog from https://github.com/Automattic/woocommerce-payments/pull/2940 to 3.3.0, as it will not be included in 3.2.0