### PR TITLE
IPP Styled Receipts: Print receipt

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@
 * Fix - Onboarding must be completed before Subscriptions products can be published.
 * Add - Support business account branding settings
 * Update - Capture order-related metadata not captured by mobile app for in-person payment transactions.
+* Add - REST endpoint to print IPP receipts
 
 = 3.3.0 - 2021-11-18 =
 * Add - Add Idempotency Key to POST headers.

--- a/includes/admin/class-wc-rest-payments-reader-controller.php
+++ b/includes/admin/class-wc-rest-payments-reader-controller.php
@@ -22,6 +22,35 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 	protected $rest_base = 'payments/readers';
 
 	/**
+	 * Instance of WC_Payment_Gateway_WCPay.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private $wcpay_gateway;
+
+	/**
+	 * Instance of WC_Payments_In_Person_Payments_Receipts_Service.
+	 *
+	 * @var WC_Payments_In_Person_Payments_Receipts_Service
+	 */
+	private $receipts_service;
+
+	/**
+	 * WC_REST_Payments_Reader_Controller
+	 *
+	 * @param  WC_Payments_API_Client                          $api_client WC_Payments_API_Client.
+	 * @param  WC_Payment_Gateway_WCPay                        $wcpay_gateway WC_Payment_Gateway_WCPay.
+	 * @param  WC_Payments_In_Person_Payments_Receipts_Service $receipts_service WC_Payments_In_Person_Payments_Receipts_Service.
+	 * @return void
+	 */
+	public function __construct( WC_Payments_API_Client $api_client, WC_Payment_Gateway_WCPay $wcpay_gateway, WC_Payments_In_Person_Payments_Receipts_Service $receipts_service ) {
+		parent::__construct( $api_client );
+
+		$this->wcpay_gateway    = $wcpay_gateway;
+		$this->receipts_service = $receipts_service;
+	}
+
+	/**
 	 * Configure REST API routes.
 	 */
 	public function register_routes() {
@@ -31,6 +60,15 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_summary' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/receipts/(?P<payment_id>\w+)',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'generate_print_receipt' ],
 				'permission_callback' => [ $this, 'check_permission' ],
 			]
 		);
@@ -62,4 +100,69 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 		return rest_ensure_response( $summary );
 	}
 
+	/**
+	 * Renders HTML for a print receipt
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_HTTP_RESPONSE|WP_Error
+	 */
+	public function generate_print_receipt( $request ) {
+		try {
+			$payment_intent = $this->api_client->get_intent( $request->get_param( 'payment_id' ) );
+
+			if ( 'succeeded' !== $payment_intent->get_status() ) {
+				return rest_ensure_response( new WP_Error( 'generate_print_receipt_error', __( 'Invalid payment', 'woocommerce-payments' ), [ 'status' => 500 ] ) );
+			}
+
+			$charge = $this->api_client->get_charge( $payment_intent->get_charge_id() );
+		} catch ( API_Exception $e ) {
+			return rest_ensure_response( new WP_Error( 'generate_print_receipt_error', $e->getMessage(), [ 'status' => $e->get_http_code() ] ) );
+		}
+
+		$order = wc_get_order( $charge['order']['number'] );
+
+		if ( ! $order ) {
+			return rest_ensure_response( new WP_Error( 'generate_print_receipt_error', __( 'Order not found', 'woocommerce-payments' ), [ 'status' => 500 ] ) );
+		}
+
+		try {
+			$settings = [
+				'business_name' => $this->wcpay_gateway->get_option( 'account_business_name' ),
+				'support_info'  => [
+					'address' => $this->wcpay_gateway->get_option( 'account_business_support_address' ),
+					'phone'   => $this->wcpay_gateway->get_option( 'account_business_support_phone' ),
+					'email'   => $this->wcpay_gateway->get_option( 'account_business_support_email' ),
+				],
+			];
+		} catch ( Exception $e ) {
+			return rest_ensure_response( new WP_Error( 'generate_print_receipt_error', __( 'There was a problem retrieving merchant settings.', 'woocommerce-payments' ), [ 'status' => 500 ] ) );
+		}
+
+		/**
+		 * WP_REST_Server will convert the response data to JSON prior to output it.
+		 * Using this filter to prevent it, and output the data from WP_HTTP_Responde instead.
+		 */
+		add_filter(
+			'rest_pre_serve_request',
+			function ( bool $served, WP_HTTP_Response $response ) : bool {
+				$served = true;
+				echo $response->get_data(); // @codingStandardsIgnoreLine
+				return $served;
+			},
+			10,
+			2
+		);
+
+		try {
+			$receipt_data = $this->receipts_service->get_receipt_markup( $settings, $order, $charge );
+		} catch ( \Throwable $th ) {
+			return rest_ensure_response( new WP_Error( 'generate_print_receipt_error', __( 'There was a problem generating the receipt.', 'woocommerce-payments' ), [ 'status' => 500 ] ) );
+		}
+
+		return new WP_HTTP_Response(
+			$receipt_data,
+			200,
+			[ 'Content-Type' => 'text/html; charset=UTF-8' ]
+		);
+	}
 }

--- a/includes/admin/class-wc-rest-payments-reader-controller.php
+++ b/includes/admin/class-wc-rest-payments-reader-controller.php
@@ -112,7 +112,7 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 			/* Collect the data, available on the server side. */
 			$payment_intent = $this->api_client->get_intent( $request->get_param( 'payment_id' ) );
 			if ( 'succeeded' !== $payment_intent->get_status() ) {
-				throw new \RuntimeException( __( 'Invalid payment', 'woocommerce-payments' ) );
+				throw new \RuntimeException( __( 'Invalid payment intent', 'woocommerce-payments' ) );
 			}
 			$charge = $this->api_client->get_charge( $payment_intent->get_charge_id() );
 

--- a/includes/admin/class-wc-rest-payments-reader-controller.php
+++ b/includes/admin/class-wc-rest-payments-reader-controller.php
@@ -138,9 +138,15 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 			return rest_ensure_response( new WP_Error( 'generate_print_receipt_error', __( 'There was a problem retrieving merchant settings.', 'woocommerce-payments' ), [ 'status' => 500 ] ) );
 		}
 
+		try {
+			$receipt_data = $this->receipts_service->get_receipt_markup( $settings, $order, $charge );
+		} catch ( \Throwable $th ) {
+			return rest_ensure_response( new WP_Error( 'generate_print_receipt_error', $th->getMessage(), [ 'status' => 500 ] ) );
+		}
+
 		/**
 		 * WP_REST_Server will convert the response data to JSON prior to output it.
-		 * Using this filter to prevent it, and output the data from WP_HTTP_Responde instead.
+		 * Using this filter to prevent it, and output the data from WP_HTTP_Response instead.
 		 */
 		add_filter(
 			'rest_pre_serve_request',
@@ -152,12 +158,6 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 			10,
 			2
 		);
