### PR TITLE
Adds order notes for dispute events

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Payments Changelog ***
 
 = 3.3.0 - 2021-xx-xx =
+* Add - Add dispute order notes to Edit Order page.
 * Update - Updated @woocommerce/components to remove ' from negative numbers on csv files
 * Update - Avoid having invalid intervals (greater than 1 year) in subscription products.
 * Update - The subscription fee label in the transaction timeline.

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -117,8 +117,11 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 				case 'charge.refund.updated':
 					$this->process_webhook_refund_updated( $body );
 					break;
-				case 'charge.dispute.created':
 				case 'charge.dispute.closed':
+				case 'charge.dispute.created':
+				case 'charge.dispute.funds_reinstated':
+				case 'charge.dispute.funds_withdrawn':
+				case 'charge.dispute.updated':
 					$this->process_webhook_dispute( $body );
 					break;
 				case 'charge.expired':
@@ -219,45 +222,6 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	}
 
 	/**
-	 * Process webhook dispute created.
-	 *
-	 * @param array $event_body The event that triggered the webhook.
-	 *
-	 * @throws Rest_Request_Exception           Required parameters not found.
-	 */
-	private function process_webhook_dispute( $event_body ) {
-		$event_data   = $this->read_rest_property( $event_body, 'data' );
-		$event_object = $this->read_rest_property( $event_data, 'object' );
-		$dispute_id   = $this->read_rest_property( $event_object, 'id' );
-		$charge_id    = $this->read_rest_property( $event_object, 'charge' );
-		$reason       = $this->read_rest_property( $event_object, 'reason' );
-		$order        = $this->wcpay_db->order_from_charge_id( $charge_id );
-
-		if ( ! $order ) {
-			throw new Rest_Request_Exception(
-				sprintf(
-					/* translators: %1: charge ID */
-					__( 'Could not find order via charge ID: %1$s', 'woocommerce-payments' ),
-					$charge_id
-				),
-				'order_not_found'
-			);
-		}
-
-		$note = sprintf(
-			/* translators: %1: the dispute reason, %2: the dispute page URL */
-			__( 'Payment disputed as %1$s. See <a href="%2$s">dispute overview</a> for more details', 'woocommerce-payments' ),
-			$reason,
-			add_query_arg(
-				[ 'id' => $dispute_id ],
-				admin_url( 'admin.php?page=wc-admin&path=/payments/disputes/details' )
-			)
-		);
-
-		$order->add_order_note( $note );
-	}
-
-	/**
 	 * Process webhook for an expired uncaptured payment.
 	 *
 	 * @param array $event_body The event that triggered the webhook.
@@ -336,6 +300,63 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 		if ( ! $order->has_status( [ 'processing', 'completed' ] ) ) {
 			$order->payment_complete();
 		}
+	}
+
+	/**
+	 * Process webhook dispute created.
+	 *
+	 * @param array $event_body The event that triggered the webhook.
+	 *
+	 * @throws Rest_Request_Exception           Required parameters not found.
+	 */
+	private function process_webhook_dispute( $event_body ) {
+		$event_type   = $this->read_rest_property( $event_body, 'type' );
+		$event_data   = $this->read_rest_property( $event_body, 'data' );
+		$event_object = $this->read_rest_property( $event_data, 'object' );
+		$dispute_id   = $this->read_rest_property( $event_object, 'id' );
+		$charge_id    = $this->read_rest_property( $event_object, 'charge' );
+		$reason       = $this->read_rest_property( $event_object, 'reason' );
+		$order        = $this->wcpay_db->order_from_charge_id( $charge_id );
+
+		if ( ! $order ) {
+			throw new Rest_Request_Exception(
+				sprintf(
+					/* translators: %1: charge ID */
+					__( 'Could not find order via charge ID: %1$s', 'woocommerce-payments' ),
+					$charge_id
+				),
+				'order_not_found'
+			);
+		}
+
+		switch ( $event_type ) {
+			case 'charge.dispute.created':
+				$message = 'Payment has been disputed as ' . $reason;
+				break;
+			case 'charge.dispute.closed':
+				$message = 'Payment dispute has been closed';
+				break;
+			case 'charge.dispute.funds_withdrawn':
+				$message = 'Payment dispute funds have been withdrawn';
+				break;
+			case 'charge.dispute.funds_reinstated':
+				$message = 'Payment dispute funds have been reinstated';
+				break;
+			default:
+				$message = 'Payment dispute updated';
+		}
+
+		$note = sprintf(
+			/* translators: %1: the dispute message, %2: the dispute page URL */
+			__( '%1$s. See <a href="%2$s">dispute overview</a> for more details.', 'woocommerce-payments' ),
+			$message,
+			add_query_arg(
+				[ 'id' => $dispute_id ],
+				admin_url( 'admin.php?page=wc-admin&path=/payments/disputes/details' )
+			)
+		);
+
+		$order->add_order_note( $note );
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -117,12 +117,16 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 				case 'charge.refund.updated':
 					$this->process_webhook_refund_updated( $body );
 					break;
-				case 'charge.dispute.closed':
 				case 'charge.dispute.created':
+					$this->process_webhook_dispute_created( $body );
+					break;
+				case 'charge.dispute.closed':
+					$this->process_webhook_dispute_closed( $body );
+					break;
 				case 'charge.dispute.funds_reinstated':
 				case 'charge.dispute.funds_withdrawn':
 				case 'charge.dispute.updated':
-					$this->process_webhook_dispute( $body );
+					$this->process_webhook_dispute_updated( $body );
 					break;
 				case 'charge.expired':
 					$this->process_webhook_expired_authorization( $body );
@@ -307,9 +311,9 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	 *
 	 * @param array $event_body The event that triggered the webhook.
 	 *
-	 * @throws Rest_Request_Exception           Required parameters not found.
+	 * @throws Rest_Request_Exception Required parameters not found.
 	 */
-	private function process_webhook_dispute( $event_body ) {
+	private function process_webhook_dispute_created( $event_body ) {
 		$event_type   = $this->read_rest_property( $event_body, 'type' );
 		$event_data   = $this->read_rest_property( $event_body, 'data' );
 		$event_object = $this->read_rest_property( $event_data, 'object' );
@@ -328,17 +332,98 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 			);
 		}
 
+		$note = sprintf(
+			/* translators: %1: the dispute reason, %2: the dispute details URL */
+			__( 'Payment has been disputed as %1$s. See <a href="%2$s">dispute overview</a> for more details.', 'woocommerce-payments' ),
+			$reason,
+			add_query_arg(
+				[ 'id' => $dispute_id ],
+				admin_url( 'admin.php?page=wc-admin&path=/payments/disputes/details' )
+			)
+		);
+
+		$order->add_order_note( $note );
+		$order->update_status( 'on-hold' );
+	}
+
+	/**
+	 * Process webhook dispute closed.
+	 *
+	 * @param array $event_body The event that triggered the webhook.
+	 *
+	 * @throws Rest_Request_Exception Required parameters not found.
+	 */
+	private function process_webhook_dispute_closed( $event_body ) {
+		$event_type   = $this->read_rest_property( $event_body, 'type' );
+		$event_data   = $this->read_rest_property( $event_body, 'data' );
+		$event_object = $this->read_rest_property( $event_data, 'object' );
+		$dispute_id   = $this->read_rest_property( $event_object, 'id' );
+		$charge_id    = $this->read_rest_property( $event_object, 'charge' );
+		$status       = $this->read_rest_property( $event_object, 'status' );
+		$order        = $this->wcpay_db->order_from_charge_id( $charge_id );
+
+		if ( ! $order ) {
+			throw new Rest_Request_Exception(
+				sprintf(
+					/* translators: %1: charge ID */
+					__( 'Could not find order via charge ID: %1$s', 'woocommerce-payments' ),
+					$charge_id
+				)
+			);
+		}
+
+		$note = sprintf(
+			/* translators: %1: the dispute status, %2: the dispute details URL */
+			__( 'Payment dispute has been closed with status %1$s. See <a href="%2$s">dispute overview</a> for more details.', 'woocommerce-payments' ),
+			$status,
+			add_query_arg(
+				[ 'id' => $dispute_id ],
+				admin_url( 'admin.php?page=wc-admin&path=/payments/disputes/details' )
+			)
+		);
+
+		$order->add_order_note( $note );
+
+		if ( 'lost' === $status ) {
+			wc_create_refund(
+				[
+					'amount'     => $order->get_total(),
+					'reason'     => __( 'dispute lost', 'woocommerce-payments' ),
+					'order_id'   => $order->get_id(),
+					'line_items' => $order->get_items(),
+				]
+			);
+		} else {
+			$order->update_status( 'completed' );
+		}
+	}
+
+	/**
+	 * Process webhook dispute updated.
+	 *
+	 * @param array $event_body The event that triggered the webhook.
+	 *
+	 * @throws Rest_Request_Exception Required parameters not found.
+	 */
+	private function process_webhook_dispute_updated( $event_body ) {
+		$event_type   = $this->read_rest_property( $event_body, 'type' );
+		$event_data   = $this->read_rest_property( $event_body, 'data' );
+		$event_object = $this->read_rest_property( $event_data, 'object' );
+		$dispute_id   = $this->read_rest_property( $event_object, 'id' );
+		$charge_id    = $this->read_rest_property( $event_object, 'charge' );
+		$order        = $this->wcpay_db->order_from_charge_id( $charge_id );
+
+		if ( ! $order ) {
+			throw new Rest_Request_Exception(
+				sprintf(
+					/* translators: %1: charge ID */
+					__( 'Could not find order via charge ID: %1$s', 'woocommerce-payments' ),
+					$charge_id
+				)
+			);
+		}
+
 		switch ( $event_type ) {
-			case 'charge.dispute.created':
-				$message = sprintf(
-					/* translators: %1: the dispute reason */
-					__( 'Payment has been disputed as %1$s', 'woocommerce-payments' ),
-					$reason
-				);
-				break;
-			case 'charge.dispute.closed':
-				$message = __( 'Payment dispute has been closed', 'woocommerce-payments' );
-				break;
 			case 'charge.dispute.funds_withdrawn':
 				$message = __( 'Payment dispute funds have been withdrawn', 'woocommerce-payments' );
 				break;
@@ -350,7 +435,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 		}
 
 		$note = sprintf(
-			/* translators: %1: the dispute message, %2: the dispute page URL */
+			/* translators: %1: the dispute message, %2: the dispute details URL */
 			__( '%1$s. See <a href="%2$s">dispute overview</a> for more details.', 'woocommerce-payments' ),
 			$message,
 			add_query_arg(

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -343,7 +343,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 				$message = 'Payment dispute funds have been reinstated';
 				break;
 			default:
-				$message = 'Payment dispute updated';
+				$message = 'Payment dispute has been updated';
 		}
 
 		$note = sprintf(

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -331,19 +331,23 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 
 		switch ( $event_type ) {
 			case 'charge.dispute.created':
-				$message = 'Payment has been disputed as ' . $reason;
+				$message = sprintf(
+					/* translators: %1: the dispute reason */
+					__( 'Payment has been disputed as %1$s', 'woocommerce-payments' ),
+					$reason
+				);
 				break;
 			case 'charge.dispute.closed':
-				$message = 'Payment dispute has been closed';
+				$message = __( 'Payment dispute has been closed', 'woocommerce-payments' );
 				break;
 			case 'charge.dispute.funds_withdrawn':
-				$message = 'Payment dispute funds have been withdrawn';
+				$message = __( 'Payment dispute funds have been withdrawn', 'woocommerce-payments' );
 				break;
 			case 'charge.dispute.funds_reinstated':
-				$message = 'Payment dispute funds have been reinstated';
+				$message = __( 'Payment dispute funds have been reinstated', 'woocommerce-payments' );
 				break;
 			default:
-				$message = 'Payment dispute has been updated';
+				$message = __( 'Payment dispute has been updated', 'woocommerce-payments' );
 		}
 
 		$note = sprintf(

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -324,8 +324,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 					/* translators: %1: charge ID */
 					__( 'Could not find order via charge ID: %1$s', 'woocommerce-payments' ),
 					$charge_id
-				),
-				'order_not_found'
+				)
 			);
 		}
 

