### PR TITLE
Bump subscriptions-core to 1.6.2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
       "automattic/jetpack-config": "1.5.3",
       "automattic/jetpack-autoloader": "2.10.10",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "1.6.1",
+      "woocommerce/subscriptions-core": "1.6.2",
       "symfony/polyfill-php71": "1.20.0",
       "symfony/polyfill-php72": "1.23.0",
       "symfony/polyfill-php73": "1.23.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "42808f84eeaa1af623316af3afceadea",
+    "content-hash": "063546e4b39b470b94d4673b7d5ce249",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1278,16 +1278,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "1.6.1",
+            "version": "1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "d23e989583e04544fcfe9602d45e1744279aa8cf"
+                "reference": "bc48cd0437fc4601643e72abc4a7cd9beffb35b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/d23e989583e04544fcfe9602d45e1744279aa8cf",
-                "reference": "d23e989583e04544fcfe9602d45e1744279aa8cf",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/bc48cd0437fc4601643e72abc4a7cd9beffb35b5",
+                "reference": "bc48cd0437fc4601643e72abc4a7cd9beffb35b5",
                 "shasum": ""
             },
             "require": {
@@ -1329,10 +1329,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/1.6.1",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/1.6.2",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-01-18T05:09:25+00:00"
+            "time": "2022-01-19T13:46:30+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Increase subscriptions-core's version to `1.6.2`.

Note: not adding changelog because this is fixing a bug that didn't exist in previous release.

#### Testing instructions

* Upon checking out PR branch, confirm `vendor/woocommerce/subscriptions-core/changelog.txt` is up to `1.6.2`.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
