### PR TITLE
Revert "Cache UPE intents for reuse (#3684)"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,7 +13,6 @@
 * Add - Implement Jetpack Identity Crisis / Safe Mode banner.
 * Fix - Checkout with block-based themes.
 * Add - UPE payment method - EPS.
-* Fix - Redundant payment intents for UPE.
 * Fix - Replace uses of is_ajax() with wp_doing_ajax() in subscriptions-core.
 * Improve handling of session data.
 

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -13,7 +13,6 @@ import WCPayAPI from '../api';
 import enqueueFraudScripts from 'fraud-scripts';
 import { getFontRulesFromPage, getAppearance } from '../upe-styles';
 import { getTerms } from '../utils/upe';
-import { getCookieValue } from '../../utils';
 import { handlePlatformCheckoutEmailInput } from '../utils/platform-checkout';
 
 jQuery( function ( $ ) {
@@ -24,9 +23,6 @@ jQuery( function ( $ ) {
 	const isUPEEnabled = getConfig( 'isUPEEnabled' );
 	const paymentMethodsConfig = getConfig( 'paymentMethodsConfig' );
 	const enabledBillingFields = getConfig( 'enabledBillingFields' );
-	const cookieCartHash = getConfig( 'cookieCartHash' );
-	const cookieUPEPaymentIntent = getConfig( 'cookieUPEPaymentIntent' );
-	const cookieUPESetupIntent = getConfig( 'cookieUPESetupIntent' );
 
 	if ( ! publishableKey ) {
 		// If no configuration is present, probably this is not the checkout page.
@@ -271,7 +267,7 @@ jQuery( function ( $ ) {
 	 *
 	 * @param {boolean} isSetupIntent {Boolean} isSetupIntent Set to true if we are on My Account adding a payment method.
 	 */
-	const mountUPEElement = async function ( isSetupIntent = false ) {
+	const mountUPEElement = function ( isSetupIntent = false ) {
 		// Do not mount UPE twice.
 		if ( upeElement || paymentIntentId ) {
 			return;
@@ -296,21 +292,73 @@ jQuery( function ( $ ) {
 			orderId = getConfig( 'orderId' );
 		}
 
-		let { intentId, clientSecret } = isSetupIntent
-			? getSetupIntentFromCookie()
-			: getPaymentIntentFromCookie();
+		const intentAction = isSetupIntent
+			? api.initSetupIntent()
+			: api.createIntent( orderId );
 
 		const $upeContainer = $( '#wcpay-upe-element' );
 		blockUI( $upeContainer );
 
-		if ( ! intentId ) {
-			try {
-				const newIntent = isSetupIntent
-					? await api.initSetupIntent()
-					: await api.createIntent( orderId );
-				intentId = newIntent.id;
-				clientSecret = newIntent.client_secret;
-			} catch ( error ) {
+		intentAction
+			.then( ( response ) => {
+				// I repeat, do NOT mount UPE twice.
+				if ( upeElement || paymentIntentId ) {
+					unblockUI( $upeContainer );
+					return;
+				}
+
+				const { client_secret: clientSecret, id: id } = response;
+				paymentIntentId = id;
+
+				let appearance = getConfig( 'upeAppearance' );
+
+				if ( ! appearance ) {
+					hiddenElementsForUPE.init();
+					appearance = getAppearance();
+					hiddenElementsForUPE.cleanup();
+					api.saveUPEAppearance( appearance );
+				}
+
+				elements = api.getStripe().elements( {
+					clientSecret,
+					appearance,
+					fonts: getFontRulesFromPage(),
+				} );
+
+				const upeSettings = {};
+				if ( getConfig( 'cartContainsSubscription' ) ) {
+					upeSettings.terms = getTerms(
+						paymentMethodsConfig,
+						'always'
+					);
+				}
+				if ( isCheckout && ! ( isOrderPay || isChangingPayment ) ) {
+					upeSettings.fields = {
+						billingDetails: hiddenBillingFields,
+					};
+				}
+
+				upeElement = elements.create( 'payment', {
+					...upeSettings,
+					wallets: {
+						applePay: 'never',
+						googlePay: 'never',
+					},
+				} );
+				upeElement.mount( '#wcpay-upe-element' );
+				unblockUI( $upeContainer );
+				upeElement.on( 'change', ( event ) => {
+					const selectedUPEPaymentType = event.value.type;
+					const isPaymentMethodReusable =
+						paymentMethodsConfig[ selectedUPEPaymentType ]
+							.isReusable;
+					showNewPaymentMethodCheckbox( isPaymentMethodReusable );
+					setSelectedUPEPaymentType( selectedUPEPaymentType );
+					setPaymentCountry( event.value.country );
+					isUPEComplete = event.complete;
+				} );
+			} )
+			.catch( ( error ) => {
 				unblockUI( $upeContainer );
 				showError( error.message );
 				const gatewayErrorMessage =
@@ -318,60 +366,7 @@ jQuery( function ( $ ) {
 				$( '.payment_box.payment_method_woocommerce_payments' ).html(
 					gatewayErrorMessage
 				);
-			}
-		}
-
-		// I repeat, do NOT mount UPE twice.
-		if ( upeElement || paymentIntentId ) {
-			unblockUI( $upeContainer );
-			return;
-		}
-
-		paymentIntentId = intentId;
-
-		let appearance = getConfig( 'upeAppearance' );
-
-		if ( ! appearance ) {
-			hiddenElementsForUPE.init();
-			appearance = getAppearance();
-			hiddenElementsForUPE.cleanup();
-			api.saveUPEAppearance( appearance );
-		}
-
-		elements = api.getStripe().elements( {
-			clientSecret,
-			appearance,
-			fonts: getFontRulesFromPage(),
-		} );
-
-		const upeSettings = {};
-		if ( getConfig( 'cartContainsSubscription' ) ) {
-			upeSettings.terms = getTerms( paymentMethodsConfig, 'always' );
-		}
-		if ( isCheckout && ! ( isOrderPay || isChangingPayment ) ) {
-			upeSettings.fields = {
-				billingDetails: hiddenBillingFields,
-			};
-		}
-
-		upeElement = elements.create( 'payment', {
-			...upeSettings,
-			wallets: {
-				applePay: 'never',
-				googlePay: 'never',
-			},
-		} );
-		upeElement.mount( '#wcpay-upe-element' );
-		unblockUI( $upeContainer );
-		upeElement.on( 'change', ( event ) => {
-			const selectedUPEPaymentType = event.value.type;
-			const isPaymentMethodReusable =
-				paymentMethodsConfig[ selectedUPEPaymentType ].isReusable;
-			showNewPaymentMethodCheckbox( isPaymentMethodReusable );
-			setSelectedUPEPaymentType( selectedUPEPaymentType );
-			setPaymentCountry( event.value.country );
-			isUPEComplete = event.complete;
-		} );
+			} );
 	};
 
 	const renameGatewayTitle = () =>
@@ -659,41 +654,6 @@ jQuery( function ( $ ) {
 			$( '#wc-woocommerce_payments-payment-token-new' ).length &&
 			! $( '#wc-woocommerce_payments-payment-token-new' ).is( ':checked' )
 		);
-	}
-
-	/**
-	 * Returns the cached payment intent for the current cart state.
-	 *
-	 * @return {Object} The intent id and client secret required for mounting the UPE element.
-	 */
-	function getPaymentIntentFromCookie() {
-		const cartHash = getCookieValue( cookieCartHash );
-		const cookieVal = getCookieValue( cookieUPEPaymentIntent );
-
-		if ( cartHash && cookieVal && cookieVal.startsWith( cartHash ) ) {
-			const intentId = cookieVal.split( '-' )[ 1 ];
-			const clientSecret = cookieVal.split( '-' )[ 2 ];
-			return { intentId, clientSecret };
-		}
-
-		return {};
-	}
-
-	/**
-	 * Returns the cached setup intent.
-	 *
-	 * @return {Object} The intent id and client secret required for mounting the UPE element.
-	 */
-	function getSetupIntentFromCookie() {
-		const cookieVal = getCookieValue( cookieUPESetupIntent );
-
-		if ( cookieVal ) {
-			const intentId = cookieVal.split( '-' )[ 0 ];
-			const clientSecret = cookieVal.split( '-' )[ 1 ];
-			return { intentId, clientSecret };
-		}
-
-		return {};
 	}
 
 	// Handle the checkout form when WooCommerce Payments is chosen.

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -96,14 +96,3 @@ export const formatDateValue = ( date, upperBound = false ) => {
 		)
 	);
 };
-
-/**
- * Returns the value of the given cookie.
- *
- * @param {string} name Name of the cookie.
- *
- * @return {string} Value of the given cookie. Empty string if cookie doesn't exist.
- */
-export const getCookieValue = ( name ) =>
-	document.cookie.match( '(^|;)\\s*' + name + '\\s*=\\s*([^;]+)' )?.pop() ||
-	'';

--- a/client/utils/test/index.js
+++ b/client/utils/test/index.js
@@ -3,31 +3,12 @@
 /**
  * Internal dependencies
  */
-import { getCookieValue, getPaymentMethodSettingsUrl } from '../index';
+import { getPaymentMethodSettingsUrl } from '../index';
 
 describe( 'Utilities', () => {
 	test( 'payment method settings link matches expected', () => {
 		expect( getPaymentMethodSettingsUrl( 'foo' ) ).toEqual(
 			'admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments&method=foo'
 		);
-	} );
-
-	describe( 'getCookieValue', () => {
-		beforeAll( () => {
-			Object.defineProperty( document, 'cookie', {
-				writable: true,
-				value: 'some_cookie=a_value',
-			} );
-		} );
-
-		it( 'returns the value of an existing cookie', () => {
-			const val = getCookieValue( 'some_cookie' );
-			expect( val ).toEqual( 'a_value' );
-		} );
-
-		it( 'returns empty string for a non-existant cookie', () => {
-			const val = getCookieValue( 'ghost_cookie' );
-			expect( val ).toEqual( '' );
-		} );
 	} );
 } );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -16,7 +16,6 @@ use WCPay\Constants\Payment_Type;
 use WCPay\Constants\Payment_Initiated_By;
 use WCPay\Constants\Payment_Capture_Type;
 use WCPay\Tracker;
-use WCPay\Payment_Methods\UPE_Payment_Gateway;
 
 /**
  * Gateway class for WooCommerce Payments
@@ -833,8 +832,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				);
 			}
 
-			UPE_Payment_Gateway::remove_upe_payment_intent_cookie();
-
 			$payment_information = $this->prepare_payment_information( $order );
 			return $this->process_payment_for_order( WC()->cart, $payment_information );
 		} catch ( Exception $e ) {
@@ -899,8 +896,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				);
 				$order->add_order_note( $note );
 			}
-
-			UPE_Payment_Gateway::remove_upe_payment_intent_cookie();
 
 			// Re-throw the exception after setting everything up.
 			// This makes the error notice show up both in the regular and block checkout.

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -46,14 +46,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 	const UPE_APPEARANCE_TRANSIENT = 'wcpay_upe_appearance';
 
-	const COOKIE_UPE_PAYMENT_INTENT = 'wcpay_upe_payment_intent';
-
-	const COOKIE_UPE_SETUP_INTENT = 'wcpay_upe_setup_intent';
-
-	const COOKIE_UPE_EXPIRES_IN_MINS = 10;
-
-	const COOKIE_CART_HASH = 'woocommerce_cart_hash'; // maintained in WC core.
-
 	/**
 	 * Array mapping payment method string IDs to classes
 	 *
@@ -98,9 +90,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		add_action( 'switch_theme', [ $this, 'clear_upe_appearance_transient' ] );
 
 		add_action( 'wp', [ $this, 'maybe_process_upe_redirect' ] );
-
-		add_action( 'woocommerce_order_payment_status_changed', [ 'WCPay\Payment_Methods\UPE_Payment_Gateway', 'remove_upe_payment_intent_cookie' ], 10, 0 );
-		add_action( 'woocommerce_after_account_payment_methods', [ $this, 'remove_upe_setup_intent_cookie' ], 10, 0 );
 
 		if ( ! is_admin() ) {
 			add_filter( 'woocommerce_gateway_title', [ $this, 'maybe_filter_gateway_title' ], 10, 2 );
@@ -233,15 +222,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			// If paying from order, we need to get the total from the order instead of the cart.
 			$order_id = isset( $_POST['wcpay_order_id'] ) ? absint( $_POST['wcpay_order_id'] ) : null;
 
-			// Create a new intent.
-			$response = $this->create_payment_intent( $order_id );
-
-			// Cache the intent id in cookie.
-			if ( strpos( $response['id'], 'pi_' ) === 0 ) { // response is a payment intent (could possibly be a setup intent).
-				$this->create_upe_payment_intent_cookie( $response['id'], $response['client_secret'] );
-			}
-
-			wp_send_json_success( $response, 200 );
+			wp_send_json_success( $this->create_payment_intent( $order_id ), 200 );
 		} catch ( Exception $e ) {
 			// Send back error so it can be displayed to the customer.
 			wp_send_json_error(
@@ -334,13 +315,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 				);
 			}
 
-			// Create a new intent.
-			$response = $this->create_setup_intent();
-
-			// Cache the intent id in cookie.
-			$this->create_upe_setup_intent_cookie( $response['id'], $response['client_secret'] );
-
-			wp_send_json_success( $response, 200 );
+			wp_send_json_success( $this->create_setup_intent(), 200 );
 		} catch ( Exception $e ) {
 			// Send back error so it can be displayed to the customer.
 			wp_send_json_error(
@@ -627,8 +602,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 				$this->update_order_status_from_intent( $order, $intent_id, $status, $charge_id, $currency );
 				$this->set_payment_method_title_for_order( $order, $payment_method_type, $payment_method_details );
 
-				self::remove_upe_payment_intent_cookie();
-
 				if ( 'requires_action' === $status ) {
 					// I don't think this case should be possible, but just in case...
 					$next_action = $intent->get_next_action();
@@ -654,8 +627,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			/* translators: localized exception message */
 			$order->update_status( 'failed', sprintf( __( 'UPE payment failed: %s', 'woocommerce-payments' ), $e->getMessage() ) );
 
-			self::remove_upe_payment_intent_cookie();
-
 			wc_add_notice( WC_Payments_Utils::get_filtered_error_message( $e ), 'error' );
 			wp_safe_redirect( wc_get_checkout_url() );
 			exit;
@@ -680,9 +651,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		$payment_fields['checkoutTitle']            = $this->checkout_title;
 		$payment_fields['cartContainsSubscription'] = $this->is_subscription_item_in_cart();
 		$payment_fields['logPaymentErrorNonce']     = wp_create_nonce( 'wcpay_log_payment_error_nonce' );
-		$payment_fields['cookieCartHash']           = self::COOKIE_CART_HASH;
-		$payment_fields['cookieUPEPaymentIntent']   = self::COOKIE_UPE_PAYMENT_INTENT;
-		$payment_fields['cookieUPESetupIntent']     = self::COOKIE_UPE_SETUP_INTENT;
 
 		$enabled_billing_fields = [];
 		foreach ( WC()->checkout()->get_checkout_fields( 'billing' ) as $billing_field => $billing_field_options ) {
@@ -1103,12 +1071,8 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			}
 			$order->add_order_note( $order_note );
 
-			self::remove_upe_payment_intent_cookie();
-
 			wp_send_json_success();
 		} catch ( Exception $e ) {
-			self::remove_upe_payment_intent_cookie();
-
 			wp_send_json_error(
 				[
 					'error' => [
@@ -1116,59 +1080,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 					],
 				]
 			);
-		}
-	}
-
-	/**
-	 * Creates a cookie to store the id and client secret of payment intent needed to mount the UPE element in frontend.
-	 *
-	 * An intent is tied to the cart's current state. New or removed items will likely impact the cart value,
-	 * necessitating the creation of a new intent with the revised cart value.
-	 * So a new cookie is expected to be created whenever the cart is modified.
-	 *
-	 * @param string $intent_id     The payment intent id.
-	 * @param string $client_secret The payment intent client secret.
-	 */
-	private function create_upe_payment_intent_cookie( string $intent_id = '', string $client_secret = '' ) {
-		$cart_hash = 'undefined';
-
-		if ( isset( $_COOKIE[ self::COOKIE_CART_HASH ] ) ) {
-			$cart_hash = sanitize_text_field( wp_unslash( $_COOKIE[ self::COOKIE_CART_HASH ] ) );
-		}
-
-		$cookie_val = $cart_hash . '-' . $intent_id . '-' . $client_secret;
-
-		wc_setcookie( self::COOKIE_UPE_PAYMENT_INTENT, $cookie_val, time() + MINUTE_IN_SECONDS * self::COOKIE_UPE_EXPIRES_IN_MINS );
-	}
-
-	/**
-	 * Creates a cookie to store the id and client secret of setup intent needed to mount the UPE element in frontend.
-	 *
-	 * @param string $intent_id     The setup intent id.
-	 * @param string $client_secret The setup intent client secret.
-	 */
-	private function create_upe_setup_intent_cookie( string $intent_id = '', string $client_secret = '' ) {
-		$cookie_val = $intent_id . '-' . $client_secret;
-		wc_setcookie( self::COOKIE_UPE_SETUP_INTENT, $cookie_val, time() + MINUTE_IN_SECONDS * self::COOKIE_UPE_EXPIRES_IN_MINS );
-	}
-
-	/**
-	 * Removes the payment intent cookie created for UPE.
-	 */
-	public static function remove_upe_payment_intent_cookie() {
-		if ( isset( $_COOKIE[ self::COOKIE_UPE_PAYMENT_INTENT ] ) ) {
-			unset( $_COOKIE[ self::COOKIE_UPE_PAYMENT_INTENT ] );
-			wc_setcookie( self::COOKIE_UPE_PAYMENT_INTENT, '', time() - HOUR_IN_SECONDS );
-		}
-	}
-
-	/**
-	 * Removes the payment setup intent cookie created for UPE.
-	 */
-	public function remove_upe_setup_intent_cookie() {
-		if ( isset( $_COOKIE[ self::COOKIE_UPE_SETUP_INTENT ] ) ) {
-			unset( $_COOKIE[ self::COOKIE_UPE_SETUP_INTENT ] );
-			wc_setcookie( self::COOKIE_UPE_SETUP_INTENT, '', time() - HOUR_IN_SECONDS );
 		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,6 @@ Please note that our support for the checkout block is still experimental and th
 * Add - Implement Jetpack Identity Crisis / Safe Mode banner.
 * Fix - Checkout with block-based themes.
 * Add - UPE payment method - EPS.
-* Fix - Redundant payment intents for UPE.
 * Fix - Replace uses of is_ajax() with wp_doing_ajax() in subscriptions-core.
 * Improve handling of session data.
 


### PR DESCRIPTION
This reverts commit 06f61ac608e305fa0a270970fcb3442868835769.

#### Changes proposed in this Pull Request
Context: p1644227430507589/1643853625.301609-slack-CGGCLBN58

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_