### PR TITLE
Upgrade WP from 5.4 to 5.6 for the edge case in the compatibility CI tests

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -13,15 +13,18 @@ jobs:
       matrix:
         woocommerce: [ '4.4.0', '4.5.0', '4.6.0', '4.7.0', '4.8.0', '4.9.0', '5.0.0', '5.1.0', '5.2.0', '5.3.0', '5.4.0', '5.5.0', '5.6.0', '5.7.0', '5.8.0', '5.9.0', '6.0.0' ]
         wordpress:   [ 'latest' ]
+        gutenberg:   [ 'latest' ]
         php:         [ '7.4' ]
         include:
           # Edge case: oldest dependencies compatibility
           - woocommerce: '4.4.0'
-            wordpress:   '5.4'
+            wordpress:   '5.6'
+            gutenberg:   '11.4.0' # The latest version supporting WP 5.6.
             php:         '7.1' # TODO This should be 7.0. Pending to fix in issue #2970.
     env:
-      WP_VERSION: ${{ matrix.wordpress }}
-      WC_VERSION: ${{ matrix.woocommerce }}
+      WP_VERSION:        ${{ matrix.wordpress }}
+      WC_VERSION:        ${{ matrix.woocommerce }}
+      GUTENBERG_VERSION: ${{ matrix.gutenberg }}
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -50,10 +53,12 @@ jobs:
       matrix:
         woocommerce: [ 'beta' ]
         wordpress:   [ 'latest' ]
+        gutenberg:   [ 'latest' ]
         php:         [ '7.1', '8.0', '8.1' ]
     env:
-      WP_VERSION: ${{ matrix.wordpress }}
-      WC_VERSION: ${{ matrix.woocommerce }}
+      WP_VERSION:        ${{ matrix.wordpress }}
+      WC_VERSION:        ${{ matrix.woocommerce }}
+      GUTENBERG_VERSION: ${{ matrix.gutenberg }}
     steps:
       # clone the repository
       - uses: actions/checkout@v2

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -4,8 +4,9 @@ on:
   pull_request
 
 env:
-  WP_VERSION: latest
-  WC_VERSION: 5.5.0  # the min supported version as per L-2 policy
+  WP_VERSION:        latest
+  WC_VERSION:        5.5.0  # the min supported version as per L-2 policy
+  GUTENBERG_VERSION: latest
 
 jobs:
   lint:

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -12,6 +12,7 @@ DB_HOST=${4-$WORDPRESS_DB_HOST}
 WP_VERSION=${5-latest}
 WC_VERSION=${6-latest}
 SKIP_DB_CREATE=${7-false}
+GUTENBERG_VERSION=${8-latest}
 
 TMPDIR=${TMPDIR-/tmp}
 TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
@@ -207,12 +208,21 @@ install_woocommerce() {
 install_gutenberg() {
 	INSTALLED_GUTENBERG_VERSION=$(wp plugin get gutenberg --field=version)
 
-	if [[ -n $INSTALLED_GUTENBERG_VERSION ]]; then
+	if [[ -n $INSTALLED_GUTENBERG_VERSION ]] && [[ $GUTENBERG_VERSION == 'latest' ]]; then
 		# Gutenberg is already installed, we just must update it to the latest stable version
 		wp plugin update gutenberg
 		wp plugin activate gutenberg
 	else
-		wp plugin install gutenberg --activate
+		if [[ $INSTALLED_GUTENBERG_VERSION != $GUTENBERG_VERSION ]]; then
+			# Gutenberg is installed but it's the wrong version, overwrite the installed version
+			GUTENBERG_INSTALL_EXTRA+=" --force"
+		fi
+
+		if [[ $GUTENBERG_VERSION != 'latest' ]]; then
+			GUTENBERG_INSTALL_EXTRA+=" --version=$GUTENBERG_VERSION"
+		fi
+
+		wp plugin install gutenberg --activate$GUTENBERG_INSTALL_EXTRA
 	fi
 }
 

--- a/bin/run-ci-tests.bash
+++ b/bin/run-ci-tests.bash
@@ -9,6 +9,6 @@ WCPAY_DIR="$GITHUB_WORKSPACE"
 
 composer self-update 2.0.6 && composer install --no-progress
 sudo systemctl start mysql.service
-bash bin/install-wp-tests.sh woocommerce_test root root localhost $WP_VERSION $WC_VERSION false
+bash bin/install-wp-tests.sh woocommerce_test root root localhost $WP_VERSION $WC_VERSION false $GUTENBERG_VERSION
 echo 'Running the tests...'
 bash bin/phpunit.sh


### PR DESCRIPTION
Coming from this comment https://github.com/Automattic/woocommerce-payments/pull/3592#discussion_r778521350

#### Issue 

The current process of setting up test sites, we install the latest version 12.0.x of Gutenberg, which is only compatible with WP 5.7+. 

This issue has already existed for a while but the behavior is different among WP versions: 

- With WP < 5.4, it's just not activating Gutenberg without yelling any error. See [this test run](https://github.com/Automattic/woocommerce-payments/runs/4705827838?check_suite_focus=true#step:5:139).
> Warning: Failed to activate plugin. Current WordPress version does not meet minimum requirements for Gutenberg.
> Success: Installed 1 of 1 plugins.

- Since WP 5.5 ([src](https://github.com/WordPress/wordpress-develop/commit/289c28637ccaa75b5711b82904fff05e2c89bd36#diff-679826964bdb1599506cdfa3508ccd982e2f21f3de25e6f686b5aefc9175fa0dR272) - [core trac](https://core.trac.wordpress.org/ticket/9757)), it stops installing the plugin and throw this error. [See this test run](https://github.com/Automattic/woocommerce-payments/runs/4705683866?check_suite_focus=true#step:5:137).
> Warning: The package could not be installed. "Your WordPress version is 5.6, however the uploaded plugin requires 5.7."
> Plugin installation failed.

#### Changes proposed in this Pull Request

- Add Gutenberg versions in GitHub workflows and relevant bash scripts.
- Upgrade WP from 5.4 to 5.6 for the edge case in the compatibility CI tests.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that there is no CI test failure.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
