### PR TITLE
Add note to readme about node version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ This is a feature plugin for accepting payments via a WooCommerce-branded paymen
 
 ### Install dependencies & build
 
--   `npm install`
+-   `npm install` 
 -   `composer install`
 -   `npm run build:client`, or if you're developing the client you can have it auto-update when changes are made: `npm start`
+
+If you run into errors with `npm install` it may be due to node version, try `nvm install` followed by `nvm use` then try again.
 
 When running the `composer install/update`, composer may prompt you for a GitHub OAuth token before it can fetch the `subscriptions-core` package from github.
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add note to README about `nvm`.

Mismatch of node versions can cause issues with `npm install` command. Added note to README that shows how to install another node version easily to fix this.

