### PR TITLE
Update the subscription fee label in the transaction timeline.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 3.3.0 - 2021-xx-xx =
 * Update - Updated @woocommerce/components to remove ' from negative numbers on csv files
 * Update - Avoid having invalid intervals (greater than 1 year) in subscription products.
+* Update - The subscription fee label in the transaction timeline.
 * Add - Add compatibility between Multi-Currency and WooCommerce Bookings.
 * Fix - Do not show default currency selector on Account Details page when only one currency is available.
 * Add - Add filters to disable or filter Multi-Currency sql query clauses for analytics.

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -323,12 +323,12 @@ const feeBreakdown = ( event ) => {
 			0 !== fixedRate
 				? __(
 						/* translators: %1$s% is the fee amount and %2$s is the fixed rate */
-						'Recurring transaction fee: %1$s%% + %2$s',
+						'Subscription transaction fee: %1$s%% + %2$s',
 						'woocommerce-payments'
 				  )
 				: __(
 						/* translators: %1$s% is the fee amount */
-						'Recurring transaction fee: %1$s%%',
+						'Subscription transaction fee: %1$s%%',
 						'woocommerce-payments'
 				  ),
 		discount: __( 'Discount', 'woocommerce-payments' ),

--- a/client/payment-details/timeline/test/__snapshots__/index.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/index.js.snap
@@ -1437,7 +1437,7 @@ exports[`PaymentDetailsTimeline renders subscription fee correctly 1`] = `
                         Base fee: 2.9% + $0.30
                       </li>
                       <li>
-                        Recurring transaction fee: 1%
+                        Subscription transaction fee: 1%
                       </li>
                        
                     </ul>

--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 3.3.0 - 2021-xx-xx =
 * Update - Updated @woocommerce/components to remove ' from negative numbers on csv files
+* Update - The subscription fee label in the transaction timeline.
 * Add - Add compatibility between Multi-Currency and WooCommerce Bookings.
 * Add - Add filters to disable or filter Multi-Currency sql query clauses for analytics.
 * Fix - Display risk for payment methods without risk assessment


### PR DESCRIPTION
Fixes #3298

#### Changes proposed in this Pull Request

Updates the subscription fee label in the transaction timeline from "Recurring transaction fee" to "Subscription transaction fee" to better reflect that it is not applied only to recurring payments.

| Before | After |
| -- | -- |
| <img width="446" alt="Screen Shot 2021-11-10 at 4 34 28 pm" src="https://user-images.githubusercontent.com/1527164/141056606-6dd20893-b585-47f9-85c5-e0ba124f5689.png"> | <img width="440" alt="Screen Shot 2021-11-10 at 4 35 06 pm" src="https://user-images.githubusercontent.com/1527164/141056658-7adc3ede-5b81-4626-8ee8-3ae54ab746bc.png">  |

#### Testing instructions

* WC Subscriptions is **not** installed.
* As a merchant, create a simple subscription product.
* As a shopper, purchase that subscription product.
* Navigate to **Payments → Transactions**.
* Open the most recent transaction.
* Observe the transaction timeline contains a fee that reads "Subscription transaction fee".

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
