### PR TITLE
Handle payment_failed payment intent webhooks.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Fix - Flag emoji rendering in currency switcher block widget
 * Fix - Error when saved Google Pay payment method does not have billing address name
 * Update - Update Payment Element from beta version to release version.
+* Add - Add handling for payment_failed webhooks.
 
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -269,7 +269,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	 * @throws Invalid_Payment_Method_Exception When unable to resolve charge ID to order.
 	 */
 	private function process_webhook_payment_intent_failed( $event_body ) {
-		$order = $this->get_order_from_event( $event_body );
+		$order = $this->get_order_from_event_intent_id( $event_body );
 
 		if ( $order && ! $order->has_status( [ 'failed' ] ) ) {
 			$order->update_status( 'failed', $this->get_failure_message_from_event( $event_body ) );
@@ -285,7 +285,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	 * @throws Invalid_Payment_Method_Exception When unable to resolve charge ID to order.
 	 */
 	private function process_webhook_payment_intent_succeeded( $event_body ) {
-		$order = $this->get_order_from_event( $event_body );
+		$order = $this->get_order_from_event_intent_id( $event_body );
 
 		if ( ! $order || $order->has_status( [ 'processing', 'completed' ] ) ) {
 			return;
@@ -465,7 +465,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	}
 
 	/**
-	 * Gets the order related to the event.
+	 * Gets the order related to the event intent id.
 	 *
 	 * @param array $event_body The event that triggered the webhook.
 	 *
@@ -474,7 +474,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	 *
 	 * @return WC_Order|null
 	 */
-	private function get_order_from_event( $event_body ) {
+	private function get_order_from_event_intent_id( $event_body ) {
 		$event_data   = $this->read_rest_property( $event_body, 'data' );
 		$event_object = $this->read_rest_property( $event_data, 'object' );
 		$intent_id    = $this->read_rest_property( $event_object, 'id' );

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -138,6 +138,9 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 					$note = $this->read_rest_property( $body, 'data' );
 					$this->remote_note_service->put_note( $note );
 					break;
+				case 'payment_intent.payment_failed':
+					$this->process_webhook_payment_intent_failed( $body );
+					break;
 				case 'payment_intent.succeeded':
 					$this->process_webhook_payment_intent_succeeded( $body );
 					break;
@@ -258,6 +261,22 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	}
 
 	/**
+	 * Process webhook for a failed payment intent.
+	 *
+	 * @param array $event_body The event that triggered the webhook.
+	 *
+	 * @throws Rest_Request_Exception           Required parameters not found.
+	 * @throws Invalid_Payment_Method_Exception When unable to resolve charge ID to order.
+	 */
+	private function process_webhook_payment_intent_failed( $event_body ) {
+		$order = $this->get_order_from_event( $event_body );
+
+		if ( $order && ! $order->has_status( [ 'failed' ] ) ) {
+			$order->update_status( 'failed', $this->get_failure_message_from_event( $event_body ) );
+		}
+	}
+
+	/**
 	 * Process webhook for a successul payment intent.
 	 *
 	 * @param array $event_body The event that triggered the webhook.
@@ -266,53 +285,11 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	 * @throws Invalid_Payment_Method_Exception When unable to resolve charge ID to order.
 	 */
 	private function process_webhook_payment_intent_succeeded( $event_body ) {
-		$event_data   = $this->read_rest_property( $event_body, 'data' );
-		$event_object = $this->read_rest_property( $event_data, 'object' );
-		$intent_id    = $this->read_rest_property( $event_object, 'id' );
+		$order = $this->get_order_from_event( $event_body );
 
-		// Look up the order related to this charge.
-		$order = $this->wcpay_db->order_from_intent_id( $intent_id );
-
-		if ( ! $order ) {
-			// Retrieving order with order_id in case intent_id was not properly set.
-			Logger::debug( 'intent_id not found, using order_id to retrieve order' );
-			$metadata = $this->read_rest_property( $event_object, 'metadata' );
-
-			if ( isset( $metadata['order_id'] ) ) {
-				$order_id = $metadata['order_id'];
-				$order    = $this->wcpay_db->order_from_order_id( $order_id );
-			} elseif ( ! empty( $event_object['invoice'] ) ) {
-				// If the payment intent contains an invoice it is a WCPay Subscription-related intent and will be handled by the `invoice.paid` event.
-				return;
-			}
+		if ( $order && ! $order->has_status( [ 'processing', 'completed' ] ) ) {
+			$order->payment_complete();
 		}
-
-		if ( ! $order ) {
-			throw new Invalid_Payment_Method_Exception(
-				sprintf(
-					/* translators: %1: charge ID */
-					__( 'Could not find order via intent ID: %1$s', 'woocommerce-payments' ),
-					$intent_id
-				),
-				'order_not_found'
-			);
-		}
-
-		// Get an updated set of order properties to avoid race conditions when the server sends the paid webhook before we've finished processing the original payment request.
-		$order->get_data_store()->read( $order );
-
-		if ( $order->has_status( [ 'processing', 'completed' ] ) ) {
-			return;
-		}
-
-		// Prevent parallel order processing attempts.
-		if ( WC_Payments_Utils::is_order_locked( $order, $intent_id ) ) {
-			return;
-		}
-
-		WC_Payments_Utils::lock_order_payment( $order, $intent_id );
-		$order->payment_complete();
-		WC_Payments_Utils::unlock_order_payment( $order );
 	}
 
 	/**
@@ -476,5 +453,97 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 			);
 		}
 		return $array[ $key ];
+	}
+
+	/**
+	 * Gets the order related to the event.
+	 *
+	 * @param array $event_body The event that triggered the webhook.
+	 *
+	 * @throws Rest_Request_Exception           Required parameters not found.
+	 * @throws Invalid_Payment_Method_Exception When unable to resolve charge ID to order.
+	 *
+	 * @return WC_Order|null
+	 */
+	private function get_order_from_event( $event_body ) {
+		$event_data   = $this->read_rest_property( $event_body, 'data' );
+		$event_object = $this->read_rest_property( $event_data, 'object' );
+		$intent_id    = $this->read_rest_property( $event_object, 'id' );
+
+		// Look up the order related to this charge.
+		$order = $this->wcpay_db->order_from_intent_id( $intent_id );
+
+		if ( ! $order ) {
+			// Retrieving order with order_id in case intent_id was not properly set.
+			Logger::debug( 'intent_id not found, using order_id to retrieve order' );
+			$metadata = $this->read_rest_property( $event_object, 'metadata' );
+
+			if ( isset( $metadata['order_id'] ) ) {
+				$order_id = $metadata['order_id'];
+				$order    = $this->wcpay_db->order_from_order_id( $order_id );
+			} elseif ( ! empty( $event_object['invoice'] ) ) {
+				// If the payment intent contains an invoice it is a WCPay Subscription-related intent and will be handled by the `invoice.paid` event.
+				return;
+			}
+		}
+
+		if ( ! $order ) {
+			throw new Invalid_Payment_Method_Exception(
+				sprintf(
+					/* translators: %1: charge ID */
+					__( 'Could not find order via intent ID: %1$s', 'woocommerce-payments' ),
+					$intent_id
+				),
+				'order_not_found'
+			);
+		}
+
+		// Get an updated set of order properties to avoid race conditions when the server sends the paid webhook before we've finished processing the original payment request.
+		$order->get_data_store()->read( $order );
+
+		return $order;
+	}
+
+	/**
+	 * Gets the proper failure message from the code in the event.
+	 *
+	 * @param array $event_body The event that triggered the webhook.
+	 *
+	 * @return string The failure message.
+	 */
+	private function get_failure_message_from_event( $event_body ):string {
+		// Get the failure code from the event body.
+		$event_data    = $this->read_rest_property( $event_body, 'data' );
+		$event_object  = $this->read_rest_property( $event_data, 'object' );
+		$event_charges = $this->read_rest_property( $event_object, 'charges' );
+		$charges_data  = $this->read_rest_property( $event_charges, 'data' );
+		$failure_code  = $charges_data[0]['failure_code'];
+
+		switch ( $failure_code ) {
+			case 'account_closed':
+				$failure_message = __( "The customer's bank account has been closed.", 'woocommerce-payments' );
+				break;
+			case 'debit_not_authorized':
+				$failure_message = __( 'The customer has notified their bank that this payment was unauthorized.', 'woocommerce-payments' );
+				break;
+			case 'insufficient_funds':
+				$failure_message = __( "The customer's account has insufficient funds to cover this payment.", 'woocommerce-payments' );
+				break;
+			case 'no_account':
+				$failure_message = __( "The customer's bank account could not be located.", 'woocommerce-payments' );
+				break;
+			case 'payment_method_microdeposit_failed':
+				$failure_message = __( 'Microdeposit transfers failed. Please check the account, institution and transit numbers.', 'woocommerce-payments' );
+				break;
+			case 'payment_method_microdeposit_verification_attempts_exceeded':
+				$failure_message = __( 'You have exceeded the number of allowed verification attempts.', 'woocommerce-payments' );
+				break;
+
+			default:
+				$failure_message = __( 'The payment was not able to be processed.', 'woocommerce-payments' );
+				break;
+		}
+
+		return $failure_message;
 	}
 }

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -518,7 +518,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 		$event_object  = $this->read_rest_property( $event_data, 'object' );
 		$event_charges = $this->read_rest_property( $event_object, 'charges' );
 		$charges_data  = $this->read_rest_property( $event_charges, 'data' );
-		$failure_code  = isset( $charges_data[0]['failure_code'] ) ? $charges_data[0]['failure_code'] : '';
+		$failure_code  = $charges_data[0]['failure_code'] ?? '';
 
 		switch ( $failure_code ) {
 			case 'account_closed':

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -269,7 +269,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	 * @throws Invalid_Payment_Method_Exception When unable to resolve charge ID to order.
 	 */
 	private function process_webhook_payment_intent_failed( $event_body ) {
-		$order = $this->get_order_from_event_intent_id( $event_body );
+		$order = $this->get_order_from_event_body_intent_id( $event_body );
 
 		if ( $order && ! $order->has_status( [ 'failed' ] ) ) {
 			$order->update_status( 'failed', $this->get_failure_message_from_event( $event_body ) );
@@ -277,7 +277,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	}
 
 	/**
-	 * Process webhook for a successul payment intent.
+	 * Process webhook for a successful payment intent.
 	 *
 	 * @param array $event_body The event that triggered the webhook.
 	 *
@@ -285,7 +285,10 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	 * @throws Invalid_Payment_Method_Exception When unable to resolve charge ID to order.
 	 */
 	private function process_webhook_payment_intent_succeeded( $event_body ) {
-		$order = $this->get_order_from_event_intent_id( $event_body );
+		$event_data   = $this->read_rest_property( $event_body, 'data' );
+		$event_object = $this->read_rest_property( $event_data, 'object' );
+		$intent_id    = $this->read_rest_property( $event_object, 'id' );
+		$order        = $this->get_order_from_event_body_intent_id( $event_body );
 
 		WC_Payments_Utils::mark_payment_completed( $order, $intent_id );
 	}
@@ -461,9 +464,9 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	 * @throws Rest_Request_Exception           Required parameters not found.
 	 * @throws Invalid_Payment_Method_Exception When unable to resolve charge ID to order.
 	 *
-	 * @return WC_Order|null
+	 * @return ?WC_Order
 	 */
-	private function get_order_from_event_intent_id( $event_body ) {
+	private function get_order_from_event_body_intent_id( $event_body ) {
 		$event_data   = $this->read_rest_property( $event_body, 'data' );
 		$event_object = $this->read_rest_property( $event_data, 'object' );
 		$intent_id    = $this->read_rest_property( $event_object, 'id' );

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -518,7 +518,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 		$event_object  = $this->read_rest_property( $event_data, 'object' );
 		$event_charges = $this->read_rest_property( $event_object, 'charges' );
 		$charges_data  = $this->read_rest_property( $event_charges, 'data' );
-		$failure_code  = $charges_data[0]['failure_code'];
+		$failure_code  = isset( $charges_data[0]['failure_code'] ) ? $charges_data[0]['failure_code'] : '';
 
 		switch ( $failure_code ) {
 			case 'account_closed':

--- a/includes/admin/class-wc-rest-payments-webhook-controller.php
+++ b/includes/admin/class-wc-rest-payments-webhook-controller.php
@@ -464,7 +464,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 	 * @throws Rest_Request_Exception           Required parameters not found.
 	 * @throws Invalid_Payment_Method_Exception When unable to resolve charge ID to order.
 	 *
-	 * @return ?WC_Order
+	 * @return boolean|WC_Order|WC_Order_Refund
 	 */
 	private function get_order_from_event_body_intent_id( $event_body ) {
 		$event_data   = $this->read_rest_property( $event_body, 'data' );
@@ -484,7 +484,7 @@ class WC_REST_Payments_Webhook_Controller extends WC_Payments_REST_Controller {
 				$order    = $this->wcpay_db->order_from_order_id( $order_id );
 			} elseif ( ! empty( $event_object['invoice'] ) ) {
 				// If the payment intent contains an invoice it is a WCPay Subscription-related intent and will be handled by the `invoice.paid` event.
-				return;
+				return false;
 			}
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Flag emoji rendering in currency switcher block widget
 * Fix - Error when saved Google Pay payment method does not have billing address name
 * Update - Update Payment Element from beta version to release version.
+* Add - Add handling for payment_failed webhooks.
 
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.

--- a/tests/unit/admin/test-class-wc-rest-payments-webhook.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-webhook.php
@@ -685,27 +685,58 @@ class WC_REST_Payments_Webhook_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that an invoice upoming event creates invoice items for subscription.
+	 * Tests that a payment_intent.succeeded event will complete the order.
 	 */
-	public function test_invoice_upcoming_webhook() {
-		// Stub.
-		$this->assertTrue( true );
-	}
+	public function test_payment_intent_fails_and_fails_order() {
+		$this->request_body['type']           = 'payment_intent.payment_failed';
+		$this->request_body['data']['object'] = [
+			'id'       => 'pi_123123123123123', // payment_intent's ID.
+			'object'   => 'payment_intent',
+			'amount'   => 1500,
+			'charges'  => [
+				'data' => [],
+			],
+			'currency' => 'usd',
+		];
 
-	/**
-	 * Tests that an invoice paid event renews a subscription.
-	 */
-	public function test_invoice_paid_webhook() {
-		// Stub.
-		$this->assertTrue( true );
-	}
+		$this->request->set_body( wp_json_encode( $this->request_body ) );
 
-	/**
-	 * Tests that an invoice payment failed event places a subscription on-hold.
-	 */
-	public function test_invoice_payment_failed_webhook() {
-		// Stub.
-		$this->assertTrue( true );
+		$mock_order = $this->createMock( WC_Order::class );
+
+		$mock_order
+			->expects( $this->once() )
+			->method( 'has_status' )
+			->with( [ 'failed' ] )
+			->willReturn( false );
+
+		$mock_order
+			->expects( $this->once() )
+			->method( 'update_status' )
+			->with(
+				'failed',
+				$this->matchesRegularExpression(
+					'/The payment was not able to be processed.*/'
+				)
+			);
+
+		$mock_order
+			->method( 'get_data_store' )
+			->willReturn( new \WC_Mock_WC_Data_Store() );
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_intent_id' )
+			->with( 'pi_123123123123123' )
+			->willReturn( $mock_order );
+
+		// Run the test.
+		$response = $this->controller->handle_webhook( $this->request );
+
+		// Check the response.
+		$response_data = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( [ 'result' => 'success' ], $response_data );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3620

#### Changes proposed in this Pull Request

* Add handling for `payment_intent.payment_failed` webhooks.
  * Add `process_webhook_payment_intent_failed` method that updates the order to the _Failed_ status and adds the reason why.
* Add `get_order_from_event_body_intent_id` method to get the `WC_Order` object from the payment intent id.
  *  Refactor `process_webhook_payment_intent_succeeded` to use the new method.
* Add `get_failure_message_from_event` method to get the `failure_code` from the webhook event, then provide a translated error message from the code.
  * Used in `process_webhook_payment_intent_failed` to add the note to the order
* Add test for `process_webhook_payment_intent_failed` and remove unused stub tests.

#### Testing instructions

* Tests should pass.

I found the easiest way to manually test is to use Postman, unless you have another method for sending in requests to the REST API.

* Use filter below to get around authentication, be sure to remove it afterwards.
* Set to POST to `https://YOURSITE/?rest_route=/wc/v3/payments/webhook`.
* Use the json below as the body of the post, updating where needed.
  * It's best to use an existing order, and get the payment intent id out of it, then add it to the json data.
  * Set the order to On Hold, Pending, etc.
* After posting, the order should be moved to Failed status, and there should be a note in the order that the account was not found.

filter:
```
add_filter( 'user_has_cap', function( $caps ) {
	$caps['manage_woocommerce'] = true;
	return $caps;
});
```

json:
```
{
    "type": "payment_intent.payment_failed",
    "data": {
        "object": {
            "id": "ADD_INTENT_ID_HERE",
            "object": "payment_intent",
            "charges": {
                "data": [
                    {
                        "failure_code": "no_account"
                    }
                ]
            }
        }
    }
}
```

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _ 'QA Testing Not Applicable'_
