### PR TITLE
Add tracking events to the subscriptions empty state

### DIFF
--- a/client/subscriptions-empty-state/index.js
+++ b/client/subscriptions-empty-state/index.js
@@ -3,10 +3,12 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { render, useState } from '@wordpress/element';
+import { render, useEffect, useState } from '@wordpress/element';
 
 import { __experimentalCreateInterpolateElement as createInterpolateElement } from 'wordpress-element';
 import { Button } from '@wordpress/components';
+
+import wcpayTracks from '../tracks';
 
 import connectedImage from '../../assets/images/subscriptions-empty-state-connected.svg';
 import unconnectedImage from '../../assets/images/subscriptions-empty-state-unconnected.svg';
@@ -70,7 +72,13 @@ const ActionButtons = () => {
 					href={ connectUrl }
 					isBusy={ isFinishingSetup }
 					isPrimary
-					onClick={ () => setIsFinishingSetup( true ) }
+					onClick={ () => {
+						wcpayTracks.recordEvent(
+							wcpayTracks.events
+								.SUBSCRIPTIONS_EMPTY_STATE_FINISH_SETUP
+						);
+						setIsFinishingSetup( true );
+					} }
 				>
 					{ __( 'Finish setup', 'woocommerce-payments' ) }
 				</Button>
@@ -80,7 +88,13 @@ const ActionButtons = () => {
 				href={ newProductUrl }
 				isBusy={ isCreatingProduct }
 				isSecondary
-				onClick={ () => setIsCreatingProduct( true ) }
+				onClick={ () => {
+					wcpayTracks.recordEvent(
+						wcpayTracks.events
+							.SUBSCRIPTIONS_EMPTY_STATE_CREATE_PRODUCT
+					);
+					setIsCreatingProduct( true );
+				} }
 			>
 				{ __( 'Create subscription product', 'woocommerce-payments' ) }
 			</Button>
@@ -88,12 +102,27 @@ const ActionButtons = () => {
 	);
 };
 
+const EmptyState = () => {
+	useEffect( () => {
+		wcpayTracks.recordEvent(
+			wcpayTracks.events.SUBSCRIPTIONS_EMPTY_STATE_VIEW,
+			{
+				is_connected: isConnected ? 'yes' : 'no',
+			}
+		);
+	}, [] );
+
+	return (
+		<div className="wcpay-empty-subscriptions__container">
+			<Image />
+			<Description />
+			{ ! isConnected && <TOS /> }
+			<ActionButtons />
+		</div>
+	);
+};
+
 render(
-	<div className="wcpay-empty-subscriptions__container">
-		<Image />
-		<Description />
-		{ ! isConnected && <TOS /> }
-		<ActionButtons />
-	</div>,
+	<EmptyState />,
 	document.querySelector( '#wcpay_subscriptions_empty_state' )
 );

--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -38,6 +38,11 @@ const events = {
 	MULTI_CURRENCY_ENABLED_CURRENCIES_UPDATED:
 		'wcpay_multi_currency_enabled_currencies_updated',
 	PAYMENT_REQUEST_SETTINGS_CHANGE: 'wcpay_payment_request_settings_change',
+	SUBSCRIPTIONS_EMPTY_STATE_VIEW: 'wcpay_subscriptions_empty_state_view',
+	SUBSCRIPTIONS_EMPTY_STATE_FINISH_SETUP:
+		'wcpay_subscriptions_empty_state_finish_setup',
+	SUBSCRIPTIONS_EMPTY_STATE_CREATE_PRODUCT:
+		'wcpay_subscriptions_empty_state_create_product',
 };
 
 export default {


### PR DESCRIPTION
Fixes #3420

#### Changes proposed in this Pull Request

Adds 3 tracking events to the subscriptions empty state page (located at `/wp-admin/edit.php?post_type=shop_subscription`).

- `wcpay_subscriptions_empty_state_view` - When the empty state is viewed.
- `wcpay_subscriptions_empty_state_finish_setup` - When the "Finish setup" button is clicked.
- `wcpay_subscriptions_empty_state_create_product` - When the "Create subscription product" button is clicked.

#### Testing instructions

**Prerequisites**

* Store is **not** onboarded (I think you can fake this by using the "Force the plugin to act as disconnected from WCPay" option in WCPay Dev Utils)
* Store **does not** have existing subscriptions (see the SQL snippets below to temporarily delete existing subscriptions.)
* Store has WC tracking enabled (execute this to enable ```UPDATE `wp_options` SET `option_value` = 'yes' WHERE `wp_options`.`option_name` = 'woocommerce_allow_tracking';```)

**"Delete" all subscriptions** 
```sql
UPDATE `wp_posts`
SET `post_type` = 'subscription_backup'
WHERE `post_type` = 'shop_subscription';
```

**Bring back all subscriptions** 
```sql
UPDATE `wp_posts`
SET `post_type` = 'shop_subscription'
WHERE `post_type` = 'subscription_backup';
```

**Then**
- Open Chrome dev tools
- Go to the "Network tab", enable "Preserve log" and filter by "Img" requests.
<img width="755" alt="Screen Shot 2021-11-29 at 2 08 38 pm" src="https://user-images.githubusercontent.com/1527164/143802706-0408cc97-d3e0-4b28-897a-6b94ac497643.png">

- Filter requests using this string `wcpay_subscriptions_empty_state_view`.
<img width="668" alt="Screen Shot 2021-11-29 at 2 10 41 pm" src="https://user-images.githubusercontent.com/1527164/143802832-1a088851-1d2d-4e2a-9033-ce2de99f526f.png">

- Navigate to `/wp-admin/edit.php?post_type=shop_subscription`
- Observe the tracking pixel image request in the log.
- Filter requests using this string `wcpay_subscriptions_empty_state_finish_setup`.
- Click the "Finish setup" button.
- Observe the tracking pixel image request in the log.
- Navigate back to the Subscriptions page.
- Filter requests using this string `wcpay_subscriptions_empty_state_create_product`.
- Click the "Create subscription product" button.
- Observe the tracking pixel image request in the log.

-------------------

- [ ] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