--- a/tests/unit/admin/test-class-wc-rest-payments-webhook.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-webhook.php
@@ -159,6 +159,9 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 		$this->assertEquals( [ 'result' => 'bad_request' ], $response_data );
 	}
 
+	/**
+	 * Test a valid refund sets failed meta.
+	 */
 	public function test_valid_failed_refund_webhook_sets_failed_meta() {
 		// Setup test request data.
 		$this->request_body['type']           = 'charge.refund.updated';
@@ -202,6 +205,9 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 		$this->controller->handle_webhook( $this->request );
 	}
 
+	/**
+	 * Test a valid refund does not set failed meta.
+	 */
 	public function test_non_failed_refund_update_webhook_does_not_set_failed_meta() {
 		// Setup test request data.
 		$this->request_body['type']           = 'charge.refund.updated';
@@ -225,7 +231,6 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 
 		// Run the test.
 		$this->controller->handle_webhook( $this->request );
-
 	}
 
 	/**
@@ -693,5 +698,175 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 	public function test_invoice_payment_failed_webhook() {
 		// Stub.
 		$this->assertTrue( true );
+	}
+
+	/**
+	 * Tests that a dispute created event adds a respective order note.
+	 */
+	public function test_dispute_created_order_note() {
+		// Setup test request data.
+		$this->request_body['type']           = 'charge.dispute.created';
+		$this->request_body['data']['object'] = [
+			'id'     => 'test_dispute_id',
+			'charge' => 'test_charge_id',
+			'reason' => 'test_reason',
+		];
+
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
+
+		$mock_order = $this->createMock( WC_Order::class );
+		$mock_order
+			->expects( $this->once() )
+			->method( 'add_order_note' )
+			->with(
+				$this->matchesRegularExpression(
+					'/Payment has been disputed as test_reason/'
+				)
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'test_charge_id' )
+			->willReturn( $mock_order );
+
+		// Run the test.
+		$this->controller->handle_webhook( $this->request );
+	}
+
+	/**
+	 * Tests that a dispute closed event adds a respective order note.
+	 */
+	public function test_dispute_closed_order_note() {
+		// Setup test request data.
+		$this->request_body['type']           = 'charge.dispute.closed';
+		$this->request_body['data']['object'] = [
+			'id'     => 'test_dispute_id',
+			'charge' => 'test_charge_id',
+			'reason' => 'test_reason',
+		];
+
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
+
+		$mock_order = $this->createMock( WC_Order::class );
+		$mock_order
+			->expects( $this->once() )
+			->method( 'add_order_note' )
+			->with(
+				$this->matchesRegularExpression(
+					'/Payment dispute has been closed/'
+				)
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'test_charge_id' )
+			->willReturn( $mock_order );
+
+		// Run the test.
+		$this->controller->handle_webhook( $this->request );
+	}
+
+	/**
+	 * Tests that a dispute updated event adds a respective order note.
+	 */
+	public function test_dispute_updated_order_note() {
+		// Setup test request data.
+		$this->request_body['type']           = 'charge.dispute.updated';
+		$this->request_body['data']['object'] = [
+			'id'     => 'test_dispute_id',
+			'charge' => 'test_charge_id',
+			'reason' => 'test_reason',
+		];
+
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
+
+		$mock_order = $this->createMock( WC_Order::class );
+		$mock_order
+			->expects( $this->once() )
+			->method( 'add_order_note' )
+			->with(
+				$this->matchesRegularExpression(
+					'/Payment dispute has been updated/'
+				)
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'test_charge_id' )
+			->willReturn( $mock_order );
+
+		// Run the test.
+		$this->controller->handle_webhook( $this->request );
+	}
+
+	/**
+	 * Tests that a dispute funds withdrawn event adds a respective order note.
+	 */
+	public function test_dispute_funds_withdrawn_order_note() {
+		// Setup test request data.
+		$this->request_body['type']           = 'charge.dispute.funds_withdrawn';
+		$this->request_body['data']['object'] = [
+			'id'     => 'test_dispute_id',
+			'charge' => 'test_charge_id',
+			'reason' => 'test_reason',
+		];
+
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
+
+		$mock_order = $this->createMock( WC_Order::class );
+		$mock_order
+			->expects( $this->once() )
+			->method( 'add_order_note' )
+			->with(
+				$this->matchesRegularExpression(
+					'/Payment dispute funds have been withdrawn/'
+				)
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'test_charge_id' )
+			->willReturn( $mock_order );
+
+		// Run the test.
+		$this->controller->handle_webhook( $this->request );
+	}
+
+	/**
+	 * Tests that a dispute funds reinstated event adds a respective order note.
+	 */
+	public function test_dispute_funds_reinstated_order_note() {
+		// Setup test request data.
+		$this->request_body['type']           = 'charge.dispute.funds_reinstated';
+		$this->request_body['data']['object'] = [
+			'id'     => 'test_dispute_id',
+			'charge' => 'test_charge_id',
+			'reason' => 'test_reason',
+		];
+
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
+
+		$mock_order = $this->createMock( WC_Order::class );
+		$mock_order
+			->expects( $this->once() )
+			->method( 'add_order_note' )
+			->with(
+				$this->matchesRegularExpression(
+					'/Payment dispute funds have been reinstated/'
+				)
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'test_charge_id' )
+			->willReturn( $mock_order );
+
+		// Run the test.
+		$this->controller->handle_webhook( $this->request );
 	}
 }

