### PR TITLE
Check for EUR currency code before adding SEPA payment method type

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -205,8 +205,9 @@ class WC_Payments_API_Client {
 
 		$available_payment_methods = WC_Payments::get_gateway()->get_upe_available_payment_methods();
 		if (
-			WC_Payments_Features::is_sepa_enabled()
-			|| in_array( Payment_Method::SEPA, $available_payment_methods, true )
+			'eur' === $currency_code &&
+			( WC_Payments_Features::is_sepa_enabled()
+			|| in_array( Payment_Method::SEPA, $available_payment_methods, true ) )
 		) {
 			$request['payment_method_types'] = [ Payment_Method::CARD, Payment_Method::SEPA ];
 			$request['mandate_data']         = [


### PR DESCRIPTION
Fixes #3232

#### Changes proposed in this Pull Request

Fixes a bug whereby using a saved card with UPE checkout results in a "We're not able to process this request" error.

The reason this bug happens is because as of #3164, we now add `sepa_debit` to the available UPE payment methods. This [gets added to `payment_method_types` in the request](https://github.com/Automattic/woocommerce-payments/blob/203e7c04b8a52d2456e0dc72b7e3ccd098c8bd77/includes/wc-payment-api/class-wc-payments-api-client.php#L211) to create and confirm a payment intention, but results in the following error from Stripe for any non-Euro payment:

> The currency provided (usd) is invalid for one or more payment method types on this PaymentIntent. The payment method type sepa_debit only supports the following currencies: eur. Either correct the provided currency, or use a different PaymentIntent to accept this payment method type. (invalid_request_error)

This PR checks that the `currency_code` is `eur` before adding `sepa_debit` to the list of payment method types to avoid this error.

#### Testing instructions

1. Enable UPE, set store currency to USD.
2. Make a purchase using a saved card.
3. Verify that the purchase completes successfully.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
