### PR TITLE
Add test to confirm `payment_complete` is triggered when `attach_intent_info_to_order` is successful

### DIFF
--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -1735,6 +1735,38 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_attach_intent_info_to_order_success_payment_complete() {
+		// test if metadata needed for refunds is being saved despite the payment_complete method.
+		$order = $this->getMockBuilder( WC_Order::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'update_meta_data', 'save', 'payment_complete', 'get_data_store' ] )
+			->getMock();
+
+		$order
+			->method( 'get_data_store' )
+			->willReturn( new \WC_Mock_WC_Data_Store() );
+
+		$intent_id      = 'pi_xxxxxxxxxxxxx';
+		$charge_id      = 'ch_yyyyyyyyyyyyy';
+		$customer_id    = 'cus_12345';
+		$payment_method = 'woocommerce_payments';
+		$intent_status  = 'succeeded';
+		$currency       = 'USD';
+
+		$order->expects( $this->atLeast( 2 ) )->method( 'update_meta_data' )->withConsecutive(
+			[ '_intent_id', $intent_id ],
+			[ '_charge_id', $charge_id ]
+		);
+
+		$order->expects( $this->once() )
+			->method( 'payment_complete' )
+			->with( $intent_id );
+
+		$order->expects( $this->once() )->method( 'save' );
+
+		$this->wcpay_gateway->attach_intent_info_to_order( $order, $intent_id, $intent_status, $payment_method, $customer_id, $charge_id, $currency );
+	}
+
 	public function test_attach_intent_info_to_order_fails_payment_complete() {
 		// test if metadata needed for refunds is being saved despite the payment_complete method.
 		$order = $this->getMockBuilder( WC_Order::class )


### PR DESCRIPTION
Fixes #2267 

#### Changes proposed in this Pull Request

This adds a test that confirms `payment_complete` is called when `attach_intent_info_to_order` is successful. The referenced issue actually calls for testing for stock reduction, but I decided to instead confirm `payment_complete` is called because at this point I think we can assume WC will handle stock reduction appropriately.

#### Testing instructions

* Run PHPUnit tests

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
