### PR TITLE
Use the project's pinned Node.js version for e2e workflows

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -45,6 +45,7 @@ jobs:
       WC_VERSION: ${{ matrix.woocommerce }}
     steps:
       # clone the repository
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -45,7 +45,9 @@ jobs:
       WC_VERSION: ${{ matrix.woocommerce }}
     steps:
       # clone the repository
-      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
       # enable dependencies caching
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
Similar to #3462 (and heavily based on it)

#### Fixes

E2E checks that are run on commits in the `develop` branch.

#### Changes proposed in this Pull Request

Prior to this PR, the [E2E tests](https://github.com/Automattic/woocommerce-payments/blob/develop/.github/workflows/e2e-test.yml) workflow **did not** use the Node version (currently `12.22.6`) defined in https://github.com/Automattic/woocommerce-payments/blob/develop/.nvmrc.

This meant that these jobs were using significantly newer versions of Node/npm during linting and test runs. While this has seemingly worked fine for a while, these jobs recently start failing with the following errors:

```
npm WARN old lockfile 
npm WARN old lockfile The package-lock.json file was created with an old version of npm,
npm WARN old lockfile so supplemental metadata must be fetched from the registry.
```

and

```
npm ERR! Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /home/runner/.npm/_cacache/tmp/git-cloneGBcZjn/node_modules/@babel/helper-compilation-targets/package.json
npm ERR!     at new NodeError (node:internal/errors:371:5)
npm ERR!     at throwExportsNotFound (node:internal/modules/esm/resolve:440:9)
npm ERR!     at packageExportsResolve (node:internal/modules/esm/resolve:692:3)
npm ERR!     at resolveExports (node:internal/modules/cjs/loader:482:36)
npm ERR!     at Function.Module._findPath (node:internal/modules/cjs/loader:522:31)
npm ERR!     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:919:27)
npm ERR!     at Function.Module._load (node:internal/modules/cjs/loader:778:27)
npm ERR!     at Module.require (node:internal/modules/cjs/loader:1005:19)
npm ERR!     at require (node:internal/modules/cjs/helpers:102:18)
npm ERR!     at Object.<anonymous> (/home/runner/.npm/_cacache/tmp/git-cloneGBcZjn/node_modules/@babel/preset-env/lib/debug.js:8:33) {
npm ERR!   code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
npm ERR! }
```

Example of failed job here → https://github.com/Automattic/woocommerce-payments/actions/runs/1534165725

This PR introduces a `actions/setup-node@v2` step with some config to use this project's `.nvmrc` file. As a result, the issues referenced above are resolved.

#### Testing instructions

* All workflow jobs pass on this PR (especially the E2E ones).

-------------------

- [ ] Added changelog entries to both `readme.txt` and `changelog.txt` (does not apply)
- [ ] Covered with tests (does not apply)
- [ ] Tested on mobile (does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (does not apply)
