### PR TITLE
Display an admin notice when assets have not been built

### DIFF
--- a/includes/class-wc-payments-dependency-service.php
+++ b/includes/class-wc-payments-dependency-service.php
@@ -310,7 +310,7 @@ class WC_Payments_Dependency_Service {
 	 */
 	private static function is_at_plugin_install_page() {
 		$cur_screen = get_current_screen();
-		return 'update' === $cur_screen->id && 'plugins' === $cur_screen->parent_base;
+		return $cur_screen && 'update' === $cur_screen->id && 'plugins' === $cur_screen->parent_base;
 	}
 
 	/**

--- a/includes/class-wc-payments-dependency-service.php
+++ b/includes/class-wc-payments-dependency-service.php
@@ -20,6 +20,7 @@ class WC_Payments_Dependency_Service {
 	const WOOADMIN_NOT_FOUND    = 'wc_admin_not_found';
 	const WOOADMIN_INCOMPATIBLE = 'wc_admin_outdated';
 	const WP_INCOMPATIBLE       = 'wp_outdated';
+	const DEV_ASSETS_NOT_BUILT  = 'dev_assets_not_built';
 
 	/**
 	 * Constructor.
@@ -54,6 +55,11 @@ class WC_Payments_Dependency_Service {
 		// Do not show alerts while installing plugins.
 		if ( self::is_at_plugin_install_page() ) {
 			return;
+		}
+
+		// Show a message when assets are not built in a dev build.
+		if ( ! $this->are_assets_built() ) {
+			WC_Payments::display_admin_error( $this->get_notice_for_invalid_dependency( self::DEV_ASSETS_NOT_BUILT ) );
 		}
 
 		$invalid_dependencies = $this->get_invalid_dependencies();
@@ -166,6 +172,15 @@ class WC_Payments_Dependency_Service {
 	}
 
 	/**
+	 * Checks some of the asset files to confirm scripts and styles have been correctly built.
+	 *
+	 * @return bool TRUE if assets have been built or FALSE otherwise.
+	 */
+	public function are_assets_built() {
+		return ( file_exists( WCPAY_ABSPATH . 'dist/index.js' ) && file_exists( WCPAY_ABSPATH . 'dist/index.css' ) );
+	}
+
+	/**
 	 * Get the error constant of an invalid dependency, and transforms it into HTML to be used in an Admin Notice.
 	 *
 	 * @param string $code - invalid dependency constant.
@@ -269,6 +284,19 @@ class WC_Payments_Dependency_Service {
 				if ( current_user_can( 'update_core' ) ) {
 					$error_message .= ' <a href="' . admin_url( 'update-core.php' ) . '">' . __( 'Update WordPress', 'woocommerce-payments' ) . '</a>';
 				}
+				break;
+			case self::DEV_ASSETS_NOT_BUILT:
+				$error_message = WC_Payments_Utils::esc_interpolated_html(
+					__(
+						'You have installed a development version of WooCommerce Payments which requires files to be built. From the plugin directory, run <code>npm run build:client</code> to build and minify assets. Alternatively, you can download a pre-built version of the plugin from the <a1>WordPress.org repository</a1> or by visiting the <a2>releases page in the GitHub repository</a2>.',
+						'woocommerce-payments'
+					),
+					[
+						'code' => '<code>',
+						'a1'   => '<a href="https://wordpress.org/plugins/woocommerce-payments/">',
+						'a2'   => '<a href="https://github.com/automattic/woocommerce-payments/releases/">',
+					]
+				);
 				break;
 		}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -666,7 +666,7 @@ class WC_Payments {
 	 * @return string The cache buster value to use for the given file.
 	 */
 	public static function get_file_version( $file ) {
-		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG && file_exists( WCPAY_ABSPATH . $file ) ) {
 			$file = trim( $file, '/' );
 			return filemtime( WCPAY_ABSPATH . $file );
 		}

--- a/tests/unit/test-class-wc-payments-dependency-service.php
+++ b/tests/unit/test-class-wc-payments-dependency-service.php
@@ -87,4 +87,26 @@ class WC_Payments_Dependency_Service_Test extends WP_UnitTestCase {
 
 	}
 
+	public function test_display_admin_notices_assets_not_built() {
+		// Create a partial mock, leaving out the method under test.
+		$dependency_service = $this->getMockBuilder( WC_Payments_Dependency_Service::class )
+			->setConstructorArgs( [] )
+			->setMethodsExcept( [ 'display_admin_notices' ] )
+			->getMock();
+
+		$dependency_service
+			->expects( $this->once() )
+			->method( 'are_assets_built' )
+			->willReturn( false );
+
+		// Call the unmocked method.
+		ob_start();
+		$dependency_service->display_admin_notices();
+		$result = ob_get_clean();
+
+		// Perform assertions...
+		$this->assertIsString( $result );
+		$this->assertStringContainsStringIgnoringCase( 'You have installed a development version of WooCommerce Payments which requires files to be built', $result );
+	}
+
 }


### PR DESCRIPTION
Fixes #58.

#### Changes proposed in this Pull Request
- Adds an admin notice similar to the one WooCommerce has when assets have not been built, reminding devs to manually run the relevant `npm` command.
- Adds some checks to avoid PHP warnings that can occur when assets have not been built or when testing `WC_Payments_Dependency_Service` in isolation.

#### Testing instructions
1. Check out `develop`.
1. Manually remove `dist/index.js` or `dist/index.css` from your local copy of the repo.
1. Visit a page on the backend and confirm that various PHP warnings are logged because the WC Pay assets don't exist.
1. Check out this branch.
1. Visit a backend page.
1. Confirm that the PHP warnings are no longer logged/triggered.
1. You should see an admin notice indicating that assets need to be built:
   <img width="1157" alt="Screen Shot 2021-11-09 at 15 54 17" src="https://user-images.githubusercontent.com/184724/141003033-69b9e421-2bbb-423d-8bbf-544b1d20e13d.png">
1. Build the assets by running `npm run build:client`.
1. Confirm that the admin notice no longer appears on backend pages.

#### Questions/TODO
Not sure if [`WC_Payments_Dependency_Service`](https://github.com/Automattic/woocommerce-payments/blob/1caefac6d1a5cf58f5ff455f89cc4ef21bdecddc/includes/class-wc-payments-dependency-service.php#L16) was the best place for this code to be added, so feel free to suggest a different location. I chose it because this is kind of a "dev" dependency and also because this class already handles some admin notices. The only difference between this new check and checks for other (runtime) dependencies in this class is that this warning is independent from the others and [doesn't prevent WC Pay from loading](https://github.com/Automattic/woocommerce-payments/blob/1caefac6d1a5cf58f5ff455f89cc4ef21bdecddc/includes/class-wc-payments.php#L170).

-------------------

- [X] Added changelog entry (or does not apply)
- [X] Covered with tests (or have a good reason not to test in description ☝️)
- [X] Tested on mobile (or does not apply)
