### PR TITLE
Change file ignore regex to `--extensions` argument in phpcs configuration

### DIFF
--- a/phpcs-compat.xml.dist
+++ b/phpcs-compat.xml.dist
@@ -4,6 +4,7 @@
 
 	<arg value="ps"/>
 	<arg name="parallel" value="20"/>
+	<arg name="extensions" value="php"/>
 
     <!-- Exclude paths -->
 	<exclude-pattern>./dist/*</exclude-pattern>
@@ -12,7 +13,6 @@
 	<exclude-pattern>./node_modules/*</exclude-pattern>
 	<exclude-pattern>./vendor/*</exclude-pattern>
 	<exclude-pattern>./vendor-dist/*</exclude-pattern>
-	<exclude-pattern>*\.(?!php$)</exclude-pattern>
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="5.6" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,6 +4,7 @@
 
 	<arg value="ps"/>
 	<arg name="parallel" value="20"/>
+	<arg name="extensions" value="php"/>
 
     <!-- Exclude paths -->
 	<exclude-pattern>./dist/*</exclude-pattern>
@@ -12,7 +13,6 @@
 	<exclude-pattern>./node_modules/*</exclude-pattern>
 	<exclude-pattern>./vendor/*</exclude-pattern>
 	<exclude-pattern>./vendor-dist/*</exclude-pattern>
-	<exclude-pattern>*\.(?!php$)</exclude-pattern>
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="5.6" />


### PR DESCRIPTION
#### Changes proposed

While using PHPCS format file shortcut <kbd>Option</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd> in VSCode, and running the cli command `./vendor/bin/phpcs --standard=phpcs.xml -v $(git ls-files)`, the code sniffer doesn't work right as it should. The cause of it was the regex to exclude files other than `*.php` files. This PR converts it to the `--extensions=php` argument to make it work.

#### Testing instructions

* Test it using `./vendor/bin/phpcs --standard=phpcs.xml -v $(git ls-files)` and check if the GitHub action output and your local one match.
* Test it using VSCode, check if the key combination, or context menu item (Format document) works as expected.
* I don't know about other editors, but the ones using the `phpcs.xml` ruleset file as the source, should start/continue working too.

-------------------

- [x] These changes do NOT negatively impact backward compatibility (e.g. for 0.7.0 clients)
