### PR TITLE
Fix Card readers page checks causing account cached data missing

### DIFF
--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -118,19 +118,6 @@ class WC_Payments_Admin {
 				],
 			],
 		];
-
-		if ( $this->account->is_card_present_eligible() && self::is_card_readers_page_enabled() ) {
-			$this->admin_child_pages['wc-payments-card-readers'] = [
-				'id'       => 'wc-payments-card-readers',
-				'title'    => __( 'Card Readers', 'woocommerce-payments' ),
-				'parent'   => 'wc-payments',
-				'path'     => '/payments/card-readers',
-				'nav_args' => [
-					'parent' => 'wc-payments',
-					'order'  => 50,
-				],
-			];
-		}
 	}
 
 	/**
@@ -226,6 +213,18 @@ class WC_Payments_Admin {
 		);
 
 		if ( $should_render_full_menu ) {
+			if ( self::is_card_readers_page_enabled() && $this->account->is_card_present_eligible() ) {
+				$this->admin_child_pages['wc-payments-card-readers'] = [
+					'id'       => 'wc-payments-card-readers',
+					'title'    => __( 'Card Readers', 'woocommerce-payments' ),
+					'parent'   => 'wc-payments',
+					'path'     => '/payments/card-readers',
+					'nav_args' => [
+						'parent' => 'wc-payments',
+						'order'  => 50,
+					],
+				];
+			}
 
 			/**
 			 * Please note that if any other page is registered first and it's


### PR DESCRIPTION
Fixes #3478

#### Changes proposed in this Pull Request

Updates the Card Readers page object to be set-up in `admin_menu` hook instead of class `constructor`. Calling the account cache data in `constructor` is too early which is likely running before Action Scheduler has registered its tables and causes errors and disconnecting account.

#### Testing instructions

- Update the `_wcpay_feature_card_readers` option to `1`.
- Verify your `wcpay_account_data` is not missing and your account is not disconnected. 

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

Cherry-pick changes to `3.4.0-test-3` branch.
