### PR TITLE
Add changelog about forcing currency check when creating a payment intent to readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -114,6 +114,7 @@ Please note that our support for the checkout block is still experimental and th
 * Changed - Subscription products must have a recurring amount greater than $0.
 * Fix - Return correct product prices datatype in WCPay.
 * Fix - Stop errors when viewing Subscription details when purchased via SEPA Direct Debit.
+* Fix - Force currency check when preparing a payment intent to request even when is_admin() returns true.
 * Update - Bump minimum supported version of WooCommerce from 5.5 to 5.8.
 
 = 3.4.0 - 2021-12-08 =


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adding changelog entry of https://github.com/Automattic/woocommerce-payments/pull/3582 to the readme.

#### Testing instructions

* Make sure changelog entries in changelog.txt and readme.txt are the same.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
