### PR TITLE
Fetch the minimum amount that can be processed by WC Pay subscriptions and display a warning during product creation

### DIFF
--- a/includes/subscriptions/class-wc-payments-subscription-minimum-amount-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscription-minimum-amount-handler.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Class WC_Payments_Subscription_Minimum_Amount_Handler
+ *
+ * @package WooCommerce\Payments
+ */
+
+/**
+ * The WC_Payments_Subscription_Minimum_Amount_Handler class
+ */
+class WC_Payments_Subscription_Minimum_Amount_Handler {
+
+	/**
+	 * The API client object.
+	 *
+	 * @var WC_Payments_API_Client
+	 */
+	private $api_client;
+
+	/**
+	 * The transient key used to store the minimum amounts for a given currency.
+	 *
+	 * @const string
+	 */
+	const MINIMUM_RECURRING_AMOUNT_TRANSIENT_KEY = 'wcpay_subscription_minimum_recurring_amounts';
+
+	/**
+	 * The length of time in seconds the minimum amount is stored in a transient.
+	 *
+	 * @const int
+	 */
+	const MINIMUM_RECURRING_AMOUNTS_TRANSIENT_EXPIRATION = DAY_IN_SECONDS;
+
+	/**
+	 * Initialize the class.
+	 *
+	 * @param WC_Payments_API_Client $api_client The API client object.
+	 */
+	public function __construct( WC_Payments_API_Client $api_client ) {
+		$this->api_client = $api_client;
+		add_filter( 'woocommerce_subscriptions_minimum_processable_recurring_amount', [ $this, 'get_minimum_recurring_amount' ], 10, 2 );
+	}
+
+	/**
+	 * Gets the minimum WC Pay Subscription recurring amount that can be transacted in a given currency.
+	 *
+	 * @param int|bool $minimum_amount The minimum amount that can be processed in recurring transactions. Can be an int (the minimum amount) or false if no minimum exists.
+	 * @param string   $currency_code  The currency to fetch the minimum amount in.
+	 *
+	 * @return int The minimum recurring amount.
+	 */
+	public function get_minimum_recurring_amount( $minimum_amount, $currency_code ) {
+		$transient_key  = self::MINIMUM_RECURRING_AMOUNT_TRANSIENT_KEY . "_$currency_code";
+		$minimum_amount = get_transient( $transient_key );
+
+		if ( false === $minimum_amount ) {
+			$minimum_amount = $this->api_client->get_currency_minimum_recurring_amount( $currency_code );
+			set_transient( $transient_key, $minimum_amount, self::MINIMUM_RECURRING_AMOUNTS_TRANSIENT_EXPIRATION );
+		}
+
+		return WC_Payments_Utils::interpret_stripe_amount( $minimum_amount, strtolower( $currency_code ) );
+	}
+}

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -75,6 +75,9 @@ class WC_Payments_Subscriptions {
 		// Load the Subscriptions Onboarding class.
 		include_once __DIR__ . '/class-wc-payments-subscriptions-onboarding-handler.php';
 		new WC_Payments_Subscriptions_Onboarding_Handler( $account );
+
+		include_once __DIR__ . '/class-wc-payments-subscription-minimum-amount-handler.php';
+		new WC_Payments_Subscription_Minimum_Amount_Handler( $api_client );
 	}
 
 	/**

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -27,32 +27,33 @@ class WC_Payments_API_Client {
 
 	const API_TIMEOUT_SECONDS = 70;
 
-	const ACCOUNTS_API           = 'accounts';
-	const CAPABILITIES_API       = 'accounts/capabilities';
-	const APPLE_PAY_API          = 'apple_pay';
-	const CHARGES_API            = 'charges';
-	const CONN_TOKENS_API        = 'terminal/connection_tokens';
-	const TERMINAL_LOCATIONS_API = 'terminal/locations';
-	const CUSTOMERS_API          = 'customers';
-	const CURRENCY_API           = 'currency';
-	const INTENTIONS_API         = 'intentions';
-	const REFUNDS_API            = 'refunds';
-	const DEPOSITS_API           = 'deposits';
-	const TRANSACTIONS_API       = 'transactions';
-	const DISPUTES_API           = 'disputes';
-	const FILES_API              = 'files';
-	const ONBOARDING_API         = 'onboarding';
-	const TIMELINE_API           = 'timeline';
-	const PAYMENT_METHODS_API    = 'payment_methods';
-	const SETUP_INTENTS_API      = 'setup_intents';
-	const TRACKING_API           = 'tracking';
-	const PRODUCTS_API           = 'products';
-	const PRICES_API             = 'products/prices';
-	const INVOICES_API           = 'invoices';
-	const SUBSCRIPTIONS_API      = 'subscriptions';
-	const SUBSCRIPTION_ITEMS_API = 'subscriptions/items';
-	const READERS_CHARGE_SUMMARY = 'reader-charges/summary';
-	const TERMINAL_READERS_API   = 'terminal/readers';
+	const ACCOUNTS_API                 = 'accounts';
+	const CAPABILITIES_API             = 'accounts/capabilities';
+	const APPLE_PAY_API                = 'apple_pay';
+	const CHARGES_API                  = 'charges';
+	const CONN_TOKENS_API              = 'terminal/connection_tokens';
+	const TERMINAL_LOCATIONS_API       = 'terminal/locations';
+	const CUSTOMERS_API                = 'customers';
+	const CURRENCY_API                 = 'currency';
+	const INTENTIONS_API               = 'intentions';
+	const REFUNDS_API                  = 'refunds';
+	const DEPOSITS_API                 = 'deposits';
+	const TRANSACTIONS_API             = 'transactions';
+	const DISPUTES_API                 = 'disputes';
+	const FILES_API                    = 'files';
+	const ONBOARDING_API               = 'onboarding';
+	const TIMELINE_API                 = 'timeline';
+	const PAYMENT_METHODS_API          = 'payment_methods';
+	const SETUP_INTENTS_API            = 'setup_intents';
+	const TRACKING_API                 = 'tracking';
+	const PRODUCTS_API                 = 'products';
+	const PRICES_API                   = 'products/prices';
+	const INVOICES_API                 = 'invoices';
+	const SUBSCRIPTIONS_API            = 'subscriptions';
+	const SUBSCRIPTION_ITEMS_API       = 'subscriptions/items';
+	const READERS_CHARGE_SUMMARY       = 'reader-charges/summary';
+	const TERMINAL_READERS_API         = 'terminal/readers';
+	const MINIMUM_RECURRING_AMOUNT_API = 'subscriptions/minimum_amount';
 
 	/**
 	 * Common keys in API requests/responses that we might want to redact.
@@ -1916,5 +1917,22 @@ class WC_Payments_API_Client {
 	 */
 	public function get_readers_charge_summary( string $charge_date ) : array {
 		return $this->request( [ 'charge_date' => $charge_date ], self::READERS_CHARGE_SUMMARY, self::GET );
+	}
+
+	/**
+	 * Fetches from the server the minimum amount that can be processed in recurring transactions for a given currency.
+	 *
+	 * @param string $currency The currency code.
+	 *
+	 * @return int The minimum amount that can be processed in cents (with no decimals).
+	 *
+	 * @throws API_Exception If an error occurs.
+	 */
+	public function get_currency_minimum_recurring_amount( $currency ) {
+		return $this->request(
+			[],
+			self::MINIMUM_RECURRING_AMOUNT_API . '/' . $currency,
+			self::GET
+		);
 	}
 }


