### PR TITLE
Add currency to Disputes export

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Currency name not translated the Overview card title.
 * Add - Introduce advance filters on disputes page.
 * Add - UPE payment methods - BECS Direct Debit.
+* Fix - Missing currency field in disputes export file.
 
 = 3.6.0 - 2022-01-20 =
 * Update - Bump minimum required version of WooCommerce from 4.4 to 4.5.

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -56,6 +56,12 @@ const getHeaders = ( sortColumn?: string ): DisputesTableHeader[] => [
 		isLeftAligned: true,
 	},
 	{
+		key: 'currency',
+		label: __( 'Currency', 'woocommerce-payments' ),
+		visible: false,
+		required: true,
+	},
+	{
 		key: 'status',
 		label: __( 'Status', 'woocommerce-payments' ),
 		screenReaderLabel: __( 'Status', 'woocommerce-payments' ),
@@ -161,6 +167,10 @@ export const DisputesList = (): JSX.Element => {
 					formatExplicitCurrency( dispute.amount, dispute.currency )
 				),
 			},
+			currency: {
+				value: dispute.currency,
+				display: clickable( dispute.currency ),
+			},
 			status: {
 				value: dispute.status,
 				display: clickable(
@@ -237,30 +247,30 @@ export const DisputesList = (): JSX.Element => {
 
 		const csvRows = rows.map( ( row ) => {
 			return [
-				...row.slice( 0, 2 ),
-				{
-					...row[ 2 ],
-					value: disputeStatusMapping[ row[ 2 ].value ?? '' ].message,
-				},
+				...row.slice( 0, 3 ),
 				{
 					...row[ 3 ],
-					value: formatStringValue(
-						( row[ 3 ].value ?? '' ).toString()
-					),
+					value: disputeStatusMapping[ row[ 3 ].value ?? '' ].message,
 				},
-				...row.slice( 4, 9 ),
 				{
-					...row[ 9 ],
-					value: dateI18n(
-						'Y-m-d',
-						moment( row[ 9 ].value ).toISOString()
+					...row[ 4 ],
+					value: formatStringValue(
+						( row[ 4 ].value ?? '' ).toString()
 					),
 				},
+				...row.slice( 5, 10 ),
 				{
 					...row[ 10 ],
 					value: dateI18n(
-						'Y-m-d / g:iA',
+						'Y-m-d',
 						moment( row[ 10 ].value ).toISOString()
+					),
+				},
+				{
+					...row[ 11 ],
+					value: dateI18n(
+						'Y-m-d / g:iA',
+						moment( row[ 11 ].value ).toISOString()
 					),
 				},
 			];

--- a/client/disputes/test/index.tsx
+++ b/client/disputes/test/index.tsx
@@ -169,6 +169,7 @@ describe( 'Disputes list', () => {
 			const expected = [
 				'"Dispute Id"',
 				'Amount',
+				'Currency',
 				'Status',
 				'Reason',
 				'Source',
@@ -202,8 +203,9 @@ describe( 'Disputes list', () => {
 
 			// Note:
 			//
-			// 1. CSV and display indexes are off by 1 because the first field in CSV is dispute id,
-			//    which is missing in display.
+			// 1. CSV and display indexes are off by 2 because:
+			// 		- the first field in CSV is dispute id, which is missing in display.
+			// 		- the third field in CSV is currency, which is missing in display (it's displayed in "amount" column).
 			//
 			// 2. The indexOf check in amount's expect is because the amount in CSV may not contain
 			//    trailing zeros as in the display amount.
@@ -214,23 +216,25 @@ describe( 'Disputes list', () => {
 				)
 			).not.toBe( -1 ); // amount
 
-			expect( csvFirstDispute[ 2 ] ).toBe(
+			expect( csvFirstDispute[ 2 ] ).toBe( 'usd' );
+
+			expect( csvFirstDispute[ 3 ] ).toBe(
 				`"${ displayFirstDispute[ 1 ] }"`
 			); //status
 
-			expect( csvFirstDispute[ 3 ] ).toBe( displayFirstDispute[ 2 ] ); // reason
+			expect( csvFirstDispute[ 4 ] ).toBe( displayFirstDispute[ 2 ] ); // reason
 
-			expect( csvFirstDispute[ 5 ] ).toBe( displayFirstDispute[ 4 ] ); // order
+			expect( csvFirstDispute[ 6 ] ).toBe( displayFirstDispute[ 4 ] ); // order
 
-			expect( csvFirstDispute[ 6 ] ).toBe(
+			expect( csvFirstDispute[ 7 ] ).toBe(
 				`"${ displayFirstDispute[ 5 ] }"`
 			); // customer
 
-			expect( formatDate( csvFirstDispute[ 9 ], 'Y-m-d' ) ).toBe(
+			expect( formatDate( csvFirstDispute[ 10 ], 'Y-m-d' ) ).toBe(
 				formatDate( displayFirstDispute[ 6 ], 'Y-m-d' )
 			); // date disputed on
 
-			expect( formatDate( csvFirstDispute[ 10 ], 'Y-m-d / g:iA' ) ).toBe(
+			expect( formatDate( csvFirstDispute[ 11 ], 'Y-m-d / g:iA' ) ).toBe(
 				formatDate( displayFirstDispute[ 7 ], 'Y-m-d / g:iA' )
 			); // date respond by
 		} );

--- a/client/types/disputes.d.ts
+++ b/client/types/disputes.d.ts
@@ -123,6 +123,7 @@ export interface DisputesTableHeader extends TableCardColumn {
 	key:
 		| 'details'
 		| 'amount'
+		| 'currency'
 		| 'status'
 		| 'reason'
 		| 'source'

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Currency name not translated the Overview card title.
 * Add - Introduce advance filters on disputes page.
 * Add - UPE payment methods - BECS Direct Debit.
+* Fix - Missing currency field in disputes export file.
 
 = 3.6.0 - 2022-01-20 =
 * Update - Bump minimum required version of WooCommerce from 4.4 to 4.5.


### PR DESCRIPTION
Fixes #3689 

#### Changes proposed in this Pull Request

Adds currency field to the Disputes export that is generated in the frontend. 

#### Testing instructions

1. Populate disputes list table
2. Press "Download" button
3. Check that the downloaded CSV export contains currency field

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

