### PR TITLE
Use the project's pinned Node.js version for JS linting and tests

### DIFF
--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -20,7 +20,7 @@ jobs:
           path: ~/.npm/
           key:  ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
       # install dependencies and run linter
-      - run: npm ci && npm run lint:js && npm run lint:css
+      - run: npm -v && node -v && npm ci && npm run lint:js && npm run lint:css
 
   test:
     name:    JS testing

--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -23,7 +23,7 @@ jobs:
           path: ~/.npm/
           key:  ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
       # install dependencies and run linter
-      - run: npm -v && node -v && npm ci && npm run lint:js && npm run lint:css
+      - run: npm ci && npm run lint:js && npm run lint:css
 
   test:
     name:    JS testing

--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -10,6 +10,14 @@ jobs:
     steps:
       # clone the repository
       - uses: actions/checkout@v2
+      # use the project's pinned Node.js version
+      - name: Read .nvmrc
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        id: nvm
+      - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       # enable dependencies caching
       - uses: actions/cache@v2
         with:
@@ -28,6 +36,14 @@ jobs:
     steps:
       # clone the repository
       - uses: actions/checkout@v2
+      # use the project's pinned Node.js version
+      - name: Read .nvmrc
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        id: nvm
+      - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       # enable dependencies caching
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -12,12 +12,12 @@ jobs:
       - uses: actions/checkout@v2
       # use the project's pinned Node.js version
       - name: Read .nvmrc
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
         id: nvm
-      - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
-        uses: actions/setup-node@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
         with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+          node-version: '${{ steps.nvm.outputs.NVMRC }}'
       # enable dependencies caching
       - uses: actions/cache@v2
         with:
@@ -38,12 +38,12 @@ jobs:
       - uses: actions/checkout@v2
       # use the project's pinned Node.js version
       - name: Read .nvmrc
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
         id: nvm
-      - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
-        uses: actions/setup-node@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
         with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+          node-version: '${{ steps.nvm.outputs.NVMRC }}'
       # enable dependencies caching
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -10,14 +10,9 @@ jobs:
     steps:
       # clone the repository
       - uses: actions/checkout@v2
-      # use the project's pinned Node.js version
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
-      - name: Setup node
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+          node-version-file: '.nvmrc'
       # enable dependencies caching
       - uses: actions/cache@v2
         with:
@@ -36,14 +31,9 @@ jobs:
     steps:
       # clone the repository
       - uses: actions/checkout@v2
-      # use the project's pinned Node.js version
-      - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-        id: nvm
-      - name: Setup node
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+          node-version-file: '.nvmrc'
       # enable dependencies caching
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Prior to this PR, the [JS linting and tests](https://github.com/Automattic/woocommerce-payments/blob/develop/.github/workflows/js-lint-test.yml) workflow **did not** use the Node version (currently `12.22.6`) defined in https://github.com/Automattic/woocommerce-payments/blob/develop/.nvmrc.

This meant that these jobs were using significantly newer versions of Node/npm during linting and test runs. While this has seemingly worked fine for a while, these jobs recently start failing with the following errors:

```
npm WARN old lockfile 
npm WARN old lockfile The package-lock.json file was created with an old version of npm,
npm WARN old lockfile so supplemental metadata must be fetched from the registry.
```

and

```
npm ERR! Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /home/runner/.npm/_cacache/tmp/git-cloneGBcZjn/node_modules/@babel/helper-compilation-targets/package.json
npm ERR!     at new NodeError (node:internal/errors:371:5)
npm ERR!     at throwExportsNotFound (node:internal/modules/esm/resolve:440:9)
npm ERR!     at packageExportsResolve (node:internal/modules/esm/resolve:692:3)
npm ERR!     at resolveExports (node:internal/modules/cjs/loader:482:36)
npm ERR!     at Function.Module._findPath (node:internal/modules/cjs/loader:522:31)
npm ERR!     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:919:27)
npm ERR!     at Function.Module._load (node:internal/modules/cjs/loader:778:27)
npm ERR!     at Module.require (node:internal/modules/cjs/loader:1005:19)
npm ERR!     at require (node:internal/modules/cjs/helpers:102:18)
npm ERR!     at Object.<anonymous> (/home/runner/.npm/_cacache/tmp/git-cloneGBcZjn/node_modules/@babel/preset-env/lib/debug.js:8:33) {
npm ERR!   code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
npm ERR! }
```

This PR introduces a `actions/setup-node@v2` step with some config to use this project's `.nvmrc` file. As a result, the issues referenced above are resolved.

#### Testing instructions

* All workflow jobs pass on this PR.

-------------------

- [ ] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
