### PR TITLE
Fix UPE gateway remount

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@
 * Fix - Do not create WooCommerce Payments Subscriptions when using payment methods other than WooCommerce Payments.
 * Fix - Prevent a race condition leading to duplicate order paid statuses transitions.
 * Fix - 'payment_intent not found' errors when attempting to process the first invoice for a subscription.
+* Fix - UPE element not remounting on checkout update
 
 = 3.2.3 - 2021-11-01 =
 * Fix - Card fields on checkout not shown when the 'Enable payments via saved cards' setting is disabled.

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -378,11 +378,14 @@ jQuery( function ( $ ) {
 		if (
 			$( '#wcpay-upe-element' ).length &&
 			! $( '#wcpay-upe-element' ).children().length &&
-			isUPEEnabled &&
-			! upeElement
+			isUPEEnabled
 		) {
+			if ( upeElement ) {
+				upeElement.mount( '#wcpay-upe-element' );
+			} else {
+				mountUPEElement();
+			}
 			renameGatewayTitle();
-			mountUPEElement();
 		}
 	} );
 

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Do not create WooCommerce Payments Subscriptions when using payment methods other than WooCommerce Payments.
 * Fix - Prevent a race condition leading to duplicate order paid statuses transitions.
 * Fix - 'payment_intent not found' errors when attempting to process the first invoice for a subscription.
+* Fix - UPE element not remounting on checkout update
 
 = 3.2.3 - 2021-11-01 =
 * Fix - Card fields on checkout not shown when the 'Enable payments via saved cards' setting is disabled.


### PR DESCRIPTION
Fix for https://github.com/Automattic/woocommerce-payments/issues/2891#issuecomment-939525387

#### Changes proposed in this Pull Request
Remount UPE element on `updated_checkout` event if it's enabled but not mounted. Until now we were only mounting it the first time. But it causes issues with plugins like [Extra Fees for WooCommerce](https://woocommerce.com/products/extra-fees-for-woocommerce/) that triggers a `update_checkout` event. And ensure that the `renameGatewayTitle` method is called in both cases.

#### Testing instructions
- Having UPE checkout enabled.
- Go to checkout, wait until it load and select another payment gateway.
- Run `jQuery( 'body' ).trigger( 'update_checkout' );` to simulate the plugin behaviour.
- Select WC Pay again, it should load the UPE element and the title should still be the same non `WooCommerce Payments`.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
