### PR TITLE
Redirect back to WooCommerce → Subscriptions after onboarding

### DIFF
--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -416,10 +416,12 @@ class WC_Payments_Account {
 	/**
 	 * Get Stripe connect url
 	 *
+	 * @param string $wcpay_connect_from A page ID representing where the user should be returned to after connecting.
+	 *
 	 * @return string Stripe account login url.
 	 */
-	public static function get_connect_url() {
-		return wp_nonce_url( add_query_arg( [ 'wcpay-connect' => '1' ] ), 'wcpay-connect' );
+	public static function get_connect_url( $wcpay_connect_from = '1' ) {
+		return wp_nonce_url( add_query_arg( [ 'wcpay-connect' => $wcpay_connect_from ] ), 'wcpay-connect' );
 	}
 
 	/**
@@ -536,9 +538,14 @@ class WC_Payments_Account {
 	private function get_onboarding_return_url( $wcpay_connect_from ) {
 		// If connection originated on the WCADMIN payment task page, return there.
 		// else goto the overview page, since now it is GA (earlier it was redirected to plugin settings page).
-		return 'WCADMIN_PAYMENT_TASK' === $wcpay_connect_from
-			? $this->get_payments_task_page_url()
-			: $this->get_overview_page_url();
+		switch ( $wcpay_connect_from ) {
+			case 'WCADMIN_PAYMENT_TASK':
+				return $this->get_payments_task_page_url();
+			case 'WC_SUBSCRIPTIONS':
+				return admin_url( add_query_arg( [ 'post_type' => 'shop_subscription' ], 'edit.php' ) );
+			default:
+				return $this->get_overview_page_url();
+		}
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions-empty-state-manager.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-empty-state-manager.php
@@ -52,7 +52,7 @@ class WC_Payments_Subscriptions_Empty_State_Manager {
 		$script_asset_path = WCPAY_ABSPATH . 'dist/subscriptions-empty-state.asset.php';
 		$script_asset      = file_exists( $script_asset_path ) ? require_once $script_asset_path : [ 'dependencies' => [] ];
 		$wcpay_settings    = [
-			'connectUrl'    => WC_Payments_Account::get_connect_url(),
+			'connectUrl'    => WC_Payments_Account::get_connect_url( 'WC_SUBSCRIPTIONS' ),
 			'isConnected'   => $this->account->is_stripe_connected(),
 			'newProductUrl' => WC_Subscriptions_Admin::add_subscription_url(),
 		];


### PR DESCRIPTION
Proposed changes for https://github.com/Automattic/woocommerce-payments/pull/3403

Ability to redirect the merchant back to the WooCommerce → Subscriptions page after they complete WCPay onboarding.