### PR TITLE
Bump plugin version to see if that fixes breaking Disputes E2Es

### DIFF
--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -12,7 +12,7 @@
  * WC tested up to: 6.1
  * Requires at least: 5.6
  * Requires PHP: 7.0
- * Version: 3.5.0
+ * Version: 3.6.0
  *
  * @package WooCommerce\Payments
  */


### PR DESCRIPTION
🧪 **EXPERIMENT-ONLY: NOT INTENDED TO BE MERGED**

The sole purpose of this PR is to see if bumping up the plugin version to 3.6.0 fixes E2Es that are purported to be [breaking](https://github.com/Automattic/woocommerce-payments/actions/runs/1710384484) after the merging of #3545.