### PR TITLE
Pass `elements` instead of payment element to `confirmPayment()` and `confirmSetup()`.

### DIFF
--- a/client/checkout/blocks/confirm-upe-payment.js
+++ b/client/checkout/blocks/confirm-upe-payment.js
@@ -4,7 +4,7 @@
  * @param {WCPayAPI} api            The API used for connection both with the server and Stripe.
  * @param {string}   redirectUrl    The URL to redirect to after confirming the intent on Stripe.
  * @param {boolean}  paymentNeeded  A boolean whether a payment or a setup confirmation is needed.
- * @param {Object}   paymentElement Reference to the UPE element mounted on the page.
+ * @param {Object}   elements       Reference to the UPE elements mounted on the page.
  * @param {Object}   billingData    An object containing the customer's billing data.
  * @param {Object}   emitResponse   Various helpers for usage with observer response objects.
  * @return {Object}                An object, which contains the result from the action.
@@ -13,7 +13,7 @@ export default async function confirmUPEPayment(
 	api,
 	redirectUrl,
 	paymentNeeded,
-	paymentElement,
+	elements,
 	billingData,
 	emitResponse
 ) {
@@ -42,7 +42,7 @@ export default async function confirmUPEPayment(
 
 		if ( paymentNeeded ) {
 			const { error } = await api.getStripe().confirmPayment( {
-				element: paymentElement,
+				elements,
 				confirmParams,
 			} );
 			if ( error ) {
@@ -50,7 +50,7 @@ export default async function confirmUPEPayment(
 			}
 		} else {
 			const { error } = await api.getStripe().confirmSetup( {
-				element: paymentElement,
+				elements,
 				confirmParams,
 			} );
 			if ( error ) {

--- a/client/checkout/blocks/upe-fields.js
+++ b/client/checkout/blocks/upe-fields.js
@@ -138,15 +138,11 @@ const WCPayUPEFields = ( {
 							paymentCountry
 						);
 
-						const paymentElement = elements.getElement(
-							PaymentElement
-						);
-
 						return confirmUPEPayment(
 							api,
 							paymentDetails.redirect_url,
 							paymentDetails.payment_needed,
-							paymentElement,
+							elements,
 							billingData,
 							emitResponse
 						);

--- a/client/checkout/blocks/upe-fields.js
+++ b/client/checkout/blocks/upe-fields.js
@@ -3,7 +3,8 @@
  */
 import {
 	Elements,
-	ElementsConsumer,
+	useStripe,
+	useElements,
 	PaymentElement,
 } from '@stripe/react-stripe-js';
 import { useEffect, useState } from '@wordpress/element';
@@ -20,8 +21,6 @@ import { PAYMENT_METHOD_NAME_CARD } from '../constants.js';
 const WCPayUPEFields = ( {
 	api,
 	activePaymentMethod,
-	stripe,
-	elements,
 	billing: { billingData },
 	eventRegistration: {
 		onPaymentProcessing,
@@ -30,6 +29,9 @@ const WCPayUPEFields = ( {
 	emitResponse,
 	shouldSavePayment,
 } ) => {
+	const stripe = useStripe();
+	const elements = useElements();
+
 	const [ paymentIntentId, setPaymentIntentId ] = useState( null );
 	const [ clientSecret, setClientSecret ] = useState( null );
 	const [ hasRequestedIntent, setHasRequestedIntent ] = useState( false );
@@ -216,14 +218,14 @@ const WCPayUPEFields = ( {
 	}
 
 	return (
-		<>
+		<Elements stripe={ api.getStripe() } options={ elementOptions }>
 			{ testMode ? testCopy : '' }
 			<PaymentElement
 				options={ elementOptions }
 				onChange={ upeOnChange }
 				className="wcpay-payment-element"
 			/>
-		</>
+		</Elements>
 	);
 };
 
@@ -233,19 +235,12 @@ const WCPayUPEFields = ( {
  * @param {Object} props All props given by WooCommerce Blocks.
  * @return {Object}     The wrapped React element.
  */
-const ConsumableWCPayFields = ( { api, ...props } ) => (
-	<Elements stripe={ api.getStripe() }>
-		<ElementsConsumer>
-			{ ( { elements, stripe } ) => (
-				<WCPayUPEFields
-					api={ api }
-					elements={ elements }
-					stripe={ stripe }
-					{ ...props }
-				/>
-			) }
-		</ElementsConsumer>
-	</Elements>
-);
+const ConsumableWCPayFields = ( { api, ...props } ) => {
+	return (
+		<Elements stripe={ api.getStripe() }>
+			<WCPayUPEFields api={ api } { ...props } />
+		</Elements>
+	);
+};
 
 export default ConsumableWCPayFields;

--- a/client/checkout/blocks/upe-fields.js
+++ b/client/checkout/blocks/upe-fields.js
@@ -165,6 +165,10 @@ const WCPayUPEFields = ( {
 				},
 			},
 		},
+		wallets: {
+			applePay: 'never',
+			googlePay: 'never',
+		},
 	};
 
 	const showTerms =


### PR DESCRIPTION
Fixes #3664

#### Changes proposed in this Pull Request

Following https://stripe.com/docs/payments/payment-element/upgrade-from-beta, ie:
- Pass client secret to elements instead of to payment element.
- Pass elements to `confirmPayment()` and `confirmSetup()`.

Note: no changelog needed because in previous release, this bug didn't exist.

#### Testing instructions

Copied from https://github.com/Automattic/woocommerce-payments/issues/3664:
1. Enable UPE.
2. Install WooCommerce Blocks.
3. Create a checkout page using blocks. Admin > Pages > Add New > Click on the plus sign (Add block) > Select Checkout. Note the newly created page's URL.
4. Add a product to cart.
5. Go to the newly created checkout blocks page.
6. Trying to pay with a new payment should be successful.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
