### PR TITLE
Fix payment intent having unsupported payment methods

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2434,24 +2434,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @param string $order_id optional Order ID.
 	 * @return string[]
 	 */
-	public function get_upe_enabled_at_checkout_payment_method_ids( $order_id = null ) {
-		$capture                    = empty( $this->get_option( 'manual_capture' ) ) || $this->get_option( 'manual_capture' ) === 'no';
-		$capturable_payment_methods = $capture ? $this->get_upe_enabled_payment_method_ids() : [ 'card' ];
-		$enabled_payment_methods    = [];
-		$active_payment_methods     = $this->get_upe_enabled_payment_method_statuses();
-		foreach ( $capturable_payment_methods as $payment_method_id ) {
-			$payment_method_capability_key = $this->payment_method_capability_key_map[ $payment_method_id ] ?? 'undefined_capability_key';
-			if ( isset( $this->payment_methods[ $payment_method_id ] )
-				&& $this->payment_methods[ $payment_method_id ]->is_enabled_at_checkout( $order_id )
-				&& ( is_admin() || $this->payment_methods[ $payment_method_id ]->is_currency_valid() )
-				&& isset( $active_payment_methods[ $payment_method_capability_key ] )
-				&& 'active' === $active_payment_methods[ $payment_method_capability_key ]['status']
-			) {
-				$enabled_payment_methods[] = $payment_method_id;
-			}
-		}
-
-		return $enabled_payment_methods;
+	public function get_payment_method_ids_enabled_at_checkout( $order_id = null ) {
+		return [
+			'card',
+		];
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1015,6 +1015,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				throw new Exception( WC_Payments_Utils::get_filtered_error_message( $e ) );
 			}
 
+			$payment_methods = WC_Payments::get_gateway()->get_payment_method_ids_enabled_at_checkout();
+
 			// Create intention, try to confirm it & capture the charge (if 3DS is not required).
 			$intent = $this->payments_api_client->create_and_confirm_intention(
 				$converted_amount,
@@ -1026,7 +1028,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$metadata,
 				$this->get_level3_data_from_order( $order ),
 				$payment_information->is_merchant_initiated(),
-				$additional_api_parameters
+				$additional_api_parameters,
+				$payment_methods
 			);
 
 			$intent_id     = $intent->get_id();

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -262,7 +262,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		}
 
 		$capture_method          = empty( $this->settings['manual_capture'] ) || 'no' === $this->settings['manual_capture'] ? 'automatic' : 'manual';
