### PR TITLE
[Settings] Add shortened customer bank statement

### DIFF
--- a/changelog/update-statement-descriptors
+++ b/changelog/update-statement-descriptors
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Shortened bank statement in the settings.

--- a/client/data/settings/actions.js
+++ b/client/data/settings/actions.js
@@ -97,7 +97,7 @@ export function updateAccountStatementDescriptor( accountStatementDescriptor ) {
 	} );
 }
 
-export function updateIsShortStatementEnabled( isEnabled ) {
+export function updateIsShortStatementDescriptorEnabled( isEnabled ) {
 	return updateSettingsValues( {
 		is_short_statement_descriptor_enabled: isEnabled,
 	} );

--- a/client/data/settings/actions.js
+++ b/client/data/settings/actions.js
@@ -97,6 +97,12 @@ export function updateAccountStatementDescriptor( accountStatementDescriptor ) {
 	} );
 }
 
+export function updateIsShortStatementEnabled( isEnabled ) {
+	return updateSettingsValues( {
+		is_short_statement_descriptor_enabled: isEnabled,
+	} );
+}
+
 export function updateAccountBusinessName( accountBusinessName ) {
 	return updateSettingsValues( {
 		account_business_name: accountBusinessName,

--- a/client/data/settings/actions.js
+++ b/client/data/settings/actions.js
@@ -103,6 +103,12 @@ export function updateIsShortStatementEnabled( isEnabled ) {
 	} );
 }
 
+export function updateShortStatementDescriptor( shortStatementDescriptor ) {
+	return updateSettingsValues( {
+		short_statement_descriptor: shortStatementDescriptor,
+	} );
+}
+
 export function updateAccountBusinessName( accountBusinessName ) {
 	return updateSettingsValues( {
 		account_business_name: accountBusinessName,

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -135,19 +135,23 @@ export const useAccountStatementDescriptor = () => {
 	);
 };
 
-export const useIsShortStatementEnabled = () => {
-	const { updateIsShortStatementEnabled } = useDispatch( STORE_NAME );
+export const useIsShortStatementDescriptorEnabled = () => {
+	const { updateIsShortStatementDescriptorEnabled } = useDispatch(
+		STORE_NAME
+	);
 
 	return useSelect(
 		( select ) => {
-			const { getIsShortStatementEnabled } = select( STORE_NAME );
+			const { getIsShortStatementDescriptorEnabled } = select(
+				STORE_NAME
+			);
 
 			return [
-				getIsShortStatementEnabled(),
-				updateIsShortStatementEnabled,
+				getIsShortStatementDescriptorEnabled(),
+				updateIsShortStatementDescriptorEnabled,
 			];
 		},
-		[ updateIsShortStatementEnabled ]
+		[ updateIsShortStatementDescriptorEnabled ]
 	);
 };
 

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -135,6 +135,22 @@ export const useAccountStatementDescriptor = () => {
 	);
 };
 
+export const useIsShortStatementEnabled = () => {
+	const { updateIsShortStatementEnabled } = useDispatch( STORE_NAME );
+
+	return useSelect(
+		( select ) => {
+			const { getIsShortStatementEnabled } = select( STORE_NAME );
+
+			return [
+				getIsShortStatementEnabled(),
+				updateIsShortStatementEnabled,
+			];
+		},
+		[ updateIsShortStatementEnabled ]
+	);
+};
+
 export const useAccountBusinessName = () => {
 	const { updateAccountBusinessName } = useDispatch( STORE_NAME );
 

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -151,6 +151,22 @@ export const useIsShortStatementEnabled = () => {
 	);
 };
 
+export const useShortStatementDescriptor = () => {
+	const { updateShortStatementDescriptor } = useDispatch( STORE_NAME );
+
+	return useSelect(
+		( select ) => {
+			const { getShortStatementDescriptor } = select( STORE_NAME );
+
+			return [
+				getShortStatementDescriptor(),
+				updateShortStatementDescriptor,
+			];
+		},
+		[ updateShortStatementDescriptor ]
+	);
+};
+
 export const useAccountBusinessName = () => {
 	const { updateAccountBusinessName } = useDispatch( STORE_NAME );
 

--- a/client/data/settings/selectors.js
+++ b/client/data/settings/selectors.js
@@ -43,7 +43,7 @@ export const getAccountStatementDescriptor = ( state ) => {
 	return getSettings( state ).account_statement_descriptor || '';
 };
 
-export const getIsShortStatementEnabled = ( state ) => {
+export const getIsShortStatementDescriptorEnabled = ( state ) => {
 	return getSettings( state ).is_short_statement_descriptor_enabled || false;
 };
 

--- a/client/data/settings/selectors.js
+++ b/client/data/settings/selectors.js
@@ -43,6 +43,10 @@ export const getAccountStatementDescriptor = ( state ) => {
 	return getSettings( state ).account_statement_descriptor || '';
 };
 
+export const getIsShortStatementEnabled = ( state ) => {
+	return getSettings( state ).is_short_statement_descriptor_enabled || false;
+};
+
 export const getAccountBusinessName = ( state ) => {
 	return getSettings( state ).account_business_name || '';
 };

--- a/client/data/settings/selectors.js
+++ b/client/data/settings/selectors.js
@@ -47,6 +47,10 @@ export const getIsShortStatementEnabled = ( state ) => {
 	return getSettings( state ).is_short_statement_descriptor_enabled || false;
 };
 
+export const getShortStatementDescriptor = ( state ) => {
+	return getSettings( state ).short_statement_descriptor || '';
+};
+
 export const getAccountBusinessName = ( state ) => {
 	return getSettings( state ).account_business_name || '';
 };

--- a/client/settings/transactions-and-deposits/index.js
+++ b/client/settings/transactions-and-deposits/index.js
@@ -54,6 +54,8 @@ const TransactionsAndDeposits = () => {
 	] = useShortStatementDescriptor();
 	const customerBankStatementErrorMessage = useGetSavingError()?.data?.details
 		?.account_statement_descriptor?.message;
+	const shortStatementDescriptorErrorMessage = useGetSavingError()?.data
+		?.details?.short_statement_descriptor?.message;
 	const [ isCardPresentEligible ] = useCardPresentEligible();
 
 	return (
@@ -100,15 +102,6 @@ const TransactionsAndDeposits = () => {
 						</span>
 					}
 				/>
-				{ customerBankStatementErrorMessage && (
-					<Notice status="error" isDismissible={ false }>
-						<span
-							dangerouslySetInnerHTML={ {
-								__html: customerBankStatementErrorMessage,
-							} }
-						/>
-					</Notice>
-				) }
 				<div className="transactions-and-deposits__account-statement-wrapper">
 					<h4>
 						{ __(
@@ -116,6 +109,15 @@ const TransactionsAndDeposits = () => {
 							'woocommerce-payments'
 						) }
 					</h4>
+					{ customerBankStatementErrorMessage && (
+						<Notice status="error" isDismissible={ false }>
+							<span
+								dangerouslySetInnerHTML={ {
+									__html: customerBankStatementErrorMessage,
+								} }
+							/>
+						</Notice>
+					) }
 					<TextLengthHelpInputWrapper
 						textLength={ accountStatementDescriptor.length }
 						maxLength={ ACCOUNT_STATEMENT_MAX_LENGTH }
@@ -152,7 +154,7 @@ const TransactionsAndDeposits = () => {
 					/>
 					{ isShortStatementEnabled && (
 						<>
-							{ /* { shortStatementDescriptorErrorMessage && (
+							{ shortStatementDescriptorErrorMessage && (
 								<Notice status="error" isDismissible={ false }>
 									<span
 										dangerouslySetInnerHTML={ {
@@ -160,7 +162,7 @@ const TransactionsAndDeposits = () => {
 										} }
 									/>
 								</Notice>
-							) } */ }
+							) }
 							<TextLengthHelpInputWrapper
 								textLength={
 									shortAccountStatementDescriptor.length

--- a/client/settings/transactions-and-deposits/index.js
+++ b/client/settings/transactions-and-deposits/index.js
@@ -101,11 +101,12 @@ const TransactionsAndDeposits = () => {
 					<TextControl
 						className="transactions-and-deposits__account-statement-input"
 						help={ __(
-							"Edit the way your store name appears on your customers' bank statements.",
+							'Enter the name your customers will see on their transactions. Use a recognizable name – e.g. ' +
+								'the legal entity name or website address – to avoid potential disputes and chargebacks.',
 							'woocommerce-payments'
 						) }
 						label={ __(
-							'Customer bank statement',
+							'Full bank statement',
 							'woocommerce-payments'
 						) }
 						value={ accountStatementDescriptor }

--- a/client/settings/transactions-and-deposits/index.js
+++ b/client/settings/transactions-and-deposits/index.js
@@ -16,9 +16,11 @@ import {
  */
 import WCPaySettingsContext from '../wcpay-settings-context';
 import CardBody from '../card-body';
+import TextLengthHelpInputWrapper from './text-length-help-input-wrapper';
 import {
 	useAccountStatementDescriptor,
 	useIsShortStatementEnabled,
+	useShortStatementDescriptor,
 	useManualCapture,
 	useGetSavingError,
 	useSavedCards,
@@ -27,7 +29,7 @@ import {
 import './style.scss';
 
 const ACCOUNT_STATEMENT_MAX_LENGTH = 22;
-// const SHORT_STATEMENT_MAX_LENGTH = 10;
+const SHORT_STATEMENT_MAX_LENGTH = 10;
 
 const TransactionsAndDeposits = () => {
 	const {
@@ -46,6 +48,10 @@ const TransactionsAndDeposits = () => {
 		isShortStatementEnabled,
 		setIsShortStatementEnabled,
 	] = useIsShortStatementEnabled();
+	const [
+		shortAccountStatementDescriptor,
+		setShortAccountStatementDescriptor,
+	] = useShortStatementDescriptor();
 	const customerBankStatementErrorMessage = useGetSavingError()?.data?.details
 		?.account_statement_descriptor?.message;
 	const [ isCardPresentEligible ] = useCardPresentEligible();
@@ -110,25 +116,27 @@ const TransactionsAndDeposits = () => {
 							'woocommerce-payments'
 						) }
 					</h4>
-					<TextControl
-						className="transactions-and-deposits__account-statement-input"
-						help={ __(
-							'Enter the name your customers will see on their transactions. Use a recognizable name – e.g. ' +
-								'the legal entity name or website address – to avoid potential disputes and chargebacks.',
-							'woocommerce-payments'
-						) }
-						label={ __(
-							'Full bank statement',
-							'woocommerce-payments'
-						) }
-						value={ accountStatementDescriptor }
-						onChange={ setAccountStatementDescriptor }
+					<TextLengthHelpInputWrapper
+						textLength={ accountStatementDescriptor.length }
 						maxLength={ ACCOUNT_STATEMENT_MAX_LENGTH }
 						data-testid={ 'store-name-bank-statement' }
-					/>
-					<span className="input-help-text" aria-hidden="true">
-						{ `${ accountStatementDescriptor.length } / ${ ACCOUNT_STATEMENT_MAX_LENGTH }` }
-					</span>
+					>
+						<TextControl
+							className="transactions-and-deposits__account-statement-input"
+							help={ __(
+								'Enter the name your customers will see on their transactions. Use a recognizable name – e.g. ' +
+									'the legal entity name or website address – to avoid potential disputes and chargebacks.',
+								'woocommerce-payments'
+							) }
+							label={ __(
+								'Full bank statement',
+								'woocommerce-payments'
+							) }
+							value={ accountStatementDescriptor }
+							onChange={ setAccountStatementDescriptor }
+							maxLength={ ACCOUNT_STATEMENT_MAX_LENGTH }
+						/>
+					</TextLengthHelpInputWrapper>
 
 					<CheckboxControl
 						checked={ isShortStatementEnabled }
@@ -152,20 +160,29 @@ const TransactionsAndDeposits = () => {
 										} }
 									/>
 								</Notice>
-							) }
-							<TextControl
-								help={ __(
-									"We'll use the short version in combination with the customer order number.",
-									'woocommerce-payments'
-								) }
-								label={ __(
-									'Shortened customer bank statement',
-									'woocommerce-payments'
-								) }
-								value={ shortAccountStatementDescriptor }
-								onChange={ setShortAccountStatementDescriptor }
+							) } */ }
+							<TextLengthHelpInputWrapper
+								textLength={
+									shortAccountStatementDescriptor.length
+								}
 								maxLength={ SHORT_STATEMENT_MAX_LENGTH }
-							/> */ }
+							>
+								<TextControl
+									help={ __(
+										"We'll use the short version in combination with the customer order number.",
+										'woocommerce-payments'
+									) }
+									label={ __(
+										'Shortened customer bank statement',
+										'woocommerce-payments'
+									) }
+									value={ shortAccountStatementDescriptor }
+									onChange={
+										setShortAccountStatementDescriptor
+									}
+									maxLength={ SHORT_STATEMENT_MAX_LENGTH }
+								/>
+							</TextLengthHelpInputWrapper>
 						</>
 					) }
 				</div>

--- a/client/settings/transactions-and-deposits/index.js
+++ b/client/settings/transactions-and-deposits/index.js
@@ -19,7 +19,7 @@ import CardBody from '../card-body';
 import TextLengthHelpInputWrapper from './text-length-help-input-wrapper';
 import {
 	useAccountStatementDescriptor,
-	useIsShortStatementEnabled,
+	useIsShortStatementDescriptorEnabled,
 	useShortStatementDescriptor,
 	useManualCapture,
 	useGetSavingError,
@@ -47,7 +47,7 @@ const TransactionsAndDeposits = () => {
 	const [
 		isShortStatementEnabled,
 		setIsShortStatementEnabled,
-	] = useIsShortStatementEnabled();
+	] = useIsShortStatementDescriptorEnabled();
 	const [
 		shortAccountStatementDescriptor,
 		setShortAccountStatementDescriptor,

--- a/client/settings/transactions-and-deposits/index.js
+++ b/client/settings/transactions-and-deposits/index.js
@@ -18,6 +18,7 @@ import WCPaySettingsContext from '../wcpay-settings-context';
 import CardBody from '../card-body';
 import {
 	useAccountStatementDescriptor,
+	useIsShortStatementEnabled,
 	useManualCapture,
 	useGetSavingError,
 	useSavedCards,
@@ -26,6 +27,7 @@ import {
 import './style.scss';
 
 const ACCOUNT_STATEMENT_MAX_LENGTH = 22;
+// const SHORT_STATEMENT_MAX_LENGTH = 10;
 
 const TransactionsAndDeposits = () => {
 	const {
@@ -40,6 +42,10 @@ const TransactionsAndDeposits = () => {
 		accountStatementDescriptor,
 		setAccountStatementDescriptor,
 	] = useAccountStatementDescriptor();
+	const [
+		isShortStatementEnabled,
+		setIsShortStatementEnabled,
+	] = useIsShortStatementEnabled();
 	const customerBankStatementErrorMessage = useGetSavingError()?.data?.details
 		?.account_statement_descriptor?.message;
 	const [ isCardPresentEligible ] = useCardPresentEligible();
@@ -98,6 +104,12 @@ const TransactionsAndDeposits = () => {
 					</Notice>
 				) }
 				<div className="transactions-and-deposits__account-statement-wrapper">
+					<h4>
+						{ __(
+							'Customer bank statement',
+							'woocommerce-payments'
+						) }
+					</h4>
 					<TextControl
 						className="transactions-and-deposits__account-statement-input"
 						help={ __(
@@ -117,6 +129,45 @@ const TransactionsAndDeposits = () => {
 					<span className="input-help-text" aria-hidden="true">
 						{ `${ accountStatementDescriptor.length } / ${ ACCOUNT_STATEMENT_MAX_LENGTH }` }
 					</span>
+
+					<CheckboxControl
+						checked={ isShortStatementEnabled }
+						onChange={ setIsShortStatementEnabled }
+						label={ __(
+							'Add customer order number to the bank statement',
+							'woocommerce-payments'
+						) }
+						help={ __(
+							"When enabled, we'll include the order number for card and express checkout transactions.",
+							'woocommerce-payments'
+						) }
+					/>
+					{ isShortStatementEnabled && (
+						<>
+							{ /* { shortStatementDescriptorErrorMessage && (
+								<Notice status="error" isDismissible={ false }>
+									<span
+										dangerouslySetInnerHTML={ {
+											__html: shortStatementDescriptorErrorMessage,
+										} }
+									/>
+								</Notice>
+							) }
+							<TextControl
+								help={ __(
+									"We'll use the short version in combination with the customer order number.",
+									'woocommerce-payments'
+								) }
+								label={ __(
+									'Shortened customer bank statement',
+									'woocommerce-payments'
+								) }
+								value={ shortAccountStatementDescriptor }
+								onChange={ setShortAccountStatementDescriptor }
+								maxLength={ SHORT_STATEMENT_MAX_LENGTH }
+							/> */ }
+						</>
+					) }
 				</div>
 				<div className="transactions-and-deposits__bank-information">
 					<h4>

--- a/client/settings/transactions-and-deposits/test/index.test.js
+++ b/client/settings/transactions-and-deposits/test/index.test.js
@@ -11,7 +11,7 @@ import WCPaySettingsContext from '../../wcpay-settings-context';
 import {
 	useGetSavingError,
 	useAccountStatementDescriptor,
-	useIsShortStatementEnabled,
+	useIsShortStatementDescriptorEnabled,
 	useShortStatementDescriptor,
 	useManualCapture,
 	useSavedCards,
@@ -20,7 +20,7 @@ import {
 
 jest.mock( 'wcpay/data', () => ( {
 	useAccountStatementDescriptor: jest.fn(),
-	useIsShortStatementEnabled: jest.fn(),
+	useIsShortStatementDescriptorEnabled: jest.fn(),
 	useShortStatementDescriptor: jest.fn(),
 	useManualCapture: jest.fn(),
 	useGetSavingError: jest.fn(),
@@ -31,7 +31,10 @@ jest.mock( 'wcpay/data', () => ( {
 describe( 'TransactionsAndDeposits', () => {
 	beforeEach( () => {
 		useAccountStatementDescriptor.mockReturnValue( [ '', jest.fn() ] );
-		useIsShortStatementEnabled.mockReturnValue( [ false, jest.fn() ] );
+		useIsShortStatementDescriptorEnabled.mockReturnValue( [
+			false,
+			jest.fn(),
+		] );
 		useShortStatementDescriptor.mockReturnValue( [ '', jest.fn() ] );
 		useManualCapture.mockReturnValue( [ false, jest.fn() ] );
 		useGetSavingError.mockReturnValue( null );
@@ -111,10 +114,10 @@ describe( 'TransactionsAndDeposits', () => {
 	} );
 
 	it( 'toggles the shortened bank statement checkbox', () => {
-		const updateIsShortStatementEnabled = jest.fn();
-		useIsShortStatementEnabled.mockReturnValue( [
+		const updateIsShortStatementDescriptorEnabled = jest.fn();
+		useIsShortStatementDescriptorEnabled.mockReturnValue( [
 			false,
-			updateIsShortStatementEnabled,
+			updateIsShortStatementDescriptorEnabled,
 		] );
 
 		render( <TransactionsAndDeposits /> );
@@ -125,11 +128,16 @@ describe( 'TransactionsAndDeposits', () => {
 			)
 		);
 
-		expect( updateIsShortStatementEnabled ).toHaveBeenCalledWith( true );
+		expect( updateIsShortStatementDescriptorEnabled ).toHaveBeenCalledWith(
+			true
+		);
 	} );
 
 	it( 'does not display shortened bank statement input if it is disabled', () => {
-		useIsShortStatementEnabled.mockReturnValue( [ false, jest.fn() ] );
+		useIsShortStatementDescriptorEnabled.mockReturnValue( [
+			false,
+			jest.fn(),
+		] );
 		expect(
 			screen.queryByLabelText( 'Shortened customer bank statement' )
 		).not.toBeInTheDocument();
@@ -137,7 +145,10 @@ describe( 'TransactionsAndDeposits', () => {
 
 	it( 'displays the length of the shortened bank statement input', () => {
 		const updateShortStatementDescriptor = jest.fn();
-		useIsShortStatementEnabled.mockReturnValue( [ true, jest.fn() ] );
+		useIsShortStatementDescriptorEnabled.mockReturnValue( [
+			true,
+			jest.fn(),
+		] );
 		useShortStatementDescriptor.mockReturnValue( [
 			'Statement',
 			updateShortStatementDescriptor,
@@ -160,7 +171,10 @@ describe( 'TransactionsAndDeposits', () => {
 	} );
 
 	it( 'displays the error message for the statement input', () => {
-		useIsShortStatementEnabled.mockReturnValue( [ true, jest.fn() ] );
+		useIsShortStatementDescriptorEnabled.mockReturnValue( [
+			true,
+			jest.fn(),
+		] );
 		useShortStatementDescriptor.mockReturnValue( [ '111', jest.fn() ] );
 		useGetSavingError.mockReturnValue( {
 			code: 'rest_invalid_param',

--- a/client/settings/transactions-and-deposits/test/index.test.js
+++ b/client/settings/transactions-and-deposits/test/index.test.js
@@ -11,6 +11,8 @@ import WCPaySettingsContext from '../../wcpay-settings-context';
 import {
 	useGetSavingError,
 	useAccountStatementDescriptor,
+	useIsShortStatementEnabled,
+	useShortStatementDescriptor,
 	useManualCapture,
 	useSavedCards,
 	useCardPresentEligible,
@@ -18,6 +20,8 @@ import {
 
 jest.mock( 'wcpay/data', () => ( {
 	useAccountStatementDescriptor: jest.fn(),
+	useIsShortStatementEnabled: jest.fn(),
+	useShortStatementDescriptor: jest.fn(),
 	useManualCapture: jest.fn(),
 	useGetSavingError: jest.fn(),
 	useSavedCards: jest.fn(),
@@ -27,6 +31,8 @@ jest.mock( 'wcpay/data', () => ( {
 describe( 'TransactionsAndDeposits', () => {
 	beforeEach( () => {
 		useAccountStatementDescriptor.mockReturnValue( [ '', jest.fn() ] );
+		useIsShortStatementEnabled.mockReturnValue( [ false, jest.fn() ] );
+		useShortStatementDescriptor.mockReturnValue( [ '', jest.fn() ] );
 		useManualCapture.mockReturnValue( [ false, jest.fn() ] );
 		useGetSavingError.mockReturnValue( null );
 		useSavedCards.mockReturnValue( [ false, jest.fn() ] );
@@ -63,7 +69,7 @@ describe( 'TransactionsAndDeposits', () => {
 
 		expect( screen.getByText( '14 / 22' ) ).toBeInTheDocument();
 
-		fireEvent.change( screen.getByLabelText( 'Customer bank statement' ), {
+		fireEvent.change( screen.getByLabelText( 'Full bank statement' ), {
 			target: { value: 'New Statement Name' },
 		} );
 
@@ -100,6 +106,88 @@ describe( 'TransactionsAndDeposits', () => {
 		expect(
 			screen.getByText(
 				`Customer bank statement is invalid. It should not contain special characters: ' " * < >`
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'toggles the shortened bank statement checkbox', () => {
+		const updateIsShortStatementEnabled = jest.fn();
+		useIsShortStatementEnabled.mockReturnValue( [
+			false,
+			updateIsShortStatementEnabled,
+		] );
+
+		render( <TransactionsAndDeposits /> );
+
+		fireEvent.click(
+			screen.getByLabelText(
+				'Add customer order number to the bank statement'
+			)
+		);
+
+		expect( updateIsShortStatementEnabled ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'does not display shortened bank statement input if it is disabled', () => {
+		useIsShortStatementEnabled.mockReturnValue( [ false, jest.fn() ] );
+		expect(
+			screen.queryByLabelText( 'Shortened customer bank statement' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'displays the length of the shortened bank statement input', () => {
+		const updateShortStatementDescriptor = jest.fn();
+		useIsShortStatementEnabled.mockReturnValue( [ true, jest.fn() ] );
+		useShortStatementDescriptor.mockReturnValue( [
+			'Statement',
+			updateShortStatementDescriptor,
+		] );
+
+		render( <TransactionsAndDeposits /> );
+
+		expect( screen.getByText( '9 / 10' ) ).toBeInTheDocument();
+
+		fireEvent.change(
+			screen.getByLabelText( 'Shortened customer bank statement' ),
+			{
+				target: { value: 'New Stmnt' },
+			}
+		);
+
+		expect( updateShortStatementDescriptor ).toHaveBeenCalledWith(
+			'New Stmnt'
+		);
+	} );
+
+	it( 'displays the error message for the statement input', () => {
+		useIsShortStatementEnabled.mockReturnValue( [ true, jest.fn() ] );
+		useShortStatementDescriptor.mockReturnValue( [ '111', jest.fn() ] );
+		useGetSavingError.mockReturnValue( {
+			code: 'rest_invalid_param',
+			message: 'Invalid parameter(s): short_statement_descriptor',
+			data: {
+				status: 400,
+				params: {
+					short_statement_descriptor:
+						'Shortened customer bank statement is invalid. It should not contain special characters: \' " * &lt; &gt;',
+				},
+				details: {
+					short_statement_descriptor: {
+						code: 'rest_invalid_pattern',
+						message:
+							'Shortened customer bank statement is invalid. It should not contain special characters: \' " * &lt; &gt;',
+						data: null,
+					},
+				},
+			},
+		} );
+
+		render( <TransactionsAndDeposits /> );
+
+		expect( screen.getByText( '3 / 10' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				`Shortened customer bank statement is invalid. It should not contain special characters: ' " * < >`
 			)
 		).toBeInTheDocument();
 	} );

--- a/client/settings/transactions-and-deposits/text-length-help-input-wrapper.js
+++ b/client/settings/transactions-and-deposits/text-length-help-input-wrapper.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import styled from '@emotion/styled';
+
+const Wrapper = styled.div`
+	position: relative;
+
+	.components-base-control__field {
+		@media ( min-width: 783px ) {
+			width: 50%;
+		}
+
+		.components-text-control__input {
+			// to make room for the help text, so that the input's text and the help text don't overlap
+			padding-right: 55px;
+		}
+	}
+`;
+
+const HelpText = styled.span`
+	position: absolute;
+	right: 10px;
+	top: 38px;
+	font-size: 12px;
+	color: #757575;
+
+	@media ( min-width: 783px ) {
+		top: 32px;
+		right: calc( 50% + 10px );
+	}
+`;
+
+const TextLengthHelpInputWrapper = ( {
+	children,
+	textLength = 0,
+	maxLength,
+} ) => (
+	<Wrapper>
+		{ children }
+		<HelpText aria-hidden="true">
+			{ `${ textLength } / ${ maxLength }` }
+		</HelpText>
+	</Wrapper>
+);
+
+export default TextLengthHelpInputWrapper;

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -126,7 +126,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 					'account_statement_descriptor'      => [
 						'description'       => __( 'WooCommerce Payments bank account descriptor to be displayed in customers\' bank accounts.', 'woocommerce-payments' ),
 						'type'              => 'string',
-						'validate_callback' => [ $this, 'validate_regular_statement_descriptor' ],
+						'validate_callback' => [ $this, 'validate_full_statement_descriptor' ],
 					],
 					'account_business_name'             => [
 						'description' => __( 'The customer-facing business name.', 'woocommerce-payments' ),
@@ -233,7 +233,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	 * @param string          $param The parameter name, used in error messages.
 	 * @return true|WP_Error
 	 */
-	public function validate_regular_statement_descriptor( $value, $request, $param ) {
+	public function validate_full_statement_descriptor( $value, $request, $param ) {
 		return $this->validate_statement_descriptor( $value, $request, $param, 22 );
 	}
 

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -113,6 +113,11 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
+					'is_short_statement_descriptor_enabled' => [
+						'description'       => __( 'When enabled, we\'ll include the order number for card and express checkout transactions.', 'woocommerce-payments' ),
+						'type'              => 'boolean',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
 					'account_statement_descriptor'      => [
 						'description'       => __( 'WooCommerce Payments bank account descriptor to be displayed in customers\' bank accounts.', 'woocommerce-payments' ),
 						'type'              => 'string',
@@ -351,37 +356,38 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	public function get_settings(): WP_REST_Response {
 		return new WP_REST_Response(
 			[
-				'enabled_payment_method_ids'        => $this->wcpay_gateway->get_upe_enabled_payment_method_ids(),
-				'available_payment_method_ids'      => $this->wcpay_gateway->get_upe_available_payment_methods(),
-				'payment_method_statuses'           => $this->wcpay_gateway->get_upe_enabled_payment_method_statuses(),
-				'is_wcpay_enabled'                  => $this->wcpay_gateway->is_enabled(),
-				'is_manual_capture_enabled'         => 'yes' === $this->wcpay_gateway->get_option( 'manual_capture' ),
-				'is_test_mode_enabled'              => $this->wcpay_gateway->is_in_test_mode(),
-				'is_dev_mode_enabled'               => $this->wcpay_gateway->is_in_dev_mode(),
-				'is_multi_currency_enabled'         => WC_Payments_Features::is_customer_multi_currency_enabled(),
-				'is_wcpay_subscriptions_enabled'    => WC_Payments_Features::is_wcpay_subscriptions_enabled(),
-				'is_wcpay_subscriptions_eligible'   => WC_Payments_Features::is_wcpay_subscriptions_eligible(),
-				'is_subscriptions_plugin_active'    => $this->wcpay_gateway->is_subscriptions_plugin_active(),
-				'account_statement_descriptor'      => $this->wcpay_gateway->get_option( 'account_statement_descriptor' ),
-				'account_business_name'             => $this->wcpay_gateway->get_option( 'account_business_name' ),
-				'account_business_url'              => $this->wcpay_gateway->get_option( 'account_business_url' ),
-				'account_business_support_address'  => $this->wcpay_gateway->get_option( 'account_business_support_address' ),
-				'account_business_support_email'    => $this->wcpay_gateway->get_option( 'account_business_support_email' ),
-				'account_business_support_phone'    => $this->wcpay_gateway->get_option( 'account_business_support_phone' ),
-				'account_branding_logo'             => $this->wcpay_gateway->get_option( 'account_branding_logo' ),
-				'account_branding_icon'             => $this->wcpay_gateway->get_option( 'account_branding_icon' ),
-				'account_branding_primary_color'    => $this->wcpay_gateway->get_option( 'account_branding_primary_color' ),
-				'account_branding_secondary_color'  => $this->wcpay_gateway->get_option( 'account_branding_secondary_color' ),
-				'is_payment_request_enabled'        => 'yes' === $this->wcpay_gateway->get_option( 'payment_request' ),
-				'is_debug_log_enabled'              => 'yes' === $this->wcpay_gateway->get_option( 'enable_logging' ),
-				'payment_request_enabled_locations' => $this->wcpay_gateway->get_option( 'payment_request_button_locations' ),
-				'payment_request_button_size'       => $this->wcpay_gateway->get_option( 'payment_request_button_size' ),
-				'payment_request_button_type'       => $this->wcpay_gateway->get_option( 'payment_request_button_type' ),
-				'payment_request_button_theme'      => $this->wcpay_gateway->get_option( 'payment_request_button_theme' ),
-				'is_saved_cards_enabled'            => $this->wcpay_gateway->is_saved_cards_enabled(),
-				'is_card_present_eligible'          => $this->wcpay_gateway->is_card_present_eligible(),
-				'is_platform_checkout_enabled'      => 'yes' === $this->wcpay_gateway->get_option( 'platform_checkout' ),
-				'platform_checkout_custom_message'  => $this->wcpay_gateway->get_option( 'platform_checkout_custom_message' ),
+				'enabled_payment_method_ids'            => $this->wcpay_gateway->get_upe_enabled_payment_method_ids(),
+				'available_payment_method_ids'          => $this->wcpay_gateway->get_upe_available_payment_methods(),
+				'payment_method_statuses'               => $this->wcpay_gateway->get_upe_enabled_payment_method_statuses(),
+				'is_wcpay_enabled'                      => $this->wcpay_gateway->is_enabled(),
+				'is_manual_capture_enabled'             => 'yes' === $this->wcpay_gateway->get_option( 'manual_capture' ),
+				'is_test_mode_enabled'                  => $this->wcpay_gateway->is_in_test_mode(),
+				'is_dev_mode_enabled'                   => $this->wcpay_gateway->is_in_dev_mode(),
+				'is_multi_currency_enabled'             => WC_Payments_Features::is_customer_multi_currency_enabled(),
+				'is_wcpay_subscriptions_enabled'        => WC_Payments_Features::is_wcpay_subscriptions_enabled(),
+				'is_wcpay_subscriptions_eligible'       => WC_Payments_Features::is_wcpay_subscriptions_eligible(),
+				'is_subscriptions_plugin_active'        => $this->wcpay_gateway->is_subscriptions_plugin_active(),
+				'is_short_statement_descriptor_enabled' => 'yes' === $this->wcpay_gateway->get_option( 'is_short_statement_descriptor_enabled' ),
+				'account_statement_descriptor'          => $this->wcpay_gateway->get_option( 'account_statement_descriptor' ),
+				'account_business_name'                 => $this->wcpay_gateway->get_option( 'account_business_name' ),
+				'account_business_url'                  => $this->wcpay_gateway->get_option( 'account_business_url' ),
+				'account_business_support_address'      => $this->wcpay_gateway->get_option( 'account_business_support_address' ),
+				'account_business_support_email'        => $this->wcpay_gateway->get_option( 'account_business_support_email' ),
+				'account_business_support_phone'        => $this->wcpay_gateway->get_option( 'account_business_support_phone' ),
+				'account_branding_logo'                 => $this->wcpay_gateway->get_option( 'account_branding_logo' ),
+				'account_branding_icon'                 => $this->wcpay_gateway->get_option( 'account_branding_icon' ),
+				'account_branding_primary_color'        => $this->wcpay_gateway->get_option( 'account_branding_primary_color' ),
+				'account_branding_secondary_color'      => $this->wcpay_gateway->get_option( 'account_branding_secondary_color' ),
+				'is_payment_request_enabled'            => 'yes' === $this->wcpay_gateway->get_option( 'payment_request' ),
+				'is_debug_log_enabled'                  => 'yes' === $this->wcpay_gateway->get_option( 'enable_logging' ),
+				'payment_request_enabled_locations'     => $this->wcpay_gateway->get_option( 'payment_request_button_locations' ),
+				'payment_request_button_size'           => $this->wcpay_gateway->get_option( 'payment_request_button_size' ),
+				'payment_request_button_type'           => $this->wcpay_gateway->get_option( 'payment_request_button_type' ),
+				'payment_request_button_theme'          => $this->wcpay_gateway->get_option( 'payment_request_button_theme' ),
+				'is_saved_cards_enabled'                => $this->wcpay_gateway->is_saved_cards_enabled(),
+				'is_card_present_eligible'              => $this->wcpay_gateway->is_card_present_eligible(),
+				'is_platform_checkout_enabled'          => 'yes' === $this->wcpay_gateway->get_option( 'platform_checkout' ),
+				'platform_checkout_custom_message'      => $this->wcpay_gateway->get_option( 'platform_checkout_custom_message' ),
 			]
 		);
 	}
@@ -403,6 +409,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		$this->update_payment_request_enabled_locations( $request );
 		$this->update_payment_request_appearance( $request );
 		$this->update_is_saved_cards_enabled( $request );
+		$this->update_is_short_statement_descriptor_enabled( $request );
 		$this->update_account( $request );
 		$this->update_is_platform_checkout_enabled( $request );
 		$this->update_platform_checkout_custom_message( $request );
@@ -677,5 +684,20 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		$platform_checkout_custom_message = $request->get_param( 'platform_checkout_custom_message' );
 
 		$this->wcpay_gateway->update_option( 'platform_checkout_custom_message', $platform_checkout_custom_message );
+	}
+
+	/**
+	 * Updates the "is short statement descriptor" enable/disable setting.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 */
+	private function update_is_short_statement_descriptor_enabled( WP_REST_Request $request ) {
+		if ( ! $request->has_param( 'is_short_statement_descriptor_enabled' ) ) {
+			return;
+		}
+
+		$is_short_statement_descriptor_enabled = $request->get_param( 'is_short_statement_descriptor_enabled' );
+
+		$this->wcpay_gateway->update_option( 'is_short_statement_descriptor_enabled', $is_short_statement_descriptor_enabled ? 'yes' : 'no' );
 	}
 }

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -228,7 +228,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	/**
 	 * Validate the regular statement descriptor.
 	 *
-	 * @param mixed           $value The value being validated.
+	 * @param string          $value The value being validated.
 	 * @param WP_REST_Request $request The request made.
 	 * @param string          $param The parameter name, used in error messages.
 	 * @return true|WP_Error
@@ -240,7 +240,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	/**
 	 * Validate the short statement descriptor.
 	 *
-	 * @param mixed           $value The value being validated.
+	 * @param string          $value The value being validated.
 	 * @param WP_REST_Request $request The request made.
 	 * @param string          $param The parameter name, used in error messages.
 	 * @return true|WP_Error
@@ -261,7 +261,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @param mixed           $value The value being validated.
+	 * @param string          $value The value being validated.
 	 * @param WP_REST_Request $request The request made.
 	 * @param string          $param The parameter name, used in error messages.
 	 * @param int             $max_length Maximum statement length.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1880,7 +1880,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		// Validation can be done with a single regex but splitting into multiple for better readability.
-		$valid_length   = '/^.{5,' . $max_length . '}$/';
+		$valid_length   = '/^.{5,' . $max_length . '}$/u';
 		$has_one_letter = '/^.*[a-zA-Z]+/';
 		$no_specials    = '/^[^*"\'<>]*$/';
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1892,7 +1892,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			throw new InvalidArgumentException(
 				sprintf(
 					/* translators: %1 field name, %2 Number of the maximum characters allowed */
-					__( '%1$s is invalid. Statement should be between 5 and %2$u characters long, contain at least a single Latin character, and not contain any of following special characters: \' " * &lt; &gt;', 'woocommerce-payments' ),
+					__( '%1$s is invalid. Statement should be between 5 and %2$u characters long, contain at least a single Latin character, and not contain any of the following special characters: \' " * &lt; &gt;', 'woocommerce-payments' ),
 					$field,
 					$max_length
 				)

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1892,7 +1892,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			throw new InvalidArgumentException(
 				sprintf(
 					/* translators: %1 field name, %2 Number of the maximum characters allowed */
-					__( '%1$s is invalid. Statement should be between 5 and %2$u characters long, contain at least single Latin character and does not contain special characters: \' " * &lt; &gt;', 'woocommerce-payments' ),
+					__( '%1$s is invalid. Statement should be between 5 and %2$u characters long, contain at least a single Latin character, and not contain any of following special characters: \' " * &lt; &gt;', 'woocommerce-payments' ),
 					$field,
 					$max_length
 				)

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1863,18 +1863,24 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	/**
 	 * Validates statement descriptor value
 	 *
-	 * @param  string $key Field key.
+	 * @param  string $param Param name.
 	 * @param  string $value Posted Value.
+	 * @param  int    $max_length Maximum statement length.
 	 *
 	 * @return string                   Sanitized statement descriptor.
 	 * @throws InvalidArgumentException When statement descriptor is invalid.
 	 */
-	public function validate_account_statement_descriptor_field( $key, $value ) {
+	public function validate_account_statement_descriptor_field( $param, $value, $max_length ) {
 		// Since the value is escaped, and we are saving in a place that does not require escaping, apply stripslashes.
 		$value = trim( stripslashes( $value ) );
+		$field = __( 'Customer bank statement', 'woocommerce-payments' );
+
+		if ( 'short_statement_descriptor' === $param ) {
+			$field = __( 'Shortened customer bank statement', 'woocommerce-payments' );
+		}
 
 		// Validation can be done with a single regex but splitting into multiple for better readability.
-		$valid_length   = '/^.{5,22}$/';
+		$valid_length   = '/^.{5,' . $max_length . '}$/';
 		$has_one_letter = '/^.*[a-zA-Z]+/';
 		$no_specials    = '/^[^*"\'<>]*$/';
 
@@ -1883,7 +1889,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			! preg_match( $has_one_letter, $value ) ||
 			! preg_match( $no_specials, $value )
 		) {
-			throw new InvalidArgumentException( __( 'Customer bank statement is invalid. Statement should be between 5 and 22 characters long, contain at least single Latin character and does not contain special characters: \' " * &lt; &gt;', 'woocommerce-payments' ) );
+			throw new InvalidArgumentException(
+				sprintf(
+					/* translators: %1 field name, %2 Number of the maximum characters allowed */
+					__( '%1$s is invalid. Statement should be between 5 and %2$u characters long, contain at least single Latin character and does not contain special characters: \' " * &lt; &gt;', 'woocommerce-payments' ),
+					$field,
+					$max_length
+				)
+			);
 		}
 
 		return $value;

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -216,6 +216,16 @@ class WC_REST_Payments_Settings_Controller_Test extends WP_UnitTestCase {
 		$this->assertFalse( $response->get_data()['is_wcpay_enabled'] );
 	}
 
+	public function test_get_settings_returns_is_short_statement_descriptor_enabled() {
+		$response = $this->upe_controller->get_settings();
+		$this->assertEquals( false, $response->get_data()['is_short_statement_descriptor_enabled'] );
+	}
+
+	public function test_get_settings_returns_short_statement_descriptor() {
+		$response = $this->upe_controller->get_settings();
+		$this->assertEquals( '', $response->get_data()['short_statement_descriptor'] );
+	}
+
 	public function test_get_settings_fails_if_user_cannot_manage_woocommerce() {
 		$cb = $this->create_can_manage_woocommerce_cap_override( false );
 		add_filter( 'user_has_cap', $cb );
@@ -499,6 +509,49 @@ class WC_REST_Payments_Settings_Controller_Test extends WP_UnitTestCase {
 		$this->controller->update_settings( $request );
 
 		$this->assertEquals( 'no', $this->gateway->get_option( 'saved_cards' ) );
+	}
+
+	public function test_update_settings_enables_is_short_statement_descriptor_enabled() {
+		$request = new WP_REST_Request();
+		$request->set_param( 'is_short_statement_descriptor_enabled', true );
+
+		$this->controller->update_settings( $request );
+
+		$this->assertEquals( 'yes', $this->gateway->get_option( 'is_short_statement_descriptor_enabled' ) );
+	}
+
+	public function test_update_settings_disables_is_short_statement_descriptor_enabled() {
+		$request = new WP_REST_Request();
+		$request->set_param( 'is_short_statement_descriptor_enabled', false );
+
+		$this->controller->update_settings( $request );
+
+		$this->assertEquals( 'no', $this->gateway->get_option( 'is_short_statement_descriptor_enabled' ) );
+	}
+
+	public function test_update_settings_does_not_save_short_statement_descriptor_if_short_descriptor_is_disabled() {
+		$this->assertEquals( false, $this->gateway->get_option( 'is_short_statement_descriptor_enabled' ) );
+		$this->assertEquals( '', $this->gateway->get_option( 'short_statement_descriptor' ) );
+
+		$request = new WP_REST_Request();
+		$request->set_param( 'short_statement_descriptor', 'foobar' );
+
+		$this->controller->update_settings( $request );
+
+		$this->assertEquals( '', $this->gateway->get_option( 'short_statement_descriptor' ) );
+	}
+
+	public function test_update_settings_saves_short_statement_descriptor() {
+		$this->assertEquals( false, $this->gateway->get_option( 'is_short_statement_descriptor_enabled' ) );
+		$this->assertEquals( '', $this->gateway->get_option( 'short_statement_descriptor' ) );
+
+		$request = new WP_REST_Request();
+		$request->set_param( 'is_short_statement_descriptor_enabled', true );
+		$request->set_param( 'short_statement_descriptor', 'foobar' );
+
+		$this->controller->update_settings( $request );
+
+		$this->assertEquals( 'foobar', $this->gateway->get_option( 'short_statement_descriptor' ) );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -1817,37 +1817,55 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider account_statement_descriptor_validation_provider
 	 */
-	public function test_validate_account_statement_descriptor_field( $is_valid, $value, $max_length, $expected = null ) {
-		$key = 'account_statement_descriptor';
+	public function test_validate_account_statement_descriptor_fields( $is_valid, $key, $value, $max_length, $expected = null ) {
 		if ( $is_valid ) {
 			$validated_value = $this->wcpay_gateway->validate_account_statement_descriptor_field( $key, $value, $max_length );
 			$this->assertEquals( $expected ?? $value, $validated_value );
 		} else {
-			$this->expectExceptionMessage( 'Customer bank statement is invalid.' );
+			$message = 'account_statement_descriptor' === $key ? 'Customer bank statement' : 'Shortened customer bank statement';
+			$this->expectExceptionMessage( $message . ' is invalid.' );
 			$this->wcpay_gateway->validate_account_statement_descriptor_field( $key, $value, $max_length );
 		}
 	}
 
 	public function account_statement_descriptor_validation_provider() {
 		return [
-			'valid'          => [ true, 'WCPAY dev', 22 ],
-			'allow_digits'   => [ true, 'WCPay dev 2020', 22 ],
-			'allow_special'  => [ true, 'WCPay-Dev_2020', 22 ],
-			'allow_amp'      => [ true, 'WCPay&Dev_2020', 22 ],
-			'strip_slashes'  => [ true, 'WCPay\\\\Dev_2020', 22, 'WCPay\\Dev_2020' ],
-			'allow_long_amp' => [ true, 'aaaaaaaaaaaaaaaaaaa&aa', 22 ],
-			'trim_valid'     => [ true, '   good_descriptor  ', 22, 'good_descriptor' ],
-			'empty'          => [ false, '', 22 ],
-			'short'          => [ false, 'WCP', 22 ],
-			'long'           => [ false, 'WCPay_dev_WCPay_dev_WCPay_dev_WCPay_dev', 22 ],
-			'no_*'           => [ false, 'WCPay * dev', 22 ],
-			'no_sqt'         => [ false, 'WCPay \'dev\'', 22 ],
-			'no_dqt'         => [ false, 'WCPay "dev"', 22 ],
-			'no_lt'          => [ false, 'WCPay<dev', 22 ],
-			'no_gt'          => [ false, 'WCPay>dev', 22 ],
-			'req_latin'      => [ false, 'дескриптор', 22 ],
-			'req_letter'     => [ false, '123456', 22 ],
-			'trim_too_short' => [ false, '  aaa    ', 22 ],
+			'valid'                  => [ true, 'account_statement_descriptor', 'WCPAY dev', 22 ],
+			'allow_digits'           => [ true, 'account_statement_descriptor', 'WCPay dev 2020', 22 ],
+			'allow_special'          => [ true, 'account_statement_descriptor', 'WCPay-Dev_2020', 22 ],
+			'allow_amp'              => [ true, 'account_statement_descriptor', 'WCPay&Dev_2020', 22 ],
+			'strip_slashes'          => [ true, 'account_statement_descriptor', 'WCPay\\\\Dev_2020', 22, 'WCPay\\Dev_2020' ],
+			'allow_long_amp'         => [ true, 'account_statement_descriptor', 'aaaaaaaaaaaaaaaaaaa&aa', 22 ],
+			'trim_valid'             => [ true, 'account_statement_descriptor', '   good_descriptor  ', 22, 'good_descriptor' ],
+			'empty'                  => [ false, 'account_statement_descriptor', '', 22 ],
+			'short'                  => [ false, 'account_statement_descriptor', 'WCP', 22 ],
+			'long'                   => [ false, 'account_statement_descriptor', 'WCPay_dev_WCPay_dev_WCPay_dev_WCPay_dev', 22 ],
+			'no_*'                   => [ false, 'account_statement_descriptor', 'WCPay * dev', 22 ],
+			'no_sqt'                 => [ false, 'account_statement_descriptor', 'WCPay \'dev\'', 22 ],
+			'no_dqt'                 => [ false, 'account_statement_descriptor', 'WCPay "dev"', 22 ],
+			'no_lt'                  => [ false, 'account_statement_descriptor', 'WCPay<dev', 22 ],
+			'no_gt'                  => [ false, 'account_statement_descriptor', 'WCPay>dev', 22 ],
+			'req_latin'              => [ false, 'account_statement_descriptor', 'дескриптор', 22 ],
+			'req_letter'             => [ false, 'account_statement_descriptor', '123456', 22 ],
+			'trim_too_short'         => [ false, 'account_statement_descriptor', '  aaa    ', 22 ],
+			'valid (short)'          => [ true, 'short_statement_descriptor', 'WCPAY dev', 10 ],
+			'allow_digits (short)'   => [ true, 'short_statement_descriptor', 'WCPay 2020', 10 ],
+			'allow_special (short)'  => [ true, 'short_statement_descriptor', 'WCPay-_202', 10 ],
+			'allow_amp (short)'      => [ true, 'short_statement_descriptor', 'WCPay&_202', 10 ],
+			'strip_slashes (short)'  => [ true, 'short_statement_descriptor', 'WCPay\\\\D_20', 10, 'WCPay\\D_20' ],
+			'allow_long_amp (short)' => [ true, 'short_statement_descriptor', 'aaaaaaaa&a', 10 ],
+			'trim_valid (short)'     => [ true, 'short_statement_descriptor', '   good_d ', 10, 'good_d' ],
+			'empty (short)'          => [ false, 'short_statement_descriptor', '', 10 ],
+			'short (short)'          => [ false, 'short_statement_descriptor', 'WCP', 10 ],
+			'long (short)'           => [ false, 'short_statement_descriptor', 'WCPay_dev_WCPay_dev_WCPay_dev_WCPay_dev', 10 ],
+			'no_* (short)'           => [ false, 'short_statement_descriptor', 'WCPay * de', 10 ],
+			'no_sqt (short)'         => [ false, 'short_statement_descriptor', 'WCPay \'d\'', 10 ],
+			'no_dqt (short)'         => [ false, 'short_statement_descriptor', 'WCPay "de"', 10 ],
+			'no_lt (short)'          => [ false, 'short_statement_descriptor', 'WCPay<dev', 10 ],
+			'no_gt (short)'          => [ false, 'short_statement_descriptor', 'WCPay>dev', 10 ],
+			'req_latin (short)'      => [ false, 'short_statement_descriptor', 'дескриптор', 10 ],
+			'req_letter (short)'     => [ false, 'short_statement_descriptor', '123456', 10 ],
+			'trim_too_short (short)' => [ false, 'short_statement_descriptor', '  aaa    ', 10 ],
 		];
 	}
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -1817,37 +1817,37 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider account_statement_descriptor_validation_provider
 	 */
-	public function test_validate_account_statement_descriptor_field( $is_valid, $value, $expected = null ) {
+	public function test_validate_account_statement_descriptor_field( $is_valid, $value, $max_length, $expected = null ) {
 		$key = 'account_statement_descriptor';
 		if ( $is_valid ) {
-			$validated_value = $this->wcpay_gateway->validate_account_statement_descriptor_field( $key, $value );
+			$validated_value = $this->wcpay_gateway->validate_account_statement_descriptor_field( $key, $value, $max_length );
 			$this->assertEquals( $expected ?? $value, $validated_value );
 		} else {
 			$this->expectExceptionMessage( 'Customer bank statement is invalid.' );
-			$this->wcpay_gateway->validate_account_statement_descriptor_field( $key, $value );
+			$this->wcpay_gateway->validate_account_statement_descriptor_field( $key, $value, $max_length );
 		}
 	}
 
 	public function account_statement_descriptor_validation_provider() {
 		return [
-			'valid'          => [ true, 'WCPAY dev' ],
-			'allow_digits'   => [ true, 'WCPay dev 2020' ],
-			'allow_special'  => [ true, 'WCPay-Dev_2020' ],
-			'allow_amp'      => [ true, 'WCPay&Dev_2020' ],
-			'strip_slashes'  => [ true, 'WCPay\\\\Dev_2020', 'WCPay\\Dev_2020' ],
-			'allow_long_amp' => [ true, 'aaaaaaaaaaaaaaaaaaa&aa' ],
-			'trim_valid'     => [ true, '   good_descriptor  ', 'good_descriptor' ],
-			'empty'          => [ false, '' ],
-			'short'          => [ false, 'WCP' ],
-			'long'           => [ false, 'WCPay_dev_WCPay_dev_WCPay_dev_WCPay_dev' ],
-			'no_*'           => [ false, 'WCPay * dev' ],
-			'no_sqt'         => [ false, 'WCPay \'dev\'' ],
-			'no_dqt'         => [ false, 'WCPay "dev"' ],
-			'no_lt'          => [ false, 'WCPay<dev' ],
-			'no_gt'          => [ false, 'WCPay>dev' ],
-			'req_latin'      => [ false, 'дескриптор' ],
-			'req_letter'     => [ false, '123456' ],
-			'trim_too_short' => [ false, '  aaa    ' ],
+			'valid'          => [ true, 'WCPAY dev', 22 ],
+			'allow_digits'   => [ true, 'WCPay dev 2020', 22 ],
+			'allow_special'  => [ true, 'WCPay-Dev_2020', 22 ],
+			'allow_amp'      => [ true, 'WCPay&Dev_2020', 22 ],
+			'strip_slashes'  => [ true, 'WCPay\\\\Dev_2020', 22, 'WCPay\\Dev_2020' ],
+			'allow_long_amp' => [ true, 'aaaaaaaaaaaaaaaaaaa&aa', 22 ],
+			'trim_valid'     => [ true, '   good_descriptor  ', 22, 'good_descriptor' ],
+			'empty'          => [ false, '', 22 ],
+			'short'          => [ false, 'WCP', 22 ],
+			'long'           => [ false, 'WCPay_dev_WCPay_dev_WCPay_dev_WCPay_dev', 22 ],
+			'no_*'           => [ false, 'WCPay * dev', 22 ],
+			'no_sqt'         => [ false, 'WCPay \'dev\'', 22 ],
+			'no_dqt'         => [ false, 'WCPay "dev"', 22 ],
+			'no_lt'          => [ false, 'WCPay<dev', 22 ],
+			'no_gt'          => [ false, 'WCPay>dev', 22 ],
+			'req_latin'      => [ false, 'дескриптор', 22 ],
+			'req_letter'     => [ false, '123456', 22 ],
+			'trim_too_short' => [ false, '  aaa    ', 22 ],
 		];
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is the first part of two PRs to get the statement descriptor info sent in the payment intents. That information seems to be sent over inconsistently across the many ways we use to create/update the intent.

In this part, the shortened descriptor is being added to the settings. The user should be able to provide a shortened version of the descriptor that will be concatenated with the order number. The shortened version is meant to be used for card transactions only.

See the design below. The focus of this PR is the functionality, hence the preview is not included – it can be addressed in another PR later on.

![image](https://user-images.githubusercontent.com/10233985/149021002-3137398a-2475-4519-a086-35d5fd3d587d.png)

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to the WCPay [settings](http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments).
2. You should see a new unticked checkbox `Add customer order number to the bank statement` below the regular bank statement.
3. Tick it and the `Shortened customer bank statement` field should appear.
4. Type in something and save.
5. Play with some values in the `Shortened customer bank statement` field. Validation should work the same way as for the regular bank statement, except for the field max length.
6. Untick `Add customer order number to the bank statement` and `Shortened customer bank statement` field should disappear.
7. `Full bank statement` should work as usual.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
