### PR TITLE
Saving Payments -> Settings fails because of the Card Readers settings validation along with E2E tests

### DIFF
--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -247,14 +247,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 			return $string_validation_result;
 		}
 
-		if ( '' === $value ) {
-			return new WP_Error(
-				'rest_invalid_pattern',
-				__( 'Error: Support email address is required!', 'woocommerce-payments' )
-			);
-		}
-
-		if ( ! is_email( $value ) ) {
+		if ( '' !== $value && ! is_email( $value ) ) {
 			return new WP_Error(
 				'rest_invalid_pattern',
 				__( 'Error: Invalid email address: ', 'woocommerce-payments' ) . $value
@@ -302,7 +295,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 			return $string_validation_result;
 		}
 
-		if ( '' !== $value && ! wp_http_validate_url( $value ) ) {
+		if ( '' !== $value && ! filter_var( $value, FILTER_VALIDATE_URL ) ) {
 			return new WP_Error(
 				'rest_invalid_pattern',
 				__( 'Error: Invalid business URL: ', 'woocommerce-payments' ) . $value
@@ -326,12 +319,14 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 			return $string_validation_result;
 		}
 
-		foreach ( $value as $field => $field_value ) {
-			if ( ! in_array( $field, [ 'city', 'country', 'line1', 'line2', 'postal_code', 'state' ], true ) ) {
-				return new WP_Error(
-					'rest_invalid_pattern',
-					__( 'Error: Invalid address format!', 'woocommerce-payments' )
-				);
+		if ( [] !== $value ) {
+			foreach ( $value as $field => $field_value ) {
+				if ( ! in_array( $field, [ 'city', 'country', 'line1', 'line2', 'postal_code', 'state' ], true ) ) {
+					return new WP_Error(
+						'rest_invalid_pattern',
+						__( 'Error: Invalid address format!', 'woocommerce-payments' )
+					);
+				}
 			}
 		}
 

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -571,7 +571,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		};
 		$updated_fields          = array_filter( $request->get_params(), $updated_fields_callback, ARRAY_FILTER_USE_BOTH );
 
-		return $this->wcpay_gateway->update_account_settings( $updated_fields );
+		$this->wcpay_gateway->update_account_settings( $updated_fields );
 	}
 
 	/**

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -581,7 +581,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WP_UnitTestCase {
 				'', // Empty value should trigger error.
 				$request,
 				'account_business_support_email',
-				new WP_Error( 'rest_invalid_pattern', 'Error: Support email address is required!' ),
+				true,
 			],
 			[
 				'test@test',
@@ -660,10 +660,10 @@ class WC_REST_Payments_Settings_Controller_Test extends WP_UnitTestCase {
 				true,
 			],
 			[
-				'http://test',
+				'test',
 				$request,
 				'account_business_url',
-				new WP_Error( 'rest_invalid_pattern', 'Error: Invalid business URL: http://test' ),
+				new WP_Error( 'rest_invalid_pattern', 'Error: Invalid business URL: test' ),
 			],
 		];
 	}


### PR DESCRIPTION
Fixes #3740  
Fixes #3737

#### Changes proposed in this Pull Request

- Fixing saving `Payments` -> `Settings` when the `business_email_address` setting field is not presented from Card Readers settings page.
- Fixing E2E tests. 

#### Testing instructions

- Go to Payments > Settings.
- Make a change to a setting.
- Attempt to save.
- Verify the saving is successful and the setting is updated.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)