### PR TITLE
Move Analytics constructor outside of Multi Currency

### DIFF
--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -86,13 +86,6 @@ class MultiCurrency {
 	protected $utils;
 
 	/**
-	 * Analytics instance.
-	 *
-	 * @var Analytics
-	 */
-	protected $analytics;
-
-	/**
 	 * FrontendPrices instance.
 	 *
 	 * @var FrontendPrices
@@ -205,7 +198,6 @@ class MultiCurrency {
 		$this->geolocation             = new Geolocation( $this->localization_service );
 		$this->utils                   = new Utils();
 		$this->compatibility           = new Compatibility( $this, $this->utils );
-		$this->analytics               = new Analytics( $this );
 		$this->currency_switcher_block = new CurrencySwitcherBlock( $this, $this->compatibility );
 
 		if ( is_admin() ) {
@@ -255,6 +247,7 @@ class MultiCurrency {
 		new PaymentMethodsCompatibility( $this, WC_Payments::get_gateway() );
 		new AdminNotices();
 		new UserSettings( $this );
+		new Analytics( $this );
 
 		$this->frontend_prices     = new FrontendPrices( $this, $this->compatibility );
 		$this->frontend_currencies = new FrontendCurrencies( $this, $this->localization_service, $this->utils, $this->compatibility );


### PR DESCRIPTION
Fixes #3312 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- Move the Analytics constructor out of the __construct for MultiCurrency (since it is not actually used in this class itself).

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check code makes sense.
* Test the analytics is working as expected as follows:
* Purchase a product using multi currency (in a currency other than the default store currency)
* Go to `Tools -> Scheduled Actions` and run the `wc-admin_import_orders` action created for the order (should have the same ID as the order).
* Go to `Analytics -> Orders`, set the date range to only show today, and verify you can see the order you just made (should be in your store default currency, at the amount calculated by the Stripe exchange rate at time of purchase). 

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