--- a/tests/unit/admin/test-class-wc-rest-payments-webhook.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-webhook.php
@@ -724,6 +724,11 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 				)
 			);
 
+		$mock_order
+			->expects( $this->once() )
+			->method( 'update_status' )
+			->with( 'on-hold' );
+
 		$this->mock_db_wrapper
 			->expects( $this->once() )
 			->method( 'order_from_charge_id' )
@@ -743,7 +748,7 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 		$this->request_body['data']['object'] = [
 			'id'     => 'test_dispute_id',
 			'charge' => 'test_charge_id',
-			'reason' => 'test_reason',
+			'status' => 'test_status',
 		];
 
 		$this->request->set_body( wp_json_encode( $this->request_body ) );
@@ -754,9 +759,14 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 			->method( 'add_order_note' )
 			->with(
 				$this->matchesRegularExpression(
-					'/Payment dispute has been closed/'
+					'/Payment dispute has been closed with status test_status/'
 				)
 			);
+
+		$mock_order
+			->expects( $this->once() )
+			->method( 'update_status' )
+			->with( 'completed' );
 
 		$this->mock_db_wrapper
 			->expects( $this->once() )
@@ -777,7 +787,6 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 		$this->request_body['data']['object'] = [
 			'id'     => 'test_dispute_id',
 			'charge' => 'test_charge_id',
-			'reason' => 'test_reason',
 		];
 
 		$this->request->set_body( wp_json_encode( $this->request_body ) );
