### PR TITLE
Improve transactions query

### DIFF
--- a/includes/class-wc-payments-db.php
+++ b/includes/class-wc-payments-db.php
@@ -31,6 +31,38 @@ class WC_Payments_DB {
 	}
 
 	/**
+	 * Retrieve orders from the DB using a list of corresponding Stripe charge IDs.
+	 *
+	 * @param array $charge_ids List of charge IDs corresponding to an order ID.
+	 *
+	 * @return boolean|WC_Order|WC_Order_Refund
+	 */
+	public function orders_with_charge_id_from_charge_ids( $charge_ids ) {
+		global $wpdb;
+
+		$charge_id_placeholder = join( ',', array_fill( 0, count( $charge_ids ), '%s' ) );
+
+		// The order ID is saved to DB in `WC_Payment_Gateway_WCPay::process_payment()`.
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+				"SELECT DISTINCT ID as order_id, meta.meta_value as charge_id FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_key = '_charge_id' AND meta.meta_value IN ($charge_id_placeholder)",
+				$charge_ids
+			)
+		);
+
+		return array_map(
+			function ( $row ) {
+				return [
+					'order'     => $this->order_from_order_id( $row->order_id ),
+					'charge_id' => $row->charge_id,
+				];
+			},
+			$results
+		);
+	}
+
+	/**
 	 * Retrieve an order from the DB using a corresponding Stripe intent ID.
 	 *
 	 * @param string $intent_id Intent ID corresponding to an order ID.


### PR DESCRIPTION
Fixes #132 

#### Changes proposed in this Pull Request

When fetching a list of transactions from wp.com, for each transaction we're making 2 database queries:
- One to fetch the order id associated with that Stripe transaction.
- One to fetch the order from that order ID

For long lists of transactions, that can add up to a significant amount of time on low-end hosts.

Changes proposed in this draft:
- Combine all the queries to fetch the order IDs into a single query that uses `SELECT DISTINCT ID as order_id, meta.meta_value as charge_id ... meta_value IN ( charge_id_1, charge_id_2, etc )`
- For each `order_id` fetch the Order and map to corresponding `charge_id`
- Map orders with transactions by `charge_id`

This decreases the number of database queries from `2n` to `n + 1`. 

#### Testing instructions

To be added

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
