### PR TITLE
Fix stripe.confirmSetup() expected either `elements` or `clientSecret`.

### DIFF
--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -519,7 +519,7 @@ jQuery( function ( $ ) {
 
 		try {
 			const { error } = await api.getStripe().confirmSetup( {
-				element: upeElement,
+				elements,
 				confirmParams: {
 					return_url: returnUrl,
 				},


### PR DESCRIPTION
Fixes #3656

#### Changes proposed in this Pull Request

Pass `elements` instead of `element` to stripe.confirmSetup().

Note: I don't add changelog because this bug isn't present in previous release.

#### Testing instructions

Make sure adding payment methods works.
1. Go to My Account > Payment methods (/my-account/payment-methods/).
2. Click `Add payment method` button.
3. Select `Use a new payment method` and fill in card number `4242424242424242` and valid expiry and cvc.
4. Click `Add payment method` button.
5. Expect a success. With base branch, there should be an error like the screenshot in https://github.com/Automattic/woocommerce-payments/issues/3656.

Make sure changing payment for subscriptions works.
1. Create a subscription product.
2. Purchase that subscription product.
3. Go to My Account > Subscriptions (/my-account/subscriptions/).
4. Select one of the subscriptions.
5. Click `Change payment` button.
6. Select `Use a new payment method` and fill in card number `4242424242424242` and valid expiry and cvc.
7. Click `Change payment method` button.
8. Expect a success. With base branch, there should be an error like the screenshot in https://github.com/Automattic/woocommerce-payments/issues/3656.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
