### PR TITLE
My Account - Only show default currency selector when multiple currencies are selected

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 3.3.0 - 2021-xx-xx =
 * Update - Updated @woocommerce/components to remove ' from negative numbers on csv files
+* Fix - Do not show default currency selector on Account Details page when only one currency is available.
 
 = 3.2.3 - 2021-11-01 =
 * Fix - Card fields on checkout not shown when the 'Enable payments via saved cards' setting is disabled.

--- a/includes/multi-currency/UserSettings.php
+++ b/includes/multi-currency/UserSettings.php
@@ -29,8 +29,11 @@ class UserSettings {
 	public function __construct( MultiCurrency $multi_currency ) {
 		$this->multi_currency = $multi_currency;
 
-		add_action( 'woocommerce_edit_account_form', [ $this, 'add_presentment_currency_switch' ] );
-		add_action( 'woocommerce_save_account_details', [ $this, 'save_presentment_currency' ] );
+		// Only show currency selector if more than one currency is enabled.
+		if ( 1 < count( $this->multi_currency->get_enabled_currencies() ) ) {
+			add_action( 'woocommerce_edit_account_form', [ $this, 'add_presentment_currency_switch' ] );
+			add_action( 'woocommerce_save_account_details', [ $this, 'save_presentment_currency' ] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3135 

#### Changes proposed in this Pull Request

My Account - Only show default currency selector when multiple currencies are selected

When multi-currency is enabled, a default currency selector is shown on the My Account > Account details page. If the merchant has only one currency selected, there's no reason to show the default currency selector, as only on option is given. Showing the selector in this case gives an illusion of choice and can be confusing.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

![Screen Capture on 2021-11-01 at 13-26-31](https://user-images.githubusercontent.com/3473953/139713807-4bd722a9-940c-4755-ac48-8b56b76cd73c.gif)


#### Testing instructions

*To reproduce*
1. Enable Multi-currency
2. Navigate to **WooCommerce > Settings > Multi-Currency**
3. Enable a single currency
4. Navigate to **My Account > Account Details** on the front-end
5. Notice the **Default currency** selector is visible, but only one currency is available.

*Testing the fix*
1. Apply this PR
2. Navigate to **WooCommerce > Settings > Multi-Currency**
3. Enable 2 or more currencies
4. Navigate to **My Account > Account Details** on the front-end
5. Notice the **Default currency** selector is visible and contains multiple options
6. Navigate to **WooCommerce > Settings > Multi-Currency**
7. Enable only a single currency
8. Check **My Account > Account Details** again to see the currency selector removed.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
