### PR TITLE
Introduce compat module for multicurrency and Name Your Price. 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Payments Changelog ***
 
 = 3.5.0 - 2021-xx-xx =
+* Add - Add compatibility between Multi-Currency and WooCommerce Name Your Price.
 * Fix - Error when renewing subscriptions with saved payment methods disabled.
 * Add - JS error boundaries to admin screens.
 * Update - Remove task from the overview list for setting up multiple currencies.

--- a/includes/multi-currency/Compatibility.php
+++ b/includes/multi-currency/Compatibility.php
@@ -14,6 +14,7 @@ use WC_Order_Refund;
 use WCPay\MultiCurrency\Compatibility\BaseCompatibility;
 use WCPay\MultiCurrency\Compatibility\WooCommerceBookings;
 use WCPay\MultiCurrency\Compatibility\WooCommerceFedEx;
+use WCPay\MultiCurrency\Compatibility\WooCommerceNameYourPrice;
 use WCPay\MultiCurrency\Compatibility\WooCommercePreOrders;
 use WCPay\MultiCurrency\Compatibility\WooCommerceProductAddOns;
 use WCPay\MultiCurrency\Compatibility\WooCommerceSubscriptions;
@@ -56,6 +57,7 @@ class Compatibility extends BaseCompatibility {
 		if ( 1 < count( $this->multi_currency->get_enabled_currencies() ) ) {
 			$this->compatibility_classes[] = new WooCommerceBookings( $this->multi_currency, $this->utils, $this->multi_currency->get_frontend_currencies() );
 			$this->compatibility_classes[] = new WooCommerceFedEx( $this->multi_currency, $this->utils );
+			$this->compatibility_classes[] = new WooCommerceNameYourPrice( $this->multi_currency, $this->utils );
 			$this->compatibility_classes[] = new WooCommercePreOrders( $this->multi_currency, $this->utils );
 			$this->compatibility_classes[] = new WooCommerceProductAddOns( $this->multi_currency, $this->utils );
 			$this->compatibility_classes[] = new WooCommerceSubscriptions( $this->multi_currency, $this->utils );

--- a/includes/multi-currency/Compatibility/WooCommerceNameYourPrice.php
+++ b/includes/multi-currency/Compatibility/WooCommerceNameYourPrice.php
@@ -32,8 +32,8 @@ class WooCommerceNameYourPrice extends BaseCompatibility {
 			add_filter( 'wc_nyp_raw_suggested_price', [ $this, 'get_nyp_prices' ] );
 
 			// Maybe translate cart prices.
-			add_action( 'woocommerce_add_cart_item_data', [ $this, 'add_initial_currency' ], 10, 3 );
-			add_filter( 'woocommerce_get_cart_item_from_session', [ $this, 'convert_cart_currency' ], 10, 2 );
+			add_action( 'woocommerce_add_cart_item_data', [ $this, 'add_initial_currency' ], 20, 3 );
+			add_filter( 'woocommerce_get_cart_item_from_session', [ $this, 'convert_cart_currency' ], 20, 2 );
 			add_filter( MultiCurrency::FILTER_PREFIX . 'should_convert_product_price', [ $this, 'should_convert_product_price' ], 50, 2 );
 		}
 	}

--- a/includes/multi-currency/Compatibility/WooCommerceNameYourPrice.php
+++ b/includes/multi-currency/Compatibility/WooCommerceNameYourPrice.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Class WooCommerceNameYourPrice
+ *
+ * @package WCPay\MultiCurrency\Compatibility
+ */
+
+namespace WCPay\MultiCurrency\Compatibility;
+
+use WC_Product;
+use WCPay\MultiCurrency\MultiCurrency;
+use WCPay\MultiCurrency\Utils;
+
+/**
+ * Class that controls Multi Currency Compatibility with WooCommerce Name Your Price Plugin.
+ */
+class WooCommerceNameYourPrice extends BaseCompatibility {
+
+	const NYP_CURRENCY = '_wcpay_multi_currency_nyp_currency';
+
+	/**
+	 * Init the class.
+	 *
+	 * @return  void
+	 */
+	protected function init() {
+		// Add needed actions and filters if Name Your Price is active.
+		if ( class_exists( 'WC_Name_Your_Price' ) ) {
+			// Convert meta prices.
+			add_filter( 'wc_nyp_raw_minimum_price', [ $this, 'get_nyp_prices' ] );
+			add_filter( 'wc_nyp_raw_maximum_price', [ $this, 'get_nyp_prices' ] );
+			add_filter( 'wc_nyp_raw_suggested_price', [ $this, 'get_nyp_prices' ] );
+
+			// Maybe translate cart prices.
+			add_action( 'woocommerce_add_cart_item_data', [ $this, 'add_initial_currency' ], 10, 3 );
+			add_filter( 'woocommerce_get_cart_item_from_session', [ $this, 'convert_cart_currency' ], 10, 2 );
+			add_filter( MultiCurrency::FILTER_PREFIX . 'should_convert_product_price', [ $this, 'should_convert_product_price' ], 50, 2 );
+		}
+	}
+
+	/**
+	 * Converts the min/max/suggested prices of Name Your Price extension.
+	 *
+	 * @param mixed $price   The price to be filtered.
+
+	 * @return mixed         The price as a string or float.
+	 */
+	public function get_nyp_prices( $price ): float {
+		return '' !== $price ? $this->multi_currency->get_price( $price, 'product' ) : $price;
+	}
+
+	/**
+	 * Store the inintial currency when item is added.
+	 *
+	 * @param array $cart_item Extra cart item data being passed to the cart item.
+	 * @param int   $product_id The id of the product being added to the cart.
+	 * @param int   $variation_id The id of the variation being added to the cart.
+	 *
+	 * @return array
+	 */
+	public function add_initial_currency( $cart_item, $product_id, $variation_id ) {
+
+		$nyp_id = $variation_id ? $variation_id : $product_id;
+
+		if ( \WC_Name_Your_Price_Helpers::is_nyp( $nyp_id ) && isset( $cart_item['nyp'] ) ) {
+			$currency                  = $this->multi_currency->get_selected_currency();
+			$cart_item['nyp_currency'] = $currency->get_code();
+			$cart_item['nyp_original'] = $cart_item['nyp'];
+		}
+
+		return $cart_item;
+	}
+
+	/**
+	 * Switch the cart price when currency changes.
+	 * Do not convert price if in the same currency as when added to the cart.
+	 * This prevevents USD > EUR > USD style conversions and potential rounding problems.
+	 *
+	 * @param array $cart_item Cart item array.
+	 * @param array $values Cart item values e.g. quantity and product_id.
+	 *
+	 * @return array
+	 */
+	public function convert_cart_currency( $cart_item, $values ) {
+
+		if ( isset( $cart_item['nyp_original'] ) && isset( $cart_item['nyp_currency'] ) ) {
+
+			// Store the original currency in $product meta.
+			$cart_item['data']->update_meta_data( self::NYP_CURRENCY, $cart_item['nyp_currency'] );
+
+			$current_currency = $this->multi_currency->get_selected_currency();
+
+			// If the currency is currently the same as at time price entered, restore NYP to original value.
+			if ( $cart_item['nyp_currency'] === $current_currency->get_code() ) {
+				$cart_item['nyp'] = $cart_item['nyp_original'];
+			} else {
+
+				$nyp_currency = $this->multi_currency->get_enabled_currencies()[ $cart_item['nyp_currency'] ] ?? null;
+
+				// Convert entered price back to default currency.
+				$converted_price = ( (float) $cart_item['nyp_original'] ) / $nyp_currency->get_rate();
+
+				$cart_item['nyp'] = $converted_price;
+			}
+
+			$cart_item = WC_Name_Your_Price()->cart->set_cart_item( $cart_item );
+
+		}
+
+		return $cart_item;
+
+	}
+
+	/**
+	 * Checks to see if the product's price should be converted.
+	 *
+	 * @param bool   $return  Whether to convert the product's price or not. Default is true.
+	 * @param object $product Product object to test.
+	 *
+	 * @return bool True if it should be converted.
+	 */
+	public function should_convert_product_price( bool $return, $product ): bool {
+		// If it's already false, return it.
+		if ( ! $return ) {
+			return $return;
+		}
+
+		$currency = $this->multi_currency->get_selected_currency();
+
+		// Check for cart items to see if they are in the original currency.
+		if ( $currency->get_code() === $product->get_meta( self::NYP_CURRENCY ) ) {
+			$return = false;
+		}
+
+		return $return;
+	}
+
+}

--- a/includes/multi-currency/Compatibility/WooCommerceNameYourPrice.php
+++ b/includes/multi-currency/Compatibility/WooCommerceNameYourPrice.php
@@ -132,6 +132,11 @@ class WooCommerceNameYourPrice extends BaseCompatibility {
 			$return = false;
 		}
 
+		// Check to see if the product is a NYP product.
+		if ( \WC_Name_Your_Price_Helpers::is_nyp( $product ) ) {
+			return false;
+		}
+
 		return $return;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -99,6 +99,7 @@ Please note that our support for the checkout block is still experimental and th
 == Changelog ==
 
 = 3.5.0 - 2021-xx-xx =
+* Add - Add compatibility between Multi-Currency and WooCommerce Name Your Price.
 * Fix - Error when renewing subscriptions with saved payment methods disabled.
 * Add - JS error boundaries to admin screens.
 * Update - Remove task from the overview list for setting up multiple currencies


### PR DESCRIPTION
Fixes #3507

#### Changes proposed in this Pull Request

Introduce a class that:
filters the raw minimum, maximum, and suggested prices to other currencies.
and
convert prices for NYP products from entered currency to current currency


#### Testing instructions

* Create a simple product with a minimum price
* On frontend, switch to a different currency. See min price change.
* Add the product to the cart.
* Go to cart, change currency. Cart price should now be converted from the price in the entered currency to the current currency.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) - Does not apply

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)


This ended up a little more complex than I started out with... My thinking what that we should avoid converting from a currency to the default store currency, to then convert it back to the initial currency. Something like: USD > EUR > USD. While I didn't run into any errors myself, I've run into rounding issues with things like that in the past. 

There's also a point [here](https://github.com/Automattic/woocommerce-payments/pull/3578/files#diff-6671eecca02fb2be4da9826c4286eae7a3f89eea2fb14c2963c041ebd1f4be19R106) where I tell NYP to use the price setters to manipulate the price of the cart item product object. I was hoping I could just set the `$cart_item['nyp']` value, but that's not possible without a change to the NYP plugin. I might make the change anyway, but then there's a change here that would be required (remove above mentioned line and run that callback at an earlier priority) _and_ it would only work with a new version of NYP. This approach will work with any version. 

