### PR TITLE
Only limit subscription interval to one year if the Subscriptions plugin not active

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,7 +18,7 @@
 * Add - Show a warning when attempting to create a subscription product with a price below the minimum amount.
 * Fix - When viewing a WCPay Subscription product page, make sure other gateway's express payment buttons aren't shown.
 * Fix - When viewing a WC Product page with a WCPay subscription product in cart, make sure other gateway's express payment buttons are shown.
-
+* Fix - Don't limit subscription products being created with an interval of more than one year when the WC Subscriptions plugin is active.
 
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -15,6 +15,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class WC_Payments_Product_Service {
 
+	use WC_Payments_Subscriptions_Utilities;
+
 	/**
 	 * The product meta key used to store the product data we last sent to WC Pay as a hash. Used to compare current WC product data with WC Pay data.
 	 *
@@ -420,8 +422,13 @@ class WC_Payments_Product_Service {
 	 * @param int $product_id Post ID of the product.
 	 */
 	public function limit_subscription_product_intervals( $product_id ) {
+		if ( $this->is_subscriptions_plugin_active() ) {
+			return;
+		}
+
 		// Skip products that aren't subscriptions.
 		$product = wc_get_product( $product_id );
+
 		if (
 			! $product ||
 			! WC_Subscriptions_Product::is_subscription( $product ) ||
@@ -456,6 +463,10 @@ class WC_Payments_Product_Service {
 	 * @param int $index Variation index in the incoming array.
 	 */
 	public function limit_subscription_variation_intervals( $product_id, $index ) {
+		if ( $this->is_subscriptions_plugin_active() ) {
+			return;
+		}
+
 		// Skip products that aren't subscriptions.
 		$product           = wc_get_product( $product_id );
 		$admin_notice_sent = false;

--- a/readme.txt
+++ b/readme.txt
@@ -116,6 +116,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Show a warning when attempting to create a subscription product with a price below the minimum amount.
 * Fix - When viewing a WCPay Subscription product page, make sure other gateway's express payment buttons aren't shown.
 * Fix - When viewing a WC Product page with a WCPay subscription product in cart, make sure other gateway's express payment buttons are shown.
+* Fix - Don't limit subscription products being created with an interval of more than one year when the WC Subscriptions plugin is active.
 
 = 3.5.0 - 2021-12-29 =
 * Fix - Error when renewing subscriptions with saved payment methods disabled.


### PR DESCRIPTION
Fixes #3648

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

The Subscriptions with WooCommerce Payments feature has a limitation where subscription products can only be created with one year or less recurring billing interval.
This limitation was being applied to all subscription products even when the WC Subscriptions plugin active on the store.

This PR fixes this by introducing checks to the top our limiting functions which first checks if the subscription plugin is active and returns early if so:

```
if ( $this->is_subscriptions_plugin_active() ) {
	return;
}
``` 

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

1. On WC Payments `develop` branch with the WC Subscriptions plugin active
1. Go into **Products > Add New** and create a subscription product that renews every 3 years.
1. When saving/publishing the product, you will see a notice saying "A subscription product's billing period cannot be longer than one year" :x:
  - This error shouldn't be shown when WC Subscriptions is active
  - The new product interval is also updated to be the maximum interval supported (one year)
1. Checkout this PRs branch and keep the WC Subscriptions plugin active
1. Edit this new product to renew every 3 years.
1. Upon saving, you should notice the product now saves with a 3-year billing period.
1. Deactivate the WC Subscriptions plugin and make sure the WCPay Subscriptions feature is enabled.
1. Go back to this 3-year product and hit publish
1. The product should be forced to 1 year max interval and you should see a notice on the product page. 

![image](https://user-images.githubusercontent.com/2275145/150038026-504e3a64-8c10-49d3-a335-7729f1de28a7.png)

-------------------

- [ ] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
