### PR TITLE
Conditionally add woocommerce-tokenization-form as a checkout script dependency

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Payments Changelog ***
 
+= 3.2.3 - 2021-xx-xx =
+* Fix - Card fields on checkout not shown when the 'Enable payments via saved cards' setting is disabled.
+
 = 3.2.2 - 2021-10-29 =
 * Fix - Multisite compatibility - don't load subscriptions-core if already loaded by another multisite plugin.
 * Fix - Errors when attempting to get the WooCommerce Subscriptions Core version during PayPal requests.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -659,10 +659,16 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			true
 		);
 
+		$script_dependencies = [ 'stripe', 'wc-checkout' ];
+
+		if ( $this->supports( 'tokenization' ) ) {
+			$script_dependencies = array_merge( $script_dependencies, [ 'woocommerce-tokenization-form' ] );
+		}
+
 		wp_register_script(
 			'WCPAY_CHECKOUT',
 			plugins_url( 'dist/checkout.js', WCPAY_PLUGIN_FILE ),
-			[ 'stripe', 'wc-checkout', 'woocommerce-tokenization-form' ],
+			$script_dependencies,
 			WC_Payments::get_file_version( 'dist/checkout.js' ),
 			true
 		);

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -662,7 +662,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$script_dependencies = [ 'stripe', 'wc-checkout' ];
 
 		if ( $this->supports( 'tokenization' ) ) {
-			$script_dependencies = array_merge( $script_dependencies, [ 'woocommerce-tokenization-form' ] );
+			$script_dependencies[] = 'woocommerce-tokenization-form';
 		}
 
 		wp_register_script(

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -111,7 +111,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		$script_dependencies = [ 'stripe', 'wc-checkout' ];
 
 		if ( $this->supports( 'tokenization' ) ) {
-			$script_dependencies = array_merge( $script_dependencies, [ 'woocommerce-tokenization-form' ] );
+			$script_dependencies[] = 'woocommerce-tokenization-form';
 		}
 
 		wp_register_script(

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -108,10 +108,16 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			true
 		);
 
+		$script_dependencies = [ 'stripe', 'wc-checkout' ];
+
+		if ( $this->supports( 'tokenization' ) ) {
+			$script_dependencies = array_merge( $script_dependencies, [ 'woocommerce-tokenization-form' ] );
+		}
+
 		wp_register_script(
 			'wcpay-upe-checkout',
 			plugins_url( 'dist/upe_checkout.js', WCPAY_PLUGIN_FILE ),
-			[ 'stripe', 'wc-checkout', 'woocommerce-tokenization-form' ],
+			$script_dependencies,
 			WC_Payments::get_file_version( 'dist/upe_checkout.js' ),
 			true
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,9 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 3.2.3 - 2021-xx-xx =
+* Fix - Card fields on checkout not shown when the 'Enable payments via saved cards' setting is disabled.
+
 = 3.2.2 - 2021-10-29 =
 * Fix - Multisite compatibility - don't load subscriptions-core if already loaded by another multisite plugin.
 * Fix - Errors when attempting to get the WooCommerce Subscriptions Core version during PayPal requests.


### PR DESCRIPTION
Fixes #3261

#### Changes proposed in this Pull Request

The `woocommerce-tokenization-form` script is a dependency for standard and UPE checkout. This becomes a problem when the "Enable payments via saved cards" setting is disabled via **Payments → Settings**.

In this scenario, the `woocommerce-tokenization-form` is **not** registered which prevents the WCPay checkout script from loading on checkout (because it has a missing dependency).

This PR introduces a change to conditionally add the `woocommerce-tokenization-form` as a checkout script dependency when tokenization is supported.

<img width="1629" alt="Screen Shot 2021-11-01 at 9 13 36 am" src="https://user-images.githubusercontent.com/1527164/139603928-57428d15-710c-4614-beb2-8ab8fbe117d0.png">

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The checkout credit card form fields should load properly with every combination of the following two settings:
- Enable UPE checkout
- Enable payments via saved cards

You can find the "Enable UPE checkout" setting in the WCPay Dev page and the "Enable payments via saved cards" setting by navigating to **Payments → Settings**.

|  | UPE Enabled | Saved Cards Enabled |
|---|---|---|
| Combination 1 | ❌ | ❌ |
| Combination 2 | ❌ | ✅ |
| Combination 3 | ✅ | ❌ |
| Combination 4 | ✅ | ✅ |

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
