### PR TITLE
Fix incorrect calculated cost of booking via Multi-Currency

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 3.3.0 - 2021-xx-xx =
 * Update - Updated @woocommerce/components to remove ' from negative numbers on csv files
+* Add - Add compatibility between Multi-Currency and WooCommerce Bookings.
 
 = 3.2.0 - 2021-10-28 =
 * Add - Add subscriptions functionality via Stripe Billing and WC Subscriptions core.

--- a/includes/multi-currency/Compatibility.php
+++ b/includes/multi-currency/Compatibility.php
@@ -56,9 +56,18 @@ class Compatibility {
 		$this->utils          = $utils;
 		$this->init_filters();
 
-		$compatibility_classes[] = new WooCommerceBookings( $multi_currency, $utils );
-		$compatibility_classes[] = new WooCommerceFedEx( $multi_currency, $utils );
-		$compatibility_classes[] = new WooCommerceUPS( $multi_currency, $utils );
+		add_action( 'init', [ $this, 'init_compatibility_classes' ], 11 );
+	}
+
+	/**
+	 * Initializes our compatibility classes.
+	 *
+	 * @return void
+	 */
+	public function init_compatibility_classes() {
+		$compatibility_classes[] = new WooCommerceBookings( $this->multi_currency, $this->utils, $this->multi_currency->get_frontend_currencies() );
+		$compatibility_classes[] = new WooCommerceFedEx( $this->multi_currency, $this->utils );
+		$compatibility_classes[] = new WooCommerceUPS( $this->multi_currency, $this->utils );
 	}
 
 	/**

--- a/includes/multi-currency/Compatibility.php
+++ b/includes/multi-currency/Compatibility.php
@@ -10,6 +10,7 @@ namespace WCPay\MultiCurrency;
 use WC_Order;
 use WC_Order_Refund;
 use WC_Product;
+use WCPay\MultiCurrency\Compatibility\WooCommerceBookings;
 use WCPay\MultiCurrency\Compatibility\WooCommerceFedEx;
 use WCPay\MultiCurrency\Compatibility\WooCommerceUPS;
 
@@ -55,6 +56,7 @@ class Compatibility {
 		$this->utils          = $utils;
 		$this->init_filters();
 
+		$compatibility_classes[] = new WooCommerceBookings( $multi_currency, $utils );
 		$compatibility_classes[] = new WooCommerceFedEx( $multi_currency, $utils );
 		$compatibility_classes[] = new WooCommerceUPS( $multi_currency, $utils );
 	}
@@ -268,7 +270,7 @@ class Compatibility {
 			return false;
 		}
 
-		return true;
+		return apply_filters( self::FILTER_PREFIX . 'should_convert_product_price', true );
 	}
 
 	/**

--- a/includes/multi-currency/Compatibility/WooCommerceBookings.php
+++ b/includes/multi-currency/Compatibility/WooCommerceBookings.php
@@ -105,6 +105,7 @@ class WooCommerceBookings {
 			return $return;
 		}
 
+		// This prevents a double conversion of the price in the cart.
 		if ( $this->utils->is_call_in_backtrace( [ 'WC_Product_Booking->get_price' ] ) ) {
 			$calls = [
 				'WC_Cart_Totals->calculate_item_totals',
@@ -114,6 +115,11 @@ class WooCommerceBookings {
 			if ( $this->utils->is_call_in_backtrace( $calls ) ) {
 				return false;
 			}
+		}
+
+		// Fixes price display on product page and in shop.
+		if ( $this->utils->is_call_in_backtrace( [ 'WC_Product_Booking->get_price_html' ] ) ) {
+			return false;
 		}
 
 		return $return;

--- a/includes/multi-currency/Compatibility/WooCommerceBookings.php
+++ b/includes/multi-currency/Compatibility/WooCommerceBookings.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Class WooCommerceBookings
+ *
+ * @package WCPay\MultiCurrency\Compatibility
+ */
+
+namespace WCPay\MultiCurrency\Compatibility;
+
+use WC_Product;
+use WCPay\MultiCurrency\MultiCurrency;
+use WCPay\MultiCurrency\Utils;
+
+/**
+ * Class that controls Multi Currency Compatibility with WooCommerce Bookings Plugin.
+ */
+class WooCommerceBookings {
+
+	const FILTER_PREFIX = 'wcpay_multi_currency_';
+
+	/**
+	 * MultiCurrency class.
+	 *
+	 * @var MultiCurrency
+	 */
+	private $multi_currency;
+
+	/**
+	 * Utils class.
+	 *
+	 * @var Utils
+	 */
+	private $utils;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param MultiCurrency $multi_currency MultiCurrency class.
+	 * @param Utils         $utils Utils class.
+	 */
+	public function __construct( MultiCurrency $multi_currency, Utils $utils ) {
+		$this->multi_currency = $multi_currency;
+		$this->utils          = $utils;
+		$this->initialize_hooks();
+	}
+
+	/**
+	 * Adds compatibility filters if the plugin exists and loaded
+	 *
+	 * @return  void
+	 */
+	protected function initialize_hooks() {
+		if ( class_exists( 'WC_Bookings' ) ) {
+			add_filter( 'woocommerce_product_get_block_cost', [ $this, 'get_price' ], 50, 1 );
+			add_filter( 'woocommerce_product_get_cost', [ $this, 'get_price' ], 50, 1 );
+			add_filter( 'woocommerce_product_get_display_cost', [ $this, 'get_price' ], 50, 1 );
+			add_filter( 'woocommerce_product_booking_person_type_get_block_cost', [ $this, 'get_price' ], 50, 1 );
+			add_filter( 'woocommerce_product_booking_person_type_get_cost', [ $this, 'get_price' ], 50, 1 );
+			add_filter( 'woocommerce_product_get_resource_base_costs', [ $this, 'get_resource_prices' ], 50, 1 );
+			add_filter( 'woocommerce_product_get_resource_block_costs', [ $this, 'get_resource_prices' ], 50, 1 );
+			add_filter( self::FILTER_PREFIX . 'should_convert_product_price', [ $this, 'should_convert_product_price' ] );
+		}
+	}
+
+	/**
+	 * Returns the price for an item.
+	 *
+	 * @param mixed $price The item's price.
+	 *
+	 * @return mixed The converted item's price.
+	 */
+	public function get_price( $price ) {
+		if ( ! $price ) {
+			return $price;
+		}
+		return $this->multi_currency->get_price( $price, 'product' );
+	}
+
+	/**
+	 * Returns the prices for a resource.
+	 *
+	 * @param mixed $prices The resource's prices in array format.
+	 *
+	 * @return mixed The converted resource's prices.
+	 */
+	public function get_resource_prices( $prices ) {
+		if ( is_array( $prices ) ) {
+			foreach ( $prices as $key => $price ) {
+				$prices[ $key ] = $this->get_price( $price );
+			}
+		}
+		return $prices;
+	}
+
+	/**
+	 * Checks to see if the product's price should be converted.
+	 *
+	 * @param bool $return Whether to convert the product's price or not. Default is true.
+	 *
+	 * @return bool True if it should be converted.
+	 */
+	public function should_convert_product_price( bool $return ): bool {
+		// If it's already false, return it.
+		if ( ! $return ) {
+			return $return;
+		}
+
+		if ( $this->utils->is_call_in_backtrace( [ 'WC_Product_Booking->get_price' ] ) ) {
+			$calls = [
+				'WC_Cart_Totals->calculate_item_totals',
+				'WC_Cart->get_product_price',
+				'WC_Cart->get_product_subtotal',
+			];
+			if ( $this->utils->is_call_in_backtrace( $calls ) ) {
+				return false;
+			}
+		}
+
+		return $return;
+	}
+}

