### PR TITLE
Suppress extra console logs for E2E tests

### DIFF
--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -110,6 +110,21 @@ function observeConsoleLogging() {
 			return;
 		}
 
+		// Since we block assets from loading intentionally, these messages
+		// might flood the console and can be ignored.
+		if ( text.includes( 'Failed to load resource' ) ) {
+			return;
+		}
+
+		// CSP report only issues for loading resources can be ignored.
+		if (
+			text.includes(
+				'violates the following Content Security Policy directive'
+			)
+		) {
+			return;
+		}
+
 		// As of WordPress 5.3.2 in Chrome 79, navigating to the block editor
 		// (Posts > Add New) will display a console warning about
 		// non - unique IDs.

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -8,7 +8,16 @@ import {
 	setBrowserViewport,
 } from '@wordpress/e2e-test-utils';
 import { addConsoleSuppression } from '@woocommerce/e2e-environment';
+
+// Since we block assets from loading intentionally, these messages
+// might flood the console and can be ignored.
 addConsoleSuppression( 'Failed to load resource', false );
+
+// CSP report only issues for loading resources can be ignored.
+addConsoleSuppression(
+	'violates the following Content Security Policy directive',
+	false
+);
 
 /**
  * Array of page event tuples of [ eventName, handler ].
@@ -97,21 +106,6 @@ function observeConsoleLogging() {
 		if (
 			text.includes( 'net::ERR_INTERNET_DISCONNECTED' ) &&
 			isOfflineMode()
-		) {
-			return;
-		}
-
-		// Since we block assets from loading intentionally, these messages
-		// might flood the console and can be ignored.
-		if ( text.includes( 'Failed to load resource' ) ) {
-			return;
-		}
-
-		// CSP report only issues for loading resources can be ignored.
-		if (
-			text.includes(
-				'violates the following Content Security Policy directive'
-			)
 		) {
 			return;
 		}

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -7,6 +7,8 @@ import {
 	isOfflineMode,
 	setBrowserViewport,
 } from '@wordpress/e2e-test-utils';
+import { addConsoleSuppression } from '@woocommerce/e2e-environment';
+addConsoleSuppression( 'Failed to load resource', false );
 
 /**
  * Array of page event tuples of [ eventName, handler ].


### PR DESCRIPTION
Fixes #3614 

#### Changes proposed in this Pull Request
Use the `addConsoleSuppression` method to suppress extra console logs that flood the E2E test due to selective asset blocking.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- Go to E2E tests in the actions tab
- Trigger a new workflow.
- Scroll down to see the test run logs
- Observe that resource loading and CSP errors don't show up there
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [ ] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
