### PR TITLE
Re-Initiate transactions export in server via download button (un-revert)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 3.6.0 - 2022-xx-xx =
 * Fix UPE validation error visibility on checkout page.
+* Add - Add support for full transaction exports.
 
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.

--- a/client/data/transactions/resolvers.js
+++ b/client/data/transactions/resolvers.js
@@ -18,7 +18,7 @@ import {
 } from './actions';
 import { formatDateValue } from 'utils';
 
-const formatQueryFilters = ( query ) => ( {
+export const formatQueryFilters = ( query ) => ( {
 	match: query.match,
 	date_before: formatDateValue( query.dateBefore, true ),
 	date_after: formatDateValue( query.dateAfter ),
@@ -53,6 +53,15 @@ export function* getTransactions( query ) {
 	} catch ( e ) {
 		yield updateErrorForTransactions( query, null, e );
 	}
+}
+
+export function getTransactionsCSV( query ) {
+	const path = addQueryArgs(
+		`${ NAMESPACE }/transactions/download`,
+		formatQueryFilters( query )
+	);
+
+	return path;
 }
 
 /**

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -3,8 +3,9 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React, { useState } from 'react';
 import { uniq } from 'lodash';
+import { useDispatch } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { dateI18n } from '@wordpress/date';
 import { __, _n } from '@wordpress/i18n';
@@ -25,7 +26,7 @@ import {
 	generateCSVDataFromTable,
 	generateCSVFileName,
 } from '@woocommerce/csv-export';
-
+import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
@@ -46,6 +47,7 @@ import TransactionsFilters from '../filters';
 import Page from '../../components/page';
 import wcpayTracks from 'tracks';
 import DownloadButton from 'components/download-button';
+import { getTransactionsCSV } from '../../data/transactions/resolvers';
 
 interface TransactionsListProps {
 	depositId?: string;
@@ -186,6 +188,8 @@ const getColumns = (
 export const TransactionsList = (
 	props: TransactionsListProps
 ): JSX.Element => {
+	const [ isDownloading, setIsDownloading ] = useState( false );
+	const { createNotice } = useDispatch( 'core/notices' );
 	const { transactions, isLoading } = useTransactions(
 		getQuery(),
 		props.depositId ?? ''
@@ -397,20 +401,83 @@ export const TransactionsList = (
 
 	const downloadable = !! rows.length;
 
-	const onDownload = () => {
-		// We destructure page and path to get the right params.
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const { page, path, ...params } = getQuery();
+	const onDownload = async () => {
+		setIsDownloading( true );
 
-		downloadCSVFile(
-			generateCSVFileName( title, params ),
-			generateCSVDataFromTable( columnsToDisplay, rows )
-		);
+		const {
+			date_before: dateBefore,
+			date_after: dateAfter,
+			date_between: dateBetween,
+			match,
+			search,
+			type_is: typeIs,
+			type_is_not: typeIsNot,
+		} = getQuery();
 
-		wcpayTracks.recordEvent( 'wcpay_transactions_download', {
-			exported_transactions: rows.length,
-			total_transactions: transactionsSummary.count,
-		} );
+		if (
+			!! dateBefore ||
+			!! dateAfter ||
+			!! dateBetween ||
+			!! typeIs ||
+			!! typeIsNot ||
+			!! search
+		) {
+			try {
+				const {
+					exported_transactions: exportedTransactions,
+				} = await apiFetch( {
+					path: getTransactionsCSV( {
+						dateAfter,
+						dateBefore,
+						dateBetween,
+						match,
+						search,
+						typeIs,
+						typeIsNot,
+					} ),
+					method: 'POST',
+				} );
+
+				createNotice(
+					'success',
+					__(
+						'Your export will be emailed to you.',
+						'woocommerce-payments'
+					)
+				);
+
+				wcpayTracks.recordEvent( 'wcpay_transactions_download', {
+					exported_transactions: exportedTransactions,
+					total_transactions: exportedTransactions,
+					download_type: 'endpoint',
+				} );
+			} catch {
+				createNotice(
+					'error',
+					__(
+						'There was a problem generating your export.',
+						'woocommerce-payments'
+					)
+				);
+			}
+		} else {
+			// We destructure page and path to get the right params.
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const { page, path, ...params } = getQuery();
+
+			downloadCSVFile(
+				generateCSVFileName( title, params ),
+				generateCSVDataFromTable( columnsToDisplay, rows )
+			);
+
+			wcpayTracks.recordEvent( 'wcpay_transactions_download', {
+				exported_transactions: rows.length,
+				total_transactions: transactionsSummary.count,
+				download_type: 'browser',
+			} );
+		}
+
+		setIsDownloading( false );
 	};
 
 	if ( ! wcpaySettings.featureFlags.customSearch ) {
@@ -490,11 +557,7 @@ export const TransactionsList = (
 			) }
 			<TableCard
 				className="transactions-list woocommerce-report-table has-search"
-				title={
-					props.depositId
-						? __( 'Deposit transactions', 'woocommerce-payments' )
-						: __( 'Transactions', 'woocommerce-payments' )
-				}
+				title={ title }
 				isLoading={ isLoading }
 				rowsPerPage={ parseInt( getQuery().per_page ?? '', 10 ) || 25 }
 				totalRows={ transactionsSummary.count || 0 }
@@ -522,7 +585,7 @@ export const TransactionsList = (
 					downloadable && (
 						<DownloadButton
 							key="download"
-							isDisabled={ isLoading }
+							isDisabled={ isLoading || isDownloading }
 							onClick={ onDownload }
 						/>
 					),

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -429,7 +429,7 @@ export const TransactionsList = (
 				!! typeIs ||
 				!! typeIsNot;
 
-			const confirmThreshold = 1000;
+			const confirmThreshold = 10000;
 			const confirmMessage = sprintf(
 				__(
 					"You are about to export %d transactions. If you'd like to reduce the size of your export, you can use one or more filters. Would you like to continue?",

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -6,8 +6,9 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
-import { getQuery, updateQueryString } from '@woocommerce/navigation';
 import { dateI18n } from '@wordpress/date';
+import { downloadCSVFile } from '@woocommerce/csv-export';
+import { getQuery, updateQueryString } from '@woocommerce/navigation';
 import moment from 'moment';
 import os from 'os';
 
@@ -18,20 +19,6 @@ import { TransactionsList } from '../';
 import { useTransactions, useTransactionsSummary } from 'data/index';
 import type { Transaction } from 'data/transactions/hooks';
 
-import { downloadCSVFile } from '@woocommerce/csv-export';
-
-jest.mock( 'data/index', () => ( {
-	useTransactions: jest.fn(),
-	useTransactionsSummary: jest.fn(),
-} ) );
-
-const mockUseTransactions = useTransactions as jest.MockedFunction<
-	typeof useTransactions
->;
-const mockUseTransactionsSummary = useTransactionsSummary as jest.MockedFunction<
-	typeof useTransactionsSummary
->;
-
 jest.mock( '@woocommerce/csv-export', () => {
 	const actualModule = jest.requireActual( '@woocommerce/csv-export' );
 
@@ -41,8 +28,32 @@ jest.mock( '@woocommerce/csv-export', () => {
 	};
 } );
 
+// Workaround for mocking @wordpress/data.
+// See https://github.com/WordPress/gutenberg/issues/15031
+jest.mock( '@wordpress/data', () => ( {
+	createRegistryControl: jest.fn(),
+	dispatch: jest.fn( () => ( { setIsMatching: jest.fn() } ) ),
+	registerStore: jest.fn(),
+	select: jest.fn(),
+	useDispatch: jest.fn( () => ( { createNotice: jest.fn() } ) ),
+	withDispatch: jest.fn( () => jest.fn() ),
+	withSelect: jest.fn( () => jest.fn() ),
+} ) );
+
+jest.mock( 'data/index', () => ( {
+	useTransactions: jest.fn(),
+	useTransactionsSummary: jest.fn(),
+} ) );
+
 const mockDownloadCSVFile = downloadCSVFile as jest.MockedFunction<
 	typeof downloadCSVFile
+>;
+
+const mockUseTransactions = useTransactions as jest.MockedFunction<
+	typeof useTransactions
+>;
+const mockUseTransactionsSummary = useTransactionsSummary as jest.MockedFunction<
+	typeof useTransactionsSummary
 >;
 
 declare const global: {
@@ -413,14 +424,6 @@ describe( 'Transactions list', () => {
 				},
 				isLoading: false,
 			} );
-		} );
-
-		afterEach( () => {
-			jest.resetAllMocks();
-		} );
-
-		afterAll( () => {
-			jest.restoreAllMocks();
 		} );
 
 		test( 'should render expected columns in CSV when the download button is clicked', () => {

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -415,7 +415,7 @@ describe( 'Transactions list', () => {
 
 			mockUseTransactionsSummary.mockReturnValue( {
 				transactionsSummary: {
-					count: 10,
+					count: 2,
 					currency: 'usd',
 					store_currencies: [ 'eur', 'usd' ],
 					fees: 100,
@@ -426,8 +426,28 @@ describe( 'Transactions list', () => {
 			} );
 		} );
 
+		test( 'should request confirmation when the download button is clicked', () => {
+			mockUseTransactionsSummary.mockReturnValue( {
+				transactionsSummary: {
+					count: 2000,
+				},
+				isLoading: false,
+			} );
+
+			window.confirm = jest.fn();
+
+			const { getByRole } = render( <TransactionsList /> );
+			getByRole( 'button', { name: 'Download' } ).click();
+
+			expect( window.confirm ).toHaveBeenCalledTimes( 1 );
+			expect( window.confirm ).toHaveBeenCalledWith(
+				"You are about to export 2000 transactions. If you'd like to reduce the size of your export, you can use one or more filters. Would you like to continue?"
+			);
+		} );
+
 		test( 'should render expected columns in CSV when the download button is clicked', () => {
 			const { getByRole } = render( <TransactionsList /> );
+
 			getByRole( 'button', { name: 'Download' } ).click();
 
 			const expected = [
@@ -457,6 +477,7 @@ describe( 'Transactions list', () => {
 
 		test( 'should match the visible rows', () => {
 			const { getByRole, getAllByRole } = render( <TransactionsList /> );
+
 			getByRole( 'button', { name: 'Download' } ).click();
 
 			const csvContent = mockDownloadCSVFile.mock.calls[ 0 ][ 1 ];

--- a/includes/admin/class-wc-rest-payments-transactions-controller.php
+++ b/includes/admin/class-wc-rest-payments-transactions-controller.php
@@ -34,6 +34,15 @@ class WC_REST_Payments_Transactions_Controller extends WC_Payments_REST_Controll
 		);
 		register_rest_route(
 			$this->namespace,
+			'/' . $this->rest_base . '/download',
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_transactions_export' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base . '/summary',
 			[
 				'methods'             => WP_REST_Server::READABLE,
@@ -74,6 +83,17 @@ class WC_REST_Payments_Transactions_Controller extends WC_Payments_REST_Controll
 		$deposit_id = $request->get_param( 'deposit_id' );
 		$filters    = $this->get_transactions_filters( $request );
 		return $this->forward_request( 'list_transactions', [ $page, $page_size, $sort, $direction, $filters, $deposit_id ] );
+	}
+
+	/**
+	 * Initiate transactions export via API.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public function get_transactions_export( $request ) {
+		$filters = $this->get_transactions_filters( $request );
+
+		return $this->forward_request( 'get_transactions_export', [ $filters ] );
 	}
 
 	/**

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -624,6 +624,24 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Initiates transactions export via API.
+	 *
+	 * @param array $filters The filters to be used in the query.
+	 *
+	 * @return array Export summary
+	 *
+	 * @throws API_Exception - Exception thrown on request failure.
+	 */
+	public function get_transactions_export( $filters = [] ) {
+		// Map Order # terms to the actual charge id to be used in the server.
+		if ( ! empty( $filters['search'] ) ) {
+			$filters['search'] = WC_Payments_Utils::map_search_orders_to_charge_ids( $filters['search'] );
+		}
+
+		return $this->request( $filters, self::TRANSACTIONS_API . '/download', self::POST );
+	}
+
+	/**
 	 * Fetch a single transaction with provided id.
 	 *
 	 * @param string $transaction_id id of requested transaction.

--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 3.6.0 - 2022-xx-xx =
 * Fix UPE validation error visibility on checkout page.
+* Add - Add support for full transaction exports.
 
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.


### PR DESCRIPTION
This undos the revert of [#1178](https://github.com/Automattic/woocommerce-payments/pull/2939)

#2939 was reverted since the server changes it depended on were causing issues with PHPUnit tests which were only discovered during the deploy process. Since it was the end of the week and I didn't have time to look further into this, I simply reverted so as not to cause problems for others working on Server.

This re-introduces the client changes from #2939 

### Testing Instructions

- If possible sync a connected account with `< 100` transactions
- Via WP-Admin go to Payments > Transactions
- Expand the number of rows in the list to 100, then [click the download link](https://cloudup.com/ccse5g7T_wc)
- Ensure a CSV containing the transactions listed in the table view immediately downloads
- If possible sync a connected account with `> 10000` transactions. If this is not possible, you may need to change the value of [`confirmThreshold`](https://github.com/Automattic/woocommerce-payments/blob/c84f2524b7a309adc80e6d9db531bde35117f09e/client/transactions/list/index.tsx#L418) to be less than the total number of transactions in the connected site while testing.
- Again, click the download link, making sure the number of rows is `<` the total number of transactions to be exported.
- Ensure a confirmation window appears asking if you would like to proceed. Confirm.
- Ensure a notice appears letting you know an export will be emailed to you
- Confirm you receive an email containing a download link for an export containing transactions that meet the criteria
- Select any filter (i.e. before December 1) and click the download link
- Ensure no confirmation window appears
- Ensure a notice appears letting you know an export will be emailed to you
- Confirm you receive an email containing a download link for an export containing transactions that meet the criteria
- Repeat the steps above with different combinations of filters