### PR TITLE
Aligned the changelog in readme.txt and changelog.txt

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -38,6 +38,7 @@
 * Fix - Incorrect customer links on Transactions page.
 * Fix - Incorrect prices in Payment Request Button for certain currencies.
 * Fix - Updates to fraud protection.
+* Add - Add support for suggested gateway methods in WC-Admin.
 * Fix - Prevent Payment Request buttons from showing up in Composite Product pages.
 * Update - Updated @woocommerce/experimental package to v2.1.0.
 * Add - Add support for suggested gateway methods in WC-Admin.
@@ -130,9 +131,9 @@
 
 = 3.1.0 - 2021-10-06 =
 * Fix - Issue affecting analytics for Multi-Currency orders made with a zero-decimal to non-zero decimal conversion.
-* Add - Customer multi-currency onboarding flow.
+* Add - Customer Multi-Currency onboarding flow.
 * Add - Checkbox toggle for disabling customer Multi-Currency feature in Advanced Settings.
-* Add - Update layout of the Multi-currency settings screen.
+* Add - Update layout of the Multi-Currency settings screen.
 * Fix - Fixed missing file error for removed CSS file.
 * Add - Currency deletion confirmation modal for currencies that are bound to an UPE method.
 * Fix - Currency switcher does not affect order confirmation screen prices.
@@ -232,6 +233,7 @@
 * Fix - WooCommerce Payments admin pages redirect to the onboarding page when the WooCommerce Payments account is disconnected.
 * Fix - Do not overwrite admin pages when account is disconnected.
 * Update - Set a description when creating payment intents.
+* Add - Add dispute resolution task.
 
 = 2.6.1 - 2021-07-01 =
 * Fix - Updates the notes query filters to prevent breaking the WooCommerce > Home inbox.
@@ -337,13 +339,13 @@
 
 = 2.0.0 - 2021-02-22 =
 * Update - Render customer details in transactions list as text instead of link if order missing.
-* Update - Render transaction summary on details page for multi-currency transactions.
+* Update - Render transaction summary on details page for Multi-Currency transactions.
 * Update - Improvements to fraud prevention.
 * Fix - Added better notices for end users if there are connection errors when making payments.
 * Fix - If account is set to manual payouts display 'Temporarily suspended' under Payments > Settings.
 * Add - Add file dropzones to dispute evidence upload fields
 * Add - Currency conversion indicator to Transactions list.
-* Add - Transaction timeline details for multi-currency transactions.
+* Add - Transaction timeline details for Multi-Currency transactions.
 * Update - Link order note with transaction details page.
 * Fix - Updating payment method using saved payment for WC Subscriptions orders.
 

--- a/readme.txt
+++ b/readme.txt
@@ -113,7 +113,7 @@ Please note that our support for the checkout block is still experimental and th
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.
 * Add - JS error boundaries to admin screens.
-* Update - Remove task from the overview list for setting up multiple currencies
+* Update - Remove task from the overview list for setting up multiple currencies.
 * Update - Return to task "Set up payments" after finishing KYC from WC-Admin.
 * Fix - Improve race condition checks to prevent duplicate order status changes.
 * Fix - Explicit currency formatting in customer-facing emails.
@@ -138,10 +138,14 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Updates to fraud protection.
 * Add - Add support for suggested gateway methods in WC-Admin.
 * Fix - Prevent Payment Request buttons from showing up in Composite Product pages.
+* Update - Updated @woocommerce/experimental package to v2.1.0.
+* Add - Add support for suggested gateway methods in WC-Admin.
 * Add - Onboarding flows on the admin WooCommerce > Subscriptions screen for stores with no subscriptions yet.
 * Add - Card Reader receipt settings page.
 * Fix - Fatal error on thank you page for deleted orders.
 * Add - Error messages when dispute evidence exceeds Stripe limits.
+* Add - Export Disputes to CSV
+* Update - Remove "Boost your sales by accepting new payment methods" from the overview tasks list.
 * Fix - Onboarding must be completed before Subscriptions products can be published.
 * Fix - Show the prices in the correct currency when using the "All Products" block.
 * Add - Support business account branding settings.
@@ -192,13 +196,19 @@ Please note that our support for the checkout block is still experimental and th
 
 = 3.2.0 - 2021-10-28 =
 * Add - Add subscriptions functionality via Stripe Billing and WC Subscriptions core.
+* Add - UPE track on upgrade and on setting toggle.
 * Fix - Prevent currency switcher to show when enabled currencies list is empty.
 * Fix - Show currency switcher notice until customer explicitly dismisses it.
+* Update - Switch the PaymentIntent ID and the Charge ID in the order notes and transaction details pages.
+* Fix - Track 'wcpay_payment_request_settings_change' for when updating the Payment Requests setting not being recorded.
 * Update - Fee breakdown when there's only a base fee
 * Fix - Inconsistent shipping options in Payment Request popup.
+* Fix - Payment methods checkbox UI looking off when Gutenberg is active.
+* Update - Remove unused "wcpay_deposits_summary_empty_state_click" track.
 * Fix - Border style not being applied properly on Multi-Currency block widget.
 * Fix - Applied sentence case on all strings
-* Fix - Missing customer information after guest checkout via Checkout Block
+* Fix - Missing customer information after guest checkout via Checkout Block.
+* Fix - Show correct payment method name during checkout using upe methods.
 * Fix - Multi-Currency settings rounding option and preview.
 * Fix - Payment failure on checkout block with UPE when phone number field is hidden
 * Update - Adds a scheduled action which makes updating the account cache more efficient
@@ -255,6 +265,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Fix subscription change payment method errors after entering a payment method that fails.
 * Fix - Prevent duplicate account onboarding requests.
 * Fix - Filter out merchant-facing payment errors from customer error notices.
+* Fix - Add primary action to high priority tasks.
 
 = 2.9.1 - 2021-09-07 =
 * Fix - Error while checking out with UPE when fields are hidden.


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

`changelog.txt` and `readme.txt` had some differences in their changelog. Aligned them, corrected the spelling and punctuation differences as well so they are perfectly identical.

#### Testing instructions
Changelog in `readme.txt` and `changelog.txt` should be identical.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : QA Testing Not Applicable
