### PR TITLE
Force currency check when creating payment intents

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@
 * Changed - Subscription products must have a recurring amount greater than $0.
 * Fix - Return correct product prices datatype in WCPay.
 * Fix - Stop errors when viewing Subscription details when purchased via SEPA Direct Debit.
+* Fix - Force currency check when preparing a payment intent to request even when is_admin() returns true.
 * Update - Bump minimum supported version of WooCommerce from 5.5 to 5.8.
 
 = 3.4.0 - 2021-12-08 =

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1029,7 +1029,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				throw new Exception( WC_Payments_Utils::get_filtered_error_message( $e ) );
 			}
 
-			$payment_methods = WC_Payments::get_gateway()->get_payment_method_ids_enabled_at_checkout();
+			$payment_methods = WC_Payments::get_gateway()->get_payment_method_ids_enabled_at_checkout( null, true );
 
 			// Create intention, try to confirm it & capture the charge (if 3DS is not required).
 			$intent = $this->payments_api_client->create_and_confirm_intention(

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2699,9 +2699,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * Returns the list of enabled payment method types that will function with the current checkout.
 	 *
 	 * @param string $order_id optional Order ID.
+	 * @param bool   $force_currency_check optional Whether the currency check is required even if is_admin().
 	 * @return string[]
 	 */
-	public function get_payment_method_ids_enabled_at_checkout( $order_id = null ) {
+	public function get_payment_method_ids_enabled_at_checkout( $order_id = null, $force_currency_check = false ) {
 		return [
 			'card',
 		];

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -263,7 +263,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		}
 
 		$capture_method          = empty( $this->settings['manual_capture'] ) || 'no' === $this->settings['manual_capture'] ? 'automatic' : 'manual';
-		$enabled_payment_methods = $this->get_payment_method_ids_enabled_at_checkout( $order_id );
+		$enabled_payment_methods = $this->get_payment_method_ids_enabled_at_checkout( $order_id, true );
 
 		try {
 			$payment_intent = $this->payments_api_client->create_intention(
@@ -828,9 +828,11 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	 * Returns the list of enabled payment method types that will function with the current checkout.
 	 *
 	 * @param string $order_id optional Order ID.
+	 * @param bool   $force_currency_check optional Whether the currency check is required even if is_admin().
+	 *
 	 * @return string[]
 	 */
-	public function get_payment_method_ids_enabled_at_checkout( $order_id = null ) {
+	public function get_payment_method_ids_enabled_at_checkout( $order_id = null, $force_currency_check = false ) {
 		$capture                    = empty( $this->get_option( 'manual_capture' ) ) || $this->get_option( 'manual_capture' ) === 'no';
 		$capturable_payment_methods = $capture ? $this->get_upe_enabled_payment_method_ids() : [ 'card' ];
 		$enabled_payment_methods    = [];
@@ -838,8 +840,18 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		foreach ( $capturable_payment_methods as $payment_method_id ) {
 			$payment_method_capability_key = $this->payment_method_capability_key_map[ $payment_method_id ] ?? 'undefined_capability_key';
 			if ( isset( $this->payment_methods[ $payment_method_id ] ) ) {
+				// When creating a payment intent, we need to ensure the currency is matching
+				// with the payment methods which are sent with the payment intent request, otherwise
+				// Stripe returns an error.
+
+				// force_currency_check = 0 is_admin = 0 currency_is_checked = 1.
+				// force_currency_check = 0 is_admin = 1 currency_is_checked = 0.
+				// force_currency_check = 1 is_admin = 0 currency_is_checked = 1.
+				// force_currency_check = 1 is_admin = 1 currency_is_checked = 1.
+
+				$skip_currency_check       = ! $force_currency_check && is_admin();
 				$processing_payment_method = $this->payment_methods[ $payment_method_id ];
-				if ( $processing_payment_method->is_enabled_at_checkout() && ( is_admin() || $processing_payment_method->is_currency_valid() ) ) {
+				if ( $processing_payment_method->is_enabled_at_checkout() && ( $skip_currency_check || $processing_payment_method->is_currency_valid() ) ) {
 					$status = $active_payment_methods[ $payment_method_capability_key ]['status'] ?? null;
 					if ( 'active' === $status ) {
 						$enabled_payment_methods[] = $payment_method_id;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a payment intent is created when is_admin() is true, the `UPE_Payment_Gateway::get_payment_method_ids_enabled_at_checkout` method skips the currency check and returns all the enabled payment methods instead. This causes errors on Stripe side when the sent currency doesn't match the payment method sent in the payment intent. This PR fixes it by enabling the currency check on payment intent creation, even if is_admin() returns true or not. 

#### Testing instructions



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set your store currency to USD.
* Enable UPE and one of the methods that only use EUR. (giropay for example)
* Create a subscription and pay it's initial order with USD.
* Go to the subscription details in WooCommerce > Subscriptions
* On the "Subscription Actions" dropdown, select "Process Renewal" and complete the renewal.
* Without the fix, you should see this error: 

![image](https://user-images.githubusercontent.com/3295/147572387-9bb4b9f3-9b09-4a80-a4cb-dd14f875589a.png)

![image](https://user-images.githubusercontent.com/3295/147572666-fd1d8d36-709c-4289-b1c6-0577992b50f2.png)

* With the fix applied, the payment succeeds.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
