### PR TITLE
Fix fee amount not showing negative value in transactions CSV

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@
 * Fix - When viewing a WC Product page with a WCPay subscription product in cart, make sure other gateway's express payment buttons are shown.
 * Fix - Don't limit subscription products being created with an interval of more than one year when the WC Subscriptions plugin is active.
 * Fix - Subscriptions not renewing with subscription products that use a free trial period.
+* Fix - "Fees" column values are different in the downloaded CSV file for the transaction table
 
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -283,7 +283,7 @@ export const TransactionsList = (
 			const isCardReader =
 				txn.metadata && txn.metadata.charge_type === 'card_reader_fee';
 			return {
-				value: ( isCardReader ? txn.amount : txn.fees ) / 100,
+				value: ( isCardReader ? txn.amount : txn.fees * -1 ) / 100,
 				display: clickable(
 					formatCurrency(
 						isCardReader ? txn.amount : txn.fees * -1,

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -555,10 +555,12 @@ describe( 'Transactions list', () => {
 				)
 			).not.toBe( -1 ); // amount
 			expect(
-				getUnformattedAmount( displayFirstTransaction[ 3 ] ).indexOf(
-					csvFirstTransaction[ 4 ]
+				-Number( getUnformattedAmount( displayFirstTransaction[ 3 ] ) )
+			).toEqual(
+				Number(
+					csvFirstTransaction[ 4 ].replace( /['"]+/g, '' ) // strip extra quotes
 				)
-			).not.toBe( -1 ); // fees
+			); // fees
 			expect(
 				getUnformattedAmount( displayFirstTransaction[ 4 ] ).indexOf(
 					csvFirstTransaction[ 5 ]

--- a/readme.txt
+++ b/readme.txt
@@ -118,6 +118,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - When viewing a WC Product page with a WCPay subscription product in cart, make sure other gateway's express payment buttons are shown.
 * Fix - Don't limit subscription products being created with an interval of more than one year when the WC Subscriptions plugin is active.
 * Fix - Subscriptions not renewing with subscription products that use a free trial period.
+* Fix - "Fees" column values are different in the downloaded CSV file for the transaction table
 
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.


### PR DESCRIPTION
Fixes #3657 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
Fixes a bug where the fee amount in the downloaded CSV does not have the same value as the fee amount column in the Transactions list. In the downloaded CSV, the fee amount is displayed as a positive number, but it should be displayed as a negative number.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
**Before:**
![149965942-9b60c9da-bfdf-480f-9e95-80a960f981df](https://user-images.githubusercontent.com/1553182/149969091-65af29f0-4d77-41b1-babe-96d14f12559c.jpeg)

**After:**

<img width="1562" alt="Screen Shot 2022-01-18 at 16 38 34" src="https://user-images.githubusercontent.com/1553182/149969413-9b897181-7c09-4ffd-b3ab-94d1f248948b.png">

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->



<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to frontend and purchase some products with WooCommerce payments.
2. Go to WP admin, Payments->Transactions.
3. Click on download icon.
4. Observe that "Fees" column values are different in the downloaded CSV file for the transaction table..

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : [Testing Instuctions](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-3.6.0#fix-for-fees-column-values-are-different-in-the-downloaded-csv-file-for-the-transaction-table)
