### PR TITLE
Phone number input with country code

### DIFF
--- a/client/components/platform-checkout/hooks/use-phone-number-validity.js
+++ b/client/components/platform-checkout/hooks/use-phone-number-validity.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useState } from 'react';
+
+// hook for checking the validity of phone number.
+const usePhoneNumberValidity = ( element, phoneNumber ) => {
+	const [ isValidNumber, setIsValidNumber ] = useState( false );
+
+	useEffect( () => {
+		const checkValidity = () => {
+			const instance = window.intlTelInputGlobals.getInstance( element );
+			setIsValidNumber( instance.isValidNumber() );
+		};
+
+		if ( element ) {
+			checkValidity();
+			element.addEventListener( 'countrychange', checkValidity );
+		}
+
+		return () => {
+			if ( element ) {
+				element.removeEventListener( 'countrychange', checkValidity );
+			}
+		};
+	}, [ element, phoneNumber ] );
+
+	return {
+		isValidNumber,
+	};
+};
+
+export default usePhoneNumberValidity;

--- a/client/components/platform-checkout/save-user/checkout-page-save-user.js
+++ b/client/components/platform-checkout/save-user/checkout-page-save-user.js
@@ -34,6 +34,7 @@ const CheckoutPageSaveUser = () => {
 			<CheckboxControl
 				checked={ isSaveDetailsChecked }
 				onChange={ setIsSaveDetailsChecked }
+				name="save_user_in_platform_checkout"
 				label={ __(
 					'Save my information for faster checkouts',
 					'woocommerce-payments'

--- a/client/components/platform-checkout/save-user/checkout-page-save-user.js
+++ b/client/components/platform-checkout/save-user/checkout-page-save-user.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { CheckboxControl, TextControl } from '@wordpress/components';
+import { CheckboxControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -13,11 +13,13 @@ import usePlatformCheckoutUser from '../hooks/use-platform-checkout-user';
 import useSelectedPaymentMethod from '../hooks/use-selected-payment-method';
 import AboutPlatformCheckout from './about-platform-checkout';
 import AdditionalInformation from './additional-information';
+import PhoneNumberInput from './phone-number-input';
 import Agreement from './agreement';
 import './style.scss';
 
 const CheckoutPageSaveUser = () => {
 	const [ isSaveDetailsChecked, setIsSaveDetailsChecked ] = useState( false );
+	// eslint-disable-next-line no-unused-vars
 	const [ phoneNumber, setPhoneNumber ] = useState( '' );
 	const { isRegisteredUser } = usePlatformCheckoutUser();
 	const { isWCPayChosen } = useSelectedPaymentMethod();
@@ -38,16 +40,13 @@ const CheckoutPageSaveUser = () => {
 				) }
 			/>
 			{ isSaveDetailsChecked && (
-				<div className="save-details-form place-order">
+				<div
+					className="save-details-form place-order"
+					data-testid="save-user-form"
+				>
 					<AboutPlatformCheckout />
-					<TextControl
-						type="text"
-						label={ __(
-							'Mobile phone number',
-							'woocommerce-payments'
-						) }
-						value={ phoneNumber }
-						onChange={ setPhoneNumber }
+					<PhoneNumberInput
+						handlePhoneNumberChange={ setPhoneNumber }
 					/>
 					<AdditionalInformation />
 					<Agreement />

--- a/client/components/platform-checkout/save-user/phone-number-input.js
+++ b/client/components/platform-checkout/save-user/phone-number-input.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect, useState } from 'react';
+import { TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import intlTelInput from 'intl-tel-input';
+
+/**
+ * Internal dependencies
+ */
+// eslint-disable-next-line import/no-unresolved
+import utils from 'iti/utils';
+
+const PhoneNumberInput = ( { handlePhoneNumberChange } ) => {
+	const [ inputValue, setInputValue ] = useState( '' );
+	const [ inputInstance, setInputInstance ] = useState( null );
+
+	const handlePhoneNumberInputChange = ( value = inputValue ) => {
+		setInputValue( value );
+		if ( inputInstance ) {
+			handlePhoneNumberChange( inputInstance.getNumber() );
+		}
+	};
+
+	useEffect( () => {
+		let iti = null;
+		const input = document.querySelector( '#phone-number' );
+
+		const handleCountryChange = () => {
+			handlePhoneNumberChange( iti.getNumber() );
+		};
+
+		if ( input ) {
+			iti = intlTelInput( input, {
+				initialCountry: 'US',
+				customPlaceholder: function ( selectedCountryPlaceholder ) {
+					return selectedCountryPlaceholder;
+				},
+				separateDialCode: true,
+				utilsScript: utils,
+			} );
+			setInputInstance( iti );
+
+			input.addEventListener( 'countrychange', handleCountryChange );
+		}
+
+		return () => {
+			if ( iti ) {
+				iti.destroy();
+				input.removeEventListener(
+					'countrychange',
+					handleCountryChange
+				);
+			}
+		};
+	}, [ handlePhoneNumberChange ] );
+
+	return (
+		<TextControl
+			type="tel"
+			id="phone-number"
+			label={ __( 'Mobile phone number', 'woocommerce-payments' ) }
+			value={ inputValue }
+			onChange={ handlePhoneNumberInputChange }
+		/>
+	);
+};
+
+export default PhoneNumberInput;

--- a/client/components/platform-checkout/save-user/phone-number-input.js
+++ b/client/components/platform-checkout/save-user/phone-number-input.js
@@ -25,7 +25,12 @@ const PhoneNumberInput = ( { handlePhoneNumberChange } ) => {
 
 	useEffect( () => {
 		let iti = null;
-		const input = document.querySelector( '#phone-number' );
+		const input = document.querySelector(
+			`input[aria-label="${ __(
+				'Mobile phone number',
+				'woocommerce-payments'
+			) }"]`
+		);
 
 		const handleCountryChange = () => {
 			handlePhoneNumberChange( iti.getNumber() );
@@ -59,7 +64,7 @@ const PhoneNumberInput = ( { handlePhoneNumberChange } ) => {
 	return (
 		<TextControl
 			type="tel"
-			id="phone-number"
+			aria-label={ __( 'Mobile phone number', 'woocommerce-payments' ) }
 			label={ __( 'Mobile phone number', 'woocommerce-payments' ) }
 			value={ inputValue }
 			onChange={ handlePhoneNumberInputChange }

--- a/client/components/platform-checkout/save-user/phone-number-input.js
+++ b/client/components/platform-checkout/save-user/phone-number-input.js
@@ -66,6 +66,7 @@ const PhoneNumberInput = ( { handlePhoneNumberChange } ) => {
 			type="tel"
 			aria-label={ __( 'Mobile phone number', 'woocommerce-payments' ) }
 			label={ __( 'Mobile phone number', 'woocommerce-payments' ) }
+			name="platform_checkout_user_phone_field"
 			value={ inputValue }
 			onChange={ handlePhoneNumberInputChange }
 		/>

--- a/client/components/platform-checkout/save-user/style.scss
+++ b/client/components/platform-checkout/save-user/style.scss
@@ -1,5 +1,6 @@
 @import '../../../stylesheets/abstracts/colors';
 @import '../../../stylesheets/abstracts/variables';
+@import '/node_modules/intl-tel-input/build/css/intlTelInput.css';
 
 .platform-checkout-save-new-user-container {
 	display: flex;
@@ -69,6 +70,54 @@
 	}
 }
 
+#phone-number {
+	height: 42px;
+	box-shadow: inset 0 1px #d6d6d6;
+	border: none;
+	font-size: 15px;
+	line-height: 26px;
+}
+
 #payment .place-order {
 	margin-top: $gap-large !important;
+}
+
+// compulsary overrides required for intl-tel-input
+.iti__flag {
+	background-image: url( '/node_modules/intl-tel-input/build/img/flags.png' );
+}
+
+@media ( -webkit-min-device-pixel-ratio: 2 ), ( min-resolution: 192dpi ) {
+	.iti__flag {
+		background-image: url( '/node_modules/intl-tel-input/build/img/flags@2x.png' );
+	}
+}
+
+// override intl-tel-input styles
+.iti {
+	width: 100%;
+}
+
+.iti__selected-flag {
+	background-color: inherit !important;
+
+	.iti__flag {
+		transform: scale( 1.1 );
+	}
+
+	.iti__selected-dial-code {
+		font-size: 16px;
+		color: $gray-800;
+	}
+
+	.iti__arrow {
+		border-left: 5px solid transparent;
+		border-right: 5px solid transparent;
+		border-top: 5px solid #2c3338;
+
+		&--up {
+			border-top: none;
+			border-bottom: 5px solid #2c3338;
+		}
+	}
 }

--- a/client/components/platform-checkout/save-user/test/checkout-page-save-user.test.js
+++ b/client/components/platform-checkout/save-user/test/checkout-page-save-user.test.js
@@ -88,7 +88,7 @@ describe( 'CheckoutPageSaveUser', () => {
 			)
 		).not.toBeChecked();
 		expect(
-			screen.queryByTestId( 'save-user-form' )
+			screen.queryByLabelText( 'Mobile phone number' )
 		).not.toBeInTheDocument();
 
 		// click on the checkbox
@@ -103,6 +103,8 @@ describe( 'CheckoutPageSaveUser', () => {
 				'Save my information for faster checkouts'
 			)
 		).toBeChecked();
-		expect( screen.queryByTestId( 'save-user-form' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByLabelText( 'Mobile phone number' )
+		).toBeInTheDocument();
 	} );
 } );

--- a/client/components/platform-checkout/save-user/test/checkout-page-save-user.test.js
+++ b/client/components/platform-checkout/save-user/test/checkout-page-save-user.test.js
@@ -88,7 +88,7 @@ describe( 'CheckoutPageSaveUser', () => {
 			)
 		).not.toBeChecked();
 		expect(
-			screen.queryByLabelText( 'Mobile phone number' )
+			screen.queryByTestId( 'save-user-form' )
 		).not.toBeInTheDocument();
 
 		// click on the checkbox
@@ -103,8 +103,6 @@ describe( 'CheckoutPageSaveUser', () => {
 				'Save my information for faster checkouts'
 			)
 		).toBeChecked();
-		expect(
-			screen.queryByLabelText( 'Mobile phone number' )
-		).toBeInTheDocument();
+		expect( screen.queryByTestId( 'save-user-form' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/components/platform-checkout/save-user/test/phone-number-input.test.js
+++ b/client/components/platform-checkout/save-user/test/phone-number-input.test.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import PhoneNumberInput from '../phone-number-input';
+
+describe( 'PhoneNumberInput', () => {
+	const handlePhoneNumberChangeMock = jest.fn();
+
+	it( 'should render phone number input', () => {
+		render(
+			<PhoneNumberInput
+				handlePhoneNumberChange={ handlePhoneNumberChangeMock }
+			/>
+		);
+		expect(
+			screen.queryByText( 'Mobile phone number' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render the default selected country with code', () => {
+		render(
+			<PhoneNumberInput
+				handlePhoneNumberChange={ handlePhoneNumberChangeMock }
+			/>
+		);
+		expect(
+			screen.queryByRole( 'combobox', { name: 'United States: +1' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should call the handlePhoneNumberChange with phone number including country code', () => {
+		render(
+			<PhoneNumberInput
+				handlePhoneNumberChange={ handlePhoneNumberChangeMock }
+			/>
+		);
+
+		expect( handlePhoneNumberChangeMock ).not.toHaveBeenCalled();
+
+		const input = screen.queryByPlaceholderText( '201-555-0123' ); // placeholder number for us
+		fireEvent.change( input, { target: { value: '201' } } );
+
+		expect( handlePhoneNumberChangeMock ).toHaveBeenCalledWith( '+1201' );
+	} );
+} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -21386,6 +21386,11 @@
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
+    "intl-tel-input": {
+      "version": "17.0.15",
+      "resolved": "https://registry.npmjs.org/intl-tel-input/-/intl-tel-input-17.0.15.tgz",
+      "integrity": "sha512-mhgx+JbF6f5AJoJXupcoX7Ocr6s6znnmATFI0YBUIDevFGRhlpSe+Iz/CmMuM4uFuzIr5dfBoaCvyFYtkaUczA=="
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@woocommerce/explat": "^1.0.1",
     "debug": "^4.1.1",
     "interpolate-components": "^1.1.1",
+    "intl-tel-input": "^17.0.15",
     "lodash": "^4.17.14",
     "wordpress-element": "npm:@wordpress/element@2.11.0"
   },

--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
 		'^moment$': '<rootDir>/node_modules/moment',
 		'^moment-timezone$': '<rootDir>/node_modules/moment-timezone',
 		'^wcpay(.*)$': '<rootDir>/client$1',
+		'^iti/utils$': '<rootDir>/node_modules/intl-tel-input/build/js/utils',
 	},
 	globalSetup: '<rootDir>/tests/js/jest-global-setup.js',
 	setupFiles: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,6 +97,10 @@ const webpackConfig = {
 		modules: [ path.join( __dirname, 'client' ), 'node_modules' ],
 		alias: {
 			wcpay: path.resolve( __dirname, 'client' ),
+			iti: path.resolve(
+				__dirname,
+				'node_modules/intl-tel-input/build/js'
+			),
 		},
 		fallback: {
 			crypto: require.resolve( 'crypto-browserify' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request

Description: 
Creates a phone number input field with country selector. The input field is implemented using the JS plugging `intl-tel-input` to show country dropdown and country code selection.

### Testing instructions
- Enable `_wcpay_feature_platform_checkout`
- Set short code version of the checkout page
- Return from `isRegisteredUser=false` from `client/components/platform-checkout/hooks/use-platform-checkout-user.js`
- Select card payment method
- Select the checkbox
- Phone number input field is present and supports country codes

![phone number](https://user-images.githubusercontent.com/33387139/150841789-4f7cba88-1e65-478b-9d66-bb441964e8e7.png)



-------------------

- [ ] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
