### PR TITLE
Validate product data and subscription price data before sending requests to server

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@
 * Fix - Prevent a race condition leading to duplicate order paid statuses transitions.
 * Fix - 'payment_intent not found' errors when attempting to process the first invoice for a subscription.
 * Fix - UPE element not remounting on checkout update
+* Fix - Validate subscription product create and update args before submitting them to server.
 
 = 3.2.3 - 2021-11-01 =
 * Fix - Card fields on checkout not shown when the 'Enable payments via saved cards' setting is disabled.

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -679,11 +679,12 @@ class WC_Payments_Product_Service {
 				}
 
 				// Now that the price has been archived, delete the record of it.
-				$product->delete_meta_data( self::PRICE_HASH_KEY );
 				$product->delete_meta_data( $price_id_meta_key );
-				$product->save();
 			}
 		}
+
+		$product->delete_meta_data( self::PRICE_HASH_KEY );
+		$product->save();
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -636,7 +636,7 @@ class WC_Payments_Product_Service {
 	 * @param int    $interval Cycle interval.
 	 * @return boolean
 	 */
-	private function is_valid_billing_cycle( $period, $interval ) {
+	public function is_valid_billing_cycle( $period, $interval ) {
 		$interval_limit = $this->get_period_interval_limit( $period );
 
 		// A cycle is valid when we have a defined limit, and the given interval isn't 0 nor greater than the limit.

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -395,6 +395,22 @@ class WC_Payments_Product_Service {
 	}
 
 	/**
+	 * Archives a WC Pay price object.
+	 *
+	 * @param string    $wcpay_price_id The price object's ID to archive.
+	 * @param bool|null $test_mode      Is WC Pay in test/dev mode.
+	 */
+	public function archive_price( string $wcpay_price_id, $test_mode = null ) {
+		$data = [ 'active' => 'false' ];
+
+		if ( null !== $test_mode ) {
+			$data['test_mode'] = $test_mode;
+		}
+
+		$this->payments_api_client->update_price( $wcpay_price_id, $data );
+	}
+
+	/**
 	 * Prevents the subscription interval to be greater than 1 for yearly subscriptions.
 	 *
 	 * @param int $product_id Post ID of the product.
@@ -578,6 +594,18 @@ class WC_Payments_Product_Service {
 	}
 
 	/**
+	 * Returns the name of the price id option meta, taking test mode into account.
+	 *
+	 * @param bool|null $test_mode Is WC Pay in test/dev mode.
+	 *
+	 * @return string The price hash option name.
+	 */
+	public static function get_wcpay_price_id_option( $test_mode = null ) : string {
+		$test_mode = null === $test_mode ? WC_Payments::get_gateway()->is_in_test_mode() : $test_mode;
+		return $test_mode ? self::TEST_PRICE_ID_KEY : self::LIVE_PRICE_ID_KEY;
+	}
+
+	/**
 	 * Gets all WCPay Product IDs linked to a WC Product (live and testmode products).
 	 *
 	 * @param WC_Product $product The product to fetch WCPay product IDs for.
@@ -625,10 +653,6 @@ class WC_Payments_Product_Service {
 	}
 
 	/**
-	 * WCPay Price IDs Functions
-	 */
-
-	/**
 	 * Deletes and archives a product WCPay Price IDs.
 	 *
 	 * @param WC_Product $product The WC Product object to delete and archive the a price IDs.
@@ -653,32 +677,8 @@ class WC_Payments_Product_Service {
 	}
 
 	/**
-	 * Returns the name of the price id option meta, taking test mode into account.
-	 *
-	 * @param bool|null $test_mode Is WC Pay in test/dev mode.
-	 *
-	 * @return string The price hash option name.
+	 * Deprecated functions
 	 */
-	public static function get_wcpay_price_id_option( $test_mode = null ) : string {
-		$test_mode = null === $test_mode ? WC_Payments::get_gateway()->is_in_test_mode() : $test_mode;
-		return $test_mode ? self::TEST_PRICE_ID_KEY : self::LIVE_PRICE_ID_KEY;
-	}
-
-	/**
-	 * Archives a WC Pay price object.
-	 *
-	 * @param string    $wcpay_price_id The price object's ID to archive.
-	 * @param bool|null $test_mode      Is WC Pay in test/dev mode.
-	 */
-	public function archive_price( string $wcpay_price_id, $test_mode = null ) {
-		$data = [ 'active' => 'false' ];
-
-		if ( null !== $test_mode ) {
-			$data['test_mode'] = $test_mode;
-		}
-
-		$this->payments_api_client->update_price( $wcpay_price_id, $data );
-	}
 
 	/**
 	 * Unarchives a WC Pay Price object.

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -634,14 +634,14 @@ class WC_Payments_Product_Service {
 	 * @param WC_Product $product The WC Product object to delete and archive the a price IDs.
 	 */
 	private function delete_all_wcpay_price_ids( $product ) {
-
 		// Delete and archive all price IDs for all environments.
 		foreach ( [ 'test', 'live' ] as $environment ) {
-			$price_id_meta_key = self::get_wcpay_price_id_option( $environment );
+			$test_mode         = 'test' === $environment;
+			$price_id_meta_key = self::get_wcpay_price_id_option( $test_mode );
 
 			if ( $product->meta_exists( $price_id_meta_key ) ) {
 				try {
-					$this->archive_price( $product->get_meta( $price_id_meta_key, true ), $environment );
+					$this->archive_price( $product->get_meta( $price_id_meta_key, true ), $test_mode );
 				} catch ( API_Exception $e ) {
 					Logger::log( 'There was a problem archiving the ' . $environment . 'product price ID in WC Pay: ' . $e->getMessage() );
 				}
@@ -683,10 +683,13 @@ class WC_Payments_Product_Service {
 	/**
 	 * Unarchives a WC Pay Price object.
 	 *
+	 * @deprecated 3.3.0
+	 *
 	 * @param string    $wcpay_price_id The Price object's ID to unarchive.
 	 * @param bool|null $test_mode      Is WC Pay in test/dev mode.
 	 */
 	public function unarchive_price( string $wcpay_price_id, $test_mode = null ) {
+		wc_deprecated_function( __FUNCTION__, '3.3.0' );
 		$data = [ 'active' => 'true' ];
 
 		if ( null !== $test_mode ) {
@@ -699,22 +702,28 @@ class WC_Payments_Product_Service {
 	/**
 	 * Gets the WC Pay price hash associated with a WC product.
 	 *
+	 * @deprecated 3.3.0
+	 *
 	 * @param WC_Product $product The product to get the hash for.
 	 * @return string             The product's price hash or an empty string.
 	 */
 	public static function get_wcpay_price_hash( WC_Product $product ) : string {
+		wc_deprecated_function( __FUNCTION__, '3.3.0' );
 		return $product->get_meta( self::PRICE_HASH_KEY, true );
 	}
 
 	/**
 	 * Gets the WC Pay price ID associated with a WC product.
 	 *
+	 * @deprecated 3.3.0
+	 *
 	 * @param WC_Product $product   The product to get the WC Pay price ID for.
 	 * @param bool|null  $test_mode Is WC Pay in test/dev mode.
 	 *
-	 * @return string             The product's WC Pay price ID or an empty string.
+	 * @return string The product's WC Pay price ID or an empty string.
 	 */
 	public function get_wcpay_price_id( WC_Product $product, $test_mode = null ) : string {
+		wc_deprecated_function( __FUNCTION__, '3.3.0' );
 		$price_id = $product->get_meta( self::get_wcpay_price_id_option( $test_mode ), true );
 
 		// If the subscription product doesn't have a WC Pay price ID, create one now.

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -203,7 +203,7 @@ class WC_Payments_Product_Service {
 	/**
 	 * Schedules a subscription product to be created or updated in WC Pay on shutdown.
 	 *
-	 * @since x.x.x
+	 * @since 3.2.0
 	 *
 	 * @param int $product_id The ID of the product to handle.
 	 */
@@ -237,7 +237,7 @@ class WC_Payments_Product_Service {
 	 *
 	 * Hooked onto shutdown so all products which have been changed in the current request can be updated once.
 	 *
-	 * @since x.x.x
+	 * @since 3.2.0
 	 */
 	public function create_or_update_products() {
 		foreach ( $this->products_to_update as $product_id ) {
@@ -305,7 +305,7 @@ class WC_Payments_Product_Service {
 		$wcpay_product_ids = $this->get_all_wcpay_product_ids( $product );
 		$test_mode         = WC_Payments::get_gateway()->is_in_test_mode();
 
-		// if the current environment doesn't have a product ID, make sure we create one.
+		// If the current environment doesn't have a product ID, make sure we create one.
 		if ( ! isset( $wcpay_product_ids[ $test_mode ? 'test' : 'live' ] ) ) {
 			$this->create_product( $product );
 		}
@@ -355,7 +355,7 @@ class WC_Payments_Product_Service {
 	/**
 	 * Archives a subscription product in WC Pay.
 	 *
-	 * @since x.x.x
+	 * @since 3.2.0
 	 *
 	 * @param int $post_id The ID of the post to handle. Only subscription product IDs will be archived in WC Pay.
 	 */
@@ -372,7 +372,7 @@ class WC_Payments_Product_Service {
 	/**
 	 * Unarchives a subscription product in WC Pay.
 	 *
-	 * @since x.x.x
+	 * @since 3.2.0
 	 *
 	 * @param int $post_id The ID of the post to handle. Only Subscription product post IDs will be unarchived in WC Pay.
 	 */
@@ -643,7 +643,7 @@ class WC_Payments_Product_Service {
 	}
 
 	/**
-	 * Checks if a prouduct needs to be updated in WC Pay.
+	 * Checks if a product needs to be updated in WC Pay.
 	 *
 	 * @param WC_Product $product The product to check updates for.
 	 *
@@ -654,7 +654,7 @@ class WC_Payments_Product_Service {
 	}
 
 	/**
-	 * Checks if a prouduct price needs to be updated in WC Pay.
+	 * Checks if a product price needs to be updated in WC Pay.
 	 *
 	 * @param WC_Product $product The product to check updates for.
 	 *

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -286,7 +286,7 @@ class WC_Payments_Product_Service {
 		$this->remove_product_update_listeners();
 
 		try {
-			// Update all versions of WCPay Products and Prices that need updating.
+			// Update all versions of WCPay Products that need updating.
 			foreach ( $wcpay_product_ids as $environment => $wcpay_product_id ) {
 				$data['test_mode'] = 'live' === $environment ? false : true;
 				$this->payments_api_client->update_product( $wcpay_product_id, $data );
@@ -526,7 +526,7 @@ class WC_Payments_Product_Service {
 	 * Used to compare WC changes with WC Pay data.
 	 *
 	 * @param WC_Product $product The product to generate the hash for.
-	 * @return string             The product's price hash.
+	 * @return string             The product's hash.
 	 */
 	private function get_product_hash( WC_Product $product ) : string {
 		return md5( implode( $this->get_product_data( $product ) ) );
@@ -570,7 +570,7 @@ class WC_Payments_Product_Service {
 	 *
 	 * @param bool|null $test_mode Is WC Pay in test/dev mode.
 	 *
-	 * @return string The price hash option name.
+	 * @return string The WCPay product ID meta key/option name.
 	 */
 	public static function get_wcpay_product_id_option( $test_mode = null ) : string {
 		$test_mode = null === $test_mode ? WC_Payments::get_gateway()->is_in_test_mode() : $test_mode;

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -679,7 +679,9 @@ class WC_Payments_Product_Service {
 				}
 
 				// Now that the price has been archived, delete the record of it.
+				$product->delete_meta_data( self::PRICE_HASH_KEY );
 				$product->delete_meta_data( $price_id_meta_key );
+				$product->save();
 			}
 		}
 	}

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -226,7 +226,7 @@ class WC_Payments_Product_Service {
 				continue;
 			}
 
-			if ( ! self::has_wcpay_product_id( $product_to_update ) || $this->product_needs_update( $product_to_update ) || $this->price_needs_update( $product_to_update ) ) {
+			if ( ! self::has_wcpay_product_id( $product_to_update ) || $this->product_needs_update( $product_to_update ) ) {
 				$this->products_to_update[ $product_to_update->get_id() ] = $product_to_update->get_id();
 			}
 		}

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -418,10 +418,6 @@ class WC_Payments_Product_Service {
 			try {
 				$test_mode = 'live' === $environment ? false : true;
 
-				if ( $this->has_wcpay_price_id( $product ) ) {
-					$this->unarchive_price( $this->get_wcpay_price_id( $product, $test_mode ), $test_mode );
-				}
-
 				$this->payments_api_client->update_product(
 					$wcpay_product_id,
 					[

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -223,15 +223,19 @@ class WC_Payments_Product_Service {
 	 */
 	public function create_product( WC_Product $product ) {
 		try {
-			$product_data  = $this->get_product_data( $product );
+			$product_data = $this->get_product_data( $product );
+
+			// Validate that we have enough data to create the product.
+			$this->validate_product_data( $product_data );
+
 			$wcpay_product = $this->payments_api_client->create_product( $product_data );
 
 			$this->remove_product_update_listeners();
 			$this->set_wcpay_product_hash( $product, $this->get_product_hash( $product ) );
 			$this->set_wcpay_product_id( $product, $wcpay_product['wcpay_product_id'] );
 			$this->add_product_update_listeners();
-		} catch ( API_Exception $e ) {
-			Logger::log( 'There was a problem creating the product in WC Pay: ' . $e->getMessage() );
+		} catch ( \Exception $e ) {
+			Logger::log( sprintf( 'There was a problem creating the product #%s in WC Pay: %s', $product->get_id(), $e->getMessage() ) );
 		}
 	}
 

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -385,7 +385,10 @@ class WC_Payments_Product_Service {
 			try {
 				$test_mode = 'live' === $environment ? false : true;
 
-				$this->archive_price( $this->get_wcpay_price_id( $product, $test_mode ), $test_mode );
+				if ( $this->has_wcpay_price_id( $product ) ) {
+					$this->archive_price( $this->get_wcpay_price_id( $product, $test_mode ), $test_mode );
+				}
+
 				$this->payments_api_client->update_product(
 					$wcpay_product_id,
 					[
@@ -415,7 +418,10 @@ class WC_Payments_Product_Service {
 			try {
 				$test_mode = 'live' === $environment ? false : true;
 
-				$this->unarchive_price( $this->get_wcpay_price_id( $product, $test_mode ), $test_mode );
+				if ( $this->has_wcpay_price_id( $product ) ) {
+					$this->unarchive_price( $this->get_wcpay_price_id( $product, $test_mode ), $test_mode );
+				}
+
 				$this->payments_api_client->update_product(
 					$wcpay_product_id,
 					[
@@ -762,5 +768,15 @@ class WC_Payments_Product_Service {
 		];
 
 		return ! empty( $max_intervals[ $period ] ) ? $max_intervals[ $period ] : false;
+	}
+
+	/**
+	 * Determines if a product has a price ID.
+	 *
+	 * @param WC_Product $product The WC Product object to check for a price ID.
+	 * @return bool Whether the product has a price ID.
+	 */
+	private function has_wcpay_price_id( $product ) {
+		return $product->meta_exists( self::get_wcpay_price_id_option() );
 	}
 }

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -950,9 +950,13 @@ class WC_Payments_Subscription_Service {
 		}
 
 		foreach ( $subscription_data['items'] as $item_data ) {
-			$required_price_keys  = [ 'currency', 'product', 'unit_amount_decimal', 'recurring' ];
+			$required_price_keys  = [ 'currency', 'product', 'recurring' ];
 			$required_period_keys = [ 'interval', 'interval_count' ];
 			$errors               = [];
+
+			if ( ! isset( $item_data['price_data']['unit_amount_decimal'] ) ) {
+				$errors[] = 'unit_amount_decimal';
+			}
 
 			foreach ( $required_price_keys as $required_key ) {
 				if ( empty( $item_data['price_data'][ $required_key ] ) ) {

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -971,7 +971,8 @@ class WC_Payments_Subscription_Service {
 			}
 
 			if ( ! empty( $errors ) ) {
-				throw new Exception( sprintf( 'The "%s" line item properties are required to create the subscription.', implode( '", "', $errors ) ) );
+				$error_message = count( $errors ) > 1 ? 'The "%s" line item properties are required to create the subscription.' : 'The "%s" line item property is required to create the subscription.';
+				throw new Exception( sprintf( $error_message, implode( '", "', $errors ) ) );
 			}
 
 			$billing_period   = $item_data['price_data']['recurring']['interval'];

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -359,7 +359,9 @@ class WC_Payments_Subscription_Service {
 
 		try {
 			$subscription_data = $this->prepare_wcpay_subscription_data( $wcpay_customer_id, $subscription );
-			$response          = $this->payments_api_client->create_subscription( $subscription_data );
+			$this->validate_subscription_data( $subscription_data );
+
+			$response = $this->payments_api_client->create_subscription( $subscription_data );
 
 			$this->set_wcpay_subscription_id( $subscription, $response['id'] );
 			$this->set_wcpay_subscription_item_ids( $subscription, $response['items']['data'] );
@@ -371,8 +373,8 @@ class WC_Payments_Subscription_Service {
 			if ( ! empty( $response['latest_invoice'] ) ) {
 				$this->invoice_service->set_subscription_invoice_id( $subscription, $response['latest_invoice'] );
 			}
-		} catch ( API_Exception $e ) {
-			Logger::log( sprintf( 'There was a problem creating the WCPay subscription %s', $e->getMessage() ) );
+		} catch ( \Exception $e ) {
+			Logger::log( sprintf( 'There was a problem creating the WCPay subscription. %s', $e->getMessage() ) );
 			throw new Exception( $checkout_error_message );
 		}
 	}
@@ -929,5 +931,52 @@ class WC_Payments_Subscription_Service {
 		}
 
 		return $metadata;
+	}
+
+	/**
+	 * Validates that the data used to create the WCPay Subscription.
+	 *
+	 * @param array $subscription_data The data used to create a WCPay subscription.
+	 * @throws Exception If the subscription data contains invalid or missing data.
+	 */
+	private function validate_subscription_data( $subscription_data ) {
+
+		if ( empty( $subscription_data['customer'] ) ) {
+			throw new Exception( 'The "customer" arg is required to create the subscription.' );
+		}
+
+		if ( ! isset( $subscription_data['items'] ) ) {
+			throw new Exception( 'The "items" arg is required to create the subscription.' );
+		}
+
+		foreach ( $subscription_data['items'] as $item_data ) {
+			$required_price_keys  = [ 'currency', 'product', 'unit_amount_decimal', 'recurring' ];
+			$required_period_keys = [ 'interval', 'interval_count' ];
+			$errors               = [];
+
+			foreach ( $required_price_keys as $required_key ) {
+				if ( empty( $item_data['price_data'][ $required_key ] ) ) {
+					$errors[] = $required_key;
+				}
+			}
+
+			foreach ( $required_period_keys as $required_price_key ) {
+				if ( empty( $item_data['price_data']['recurring'][ $required_price_key ] ) ) {
+					$errors[] = $required_price_key;
+				}
+			}
+
+			if ( ! empty( $errors ) ) {
+				throw new Exception( sprintf( 'The "%s" line item properties are required to create the subscription.', implode( '", "', $errors ) ) );
+			}
+
+			$billing_period   = $item_data['price_data']['recurring']['interval'];
+			$billing_interval = $item_data['price_data']['recurring']['interval_count'];
+
+			// Confirm the billing period is valid (no greater than 1 year in length).
+			if ( ! $this->product_service->is_valid_billing_cycle( $billing_period, $billing_interval ) ) {
+				throw new Exception( sprintf( 'The subscription billing period cannot be any longer than one year. A billing period of "every %s %s(s)" was given.', $billing_interval, $billing_period ) );
+			}
+		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Prevent a race condition leading to duplicate order paid statuses transitions.
 * Fix - 'payment_intent not found' errors when attempting to process the first invoice for a subscription.
 * Fix - UPE element not remounting on checkout update
+* Fix - Validate subscription product create and update args as well as subscription item data before submitting them to server.
 
 = 3.2.3 - 2021-11-01 =
 * Fix - Card fields on checkout not shown when the 'Enable payments via saved cards' setting is disabled.

--- a/tests/unit/subscriptions/test-class-wc-payments-product-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-product-service.php
@@ -16,7 +16,7 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 	const LIVE_PRODUCT_ID_KEY = '_wcpay_product_id_live';
 	const TEST_PRODUCT_ID_KEY = '_wcpay_product_id_test';
 	const LIVE_PRICE_ID_KEY   = '_wcpay_product_price_id_live';
-
+	const TEST_PRICE_ID_KEY   = '_wcpay_product_price_id_test';
 	/**
 	 * System under test.
 	 *
@@ -53,18 +53,12 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 		$this->mock_api_client->expects( $this->once() )
 			->method( 'create_product' )
 			->with( $this->get_mock_product_data() )
-			->willReturn(
-				[
-					'wcpay_product_id' => 'prod_test123',
-					'wcpay_price_id'   => 'price_test123',
-				]
-			);
+			->willReturn( [ 'wcpay_product_id' => 'prod_test123' ] );
 
 		$this->mock_get_period( 'month' );
 		$this->mock_get_interval( 3 );
 		$this->product_service->create_product( $this->mock_product );
 		$this->assertEquals( 'prod_test123', $this->mock_product->get_meta( self::LIVE_PRODUCT_ID_KEY, true ) );
-		$this->assertEquals( 'price_test123', $this->mock_product->get_meta( self::LIVE_PRICE_ID_KEY, true ) );
 	}
 
 	/**
@@ -132,23 +126,8 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 	public function test_archive_product() {
 		$this->mock_product->update_meta_data( self::LIVE_PRODUCT_ID_KEY, 'prod_test123' );
 		$this->mock_product->update_meta_data( self::LIVE_PRICE_ID_KEY, 'price_test123' );
+		$this->mock_product->update_meta_data( self::TEST_PRICE_ID_KEY, 'price_test456' );
 		$this->mock_product->save();
-
-		$this->mock_api_client->expects( $this->once() )
-			->method( 'update_price' )
-			->with(
-				'price_test123',
-				[
-					'active'    => 'false',
-					'test_mode' => false,
-				]
-			)
-			->willReturn(
-				[
-					'wcpay_price_id' => 'price_test123',
-					'object'         => 'price',
-				]
-			);
 
 		$this->mock_api_client->expects( $this->once() )
 			->method( 'update_product' )
@@ -166,7 +145,30 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 				]
 			);
 
+		$this->mock_api_client->expects( $this->exactly( 2 ) )
+			->method( 'update_price' )
+			->withConsecutive(
+				[
+					'price_test456',
+					[
+						'active'    => 'false',
+						'test_mode' => true,
+					],
+				],
+				[
+					'price_test123',
+					[
+						'active'    => 'false',
+						'test_mode' => false,
+					],
+				]
+			);
+
 		$this->product_service->archive_product( $this->mock_product );
+
+		// Confirm that the product price IDs have been deleted.
+		$this->assertFalse( $this->mock_product->meta_exists( self::LIVE_PRICE_ID_KEY ) );
+		$this->assertFalse( $this->mock_product->meta_exists( self::LIVE_PRICE_ID_KEY ) );
 	}
 
 	/**
@@ -213,12 +215,8 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 	private function get_mock_product_data( $overrides = [] ) {
 		return array_merge(
 			[
-				'currency'       => 'USD',
-				'description'    => 'Test product description',
-				'name'           => 'Test product',
-				'interval'       => 'month',
-				'interval_count' => 3,
-				'unit_amount'    => 10000,
+				'description' => 'Test product description',
+				'name'        => 'Test product',
 			],
 			$overrides
 		);
@@ -240,40 +238,6 @@ class WC_Payments_Product_Service_Test extends WP_UnitTestCase {
 	 */
 	private function mock_get_interval( $interval ) {
 		WC_Subscriptions_Product::set_interval( $interval );
-	}
-
-	/**
-	 * Tests for WC_Payments_Product_Service::get_wcpay_price_id()
-	 */
-	public function test_get_wcpay_price_id() {
-		WC_Subscriptions_Product::$is_subscription = true;
-
-		// Make sure the WC_Payments_Subscriptions::get_product_service() returns our mock product service object.
-		$ref = new ReflectionProperty( 'WC_Payments_Subscriptions', 'product_service' );
-		$ref->setAccessible( true );
-		$ref->setValue( null, $this->product_service );
-
-		$mock_price_id = 'wcpay_test_price_id';
-		$this->mock_product->update_meta_data( WC_Payments_Product_Service::LIVE_PRICE_ID_KEY, $mock_price_id );
-
-		$this->assertSame( $mock_price_id, $this->product_service->get_wcpay_price_id( $this->mock_product ) );
-
-		// Test that deleting the price will cause the product to be created.
-		$this->mock_product->delete_meta_data( WC_Payments_Product_Service::LIVE_PRICE_ID_KEY );
-		$this->mock_api_client->expects( $this->once() )
-			->method( 'create_product' )
-			->with( $this->get_mock_product_data() )
-			->willReturn(
-				[
-					'wcpay_product_id' => 'prod_test123',
-					'wcpay_price_id'   => $mock_price_id,
-				]
-			);
-
-		$this->mock_get_period( 'month' );
-		$this->mock_get_interval( 3 );
-
-		$this->assertSame( $mock_price_id, $this->product_service->get_wcpay_price_id( $this->mock_product ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3280 

#### Changes proposed in this Pull Request

1. I've removed most of the price ID handling from the product service class. This means: 
     - When creating and updating products we will now only send the product's name and description.
     - If a product has a price ID it will get archived if the product is deleted.
     - Untrashing a product will no longer reinstate (unarchive) the price. 
     - Price ID will remain stored in product meta until we decide to clean them up.
2. I've added a function to validate that we have the required product properties before creating/updating a product. 
   - Eg if a product doesn't have a name, we won't create a product in Stripe. This fixes the first error message mentioned on #3280 
3. I've added a function to validate the subscription data on checkout. If any of the required fields are missing or empty, we will throw an exception to prevent checkout and will no longer send that request off to server. This fixes the second error message mentioned on #3280

#### Testing instructions

**Product**

1. Go to **Product > Add new** from the admin dashboard.
2. Enter a product description, don't set any title, select Simple subscription as the type and hit publish.
3. Previously this would have resulted in a request to the server which would eventually fail. On this branch, it now gets caught before the request.

eg

```
INFO There was a problem updating the product #2164 in WC Pay: The product "name" is required.
```

**Subscription creation on checkout**

1. Purchase any standard subscription product via the checkout. You shouldn't get any errors. 
2. Add the following code snippet to your site.
3. Trying to checkout will result in an error notice preventing you from completing the checkout. 
4. The error message, in this case, is the exact same, we've just avoided sending invalid data to the server. 
5. Checking the `woocommerce-payments` log and you will find the following error.

```
INFO There was a problem creating the WCPay subscription. The subscription billing period cannot be any longer than one year. A billing period of "every 56 week(s)" was given.
``` 

```php
add_filter( 'woocommerce_subscription_get_billing_interval', function() {
	return 56;
} );
```

Make sure to remove that code snippet immediately after testing. It will turn all your subscriptions into "every 56 weeks/months/days" etc.

-------------------

- [x] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
