### PR TITLE
E2E Tests - Optimize console logging, wcpay shopper checkout-failures & checkout-purchase tests

### DIFF
--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
 import {
 	enablePageDialogAccept,
-	isOfflineMode,
 	setBrowserViewport,
 } from '@wordpress/e2e-test-utils';
 
@@ -17,6 +15,7 @@ addConsoleSuppression(
 	'You may test your Stripe.js integration over HTTP.',
 	false
 );
+addConsoleSuppression( 'is deprecated', false );
 
 /**
  * Array of page event tuples of [ eventName, handler ].
@@ -24,18 +23,6 @@ addConsoleSuppression(
  * @type {Array}
  */
 const pageEvents = [];
-/**
- * Set of console logging types observed to protect against unexpected yet
- * handled (i.e. not catastrophic) errors or warnings. Each key corresponds
- * to the Puppeteer ConsoleMessage type, its value the corresponding function
- * on the console global object.
- *
- * @type {Object<string,string>}
- */
-const OBSERVED_CONSOLE_MESSAGE_TYPES = {
-	warning: 'warn',
-	error: 'error',
-};
 
 async function setupBrowser() {
 	await setBrowserViewport( 'large' );
@@ -60,113 +47,6 @@ function removePageEvents() {
 	} );
 }
 
