### PR TITLE
Don't load `subscriptions-core` if already loaded by another multisite plugin

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 3.2.2 - 2021-xx-xx =
+* Fix - Multisite compatibility - don't load subscriptions-core if already loaded by another multisite plugin.
+
 = 3.2.1 - 2021-10-28 =
 * Fix - PHP 7.2 compatibility - remove trailing commas from function args in subscriptions-core.
 

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,9 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 3.2.2 - 2021-xx-xx =
+* Fix - Multisite compatibility - don't load subscriptions-core if already loaded by another multisite plugin.
+
 = 3.2.1 - 2021-10-28 =
 * Fix - PHP 7.2 compatibility - remove trailing commas from function args in subscriptions-core.
 

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -121,6 +121,13 @@ if ( ! function_exists( 'wcpay_init_subscriptions_core' ) ) {
 				return true;
 			}
 
+			if ( is_multisite() ) {
+				$plugins = get_site_option( 'active_sitewide_plugins' );
+				if ( isset( $plugins[ $plugin_slug ] ) ) {
+					return true;
+				}
+			}
+
 			return Automattic\WooCommerce\Admin\PluginsHelper::is_plugin_active( $plugin_slug );
 		};
 


### PR DESCRIPTION
Fixes #3248

(Duplicate of #3249, this time merging into `trunk` instead of `develop`).

#### Changes proposed in this Pull Request

Before loading subscriptions-core in WCPay, check to see if it's already loaded by another multisite plugin.

This PR fixes a bug whereby when WooCommerce Payments is activated on a multisite network, it tries to load WC Subscriptions Core even if it's already been loaded by another plugin. This was causing fatal errors by redeclaring constants/functions already defined by WC Subscriptions.

The problem is that we currently check for an already active WC Subscriptions or subscriptions-core by relying on WooCommerce's `PluginsHelper::is_plugin_active`, which checks the `active_plugins` option. This doesn't take into consideration multisite network-wide plugins, which are instead in the `active_sitewide_plugins` site option. The result was that we incorrectly assume WC Subscriptions isn't loaded.

This PR addresses the issue by checking the `active_sitewide_plugins` if multisite is enabled.

Note that I did consider using the `is_plugin_active` or `is_plugin_active_for_network` functions, which work, but they don't seem to be loaded on every request (they're in `wp-admin/includes/`). So to avoid possible undefined function errors, I'm accessing the option directly.

#### Testing instructions

1. [Create a WordPress multisite network](https://wordpress.org/support/article/create-a-network/) by setting `WP_ALLOW_MULTISITE` to `true` and then installing/enabling the network.
2. As the network admin, go to `/wp-admin/network/plugins.php`.
3. Add WooCommerce v5.8.0 as a plugin, activate it network-wide.
4. Add WooCommerce Subscriptions v3.1.6 as a plugin, activate it network-wide.
5. Add WooCommerce Payments (from this PR branch) as a plugin, activate it network-wide.
6. You should be able to activate it now, whereas before you would get a fatal error.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)