### PR TITLE
Tweak payment identifier parameter in generate_print_receipt of \WC_REST_Payments_Reader_Controller

### DIFF
--- a/includes/admin/class-wc-rest-payments-reader-controller.php
+++ b/includes/admin/class-wc-rest-payments-reader-controller.php
@@ -188,7 +188,7 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 	public function generate_print_receipt( $request ) {
 		try {
 			/* Collect the data, available on the server side. */
-			$payment_intent = $this->api_client->get_intent( $request->get_param( 'payment_id' ) );
+			$payment_intent = $this->api_client->get_intent( $request->get_param( 'payment_intent_id' ) );
 			if ( 'succeeded' !== $payment_intent->get_status() ) {
 				throw new \RuntimeException( __( 'Invalid payment intent', 'woocommerce-payments' ) );
 			}

--- a/tests/unit/admin/test-class-wc-rest-payments-reader-charges-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-reader-charges-controller.php
@@ -206,7 +206,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 			->willReturn( $receipt );
 
 		$request = new WP_REST_Request( 'GET' );
-		$request->set_param( 'payment_id', 42 );
+		$request->set_param( 'payment_intent_id', 42 );
 
 		$response = $this->controller->generate_print_receipt( $request );
 
@@ -234,7 +234,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 			->method( 'get_receipt_markup' );
 
 		$request = new WP_REST_Request( 'GET' );
-		$request->set_param( 'payment_id', 42 );
+		$request->set_param( 'payment_intent_id', 42 );
 
 		$response = $this->controller->generate_print_receipt( $request );
 
@@ -264,7 +264,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 			->method( 'get_receipt_markup' );
 
 		$request = new WP_REST_Request( 'GET' );
-		$request->set_param( 'payment_id', 42 );
+		$request->set_param( 'payment_intent_id', 42 );
 
 		$response = $this->controller->generate_print_receipt( $request );
 
@@ -300,7 +300,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 			->method( 'get_receipt_markup' );
 
 		$request = new WP_REST_Request( 'GET' );
-		$request->set_param( 'payment_id', 42 );
+		$request->set_param( 'payment_intent_id', 42 );
 
 		$response = $this->controller->generate_print_receipt( $request );
 
@@ -339,7 +339,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 			->method( 'get_receipt_markup' );
 
 		$request = new WP_REST_Request( 'GET' );
-		$request->set_param( 'payment_id', 42 );
+		$request->set_param( 'payment_intent_id', 42 );
 
 		$response = $this->controller->generate_print_receipt( $request );
 
@@ -382,7 +382,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 			->willThrowException( new Exception( 'Something bad' ) );
 
 		$request = new WP_REST_Request( 'GET' );
-		$request->set_param( 'payment_id', 42 );
+		$request->set_param( 'payment_intent_id', 42 );
 
 		$response = $this->controller->generate_print_receipt( $request );
 


### PR DESCRIPTION
Fixes #3522 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
The name of the payment identifier parameter of the generate_print_receipt method is `payment_id`. This PR renames it to `payment_intent_id` to align with the codebase. 
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that unit tests are passing

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
