### PR TITLE
Update subscriptions-core to `1.6.3`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,8 @@
 * Fix - Checkout with block-based themes.
 * Add - UPE payment method - EPS.
 * Fix - Redundant payment intents for UPE.
+* Fix - Replace uses of is_ajax() with wp_doing_ajax() in subscriptions-core.
+* Security update.
 
 = 3.6.1 - 2022-01-27 =
 * Fix - Remove packages not compatible with PHP 7.0

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
       "automattic/jetpack-autoloader": "2.10.11",
       "automattic/jetpack-identity-crisis": "0.7.0",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "1.6.2"
+      "woocommerce/subscriptions-core": "1.6.3"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9945c795139fa0f7590109e89cc9dca",
+    "content-hash": "17133e98dfa354883b3b054937d1a0ab",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -955,16 +955,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "1.6.2",
+            "version": "1.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "bc48cd0437fc4601643e72abc4a7cd9beffb35b5"
+                "reference": "dcb5a50c35b3bbba68984a3fedd6a128990a3cb3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/bc48cd0437fc4601643e72abc4a7cd9beffb35b5",
-                "reference": "bc48cd0437fc4601643e72abc4a7cd9beffb35b5",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/dcb5a50c35b3bbba68984a3fedd6a128990a3cb3",
+                "reference": "dcb5a50c35b3bbba68984a3fedd6a128990a3cb3",
                 "shasum": ""
             },
             "require": {
@@ -1006,10 +1006,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/1.6.2",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/1.6.3",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-01-19T13:46:30+00:00"
+            "time": "2022-02-07T01:32:45+00:00"
         }
     ],
     "packages-dev": [

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,8 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Checkout with block-based themes.
 * Add - UPE payment method - EPS.
 * Fix - Redundant payment intents for UPE.
+* Fix - Replace uses of is_ajax() with wp_doing_ajax() in subscriptions-core.
+* Security update.
 
 = 3.6.1 - 2022-01-27 =
 * Fix - Remove packages not compatible with PHP 7.0


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Load newer woocommerce-subscriptions-core's version, `1.6.3`.
- Add changes of woocommerce-subscriptions-core to the changelog.
- Updated `composer.lock` as a result of running `composer update woocommerce/subscriptions-core`.

#### Testing instructions

* Checkout this branch.
* [Husky hook should run `composer install`](https://github.com/Automattic/woocommerce-payments/blob/develop/.husky/post-checkout#L8) and your `vendor/woocommerce/subscriptions-core` should be updated to be `1.6.3`. Confirm that latest changes from `1.6.3` is present, for example, [vendor/woocommerce/subscriptions-core/changelog.txt is up-to-date](https://github.com/Automattic/woocommerce-subscriptions-core/blob/1.6.3/changelog.txt).

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)