### PR TITLE
Fix error where url parameters would get cleared on order-pay page if currency switcher block used.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix - Display risk for payment methods without risk assessment
 * Fix - Use configured domain instead of current domain for Apple Pay verification.
 * Fix - Fatal error when deactivating the WooCommerce plugin when WCPay Subscriptions is enabled.
+* Fix - Error where url parameters would get cleared on order-pay page if currency switcher block used.
 
 = 3.2.3 - 2021-11-01 =
 * Fix - Card fields on checkout not shown when the 'Enable payments via saved cards' setting is disabled.

--- a/includes/multi-currency/CurrencySwitcherBlock.php
+++ b/includes/multi-currency/CurrencySwitcherBlock.php
@@ -142,6 +142,7 @@ class CurrencySwitcherBlock {
 		$select_styles = $this->implode_styles_array( $styles['select'] );
 
 		$widget_content  = '<form>';
+		$widget_content .= $this->get_get_params();
 		$widget_content .= '<div class="currency-switcher-holder" style="' . $div_styles . '">';
 		$widget_content .= '<select name="currency" onchange="this.form.submit()" style="' . $select_styles . '">';
 
@@ -216,5 +217,31 @@ class CurrencySwitcherBlock {
 				'background-color' => $block_attributes['backgroundColor'] ?? '#000000',
 			],
 		];
+	}
+
+	/**
+	 * Get hidden inputs for every $_GET param.
+	 * This prevents the switcher form to remove them on submit.
+	 *
+	 * @return void
+	 */
+	private function get_get_params() {
+		// phpcs:disable WordPress.Security.NonceVerification
+		if ( empty( $_GET ) ) {
+			return;
+		}
+		$params = explode( '&', urldecode( http_build_query( $_GET ) ) );
+		$return = '';
+		foreach ( $params as $param ) {
+			$name_value = explode( '=', $param );
+			$name       = $name_value[0];
+			$value      = $name_value[1];
+			if ( 'currency' === $name ) {
+				continue;
+			}
+			$return .= '<input type="hidden" name="' . esc_attr( $name ) . '" value="' . esc_attr( $value ) . '" />';
+		}
+		return $return;
+		// phpcs:enable WordPress.Security.NonceVerification
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Display risk for payment methods without risk assessment
 * Fix - Use configured domain instead of current domain for Apple Pay verification.
 * Fix - Fatal error when deactivating the WooCommerce plugin when WCPay Subscriptions is enabled.
+* Fix - Error where url parameters would get cleared on order-pay page if currency switcher block used.
 
 = 3.2.3 - 2021-11-01 =
 * Fix - Card fields on checkout not shown when the 'Enable payments via saved cards' setting is disabled.

--- a/tests/unit/multi-currency/test-class-currency-switcher-block.php
+++ b/tests/unit/multi-currency/test-class-currency-switcher-block.php
@@ -168,4 +168,32 @@ class WCPay_Multi_Currency_Currency_Switcher_Block_Tests extends WP_UnitTestCase
 			],
 		];
 	}
+
+	public function test_widget_renders_hidden_input() {
+		$_GET       = [
+			'test_name'  => 'test_value',
+			'test_array' => [ 0 => [ 0 => 'test_array_value' ] ],
+			'named_key'  => [ 'key' => 'value' ],
+		];
+		$attributes = [
+			[
+				'symbol' => false,
+				'flag'   => true,
+			],
+			false,
+		];
+
+		$this->mock_compatibility->expects( $this->once() )
+			->method( 'should_hide_widgets' )
+			->willReturn( false );
+
+		$this->mock_multi_currency->expects( $this->once() )
+			->method( 'get_enabled_currencies' )
+			->willReturn( $this->mock_currencies );
+
+		$result = $this->currency_switcher_block->render_block_widget( $attributes, '' );
+		$this->assertStringContainsString( '<input type="hidden" name="test_name" value="test_value" />', $result );
+		$this->assertStringContainsString( '<input type="hidden" name="test_array[0][0]" value="test_array_value" />', $result );
+		$this->assertStringContainsString( '<input type="hidden" name="named_key[key]" value="value" />', $result );
+	}
 }


### PR DESCRIPTION
Fixes #3317

#### Changes proposed in this Pull Request

* Copy method over from legacy currency switcher that gets the _GET params and adds them to the switcher form. 

#### Testing instructions

1. Add item to cart and proceed to checkout.
2. Use 4000000000000002 with any future expiration and cvv.
3. After order fails, go to My Account > Orders, and click to pay the order.
4. Change the currency via the block widget, order currency should remain the same, and no error should be received.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
