### PR TITLE
Skip account check before MC init event on CLI

### DIFF
--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -299,8 +299,9 @@ class MultiCurrency {
 	 */
 	public function init_settings_pages( $settings_pages ): array {
 		// We don't need to check if Stripe is connected for the
-		// Settings page generation on the incoming CLI calls.
-		if ( defined( 'WP_CLI' ) ) {
+		// Settings page generation on the incoming CLI and async job calls.
+		if ( ( defined( 'WP_CLI' ) && WP_CLI ) ||
+		( defined( 'WPCOM_JOBS' ) && WPCOM_JOBS ) ) {
 			return $settings_pages;
 		}
 

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -300,8 +300,7 @@ class MultiCurrency {
 	public function init_settings_pages( $settings_pages ): array {
 		// We don't need to check if Stripe is connected for the
 		// Settings page generation on the incoming CLI and async job calls.
-		if ( ( defined( 'WP_CLI' ) && WP_CLI ) ||
-		( defined( 'WPCOM_JOBS' ) && WPCOM_JOBS ) ) {
+		if ( ( defined( 'WP_CLI' ) && WP_CLI ) || ( defined( 'WPCOM_JOBS' ) && WPCOM_JOBS ) ) {
 			return $settings_pages;
 		}
 

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -298,6 +298,12 @@ class MultiCurrency {
 	 * @return array The new settings pages.
 	 */
 	public function init_settings_pages( $settings_pages ): array {
+		// We don't need to check if Stripe is connected for the
+		// Settings page generation on the incoming CLI calls.
+		if ( defined( 'WP_CLI' ) ) {
+			return $settings_pages;
+		}
+
 		if ( $this->payments_account->is_stripe_connected() ) {
 			$settings_pages[] = new Settings( $this );
 		} else {


### PR DESCRIPTION
Fixes #3533

#### Changes proposed in this Pull Request

On the live server or the sandbox, when a REST API request is called from the command line, the `init` event is called before `rest_api_init` and when there's a REST request in the `init` event, it's being run before the WC REST API is initialized, which fails when there's no account information cached prior the call. And because of that, the account info can't be fetched from the server. The internal call on the `init` event returns 404 and prevents the REST API endpoints to be initialized further. This PR prevents the initial REST API call when the call is being made from the CLI. Actually, the call is used to determine whether the settings page should be shown or the onboarding CTA page will be shown, so we can safely skip the settings page initialization on the CLI call. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

On your sandbox:

1. Comment out [this line](https://github.com/Automattic/woocommerce-payments/blob/f83bfef8b31c373e90394df3f6cdde76611f0ad9/includes/class-wc-payments-account.php#L765), and add `$account = false` after that.
2. Add those lines in your `0-sandbox.php` config: 
```
function sandbox_import_jobs( $sandboxed, $type ) {
    return in_array( $type, array(
        'wordpress_import',
        'tumblrpay_deliver_webhook_async'
    ) );
}

add_filter( 'sandbox_async_job', 'sandbox_import_jobs', 10, 2 );
```
3. In the `wp-content/mu-plugins/woocommerce/includes/class-wc-payments-internal-rest-request.php` file, find `remote_request()` function, and after `$response = rest_do_request( $request );` line, add this block to view the errors in your error log:
```
if( '200' != $response->get_status()) {
	error_log('ERROR ' . $response->get_status());
	exit();
}
```

4. Then open two terminals, in one of them, run `tail -f \tmp\php-errors` to see what's happening, and on the second, run 
```
wp tumblrpay trigger order.success --arg='{"id": 935}' --format=json --url=https://test-payment.tumblr.com --async
```

Without the modification in this PR, you should get an error, because it will try to get the account data from server before the REST API is initialized. With this modification, you should see the job queued.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
