### PR TITLE
Send bank statement descriptors to payment intents

### DIFF
--- a/changelog/update-send-statement-descriptors-on-pi
+++ b/changelog/update-send-statement-descriptors-on-pi
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Send statement descriptor info on intents.

--- a/client/checkout/classic/upe-split.js
+++ b/client/checkout/classic/upe-split.js
@@ -458,7 +458,9 @@ jQuery( function ( $ ) {
 				orderId,
 				savePaymentMethod,
 				paymentMethodType,
-				upeComponents.country
+				upeComponents.country,
+				null,
+				api.maybeUseAccountDescriptor( paymentMethodType, orderId )
 			);
 
 			if ( updateResponse.data ) {

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -440,12 +440,17 @@ jQuery( function ( $ ) {
 
 		try {
 			// Update payment intent with level3 data, customer and maybe setup for future use.
+			const paymentMethodType = $(
+				'#wcpay_selected_upe_payment_type'
+			).val();
 			const updateResponse = await api.updateIntent(
 				paymentIntentId,
 				orderId,
 				savePaymentMethod,
 				getSelectedUPEPaymentType(),
-				$( '#wcpay_payment_country' ).val()
+				$( '#wcpay_payment_country' ).val(),
+				null,
+				api.maybeUseAccountDescriptor( paymentMethodType, orderId )
 			);
 
 			if ( updateResponse.data ) {

--- a/client/data/settings/actions.js
+++ b/client/data/settings/actions.js
@@ -123,6 +123,18 @@ export function updateAccountStatementDescriptor( accountStatementDescriptor ) {
 	} );
 }
 
+export function updateIsShortStatementDescriptorEnabled( isEnabled ) {
+	return updateSettingsValues( {
+		is_short_statement_descriptor_enabled: isEnabled,
+	} );
+}
+
+export function updateShortStatementDescriptor( shortStatementDescriptor ) {
+	return updateSettingsValues( {
+		short_statement_descriptor: shortStatementDescriptor,
+	} );
+}
+
 export function updateAccountBusinessName( accountBusinessName ) {
 	return updateSettingsValues( {
 		account_business_name: accountBusinessName,

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -180,6 +180,42 @@ export const useAccountStatementDescriptor = () => {
 	);
 };
 
+export const useIsShortStatementDescriptorEnabled = () => {
+	const { updateIsShortStatementDescriptorEnabled } = useDispatch(
+		STORE_NAME
+	);
+
+	return useSelect(
+		( select ) => {
+			const { getIsShortStatementDescriptorEnabled } = select(
+				STORE_NAME
+			);
+
+			return [
+				getIsShortStatementDescriptorEnabled(),
+				updateIsShortStatementDescriptorEnabled,
+			];
+		},
+		[ updateIsShortStatementDescriptorEnabled ]
+	);
+};
+
+export const useShortStatementDescriptor = () => {
+	const { updateShortStatementDescriptor } = useDispatch( STORE_NAME );
+
+	return useSelect(
+		( select ) => {
+			const { getShortStatementDescriptor } = select( STORE_NAME );
+
+			return [
+				getShortStatementDescriptor(),
+				updateShortStatementDescriptor,
+			];
+		},
+		[ updateShortStatementDescriptor ]
+	);
+};
+
 export const useAccountBusinessName = () => {
 	const { updateAccountBusinessName } = useDispatch( STORE_NAME );
 

--- a/client/data/settings/selectors.js
+++ b/client/data/settings/selectors.js
@@ -52,6 +52,14 @@ export const getAccountStatementDescriptor = ( state ) => {
 	return getSettings( state ).account_statement_descriptor || '';
 };
 
+export const getIsShortStatementDescriptorEnabled = ( state ) => {
+	return getSettings( state ).is_short_statement_descriptor_enabled || false;
+};
+
+export const getShortStatementDescriptor = ( state ) => {
+	return getSettings( state ).short_statement_descriptor || '';
+};
+
 export const getAccountBusinessName = ( state ) => {
 	return getSettings( state ).account_business_name || '';
 };

--- a/client/settings/transactions/index.js
+++ b/client/settings/transactions/index.js
@@ -20,6 +20,7 @@ import {
 	useGetSavingError,
 	useSavedCards,
 } from '../../data';
+import TextLengthHelpInputWrapper from './text-lenght-help-input-wrapper';
 import './style.scss';
 import ManualCaptureControl from 'wcpay/settings/transactions/manual-capture-control';
 import SupportPhoneInput from 'wcpay/settings/support-phone-input';
@@ -89,25 +90,28 @@ const Transactions = ( { setTransactionInputsValid } ) => {
 							/>
 						</Notice>
 					) }
-					<TextControl
-						className="transactions__account-statement-input"
-						help={ __(
-							'Enter the name your customers will see on their transactions. Use a recognizable name – e.g. ' +
-								'the legal entity name or website address – to avoid potential disputes and chargebacks.',
-							'woocommerce-payments'
-						) }
-						label={ __(
-							'Full bank statement',
-							'woocommerce-payments'
-						) }
-						value={ accountStatementDescriptor }
-						onChange={ setAccountStatementDescriptor }
+					<TextLengthHelpInputWrapper
+						textLength={ accountStatementDescriptor.length }
 						maxLength={ ACCOUNT_STATEMENT_MAX_LENGTH }
-						data-testid="store-name-bank-statement"
-					/>
-					<span className="input-help-text" aria-hidden="true">
-						{ `${ accountStatementDescriptor.length } / ${ ACCOUNT_STATEMENT_MAX_LENGTH }` }
-					</span>
+						data-testid={ 'store-name-bank-statement' }
+					>
+						<TextControl
+							className="transactions__account-statement-input"
+							help={ __(
+								'Enter the name your customers will see on their transactions. Use a recognizable name – e.g. ' +
+									'the legal entity name or website address – to avoid potential disputes and chargebacks.',
+								'woocommerce-payments'
+							) }
+							label={ __(
+								'Full bank statement',
+								'woocommerce-payments'
+							) }
+							value={ accountStatementDescriptor }
+							onChange={ setAccountStatementDescriptor }
+							maxLength={ ACCOUNT_STATEMENT_MAX_LENGTH }
+							data-testid="store-name-bank-statement"
+						/>
+					</TextLengthHelpInputWrapper>
 
 					<CheckboxControl
 						checked={ isShortStatementEnabled }
@@ -133,25 +137,28 @@ const Transactions = ( { setTransactionInputsValid } ) => {
 									/>
 								</Notice>
 							) }
-							<TextControl
-								help={ __(
-									"We'll use the short version in combination with the customer order number.",
-									'woocommerce-payments'
-								) }
-								label={ __(
-									'Shortened customer bank statement',
-									'woocommerce-payments'
-								) }
-								value={ shortAccountStatementDescriptor }
-								onChange={ setShortAccountStatementDescriptor }
+							<TextLengthHelpInputWrapper
+								textLength={
+									shortAccountStatementDescriptor.length
+								}
 								maxLength={ SHORT_STATEMENT_MAX_LENGTH }
-							/>
-							<span
-								className="input-help-text"
-								aria-hidden="true"
 							>
-								{ `${ shortAccountStatementDescriptor.length } / ${ SHORT_STATEMENT_MAX_LENGTH }` }
-							</span>
+								<TextControl
+									help={ __(
+										"We'll use the short version in combination with the customer order number.",
+										'woocommerce-payments'
+									) }
+									label={ __(
+										'Shortened customer bank statement',
+										'woocommerce-payments'
+									) }
+									value={ shortAccountStatementDescriptor }
+									onChange={
+										setShortAccountStatementDescriptor
+									}
+									maxLength={ SHORT_STATEMENT_MAX_LENGTH }
+								/>
+							</TextLengthHelpInputWrapper>
 						</>
 					) }
 

--- a/client/settings/transactions/index.js
+++ b/client/settings/transactions/index.js
@@ -79,11 +79,12 @@ const Transactions = ( { setTransactionInputsValid } ) => {
 					<TextControl
 						className="transactions__account-statement-input"
 						help={ __(
-							"Edit the way your store name appears on your customers' bank statements.",
+							'Enter the name your customers will see on their transactions. Use a recognizable name – e.g. ' +
+								'the legal entity name or website address – to avoid potential disputes and chargebacks.',
 							'woocommerce-payments'
 						) }
 						label={ __(
-							'Customer bank statement',
+							'Full bank statement',
 							'woocommerce-payments'
 						) }
 						value={ accountStatementDescriptor }

--- a/client/settings/transactions/index.js
+++ b/client/settings/transactions/index.js
@@ -15,6 +15,8 @@ import {
 import CardBody from '../card-body';
 import {
 	useAccountStatementDescriptor,
+	useIsShortStatementDescriptorEnabled,
+	useShortStatementDescriptor,
 	useGetSavingError,
 	useSavedCards,
 } from '../../data';
@@ -25,6 +27,7 @@ import SupportEmailInput from 'wcpay/settings/support-email-input';
 import React, { useEffect, useState } from 'react';
 
 const ACCOUNT_STATEMENT_MAX_LENGTH = 22;
+const SHORT_STATEMENT_MAX_LENGTH = 10;
 
 const Transactions = ( { setTransactionInputsValid } ) => {
 	const [ isSavedCardsEnabled, setIsSavedCardsEnabled ] = useSavedCards();
@@ -32,8 +35,18 @@ const Transactions = ( { setTransactionInputsValid } ) => {
 		accountStatementDescriptor,
 		setAccountStatementDescriptor,
 	] = useAccountStatementDescriptor();
+	const [
+		isShortStatementEnabled,
+		setIsShortStatementEnabled,
+	] = useIsShortStatementDescriptorEnabled();
+	const [
+		shortAccountStatementDescriptor,
+		setShortAccountStatementDescriptor,
+	] = useShortStatementDescriptor();
 	const customerBankStatementErrorMessage = useGetSavingError()?.data?.details
 		?.account_statement_descriptor?.message;
+	const shortStatementDescriptorErrorMessage = useGetSavingError()?.data
+		?.details?.short_statement_descriptor?.message;
 
 	const [ isEmailInputValid, setEmailInputValid ] = useState( true );
 	const [ isPhoneInputValid, setPhoneInputValid ] = useState( true );
@@ -90,11 +103,57 @@ const Transactions = ( { setTransactionInputsValid } ) => {
 						value={ accountStatementDescriptor }
 						onChange={ setAccountStatementDescriptor }
 						maxLength={ ACCOUNT_STATEMENT_MAX_LENGTH }
-						data-testid={ 'store-name-bank-statement' }
+						data-testid="store-name-bank-statement"
 					/>
 					<span className="input-help-text" aria-hidden="true">
 						{ `${ accountStatementDescriptor.length } / ${ ACCOUNT_STATEMENT_MAX_LENGTH }` }
 					</span>
+
+					<CheckboxControl
+						checked={ isShortStatementEnabled }
+						onChange={ setIsShortStatementEnabled }
+						label={ __(
+							'Add customer order number to the bank statement',
+							'woocommerce-payments'
+						) }
+						help={ __(
+							"When enabled, we'll include the order number for card and express checkout transactions.",
+							'woocommerce-payments'
+						) }
+					/>
+
+					{ isShortStatementEnabled && (
+						<>
+							{ shortStatementDescriptorErrorMessage && (
+								<Notice status="error" isDismissible={ false }>
+									<span
+										dangerouslySetInnerHTML={ {
+											__html: shortStatementDescriptorErrorMessage,
+										} }
+									/>
+								</Notice>
+							) }
+							<TextControl
+								help={ __(
+									"We'll use the short version in combination with the customer order number.",
+									'woocommerce-payments'
+								) }
+								label={ __(
+									'Shortened customer bank statement',
+									'woocommerce-payments'
+								) }
+								value={ shortAccountStatementDescriptor }
+								onChange={ setShortAccountStatementDescriptor }
+								maxLength={ SHORT_STATEMENT_MAX_LENGTH }
+							/>
+							<span
+								className="input-help-text"
+								aria-hidden="true"
+							>
+								{ `${ shortAccountStatementDescriptor.length } / ${ SHORT_STATEMENT_MAX_LENGTH }` }
+							</span>
+						</>
+					) }
 
 					<SupportEmailInput setInputVallid={ setEmailInputValid } />
 					<SupportPhoneInput setInputVallid={ setPhoneInputValid } />

--- a/client/settings/transactions/style.scss
+++ b/client/settings/transactions/style.scss
@@ -7,23 +7,5 @@
 
 	&__customer-support {
 		max-width: 500px;
-		position: relative;
-
-		.components-base-control__field .components-text-control__input {
-			// to make room for the help text, so that the input's text and the help text don't overlap
-			padding-right: 55px;
-		}
-
-		.input-help-text {
-			position: absolute;
-			right: 10px;
-			top: 38px;
-			font-size: 12px;
-			color: #757575;
-
-			@media ( min-width: 783px ) {
-				top: 32px;
-			}
-		}
 	}
 }

--- a/client/settings/transactions/text-lenght-help-input-wrapper.js
+++ b/client/settings/transactions/text-lenght-help-input-wrapper.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import styled from '@emotion/styled';
+
+const Wrapper = styled.div`
+	position: relative;
+	.components-base-control__field {
+		@media ( min-width: 783px ) {
+			width: 50%;
+		}
+		.components-text-control__input {
+			// to make room for the help text, so that the input's text and the help text don't overlap
+			padding-right: 55px;
+		}
+	}
+`;
+
+const HelpText = styled.span`
+	position: absolute;
+	right: 10px;
+	top: 38px;
+	font-size: 12px;
+	color: #757575;
+	@media ( min-width: 783px ) {
+		top: 32px;
+		right: calc( 50% + 10px );
+	}
+`;
+
+const TextLengthHelpInputWrapper = ( {
+	children,
+	textLength = 0,
+	maxLength,
+} ) => (
+	<Wrapper>
+		{ children }
+		<HelpText aria-hidden="true">
+			{ `${ textLength } / ${ maxLength }` }
+		</HelpText>
+	</Wrapper>
+);
+
+export default TextLengthHelpInputWrapper;

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -131,7 +131,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'short_statement_descriptor'          => [
+					'short_statement_descriptor'        => [
 						'description'       => __( 'We\'ll use the short version in combination with the customer order number.', 'woocommerce-payments' ),
 						'type'              => 'string',
 						'validate_callback' => [ $this, 'validate_short_statement_descriptor' ],

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -131,6 +131,10 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
+					'short_statement_descriptor'          => [
+						'description' => __( 'We\'ll use the short version in combination with the customer order number.', 'woocommerce-payments' ),
+						'type'        => 'string',
+					],
 					'account_statement_descriptor'      => [
 						'description'       => sprintf(
 							/* translators: %s: WooPayments */
@@ -405,6 +409,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 				'is_wcpay_subscriptions_eligible'       => WC_Payments_Features::is_wcpay_subscriptions_eligible(),
 				'is_subscriptions_plugin_active'        => $this->wcpay_gateway->is_subscriptions_plugin_active(),
 				'is_short_statement_descriptor_enabled' => 'yes' === $this->wcpay_gateway->get_option( 'is_short_statement_descriptor_enabled' ),
+				'short_statement_descriptor'            => $this->wcpay_gateway->get_option( 'short_statement_descriptor' ),
 				'account_statement_descriptor'          => $this->wcpay_gateway->get_option( 'account_statement_descriptor' ),
 				'account_business_name'                 => $this->wcpay_gateway->get_option( 'account_business_name' ),
 				'account_business_url'                  => $this->wcpay_gateway->get_option( 'account_business_url' ),

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -126,6 +126,11 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
+					'is_short_statement_descriptor_enabled' => [
+						'description'       => __( 'When enabled, we\'ll include the order number for card and express checkout transactions.', 'woocommerce-payments' ),
+						'type'              => 'boolean',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
 					'account_statement_descriptor'      => [
 						'description'       => sprintf(
 							/* translators: %s: WooPayments */
@@ -387,50 +392,51 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 
 		return new WP_REST_Response(
 			[
-				'enabled_payment_method_ids'          => $enabled_payment_methods,
-				'available_payment_method_ids'        => $available_upe_payment_methods,
-				'payment_method_statuses'             => $this->wcpay_gateway->get_upe_enabled_payment_method_statuses(),
-				'is_wcpay_enabled'                    => $this->wcpay_gateway->is_enabled(),
-				'is_manual_capture_enabled'           => 'yes' === $this->wcpay_gateway->get_option( 'manual_capture' ),
-				'is_test_mode_enabled'                => WC_Payments::mode()->is_test(),
-				'is_dev_mode_enabled'                 => WC_Payments::mode()->is_dev(),
-				'is_multi_currency_enabled'           => WC_Payments_Features::is_customer_multi_currency_enabled(),
-				'is_client_secret_encryption_enabled' => WC_Payments_Features::is_client_secret_encryption_enabled(),
-				'is_wcpay_subscriptions_enabled'      => WC_Payments_Features::is_wcpay_subscriptions_enabled(),
-				'is_wcpay_subscriptions_eligible'     => WC_Payments_Features::is_wcpay_subscriptions_eligible(),
-				'is_subscriptions_plugin_active'      => $this->wcpay_gateway->is_subscriptions_plugin_active(),
-				'account_statement_descriptor'        => $this->wcpay_gateway->get_option( 'account_statement_descriptor' ),
-				'account_business_name'               => $this->wcpay_gateway->get_option( 'account_business_name' ),
-				'account_business_url'                => $this->wcpay_gateway->get_option( 'account_business_url' ),
-				'account_business_support_address'    => $this->wcpay_gateway->get_option( 'account_business_support_address' ),
-				'account_business_support_email'      => $this->wcpay_gateway->get_option( 'account_business_support_email' ),
-				'account_business_support_phone'      => $this->wcpay_gateway->get_option( 'account_business_support_phone' ),
-				'account_branding_logo'               => $this->wcpay_gateway->get_option( 'account_branding_logo' ),
-				'account_branding_icon'               => $this->wcpay_gateway->get_option( 'account_branding_icon' ),
-				'account_branding_primary_color'      => $this->wcpay_gateway->get_option( 'account_branding_primary_color' ),
-				'account_branding_secondary_color'    => $this->wcpay_gateway->get_option( 'account_branding_secondary_color' ),
-				'is_payment_request_enabled'          => 'yes' === $this->wcpay_gateway->get_option( 'payment_request' ),
-				'is_debug_log_enabled'                => 'yes' === $this->wcpay_gateway->get_option( 'enable_logging' ),
-				'payment_request_enabled_locations'   => $this->wcpay_gateway->get_option( 'payment_request_button_locations' ),
-				'payment_request_button_size'         => $this->wcpay_gateway->get_option( 'payment_request_button_size' ),
-				'payment_request_button_type'         => $this->wcpay_gateway->get_option( 'payment_request_button_type' ),
-				'payment_request_button_theme'        => $this->wcpay_gateway->get_option( 'payment_request_button_theme' ),
-				'is_saved_cards_enabled'              => $this->wcpay_gateway->is_saved_cards_enabled(),
-				'is_card_present_eligible'            => $this->wcpay_gateway->is_card_present_eligible(),
-				'is_woopay_enabled'                   => 'yes' === $this->wcpay_gateway->get_option( 'platform_checkout' ),
-				'show_woopay_incompatibility_notice'  => get_option( 'woopay_invalid_extension_found', false ),
-				'woopay_custom_message'               => $this->wcpay_gateway->get_option( 'platform_checkout_custom_message' ),
-				'woopay_store_logo'                   => $this->wcpay_gateway->get_option( 'platform_checkout_store_logo' ),
-				'woopay_enabled_locations'            => $this->wcpay_gateway->get_option( 'platform_checkout_button_locations', [] ),
-				'deposit_schedule_interval'           => $this->wcpay_gateway->get_option( 'deposit_schedule_interval' ),
-				'deposit_schedule_monthly_anchor'     => $this->wcpay_gateway->get_option( 'deposit_schedule_monthly_anchor' ),
-				'deposit_schedule_weekly_anchor'      => $this->wcpay_gateway->get_option( 'deposit_schedule_weekly_anchor' ),
-				'deposit_delay_days'                  => $this->wcpay_gateway->get_option( 'deposit_delay_days' ),
-				'deposit_status'                      => $this->wcpay_gateway->get_option( 'deposit_status' ),
-				'deposit_restrictions'                => $this->wcpay_gateway->get_option( 'deposit_restrictions' ),
-				'deposit_completed_waiting_period'    => $this->wcpay_gateway->get_option( 'deposit_completed_waiting_period' ),
-				'current_protection_level'            => $this->wcpay_gateway->get_option( 'current_protection_level' ),
-				'advanced_fraud_protection_settings'  => $this->wcpay_gateway->get_option( 'advanced_fraud_protection_settings' ),
+				'enabled_payment_method_ids'            => $enabled_payment_methods,
+				'available_payment_method_ids'          => $available_upe_payment_methods,
+				'payment_method_statuses'               => $this->wcpay_gateway->get_upe_enabled_payment_method_statuses(),
+				'is_wcpay_enabled'                      => $this->wcpay_gateway->is_enabled(),
+				'is_manual_capture_enabled'             => 'yes' === $this->wcpay_gateway->get_option( 'manual_capture' ),
+				'is_test_mode_enabled'                  => WC_Payments::mode()->is_test(),
+				'is_dev_mode_enabled'                   => WC_Payments::mode()->is_dev(),
+				'is_multi_currency_enabled'             => WC_Payments_Features::is_customer_multi_currency_enabled(),
+				'is_client_secret_encryption_enabled'   => WC_Payments_Features::is_client_secret_encryption_enabled(),
+				'is_wcpay_subscriptions_enabled'        => WC_Payments_Features::is_wcpay_subscriptions_enabled(),
+				'is_wcpay_subscriptions_eligible'       => WC_Payments_Features::is_wcpay_subscriptions_eligible(),
+				'is_subscriptions_plugin_active'        => $this->wcpay_gateway->is_subscriptions_plugin_active(),
+				'is_short_statement_descriptor_enabled' => 'yes' === $this->wcpay_gateway->get_option( 'is_short_statement_descriptor_enabled' ),
+				'account_statement_descriptor'          => $this->wcpay_gateway->get_option( 'account_statement_descriptor' ),
+				'account_business_name'                 => $this->wcpay_gateway->get_option( 'account_business_name' ),
+				'account_business_url'                  => $this->wcpay_gateway->get_option( 'account_business_url' ),
+				'account_business_support_address'      => $this->wcpay_gateway->get_option( 'account_business_support_address' ),
+				'account_business_support_email'        => $this->wcpay_gateway->get_option( 'account_business_support_email' ),
+				'account_business_support_phone'        => $this->wcpay_gateway->get_option( 'account_business_support_phone' ),
+				'account_branding_logo'                 => $this->wcpay_gateway->get_option( 'account_branding_logo' ),
+				'account_branding_icon'                 => $this->wcpay_gateway->get_option( 'account_branding_icon' ),
+				'account_branding_primary_color'        => $this->wcpay_gateway->get_option( 'account_branding_primary_color' ),
+				'account_branding_secondary_color'      => $this->wcpay_gateway->get_option( 'account_branding_secondary_color' ),
+				'is_payment_request_enabled'            => 'yes' === $this->wcpay_gateway->get_option( 'payment_request' ),
+				'is_debug_log_enabled'                  => 'yes' === $this->wcpay_gateway->get_option( 'enable_logging' ),
+				'payment_request_enabled_locations'     => $this->wcpay_gateway->get_option( 'payment_request_button_locations' ),
+				'payment_request_button_size'           => $this->wcpay_gateway->get_option( 'payment_request_button_size' ),
+				'payment_request_button_type'           => $this->wcpay_gateway->get_option( 'payment_request_button_type' ),
+				'payment_request_button_theme'          => $this->wcpay_gateway->get_option( 'payment_request_button_theme' ),
+				'is_saved_cards_enabled'                => $this->wcpay_gateway->is_saved_cards_enabled(),
+				'is_card_present_eligible'              => $this->wcpay_gateway->is_card_present_eligible(),
+				'is_woopay_enabled'                     => 'yes' === $this->wcpay_gateway->get_option( 'platform_checkout' ),
+				'show_woopay_incompatibility_notice'    => get_option( 'woopay_invalid_extension_found', false ),
+				'woopay_custom_message'                 => $this->wcpay_gateway->get_option( 'platform_checkout_custom_message' ),
+				'woopay_store_logo'                     => $this->wcpay_gateway->get_option( 'platform_checkout_store_logo' ),
+				'woopay_enabled_locations'              => $this->wcpay_gateway->get_option( 'platform_checkout_button_locations', [] ),
+				'deposit_schedule_interval'             => $this->wcpay_gateway->get_option( 'deposit_schedule_interval' ),
+				'deposit_schedule_monthly_anchor'       => $this->wcpay_gateway->get_option( 'deposit_schedule_monthly_anchor' ),
+				'deposit_schedule_weekly_anchor'        => $this->wcpay_gateway->get_option( 'deposit_schedule_weekly_anchor' ),
+				'deposit_delay_days'                    => $this->wcpay_gateway->get_option( 'deposit_delay_days' ),
+				'deposit_status'                        => $this->wcpay_gateway->get_option( 'deposit_status' ),
+				'deposit_restrictions'                  => $this->wcpay_gateway->get_option( 'deposit_restrictions' ),
+				'deposit_completed_waiting_period'      => $this->wcpay_gateway->get_option( 'deposit_completed_waiting_period' ),
+				'current_protection_level'              => $this->wcpay_gateway->get_option( 'current_protection_level' ),
+				'advanced_fraud_protection_settings'    => $this->wcpay_gateway->get_option( 'advanced_fraud_protection_settings' ),
 			]
 		);
 	}
@@ -453,6 +459,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		$this->update_payment_request_enabled_locations( $request );
 		$this->update_payment_request_appearance( $request );
 		$this->update_is_saved_cards_enabled( $request );
+		$this->update_is_short_statement_descriptor_enabled( $request );
 		$this->update_account( $request );
 		$this->update_is_woopay_enabled( $request );
 		$this->update_woopay_store_logo( $request );
@@ -886,5 +893,20 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		}
 
 		return $avs_check_enabled;
+	}
+
+	/**
+	 * Updates the "is short statement descriptor" enable/disable setting.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 */
+	private function update_is_short_statement_descriptor_enabled( WP_REST_Request $request ) {
+		if ( ! $request->has_param( 'is_short_statement_descriptor_enabled' ) ) {
+			return;
+		}
+
+		$is_short_statement_descriptor_enabled = $request->get_param( 'is_short_statement_descriptor_enabled' );
+
+		$this->wcpay_gateway->update_option( 'is_short_statement_descriptor_enabled', $is_short_statement_descriptor_enabled ? 'yes' : 'no' );
 	}
 }

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -267,7 +267,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @param mixed           $value The value being validated.
+	 * @param string          $value The value being validated.
 	 * @param WP_REST_Request $request The request made.
 	 * @param string          $param The parameter name, used in error messages.
 	 * @return true|WP_Error

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2348,7 +2348,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @param  string   $payment_method Payment method being used.
 	 * @param  WC_Order $order WC Order.
 	 *
-	 * @return string                   Statement descriptor.
+	 * @return string|null Statement descriptor.
 	 */
 	public function get_statement_descriptor( $payment_method, $order ) {
 		$full_statement_descriptor             = $this->get_account_statement_descriptor();

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1105,15 +1105,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				}
 			}
 
-			$statement_descriptor                  = $this->get_account_statement_descriptor();
-			$short_statement_descriptor            = ! empty( $this->get_option( 'short_statement_descriptor' ) ) ? str_replace( "'", '', $this->get_option( 'short_statement_descriptor' ) ) : '';
-			$is_short_statement_descriptor_enabled = ! empty( $this->get_option( 'is_short_statement_descriptor_enabled' ) ) && 'yes' === $this->get_option( 'is_short_statement_descriptor_enabled' );
-			if ( in_array( $order->get_payment_method(), [ 'card', 'woocommerce_payments' ], true ) && $is_short_statement_descriptor_enabled && ! empty( $short_statement_descriptor ) ) {
-				// Use the shortened statement descriptor for card transactions only.
-				$descriptor = WC_Payments_Utils::get_dynamic_statement_descriptor( $short_statement_descriptor, $order );
-			} elseif ( ! empty( $statement_descriptor ) ) {
-				$descriptor = WC_Payments_Utils::clean_statement_descriptor( $statement_descriptor );
-			}
+			$statement_descriptor = $this->get_statement_descriptor( $order->get_payment_method(), $order );
 
 			if ( empty( $intent ) ) {
 				$request = Create_And_Confirm_Intention::create();
@@ -1146,8 +1138,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					);
 				}
 
-				if ( $descriptor ) {
-					$request->set_statement_descriptor( $descriptor );
+				if ( $statement_descriptor ) {
+					$request->set_statement_descriptor( $statement_descriptor );
 				}
 
 				// Make sure that setting fingerprint is performed after setting metadata because metadata will override any values you set before for metadata param.
@@ -2348,6 +2340,29 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		return $value;
+	}
+
+	/**
+	 * Get the statement descriptor value considering the payment methods.
+	 *
+	 * @param  array    $payment_method Payment method being used.
+	 * @param  WC_Order $order WC Order.
+	 *
+	 * @return string                   Statement descriptor.
+	 */
+	public function get_statement_descriptor( $payment_method, $order ) {
+		$full_statement_descriptor             = $this->get_account_statement_descriptor();
+		$short_statement_descriptor            = $this->get_option( 'short_statement_descriptor', '' );
+		$is_short_statement_descriptor_enabled = 'yes' === $this->get_option( 'is_short_statement_descriptor_enabled' );
+
+		if ( in_array( $payment_method, [ 'card', 'woocommerce_payments' ], true ) && $is_short_statement_descriptor_enabled && ! empty( $short_statement_descriptor ) ) {
+			// Use the shortened statement descriptor for card transactions only.
+			return WC_Payments_Utils::get_dynamic_statement_descriptor( $short_statement_descriptor, $order );
+		} elseif ( ! empty( $full_statement_descriptor ) ) {
+			return $full_statement_descriptor;
+		}
+
+		return null;
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2318,16 +2318,22 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 *
 	 * @param  string $key Field key.
 	 * @param  string $value Posted Value.
+	 * @param  int    $max_length Maximum length of the field.
 	 *
 	 * @return string                   Sanitized statement descriptor.
 	 * @throws InvalidArgumentException When statement descriptor is invalid.
 	 */
-	public function validate_account_statement_descriptor_field( $key, $value ) {
+	public function validate_account_statement_descriptor_field( $key, $value, $max_length ) {
 		// Since the value is escaped, and we are saving in a place that does not require escaping, apply stripslashes.
 		$value = trim( stripslashes( $value ) );
+		$field = __( 'Customer bank statement', 'woocommerce-payments' );
+
+		if ( 'short_statement_descriptor' === $key ) {
+			$field = __( 'Shortened customer bank statement', 'woocommerce-payments' );
+		}
 
 		// Validation can be done with a single regex but splitting into multiple for better readability.
-		$valid_length   = '/^.{5,22}$/';
+		$valid_length   = '/^.{5,' . $max_length . '}$/';
 		$has_one_letter = '/^.*[a-zA-Z]+/';
 		$no_specials    = '/^[^*"\'<>]*$/';
 
@@ -2336,7 +2342,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			! preg_match( $has_one_letter, $value ) ||
 			! preg_match( $no_specials, $value )
 		) {
-			throw new InvalidArgumentException( __( 'Customer bank statement is invalid. Statement should be between 5 and 22 characters long, contain at least single Latin character and does not contain special characters: \' " * &lt; &gt;', 'woocommerce-payments' ) );
+			throw new InvalidArgumentException(
+				sprintf(
+					/* translators: %1 field name, %2 Number of the maximum characters allowed */
+					__( '%1$s is invalid. Statement should be between 5 and %2$u characters long, contain at least a single Latin character, and not contain any of the following special characters: \' " * &lt; &gt;', 'woocommerce-payments' ),
+					$field,
+					$max_length
+				)
+			);
 		}
 
 		return $value;

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2345,7 +2345,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	/**
 	 * Get the statement descriptor value considering the payment methods.
 	 *
-	 * @param  array    $payment_method Payment method being used.
+	 * @param  string   $payment_method Payment method being used.
 	 * @param  WC_Order $order WC Order.
 	 *
 	 * @return string                   Statement descriptor.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1108,7 +1108,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$statement_descriptor                  = $this->get_account_statement_descriptor();
 			$short_statement_descriptor            = ! empty( $this->get_option( 'short_statement_descriptor' ) ) ? str_replace( "'", '', $this->get_option( 'short_statement_descriptor' ) ) : '';
 			$is_short_statement_descriptor_enabled = ! empty( $this->get_option( 'is_short_statement_descriptor_enabled' ) ) && 'yes' === $this->get_option( 'is_short_statement_descriptor_enabled' );
-
 			if ( in_array( $order->get_payment_method(), [ 'card', 'woocommerce_payments' ], true ) && $is_short_statement_descriptor_enabled && ! empty( $short_statement_descriptor ) ) {
 				// Use the shortened statement descriptor for card transactions only.
 				$descriptor = WC_Payments_Utils::get_dynamic_statement_descriptor( $short_statement_descriptor, $order );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1111,7 +1111,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			if ( in_array( $order->get_payment_method(), [ 'card', 'woocommerce_payments' ], true ) && $is_short_statement_descriptor_enabled && ! empty( $short_statement_descriptor ) ) {
 				// Use the shortened statement descriptor for card transactions only.
-				$descriptor = WC_Payments_Utils::get_shortened_statement_descriptor( $short_statement_descriptor, $order );
+				$descriptor = WC_Payments_Utils::get_dynamic_statement_descriptor( $short_statement_descriptor, $order );
 			} elseif ( ! empty( $statement_descriptor ) ) {
 				$descriptor = WC_Payments_Utils::clean_statement_descriptor( $statement_descriptor );
 			}

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -145,16 +145,18 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 	 */
 	public function get_payment_fields_js_config() {
 
-		$payment_fields                             = parent::get_payment_fields_js_config();
-		$payment_fields['accountDescriptor']        = $this->gateway->get_account_statement_descriptor();
-		$payment_fields['addPaymentReturnURL']      = wc_get_account_endpoint_url( 'payment-methods' );
-		$payment_fields['gatewayId']                = UPE_Payment_Gateway::GATEWAY_ID;
-		$payment_fields['isCheckout']               = is_checkout();
-		$payment_fields['paymentMethodsConfig']     = $this->get_enabled_payment_method_config();
-		$payment_fields['testMode']                 = WC_Payments::mode()->is_test();
-		$payment_fields['upeAppearance']            = get_transient( UPE_Payment_Gateway::UPE_APPEARANCE_TRANSIENT );
-		$payment_fields['wcBlocksUPEAppearance']    = get_transient( UPE_Payment_Gateway::WC_BLOCKS_UPE_APPEARANCE_TRANSIENT );
-		$payment_fields['cartContainsSubscription'] = $this->gateway->is_subscription_item_in_cart();
+		$payment_fields                                    = parent::get_payment_fields_js_config();
+		$payment_fields['accountDescriptor']               = $this->gateway->get_account_statement_descriptor();
+		$payment_fields['isShortAccountDescriptorEnabled'] = 'yes' === $this->gateway->get_option( 'is_short_statement_descriptor_enabled' );
+		$payment_fields['shortAccountDescriptor']          = $this->gateway->get_option( 'short_statement_descriptor', '' );
+		$payment_fields['addPaymentReturnURL']             = wc_get_account_endpoint_url( 'payment-methods' );
+		$payment_fields['gatewayId']                       = UPE_Payment_Gateway::GATEWAY_ID;
+		$payment_fields['isCheckout']                      = is_checkout();
+		$payment_fields['paymentMethodsConfig']            = $this->get_enabled_payment_method_config();
+		$payment_fields['testMode']                        = WC_Payments::mode()->is_test();
+		$payment_fields['upeAppearance']                   = get_transient( UPE_Payment_Gateway::UPE_APPEARANCE_TRANSIENT );
+		$payment_fields['wcBlocksUPEAppearance']           = get_transient( UPE_Payment_Gateway::WC_BLOCKS_UPE_APPEARANCE_TRANSIENT );
+		$payment_fields['cartContainsSubscription']        = $this->gateway->is_subscription_item_in_cart();
 
 		if ( WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
 			$payment_fields['currency']  = get_woocommerce_currency();

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -913,7 +913,6 @@ class WC_Payments_Utils {
 	 *
 	 * Stripe requires max of 22 characters and no special characters.
 	 *
-	 * @since 4.0.0
 	 * @param string $statement_descriptor Statement descriptor.
 	 * @return string $statement_descriptor Sanitized statement descriptor
 	 */

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -887,15 +887,15 @@ class WC_Payments_Utils {
 	}
 
 	/**
-	 * Sanizite and retrieve a shortened statement descriptor.
+	 * Sanitize and retrieve a shortened statement descriptor concatenated with the order number.
 	 *
-	 * The descriptor will be used as prefix and the order ID will be concatenated, acting as a suffix.
+	 * The shortened descriptor will be used as prefix and the order ID will be concatenated, acting as a suffix.
 	 *
 	 * @param string   $statement_descriptor Shortened statement descriptor.
 	 * @param WC_Order $order Order.
 	 * @return string $statement_descriptor Final shortened statement descriptor.
 	 */
-	public static function get_shortened_statement_descriptor( $statement_descriptor = '', $order = null ) {
+	public static function get_dynamic_statement_descriptor( $statement_descriptor = '', $order = null ) {
 		$statement_descriptor = self::clean_statement_descriptor( $statement_descriptor );
 
 		if ( method_exists( $order, 'get_order_number' ) && ! empty( $order->get_order_number() ) ) {

--- a/includes/core/server/request/class-create-and-confirm-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-intention.php
@@ -110,7 +110,7 @@ class Create_And_Confirm_Intention extends Create_Intention {
 	}
 
 	/**
-	* Statement descriptor setter.
+	 * Statement descriptor setter.
 	 *
 	 * @param string $statement_descriptor The statement descriptor for this payment method (Optional).
 	 * @return void

--- a/includes/core/server/request/class-create-and-confirm-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-intention.php
@@ -108,4 +108,14 @@ class Create_And_Confirm_Intention extends Create_Intention {
 	public function set_return_url( $return_url ) {
 		$this->set_param( 'return_url', $return_url );
 	}
+
+	/**
+	* Statement descriptor setter.
+	 *
+	 * @param string $statement_descriptor The statement descriptor for this payment method (Optional).
+	 * @return void
+	 */
+	public function set_statement_descriptor( string $statement_descriptor ) {
+		$this->set_param( 'statement_descriptor', $statement_descriptor );
+	}
 }

--- a/includes/core/server/request/class-update-intention.php
+++ b/includes/core/server/request/class-update-intention.php
@@ -178,6 +178,16 @@ class Update_Intention extends Request {
 	}
 
 	/**
+	 * Statement descriptor setter.
+	 *
+	 * @param string $statement_descriptor The statement descriptor for this payment method (Optional).
+	 * @return void
+	 */
+	public function set_statement_descriptor( string $statement_descriptor ) {
+		$this->set_param( 'statement_descriptor', $statement_descriptor );
+	}
+
+	/**
 	 * Formats the response from the server.
 	 *
 	 * @param  mixed $response The response from `WC_Payments_API_Client::request`.

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -478,18 +478,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		$payment_type              = $this->is_payment_recurring( $order_id ) ? Payment_Type::RECURRING() : Payment_Type::SINGLE();
 		$save_payment_method       = $payment_type->equals( Payment_Type::RECURRING() ) || ! empty( $_POST[ 'wc-' . $this->id . '-new-payment-method' ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$payment_country           = ! empty( $_POST['wcpay_payment_country'] ) ? wc_clean( wp_unslash( $_POST['wcpay_payment_country'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-
-		$statement_descriptor                  = $this->get_account_statement_descriptor();
-		$short_statement_descriptor            = ! empty( $this->get_option( 'short_statement_descriptor' ) ) ? $this->get_option( 'short_statement_descriptor' ) : '';
-		$is_short_statement_descriptor_enabled = 'yes' === $this->get_option( 'is_short_statement_descriptor_enabled' );
-		$descriptor                            = null;
-
-		if ( 'card' === $selected_upe_payment_type && $is_short_statement_descriptor_enabled && ! empty( $short_statement_descriptor ) ) {
-			// Use the shortened statement descriptor for card transactions only.
-			$descriptor = WC_Payments_Utils::get_dynamic_statement_descriptor( $short_statement_descriptor, $order );
-		} elseif ( ! empty( $statement_descriptor ) ) {
-			$descriptor = WC_Payments_Utils::clean_statement_descriptor( $statement_descriptor );
-		}
+		$statement_descriptor      = $this->get_statement_descriptor( $selected_upe_payment_type, $order );
 
 		if ( $payment_intent_id ) {
 			list( $user, $customer_id ) = $this->manage_customer_details_for_order( $order );
@@ -552,8 +541,8 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 					if ( $customer_id ) {
 						$request->set_customer( $customer_id );
 					}
-					if ($descriptor) {
-						$request->set_statement_descriptor( $descriptor );
+					if ($statement_descriptor) {
+						$request->set_statement_descriptor( $statement_descriptor );
 					}
 					$payment_method_options = $this->get_mandate_params_for_order( $order );
 					if ( $payment_method_options ) {

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -541,7 +541,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 					if ( $customer_id ) {
 						$request->set_customer( $customer_id );
 					}
-					if ($statement_descriptor) {
+					if ( $statement_descriptor ) {
 						$request->set_statement_descriptor( $statement_descriptor );
 					}
 					$payment_method_options = $this->get_mandate_params_for_order( $order );

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -479,6 +479,17 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		$save_payment_method       = $payment_type->equals( Payment_Type::RECURRING() ) || ! empty( $_POST[ 'wc-' . $this->id . '-new-payment-method' ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$payment_country           = ! empty( $_POST['wcpay_payment_country'] ) ? wc_clean( wp_unslash( $_POST['wcpay_payment_country'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
+		$statement_descriptor                  = $this->get_account_statement_descriptor();
+		$short_statement_descriptor            = ! empty( $this->get_option( 'short_statement_descriptor' ) ) ? $this->get_option( 'short_statement_descriptor' ) : '';
+		$is_short_statement_descriptor_enabled = 'yes' === $this->get_option( 'is_short_statement_descriptor_enabled' );
+
+		if ( 'card' === $selected_upe_payment_type && $is_short_statement_descriptor_enabled && ! empty( $short_statement_descriptor ) ) {
+			// Use the shortened statement descriptor for card transactions only.
+			$descriptor = WC_Payments_Utils::get_shortened_statement_descriptor( $short_statement_descriptor, $order );
+		} elseif ( ! empty( $statement_descriptor ) ) {
+			$descriptor = WC_Payments_Utils::clean_statement_descriptor( $statement_descriptor );
+		}
+
 		if ( $payment_intent_id ) {
 			list( $user, $customer_id ) = $this->manage_customer_details_for_order( $order );
 
@@ -539,6 +550,9 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 					}
 					if ( $customer_id ) {
 						$request->set_customer( $customer_id );
+					}
+					if ($descriptor) {
+						$request->set_statement_descriptor( $descriptor );
 					}
 					$payment_method_options = $this->get_mandate_params_for_order( $order );
 					if ( $payment_method_options ) {

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -478,7 +478,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		$payment_type              = $this->is_payment_recurring( $order_id ) ? Payment_Type::RECURRING() : Payment_Type::SINGLE();
 		$save_payment_method       = $payment_type->equals( Payment_Type::RECURRING() ) || ! empty( $_POST[ 'wc-' . $this->id . '-new-payment-method' ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$payment_country           = ! empty( $_POST['wcpay_payment_country'] ) ? wc_clean( wp_unslash( $_POST['wcpay_payment_country'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$statement_descriptor      = $this->get_statement_descriptor( $selected_upe_payment_type, $order );
+		$statement_descriptor      = $this->maybe_use_statement_descriptor( $selected_upe_payment_type, $order );
 
 		if ( $payment_intent_id ) {
 			list( $user, $customer_id ) = $this->manage_customer_details_for_order( $order );

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -482,6 +482,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		$statement_descriptor                  = $this->get_account_statement_descriptor();
 		$short_statement_descriptor            = ! empty( $this->get_option( 'short_statement_descriptor' ) ) ? $this->get_option( 'short_statement_descriptor' ) : '';
 		$is_short_statement_descriptor_enabled = 'yes' === $this->get_option( 'is_short_statement_descriptor_enabled' );
+		$descriptor                            = null;
 
 		if ( 'card' === $selected_upe_payment_type && $is_short_statement_descriptor_enabled && ! empty( $short_statement_descriptor ) ) {
 			// Use the shortened statement descriptor for card transactions only.

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -485,7 +485,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 		if ( 'card' === $selected_upe_payment_type && $is_short_statement_descriptor_enabled && ! empty( $short_statement_descriptor ) ) {
 			// Use the shortened statement descriptor for card transactions only.
-			$descriptor = WC_Payments_Utils::get_shortened_statement_descriptor( $short_statement_descriptor, $order );
+			$descriptor = WC_Payments_Utils::get_dynamic_statement_descriptor( $short_statement_descriptor, $order );
 		} elseif ( ! empty( $statement_descriptor ) ) {
 			$descriptor = WC_Payments_Utils::clean_statement_descriptor( $statement_descriptor );
 		}

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -178,8 +178,9 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			$save_payment_method       = isset( $_POST['save_payment_method'] ) ? 'yes' === wc_clean( wp_unslash( $_POST['save_payment_method'] ) ) : false;
 			$selected_upe_payment_type = ! empty( $_POST['wcpay_selected_upe_payment_type'] ) ? wc_clean( wp_unslash( $_POST['wcpay_selected_upe_payment_type'] ) ) : '';
 			$payment_country           = ! empty( $_POST['wcpay_payment_country'] ) ? wc_clean( wp_unslash( $_POST['wcpay_payment_country'] ) ) : null;
+			$statement_descriptor      = isset( $_POST['statement_descriptor'] ) ? wc_clean( wp_unslash( $_POST['statement_descriptor'] ) ) : null;
 
-			wp_send_json_success( $this->update_payment_intent( $payment_intent_id, $order_id, $save_payment_method, $selected_upe_payment_type, $payment_country, $fingerprint ), 200 );
+			wp_send_json_success( $this->update_payment_intent( $payment_intent_id, $order_id, $save_payment_method, $selected_upe_payment_type, $payment_country, $fingerprint, $statement_descriptor ), 200 );
 		} catch ( Exception $e ) {
 			// Send back error so it can be displayed to the customer.
 			wp_send_json_error(
@@ -202,10 +203,11 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	 * @param string  $selected_upe_payment_type The name of the selected UPE payment type or empty string.
 	 * @param ?string $payment_country           The payment two-letter iso country code or null.
 	 * @param ?string $fingerprint               Fingerprint data.
+	 * @param ?string $statement_descriptor      Statement descriptor.
 	 *
 	 * @return array|null An array with result of the update, or nothing
 	 */
-	public function update_payment_intent( $payment_intent_id = '', $order_id = null, $save_payment_method = false, $selected_upe_payment_type = '', $payment_country = null, $fingerprint = '' ) {
+	public function update_payment_intent( $payment_intent_id = '', $order_id = null, $save_payment_method = false, $selected_upe_payment_type = '', $payment_country = null, $fingerprint = '', $statement_descriptor = null ) {
 		$order = wc_get_order( $order_id );
 		if ( ! is_a( $order, 'WC_Order' ) ) {
 			return;
@@ -244,6 +246,9 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			}
 			if ( $customer_id ) {
 				$request->set_customer( $customer_id );
+			}
+			if ( $statement_descriptor ) {
+				$request->set_statement_descriptor( $statement_descriptor );
 			}
 
 			$request->send( 'wcpay_update_intention_request', $order, $payment_intent_id );

--- a/includes/payment-methods/class-upe-split-payment-gateway.php
+++ b/includes/payment-methods/class-upe-split-payment-gateway.php
@@ -186,8 +186,9 @@ class UPE_Split_Payment_Gateway extends UPE_Payment_Gateway {
 			$save_payment_method       = isset( $_POST['save_payment_method'] ) ? 'yes' === wc_clean( wp_unslash( $_POST['save_payment_method'] ) ) : false;
 			$selected_upe_payment_type = $this->stripe_id;
 			$payment_country           = ! empty( $_POST['wcpay_payment_country'] ) ? wc_clean( wp_unslash( $_POST['wcpay_payment_country'] ) ) : null;
+			$statement_descriptor      = isset( $_POST['statement_descriptor'] ) ? wc_clean( wp_unslash( $_POST['statement_descriptor'] ) ) : null;
 
-			wp_send_json_success( $this->update_payment_intent( $payment_intent_id, $order_id, $save_payment_method, $selected_upe_payment_type, $payment_country, $fingerprint ), 200 );
+			wp_send_json_success( $this->update_payment_intent( $payment_intent_id, $order_id, $save_payment_method, $selected_upe_payment_type, $payment_country, $fingerprint, $statement_descriptor ), 200 );
 		} catch ( Exception $e ) {
 			// Send back error so it can be displayed to the customer.
 			wp_send_json_error(

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2152,6 +2152,7 @@ class WC_Payments_API_Client {
 		$processing             = $intention_array[ Payment_Intent_Status::PROCESSING ] ?? [];
 		$payment_method_types   = $intention_array['payment_method_types'] ?? [];
 		$payment_method_options = $intention_array['payment_method_options'] ?? [];
+		$statement_descriptor   = $intention_array['statement_descriptor'] ?? null;
 
 		$charge = ! empty( $charge_array ) ? self::deserialize_charge_object_from_array( $charge_array ) : null;
 		$order  = $this->get_order_info_from_intention_object( $intention_array['id'] );
@@ -2172,6 +2173,7 @@ class WC_Payments_API_Client {
 			$processing,
 			$payment_method_types,
 			$payment_method_options,
+			$statement_descriptor,
 			$order
 		);
 

--- a/includes/wc-payment-api/models/class-wc-payments-api-payment-intention.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-payment-intention.php
@@ -48,24 +48,32 @@ class WC_Payments_API_Payment_Intention extends WC_Payments_API_Abstract_Intenti
 	private $processing;
 
 	/**
+	 * The statement descriptor of the intention.
+	 *
+	 * @var string|null
+	 */
+	private $statement_descriptor;
+
+	/**
 	 * WC_Payments_API_Intention constructor.
 	 *
-	 * @param string                 $id                   - ID of the intention.
-	 * @param integer                $amount               - Amount charged.
-	 * @param string                 $currency             - The currency of the intention.
-	 * @param string|null            $customer_id          - Stripe ID of the customer.
-	 * @param string|null            $payment_method_id    - Stripe ID of the payment method.
-	 * @param DateTime               $created              - Time charge created.
-	 * @param string                 $status               - Intention status.
-	 * @param string                 $client_secret        - The client secret of the intention.
-	 * @param WC_Payments_API_Charge $charge               - An array containing payment method details of associated charge.
-	 * @param array                  $next_action          - An array containing information for next action to take.
-	 * @param array                  $last_payment_error   - An array containing details of any errors.
-	 * @param array                  $metadata             - An array containing additional metadata of associated charge or order.
-	 * @param array                  $processing           - An array containing details of the processing state of the payment.
-	 * @param array                  $payment_method_types - An array containing the possible payment methods for the intent.
+	 * @param string                 $id                     - ID of the intention.
+	 * @param integer                $amount                 - Amount charged.
+	 * @param string                 $currency               - The currency of the intention.
+	 * @param string|null            $customer_id            - Stripe ID of the customer.
+	 * @param string|null            $payment_method_id      - Stripe ID of the payment method.
+	 * @param DateTime               $created                - Time charge created.
+	 * @param string                 $status                 - Intention status.
+	 * @param string                 $client_secret          - The client secret of the intention.
+	 * @param WC_Payments_API_Charge $charge                 - An array containing payment method details of associated charge.
+	 * @param array                  $next_action            - An array containing information for next action to take.
+	 * @param array                  $last_payment_error     - An array containing details of any errors.
+	 * @param array                  $metadata               - An array containing additional metadata of associated charge or order.
+	 * @param array                  $processing             - An array containing details of the processing state of the payment.
+	 * @param array                  $payment_method_types   - An array containing the possible payment methods for the intent.
 	 * @param array                  $payment_method_options - An array containing the payment method options for the intent.
-	 * @param array                  $order                - An array containing the order data associated with this intention.
+	 * @param string|null            $statement_descriptor   - Bank statement of the intention.
+	 * @param array                  $order                  - An array containing the order data associated with this intention.
 	 */
 	public function __construct(
 		$id,
@@ -83,6 +91,7 @@ class WC_Payments_API_Payment_Intention extends WC_Payments_API_Abstract_Intenti
 		$processing = [],
 		$payment_method_types = [],
 		$payment_method_options = [],
+		$statement_descriptor = null,
 		$order = []
 	) {
 		$this->id                     = $id;
@@ -100,6 +109,7 @@ class WC_Payments_API_Payment_Intention extends WC_Payments_API_Abstract_Intenti
 		$this->processing             = $processing;
 		$this->payment_method_types   = $payment_method_types;
 		$this->payment_method_options = $payment_method_options;
+		$this->statement_descriptor   = $statement_descriptor;
 		$this->order                  = $order;
 	}
 

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -297,6 +297,16 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( $response->get_data()['is_wcpay_enabled'] );
 	}
 
+	public function test_get_settings_returns_is_short_statement_descriptor_enabled() {
+		$response = $this->upe_controller->get_settings();
+		$this->assertEquals( false, $response->get_data()['is_short_statement_descriptor_enabled'] );
+	}
+
+	public function test_get_settings_returns_short_statement_descriptor() {
+		$response = $this->upe_controller->get_settings();
+		$this->assertEquals( '', $response->get_data()['short_statement_descriptor'] );
+	}
+
 	public function test_get_settings_fails_if_user_cannot_manage_woocommerce() {
 		$cb = $this->create_can_manage_woocommerce_cap_override( false );
 		add_filter( 'user_has_cap', $cb );
@@ -607,6 +617,49 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$this->controller->update_settings( $request );
 
 		$this->assertEquals( 'no', $this->gateway->get_option( 'saved_cards' ) );
+	}
+
+	public function test_update_settings_enables_is_short_statement_descriptor_enabled() {
+		$request = new WP_REST_Request();
+		$request->set_param( 'is_short_statement_descriptor_enabled', true );
+
+		$this->controller->update_settings( $request );
+
+		$this->assertEquals( 'yes', $this->gateway->get_option( 'is_short_statement_descriptor_enabled' ) );
+	}
+
+	public function test_update_settings_disables_is_short_statement_descriptor_enabled() {
+		$request = new WP_REST_Request();
+		$request->set_param( 'is_short_statement_descriptor_enabled', false );
+
+		$this->controller->update_settings( $request );
+
+		$this->assertEquals( 'no', $this->gateway->get_option( 'is_short_statement_descriptor_enabled' ) );
+	}
+
+	public function test_update_settings_does_not_save_short_statement_descriptor_if_short_descriptor_is_disabled() {
+		$this->assertEquals( false, $this->gateway->get_option( 'is_short_statement_descriptor_enabled' ) );
+		$this->assertEquals( '', $this->gateway->get_option( 'short_statement_descriptor' ) );
+
+		$request = new WP_REST_Request();
+		$request->set_param( 'short_statement_descriptor', 'foobar' );
+
+		$this->controller->update_settings( $request );
+
+		$this->assertEquals( '', $this->gateway->get_option( 'short_statement_descriptor' ) );
+	}
+
+	public function test_update_settings_saves_short_statement_descriptor() {
+		$this->assertEquals( false, $this->gateway->get_option( 'is_short_statement_descriptor_enabled' ) );
+		$this->assertEquals( '', $this->gateway->get_option( 'short_statement_descriptor' ) );
+
+		$request = new WP_REST_Request();
+		$request->set_param( 'is_short_statement_descriptor_enabled', true );
+		$request->set_param( 'short_statement_descriptor', 'foobar' );
+
+		$this->controller->update_settings( $request );
+
+		$this->assertEquals( 'foobar', $this->gateway->get_option( 'short_statement_descriptor' ) );
 	}
 
 	public function test_enable_woopay_converts_upe_flag() {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -1762,37 +1762,56 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	 *
 	 * @dataProvider account_statement_descriptor_validation_provider
 	 */
-	public function test_validate_account_statement_descriptor_field( $is_valid, $value, $expected = null ) {
+	public function test_validate_account_statement_descriptor_field( $is_valid, $key, $value, $max_length, $expected = null ) {
 		$key = 'account_statement_descriptor';
 		if ( $is_valid ) {
-			$validated_value = $this->wcpay_gateway->validate_account_statement_descriptor_field( $key, $value );
+			$validated_value = $this->wcpay_gateway->validate_account_statement_descriptor_field( $key, $value, $max_length );
 			$this->assertEquals( $expected ?? $value, $validated_value );
 		} else {
-			$this->expectExceptionMessage( 'Customer bank statement is invalid.' );
-			$this->wcpay_gateway->validate_account_statement_descriptor_field( $key, $value );
+			$message = 'account_statement_descriptor' === $key ? 'Customer bank statement' : 'Shortened customer bank statement';
+			$this->expectExceptionMessage( $message . ' is invalid.' );
+			$this->wcpay_gateway->validate_account_statement_descriptor_field( $key, $value, $max_length );
 		}
 	}
 
 	public function account_statement_descriptor_validation_provider() {
 		return [
-			'valid'          => [ true, 'WCPAY dev' ],
-			'allow_digits'   => [ true, 'WCPay dev 2020' ],
-			'allow_special'  => [ true, 'WCPay-Dev_2020' ],
-			'allow_amp'      => [ true, 'WCPay&Dev_2020' ],
-			'strip_slashes'  => [ true, 'WCPay\\\\Dev_2020', 'WCPay\\Dev_2020' ],
-			'allow_long_amp' => [ true, 'aaaaaaaaaaaaaaaaaaa&aa' ],
-			'trim_valid'     => [ true, '   good_descriptor  ', 'good_descriptor' ],
-			'empty'          => [ false, '' ],
-			'short'          => [ false, 'WCP' ],
-			'long'           => [ false, 'WCPay_dev_WCPay_dev_WCPay_dev_WCPay_dev' ],
-			'no_*'           => [ false, 'WCPay * dev' ],
-			'no_sqt'         => [ false, 'WCPay \'dev\'' ],
-			'no_dqt'         => [ false, 'WCPay "dev"' ],
-			'no_lt'          => [ false, 'WCPay<dev' ],
-			'no_gt'          => [ false, 'WCPay>dev' ],
-			'req_latin'      => [ false, 'дескриптор' ],
-			'req_letter'     => [ false, '123456' ],
-			'trim_too_short' => [ false, '  aaa    ' ],
+			'valid'                  => [ true, 'account_statement_descriptor', 'WCPAY dev', 22 ],
+			'allow_digits'           => [ true, 'account_statement_descriptor', 'WCPay dev 2020', 22 ],
+			'allow_special'          => [ true, 'account_statement_descriptor', 'WCPay-Dev_2020', 22 ],
+			'allow_amp'              => [ true, 'account_statement_descriptor', 'WCPay&Dev_2020', 22 ],
+			'strip_slashes'          => [ true, 'account_statement_descriptor', 'WCPay\\\\Dev_2020', 22, 'WCPay\\Dev_2020' ],
+			'allow_long_amp'         => [ true, 'account_statement_descriptor', 'aaaaaaaaaaaaaaaaaaa&aa', 22 ],
+			'trim_valid'             => [ true, 'account_statement_descriptor', '   good_descriptor  ', 22, 'good_descriptor' ],
+			'empty'                  => [ false, 'account_statement_descriptor', '', 22 ],
+			'short'                  => [ false, 'account_statement_descriptor', 'WCP', 22 ],
+			'long'                   => [ false, 'account_statement_descriptor', 'WCPay_dev_WCPay_dev_WCPay_dev_WCPay_dev', 22 ],
+			'no_*'                   => [ false, 'account_statement_descriptor', 'WCPay * dev', 22 ],
+			'no_sqt'                 => [ false, 'account_statement_descriptor', 'WCPay \'dev\'', 22 ],
+			'no_dqt'                 => [ false, 'account_statement_descriptor', 'WCPay "dev"', 22 ],
+			'no_lt'                  => [ false, 'account_statement_descriptor', 'WCPay<dev', 22 ],
+			'no_gt'                  => [ false, 'account_statement_descriptor', 'WCPay>dev', 22 ],
+			'req_latin'              => [ false, 'account_statement_descriptor', 'дескриптор', 22 ],
+			'req_letter'             => [ false, 'account_statement_descriptor', '123456', 22 ],
+			'trim_too_short'         => [ false, 'account_statement_descriptor', '  aaa    ', 22 ],
+			'valid (short)'          => [ true, 'short_statement_descriptor', 'WCPAY dev', 10 ],
+			'allow_digits (short)'   => [ true, 'short_statement_descriptor', 'WCPay 2020', 10 ],
+			'allow_special (short)'  => [ true, 'short_statement_descriptor', 'WCPay-_202', 10 ],
+			'allow_amp (short)'      => [ true, 'short_statement_descriptor', 'WCPay&_202', 10 ],
+			'strip_slashes (short)'  => [ true, 'short_statement_descriptor', 'WCPay\\\\D_20', 10, 'WCPay\\D_20' ],
+			'allow_long_amp (short)' => [ true, 'short_statement_descriptor', 'aaaaaaaa&a', 10 ],
+			'trim_valid (short)'     => [ true, 'short_statement_descriptor', '   good_d ', 10, 'good_d' ],
+			'empty (short)'          => [ false, 'short_statement_descriptor', '', 10 ],
+			'short (short)'          => [ false, 'short_statement_descriptor', 'WCP', 10 ],
+			'long (short)'           => [ false, 'short_statement_descriptor', 'WCPay_dev_WCPay_dev_WCPay_dev_WCPay_dev', 10 ],
+			'no_* (short)'           => [ false, 'short_statement_descriptor', 'WCPay * de', 10 ],
+			'no_sqt (short)'         => [ false, 'short_statement_descriptor', 'WCPay \'d\'', 10 ],
+			'no_dqt (short)'         => [ false, 'short_statement_descriptor', 'WCPay "de"', 10 ],
+			'no_lt (short)'          => [ false, 'short_statement_descriptor', 'WCPay<dev', 10 ],
+			'no_gt (short)'          => [ false, 'short_statement_descriptor', 'WCPay>dev', 10 ],
+			'req_latin (short)'      => [ false, 'short_statement_descriptor', 'дескриптор', 10 ],
+			'req_letter (short)'     => [ false, 'short_statement_descriptor', '123456', 10 ],
+			'trim_too_short (short)' => [ false, 'short_statement_descriptor', '  aaa    ', 10 ],
 		];
 	}
 


### PR DESCRIPTION
Fixed #4329

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
The usage of the statement descriptor in transactions is being addressed in this PR. This is the final part of the #3625's work.

For some portion of the transactions, the regular statement descriptor is being added to the payment intents already. Here we're making sure the descriptor is passed to the payment intent and the shortened descriptor is being included to take place on card payments, if enabled.

It also includes a small fix for the Blocks checkout when using UPE, where the `wcpay_selected_upe_payment_type` was not being sent.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test the descriptors set are sent to the payment intent.

![image](https://user-images.githubusercontent.com/10233985/149672714-eacccfb3-5d0d-4397-bad9-d9b9adb817f2.png)

There's a vast amount of combinations for this test, please try to test as much as you can:
- UPE enabled and disabled.
- Classic checkout and Blocks checkout.
- Card, non-card payment method and express checkout.
- `Add customer order number to the bank statement` enabled and disabled.

Also consider the following:
1. When no `Full bank statement` and `Shortened customer bank statement` are provided, the payment intent should either contain no statement descriptor or have the `Full bank statement` descriptor set.
2. When `Full bank statement` is provided and `Add customer order number to the bank statement` is disabled, the payment intent should contain the `Full bank statement`'s value in the statement descriptor regardless the payment method chosen.
3. In card transactions (express checkout included), when `Add customer order number to the bank statement` is enabled and `Shortened customer bank statement` is provided, the payment intent should contain the `Shortened customer bank statement`'s value concatenated with the order number in the statement descriptor.

**The test:**
1. Set values for both `Full bank statement` and `Shortened customer bank statement`.
2. Go to the [shop page](http://localhost:8082/shop/) and add a product to the cart.
3. Go to checkout and complete the order using the scenarios described above.
4. Go to [Payments](https://dashboard.stripe.com/test/payments) in the Stripe dashboard, find the payment you've just made and click on it.
5. Check whether the statement descriptor value (under Payment details section) match the expected value according to the scenario being tested.

-------------------

- [ ] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