-/**
- * Adds a page event handler to emit uncaught exception to process if one of
- * the observed console logging types is encountered.
- */
-function observeConsoleLogging() {
-	page.on( 'console', ( message ) => {
-		const type = message.type();
-		if ( ! OBSERVED_CONSOLE_MESSAGE_TYPES.hasOwnProperty( type ) ) {
-			return;
-		}
-
-		let text = message.text();
-
-		// An exception is made for _blanket_ deprecation warnings: Those
-		// which log regardless of whether a deprecated feature is in use.
-		if ( text.includes( 'This is a global warning' ) ) {
-			return;
-		}
-
-		// A chrome advisory warning about SameSite cookies is informational
-		// about future changes, tracked separately for improvement in core.
-		//
-		// See: https://core.trac.wordpress.org/ticket/37000
-		// See: https://www.chromestatus.com/feature/5088147346030592
-		// See: https://www.chromestatus.com/feature/5633521622188032
-		if (
-			text.includes( 'A cookie associated with a cross-site resource' )
-		) {
-			return;
-		}
-
-		// Viewing posts on the front end can result in this error, which
-		// has nothing to do with Gutenberg.
-		if ( text.includes( 'net::ERR_UNKNOWN_URL_SCHEME' ) ) {
-			return;
-		}
-
-		// Network errors are ignored only if we are intentionally testing
-		// offline mode.
-		if (
-			text.includes( 'net::ERR_INTERNET_DISCONNECTED' ) &&
-			isOfflineMode()
-		) {
-			return;
-		}
-
-		// As of WordPress 5.3.2 in Chrome 79, navigating to the block editor
-		// (Posts > Add New) will display a console warning about
-		// non - unique IDs.
-		// See: https://core.trac.wordpress.org/ticket/23165
-		if ( text.includes( 'elements with non-unique id #_wpnonce' ) ) {
-			return;
-		}
-
-		// As of WordPress 5.3.2 in Chrome 79, navigating to the block editor
-		// (Posts > Add New) will display a console warning about
-		// non - unique IDs.
-		// See: https://core.trac.wordpress.org/ticket/23165
-		if ( text.includes( 'elements with non-unique id #_wpnonce' ) ) {
-			return;
-		}
-
-		if (
-			text.includes(
-				'You may test your Stripe.js integration over HTTP.'
-			)
-		) {
-			return;
-		}
-
-		if (
-			text.includes(
-				'violates the following Content Security Policy directive'
-			)
-		) {
-			return;
-		}
-
-		const logFunction = OBSERVED_CONSOLE_MESSAGE_TYPES[ type ];
-
-		// As of Puppeteer 1.6.1, `message.text()` wrongly returns an object of
-		// type JSHandle for error logging, instead of the expected string.
-		//
-		// See: https://github.com/GoogleChrome/puppeteer/issues/3397
-		//
-		// The recommendation there to asynchronously resolve the error value
-		// upon a console event may be prone to a race condition with the test
-		// completion, leaving a possibility of an error not being surfaced
-		// correctly. Instead, the logic here synchronously inspects the
-		// internal object shape of the JSHandle to find the error text. If it
-		// cannot be found, the default text value is used instead.
-		text = get(
-			message.args(),
-			[ 0, '_remoteObject', 'description' ],
-			text
-		);
-
-		// Disable reason: We intentionally bubble up the console message
-		// which, unless the test explicitly anticipates the logging via
-		// @wordpress/jest-console matchers, will cause the intended test
-		// failure.
-
-		// eslint-disable-next-line no-console
-		console[ logFunction ]( text );
-	} );
-}
-
 function setTestTimeouts() {
 	const TIMEOUT = 100000;
 	// Increase default value to avoid test failing due to timeouts.
@@ -182,7 +62,6 @@ function setTestTimeouts() {
 beforeAll( async () => {
 	capturePageEventsForTearDown();
 	enablePageDialogAccept();
-	observeConsoleLogging();
 	setTestTimeouts();
 	await setupBrowser();
 } );

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -8,6 +8,16 @@ import {
 	setBrowserViewport,
 } from '@wordpress/e2e-test-utils';
 
+import { addConsoleSuppression } from '@woocommerce/e2e-environment';
+addConsoleSuppression(
+	'violates the following Content Security Policy directive',
+	false
+);
+addConsoleSuppression(
+	'You may test your Stripe.js integration over HTTP.',
+	false
+);
+
 /**
  * Array of page event tuples of [ eventName, handler ].
  *
@@ -115,6 +125,14 @@ function observeConsoleLogging() {
 		if (
 			text.includes(
 				'You may test your Stripe.js integration over HTTP.'
+			)
+		) {
+			return;
+		}
+
+		if (
+			text.includes(
+				'violates the following Content Security Policy directive'
 			)
 		) {
 			return;

--- a/tests/e2e/specs/blocks/shopper/shopper-wc-blocks-checkout-failures.spec.js
+++ b/tests/e2e/specs/blocks/shopper/shopper-wc-blocks-checkout-failures.spec.js
@@ -49,7 +49,7 @@ describeif( RUN_WC_BLOCKS_TESTS )(
 
 		afterAll( async () => {
 			// Clear the cart at the end so it's ready for another test
-			await shopper.emptyCart();
+			await shopperWCP.emptyCart();
 		} );
 
 		it( 'should throw an error that the card was simply declined', async () => {

--- a/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.js
@@ -4,7 +4,6 @@
 import config from 'config';
 
 const {
-	shopper,
 	createSimpleProduct,
 	uiUnblocked,
 } = require( '@woocommerce/e2e-utils' );
@@ -12,6 +11,8 @@ const {
 /**
  * Internal dependencies
  */
+import { shopperWCP } from '../../../utils';
+
 import {
 	fillCardDetails,
 	clearCardDetails,
@@ -35,7 +36,7 @@ describe.skip( 'Shopper > Checkout > Failures with various cards', () => {
 
 	afterAll( async () => {
 		// Clear the cart at the end so it's ready for another test
-		await shopper.emptyCart();
+		await shopperWCP.emptyCart();
 	} );
 
 	it( 'should throw an error that the card was simply declined', async () => {

--- a/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.js
@@ -21,7 +21,7 @@ import {
 } from '../../../utils/payments';
 
 // Unskip this after debugging failing shopper tests.
-describe.skip( 'Shopper > Checkout > Failures with various cards', () => {
+describe( 'Shopper > Checkout > Failures with various cards', () => {
 	beforeAll( async () => {
 		await createSimpleProduct();
 		await setupProductCheckout(

--- a/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.js
@@ -140,15 +140,6 @@ describe( 'Shopper > Checkout > Failures with various cards', () => {
 	it( 'should throw an error that the card was declined due to incorrect card number', async () => {
 		const cardIncorrectNumber = config.get( 'cards.declined-incorrect' );
 		await fillCardDetails( page, cardIncorrectNumber );
-
-		// Verify the error message
-		await expect( page ).toMatchElement(
-			'div#wcpay-errors > ul.woocommerce-error > li',
-			{
-				text: 'Your card number is invalid.',
-			}
-		);
-
 		await expect( page ).toClick( '#place_order' );
 		await uiUnblocked();
 		await expect(

--- a/tests/e2e/specs/wcpay/shopper/shopper-checkout-purchase.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-checkout-purchase.spec.js
@@ -9,8 +9,6 @@ const { shopper } = require( '@woocommerce/e2e-utils' );
  * Internal dependencies
  */
 
-import { shopperWCP, takeScreenshot } from '../../../utils';
-
 import {
 	fillCardDetails,
 	setupProductCheckout,
@@ -18,14 +16,13 @@ import {
 } from '../../../utils/payments';
 
 describe( 'Successful purchase', () => {
-	beforeAll( async () => {
-		await page.goto( config.get( 'url' ), { waitUntil: 'networkidle0' } );
-	} );
-
-	it( 'using a basic card', async () => {
+	beforeEach( async () => {
 		await setupProductCheckout(
 			config.get( 'addresses.customer.billing' )
 		);
+	} );
+
+	it( 'using a basic card', async () => {
 		const card = config.get( 'cards.basic' );
 		await fillCardDetails( page, card );
 		await shopper.placeOrder();
@@ -33,21 +30,13 @@ describe( 'Successful purchase', () => {
 	} );
 
 	it( 'using a 3DS card and account signup', async () => {
-		await setupProductCheckout( {
-			...config.get( 'addresses.customer.billing' ),
-			...config.get( 'users.guest' ),
-		} );
-		await shopperWCP.toggleCreateAccount();
 		const card = config.get( 'cards.3ds' );
 		await fillCardDetails( page, card );
-		await takeScreenshot( 'shopper-checkout-purchase_filled-card-details' );
 		await expect( page ).toClick( '#place_order' );
 		await confirmCardAuthentication( page, '3DS' );
-		await takeScreenshot( 'shopper-checkout-purchase_authenticating' );
 		await page.waitForNavigation( {
 			waitUntil: 'networkidle0',
 		} );
 		await expect( page ).toMatch( 'Order received' );
-		await takeScreenshot( 'shopper-checkout-purchase_order-received' );
 	} );
 } );

--- a/tests/e2e/specs/wcpay/shopper/shopper-checkout-purchase.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-checkout-purchase.spec.js
@@ -15,11 +15,18 @@ import {
 	confirmCardAuthentication,
 } from '../../../utils/payments';
 
+import { shopperWCP } from '../../../utils';
+
 describe( 'Successful purchase', () => {
 	beforeEach( async () => {
 		await setupProductCheckout(
 			config.get( 'addresses.customer.billing' )
 		);
+	} );
+
+	afterAll( async () => {
+		// Clear the cart at the end so it's ready for another test
+		await shopperWCP.emptyCart();
 	} );
 
 	it( 'using a basic card', async () => {
@@ -29,7 +36,7 @@ describe( 'Successful purchase', () => {
 		await expect( page ).toMatch( 'Order received' );
 	} );
 
-	it( 'using a 3DS card and account signup', async () => {
+	it( 'using a 3DS card', async () => {
 		const card = config.get( 'cards.3ds' );
 		await fillCardDetails( page, card );
 		await expect( page ).toClick( '#place_order' );

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -39,9 +39,8 @@ const WC_SUBSCRIPTIONS_PAGE =
 const ACTION_SCHEDULER = baseUrl + 'wp-admin/tools.php?page=action-scheduler';
 const WP_ADMIN_PAGES = baseUrl + 'wp-admin/edit.php?post_type=page';
 const WCB_CHECKOUT = baseUrl + 'checkout-wcb/';
-const WCPAY_DEV_TOOLS = `${ config.get(
-	'url'
-) }wp-admin/admin.php?page=wcpaydev`;
+const WCPAY_DEV_TOOLS = baseUrl + 'wp-admin/admin.php?page=wcpaydev';
+const SHOP_CART_PAGE = baseUrl + 'cart/';
 
 export const RUN_SUBSCRIPTIONS_TESTS =
 	'1' !== process.env.SKIP_WC_SUBSCRIPTIONS_TESTS;
@@ -211,6 +210,35 @@ export const shopperWCP = {
 			'#billing-postcode',
 			customerBillingDetails.postcode
 		);
+	},
+
+	emptyCart: async () => {
+		await page.goto( SHOP_CART_PAGE, {
+			waitUntil: 'networkidle0',
+		} );
+
+		// Remove products if they exist
+		if ( null !== ( await page.$$( '.remove' ) ) ) {
+			let products = await page.$$( '.remove' );
+			while ( products && 0 < products.length ) {
+				for ( const product of products ) {
+					await product.click();
+					await uiUnblocked();
+				}
+				products = await page.$$( '.remove' );
+			}
+		}
+
+		// Remove coupons if they exist
+		if ( null !== ( await page.$( '.woocommerce-remove-coupon' ) ) ) {
+			await page.click( '.woocommerce-remove-coupon' );
+			await uiUnblocked();
+		}
+
+		await page.waitForSelector( '.cart-empty.woocommerce-info' );
+		await expect( page ).toMatchElement( '.cart-empty.woocommerce-info', {
+			text: 'Your cart is currently empty.',
+		} );
 	},
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR add the following changes:

* Removes `observeConsoleLogging()` from jest setup & replaced with `addConsoleSuppression` to reduce unwanted console logs & improve visibility of test summary.
* WooCommerce e2e-utils `emptyCart()` flow seems broken and was replaced with a new flow. Once the new flow works as expected, we can ship the changes to `e2e-utils` package.
* Refactored `shopper-checkout-purchase.spec.js` to reduce flakiness & added back to E2E workflow.
* Added missing teardowns to empty cart after each test suite is complete.

#### Testing instructions

* Trigger a new E2E workflow against this branch and confirm that the WCPay Shopper tests passes as expected.

-------------------

- [ ] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [x] QA Testing Not Applicable
