### PR TITLE
Logged exceptions while listing disputes

### DIFF
--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -724,7 +724,7 @@ class WC_Payments_API_Client {
 					// Wrap with try/catch to avoid failing whole request because of a single dispute.
 					$dispute = $this->add_order_info_to_object( $dispute['charge']['id'], $dispute );
 				} catch ( Exception $e ) {
-					// TODO: Log the error once Logger PR (#326) is merged.
+					Logger::error( 'Failed to add order info to dispute ' . $dispute['id'] );
 					continue;
 				}
 			}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -724,7 +724,7 @@ class WC_Payments_API_Client {
 					// Wrap with try/catch to avoid failing whole request because of a single dispute.
 					$dispute = $this->add_order_info_to_object( $dispute['charge']['id'], $dispute );
 				} catch ( Exception $e ) {
-					Logger::error( 'Failed to add order info to dispute ' . $dispute['id'] );
+					Logger::error( 'Error adding order info to dispute ' . $dispute['id'] . ' : ' . $e->getMessage() );
 					continue;
 				}
 			}


### PR DESCRIPTION
Fixes #360

#### Changes proposed in this Pull Request

Exceptions in `list_disputes` method of `wc-payment-api/class-wc-payments-api-client.php` are caught to prevent failing API calls because of a single dispute. For debugging purposes, logged the exceptions.

#### Testing instructions
- For local testing, can throw error in `list_disputes` and check that it is logged.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)
