### PR TITLE
Fix disable unavailable payment methods returning associative array

### DIFF
--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -904,7 +904,9 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			)
 		);
 
-		return array_intersect( $methods, array_keys( $fees ) );
+		$methods_with_fees = array_values( array_intersect( $methods, array_keys( $fees ) ) );
+
+		return $methods_with_fees;
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After using `array_intersect` we could end with an associative array, so we need to use `array_values` to ensure it returns a plain array. Otherwise, we could end up having an error in the JS side trying to run `.map()` on an object.

#### Testing instructions
- Look for `COUNTRIES_WITH_GIROPAY` on the server and remove your Stripe's account country from it.
- Clear the account cache from WCPay Dev
- Go to **Payments > Settings**
- You shouldn't see any error notice in the payments methods section.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)