### PR TITLE
Tracks for subscriptions product creation flow when not connected to Stripe yet.

### DIFF
--- a/client/subscription-product-onboarding/modal.js
+++ b/client/subscription-product-onboarding/modal.js
@@ -9,6 +9,7 @@ import { useEffect, useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import { removeQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
+import wcpayTracks from '../tracks';
 
 import './style.scss';
 
@@ -23,7 +24,13 @@ const FinishSetupButton = () => {
 			href={ connectUrl }
 			isBusy={ isFinishingSetup }
 			isPrimary
-			onClick={ () => setIsFinishingSetup( true ) }
+			onClick={ () => {
+				wcpayTracks.recordEvent(
+					wcpayTracks.events
+						.SUBSCRIPTIONS_ACCOUNT_NOT_CONNECTED_PRODUCT_MODAL_FINISH_SETUP
+				);
+				setIsFinishingSetup( true );
+			} }
 		>
 			{ __( 'Finish setup', 'woocommerce-payments' ) }
 		</Button>
@@ -53,7 +60,13 @@ const SubscriptionProductOnboardingModal = () => {
 	return (
 		<Modal
 			className="wcpay-subscription-product-modal"
-			onRequestClose={ () => setOpen( false ) }
+			onRequestClose={ () => {
+				wcpayTracks.recordEvent(
+					wcpayTracks.events
+						.SUBSCRIPTIONS_ACCOUNT_NOT_CONNECTED_PRODUCT_MODAL_DISMISS
+				);
+				setOpen( false );
+			} }
 			shouldCloseOnClickOutside={ false }
 		>
 			<p className="wcpay-subscription-product-modal__title">

--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -43,6 +43,10 @@ const events = {
 		'wcpay_subscriptions_empty_state_finish_setup',
 	SUBSCRIPTIONS_EMPTY_STATE_CREATE_PRODUCT:
 		'wcpay_subscriptions_empty_state_create_product',
+	SUBSCRIPTIONS_ACCOUNT_NOT_CONNECTED_PRODUCT_MODAL_FINISH_SETUP:
+		'wcpay_subscriptions_account_not_connected_product_modal_finish_setup',
+	SUBSCRIPTIONS_ACCOUNT_NOT_CONNECTED_PRODUCT_MODAL_DISMISS:
+		'wcpay_subscriptions_account_not_connected_product_modal_dismiss',
 };
 
 export default {

--- a/includes/subscriptions/class-wc-payments-subscriptions-onboarding-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-onboarding-handler.php
@@ -114,7 +114,7 @@ class WC_Payments_Subscriptions_Onboarding_Handler {
 		// Save and prevent duplicates from multiple updates.
 		update_option( self::WCPAY_SUBSCRIPTION_AUTO_PUBLISH_PRODUCTS, array_unique( $auto_publish_ids ) );
 
-		Tracker::track_admin( 'wcpay_subscriptions_empty_state_save_product' );
+		Tracker::track_admin( 'wcpay_subscriptions_account_not_connected_save_product' );
 	}
 
 	/**
@@ -148,7 +148,7 @@ class WC_Payments_Subscriptions_Onboarding_Handler {
 		// clear auto-published products from option.
 		delete_option( self::WCPAY_SUBSCRIPTION_AUTO_PUBLISH_PRODUCTS );
 
-		Tracker::track_admin( 'wcpay_subscriptions_empty_state_publish_products' );
+		Tracker::track_admin( 'wcpay_subscriptions_account_not_connected_publish_products' );
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-subscriptions-onboarding-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-onboarding-handler.php
@@ -7,6 +7,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use WCPay\Tracker;
+
 /**
  * A class to handle the onboarding of subscriptions products. Created subscription products will be set to draft until
  *   onboarding is completed.
@@ -111,6 +113,8 @@ class WC_Payments_Subscriptions_Onboarding_Handler {
 
 		// Save and prevent duplicates from multiple updates.
 		update_option( self::WCPAY_SUBSCRIPTION_AUTO_PUBLISH_PRODUCTS, array_unique( $auto_publish_ids ) );
+
+		Tracker::track_admin( 'wcpay_subscriptions_empty_state_save_product' );
 	}
 
 	/**
@@ -143,6 +147,8 @@ class WC_Payments_Subscriptions_Onboarding_Handler {
 
 		// clear auto-published products from option.
 		delete_option( self::WCPAY_SUBSCRIPTION_AUTO_PUBLISH_PRODUCTS );
+
+		Tracker::track_admin( 'wcpay_subscriptions_empty_state_publish_products' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3419

#### Changes proposed in this Pull Request

- Sends tracks event when user saves products but no wcpay account connected.
- Sends tracks event when wcpay account is connected and there are draft subscriptions products.
- Sends tracks event when user dismisses the modal from https://github.com/Automattic/woocommerce-payments/pull/3429 that is shown on the edit product page.
- Sends tracks event when user clicks the 'finish setup' button on the modal from https://github.com/Automattic/woocommerce-payments/pull/3429 that is shown on the edit product page.

Note: I need to register the track events but I thought I'd do that after the event names get blessing from this PR reviewers.

New tracks events:
- `wcpay_subscriptions_account_not_connected_save_product`
- `wcpay_subscriptions_account_not_connected_publish_products`
- `wcpay_subscriptions_account_not_connected_product_modal_finish_setup`
- `wcpay_subscriptions_account_not_connected_product_modal_dismiss`

Action item for me: register tracks events on the MC Tracks tool.

#### Testing instructions

1. Make sure WC Subscriptions is not active.
2. Enable tracking under WC settings > Advanced > WooCommerce.com (/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com).
2. Make sure store is *not* connected to a wcpay account (by starting a new JN site or use wcpay dev tool with 'Force the plugin to act as disconnected from WCPay' checked).
3. Checkout this PR branch and run `npm start` to make sure JS files are built using the latest changes from this PR branch.
4. Creates a subscriptions product.
5. The status of that product should be draft.
6. There should be a track event named `wcpay_subscriptions_account_not_connected_save_product` being sent. Not sure how to verify tracks event being sent from PHP. Maybe from the MC Tracks Live View.
7. There should be a modal being shown. Refer to https://github.com/Automattic/woocommerce-payments/pull/3429 to see how the modal looks like.
8. Do not do anything with the modal. Open Chrome dev tool and go to the Network tab. Filter with string `wcpay_subscriptions_account_not_connected`. A more detailed instructions can be found from https://github.com/Automattic/woocommerce-payments/pull/3437.
9. Close the modal and expects a pixel request containing `wcpay_subscriptions_account_not_connected_product_modal_dismiss` in the URL.
10. Clicks on the 'Update' button to save the product. This is to trigger the modal again.
11. This time, click o nthe 'Finish setup' button on the modal and expects a pixel request containing `wcpay_subscriptions_account_not_connected_product_modal_finish_setup` in the URL.
12. Go through onboarding to connect the store with a wcpay account.
13. Check on the subscription product you created earlier and expect its status to be published this time.
14. There should be a track event named `wcpay_subscriptions_account_not_connected_publish_products` being sent. Not sure how to verify tracks event being sent from PHP. Maybe from the MC Tracks Live View.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
