### PR TITLE
Run E2E Tests with every push to trunk/develop + manual trigger

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - develop
       - trunk
+  workflow_dispatch:
 
 env:
   E2E_GH_TOKEN:                                ${{ secrets.E2E_GH_TOKEN }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
       - trunk
+  push:
+    branches:
+      - develop
+      - trunk
 
 env:
   E2E_GH_TOKEN:                                ${{ secrets.E2E_GH_TOKEN }}


### PR DESCRIPTION
Fixes #3306 

#### Changes proposed in this Pull Request

The PR enables E2E tests to be run with each push / PR merge to trunk/develop. This would help to identify which PR is breaking the E2E tests.

Additionally, I've added the `workflow_dispatch` event which allows manually triggering E2E test from the repo `Actions` against a specific branch.

#### Testing instructions

No pre-merge test instructions. 

Post-merge: 
* Confirm that the tests are ran with every PR merge/push to trunk/develop. 
* Confirm that the tests can be triggered against a specific branch via repo `Actions`

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