@@ -811,7 +820,6 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 		$this->request_body['data']['object'] = [
 			'id'     => 'test_dispute_id',
 			'charge' => 'test_charge_id',
-			'reason' => 'test_reason',
 		];
 
 		$this->request->set_body( wp_json_encode( $this->request_body ) );
@@ -845,7 +853,6 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 		$this->request_body['data']['object'] = [
 			'id'     => 'test_dispute_id',
 			'charge' => 'test_charge_id',
-			'reason' => 'test_reason',
 		];
 
 		$this->request->set_body( wp_json_encode( $this->request_body ) );


### PR DESCRIPTION
Fixes #527 

#### Changes proposed in this Pull Request

This adds order notes whenever a `charge.dispute` event is received by the remote site.

#### Testing instructions

- Purchase a product using a [dispute-specific test card](https://stripe.com/docs/testing#disputes)
- Navigate to the order page as admin (WooCommerce > Orders)
- Ensure the order has been set to on-hold* and there is an order note indicating a dispute was created and that links to the correct dispute page
- Using the dispute link in the order note, navigate to the dispute page and make sure everything looks good
- Accept the dispute
- Navigate back to the order page as admin
- Ensure there is a new order note indicating the dispute was closed with an appropriate status and that links to the correct dispute page
- Repeat steps 1-4 above
- This time Challenge the dispute, being sure to include the string `winning_evidence` in the Additional Information field
- Again, navigate to the order page and confirm the order status (completed) and note
- Repeat steps 1-4 once more
- Again, Challenge the dispute, being sure to include the string `losing_evidence` in the Additional Information field
- navigate to the order page and confirm the order status (refunded if dispute results in a loss) and note

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
