### PR TITLE
Limit the number of requests for rejected client

### DIFF
--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -51,6 +51,7 @@ const OverviewPage = () => {
 		'1' === queryParams[ 'wcpay-connection-success' ];
 
 	const showLoginError = '1' === queryParams[ 'wcpay-login-error' ];
+	const accountRejected = accountStatus.status.startsWith( 'rejected' );
 
 	const activeAccountFees = Object.entries( wcpaySettings.accountFees )
 		.map( ( [ key, value ] ) => {
@@ -103,9 +104,11 @@ const OverviewPage = () => {
 
 			<TestModeNotice topic={ topics.overview } />
 
-			<ErrorBoundary>
-				<DepositsInformation />
-			</ErrorBoundary>
+			{ ! accountRejected && (
+				<ErrorBoundary>
+					<DepositsInformation />
+				</ErrorBoundary>
+			) }
 
 			<ErrorBoundary>
 				<AccountStatus
@@ -113,17 +116,23 @@ const OverviewPage = () => {
 					accountFees={ activeAccountFees }
 				/>
 			</ErrorBoundary>
-			{ !! accountOverviewTaskList && 0 < tasks.length && ! isLoading && (
+			{ !! accountOverviewTaskList &&
+				0 < tasks.length &&
+				! isLoading &&
+				! accountRejected && (
+					<ErrorBoundary>
+						<TaskList
+							tasks={ tasks }
+							overviewTasksVisibility={ overviewTasksVisibility }
+						/>
+					</ErrorBoundary>
+				) }
+
+			{ ! accountRejected && (
 				<ErrorBoundary>
-					<TaskList
-						tasks={ tasks }
-						overviewTasksVisibility={ overviewTasksVisibility }
-					/>
+					<InboxNotifications />
 				</ErrorBoundary>
 			) }
-			<ErrorBoundary>
-				<InboxNotifications />
-			</ErrorBoundary>
 		</Page>
 	);
 };

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -212,6 +212,12 @@ class WC_Payments_Admin {
 			]
 		);
 
+		if ( $this->account->is_account_rejected() ) {
+			// If the account is rejected, only show the overview page.
+			wc_admin_register_page( $this->admin_child_pages['wc-payments-overview'] );
+			return;
+		}
+
 		if ( $should_render_full_menu ) {
 			if ( self::is_card_readers_page_enabled() && $this->account->is_card_present_eligible() ) {
 				$this->admin_child_pages['wc-payments-card-readers'] = [

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -111,6 +111,28 @@ class WC_Payments_Account {
 	}
 
 	/**
+	 * Checks if the account has been rejected, assumes the value of $on_error on server error.
+	 *
+	 * @param bool $on_error Value to return on server error, defaults to false.
+	 *
+	 * @return bool True if the account is rejected, false otherwise, $on_error on error.
+	 */
+	public function is_account_rejected( bool $on_error = false ): bool {
+		try {
+			$account = $this->get_cached_account_data();
+
+			if ( empty( $account ) ) {
+				// Empty means no account, so not rejected.
+				return false;
+			}
+
+			return strpos( $account['status'], 'rejected' ) === 0;
+		} catch ( Exception $e ) {
+			return $on_error;
+		}
+	}
+
+	/**
 	 * Checks if the account is connected, throws on server error.
 	 *
 	 * @return bool      True if the account is connected, false otherwise.

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -361,8 +361,8 @@ class MultiCurrency {
 			return $cache_data;
 		}
 
-		// If connection to server cannot be established, or if Stripe is not connected, return expired data or null.
-		if ( ! $this->payments_api_client->is_server_connected() || ! $this->payments_account->is_stripe_connected() ) {
+		// If connection to server cannot be established, or if Stripe is not connected, or if the account is rejected, return expired data or null.
+		if ( ! $this->payments_api_client->is_server_connected() || ! $this->payments_account->is_stripe_connected() || $this->payments_account->is_account_rejected() ) {
 			return $cache_data ?? null;
 		}
 

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -564,6 +564,24 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_get_cached_currencies_with_account_rejected() {
+		update_option( self::CACHED_CURRENCIES_OPTION, null );
+
+		$this->mock_account
+			->expects( $this->once() )
+			->method( 'is_account_rejected' )
+			->willReturn( true );
+
+		$this->mock_api_client
+			->expects( $this->never() )
+			->method( 'get_currency_rates' );
+
+		$this->assertEquals(
+			null,
+			$this->multi_currency->get_cached_currencies()
+		);
+	}
+
 	public function test_get_expired_cached_currencies_with_server_retrieval_error() {
 		$currency_cache            = $this->mock_cached_currencies;
 		$currency_cache['expires'] = strtotime( 'yesterday' );
@@ -874,10 +892,10 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		}
 	}
 
-	private function init_multi_currency( $mock_api_client = null, $wcpay_account_connected = true ) {
+	private function init_multi_currency( $mock_api_client = null, $wcpay_account_connected = true, $mock_account = null ) {
 		$this->mock_api_client = $this->createMock( WC_Payments_API_Client::class );
 
-		$this->mock_account = $this->createMock( WC_Payments_Account::class );
+		$this->mock_account = $mock_account ?? $this->createMock( WC_Payments_Account::class );
 		$this->mock_account->method( 'is_stripe_connected' )->willReturn( $wcpay_account_connected );
 
 		$this->mock_localization_service = $this->createMock( WC_Payments_Localization_Service::class );


### PR DESCRIPTION
Fixes 1539-gh-Automattic/woocommerce-payments-server

#### Changes proposed in this Pull Request

- When the account is rejected, only load the overview page with the status card

#### Testing instructions

- See the testing instructions in 1542-gh-Automattic/woocommerce-payments-server

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)