### PR TITLE
Add change log header for 3.4.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Fix - Show a specific message instead of a generic one in the checkout block when non-UPE payment processing fails.
 * Update - Avoid having invalid intervals (greater than 1 year) in subscription products.
 * Update - The subscription fee label in the transaction timeline.
+* Update - Show red setup badge after 3 days instead of 7
 * Add - Add compatibility between Multi-Currency and WooCommerce Bookings.
 * Add - Add compatibility between Multi-Currency and WooCommerce Pre-Orders.
 * Fix - Do not show default currency selector on Account Details page when only one currency is available.
@@ -62,7 +63,6 @@
 * Fix - Multi-Currency settings rounding option and preview.
 * Fix - Payment failure on checkout block with UPE when phone number field is hidden
 * Update - Adds a scheduled action which makes updating the account cache more efficient
-* Update - Show red setup badge after 3 days instead of 7
 * Add - Add compatibility between Multi-Currency and WooCommerce UPS shipping extension.
 * Add - Early access: allow your store to collect payments with SEPA Direct Debit. Enable the feature in settings!
 * Add - Add compatibility between Multi-Currency and WooCommerce FedEx shipping extension.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** WooCommerce Payments Changelog ***
 
+= 3.4.0 - 2021-xx-xx =
+* Add - Allow UI customizations on checkout payment fields.
+* Update - Display hardware costs for the period in the transaction list with link to the details page
+* Fix - Incorrect customer links on Transactions page.
+
 = 3.3.0 - 2021-11-18 =
 * Add - Add Idempotency Key to POST headers.
 * Add - Add dispute order notes to Edit Order page.
@@ -27,10 +32,7 @@
 * Fix - Fatal error on the customer payment page for subscription renewal orders with deleted products.
 * Fix - Misleading subscription order note on payment method change.
 * Fix - Incorrect error message when card ZIP validation fails.
-* Update - Display hardware costs for the period in the transaction list with link to the details page
 * Add - `Requires PHP` and `Requires at least` to the main plugin file.
-* Fix - Incorrect customer links on Transactions page.
-* Add - Allow UI customizations on checkout payment fields.
 
 = 3.2.3 - 2021-11-01 =
 * Fix - Card fields on checkout not shown when the 'Enable payments via saved cards' setting is disabled.

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,11 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
+= 3.4.0 - 2021-xx-xx =
+* Add - Allow UI customizations on checkout payment fields.
+* Update - Display hardware costs for the period in the transaction list with link to the details page
+* Fix - Incorrect customer links on Transactions page.
+
 = 3.3.0 - 2021-11-18 =
 * Add - Add Idempotency Key to POST headers.
 * Add - Add dispute order notes to Edit Order page.
@@ -125,10 +130,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Fatal error on the customer payment page for subscription renewal orders with deleted products.
 * Fix - Misleading subscription order note on payment method change.
 * Fix - Incorrect error message when card ZIP validation fails.
-* Update - Display hardware costs for the period in the transaction list with link to the details page
 * Add - `Requires PHP` and `Requires at least` to the main plugin file.
-* Fix - Incorrect customer links on Transactions page.
-* Add - Allow UI customizations on checkout payment fields.
 
 = 3.2.3 - 2021-11-01 =
 * Fix - Card fields on checkout not shown when the 'Enable payments via saved cards' setting is disabled.

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Show a specific message instead of a generic one in the checkout block when non-UPE payment processing fails.
 * Update - Avoid having invalid intervals (greater than 1 year) in subscription products.
 * Update - The subscription fee label in the transaction timeline.
+* Update - Show red setup badge after 3 days instead of 7
 * Add - Add compatibility between Multi-Currency and WooCommerce Bookings.
 * Add - Add compatibility between Multi-Currency and WooCommerce Pre-Orders.
 * Fix - Do not show default currency selector on Account Details page when only one currency is available.


### PR DESCRIPTION
Also moves items that didn't make it into 3.3.0 under the new header and fixes an entry that was under the wrong version.