### PR TITLE
Always save subscriptions payment methods when using UPE

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@
 * Add - Support business account branding settings.
 * Update - Capture order-related metadata not captured by mobile app for in-person payment transactions.
 * Add - REST endpoint to print IPP receipts.
+* Fix - Error when renewing subscriptions with saved payment methods disabled.
 
 = 3.3.0 - 2021-11-18 =
 * Add - Add Idempotency Key to POST headers.

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -379,10 +379,10 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		$currency                  = $order->get_currency();
 		$converted_amount          = WC_Payments_Utils::prepare_amount( $amount, $currency );
 		$payment_needed            = 0 < $converted_amount;
-		$save_payment_method       = ! empty( $_POST[ 'wc-' . static::GATEWAY_ID . '-new-payment-method' ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$token                     = Payment_Information::get_token_from_request( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$selected_upe_payment_type = ! empty( $_POST['wcpay_selected_upe_payment_type'] ) ? wc_clean( wp_unslash( $_POST['wcpay_selected_upe_payment_type'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$payment_type              = $this->is_payment_recurring( $order_id ) ? Payment_Type::RECURRING() : Payment_Type::SINGLE();
+		$save_payment_method       = $payment_type->equals( Payment_Type::RECURRING() ) || ! empty( $_POST[ 'wc-' . static::GATEWAY_ID . '-new-payment-method' ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$payment_country           = ! empty( $_POST['wcpay_payment_country'] ) ? wc_clean( wp_unslash( $_POST['wcpay_payment_country'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 		if ( $payment_intent_id ) {

--- a/readme.txt
+++ b/readme.txt
@@ -116,6 +116,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Support business account branding settings.
 * Update - Capture order-related metadata not captured by mobile app for in-person payment transactions.
 * Add - REST endpoint to print IPP receipts.
+* Fix - Error when renewing subscriptions with saved payment methods disabled.
 
 = 3.3.0 - 2021-11-18 =
 * Add - Add Idempotency Key to POST headers.


### PR DESCRIPTION
Fixes #3471

#### Changes proposed in this Pull Request

WCPay offers a setting to disable "payments via saved cards." But for subscriptions, we always want to save the payment method regardless of that setting, in order to process recurring payments. This is currently the case for non-UPE checkout, but not for UPE checkout. This PR updates the UPE payment gateway to always save the payment method if it's processing a recurring payment.

#### Testing Instructions

The following steps will verify that, when saved cards is disabled, a payment method is saved for subscription products with UPE, but not for non-subscription products.

1. Enable WCPay Subscriptions if not already enabled.
2. In **Payments > Settings**, ensure **Enabled payments via saved cards** is unchecked, saving changes if needed.
3. In **WCPay Dev**, ensure **Enable UPE checkout** is checked, submitting changes if needed.
4. Create a new customer account and sign in. In that customer account, purchase a subscription product with a test card number.
5. As the customer, go to `/my-account/subscriptions/` and click on the subscription you just purchased. Verify that, next to **Payment**, you see details of your payment method (e.g. "Visa ending in 4242"). Before this PR's changes, you can verify that you instead saw something generic like "Credit card / debit card".
6. Check the database's `wp_woocommerce_payment_tokens` table and verify that there's a payment token associated with this customer's user ID.
7. Delete the saved payment method (as by enabling saved cards, cancelling the subscription, deleting the payment method at `/my-account/payment-methods/`, then disabling saved cards again). Verify that the token no longer appears in the `wp_woocommerce_payment_tokens` table.
8. Purchase a non-subscription product with a test card number.
9. Check the database's `wp_woocommerce_payment_tokens` table and verify that there was no new payment token added for the customer.
10. If you re-enable saved cards and go to `/my-account/payment-methods/` again, there should be no payment method listed.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
