### PR TITLE
Update `get_enabled_payment_method_currencies` to support more payment methods

### DIFF
--- a/includes/multi-currency/PaymentMethodsCompatibility.php
+++ b/includes/multi-currency/PaymentMethodsCompatibility.php
@@ -9,6 +9,7 @@ namespace WCPay\MultiCurrency;
 
 use WC_Payment_Gateway_WCPay;
 use WC_Payments_Features;
+use WCPay\Constants\Payment_Method;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -65,11 +66,9 @@ class PaymentMethodsCompatibility {
 				if ( in_array( $method, [ 'card', 'card_present' ], true ) ) {
 					return $result;
 				}
-				$class_key = $method;
-				if ( 'sepa_debit' === $method ) {
-					$class_key = 'sepa';
-				}
-				$class_name = '\\WCPay\\Payment_Methods\\' . ucfirst( strtolower( $class_key ) ) . '_Payment_Method';
+				$method_key = Payment_Method::search( $method );
+				$class_key  = ucfirst( strtolower( $method_key ? $method_key : $method ) );
+				$class_name = "\\WCPay\\Payment_Methods\\{$class_key}_Payment_Method";
 				if ( ! class_exists( $class_name ) ) {
 					return $result;
 				}

--- a/tests/unit/multi-currency/test-class-payment-methods-compatibility.php
+++ b/tests/unit/multi-currency/test-class-payment-methods-compatibility.php
@@ -121,8 +121,9 @@ class WCPay_Multi_Currency_Payment_Methods_Compatibility_Tests extends WP_UnitTe
 		);
 		$this->multi_currency_mock->expects( $this->atLeastOnce() )->method( 'get_available_currencies' )->willReturn(
 			[
-				'EUR' => new \WCPay\MultiCurrency\Currency( 'EUR' ),
 				'USD' => new \WCPay\MultiCurrency\Currency( 'USD' ),
+				'AUD' => new \WCPay\MultiCurrency\Currency( 'AUD' ),
+				'EUR' => new \WCPay\MultiCurrency\Currency( 'EUR' ),
 			]
 		);
 		$this->multi_currency_mock
@@ -132,6 +133,7 @@ class WCPay_Multi_Currency_Payment_Methods_Compatibility_Tests extends WP_UnitTe
 				$this->equalTo(
 					[
 						'USD',
+						'AUD',
 						'EUR',
 					]
 				)


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Update`get_enabled_payment_method_currencies` to look for a key in `Payment_Method` enum.

With the inclusion of more payment methods like ACH, BECS and Bacs, we will have more classes where their id doesn't match the name. So rather than adding more conditions like the SEPA one, we could rely on the `Payment_Method` enum to find the key that matches the class name.

#### Testing instructions
Tests should pass.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)