### PR TITLE
Add new error types to be rate-limited

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2696,6 +2696,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return bool Whether the rate limiter should be bumped.
 	 */
 	protected function should_bump_rate_limiter( string $error_code ): bool {
-		return in_array( $error_code, [ 'card_declined', 'incorrect_number', 'incorrect_cvc', 'incorrect_zip' ], true );
+		return in_array( $error_code, [ 'card_declined', 'incorrect_number', 'incorrect_cvc' ], true );
 	}
 }

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -829,7 +829,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$order->update_status( 'failed' );
 			}
 
-			if ( $e instanceof API_Exception && $e->get_error_code() === 'card_declined' ) {
+			if ( $e instanceof API_Exception && $this->should_bump_rate_limiter( $e->get_error_code() ) ) {
 				$this->failed_transaction_rate_limiter->bump();
 			}
 
@@ -2686,5 +2686,16 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	public function get_connection_url() {
 		return html_entity_decode( WC_Payments_Account::get_connect_url() );
+	}
+
+	/**
+	 * Returns true if the code returned from the API represents an error that should be rate-limited.
+	 *
+	 * @param string $error_code The error code returned from the API.
+	 *
+	 * @return bool Whether the rate limiter should be bumped.
+	 */
+	protected function should_bump_rate_limiter( string $error_code ): bool {
+		return in_array( $error_code, [ 'card_declined', 'incorrect_number', 'incorrect_cvc', 'incorrect_zip' ], true );
 	}
 }

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -420,7 +420,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 				}
 
 				$last_payment_error_code = $updated_payment_intent->get_last_payment_error()['code'] ?? '';
-				if ( 'card_declined' === $last_payment_error_code ) {
+				if ( $this->should_bump_rate_limiter( $last_payment_error_code ) ) {
 					// UPE method gives us the error of the previous payment attempt, so we use that for the Rate Limiter.
 					$this->failed_transaction_rate_limiter->bump();
 				}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -580,6 +580,47 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Tests that the rawte limiter is bumped for certain error codes
+	 *
+	 * @dataProvider rate_limiter_error_code_provider
+	 */
+	public function test_failed_transaction_rate_limiter_bumped( $error_code ) {
+		$order = WC_Helper_Order::create_order();
+
+		$this->mock_rate_limiter
+			->expects( $this->once() )
+			->method( 'bump' );
+
+		$this->mock_api_client
+			->expects( $this->any() )
+			->method( 'create_and_confirm_intention' )
+			->will(
+				$this->throwException(
+					new API_Exception(
+						'test error',
+						$error_code,
+						400,
+						'card_error'
+					)
+				)
+			);
+
+		$this->expectException( Exception::class );
+
+		// Act: process payment.
+		$this->mock_wcpay_gateway->process_payment( $order->get_id() );
+	}
+
+	public function rate_limiter_error_code_provider() {
+		return [
+			[ 'card_declined' ],
+			[ 'incorrect_number' ],
+			[ 'incorrect_cvc' ],
+			[ 'incorrect_zip' ],
+		];
+	}
+
 	public function test_failed_transaction_rate_limiter_is_limited() {
 		// Arrange: Create an order to test with.
 		$order = WC_Helper_Order::create_order();

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -617,7 +617,6 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			[ 'card_declined' ],
 			[ 'incorrect_number' ],
 			[ 'incorrect_cvc' ],
-			[ 'incorrect_zip' ],
 		];
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Adds `incorrect_number`, `incorrect_cvc`, and `incorrect_zip` to the error types that will be limited on the client side to 5 errors per 10 minutes

#### Testing instructions

* It doesn't seem to be possible to trigger the extra errors in test mode, so added a test for them
* Try to purchase something with card `4000000000000002` 6 times - you should get rate-limited

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
