### PR TITLE
Fix currency format on order-pay page if currency was changed via switcher

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix - Display risk for payment methods without risk assessment
 * Fix - Use configured domain instead of current domain for Apple Pay verification.
 * Fix - Fatal error when deactivating the WooCommerce plugin when WCPay Subscriptions is enabled.
+* Fix - Currency format on order-pay page if currency was changed via switcher.
 
 = 3.2.3 - 2021-11-01 =
 * Fix - Card fields on checkout not shown when the 'Enable payments via saved cards' setting is disabled.

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -223,7 +223,9 @@ class FrontendCurrencies {
 	 */
 	public function init_order_currency_from_query_vars() {
 		global $wp;
-		$this->init_order_currency( $wp->query_vars['order-pay'] );
+		if ( ! empty( $wp->query_vars['order-pay'] ) ) {
+			$this->init_order_currency( $wp->query_vars['order-pay'] );
+		}
 	}
 
 	/**

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -80,6 +80,7 @@ class FrontendCurrencies {
 			add_filter( 'wc_get_price_decimal_separator', [ $this, 'get_price_decimal_separator' ], 50 );
 			add_filter( 'wc_get_price_thousand_separator', [ $this, 'get_price_thousand_separator' ], 50 );
 			add_filter( 'woocommerce_price_format', [ $this, 'get_woocommerce_price_format' ], 50 );
+			add_action( 'before_woocommerce_pay', [ $this, 'init_order_currency_from_query_vars' ] );
 		}
 
 		add_filter( 'woocommerce_thankyou_order_id', [ $this, 'init_order_currency' ] );
@@ -216,6 +217,16 @@ class FrontendCurrencies {
 	}
 
 	/**
+	 * Gets the order id from the wp query_vars and then calls init_order_currency.
+	 *
+	 * @return void
+	 */
+	public function init_order_currency_from_query_vars() {
+		global $wp;
+		$this->init_order_currency( $wp->query_vars['order-pay'] );
+	}
+
+	/**
 	 * Fixes the decimals for the store currency when shipping rates are being determined.
 	 * Our `wc_get_price_decimals` filter returns the decimals for the selected currency during this calculation, which leads to incorrect results.
 	 *
@@ -251,6 +262,7 @@ class FrontendCurrencies {
 			[
 				'WC_Shortcode_My_Account::view_order',
 				'WC_Shortcode_Checkout::order_received',
+				'WC_Shortcode_Checkout::order_pay',
 			]
 		);
 	}

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -237,13 +237,14 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	 * @return array
 	 */
 	public function create_payment_intent( $order_id = null ) {
-		$amount = WC()->cart->get_total( false );
-		$order  = wc_get_order( $order_id );
+		$amount   = WC()->cart->get_total( false );
+		$currency = get_woocommerce_currency();
+		$order    = wc_get_order( $order_id );
 		if ( is_a( $order, 'WC_Order' ) ) {
-			$amount = $order->get_total();
+			$amount   = $order->get_total();
+			$currency = $order->get_currency();
 		}
 
-		$currency         = get_woocommerce_currency();
 		$converted_amount = WC_Payments_Utils::prepare_amount( $amount, $currency );
 		if ( 1 > $converted_amount ) {
 			return $this->create_setup_intent();

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Display risk for payment methods without risk assessment
 * Fix - Use configured domain instead of current domain for Apple Pay verification.
 * Fix - Fatal error when deactivating the WooCommerce plugin when WCPay Subscriptions is enabled.
+* Fix - Currency format on order-pay page if currency was changed via switcher.
 
 = 3.2.3 - 2021-11-01 =
 * Fix - Card fields on checkout not shown when the 'Enable payments via saved cards' setting is disabled.


### PR DESCRIPTION
Fixes #3318

#### Changes proposed in this Pull Request

* Add action to `before_woocommerce_pay` so that `init_order_currency_from_query_vars` will be called in order to initialize the `order_currency` for us to use.
* Set `WC_Shortcode_Checkout::order_pay` as another backtrace call that should cause the currency to be overridden. This then allows us to use the `order_currency` property set.
* Update `create_payment_intent` to get the order currency instead of the selected currency if an order is passed. 

#### Testing instructions

1. Add item to cart and proceed to checkout using USD.
2. Use 4000000000000002 with any future expiration and cvv.
3. After order fails, go to My Account > Orders, and click to pay the order.
4. Change the currency via the (legacy) widget and change the currency to GBP or JPY.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
