### PR TITLE
Fix: Unable to access Subscription details when purchased via SEPA Direct Debit

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Tweak - Update recurring payments copy on payment gateways page.
 * Fix - Incorrect text when filtering subscriptions to no results.
 * Changed - Subscription products must have a recurring amount greater than $0.
+* Fix - Stop errors when viewing Subscription details when purchased via SEPA Direct Debit.
 
 = 3.4.0 - 2021-12-08 =
 * Add - Allow UI customizations on checkout payment fields.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2609,14 +2609,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			]
 		);
 		return array_map(
-			static function ( WC_Payment_Token_CC $token ): array {
+			static function ( WC_Payment_Token $token ): array {
 				return [
 					'tokenId'         => $token->get_id(),
 					'paymentMethodId' => $token->get_token(),
-					'brand'           => $token->get_card_type(),
-					'last4'           => $token->get_last4(),
-					'expiryMonth'     => $token->get_expiry_month(),
-					'expiryYear'      => $token->get_expiry_year(),
 					'isDefault'       => $token->get_is_default(),
 					'displayName'     => $token->get_display_name(),
 				];

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ Please note that our support for the checkout block is still experimental and th
 * Tweak - Update recurring payments copy on payment gateways page.
 * Fix - Incorrect text when filtering subscriptions to no results.
 * Changed - Subscription products must have a recurring amount greater than $0.
+* Fix - Stop errors when viewing Subscription details when purchased via SEPA Direct Debit.
 
 = 3.4.0 - 2021-12-08 =
 * Add - Allow UI customizations on checkout payment fields.


### PR DESCRIPTION
Fixes #3442

#### Changes proposed in this Pull Request

I removed the problematic methods/properties from `get_user_formatted_tokens_array` due to two reasons: 

1. These methods/properties exist in `WC_Payment_Token_CC` while they do not in `WC_Payment_Token_WCPay_SEPA`. The remaining ones are available in `WC_Payment_Token`. 

2. They are not used in the two consumers of this method `get_user_formatted_tokens_array`: 

2a, [First](https://github.com/Automattic/woocommerce-payments/blob/8f140393a3f964659b373275b762855413e6016a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php#L481-L482) - only `tokenId` and `displayName` are used. 

2b, [Second](https://github.com/Automattic/woocommerce-payments/blob/8f140393a3f964659b373275b762855413e6016a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php#L436-L436) - `wcpaySubscriptionEdit` global var is generated then used in [this JS file](https://github.com/Automattic/woocommerce-payments/blob/8f140393a3f964659b373275b762855413e6016a/client/subscription-edit-page.js#L1-L1). But then only `tokenId` and `displayName` are used.

Another approach is to use `method_exists` check these methods and conditionally return their values or just return an empty string. But it's not clean and necessary IMO.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

* Follow up the `Reproduce` section in #3442.
* Expectation: no error, and the Subscription Edit page displays normally.
* If possible, test with both WooComemmerce Subscriptions and WCPay Subscription built-in feature. 

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
