### PR TITLE
Limit period intervals in yearly subscription products

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 3.3.0 - 2021-xx-xx =
 * Update - Updated @woocommerce/components to remove ' from negative numbers on csv files
+* Update - Avoid having invalid intervals (greater than 1 year) in subscription products.
 
 = 3.2.3 - 2021-11-01 =
 * Fix - Card fields on checkout not shown when the 'Enable payments via saved cards' setting is disabled.

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -483,7 +483,7 @@ class WC_Payments_Product_Service {
 	 *
 	 * @param int $product_id Post ID of the product.
 	 */
-	public function limit_yearly_subscription_intervals_on_save_product( $product_id ) {
+	public function limit_subscription_product_intervals( $product_id ) {
 		// Skip products that aren't subscriptions.
 		$product = wc_get_product( $product_id );
 		if (
@@ -515,7 +515,7 @@ class WC_Payments_Product_Service {
 	 * @param int $product_id Post ID of the variation.
 	 * @param int $index Variation index in the incoming array.
 	 */
-	public function limit_yearly_subscription_intervals_on_save_product_variation( $product_id, $index ) {
+	public function limit_subscription_variation_intervals( $product_id, $index ) {
 		// Skip products that aren't subscriptions.
 		$product = wc_get_product( $product_id );
 		if (
@@ -546,9 +546,9 @@ class WC_Payments_Product_Service {
 	 */
 	private function add_product_update_listeners() {
 		// This needs to run before WC_Subscriptions_Admin::save_subscription_meta(), which has a priority of 11.
-		add_action( 'save_post', [ $this, 'limit_yearly_subscription_intervals_on_save_product' ], 10 );
+		add_action( 'save_post', [ $this, 'limit_subscription_product_intervals' ], 10 );
 		// This needs to run before WC_Subscriptions_Admin::save_product_variation(), which has a priority of 20.
-		add_action( 'woocommerce_save_product_variation', [ $this, 'limit_yearly_subscription_intervals_on_save_product_variation' ], 19, 2 );
+		add_action( 'woocommerce_save_product_variation', [ $this, 'limit_subscription_variation_intervals' ], 19, 2 );
 
 		add_action( 'save_post', [ $this, 'maybe_schedule_product_create_or_update' ], 12 );
 		add_action( 'woocommerce_save_product_variation', [ $this, 'maybe_schedule_product_create_or_update' ], 30 );
@@ -558,8 +558,8 @@ class WC_Payments_Product_Service {
 	 * Removes the callbacks used to update product changes in WC Pay.
 	 */
 	private function remove_product_update_listeners() {
-		remove_action( 'save_post', [ $this, 'limit_yearly_subscription_intervals_on_save_product' ], 10 );
-		remove_action( 'woocommerce_save_product_variation', [ $this, 'limit_yearly_subscription_intervals_on_save_product_variation' ], 19, 2 );
+		remove_action( 'save_post', [ $this, 'limit_subscription_product_intervals' ], 10 );
+		remove_action( 'woocommerce_save_product_variation', [ $this, 'limit_subscription_variation_intervals' ], 19 );
 
 		remove_action( 'save_post', [ $this, 'maybe_schedule_product_create_or_update' ], 12 );
 		remove_action( 'woocommerce_save_product_variation', [ $this, 'maybe_schedule_product_create_or_update' ], 30 );


### PR DESCRIPTION
Fixes #3255 

#### Changes proposed in this Pull Request

Force period intervals to "1" when the period is yearly.

* Hook into 'save_post' for simple subscriptions
* Hook into "woocommerce_save_product_variation" for variable subscriptions' variations
* Set a priority so it runs before WC_Subscriptions_Admin's hooked methods
* Edit the value of the interval variable in $_POST and $_REQUEST so WC_Subscriptions_Admin saves the updated values
* Display an error notice when the period/interval combination is invalid

Still in progress. Planning to add tests and check if we can improve the UX on the client-side.

#### Testing instructions

Basically, any product or variation with a yearly period with an interval greater than 1 (that is anything from these options except "every"), must have "every" selected instead after saving.
![image](https://user-images.githubusercontent.com/41606954/139738513-bd80279c-6f22-4947-9bdb-66ff355bf7a8.png)

Simple subscription:
* Create a simple subscription product. Give it a price of 55 (or anything really) every 3rd year
* Save the product
* When the page finishes reloading, there should be an error notice saying "The period interval of a subscription can't be greater than a year", and the product's interval should be set to "every", instead of "every 3rd"

Variable subscription:
* Create a variable subscription product
* Create some variations for it
* Give the variations a price. Use 5 (or anything) every 2nd year in at least one variation
* Click on "Save changes" in the variations section
* When the section gets refreshed, the variation with the yearly period that has an interval of "every 2nd" should now have "every" selected. This should be the same if you save the parent product instead of the variations alone.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
