### PR TITLE
Changed documentation links from docs.woocommerce.com to woocommerce.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Install the following plugins:
 
 ## Test account setup
 
-For setting up a test account follow [these instructions](https://docs.woocommerce.com/document/payments/testing/dev-mode/).
+For setting up a test account follow [these instructions](https://woocommerce.com/document/payments/testing/dev-mode/).
 
 You will need a externally accessible URL to set up the plugin. You can use ngrok for this.
 

--- a/client/account-status-settings/test/__snapshots__/index.js.snap
+++ b/client/account-status-settings/test/__snapshots__/index.js.snap
@@ -115,7 +115,7 @@ exports[`AccountStatus renders manual (suspended) deposits 1`] = `
           </svg>
           Temporarily suspended (
           <a
-            href="https://docs.woocommerce.com/document/payments/faq/deposits-suspended/"
+            href="https://woocommerce.com/document/payments/faq/deposits-suspended/"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/client/additional-methods-setup/upe-preview-methods-selector/add-payment-methods-task.js
+++ b/client/additional-methods-setup/upe-preview-methods-selector/add-payment-methods-task.js
@@ -180,7 +180,7 @@ const AddPaymentMethodsTask = () => {
 						components: {
 							learnMoreLink: (
 								// eslint-disable-next-line max-len
-								<ExternalLink href="https://docs.woocommerce.com/document/payments/additional-payment-methods/#available-methods" />
+								<ExternalLink href="https://woocommerce.com/document/payments/additional-payment-methods/#available-methods" />
 							),
 						},
 					} ) }

--- a/client/additional-methods-setup/upe-preview-methods-selector/enable-upe-preview-task.js
+++ b/client/additional-methods-setup/upe-preview-methods-selector/enable-upe-preview-task.js
@@ -54,7 +54,7 @@ const EnableUpePreviewTask = () => {
 						components: {
 							learnMoreLink: (
 								// eslint-disable-next-line max-len
-								<ExternalLink href="https://docs.woocommerce.com/document/payments/additional-payment-methods/#introduction">
+								<ExternalLink href="https://woocommerce.com/document/payments/additional-payment-methods/#introduction">
 									{ __(
 										'Learn more',
 										'woocommerce-payments'

--- a/client/components/account-status/account-fees/index.js
+++ b/client/components/account-status/account-fees/index.js
@@ -23,7 +23,7 @@ const LearnMoreLink = ( { accountFees } ) => {
 				href={
 					accountFees.discount.length
 						? 'https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/'
-						: 'https://docs.woocommerce.com/document/payments/faq/fees/'
+						: 'https://woocommerce.com/document/payments/faq/fees/'
 				}
 				target="_blank"
 				rel="noopener noreferrer"

--- a/client/components/account-status/account-fees/test/__snapshots__/index.js.snap
+++ b/client/components/account-status/account-fees/test/__snapshots__/index.js.snap
@@ -307,7 +307,7 @@ exports[`AccountFees renders non-USD base fee 1`] = `
   2.9% + €0,25 per transaction
   <p>
     <a
-      href="https://docs.woocommerce.com/document/payments/faq/fees/"
+      href="https://woocommerce.com/document/payments/faq/fees/"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -324,7 +324,7 @@ exports[`AccountFees renders normal base fee 1`] = `
   2.9% + $0.30 per transaction
   <p>
     <a
-      href="https://docs.woocommerce.com/document/payments/faq/fees/"
+      href="https://woocommerce.com/document/payments/faq/fees/"
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/client/components/account-status/test/__snapshots__/index.js.snap
+++ b/client/components/account-status/test/__snapshots__/index.js.snap
@@ -138,7 +138,7 @@ exports[`AccountStatus renders normal status 1`] = `
           2.9% + €0,00 per transaction
           <p>
             <a
-              href="https://docs.woocommerce.com/document/payments/faq/fees/"
+              href="https://woocommerce.com/document/payments/faq/fees/"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/client/components/deposits-status/index.js
+++ b/client/components/deposits-status/index.js
@@ -31,7 +31,7 @@ const DepositsStatus = ( props ) => {
 		description = __( 'Monthly', 'woocommerce-payments' );
 	} else if ( 'manual' === depositsStatus ) {
 		const learnMoreHref =
-			'https://docs.woocommerce.com/document/payments/faq/deposits-suspended/';
+			'https://woocommerce.com/document/payments/faq/deposits-suspended/';
 		description = createInterpolateElement(
 			/* translators: <a> - suspended accounts FAQ URL */
 			__(

--- a/client/components/deposits-status/test/__snapshots__/index.js.snap
+++ b/client/components/deposits-status/test/__snapshots__/index.js.snap
@@ -66,7 +66,7 @@ exports[`DepositsStatus renders manual status 1`] = `
     </svg>
     Temporarily suspended (
     <a
-      href="https://docs.woocommerce.com/document/payments/faq/deposits-suspended/"
+      href="https://woocommerce.com/document/payments/faq/deposits-suspended/"
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/client/connect-account-page/modal/index.js
+++ b/client/connect-account-page/modal/index.js
@@ -17,7 +17,7 @@ import { ExperimentalList } from '@woocommerce/experimental/build/experimental-l
 const LearnMoreLink = ( props ) => (
 	<Link
 		{ ...props }
-		href="https://docs.woocommerce.com/document/payments/countries/"
+		href="https://woocommerce.com/document/payments/countries/"
 		target="_blank"
 		rel="noopener noreferrer"
 		type="external"

--- a/client/connect-account-page/modal/test/__snapshots__/index.js.snap
+++ b/client/connect-account-page/modal/test/__snapshots__/index.js.snap
@@ -69,7 +69,7 @@ exports[`Onboarding: location check dialog renders correctly when continue butto
          
         <a
           data-link-type="external"
-          href="https://docs.woocommerce.com/document/payments/countries/"
+          href="https://woocommerce.com/document/payments/countries/"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -166,7 +166,7 @@ exports[`Onboarding: location check dialog renders correctly when opened 1`] = `
          
         <a
           data-link-type="external"
-          href="https://docs.woocommerce.com/document/payments/countries/"
+          href="https://woocommerce.com/document/payments/countries/"
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/client/deposits/instant-deposits/modal.js
+++ b/client/deposits/instant-deposits/modal.js
@@ -20,7 +20,7 @@ const InstantDepositModal = ( {
 	inProgress,
 } ) => {
 	const learnMoreHref =
-		'https://docs.woocommerce.com/document/payments/instant-deposits/';
+		'https://woocommerce.com/document/payments/instant-deposits/';
 	const feePercentage = `${ percentage }%`;
 	const description = createInterpolateElement(
 		/* translators: %s: amount representing the fee percentage, <a>: instant payout doc URL */

--- a/client/deposits/instant-deposits/test/__snapshots__/index.js.snap
+++ b/client/deposits/instant-deposits/test/__snapshots__/index.js.snap
@@ -69,7 +69,7 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
     <p>
       Need cash in a hurry? Instant deposits are available within 30 minutes for a nominal 1.5% service fee. 
       <a
-        href="https://docs.woocommerce.com/document/payments/instant-deposits/"
+        href="https://woocommerce.com/document/payments/instant-deposits/"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/client/deposits/utils/index.js
+++ b/client/deposits/utils/index.js
@@ -90,7 +90,7 @@ export const getDepositScheduleDescriptor = ( {
 } ) => {
 	if ( disabled || 'manual' === schedule.interval ) {
 		const learnMoreHref =
-			'https://docs.woocommerce.com/document/payments/faq/deposits-suspended/';
+			'https://woocommerce.com/document/payments/faq/deposits-suspended/';
 		return createInterpolateElement(
 			/* translators: <a> - suspended accounts FAQ URL */
 			__(
@@ -112,7 +112,7 @@ export const getDepositScheduleDescriptor = ( {
 
 	if ( ! last ) {
 		const learnMoreHref =
-			'https://docs.woocommerce.com/document/payments/faq/deposit-schedule/';
+			'https://woocommerce.com/document/payments/faq/deposit-schedule/';
 		return createInterpolateElement(
 			sprintf(
 				/** translators: %s - deposit schedule, <a> - waiting period doc URL */

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/index.js
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/index.js
@@ -25,7 +25,7 @@ import SettingsSection from 'wcpay/settings/settings-section';
 
 const EnabledCurrenciesSettingsDescription = () => {
 	const LEARN_MORE_URL =
-		'https://docs.woocommerce.com/document/payments/currencies/multi-currency-setup/';
+		'https://woocommerce.com/document/payments/currencies/multi-currency-setup/';
 
 	return (
 		<>

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/test/__snapshots__/index.js.snap
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/test/__snapshots__/index.js.snap
@@ -576,7 +576,7 @@ exports[`Multi-Currency enabled currencies list Enabled currencies list renders 
       <p>
         Accept payments in multiple currencies. Prices are converted based on exchange rates and rounding rules. 
         <a
-          href="https://docs.woocommerce.com/document/payments/currencies/multi-currency-setup/"
+          href="https://woocommerce.com/document/payments/currencies/multi-currency-setup/"
           rel="noreferrer"
           target="_blank"
         >

--- a/client/multi-currency/multi-currency-settings/store-settings/index.js
+++ b/client/multi-currency/multi-currency-settings/store-settings/index.js
@@ -18,7 +18,7 @@ import PreviewModal from 'wcpay/multi-currency/preview-modal';
 
 const StoreSettingsDescription = () => {
 	const LEARN_MORE_URL =
-		'https://docs.woocommerce.com/document/payments/currencies/multi-currency-setup/';
+		'https://woocommerce.com/document/payments/currencies/multi-currency-setup/';
 
 	return (
 		<>

--- a/client/multi-currency/multi-currency-settings/store-settings/test/__snapshots__/index.test.js.snap
+++ b/client/multi-currency/multi-currency-settings/store-settings/test/__snapshots__/index.test.js.snap
@@ -14,7 +14,7 @@ exports[`Multi-Currency store settings store settings task renders correctly: sn
       <p>
         Store settings allow your customers to choose which currency they would like to use when shopping at your store. 
         <a
-          href="https://docs.woocommerce.com/document/payments/currencies/multi-currency-setup/"
+          href="https://woocommerce.com/document/payments/currencies/multi-currency-setup/"
           rel="noreferrer"
           target="_blank"
         >

--- a/client/multi-currency/single-currency-settings/index.js
+++ b/client/multi-currency/single-currency-settings/index.js
@@ -419,7 +419,7 @@ const SingleCurrencySettings = () => {
 													isLink
 													onClick={ () => {
 														open(
-															'http://docs.woocommerce.com/document/payments/' +
+															'http://woocommerce.com/document/payments/' +
 																'currencies/multi-currency-setup/#price-rounding',
 															'_blank'
 														);
@@ -484,7 +484,7 @@ const SingleCurrencySettings = () => {
 													isLink
 													onClick={ () => {
 														open(
-															'http://docs.woocommerce.com/document/payments/' +
+															'http://woocommerce.com/document/payments/' +
 																'currencies/multi-currency-setup/#price-charm',
 															'_blank'
 														);

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -123,7 +123,7 @@ export const getTasks = ( {
 				completed: false,
 				onClick: () => {
 					window.open(
-						'https://docs.woocommerce.com/document/ssl-and-https/#section-7',
+						'https://woocommerce.com/document/ssl-and-https/#section-7',
 						'_blank'
 					);
 				},

--- a/client/payment-gateways/disable-confirmation-modal.js
+++ b/client/payment-gateways/disable-confirmation-modal.js
@@ -92,7 +92,7 @@ const DisableConfirmationModal = ( { onClose, onConfirm } ) => {
 						strong: <strong />,
 						wooCommercePaymentsLink: (
 							// eslint-disable-next-line jsx-a11y/anchor-has-content
-							<a href="https://docs.woocommerce.com/document/payments/" />
+							<a href="https://woocommerce.com/document/payments/" />
 						),
 						contactSupportLink: (
 							// eslint-disable-next-line jsx-a11y/anchor-has-content

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -102,7 +102,7 @@ const UpeSetupBanner = () => {
 							) }
 						</Button>
 					</span>
-					<ExternalLink href="https://docs.woocommerce.com/document/payments/additional-payment-methods/">
+					<ExternalLink href="https://woocommerce.com/document/payments/additional-payment-methods/">
 						{ __( 'Learn more', 'woocommerce-payments' ) }
 					</ExternalLink>
 				</div>

--- a/client/settings/advanced-settings/multi-currency-toggle.js
+++ b/client/settings/advanced-settings/multi-currency-toggle.js
@@ -40,7 +40,7 @@ const MultiCurrencyToggle = () => {
 				components: {
 					learnMoreLink: (
 						// eslint-disable-next-line max-len
-						<ExternalLink href="https://docs.woocommerce.com/document/payments/currencies/multi-currency-setup" />
+						<ExternalLink href="https://woocommerce.com/document/payments/currencies/multi-currency-setup" />
 					),
 				},
 			} ) }

--- a/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
+++ b/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
@@ -46,7 +46,7 @@ const WCPaySubscriptionsToggle = () => {
 				components: {
 					learnMoreLink: (
 						// eslint-disable-next-line max-len
-						<ExternalLink href="https://docs.woocommerce.com/document/payments/subscriptions/" />
+						<ExternalLink href="https://woocommerce.com/document/payments/subscriptions/" />
 					),
 				},
 			} ) }

--- a/client/settings/disable-upe-modal/index.js
+++ b/client/settings/disable-upe-modal/index.js
@@ -29,7 +29,7 @@ const NeedHelpBarSection = () => {
 				components: {
 					docsLink: (
 						// eslint-disable-next-line max-len
-						<ExternalLink href="https://docs.woocommerce.com/document/payments/additional-payment-methods/#introduction">
+						<ExternalLink href="https://woocommerce.com/document/payments/additional-payment-methods/#introduction">
 							{ __(
 								'WooCommerce Payments docs',
 								'woocommerce-payments'

--- a/client/settings/general-settings/index.js
+++ b/client/settings/general-settings/index.js
@@ -58,7 +58,7 @@ const GeneralSettings = () => {
 								<a
 									target="_blank"
 									rel="noreferrer"
-									href="https://docs.woocommerce.com/document/payments/testing/#test-cards"
+									href="https://woocommerce.com/document/payments/testing/#test-cards"
 								/>
 							),
 							learnMoreLink: (
@@ -66,7 +66,7 @@ const GeneralSettings = () => {
 								<a
 									target="_blank"
 									rel="noreferrer"
-									href="https://docs.woocommerce.com/document/payments/testing/"
+									href="https://woocommerce.com/document/payments/testing/"
 								/>
 							),
 						},

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -57,7 +57,7 @@ const PaymentRequestDescription = () => (
 				'woocommerce-payments'
 			) }
 		</p>
-		<ExternalLink href="https://docs.woocommerce.com/document/payments/apple-pay/">
+		<ExternalLink href="https://woocommerce.com/document/payments/apple-pay/">
 			{ __( 'How it works?', 'woocommerce-payments' ) }
 		</ExternalLink>
 	</>
@@ -84,7 +84,7 @@ const TransactionsAndDepositsDescription = () => (
 				'woocommerce-payments'
 			) }
 		</p>
-		<ExternalLink href="https://docs.woocommerce.com/document/payments/faq/">
+		<ExternalLink href="https://woocommerce.com/document/payments/faq/">
 			{ __( 'View frequently asked questions', 'woocommerce-payments' ) }
 		</ExternalLink>
 	</>

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -151,7 +151,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'title'       => __( 'Customer bank statement', 'woocommerce-payments' ),
 				'description' => WC_Payments_Utils::esc_interpolated_html(
 					__( 'Edit the way your store name appears on your customers’ bank statements (read more about requirements <a>here</a>).', 'woocommerce-payments' ),
-					[ 'a' => '<a href="https://docs.woocommerce.com/document/payments/bank-statement-descriptor/" target="_blank" rel="noopener noreferrer">' ]
+					[ 'a' => '<a href="https://woocommerce.com/document/payments/bank-statement-descriptor/" target="_blank" rel="noopener noreferrer">' ]
 				),
 			],
 			'manual_capture'                   => [
@@ -779,7 +779,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 						__( '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC, or any test card numbers listed <a>here</a>.', 'woocommerce-payments' ),
 						[
 							'strong' => '<strong>',
-							'a'      => '<a href="https://docs.woocommerce.com/document/payments/testing/#test-cards" target="_blank">',
+							'a'      => '<a href="https://woocommerce.com/document/payments/testing/#test-cards" target="_blank">',
 						]
 					);
 				?>

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -213,7 +213,7 @@ class WC_Payments_Utils {
 
 	/**
 	 * List of countries enabled for Stripe platform account. See also
-	 * https://docs.woocommerce.com/document/payments/countries/ for the most actual status.
+	 * https://woocommerce.com/document/payments/countries/ for the most actual status.
 	 *
 	 * @return string[]
 	 */

--- a/includes/multi-currency/SettingsOnboardCta.php
+++ b/includes/multi-currency/SettingsOnboardCta.php
@@ -18,7 +18,7 @@ class SettingsOnboardCta extends \WC_Settings_Page {
 	 *
 	 * @var string
 	 */
-	const LEARN_MORE_URL = 'https://docs.woocommerce.com/document/payments/currencies/multi-currency-setup/';
+	const LEARN_MORE_URL = 'https://woocommerce.com/document/payments/currencies/multi-currency-setup/';
 
 	/**
 	 * Constructor.

--- a/includes/notes/class-wc-payments-notes-additional-payment-methods.php
+++ b/includes/notes/class-wc-payments-notes-additional-payment-methods.php
@@ -63,7 +63,7 @@ class WC_Payments_Notes_Additional_Payment_Methods {
 		$note       = new $note_class();
 
 		$note->set_title( __( 'Boost your sales by accepting new payment methods', 'woocommerce-payments' ) );
-		$note->set_content( __( 'Get early access to additional payment methods and an improved checkout experience, coming soon to WooCommerce Payments. <a href="https://docs.woocommerce.com/document/payments/additional-payment-methods/" target="wcpay_upe_learn_more">Learn more</a>', 'woocommerce-payments' ) );
+		$note->set_content( __( 'Get early access to additional payment methods and an improved checkout experience, coming soon to WooCommerce Payments. <a href="https://woocommerce.com/document/payments/additional-payment-methods/" target="wcpay_upe_learn_more">Learn more</a>', 'woocommerce-payments' ) );
 		$note->set_content_data( (object) [] );
 		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );

--- a/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
+++ b/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
@@ -31,7 +31,7 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 		$note->set_content(
 			WC_Payments_Utils::esc_interpolated_html(
 				__( "Get immediate access to your funds when you need them – including nights, weekends, and holidays. With WooCommerce Payments' <a>Instant Deposits feature</a>, you're able to transfer your earnings to a debit card within minutes.", 'woocommerce-payments' ),
-				[ 'a' => '<a href="https://docs.woocommerce.com/document/payments/instant-deposits/">' ]
+				[ 'a' => '<a href="https://woocommerce.com/document/payments/instant-deposits/">' ]
 			)
 		);
 		$note->set_content_data( (object) [] );
@@ -41,7 +41,7 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 		$note->add_action(
 			self::NOTE_NAME,
 			__( 'Request an instant deposit', 'woocommerce-payments' ),
-			'https://docs.woocommerce.com/document/payments/instant-deposits/#section-2',
+			'https://woocommerce.com/document/payments/instant-deposits/#section-2',
 			'unactioned',
 			true
 		);

--- a/includes/notes/class-wc-payments-notes-set-https-for-checkout.php
+++ b/includes/notes/class-wc-payments-notes-set-https-for-checkout.php
@@ -25,7 +25,7 @@ class WC_Payments_Notes_Set_Https_For_Checkout {
 	/**
 	 * Name of the note for use in the database.
 	 */
-	const NOTE_DOCUMENTATION_URL = 'https://docs.woocommerce.com/document/ssl-and-https/#section-7';
+	const NOTE_DOCUMENTATION_URL = 'https://woocommerce.com/document/ssl-and-https/#section-7';
 
 	/**
 	 * Checks if a note can and should be added.

--- a/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
+++ b/includes/notes/class-wc-payments-notes-set-up-refund-policy.php
@@ -23,7 +23,7 @@ class WC_Payments_Notes_Set_Up_Refund_Policy {
 	/**
 	 * Name of the note for use in the database.
 	 */
-	const NOTE_DOCUMENTATION_URL = 'https://docs.woocommerce.com/document/woocommerce-refunds#refund-policy-howto';
+	const NOTE_DOCUMENTATION_URL = 'https://woocommerce.com/document/woocommerce-refunds#refund-policy-howto';
 
 	/**
 	 * Get the note.

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -726,7 +726,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 						__( '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a>here</a>.', 'woocommerce-payments' ),
 						[
 							'strong' => '<strong>',
-							'a'      => '<a href="https://docs.woocommerce.com/document/payments/testing/#test-cards" target="_blank">',
+							'a'      => '<a href="https://woocommerce.com/document/payments/testing/#test-cards" target="_blank">',
 						]
 					);
 				?>

--- a/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
+++ b/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
@@ -33,9 +33,9 @@
 								esc_html__( 'Existing subscriptions will %1$s%3$srenew manually%4$s%2$s - subscribers will need to log in to pay for renewal. Access to premium features will also be removed. %5$sLearn more.%4$s', 'woocommerce-payments' ),
 								'<strong>',
 								'</strong>',
-								'<a href="https://docs.woocommerce.com/document/subscriptions/renewal-process/#section-4">',
+								'<a href="https://woocommerce.com/document/subscriptions/renewal-process/#section-4">',
 								'</a>',
-								'<a href="http://docs.woocommerce.com/document/subscriptions/deactivation/">'
+								'<a href="http://woocommerce.com/document/subscriptions/deactivation/">'
 							);
 							?>
 					</p>

--- a/readme.txt
+++ b/readme.txt
@@ -22,13 +22,13 @@ See payments, track cash flow into your bank account, manage refunds, and stay o
 
 Features previously only available on your payment provider’s website are now part of your store’s **integrated payments dashboard**. This enables you to:
 
-- View the details of [payments, refunds, and other transactions](https://docs.woocommerce.com/document/payments/#section-4).
-- View and respond to [disputes and chargebacks](https://docs.woocommerce.com/document/payments/disputes/).
-- [Track deposits](https://docs.woocommerce.com/document/payments/#section-5) into your bank account or debit card.
+- View the details of [payments, refunds, and other transactions](https://woocommerce.com/document/payments/#section-4).
+- View and respond to [disputes and chargebacks](https://woocommerce.com/document/payments/disputes/).
+- [Track deposits](https://woocommerce.com/document/payments/#section-5) into your bank account or debit card.
 
 **Pay as you go**
 
-WooCommerce Payments is **free to install**, with **no setup fees or monthly fees**. Pay-as-you-go fees start at 2.9% + $0.30 per transaction for U.S.-issued cards. [Read more about transaction fees](https://docs.woocommerce.com/document/payments/faq/fees/).
+WooCommerce Payments is **free to install**, with **no setup fees or monthly fees**. Pay-as-you-go fees start at 2.9% + $0.30 per transaction for U.S.-issued cards. [Read more about transaction fees](https://woocommerce.com/document/payments/faq/fees/).
 
 **Supported by the WooCommerce team**
 
@@ -56,7 +56,7 @@ Install and activate the WooCommerce and WooCommerce Payments plugins, if you ha
 
 = What countries and currencies are supported? =
 
-If you are an individual or business based in [one of these countries](https://docs.woocommerce.com/document/payments/countries/#section-1), you can sign-up with WooCommerce Payments. After completing sign up, you can accept payments from customers anywhere in the world.
+If you are an individual or business based in [one of these countries](https://woocommerce.com/document/payments/countries/#section-1), you can sign-up with WooCommerce Payments. After completing sign up, you can accept payments from customers anywhere in the world.
 
 We are actively planning to expand into additional countries based on your interest. Let us know where you would like to [see WooCommerce Payments launch next](https://woocommerce.com/payments/#request-invite).
 
@@ -66,15 +66,15 @@ WooCommerce Payments uses the WordPress.com connection to authenticate each requ
 
 = How do I set up a store for a client? =
 
-If you are setting up a store that will process real payments, have the site owner complete the WooCommerce Payments setup. This ensures that the correct business details are set on the account during [onboarding](https://docs.woocommerce.com/document/payments/#section-3).
+If you are setting up a store that will process real payments, have the site owner complete the WooCommerce Payments setup. This ensures that the correct business details are set on the account during [onboarding](https://woocommerce.com/document/payments/#section-3).
 
-After the store setup has been completed, you can use [Test Mode](https://docs.woocommerce.com/document/payments/testing/) to simulate payments, refunds, and disputes.
+After the store setup has been completed, you can use [Test Mode](https://woocommerce.com/document/payments/testing/) to simulate payments, refunds, and disputes.
 
-If you are setting up WooCommerce Payments on a development or test site that will **never need to process real payments**, try [Dev Mode](https://docs.woocommerce.com/document/payments/testing/dev-mode/#section-1).
+If you are setting up WooCommerce Payments on a development or test site that will **never need to process real payments**, try [Dev Mode](https://woocommerce.com/document/payments/testing/dev-mode/#section-1).
 
 = How is WooCommerce Payments related to Stripe? =
 
-WooCommerce Payments is proudly powered by [Stripe](https://stripe.com/). When you sign up for WooCommerce Payments, your personal and business information is verified with Stripe and stored in an account connected to the WooCommerce Payments service. This account is then used in the background for managing your business account information and activity via WooCommerce Payments. [Learn more](https://docs.woocommerce.com/document/payments/powered-by-stripe/).
+WooCommerce Payments is proudly powered by [Stripe](https://stripe.com/). When you sign up for WooCommerce Payments, your personal and business information is verified with Stripe and stored in an account connected to the WooCommerce Payments service. This account is then used in the background for managing your business account information and activity via WooCommerce Payments. [Learn more](https://woocommerce.com/document/payments/powered-by-stripe/).
 
 = Are there Terms of Service and data usage policies? =
 

--- a/tests/unit/notes/test-class-wc-payments-notes-additional-payment-methods.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-additional-payment-methods.php
@@ -28,7 +28,7 @@ class WC_Payments_Notes_Additional_Payment_Methods_Test extends WP_UnitTestCase 
 		$note = WC_Payments_Notes_Additional_Payment_Methods::get_note();
 
 		$this->assertSame( 'Boost your sales by accepting new payment methods', $note->get_title() );
-		$this->assertSame( 'Get early access to additional payment methods and an improved checkout experience, coming soon to WooCommerce Payments. <a href="https://docs.woocommerce.com/document/payments/additional-payment-methods/" target="wcpay_upe_learn_more">Learn more</a>', $note->get_content() );
+		$this->assertSame( 'Get early access to additional payment methods and an improved checkout experience, coming soon to WooCommerce Payments. <a href="https://woocommerce.com/document/payments/additional-payment-methods/" target="wcpay_upe_learn_more">Learn more</a>', $note->get_content() );
 		$this->assertSame( 'info', $note->get_type() );
 		$this->assertSame( 'wc-payments-notes-additional-payment-methods', $note->get_name() );
 		$this->assertSame( 'woocommerce-payments', $note->get_source() );


### PR DESCRIPTION
Fixes #3294

#### Changes proposed in this Pull Request

Changed  links like docs.woocommerce.com to woocommerce.com
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
