### PR TITLE
Minor tweak to logic, and add tests for init_order_currency.

### DIFF
--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -198,27 +198,24 @@ class FrontendCurrencies {
 	/**
 	 * Inits order currency code.
 	 *
-	 * @param mixed $order Either WC_Order or the id of an order.
+	 * @param mixed $arg Either WC_Order or the id of an order asre expected, but can be empty.
 	 *
-	 * @return int The order id.
+	 * @return int The order id or what was passed as $arg.
 	 */
-	public function init_order_currency( $order ) {
+	public function init_order_currency( $arg ) {
 		if ( null !== $this->order_currency ) {
-			return $order;
+			return $arg;
 		}
 
-		if ( empty( $order ) ) {
-			$this->order_currency = $this->multi_currency->get_selected_currency();
-			return $order;
+		$order = ! $arg instanceof WC_Order ? wc_get_order( $arg ) : $arg;
+
+		if ( $order ) {
+			$this->order_currency = $order->get_currency();
+			return $order->get_id();
 		}
 
-		if ( ! $order instanceof WC_Order ) {
-			$order = wc_get_order( $order );
-		}
-
-		$this->order_currency = $order->get_currency();
-
-		return $order->get_id();
+		$this->order_currency = $this->multi_currency->get_selected_currency();
+		return $arg;
 	}
 
 	/**

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -207,13 +207,13 @@ class FrontendCurrencies {
 			return $order;
 		}
 
-		if ( ! $order instanceof WC_Order ) {
-			$order = wc_get_order( $order );
-		}
-
 		if ( empty( $order ) ) {
 			$this->order_currency = $this->multi_currency->get_selected_currency();
 			return $order;
+		}
+
+		if ( ! $order instanceof WC_Order ) {
+			$order = wc_get_order( $order );
 		}
 
 		$this->order_currency = $order->get_currency();

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -198,7 +198,7 @@ class FrontendCurrencies {
 	/**
 	 * Inits order currency code.
 	 *
-	 * @param mixed $arg Either WC_Order or the id of an order asre expected, but can be empty.
+	 * @param mixed $arg Either WC_Order or the id of an order are expected, but can be empty.
 	 *
 	 * @return int The order id or what was passed as $arg.
 	 */

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -290,6 +290,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 			[ '' ],
 			[ '0' ],
 			[ false ],
+			[ '2020' ],
 		];
 	}
 

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -267,4 +267,33 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WP_UnitTestCase {
 			$this->frontend_currencies->fix_price_decimals_for_shipping_rates( [ 'price_decimals' => 42 ], null )
 		);
 	}
+
+	public function test_init_order_currency_returns_order_if_order_currency_not_null() {
+		// Set the currency and then init the order_currency.
+		$currency = 'EUR';
+		$this->mock_order->set_currency( $currency );
+		$this->frontend_currencies->init_order_currency( $this->mock_order );
+
+		// Since the order_currency is already set, this should return what's passed, the full order.
+		$this->assertSame( $this->mock_order, $this->frontend_currencies->init_order_currency( $this->mock_order ) );
+	}
+
+	/**
+	 * @dataProvider empty_order_number_provider
+	 */
+	public function test_init_order_currency_returns_empty_order_numbers( $order_id ) {
+		$this->assertSame( $order_id, $this->frontend_currencies->init_order_currency( $order_id ) );
+	}
+
+	public function empty_order_number_provider() {
+		return [
+			[ '' ],
+			[ '0' ],
+			[ false ],
+		];
+	}
+
+	public function test_init_order_currency_returns_order_id() {
+		$this->assertSame( $this->mock_order->get_id(), $this->frontend_currencies->init_order_currency( $this->mock_order ) );
+	}
 }


### PR DESCRIPTION
@brianyu28 I wanted to create tests to help prevent this from happening again and I found a problem with where the `empty` test was, so I moved it in this PR. This also includes tests that we should have included in the first place.


#### Changes proposed in this Pull Request

* Minor tweak in logic.
* Add tests for init_order_currency.

#### Testing instructions

* Tests should pass.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