-		$enabled_payment_methods = $this->get_upe_enabled_at_checkout_payment_method_ids( $order_id );
+		$enabled_payment_methods = $this->get_payment_method_ids_enabled_at_checkout( $order_id );
 
 		try {
 			$payment_intent = $this->payments_api_client->create_intention(
@@ -823,6 +823,32 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	}
 
 	/**
+	 * Returns the list of enabled payment method types that will function with the current checkout.
+	 *
+	 * @param string $order_id optional Order ID.
+	 * @return string[]
+	 */
+	public function get_payment_method_ids_enabled_at_checkout( $order_id = null ) {
+		$capture                    = empty( $this->get_option( 'manual_capture' ) ) || $this->get_option( 'manual_capture' ) === 'no';
+		$capturable_payment_methods = $capture ? $this->get_upe_enabled_payment_method_ids() : [ 'card' ];
+		$enabled_payment_methods    = [];
+		$active_payment_methods     = $this->get_upe_enabled_payment_method_statuses();
+		foreach ( $capturable_payment_methods as $payment_method_id ) {
+			$payment_method_capability_key = $this->payment_method_capability_key_map[ $payment_method_id ] ?? 'undefined_capability_key';
+			if ( isset( $this->payment_methods[ $payment_method_id ] )
+				&& $this->payment_methods[ $payment_method_id ]->is_enabled_at_checkout( $order_id )
+				&& ( is_admin() || $this->payment_methods[ $payment_method_id ]->is_currency_valid() )
+				&& isset( $active_payment_methods[ $payment_method_capability_key ] )
+				&& 'active' === $active_payment_methods[ $payment_method_capability_key ]['status']
+			) {
+				$enabled_payment_methods[] = $payment_method_id;
+			}
+		}
+
+		return $enabled_payment_methods;
+	}
+
+	/**
 	 * Returns the list of available payment method types for UPE.
 	 * See https://stripe.com/docs/stripe-js/payment-element#web-create-payment-intent for a complete list.
 	 *
@@ -895,7 +921,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	public function maybe_filter_gateway_title( $title, $id ) {
 		if ( self::GATEWAY_ID === $id && $this->title === $title ) {
 			$title                   = $this->checkout_title;
-			$enabled_payment_methods = $this->get_upe_enabled_at_checkout_payment_method_ids();
+			$enabled_payment_methods = $this->get_payment_method_ids_enabled_at_checkout();
 
 			if ( 1 === count( $enabled_payment_methods ) ) {
 				$title = $this->payment_methods[ $enabled_payment_methods[0] ]->get_title();
@@ -915,7 +941,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	 */
 	private function get_enabled_payment_method_config() {
 		$settings                = [];
-		$enabled_payment_methods = $this->get_upe_enabled_at_checkout_payment_method_ids();
+		$enabled_payment_methods = $this->get_payment_method_ids_enabled_at_checkout();
 
 		if ( $this->is_subscriptions_enabled() && $this->is_changing_payment_method_for_subscription() ) {
 			$enabled_payment_methods = array_filter( $enabled_payment_methods, [ $this, 'is_enabled_for_saved_payments' ] );

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -197,17 +197,20 @@ class WC_Payments_API_Client {
 		$payment_methods = null
 	) {
 		// TODO: There's scope to have amount and currency bundled up into an object.
-		$request                         = [];
-		$request['amount']               = $amount;
-		$request['currency']             = $currency_code;
-		$request['confirm']              = 'true';
-		$request['payment_method']       = $payment_method_id;
-		$request['customer']             = $customer_id;
-		$request['capture_method']       = $manual_capture ? 'manual' : 'automatic';
-		$request['metadata']             = $metadata;
-		$request['level3']               = $level3;
-		$request['description']          = $this->get_intent_description( $metadata['order_id'] ?? 0 );
-		$request['payment_method_types'] = $payment_methods ?? WC_Payments::get_gateway()->get_payment_method_ids_enabled_at_checkout();
+		$request                   = [];
+		$request['amount']         = $amount;
+		$request['currency']       = $currency_code;
+		$request['confirm']        = 'true';
+		$request['payment_method'] = $payment_method_id;
+		$request['customer']       = $customer_id;
+		$request['capture_method'] = $manual_capture ? 'manual' : 'automatic';
+		$request['metadata']       = $metadata;
+		$request['level3']         = $level3;
+		$request['description']    = $this->get_intent_description( $metadata['order_id'] ?? 0 );
+
+		if ( ! empty( $payment_methods ) ) {
+			$request['payment_method_types'] = $payment_methods;
+		}
 
 		$request = array_merge( $request, $additional_parameters );
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -192,34 +192,21 @@ class WC_Payments_API_Client {
 		$metadata = [],
 		$level3 = [],
 		$off_session = false,
-		$additional_parameters = []
+		$additional_parameters = [],
+		$payment_methods = null
 	) {
 		// TODO: There's scope to have amount and currency bundled up into an object.
-		$request                   = [];
-		$request['amount']         = $amount;
-		$request['currency']       = $currency_code;
-		$request['confirm']        = 'true';
-		$request['payment_method'] = $payment_method_id;
-		$request['customer']       = $customer_id;
-		$request['capture_method'] = $manual_capture ? 'manual' : 'automatic';
-		$request['metadata']       = $metadata;
-		$request['level3']         = $level3;
-		$request['description']    = $this->get_intent_description( $metadata['order_id'] ?? 0 );
-
-		$available_payment_methods = WC_Payments::get_gateway()->get_upe_available_payment_methods();
-		$filtered_payment_methods  = [];
-		foreach ( $available_payment_methods as $available_payment_method ) {
-			$class_name = '\\WCPay\\Payment_Methods\\' . ucfirst( strtolower( $available_payment_method ) ) . '_Payment_Method';
-			if ( class_exists( $class_name ) ) {
-				$payment_method_class = new $class_name( null );
-				if ( in_array( strtoupper( $currency_code ), $payment_method_class->get_currencies(), true ) ) {
-					$filtered_payment_methods[] = $available_payment_method;
-				}
-			} elseif ( 'sepa_debit' !== $available_payment_method || 'eur' === strtolower( $currency_code ) ) {
-				$filtered_payment_methods[] = $available_payment_method;
-			}
-		}
-		$request['payment_method_types'] = $filtered_payment_methods;
+		$request                         = [];
+		$request['amount']               = $amount;
+		$request['currency']             = $currency_code;
+		$request['confirm']              = 'true';
+		$request['payment_method']       = $payment_method_id;
+		$request['customer']             = $customer_id;
+		$request['capture_method']       = $manual_capture ? 'manual' : 'automatic';
+		$request['metadata']             = $metadata;
+		$request['level3']               = $level3;
+		$request['description']          = $this->get_intent_description( $metadata['order_id'] ?? 0 );
+		$request['payment_method_types'] = $payment_methods ?? WC_Payments::get_gateway()->get_payment_method_ids_enabled_at_checkout();
 
 		$request = array_merge( $request, $additional_parameters );
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -178,6 +178,7 @@ class WC_Payments_API_Client {
 	 * @param array  $level3                 - Level 3 data.
 	 * @param bool   $off_session            - Whether the payment is off-session (merchant-initiated), or on-session (customer-initiated).
 	 * @param array  $additional_parameters  - An array of any additional request parameters, particularly for additional payment methods.
+	 * @param array  $payment_methods        - An array of payment methods that might be used for the payment.
 	 *
 	 * @return WC_Payments_API_Intention
 	 * @throws API_Exception - Exception thrown on intention creation failure.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -307,7 +307,7 @@ class WC_Payments_API_Client {
 			$request['payment_method_types'] = [ $selected_upe_payment_type ];
 		}
 		if ( $payment_country && ! WC_Payments::get_gateway()->is_in_dev_mode() ) {
-			// Do not update on dev mode, Stripe tests cards don't return the appropriate country .
+			// Do not update on dev mode, Stripe tests cards don't return the appropriate country.
 			$request['payment_country'] = $payment_country;
 		}
 		if ( $customer_id ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes the error on the server side, which is produced when a payment method is added to the intentions list, even if the payment method doesn't support the order currency, which results in a 4XX status response from Stripe below:

```
[25-Nov-2021 07:59:49 UTC] WCPay extra: Request params: {"test_mode":true,"amount":1800,"currency":"usd","confirm":"true","payment_method":"pm_1JyzixR4ByxURRrFVc1Iq7qH","customer":"cus_KeA1Z7ueR5zi8Q","capture_method":"automatic","metadata":{"customer_name":"(redacted)","customer_email":"(redacted)","site_url":"http:\/\/localhost:8082","order_id":228,"order_key":"wc_order_j5JvbTpWIssgm","payment_type":"single"},"level3":{"merchant_reference":"228","customer_reference":"228","shipping_amount":0,"line_items":[{"product_code":"13","product_description":"Beanie","unit_cost":1800,"quantity":1,"tax_amount":0,"discount_amount":0}],"shipping_address_zip":"34760","shipping_from_zip":"94110"},"description":"Online Payment for Order #228 for localhost:8082 blog_id 193908337","payment_method_types":["card","bancontact","giropay","ideal","sofort","sepa_debit","p24"]}
[25-Nov-2021 07:59:49 UTC] WCPay trace: 
[25-Nov-2021 07:59:49 UTC] WCPay url: /wpcom/v2/sites/193908337/wcpay/intentions
[25-Nov-2021 07:59:49 UTC] WCPay method: POST
[25-Nov-2021 07:59:49 UTC] WCPay tags: wcpay-b7fd1433-0c5a-4a72-89e9-07ce49397268
[25-Nov-2021 07:59:49 UTC] WCPay user_id: 1

[25-Nov-2021 07:59:51 UTC] WCPay blog_id: 193908337
[25-Nov-2021 07:59:51 UTC] WCPay feature: wcpay-sandbox-proxy-error
[25-Nov-2021 07:59:51 UTC] WCPay message: Caught proxy error response:
[25-Nov-2021 07:59:51 UTC] WCPay Code: 400
[25-Nov-2021 07:59:51 UTC] WCPay Body:
[25-Nov-2021 07:59:51 UTC] WCPay {
[25-Nov-2021 07:59:51 UTC] WCPay   "error": {
[25-Nov-2021 07:59:51 UTC] WCPay     "message": "The currency provided (usd) is invalid for one or more payment method types on this PaymentIntent. The payment method type bancontact only supports the following currencies: eur. Either correct the provided currency, or use a different PaymentIntent to accept this payment method type.",
[25-Nov-2021 07:59:51 UTC] WCPay     "param": "currency",
[25-Nov-2021 07:59:51 UTC] WCPay     "type": "invalid_request_error"
[25-Nov-2021 07:59:51 UTC] WCPay   }
[25-Nov-2021 07:59:51 UTC] WCPay }
```

I've added a payment method currencies <> order currency check for the UPE methods, and a manual check for Sepa Debit to filter unsupported ones while creating a payment intent.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create an order with USD currency
* Pay it with a saved card
* Expect the payment to succeed.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
