### PR TITLE
Return to task "Set up payments" after finishing KYC from WC-Admin

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 3.5.0 - 2021-xx-xx =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.
+* Update - Return to task "Set up payments" after finishing KYC from WC-Admin.
 
 = 3.4.0 - 2021-12-08 =
 * Add - Allow UI customizations on checkout payment fields.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2687,7 +2687,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return string Connection URL.
 	 */
 	public function get_connection_url() {
-		return html_entity_decode( WC_Payments_Account::get_connect_url() );
+		return html_entity_decode( WC_Payments_Account::get_connect_url( 'WCADMIN_PAYMENT_TASK' ) );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -100,6 +100,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 3.5.0 - 2021-xx-xx =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.
+* Update - Return to task "Set up payments" after finishing KYC from WC-Admin.
 
 = 3.4.0 - 2021-12-08 =
 * Add - Allow UI customizations on checkout payment fields.


### PR DESCRIPTION
Internal discussion: pbUcTB-qN-p2#comment-2054
Regression from #2014

#### Changes proposed in this Pull Request

After finishing the KYC process from WC-Admin, i.e. WooCommerce > Home > Set up payments, merchants should be redirected back to this page. 

Currently, merchants are redirected back to Payments > Overview. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- Use WooCommerce core latest version 5.9.x.
- WCPay should not connect to any account yet. 
- Go to WP Admin > WooCommerce > Home > Set up payments.
- Follow up the steps there to finish KYC for WCPay.

Expectation: after finishing KYC, merchants are redirected back to WP Admin > WooCommerce > Home > Set up payments.


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [x] ~Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions)~ (or does not apply)