### PR TITLE
Update capability request to use the gateway map

### DIFF
--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -374,10 +374,11 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	 * @return  void
 	 */
 	private function request_unrequested_payment_methods( $payment_method_ids_to_enable ) {
+		$capability_key_map      = $this->wcpay_gateway->get_payment_method_capability_key_map();
 		$payment_method_statuses = $this->wcpay_gateway->get_upe_enabled_payment_method_statuses();
 		$cache_needs_refresh     = false;
 		foreach ( $payment_method_ids_to_enable as $payment_method_id_to_enable ) {
-			$stripe_key = $payment_method_id_to_enable . '_payments';
+			$stripe_key = $capability_key_map[ $payment_method_id_to_enable ];
 			if ( array_key_exists( $stripe_key, $payment_method_statuses ) ) {
 				if ( 'unrequested' === $payment_method_statuses[ $stripe_key ]['status'] ) {
 					$request_result      = $this->api_client->request_capability( $stripe_key, true );

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -378,7 +378,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		$payment_method_statuses = $this->wcpay_gateway->get_upe_enabled_payment_method_statuses();
 		$cache_needs_refresh     = false;
 		foreach ( $payment_method_ids_to_enable as $payment_method_id_to_enable ) {
-			$stripe_key = $capability_key_map[ $payment_method_id_to_enable ];
+			$stripe_key = $capability_key_map[ $payment_method_id_to_enable ] ?? null;
 			if ( array_key_exists( $stripe_key, $payment_method_statuses ) ) {
 				if ( 'unrequested' === $payment_method_statuses[ $stripe_key ]['status'] ) {
 					$request_result      = $this->api_client->request_capability( $stripe_key, true );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2687,6 +2687,15 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Returns the mapping list between capability keys and payment type keys
+	 *
+	 * @return string[]
+	 */
+	public function get_payment_method_capability_key_map(): array {
+		return $this->payment_method_capability_key_map;
+	}
+
+	/**
 	 * Updates the account cache with the new payment method status, until it gets fetched again from the server.
 	 *
 	 * @return  void


### PR DESCRIPTION
Fixes #3544

#### Changes proposed in this Pull Request

Use `$payment_method_capability_key_map` from `WC_Payment_Gateway_WCPay` rather than appending `_payments` to the payment method id. Some new payments methods like ACH and BECS, doesn't follow this pattern, and otherwise will fail to request capability.

#### Testing instructions
- Go to **Payments > Settings > Payment methods**
- Go to your Stripe account dashboard and check under **Capabilities** that you don't have one of the available payment methods active. Remove one of them if all are enabled.
- Enable any payment method and click on **Save changes**
- Check that the capability is active on your Stripe dashboard.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
