### PR TITLE
Update notes about the dependency extraction plugin

### DIFF
--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -15,8 +15,9 @@ to catalog our packages and provide guidance to a developer who wants to test an
   packages early.
 * Following on from above, we use the `@wordpress/dependency-extraction-webpack-plugin` to make WebPack aware of what
   can be found globally at runtime. The configuration for this can be found in `webpack.config.js`. Any `wordpress/*`
-  packages are bundled by default, in addition to any packages listed in the configuration file. Returning `null` in the
-  configuration indicates that we want to bundle the package rather than using the globally available one.
+  packages are removed from the built bundle by default, in addition to any packages listed in the configuration file.
+  Returning `null` in the configuration indicates that we want to bundle the package rather than using the globally
+  available one.
 
 ## Review Process
 1. Check the tables below for the package you’re reviewing.

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -10,10 +10,13 @@ to catalog our packages and provide guidance to a developer who wants to test an
   packages in a single repository. This behaviour makes sense for us and helps reduce noise from Renovate PRs.
 * A lot of our JavaScript dev dependencies are provided by WordPress or WooCommerce globally at runtime, we include them
   as dev dependencies so that we aren't duplicating them in our build bundle but our unit tests can still pass by
-  having them available. This means we should keep the versions of these packages in the same range as our supported 
-  version of WordPress and WooCommerce.
+  having them available. This means we should keep the versions of these packages on the highest version avaiable in our
+  supported versions of WordPress and WooCommerce, giving us the best chance of catching any issues with the bundled
+  packages early.
 * Following on from above, we use the `@wordpress/dependency-extraction-webpack-plugin` to make WebPack aware of what
-  can be found globally at runtime. The configuration for this can be found in `webpack.config.js`.
+  can be found globally at runtime. The configuration for this can be found in `webpack.config.js`. Any `wordpress/*`
+  packages are bundled by default, in addition to any packages listed in the configuration file. Returning `null` in the
+  configuration indicates that we want to bundle the package rather than using the globally available one.
 
 ## Review Process
 1. Check the tables below for the package you’re reviewing.


### PR DESCRIPTION
Makes it clearer what versions we should be upgrading extracted plugins to and adds more information about the config details.