### PR TITLE
Update subscriptions-core to `1.5.0`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Fix - Flag emoji rendering in currency switcher block widget
 * Fix - Error when saved Google Pay payment method does not have billing address name
 * Update - Update Payment Element from beta version to release version.
+* Add - Show a warning when attempting to create a subscription product with a price below the minimum amount.
 
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
       "automattic/jetpack-config": "1.5.3",
       "automattic/jetpack-autoloader": "2.10.10",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "1.4.0",
+      "woocommerce/subscriptions-core": "1.5.0",
       "symfony/polyfill-php71": "1.20.0",
       "symfony/polyfill-php72": "1.23.0",
       "symfony/polyfill-php73": "1.23.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd396360a87fc51fe044306a6490d821",
+    "content-hash": "00cace6a1491b42df10d99c89aec0e6f",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1278,16 +1278,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "659909bc7f3a80b7188a73a5226f526978e49f0b"
+                "reference": "25cb50f06c88e3de4f0f6067060cba428c8dcbbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/659909bc7f3a80b7188a73a5226f526978e49f0b",
-                "reference": "659909bc7f3a80b7188a73a5226f526978e49f0b",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/25cb50f06c88e3de4f0f6067060cba428c8dcbbf",
+                "reference": "25cb50f06c88e3de4f0f6067060cba428c8dcbbf",
                 "shasum": ""
             },
             "require": {
@@ -1329,10 +1329,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/1.4.0",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/1.5.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-01-11T02:27:55+00:00"
+            "time": "2022-01-14T05:26:28+00:00"
         }
     ],
     "packages-dev": [

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Flag emoji rendering in currency switcher block widget
 * Fix - Error when saved Google Pay payment method does not have billing address name
 * Update - Update Payment Element from beta version to release version.
+* Add - Show a warning when attempting to create a subscription product with a price below the minimum amount.
 
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Load newer woocommerce-subscriptions-core's version, `1.5.0`.
- Add changes of woocommerce-subscriptions-core to the changelog.
- Updated `composer.lock` as a result of running `composer update woocommerce/subscriptions-core`.

#### Testing instructions

* Checkout this branch.
* [Husky hook should run `composer install`](https://github.com/Automattic/woocommerce-payments/blob/develop/.husky/post-checkout#L8) and your `vendor/woocommerce/subscriptions-core` should be updated to be `1.5.0`. Confirm that [latest changes from `1.5.0`](https://github.com/Automattic/woocommerce-subscriptions-core/commits/1.5.0) is present, for example, [vendor/woocommerce/subscriptions-core/changelog.txt is up-to-date](https://github.com/Automattic/woocommerce-subscriptions-core/blob/1.5.0/changelog.txt).

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)

Closes https://github.com/Automattic/woocommerce-payments/issues/3542.