### PR TITLE
Try: Process transactions using destination charges

### DIFF
--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -36,7 +36,6 @@ export default class WCPayAPI {
 	getStripe( forceAccountRequest = false ) {
 		const {
 			publishableKey,
-			accountId,
 			forceNetworkSavedCards,
 			locale,
 			isUPEEnabled,
@@ -52,7 +51,6 @@ export default class WCPayAPI {
 		if ( ! this.stripe ) {
 			if ( isUPEEnabled ) {
 				this.stripe = new Stripe( publishableKey, {
-					stripeAccount: accountId,
 					betas: [
 						'payment_element_beta_1',
 						'card_country_event_beta_1',
@@ -61,7 +59,6 @@ export default class WCPayAPI {
 				} );
 			} else {
 				this.stripe = new Stripe( publishableKey, {
-					stripeAccount: accountId,
 					locale,
 				} );
 			}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1515,6 +1515,8 @@ class WC_Payments_API_Client {
 			|| str_contains( $api, 'timeline' )
 			|| str_contains( $api, 'intention' )
 			|| str_contains( $api, 'charges' )
+			|| str_contains( $api, 'customer' )
+			|| str_contains( $api, 'transactions' )
 		) {
 			$url .= '/woopay/' . $api;
 		} else {

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1510,7 +1510,16 @@ class WC_Payments_API_Client {
 		if ( $is_site_specific ) {
 			$url .= '/' . self::ENDPOINT_SITE_FRAGMENT;
 		}
-		$url .= '/' . self::ENDPOINT_REST_BASE . '/' . $api;
+		if (
+			str_contains( $api, 'payment_methods' )
+			|| str_contains( $api, 'timeline' )
+			|| str_contains( $api, 'intention' )
+			|| str_contains( $api, 'charges' )
+		) {
+			$url .= '/woopay/' . $api;
+		} else {
+			$url .= '/' . self::ENDPOINT_REST_BASE . '/' . $api;
+		}
 
 		$body = null;
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1511,12 +1511,12 @@ class WC_Payments_API_Client {
 			$url .= '/' . self::ENDPOINT_SITE_FRAGMENT;
 		}
 		if (
-			str_contains( $api, 'payment_methods' )
-			|| str_contains( $api, 'timeline' )
-			|| str_contains( $api, 'intention' )
-			|| str_contains( $api, 'charges' )
-			|| str_contains( $api, 'customer' )
-			|| str_contains( $api, 'transactions' )
+			strstr( $api, 'payment_methods' )
+			|| strstr( $api, 'timeline' )
+			|| strstr( $api, 'intention' )
+			|| strstr( $api, 'charges' )
+			|| strstr( $api, 'customer' )
+			|| strstr( $api, 'transactions' )
 		) {
 			$url .= '/woopay/' . $api;
 		} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use [destination charges](https://stripe.com/docs/connect/destination-charges) instead of [direct charges](https://stripe.com/docs/connect/direct-charges)
* To achieve this we have to load the Stripe JS as the platform, not as the merchant — only change applied so far.

Things that have not been tested and might not work right now:

- Saved cards
- Disputes
- Account related things
- Refunds
- POS
- Probably something else

The changes are not currently backwards compatible. You may not be able to view details of payments made without these changes applied and vice versa.

#### Testing instructions

* Checkout `try/destination-charges` on the WCPay Server (see corresponding PR: 1319-gh-Automattic/woocommerce-payments-server )
* Pay for an order
* Go to **Payments > Transactions**
* Make sure the payment is listed there
* Click on the payment to navigate to the payment details
* Make sure the transaction details and timeline are populated properly
* Go to the [Stripe dashboard](https://dashboard.stripe.com) and log in to the platform account your WCPay account is connected to
* Make sure the transaction is listed under the **platform's list of payments**
* Make sure there is an identical payment listed in the connected accounts list of payments

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
