### PR TITLE
Fix UPE validation error visibility

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Payments Changelog ***
 
 = 3.6.0 - 2022-xx-xx =
-*
+* Fix UPE validation error visibility on checkout page.
 
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -421,10 +421,10 @@ jQuery( function ( $ ) {
 	 * Checks if UPE form is filled out. Displays errors if not.
 	 *
 	 * @param {Object} $form     The jQuery object for the form.
-	 * @param {string} returnUrl The `return_url` param. (optional)
+	 * @param {string} returnUrl The `return_url` param. Defaults to '#' (optional)
 	 * @return {boolean} false if incomplete.
 	 */
-	const checkUPEForm = async ( $form, returnUrl = '' ) => {
+	const checkUPEForm = async ( $form, returnUrl = '#' ) => {
 		if ( ! upeElement ) {
 			showError( 'Your payment information is incomplete.' );
 			return false;

--- a/readme.txt
+++ b/readme.txt
@@ -99,7 +99,7 @@ Please note that our support for the checkout block is still experimental and th
 == Changelog ==
 
 = 3.6.0 - 2022-xx-xx =
-*
+* Fix UPE validation error visibility on checkout page.
 
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.


### PR DESCRIPTION
As mentioned in #3483, UPE validation errors are not visible on the UI. 
To trigger field validations on UPE when the payment fields are incomplete, we make a mock `confirmPayment` which forces the validations. The `returnUrl` for this request is a required field and expects a non-empty value. https://stripe.com/docs/js/payment_intents/confirm_payment#confirm_payment_intent-options-redirect


Fixes #3483 

#### Changes proposed in this Pull Request
This PR proposes defaulting to '#' when making the `confirmPayment` request, similar to how [Stripe Gateway handles this](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/trunk/client/classic/upe/index.js#L421). Conversely, we can also provide a valid URL, but we only make this request when the payment fields are incomplete and will never actually use the redirectUrl.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable UPE from Dev Tools
2. Add a regular product and Checkout as a guest.
3. Attempt submitting with missing credit card fields.
4. Ensure that validation errors are visible

Before

https://user-images.githubusercontent.com/6216000/147834118-e522e057-0fdc-4f2c-81f8-fb7d735598af.mp4



After
![Screen Shot 2021-12-31 at 11 30 09 AM](https://user-images.githubusercontent.com/6216000/147834048-7f10c24b-1113-4609-a96a-59643a741e78.png)


-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
