### PR TITLE
Add allow-plugins configuration to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,15 @@
     "config": {
       "platform": {
         "php": "7.1"
-      }
+      },
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/package-versions-deprecated": true,
+            "composer/installers": true,
+            "automattic/jetpack-autoloader": true,
+            "cweagans/composer-patches": true,
+            "kalessil/production-dependencies-guard": true
+        }
     },
     "require": {
       "php": "7.*",


### PR DESCRIPTION
Adds the allow-plugins property introduced in Composer 2.2

#### Changes proposed in this Pull Request
Composer 2.2.0 adds an `allow-plugins` property. Plugins that try and run that aren't included in this list throw up a prompt asking the developer to confirm they want the plugin to run.

This PR adds our existing plugins to the allowed list.

For reference, the [same change in the Stripe gateway](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2257).

#### Testing instructions
* Install Composer 2.2.0
* Run `composer install`
* Ensure no warnings are displayed