-
-		try {
-			$receipt_data = $this->receipts_service->get_receipt_markup( $settings, $order, $charge );
-		} catch ( \Throwable $th ) {
-			return rest_ensure_response( new WP_Error( 'generate_print_receipt_error', __( 'There was a problem generating the receipt.', 'woocommerce-payments' ), [ 'status' => 500 ] ) );
-		}
 
 		return new WP_HTTP_Response(
 			$receipt_data,

--- a/includes/admin/class-wc-rest-payments-reader-controller.php
+++ b/includes/admin/class-wc-rest-payments-reader-controller.php
@@ -151,9 +151,8 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 		add_filter(
 			'rest_pre_serve_request',
 			function ( bool $served, WP_HTTP_Response $response ) : bool {
-				$served = true;
 				echo $response->get_data(); // @codingStandardsIgnoreLine
-				return $served;
+				return true;
 			},
 			10,
 			2

--- a/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
+++ b/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Class WC_Payments_In_Person_Payment_Print_Receipt_Service
+ *
+ * @package WooCommerce\Payments
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class handling in person payments receipts.
+ */
+class WC_Payments_In_Person_Payments_Receipts_Service {
+
+	/**
+	 * Renders the receipt template.
+	 *
+	 * @param  array    $settings Merchant settings.
+	 * @param  WC_Order $order Order instance.
+	 * @param  array    $charge Charge data.
+	 *
+	 * @return string
+	 */
+	public function get_receipt_markup( array $settings, WC_Order $order, array $charge ) :string {
+		$this->validate_settings( $settings );
+		$this->validate_charge( $charge );
+
+		$order_data = [
+			'id'           => $order->get_id(),
+			'currency'     => $order->get_currency(),
+			'subtotal'     => $order->get_subtotal(),
+			'line_items'   => $order->get_items(),
+			'coupon_lines' => $order->get_items( 'coupon' ),
+			'tax_lines'    => $order->get_items( 'tax' ),
+			'total'        => $order->get_total(),
+		];
+
+		ob_start();
+
+		wc_get_template(
+			'html-in-person-payment-receipt.php',
+			[
+				'amount_captured'        => $charge['amount_captured'] / 100,
+				'coupon_lines'           => $order_data['coupon_lines'] ?? [],
+				'business_name'          => $settings['business_name'],
+				'line_items'             => $this->format_line_items( $order_data ),
+				'order'                  => $order_data,
+				'payment_method_details' => $charge['payment_method_details']['card_present'],
+				'receipt'                => $charge['payment_method_details']['card_present']['receipt'],
+				'support_address'        => $settings['support_info']['address'],
+				'support_email'          => $settings['support_info']['email'],
+				'support_phone'          => $settings['support_info']['phone'],
+				'tax_lines'              => $order_data['tax_lines'] ?? [],
+			],
+			'',
+			__DIR__ . '/templates/'
+		);
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * Format line items
+	 *
+	 * @param  array $order the order.
+	 * @return array
+	 */
+	private function format_line_items( array $order ) :array {
+		$line_items_data = [];
+
+		foreach ( $order['line_items'] as $item ) {
+			$item_data            = $item->get_data();
+			$item_data['product'] = $item->get_product()->get_data();
+			$line_items_data[]    = $item_data;
+		};
+
+		return $line_items_data;
+	}
+
+	/**
+	 * Validate settings
+	 *
+	 * @param  array $settings Settings.
+	 * @return void
+	 * @throws \Exception Error validating settings.
+	 */
+	private function validate_settings( $settings ) {
+		if ( ! $settings ) {
+			throw new \Exception( 'You must provide settings information' );
+		}
+
+		if ( ! array_key_exists( 'business_name', $settings ) ) {
+			throw new \Exception( 'You must provide a business name' );
+		}
+
+		$this->validate_support_info( $settings['support_info'] );
+	}
+
+	/**
+	 * Validate support info
+	 *
+	 * @param  array $support_info Support info.
+	 * @return void
+	 * @throws \Exception Error validating support info.
+	 */
+	private function validate_support_info( $support_info ) {
+		if ( ! $support_info ) {
+			throw new Exception( 'You must provide support information.' );
+		}
+
+		foreach ( $support_info as $key => $value ) {
+			if ( ! in_array( $key, [ 'address', 'email', 'phone' ], true ) ) {
+				throw new Exception( 'Invalid support information.' );
+			}
+		}
+	}
+
+	/**
+	 * Validate charge information
+	 *
+	 * @param  mixed $charge Charge info.
+	 * @return void
+	 * @throws \Exception Error validating charge info.
+	 */
+	private function validate_charge( $charge ) {
+		if ( ! $charge ) {
+			throw new Exception( 'You must provide charge information' );
+		}
+
+		if ( ! array_key_exists( 'amount_captured', $charge ) ) {
+			throw new Exception( 'You must provide a captured amount' );
+		}
+
+		if ( ! array_key_exists( 'payment_method_details', $charge ) ) {
+			throw new Exception( 'You must provide payment method details' );
+		}
+
+		if ( ! array_key_exists( 'card_present', $charge['payment_method_details'] ) ) {
+			throw new Exception( 'You must provide card present details' );
+		}
+
+		if ( ! array_key_exists( 'receipt', $charge['payment_method_details']['card_present'] ) ) {
+			throw new Exception( 'You must provide card present details' );
+		}
+
+	}
+}

--- a/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
+++ b/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
@@ -82,15 +82,15 @@ class WC_Payments_In_Person_Payments_Receipts_Service {
 	 *
 	 * @param  array $settings Settings.
 	 * @return void
-	 * @throws \Exception Error validating settings.
+	 * @throws \RuntimeException Error validating settings.
 	 */
 	private function validate_settings( array $settings ) {
 		if ( ! array_key_exists( 'business_name', $settings ) ) {
-			throw new \Exception( 'Business name needs to be provided.' );
+			throw new \RuntimeException( 'Business name needs to be provided.' );
 		}
 
 		if ( empty( $settings['support_info'] ) || ! is_array( $settings['support_info'] ) ) {
-			throw new \Exception( 'Support information needs to be provided.' );
+			throw new \RuntimeException( 'Support information needs to be provided.' );
 		}
 
 		$this->validate_required_fields(
@@ -105,25 +105,21 @@ class WC_Payments_In_Person_Payments_Receipts_Service {
 	 *
 	 * @param  array $charge Charge info.
 	 * @return void
-	 * @throws \Exception Error validating charge info.
+	 * @throws \RuntimeException Error validating charge info.
 	 */
 	private function validate_charge( array $charge ) {
 		if ( ! array_key_exists( 'amount_captured', $charge ) ) {
-			throw new Exception( 'Captured amount needs to be provided.' );
-		}
-
-		if ( empty( $charge['payment_method_details'] ) || ! is_array( $charge['payment_method_details'] ) ) {
-			throw new Exception( 'Payment method details needs to be provided.' );
+			throw new \RuntimeException( 'Captured amount needs to be provided.' );
 		}
 
 		if ( empty( $charge['payment_method_details']['card_present'] ) || ! is_array( $charge['payment_method_details']['card_present'] ) ) {
-			throw new Exception( 'Card present details needs to be provided.' );
+			throw new \RuntimeException( 'Payment method details needs to be provided.' );
 		}
 
 		$this->validate_required_fields(
 			[ 'brand', 'last4', 'receipt' ],
 			$charge['payment_method_details']['card_present'],
-			'Error validating card present information'
+			'Error validating payment information'
 		);
 
 		$this->validate_required_fields(
@@ -141,13 +137,12 @@ class WC_Payments_In_Person_Payments_Receipts_Service {
 	 * @param  array  $data Data to validate.
 	 * @param  string $message Error message.
 	 * @return void
-	 * @throws \Exception Error validating required fields.
+	 * @throws \RuntimeException Error validating required fields.
 	 */
 	private function validate_required_fields( array $required_fields, array $data, string $message ) {
-		$data_keys = array_keys( $data );
 		foreach ( $required_fields as $required_key ) {
-			if ( ! in_array( $required_key, $data_keys, true ) ) {
-				throw new Exception( sprintf( '%s. Missing key: %s', $message, $required_key ) );
+			if ( ! array_key_exists( $required_key, $data ) ) {
+				throw new \RuntimeException( sprintf( '%s. Missing key: %s', $message, $required_key ) );
 			}
 		}
 	}

--- a/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
+++ b/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
@@ -84,33 +84,22 @@ class WC_Payments_In_Person_Payments_Receipts_Service {
 	 * @return void
 	 * @throws \Exception Error validating settings.
 	 */
-	private function validate_settings( $settings ) {
+	private function validate_settings( array $settings ) {
 		if ( ! $settings ) {
-			throw new \Exception( 'You must provide settings information' );
+			throw new \Exception( 'You must provide settings information.' );
 		}
 
 		if ( ! array_key_exists( 'business_name', $settings ) ) {
-			throw new \Exception( 'You must provide a business name' );
+			throw new \Exception( 'You must provide a business name.' );
 		}
 
-		$this->validate_support_info( $settings['support_info'] );
-	}
-
-	/**
-	 * Validate support info
-	 *
-	 * @param  array $support_info Support info.
-	 * @return void
-	 * @throws \Exception Error validating support info.
-	 */
-	private function validate_support_info( $support_info ) {
-		if ( ! $support_info ) {
-			throw new Exception( 'You must provide support information.' );
+		if ( ! array_key_exists( 'support_info', $settings ) ) {
+			throw new \Exception( 'You must provide support information.' );
 		}
 
-		foreach ( $support_info as $key => $value ) {
+		foreach ( $settings['support_info'] as $key => $value ) {
 			if ( ! in_array( $key, [ 'address', 'email', 'phone' ], true ) ) {
-				throw new Exception( 'Invalid support information.' );
+				throw new Exception( sprintf( 'Error validating support information. Invalid key: %s', $key ) );
 			}
 		}
 	}
@@ -118,29 +107,29 @@ class WC_Payments_In_Person_Payments_Receipts_Service {
 	/**
 	 * Validate charge information
 	 *
-	 * @param  mixed $charge Charge info.
+	 * @param  array $charge Charge info.
 	 * @return void
 	 * @throws \Exception Error validating charge info.
 	 */
-	private function validate_charge( $charge ) {
+	private function validate_charge( array $charge ) {
 		if ( ! $charge ) {
-			throw new Exception( 'You must provide charge information' );
+			throw new Exception( 'You must provide charge information.' );
 		}
 
 		if ( ! array_key_exists( 'amount_captured', $charge ) ) {
-			throw new Exception( 'You must provide a captured amount' );
+			throw new Exception( 'You must provide a captured amount.' );
 		}
 
-		if ( ! array_key_exists( 'payment_method_details', $charge ) ) {
-			throw new Exception( 'You must provide payment method details' );
+		if ( ! array_key_exists( 'payment_method_details', $charge ) || ! is_array( $charge['payment_method_details'] ) || ! $charge['payment_method_details'] ) {
+			throw new Exception( 'You must provide payment method details.' );
 		}
 
-		if ( ! array_key_exists( 'card_present', $charge['payment_method_details'] ) ) {
-			throw new Exception( 'You must provide card present details' );
+		if ( ! array_key_exists( 'card_present', $charge['payment_method_details'] ) || ! is_array( $charge['payment_method_details']['card_present'] ) || ! $charge['payment_method_details']['card_present'] ) {
+			throw new Exception( 'You must provide card present details.' );
 		}
 
-		if ( ! array_key_exists( 'receipt', $charge['payment_method_details']['card_present'] ) ) {
-			throw new Exception( 'You must provide card present details' );
+		if ( ! array_key_exists( 'receipt', $charge['payment_method_details']['card_present'] ) || ! is_array( $charge['payment_method_details']['card_present']['receipt'] ) || ! $charge['payment_method_details']['card_present']['receipt'] ) {
+			throw new Exception( 'You must provide receipt details.' );
 		}
 
 	}

--- a/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
+++ b/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
@@ -85,15 +85,11 @@ class WC_Payments_In_Person_Payments_Receipts_Service {
 	 * @throws \Exception Error validating settings.
 	 */
 	private function validate_settings( array $settings ) {
-		if ( ! $settings ) {
-			throw new \Exception( 'Settings information needs to be provided.' );
-		}
-
 		if ( ! array_key_exists( 'business_name', $settings ) ) {
 			throw new \Exception( 'Business name needs to be provided.' );
 		}
 
-		if ( ! array_key_exists( 'support_info', $settings ) || ! is_array( $settings['support_info'] ) || empty( $settings['support_info'] ) ) {
+		if ( empty( $settings['support_info'] ) || ! is_array( $settings['support_info'] ) ) {
 			throw new \Exception( 'Support information needs to be provided.' );
 		}
 
@@ -112,31 +108,23 @@ class WC_Payments_In_Person_Payments_Receipts_Service {
 	 * @throws \Exception Error validating charge info.
 	 */
 	private function validate_charge( array $charge ) {
-		if ( ! $charge ) {
-			throw new Exception( 'Charge information needs to be provided.' );
-		}
-
 		if ( ! array_key_exists( 'amount_captured', $charge ) ) {
 			throw new Exception( 'Captured amount needs to be provided.' );
 		}
 
-		if ( ! array_key_exists( 'payment_method_details', $charge ) || ! is_array( $charge['payment_method_details'] ) || empty( $charge['payment_method_details'] ) ) {
+		if ( empty( $charge['payment_method_details'] ) || ! is_array( $charge['payment_method_details'] ) ) {
 			throw new Exception( 'Payment method details needs to be provided.' );
 		}
 
-		if ( ! array_key_exists( 'card_present', $charge['payment_method_details'] ) || ! is_array( $charge['payment_method_details']['card_present'] ) || empty( $charge['payment_method_details']['card_present'] ) ) {
+		if ( empty( $charge['payment_method_details']['card_present'] ) || ! is_array( $charge['payment_method_details']['card_present'] ) ) {
 			throw new Exception( 'Card present details needs to be provided.' );
 		}
 
 		$this->validate_required_fields(
-			[ 'brand', 'last4' ],
+			[ 'brand', 'last4', 'receipt' ],
 			$charge['payment_method_details']['card_present'],
 			'Error validating card present information'
 		);
-
-		if ( ! array_key_exists( 'receipt', $charge['payment_method_details']['card_present'] ) || ! is_array( $charge['payment_method_details']['card_present']['receipt'] ) || empty( $charge['payment_method_details']['card_present']['receipt'] ) ) {
-			throw new Exception( 'Receipt details need to be provided.' );
-		}
 
 		$this->validate_required_fields(
 			[ 'application_preferred_name', 'dedicated_file_name', 'account_type' ],
@@ -156,8 +144,9 @@ class WC_Payments_In_Person_Payments_Receipts_Service {
 	 * @throws \Exception Error validating required fields.
 	 */
 	private function validate_required_fields( array $required_fields, array $data, string $message ) {
+		$data_keys = array_keys( $data );
 		foreach ( $required_fields as $required_key ) {
-			if ( ! in_array( $required_key, array_keys( $data ), true ) ) {
+			if ( ! in_array( $required_key, $data_keys, true ) ) {
 				throw new Exception( sprintf( '%s. Missing key: %s', $message, $required_key ) );
 			}
 		}

--- a/includes/in-person-payments/templates/html-in-person-payment-receipt.php
+++ b/includes/in-person-payments/templates/html-in-person-payment-receipt.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * In Person Payments Receipt Template
+ *
+ * @package WooCommerce\Payments
+ */
+
+/**
+ * Helper to generate markup to render a price.
+ *
+ * @param  array  $product The product to display.
+ * @param  string $currency The currency to display.
+ * @return string
+ */
+function format_price_helper( array $product, string $currency ): string {
+	$active_price  = $product['price'];
+	$regular_price = $product['regular_price'];
+	$has_discount  = $active_price !== $regular_price;
+
+	if ( $has_discount ) {
+		return '<s>' . wc_price( $regular_price, [ 'currency' => $currency ] ) . '</s> ' . wc_price( $active_price, [ 'currency' => $currency ] );
+	}
+
+	return wc_price( $active_price, [ 'currency' => $currency ] );
+}
+
+?><!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Print Receipt</title>
+	<style>
+		body {
+			margin: 0;
+			padding: 0;
+			border: 0;
+		}
+
+		.align-left {
+			text-align: left;
+		}
+
+		.align-right {
+			text-align: right;
+		}
+		.align-top {
+			vertical-align: top;
+		}
+
+		.receipt {
+			min-width: 130px;
+			max-width: 300px;
+			margin: 0 auto;
+			text-align: center;
+			font-family: SF Pro Text, sans-serif;
+			font-size: 10px;
+
+		}
+
+		.receipt-table {
+			width: 100%;
+			border-collapse: separate;
+			border-spacing: 0 2px;
+		}
+
+		.receipt__header .title {
+			font-size: 14px;
+			line-height: 17px;
+			margin-bottom: 12px;
+			font-weight: 700;
+		}
+
+		.receipt__header .store {
+			padding: 0 12px;
+		}
+
+		.receipt__header .store__address {
+			margin-top: 12px;
+			line-height: 2px;
+		}
+
+		.receipt__header .store__contact {
+			margin-top: 4px;
+		}
+
+		.receipt__header .order__title {
+			font-weight: 800;
+		}
+
+		.receipt__transaction {
+			line-height: 2px;
+		}
+
+	</style>
+</head>
+<body>
+	<div class="receipt">
+		<div class="receipt__header">
+			<h1 class="title"><?php echo esc_html( $business_name ); ?></h1>
+			<hr />
+			<div class="store">
+				<?php if ( $support_address ) { ?>
+				<div class="store__address">
+					<p><?php echo esc_html( $support_address['line1'] ); ?></p>
+					<p><?php echo esc_html( $support_address['line2'] ); ?></p>
+					<p><?php echo esc_html( sprintf( '%s, %s %s %s', $support_address['city'], $support_address['state'], $support_address['postal_code'], $support_address['country'] ) ); ?></p>
+					<?php echo esc_html( gmdate( 'Y/m/d - H:iA' ) ); ?>
+				</div>
+				<?php } ?>
+				<p class="store__contact">
+					<?php echo esc_html( sprintf( '%s %s', $support_phone, $support_email ) ); ?>
+				</p>
+			</div>
+			<div class="order">
+				<p class="order__title"><?php echo sprintf( '%s %s', esc_html__( 'Order', 'woocommerce-payments' ), esc_html( $order['id'] ) ); ?></p>
+			</div>
+		</div>
+		<hr />
+		<div class="receipt__products">
+			<table class="receipt-table">
+				<?php foreach ( $line_items as $item ) { ?>
+				<tr>
+					<td class="align-left">
+						<div><?php echo esc_html( $item['name'] ); ?></div>
+						<div><?php echo esc_html( $item['quantity'] ); ?> @ <?php echo wp_kses( format_price_helper( $item['product'], $order['currency'] ), 'post' ); ?></div>
+						<div><?php echo sprintf( '%s: %s', esc_html__( 'SKU', 'woocommerce-payments' ), esc_html( $item['product']['id'] ) ); ?></div> <!-- TODO SKU or ID? -->
+					</td>
+					<td class="align-right align-top"><?php echo wp_kses( wc_price( $item['subtotal'], [ 'currency' => $order['currency'] ] ), 'post' ); ?></td>
+				</tr>
+				<?php } ?>
+			</table>
+		</div>
+		<hr />
+		<div class="receipt__subtotal">
+			<table class="receipt-table">
+				<tr>
+					<td class="align-left"><b><?php echo esc_html__( 'SUBTOTAL', 'woocommerce-payments' ); ?></b></td>
+					<td class="align-right"><b><?php echo wp_kses( wc_price( $order['subtotal'], [ 'currency' => $order['currency'] ] ), 'post' ); ?></b></td>
+				</tr>
+				<?php foreach ( $coupon_lines as $order_coupon ) { ?>
+				<tr>
+					<td class="align-left">
+						<div><?php echo sprintf( '%s: %s', esc_html__( 'Discount', 'woocommerce-payments' ), esc_html( $order_coupon['code'] ) ); ?></div>
+						<div><?php echo esc_html( $order_coupon['description'] ); ?></div>
+					</td>
+					<td class="align-right align-top"><?php echo wp_kses( wc_price( abs( $order_coupon['discount'] ) * -1, [ 'currency' => $order['currency'] ] ), 'post' ); ?></td>
+				</tr>
+				<?php } ?>
+				<?php foreach ( $tax_lines as $tax_line ) { ?>
+				<tr>
+					<td class="align-left">
+						<div><?php echo esc_html__( 'Tax', 'woocommerce-payments' ); ?></div>
+						<div><?php echo esc_html( wc_round_tax_total( $tax_line['rate_percent'] ) ); ?>%</div>
+					</td>
+					<td class="align-right align-top"><?php echo wp_kses( wc_price( $tax_line['tax_total'], [ 'currency' => $order['currency'] ] ), 'post' ); ?></td>
+				</tr>
+				<?php } ?>
+				<tr>
+					<td colspan="2" class="align-left"></td>
+				</tr>
+				<tr>
+					<td class="align-left"><b><?php echo esc_html__( 'TOTAL', 'woocommerce-payments' ); ?></b></td>
+					<td class="align-right"><b><?php echo wp_kses( wc_price( $order['total'], [ 'currency' => $order['currency'] ] ), 'post' ); ?></b></td>
+				</tr>
+			</table>
+		</div>
+		<hr />
+		<div class="receipt__amount-paid">
+			<table class="receipt-table">
+				<tr>
+					<td class="align-left"><b><?php echo esc_html__( 'AMOUNT PAID', 'woocommerce-payments' ); ?></b>:</td>
+					<td class="align-right"><b><?php echo wp_kses( wc_price( $amount_captured, [ 'currency' => $order['currency'] ] ), 'post' ); ?></b></td>
+				</tr>
+				<tr>
+					<td colspan="2" class="align-left"><?php echo esc_html( sprintf( '%s - %s', ucfirst( $payment_method_details['brand'] ), $payment_method_details['last4'] ) ); ?></td>
+				</tr>
+			</table>
+		</div>
+		<hr />
+		<div class="receipt__transaction">
+			<p id="application-preferred-name"><?php echo sprintf( '%s: %s', esc_html__( 'Application name', 'woocommerce-payments' ), esc_html( ucfirst( $receipt['application_preferred_name'] ) ) ); ?></p>
+			<p id="dedicated-file-name"><?php echo sprintf( '%s: %s', esc_html__( 'AID', 'woocommerce-payments' ), esc_html( ucfirst( $receipt['dedicated_file_name'] ) ) ); ?></p>
+			<p id="account_type"><?php echo sprintf( '%s: %s', esc_html__( 'Account Type', 'woocommerce-payments' ), esc_html( ucfirst( $receipt['account_type'] ) ) ); ?></p>
+		</div>
+	</div>
+</body>
+</html>

--- a/includes/in-person-payments/templates/html-in-person-payment-receipt.php
+++ b/includes/in-person-payments/templates/html-in-person-payment-receipt.php
@@ -105,12 +105,12 @@ function format_price_helper( array $product, string $currency ): string {
 				<div class="store__address">
 					<p><?php echo esc_html( $support_address['line1'] ); ?></p>
 					<p><?php echo esc_html( $support_address['line2'] ); ?></p>
-					<p><?php echo esc_html( sprintf( '%s, %s %s %s', $support_address['city'], $support_address['state'], $support_address['postal_code'], $support_address['country'] ) ); ?></p>
+					<p><?php echo esc_html( implode( ' ', [ $support_address['city'], $support_address['state'], $support_address['postal_code'], $support_address['country'] ] ) ); ?></p>
 					<?php echo esc_html( gmdate( 'Y/m/d - H:iA' ) ); ?>
 				</div>
 				<?php } ?>
 				<p class="store__contact">
-					<?php echo esc_html( sprintf( '%s %s', $support_phone, $support_email ) ); ?>
+					<?php echo esc_html( implode( ' ', [ $support_phone, $support_email ] ) ); ?>
 				</p>
 			</div>
 			<div class="order">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -205,5 +205,36 @@
       <code>WC_Subscriptions_Admin</code>
     </UndefinedClass>
   </file>
+  <file src="includes/in-person-payments/templates/html-in-person-payment-receipt.php">
+    <UndefinedGlobalVariable occurrences="27">
+      <code>$business_name</code>
+      <code>$support_address</code>
+      <code>$support_phone</code>
+      <code>$support_email</code>
+	  <code>$line_items</code>
+      <code>$coupon_lines</code>
+      <code>$tax_lines</code>
+      <code>$order</code>
+      <code>$order</code>
+      <code>$order</code>
+      <code>$order</code>
+      <code>$order</code>
+      <code>$order</code>
+      <code>$order</code>
+      <code>$order</code>
+      <code>$order</code>
+      <code>$order</code>
+      <code>$order</code>
+      <code>$amount_captured</code>
+      <code>$payment_method_details</code>
+      <code>$payment_method_details</code>
+      <code>$payment_method_details</code>
+      <code>$payment_method_details</code>
+      <code>$payment_method_details</code>
+      <code>$receipt</code>
+      <code>$receipt</code>
+      <code>$receipt</code>
+    </UndefinedGlobalVariable>
+  </file>
 </files>
 

--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Onboarding must be completed before Subscriptions products can be published.
 * Add - Support business account branding settings
 * Update - Capture order-related metadata not captured by mobile app for in-person payment transactions.
+* Add - REST endpoint to print IPP receipts
 
 = 3.3.0 - 2021-11-18 =
 * Add - Add Idempotency Key to POST headers.

--- a/tests/unit/admin/test-class-wc-rest-payments-reader-charges-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-reader-charges-controller.php
@@ -6,7 +6,7 @@
  */
 
 use PHPUnit\Framework\MockObject\MockObject;
-use WCPay\Exceptions\Rest_Request_Exception;
+use WCPay\Exceptions\API_Exception;
 
 /**
  * WC_REST_Payments_Reader_Controller_Test unit tests.
@@ -24,11 +24,24 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 	 */
 	private $mock_api_client;
 
+	/**
+	 * @var WC_Payment_Gateway_WCPay|MockObject
+	 */
+	private $mock_wcpay_gateway;
+
+	/**
+	 * @var WC_Payments_In_Person_Payments_Receipts_Service|MockObject
+	 */
+	private $mock_receipts_service;
+
 	public function setUp() {
 		parent::setUp();
 
-		$this->mock_api_client = $this->createMock( WC_Payments_API_Client::class );
-		$this->controller      = new WC_REST_Payments_Reader_Controller( $this->mock_api_client );
+		$this->mock_api_client       = $this->createMock( WC_Payments_API_Client::class );
+		$this->mock_wcpay_gateway    = $this->createMock( WC_Payment_Gateway_WCPay::class );
+		$this->mock_receipts_service = $this->createMock( WC_Payments_In_Person_Payments_Receipts_Service::class );
+
+		$this->controller = new WC_REST_Payments_Reader_Controller( $this->mock_api_client, $this->mock_wcpay_gateway, $this->mock_receipts_service );
 	}
 
 	public function test_get_summary_no_transaction() {
@@ -115,5 +128,273 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 		$request->set_param( 'transaction_id', 1 );
 		$response = $this->controller->get_summary( $request );
 		$this->assertSame( $readers, $response->get_data() );
+	}
+
+	public function test_generate_print_receipt() {
+		$order = WC_Helper_Order::create_order();
+
+		$payment_intent = $this->mock_payment_intent();
+
+		$charge = $this->mock_charge( $order->get_id() );
+
+		$settings = $this->mock_settings();
+
+		$receipt = 'receipt';
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->with( '42' )
+			->willReturn( $payment_intent );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_charge' )
+			->with( $payment_intent->get_charge_id() )
+			->willReturn( $charge );
+
+		$this->mock_wcpay_gateway
+			->expects( $this->exactly( 4 ) )
+			->method( 'get_option' )
+			->willReturnOnConsecutiveCalls( $settings['business_name'], $settings['support_info']['address'], $settings['support_info']['phone'], $settings['support_info']['email'] );
+
+		$this->mock_receipts_service
+			->expects( $this->once() )
+			->method( 'get_receipt_markup' )
+			->with( $settings, $this->isInstanceOf( WC_Order::class ), $charge )
+			->willReturn( $receipt );
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'payment_id', 42 );
+
+		$response = $this->controller->generate_print_receipt( $request );
+
+		$this->assertSame( $receipt, $response->get_data() );
+		$this->assertEquals( 200, $response->status );
+	}
+
+	public function test_generate_print_receipt_invalid_payment_error() {
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->with( '42' )
+			->willReturn( $this->mock_payment_intent( 'processing' ) );
+
+		$this->mock_api_client
+			->expects( $this->never() )
+			->method( 'get_charge' );
+
+		$this->mock_wcpay_gateway
+			->expects( $this->never() )
+			->method( 'get_option' );
+
+		$this->mock_receipts_service
+			->expects( $this->never() )
+			->method( 'get_receipt_markup' );
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'payment_id', 42 );
+
+		$response = $this->controller->generate_print_receipt( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertEquals( 500, $data['status'] );
+	}
+
+	public function test_generate_print_receipt_handle_api_exceptions() {
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->with( '42' )
+			->willThrowException( new API_Exception( 'Something bad happened', 'test error', 500 ) );
+
+		$this->mock_api_client
+			->expects( $this->never() )
+			->method( 'get_charge' );
+
+		$this->mock_wcpay_gateway
+			->expects( $this->never() )
+			->method( 'get_option' );
+
+		$this->mock_receipts_service
+			->expects( $this->never() )
+			->method( 'get_receipt_markup' );
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'payment_id', 42 );
+
+		$response = $this->controller->generate_print_receipt( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertEquals( 500, $data['status'] );
+	}
+
+	public function test_generate_print_receipt_order_not_found() {
+		$payment_intent = $this->mock_payment_intent();
+
+		$charge = $this->mock_charge( '42' );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->with( '42' )
+			->willReturn( $payment_intent );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_charge' )
+			->with( $payment_intent->get_charge_id() )
+			->willReturn( $charge );
+
+		$this->mock_wcpay_gateway
+			->expects( $this->never() )
+			->method( 'get_option' );
+
+		$this->mock_receipts_service
+			->expects( $this->never() )
+			->method( 'get_receipt_markup' );
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'payment_id', 42 );
+
+		$response = $this->controller->generate_print_receipt( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertEquals( 500, $data['status'] );
+	}
+
+	public function test_generate_print_receipt_handle_settings_exception() {
+		$order = WC_Helper_Order::create_order();
+
+		$payment_intent = $this->mock_payment_intent();
+
+		$charge = $this->mock_charge( $order->get_id() );
+
+		$settings = $this->mock_settings();
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->with( '42' )
+			->willReturn( $payment_intent );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_charge' )
+			->with( $payment_intent->get_charge_id() )
+			->willReturn( $charge );
+
+		$this->mock_wcpay_gateway
+			->expects( $this->exactly( 1 ) )
+			->method( 'get_option' )
+			->willThrowException( new Exception( 'Something bad' ) );
+
+		$this->mock_receipts_service
+			->expects( $this->never() )
+			->method( 'get_receipt_markup' );
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'payment_id', 42 );
+
+		$response = $this->controller->generate_print_receipt( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertEquals( 500, $data['status'] );
+	}
+
+	public function test_generate_print_receipt_handle_receipt_service_exception() {
+		$order = WC_Helper_Order::create_order();
+
+		$payment_intent = $this->mock_payment_intent();
+
+		$charge = $this->mock_charge( $order->get_id() );
+
+		$settings = $this->mock_settings();
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->with( '42' )
+			->willReturn( $payment_intent );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_charge' )
+			->with( $payment_intent->get_charge_id() )
+			->willReturn( $charge );
+
+		$this->mock_wcpay_gateway
+			->expects( $this->exactly( 4 ) )
+			->method( 'get_option' )
+			->willReturnOnConsecutiveCalls( $settings['business_name'], $settings['support_info']['address'], $settings['support_info']['phone'], $settings['support_info']['email'] );
+
+		$this->mock_receipts_service
+			->expects( $this->once() )
+			->method( 'get_receipt_markup' )
+			->with( $settings, $this->isInstanceOf( WC_Order::class ), $charge )
+			->willThrowException( new Exception( 'Something bad' ) );
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'payment_id', 42 );
+
+		$response = $this->controller->generate_print_receipt( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertEquals( 500, $data['status'] );
+	}
+
+	private function mock_payment_intent( $status = 'succeeded' ) {
+		return new WC_Payments_API_Intention(
+			'42',
+			42,
+			'USD',
+			'42',
+			'42',
+			new DateTime(),
+			$status,
+			'42',
+			'secret'
+		);
+	}
+
+	private function mock_charge( string $order_id ) {
+		return [
+			'amount_captured'        => 10,
+			'order'                  => [
+				'number' => $order_id,
+			],
+			'payment_method_details' => [
+				'card_present' => [
+					'brand'   => 'test',
+					'last4'   => 'Test',
+					'receipt' => [
+						'application_preferred_name' => 'Test',
+						'dedicated_file_name'        => 'Test 42',
+						'account_type'               => 'test',
+					],
+				],
+			],
+		];
+	}
+
+	private function mock_settings() {
+		return [
+			'business_name' => 'Test Business Name',
+			'support_info'  => [
+				'address' => [],
+				'phone'   => '4242',
+				'email'   => 'test@example.com',
+			],
+		];
 	}
 }

--- a/tests/unit/admin/test-class-wc-rest-payments-reader-charges-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-reader-charges-controller.php
@@ -170,7 +170,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 		$response = $this->controller->generate_print_receipt( $request );
 
 		$this->assertSame( $receipt, $response->get_data() );
-		$this->assertEquals( 200, $response->status );
+		$this->assertSame( 200, $response->status );
 	}
 
 	public function test_generate_print_receipt_invalid_payment_error() {
@@ -200,7 +200,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WP_Error', $response );
 		$data = $response->get_error_data();
 		$this->assertArrayHasKey( 'status', $data );
-		$this->assertEquals( 500, $data['status'] );
+		$this->assertSame( 500, $data['status'] );
 	}
 
 	public function test_generate_print_receipt_handle_api_exceptions() {
@@ -230,7 +230,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WP_Error', $response );
 		$data = $response->get_error_data();
 		$this->assertArrayHasKey( 'status', $data );
-		$this->assertEquals( 500, $data['status'] );
+		$this->assertSame( 500, $data['status'] );
 	}
 
 	public function test_generate_print_receipt_order_not_found() {
@@ -266,7 +266,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WP_Error', $response );
 		$data = $response->get_error_data();
 		$this->assertArrayHasKey( 'status', $data );
-		$this->assertEquals( 500, $data['status'] );
+		$this->assertSame( 500, $data['status'] );
 	}
 
 	public function test_generate_print_receipt_handle_settings_exception() {
@@ -275,8 +275,6 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 		$payment_intent = $this->mock_payment_intent();
 
 		$charge = $this->mock_charge( $order->get_id() );
-
-		$settings = $this->mock_settings();
 
 		$this->mock_api_client
 			->expects( $this->once() )
@@ -307,7 +305,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WP_Error', $response );
 		$data = $response->get_error_data();
 		$this->assertArrayHasKey( 'status', $data );
-		$this->assertEquals( 500, $data['status'] );
+		$this->assertSame( 500, $data['status'] );
 	}
 
 	public function test_generate_print_receipt_handle_receipt_service_exception() {
@@ -350,7 +348,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WP_Error', $response );
 		$data = $response->get_error_data();
 		$this->assertArrayHasKey( 'status', $data );
-		$this->assertEquals( 500, $data['status'] );
+		$this->assertSame( 500, $data['status'] );
 	}
 
 	private function mock_payment_intent( $status = 'succeeded' ) {

--- a/tests/unit/in-person-payments/test-class-wc-payments-in-person-payments-receipts-service.php
+++ b/tests/unit/in-person-payments/test-class-wc-payments-in-person-payments-receipts-service.php
@@ -87,6 +87,8 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 	public function provide_settings_validation_data() {
 		return [
 			[ [] ],
+			[ [ 'key' => 'value' ] ],
+			[ [ 'support_info' => 'Test' ] ],
 			[ [ 'support_info' => [ 'line1' => '42 Some Street' ] ] ],
 			[
 				[
@@ -118,6 +120,16 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 				[
 					'amount_captured'        => 100,
 					'payment_method_details' => [ 'card_present' => [] ],
+				],
+			],
+			[
+				[
+					'amount_captured'        => 100,
+					'payment_method_details' => [
+						'card_present' => [
+							'receipt' => [],
+						],
+					],
 				],
 			],
 		];

--- a/tests/unit/in-person-payments/test-class-wc-payments-in-person-payments-receipts-service.php
+++ b/tests/unit/in-person-payments/test-class-wc-payments-in-person-payments-receipts-service.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Class WC_Payments_In_Person_Payments_Receipts_Service_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * WC_Payments_In_Person_Payments_Receipts_Service_Test unit tests.
+ */
+class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCase {
+	/**
+	 * System under test.
+	 * @var WC_Payments_In_Person_Payments_Receipts_Service
+	 */
+	private $receipts_service;
+
+	/**
+	 * mock_settings
+	 *
+	 * @var array
+	 */
+	private $mock_settings = [
+		'business_name' => 'Test Business Name',
+		'support_info'  => [
+			'address' => [],
+			'phone'   => '4242',
+			'email'   => 'test@example.com',
+		],
+	];
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->receipts_service = new WC_Payments_In_Person_Payments_Receipts_Service();
+	}
+
+	public function test_get_receipt_markup_is_EMV_compliant() {
+		$mock_order  = WC_Helper_Order::create_order();
+		$mock_charge = [
+			'amount_captured'        => 10,
+			'order'                  => [
+				'number' => $mock_order->get_id(),
+			],
+			'payment_method_details' => [
+				'card_present' => [
+					'brand'   => 'test',
+					'last4'   => 'Test',
+					'receipt' => [
+						'application_preferred_name' => 'Test',
+						'dedicated_file_name'        => 'Test 42',
+						'account_type'               => 'test',
+					],
+				],
+			],
+		];
+
+		$result = $this->receipts_service->get_receipt_markup( $this->mock_settings, $mock_order, $mock_charge );
+
+		$doc = new DOMDocument();
+		$doc->loadHTML( $result );
+
+		$this->assertSame( $doc->getElementById( 'application-preferred-name' )->textContent, 'Application name: Test' );
+		$this->assertSame( $doc->getElementById( 'dedicated-file-name' )->textContent, 'AID: Test 42' );
+		$this->assertSame( $doc->getElementById( 'account_type' )->textContent, 'Account Type: Test' );
+	}
+
+	/**
+	 * @dataProvider provide_charge_validation_data
+	 */
+
+	public function test_get_receipt_markup_handles_charge_validation_errors( $input_charge ) {
+		$mock_order = WC_Helper_Order::create_order();
+		$this->expectException( Exception::class );
+		$this->receipts_service->get_receipt_markup( $this->mock_settings, $mock_order, $input_charge );
+	}
+
+	/**
+	 * @dataProvider provide_settings_validation_data
+	 */
+	public function test_get_receipt_markup_handles_settings_validation_errors( $input_settings ) {
+		$mock_order = WC_Helper_Order::create_order();
+		$this->expectException( Exception::class );
+		$this->receipts_service->get_receipt_markup( $input_settings, $mock_order, [] );
+	}
+
+	public function provide_settings_validation_data() {
+		return [
+			[ [] ],
+			[ [ 'support_info' => [ 'line1' => '42 Some Street' ] ] ],
+			[
+				[
+					'business_name' => 'test',
+					'support_info'  => [],
+				],
+			],
+			[
+				[
+					'business_name' => 'test',
+					'support_info'  => [ 'line1' => '42 Some Street' ],
+				],
+			],
+		];
+	}
+
+	public function provide_charge_validation_data() {
+		return [
+			[ [] ],
+			[ [ 'key' => 'value' ] ],
+			[ [ 'amount_captured' => 100 ] ],
+			[
+				[
+					'amount_captured'        => 100,
+					'payment_method_details' => [],
+				],
+			],
+			[
+				[
+					'amount_captured'        => 100,
+					'payment_method_details' => [ 'card_present' => [] ],
+				],
+			],
+		];
+	}
+}

--- a/tests/unit/in-person-payments/test-class-wc-payments-in-person-payments-receipts-service.php
+++ b/tests/unit/in-person-payments/test-class-wc-payments-in-person-payments-receipts-service.php
@@ -88,7 +88,7 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 
 	public function provide_settings_validation_data() {
 		return [
-			[ [], 'Settings information needs to be provided.' ],
+			[ [], 'Business name needs to be provided.' ],
 			[ [ 'key' => 'value' ], 'Business name needs to be provided.' ],
 			[
 				[
@@ -137,7 +137,7 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 
 	public function provide_charge_validation_data() {
 		return [
-			[ [], 'Charge information needs to be provided.' ],
+			[ [], 'Captured amount needs to be provided.' ],
 			[ [ 'key' => 'value' ], 'Captured amount needs to be provided.' ],
 			[ [ 'amount_captured' => '42' ], 'Payment method details needs to be provided.' ],
 			[
@@ -199,20 +199,7 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 						],
 					],
 				],
-				'Receipt details need to be provided.',
-			],
-			[
-				[
-					'amount_captured'        => '42',
-					'payment_method_details' => [
-						'card_present' => [
-							'brand'   => 'test',
-							'last4'   => 'test',
-							'receipt' => 'test',
-						],
-					],
-				],
-				'Receipt details need to be provided.',
+				'Error validating card present information. Missing key: receipt',
 			],
 			[
 				[
@@ -222,22 +209,6 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 							'brand'   => 'test',
 							'last4'   => 'test',
 							'receipt' => [],
-						],
-					],
-				],
-				'Receipt details need to be provided.',
-			],
-			[
-				[
-					'amount_captured'        => '42',
-					'payment_method_details' => [
-						'card_present' => [
-							'brand'   => 'test',
-							'last4'   => 'test',
-							'receipt' => [
-								'dedicated_file_name' => 'test',
-								'account_type'        => 'test',
-							],
 						],
 					],
 				],

--- a/tests/unit/in-person-payments/test-class-wc-payments-in-person-payments-receipts-service.php
+++ b/tests/unit/in-person-payments/test-class-wc-payments-in-person-payments-receipts-service.php
@@ -71,7 +71,7 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 
 	public function test_get_receipt_markup_handles_charge_validation_errors( $input_charge, $expected_message ) {
 		$mock_order = WC_Helper_Order::create_order();
-		$this->expectException( Exception::class );
+		$this->expectException( \RuntimeException::class );
 		$this->expectExceptionMessage( $expected_message );
 		$this->receipts_service->get_receipt_markup( $this->mock_settings, $mock_order, $input_charge );
 	}
@@ -81,7 +81,7 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 	 */
 	public function test_get_receipt_markup_handles_settings_validation_errors( $input_settings, $expected_message ) {
 		$mock_order = WC_Helper_Order::create_order();
-		$this->expectException( Exception::class );
+		$this->expectException( \RuntimeException::class );
 		$this->expectExceptionMessage( $expected_message );
 		$this->receipts_service->get_receipt_markup( $input_settings, $mock_order, [] );
 	}
@@ -159,35 +159,35 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 					'amount_captured'        => '42',
 					'payment_method_details' => [ 'key' => 'value' ],
 				],
-				'Card present details needs to be provided.',
+				'Payment method details needs to be provided.',
 			],
 			[
 				[
 					'amount_captured'        => '42',
 					'payment_method_details' => [ 'card_present' => 'value' ],
 				],
-				'Card present details needs to be provided.',
+				'Payment method details needs to be provided.',
 			],
 			[
 				[
 					'amount_captured'        => '42',
 					'payment_method_details' => [ 'card_present' => [] ],
 				],
-				'Card present details needs to be provided.',
+				'Payment method details needs to be provided.',
 			],
 			[
 				[
 					'amount_captured'        => '42',
 					'payment_method_details' => [ 'card_present' => [ 'last4' => 'test' ] ],
 				],
-				'Error validating card present information. Missing key: brand',
+				'Error validating payment information. Missing key: brand',
 			],
 			[
 				[
 					'amount_captured'        => '42',
 					'payment_method_details' => [ 'card_present' => [ 'brand' => 'test' ] ],
 				],
-				'Error validating card present information. Missing key: last4',
+				'Error validating payment information. Missing key: last4',
 			],
 			[
 				[
@@ -199,7 +199,7 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 						],
 					],
 				],
-				'Error validating card present information. Missing key: receipt',
+				'Error validating payment information. Missing key: receipt',
 			],
 			[
 				[


### PR DESCRIPTION
Fixes #3021 and #3224

#### Changes proposed in this Pull Request


<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR exposes a new REST API endpoint to generate an IPP receipt for printing. The new endpoint will collect all the data needed to generate the receipt, and will return an HTML version of it. The client can then use the returned HTML to print the receipt.

We did some tests using a thermal printer to validate the implementation (thanks again @malinajirka ). After some tweaks, this is how the receipt looks like:

![20211125_185940](https://user-images.githubusercontent.com/1553182/144287188-790bad55-93ad-4920-a7e7-12238b87b81e.jpg)

I added the new endpoint to the payment readers controller because the receipts are strictly related to the readers. A client can do a `GET` request to `payments/readers/receipts/payment_id ` to fetch the receipt. 

Initially, we had the idea of caching the receipt, to get some performance savings. But during development we decided to change the approach. The generation of the receipt in HTML does not seem to be a costly operation and it will be printed just once most of the times. With these things in mind, the complexity of caching the receipt in the database seemed to me not necessary at the moment.

 

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test this feature in your local environment you will need:

- Connect your local WC Pay client and server.
- Create an order with Cash on Delivery as payment method. Please use the proxied url of your local site.
- Start listening for webhooks in your local WC Pay server. You'll need this to refresh your order status after next step.
- Use the WooCommerce Mobile App to pay the order. You can follow this great guide to set it up locally: pdjVC1-9M-p2
- Once the payment is suceeded, you'll need to note the payment id reference i.e: you can find it in the order details
- Using Postman (note that you'll need to set up Authentication as explained in this guide: PbTz5e-12J-p2) make a GET request to `/wp-json/wc/v3/payments/readers/receipts/<payment_id>`.
- You should be able to check the HTML response within Postman. Hint: There is a preview button that let's you see the rendered HTML

![Screen Shot 2021-12-01 at 20 07 19](https://user-images.githubusercontent.com/1553182/144297787-ef02f4ed-352f-402b-8e78-1b9ecae93f1a.png)
-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)