### PR TITLE
Display a notice on checkout when server responds with an Amount_Too_Small_Exception when creating WC Pay Subscriptions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Fix - Flag emoji rendering in currency switcher block widget
 * Fix - Error when saved Google Pay payment method does not have billing address name
 * Update - Update Payment Element from beta version to release version.
+* Tweak - Display a more specific error message when a customer attempts to purchase a WCPay Subscription below the minimum transact-able amount.
 
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -6,6 +6,7 @@
  */
 
 use WCPay\Exceptions\API_Exception;
+use WCPay\Exceptions\Amount_Too_Small_Exception;
 use WCPay\Logger;
 
 /**
@@ -375,6 +376,19 @@ class WC_Payments_Subscription_Service {
 			}
 		} catch ( \Exception $e ) {
 			Logger::log( sprintf( 'There was a problem creating the WCPay subscription. %s', $e->getMessage() ) );
+
+			if ( $e instanceof Amount_Too_Small_Exception ) {
+				throw new Exception(
+					sprintf(
+						// Translators: The %1 placeholder is a currency formatted price string ($0.50). The %2 and %3 placeholders are opening and closing strong HTML tags.
+						__( 'There was a problem creating your subscription. %1$s doesn\'t meet the %2$sminimum recurring amount%3$s this payment method can process.', 'woocommerce-payments' ),
+						wc_price( $subscription->get_total() ),
+						'<strong>',
+						'</strong>'
+					)
+				);
+			}
+
 			throw new Exception( $checkout_error_message );
 		}
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Flag emoji rendering in currency switcher block widget
 * Fix - Error when saved Google Pay payment method does not have billing address name
 * Update - Update Payment Element from beta version to release version.
+* Tweak - Display a more specific error message when a customer attempts to purchase a WCPay Subscription below the minimum transact-able amount.
 
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.


### PR DESCRIPTION
Part of #3297 

#### Changes proposed in this Pull Request

When this Server PR (1446-gh-Automattic/woocommerce-payments-server) is merged we will be throwing `Amount_Too_Small_Exception` exceptions from the server. This PR catches those on the client side and displaying a more specific and helpful message. 
 
<img width="1106" alt="Screen Shot 2022-01-05 at 4 37 20 pm" src="https://user-images.githubusercontent.com/8490476/148171650-2d4525c8-2b34-4892-9582-62e5b96b9a87.png">

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

* With the changes from 1446-gh-Automattic/woocommerce-payments-server running. 
* Attempt to purchase a product below $1.00 USD.
* You should receive the error message above. 

**Note:** 

- Without 1446-gh-Automattic/woocommerce-payments-server running, the purchase will go through.
- Without this PRs changeset but with 1446-gh-Automattic/woocommerce-payments-server, the error message will just be generic rather than specific.  

-------------------

- [ ] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)