### PR TITLE
Fix emoji flag rendering in Currency Switcher Block widget

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,9 @@
 *** WooCommerce Payments Changelog ***
 
 = 3.6.0 - 2022-xx-xx =
-* Fix UPE validation error visibility on checkout page.
+* Fix - UPE validation error visibility on checkout page.
 * Add - Add support for full transaction exports.
+* Fix - Flag emoji rendering in currency switcher block widget
 
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.

--- a/includes/multi-currency/Settings.php
+++ b/includes/multi-currency/Settings.php
@@ -45,8 +45,8 @@ class Settings extends \WC_Settings_Page {
 		$this->id             = $this->multi_currency->id;
 		$this->label          = _x( 'Multi-currency', 'Settings tab label', 'woocommerce-payments' );
 
-		// TODO: We need to re-enable it on every screen we use emoji flags. Until WC Admin decide if they will enable it too: https://github.com/woocommerce/woocommerce-admin/issues/6388.
-		add_action( 'admin_print_scripts', 'print_emoji_detection_script' );
+		// TODO: Only register emoji script in settings page. Until WC Admin decide if they will enable it too: https://github.com/woocommerce/woocommerce-admin/issues/6388.
+		add_action( 'admin_print_scripts', [ $this, 'maybe_add_print_emoji_detection_script' ] );
 		add_action( 'woocommerce_admin_field_wcpay_multi_currency_settings_page', [ $this, 'wcpay_multi_currency_settings_page' ] );
 
 		parent::__construct();
@@ -75,5 +75,14 @@ class Settings extends \WC_Settings_Page {
 		?>
 			<div id="wcpay_multi_currency_settings_container" aria-describedby="wcpay_multi_currency_settings_container-description"></div>
 		<?php
+	}
+
+	/**
+	 * Load inline Emoji detection script on multi-currency settings page
+	 */
+	public function maybe_add_print_emoji_detection_script() {
+		if ( WC_Payments_Multi_Currency()->is_multi_currency_settings_page() ) {
+			print_emoji_detection_script();
+		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -99,8 +99,9 @@ Please note that our support for the checkout block is still experimental and th
 == Changelog ==
 
 = 3.6.0 - 2022-xx-xx =
-* Fix UPE validation error visibility on checkout page.
+* Fix - UPE validation error visibility on checkout page.
 * Add - Add support for full transaction exports.
+* Fix - Flag emoji rendering in currency switcher block widget
 
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.

--- a/tests/unit/multi-currency/test-class-settings.php
+++ b/tests/unit/multi-currency/test-class-settings.php
@@ -54,20 +54,8 @@ class WCPay_Multi_Currency_Settings_Tests extends WP_UnitTestCase {
 	public function woocommerce_action_provider() {
 		return [
 			[ 'woocommerce_admin_field_wcpay_multi_currency_settings_page', 'wcpay_multi_currency_settings_page' ],
+			[ 'admin_print_scripts', 'maybe_add_print_emoji_detection_script' ],
 		];
 	}
 
-	public function test_registers_external_action_with_account() {
-
-		// Init Settings again to get proper registration of hooks/filters.
-		$this->settings = new WCPay\MultiCurrency\Settings( $this->mock_multi_currency );
-
-		$action        = 'admin_print_scripts';
-		$function_name = 'print_emoji_detection_script';
-
-		$this->assertNotFalse(
-			has_action( $action, $function_name ),
-			"Action '$action' was not registered with '$function_name'"
-		);
-	}
 }


### PR DESCRIPTION
Fixes #3004 

#### Changes proposed in this Pull Request
These changes fix the flag emoji rendering issue mentioned in #3004. 
`print_emoji_detection_script` currently gets loaded when setting up the settings pages via `init_settings_pages`, this, in turn, breaks the emoji flags in Currency Switcher Block widget as the above script replaces the Unicode emojis within the widget's `select` tag with images. As such images are currently unsupported they are not being rendered. Note that this issue only affects the initial page render, toggling on/off flag visibility via "Display flags" re-renders the dropdown with Unicode emojis

![Screen Shot 2022-01-06 at 12 08 12 PM](https://user-images.githubusercontent.com/6216000/148429927-7be60507-4d07-44be-8b95-1310f0689ca4.png)

Changes proposed in the PR limits the inclusion of the `print_emoji_detection_script` to the Multi-Currency settings page.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to Appearance -> Widgets
2. Add the new "Currency Switcher Block" widget, click on the widget to open the settings, and make sure Display Flags is enabled on the Settings pane on the right. Save your changes using the button on the top right corner of the screen.
3. Verify the flag displays correctly in the preview.
4. Refresh the page, verify the flag is not displayed in the widget.

Additionally, the presence of the `print_emoji_detection_script` can be identified by seeing if `window._wpemojiSettings` is present via dev tools. Above variable should only be set on the Multi-Currency Settings page.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