--- a/includes/multi-currency/Compatibility/WooCommerceBookings.php
+++ b/includes/multi-currency/Compatibility/WooCommerceBookings.php
@@ -10,6 +10,7 @@ namespace WCPay\MultiCurrency\Compatibility;
 use WC_Product;
 use WCPay\MultiCurrency\MultiCurrency;
 use WCPay\MultiCurrency\Utils;
+use WCPay\MultiCurrency\FrontendCurrencies;
 
 /**
  * Class that controls Multi Currency Compatibility with WooCommerce Bookings Plugin.
@@ -42,13 +43,15 @@ class WooCommerceBookings {
 	/**
 	 * Constructor.
 	 *
-	 * @param MultiCurrency $multi_currency MultiCurrency class.
-	 * @param Utils         $utils Utils class.
+	 * @param MultiCurrency      $multi_currency MultiCurrency class.
+	 * @param Utils              $utils Utils class.
+	 * @param FrontendCurrencies $frontend_currencies FrontendCurrencies class.
 	 */
-	public function __construct( MultiCurrency $multi_currency, Utils $utils ) {
-		$this->multi_currency = $multi_currency;
-		$this->utils          = $utils;
-		add_action( 'init', [ $this, 'init' ], 11 );
+	public function __construct( MultiCurrency $multi_currency, Utils $utils, FrontendCurrencies $frontend_currencies ) {
+		$this->multi_currency      = $multi_currency;
+		$this->utils               = $utils;
+		$this->frontend_currencies = $frontend_currencies;
+		$this->initialize_hooks();
 	}
 
 	/**
@@ -56,10 +59,8 @@ class WooCommerceBookings {
 	 *
 	 * @return void
 	 */
-	public function init() {
+	public function initialize_hooks() {
 		if ( class_exists( 'WC_Bookings' ) ) {
-			$this->frontend_currencies = $this->multi_currency->get_frontend_currencies();
-
 			if ( ! is_admin() || wp_doing_ajax() ) {
 				add_filter( 'woocommerce_product_get_block_cost', [ $this, 'get_price' ], 50, 1 );
 				add_filter( 'woocommerce_product_get_cost', [ $this, 'get_price' ], 50, 1 );

--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 3.3.0 - 2021-xx-xx =
 * Update - Updated @woocommerce/components to remove ' from negative numbers on csv files
+* Add - Add compatibility between Multi-Currency and WooCommerce Bookings.
 
 = 3.2.0 - 2021-10-28 =
 * Add - Add subscriptions functionality via Stripe Billing and WC Subscriptions core.

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-bookings.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-bookings.php
@@ -6,6 +6,8 @@
  */
 
 use WCPay\MultiCurrency\Compatibility\WooCommerceBookings;
+use WCPay\MultiCurrency\Currency;
+use WCPay\MultiCurrency\FrontendCurrencies;
 use WCPay\MultiCurrency\MultiCurrency;
 use WCPay\MultiCurrency\Utils;
 
@@ -13,6 +15,13 @@ use WCPay\MultiCurrency\Utils;
  * WCPay\MultiCurrency\Compatibility\WooCommerceBookings unit tests.
  */
 class WCPay_Multi_Currency_WooCommerceBookings_Tests extends WP_UnitTestCase {
+
+	/**
+	 * Mock WCPay\MultiCurrency\FrontendCurrencies.
+	 *
+	 * @var WCPay\MultiCurrency\FrontendCurrencies|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_frontend_currencies;
 
 	/**
 	 * Mock WCPay\MultiCurrency\MultiCurrency.
@@ -124,5 +133,25 @@ class WCPay_Multi_Currency_WooCommerceBookings_Tests extends WP_UnitTestCase {
 			->withConsecutive( [ $first_calls ], [ $third_calls ] )
 			->willReturn( false, false );
 		$this->assertTrue( $this->woocommerce_bookings->should_convert_product_price( true ) );
+	}
+
+	public function test_filter_wc_price_args_returns_expected_results() {
+		$expected = [
+			'currency'           => 'CAD',
+			'decimal_separator'  => '.',
+			'thousand_separator' => ',',
+			'decimals'           => 2,
+			'price_format'       => '%1$s%2$s',
+		];
+
+		$this->mock_frontend_currencies = $this->createMock( FrontendCurrencies::class );
+
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $expected['currency'] ) );
+		$this->mock_frontend_currencies->method( 'get_price_decimal_separator' )->willReturn( $expected['decimal_separator'] );
+		$this->mock_frontend_currencies->method( 'get_price_thousand_separator' )->willReturn( $expected['thousand_separator'] );
+		$this->mock_frontend_currencies->method( 'get_price_decimals' )->willReturn( $expected['decimals'] );
+		$this->mock_frontend_currencies->method( 'get_woocommerce_price_format' )->willReturn( $expected['price_format'] );
+
+		$this->assertSame( $expected, $this->woocommerce_bookings->filter_wc_price_args( [] ) );
 	}
 }

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-bookings.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-bookings.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Class WCPay_Multi_Currency_WooCommerceBookings_Tests
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\MultiCurrency\Compatibility\WooCommerceBookings;
+use WCPay\MultiCurrency\MultiCurrency;
+use WCPay\MultiCurrency\Utils;
+
+/**
+ * WCPay\MultiCurrency\Compatibility\WooCommerceBookings unit tests.
+ */
+class WCPay_Multi_Currency_WooCommerceBookings_Tests extends WP_UnitTestCase {
+
+	/**
+	 * Mock WCPay\MultiCurrency\MultiCurrency.
+	 *
+	 * @var WCPay\MultiCurrency\MultiCurrency|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_multi_currency;
+
+	/**
+	 * Mock WCPay\MultiCurrency\Utils.
+	 *
+	 * @var WCPay\MultiCurrency\Utils|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_utils;
+
+	/**
+	 * WCPay\MultiCurrency\Compatibility\WooCommerceBookings instance.
+	 *
+	 * @var WCPay\MultiCurrency\Compatibility\WooCommerceBookings
+	 */
+	private $woocommerce_bookings;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->mock_multi_currency  = $this->createMock( MultiCurrency::class );
+		$this->mock_utils           = $this->createMock( Utils::class );
+		$this->woocommerce_bookings = new WooCommerceBookings( $this->mock_multi_currency, $this->mock_utils );
+	}
+
+	public function test_get_price_returns_empty_string() {
+		$expected = '';
+		$this->assertSame( $expected, $this->woocommerce_bookings->get_price( $expected ) );
+	}
+
+	public function test_get_price_returns_converted_price() {
+		$expected = 42.0;
+		$this->mock_multi_currency->method( 'get_price' )->willReturn( $expected );
+		$this->assertSame( $expected, $this->woocommerce_bookings->get_price( 12 ) );
+	}
+
+	public function test_get_resource_prices_returns_non_array_directly() {
+		$expected = 'Not an array.';
+		$this->assertSame( $expected, $this->woocommerce_bookings->get_resource_prices( $expected ) );
+	}
+
+	public function test_get_resource_prices_returns_converted_prices() {
+		$expected = [ 42.0, '' ];
+		$prices   = [ 12, '' ];
+		$this->mock_multi_currency
+			->expects( $this->once() )
+			->method( 'get_price' )
+			->with( 12 )
+			->willReturn( 42.0 );
+
+		$this->assertSame( $expected, $this->woocommerce_bookings->get_resource_prices( $prices ) );
+	}
+
+	// If false is passed, it should automatically return false.
+	public function test_should_convert_product_price_returns_false_if_false_passed() {
+		$this->mock_utils->expects( $this->exactly( 0 ) )->method( 'is_call_in_backtrace' );
+		$this->assertFalse( $this->woocommerce_bookings->should_convert_product_price( false ) );
+	}
+
+	// If the first two sets of calls are found, it should return false.
+	public function test_should_convert_product_price_returns_false_if_cart_calls_found() {
+		$first_calls  = [ 'WC_Product_Booking->get_price' ];
+		$second_calls = [
+			'WC_Cart_Totals->calculate_item_totals',
+			'WC_Cart->get_product_price',
+			'WC_Cart->get_product_subtotal',
+		];
+		$this->mock_utils
+			->expects( $this->exactly( 2 ) )
+			->method( 'is_call_in_backtrace' )
+			->withConsecutive( [ $first_calls ], [ $second_calls ] )
+			->willReturn( true, true );
+		$this->assertFalse( $this->woocommerce_bookings->should_convert_product_price( true ) );
+	}
+
+	// If the last set of calls are found, it should return false.
+	// This also tests to make sure if the first set of calls is found, but not the second, it continues.
+	public function test_should_convert_product_price_returns_false_if_display_calls_found() {
+		$first_calls  = [ 'WC_Product_Booking->get_price' ];
+		$second_calls = [
+			'WC_Cart_Totals->calculate_item_totals',
+			'WC_Cart->get_product_price',
+			'WC_Cart->get_product_subtotal',
+		];
+		$third_calls  = [ 'WC_Product_Booking->get_price_html' ];
+		$this->mock_utils
+			->expects( $this->exactly( 3 ) )
+			->method( 'is_call_in_backtrace' )
+			->withConsecutive( [ $first_calls ], [ $second_calls ], [ $third_calls ] )
+			->willReturn( true, false, true );
+		$this->assertFalse( $this->woocommerce_bookings->should_convert_product_price( true ) );
+	}
+
+	// If no calls are found, it should return true.
+	public function test_should_convert_product_price_returns_true_if_no_calls_found() {
+		$first_calls = [ 'WC_Product_Booking->get_price' ];
+		$third_calls = [ 'WC_Product_Booking->get_price_html' ];
+		$this->mock_utils
+			->expects( $this->exactly( 2 ) )
+			->method( 'is_call_in_backtrace' )
+			->withConsecutive( [ $first_calls ], [ $third_calls ] )
+			->willReturn( false, false );
+		$this->assertTrue( $this->woocommerce_bookings->should_convert_product_price( true ) );
+	}
+}

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-bookings.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-bookings.php
@@ -17,13 +17,6 @@ use WCPay\MultiCurrency\Utils;
 class WCPay_Multi_Currency_WooCommerceBookings_Tests extends WP_UnitTestCase {
 
 	/**
-	 * Mock WCPay\MultiCurrency\FrontendCurrencies.
-	 *
-	 * @var WCPay\MultiCurrency\FrontendCurrencies|PHPUnit_Framework_MockObject_MockObject
-	 */
-	private $mock_frontend_currencies;
-
-	/**
 	 * Mock WCPay\MultiCurrency\MultiCurrency.
 	 *
 	 * @var WCPay\MultiCurrency\MultiCurrency|PHPUnit_Framework_MockObject_MockObject
@@ -38,6 +31,13 @@ class WCPay_Multi_Currency_WooCommerceBookings_Tests extends WP_UnitTestCase {
 	private $mock_utils;
 
 	/**
+	 * Mock WCPay\MultiCurrency\FrontendCurrencies.
+	 *
+	 * @var WCPay\MultiCurrency\FrontendCurrencies|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_frontend_currencies;
+
+	/**
 	 * WCPay\MultiCurrency\Compatibility\WooCommerceBookings instance.
 	 *
 	 * @var WCPay\MultiCurrency\Compatibility\WooCommerceBookings
@@ -50,9 +50,10 @@ class WCPay_Multi_Currency_WooCommerceBookings_Tests extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->mock_multi_currency  = $this->createMock( MultiCurrency::class );
-		$this->mock_utils           = $this->createMock( Utils::class );
-		$this->woocommerce_bookings = new WooCommerceBookings( $this->mock_multi_currency, $this->mock_utils );
+		$this->mock_multi_currency      = $this->createMock( MultiCurrency::class );
+		$this->mock_utils               = $this->createMock( Utils::class );
+		$this->mock_frontend_currencies = $this->createMock( FrontendCurrencies::class );
+		$this->woocommerce_bookings     = new WooCommerceBookings( $this->mock_multi_currency, $this->mock_utils, $this->mock_frontend_currencies );
 	}
 
 	public function test_get_price_returns_empty_string() {
@@ -136,6 +137,13 @@ class WCPay_Multi_Currency_WooCommerceBookings_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_filter_wc_price_args_returns_expected_results() {
+		$defaults = [
+			'currency'           => '',
+			'decimal_separator'  => '',
+			'thousand_separator' => '',
+			'decimals'           => 0,
+			'price_format'       => '',
+		];
 		$expected = [
 			'currency'           => 'CAD',
 			'decimal_separator'  => '.',
@@ -144,14 +152,12 @@ class WCPay_Multi_Currency_WooCommerceBookings_Tests extends WP_UnitTestCase {
 			'price_format'       => '%1$s%2$s',
 		];
 
-		$this->mock_frontend_currencies = $this->createMock( FrontendCurrencies::class );
-
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $expected['currency'] ) );
 		$this->mock_frontend_currencies->method( 'get_price_decimal_separator' )->willReturn( $expected['decimal_separator'] );
 		$this->mock_frontend_currencies->method( 'get_price_thousand_separator' )->willReturn( $expected['thousand_separator'] );
 		$this->mock_frontend_currencies->method( 'get_price_decimals' )->willReturn( $expected['decimals'] );
 		$this->mock_frontend_currencies->method( 'get_woocommerce_price_format' )->willReturn( $expected['price_format'] );
 
-		$this->assertSame( $expected, $this->woocommerce_bookings->filter_wc_price_args( [] ) );
+		$this->assertSame( $expected, $this->woocommerce_bookings->filter_wc_price_args( $defaults ) );
 	}
 }


### PR DESCRIPTION
Fixes #3226

#### Changes proposed in this Pull Request

* Refactor how `$compatibility_classes` are initialized in `Compatibility`. They are  now hooked into `init` with a priority of 11 to allow `init` in `MultiCurrency` to complete. This allows us to call `get_frontend_currencies()` to pass `FrontendCurrencies` to `WooCommerceBookings`.
* Update `should_convert_product_price` in `Compatibility` to have its return value filtered via `wcpay_multi_currency_should_convert_product_price`. This allows other plugins and/or compatibility code to modify the value.
* Added `WooCommerceBookings` class to hold methods for Bookings compatibility.
  * `get_price` method is used to convert bookable product's block cost, base cost, display cost, person block cost, person base cost.
  * `get_resource_prices` filters resource's prices. Each element in the array is a cost, and each is passed through `get_price` to get converted.
  * `should_convert_product_price` is a filter and will return `false` to prevent double conversion in the cart and also on the product display price.
  * `add_wc_price_args_filter_for_ajax` adds a filter based on a Bookings ajax call, the filter is only needed for that specific call.
  * `filter_wc_price_args` filters the `wc_price_args` during the ajax call when the booking cost is being calculated after the customer has selected their date/time, persons, resources, etc.

#### Testing instructions

1. Install WooCommerce Bookings, available in the all-plugins repo.
2. Install Bookings Helper: https://github.com/woocommerce/bookings-helper
3. Import products: [booking-product-926-2021-10-28.zip](https://github.com/Automattic/woocommerce-payments/files/7435896/booking-product-926-2021-10-28.zip) [booking-product-964-2021-10-28.zip](https://github.com/Automattic/woocommerce-payments/files/7435898/booking-product-964-2021-10-28.zip)
4. Navigate to your shop on the front end.
5. Select a currency other than your default currency.
6. Confirm the product costs have been converted correctly.
7. Enter each product making date selections, increasing persons, etc, and confirm the cost is calculated correctly.
8. Add to cart, confirm costs in cart are still correct.
9. Proceed to checkout, and then place your order.
10. Confirm order received page has proper costs.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
