### PR TITLE
Add `refresh_url` to onboarding init, so that the server can seamlessly restart the KYC flow

### DIFF
--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -668,6 +668,7 @@ class WC_Payments_Account {
 
 		$current_user = wp_get_current_user();
 		$return_url   = $this->get_onboarding_return_url( $wcpay_connect_from );
+		$refresh_url  = html_entity_decode( $this->get_connect_url() );
 
 		$country = WC()->countries->get_base_country();
 		if ( ! array_key_exists( $country, WC_Payments_Utils::supported_countries() ) ) {
@@ -676,6 +677,7 @@ class WC_Payments_Account {
 
 		$onboarding_data = $this->payments_api_client->get_onboarding_data(
 			$return_url,
+			$refresh_url,
 			[
 				'email'         => $current_user->user_email,
 				'business_name' => get_bloginfo( 'name' ),

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -951,6 +951,7 @@ class WC_Payments_API_Client {
 	 * Get data needed to initialize the onboarding flow
 	 *
 	 * @param string $return_url     - URL to redirect to at the end of the flow.
+	 * @param string $refresh_url    - URL to restart KYC flow if user refreshes or visits invalid account links URL.
 	 * @param array  $business_data  - Data to prefill the form.
 	 * @param array  $site_data      - Data to track ToS agreement.
 	 * @param array  $actioned_notes - Actioned WCPay note names to be sent to the on-boarding flow.
@@ -959,11 +960,12 @@ class WC_Payments_API_Client {
 	 *
 	 * @throws API_Exception Exception thrown on request failure.
 	 */
-	public function get_onboarding_data( $return_url, array $business_data = [], array $site_data = [], array $actioned_notes = [] ) {
+	public function get_onboarding_data( $return_url, $refresh_url, array $business_data = [], array $site_data = [], array $actioned_notes = [] ) {
 		$request_args = apply_filters(
 			'wc_payments_get_onboarding_data_args',
 			[
 				'return_url'          => $return_url,
+				'refresh_url'         => $refresh_url,
 				'business_data'       => $business_data,
 				'site_data'           => $site_data,
 				'create_live_account' => ! WC_Payments::get_gateway()->is_in_dev_mode(),

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -561,7 +561,8 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 				wp_json_encode(
 					[
 						'test_mode'           => false,
-						'return_url'          => 'http://localhost',
+						'return_url'          => 'http://localhost?return_url',
+						'refresh_url'         => 'http://localhost?refresh_url',
 						'business_data'       => [
 							'a' => 1,
 							'b' => 2,
@@ -593,7 +594,8 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 
 		// Call the method under test.
 		$result = $this->payments_api_client->get_onboarding_data(
-			'http://localhost',
+			'http://localhost?return_url',
+			'http://localhost?refresh_url',
 			[
 				'a' => 1,
 				'b' => 2,


### PR DESCRIPTION
Server issue: 1455-gh-Automattic/woocommerce-payments-server

#### Changes proposed in this Pull Request

Add `refresh_url` parameter to onboarding init. This parameter will point to the onboarding URL, so that the server can redirect to it to restart the KYC flow, as Stripe recommends:

> Your refresh_url should trigger a method on your server to call Account Links again with the same parameters, and redirect the user to the Connect Onboarding flow to create a seamless experience.

We don't redirect to this URL directly from Stripe because Stripe wouldn't allow local URLs or HTTP URLs if in live mode. So the server must proxy the redirect with the encrypted state.

#### Testing instructions

- Make sure to checkout the server PR 1465-gh-Automattic/woocommerce-payments-server.
- Make sure you're not connected to any Stripe account.
- Start the onboarding flow by clicking "Finish setup"
- After you're redirected to Stripe's KYC page, try refreshing the page, and notice you're not redirected back to WCPay as in `develop`.

-------------------

- [ ] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