### PR DESCRIPTION
Fixes #3542 

#### Changes proposed in this Pull Request
This PR adds two things:

1. The callback attached to `woocommerce_subscriptions_minimum_processable_recurring_amount` (introduced in https://github.com/Automattic/woocommerce-subscriptions-core/pull/89) to return the minimum recurring amount that WC Pay subscriptions can support.
2. Adds a client function to interface with the server endpoint `subscriptions/minimum_amount` - introduced in 1473-gh-Automattic/woocommerce-payments-server

#### Testing instructions

**Requirements for testing:** 

- This branch of WCPay `issue/3542`
- subscriptions-core branch `issue/wcpay/3542`
- WCPay Server branch `wcpay_issue/3542`
- WC Subscriptions (plugin) disabled

1. With all those branches running, attempt to create a subscription product below your store's currency limit. You should see the error message shown above. 

The server adds an endpoint that enables the client to fetch the minimum amount in a given currency. You can use this code snippet locally to test various results. 


```php
add_action( 'shutdown', function() {
  WC_Payments::get_payments_api_client()->get_currency_minimum_recurring_amount( 'aud' );
  WC_Payments::get_payments_api_client()->get_currency_minimum_recurring_amount( 'usd' );
  WC_Payments::get_payments_api_client()->get_currency_minimum_recurring_amount( 'eur' );
} );
```

-------------------

- [ ] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_