### PR TITLE
Do not override WCA Inbox note CSS

### DIFF
--- a/client/overview/style.scss
+++ b/client/overview/style.scss
@@ -1,4 +1,12 @@
 @import '@woocommerce/experimental/build-style/style.css';
+.woocommerce-inbox-message__wrapper {
+	.woocommerce-inbox-message__content {
+		padding-bottom: 24px;
+	}
+	.woocommerce-inbox-message__actions {
+		padding-top: 16px;
+	}
+}
 
 // Adapted from woocommerce-admin:client/homescreen/style.scss
 .components-card.woocommerce-task-card {


### PR DESCRIPTION
Fixes #3527 

This PR fixes unexpected CSS override on the Inbox Note components by setting the same value from the latest WCA.

#### Testing instructions

1. Install and activate both WC and WC Pay.
2. Clone this branch and run `npm start`
3. Navigate to WooCommerce -> Home
4. Confirm the note content and actions have padding. 
