### PR TITLE
Refactor the check for rejected account 

### DIFF
--- a/changelog/tweak-rejected-acct
+++ b/changelog/tweak-rejected-acct
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -116,34 +116,6 @@ class WC_Payments_Account {
 	}
 
 	/**
-	 * Checks if the account has been rejected, assumes the value of $on_error on any account retrieval error.
-	 * Returns false if the account is not connected.
-	 *
-	 * @param bool $on_error Value to return on server error, defaults to false.
-	 *
-	 * @return bool True if the account is connected and rejected, false otherwise, $on_error on error.
-	 */
-	public function is_account_rejected( bool $on_error = false ): bool {
-		try {
-			$account = $this->get_cached_account_data();
-
-			if ( false === $account ) {
-				// False means error.
-				return $on_error;
-			}
-
-			if ( is_array( $account ) && empty( $account ) ) {
-				// Empty array means no account, so not rejected.
-				return false;
-			}
-
-			return strpos( $account['status'] ?? '', 'rejected' ) === 0;
-		} catch ( Exception $e ) {
-			return $on_error;
-		}
-	}
-
-	/**
 	 * Checks if the account is connected, throws on server error.
 	 *
 	 * @return bool      True if the account is connected, false otherwise.
@@ -157,6 +129,21 @@ class WC_Payments_Account {
 
 		// The empty array indicates that account is not connected yet.
 		return [] !== $account;
+	}
+
+	/**
+	 * Checks if the account has been rejected, assumes the value of false on any account retrieval error.
+	 * Returns false if the account is not connected.
+	 *
+	 * @return bool True if the account is connected and rejected, false otherwise or on error.
+	 */
+	public function is_account_rejected(): bool {
+		if ( ! $this->is_stripe_connected() ) {
+			return false;
+		}
+
+		$account = $this->get_cached_account_data();
+		return strpos( $account['status'] ?? '', 'rejected' ) === 0;
 	}
 
 	/**

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -128,7 +128,7 @@ class WC_Payments_Account {
 
 			if ( empty( $account ) ) {
 				// Empty means no account, so not rejected.
-				return false;
+				return $on_error;
 			}
 
 			return strpos( $account['status'], 'rejected' ) === 0;

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -116,11 +116,12 @@ class WC_Payments_Account {
 	}
 
 	/**
-	 * Checks if the account has been rejected, assumes the value of $on_error on server error.
+	 * Checks if the account has been rejected, assumes the value of $on_error on any account retrieval error.
+	 * Returns false if the account is not connected.
 	 *
 	 * @param bool $on_error Value to return on server error, defaults to false.
 	 *
-	 * @return bool True if the account is rejected, false otherwise, $on_error on error.
+	 * @return bool True if the account is connected and rejected, false otherwise, $on_error on error.
 	 */
 	public function is_account_rejected( bool $on_error = false ): bool {
 		try {

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -126,12 +126,17 @@ class WC_Payments_Account {
 		try {
 			$account = $this->get_cached_account_data();
 
-			if ( empty( $account ) ) {
-				// Empty means no account, so not rejected.
+			if ( false === $account ) {
+				// False means error.
 				return $on_error;
 			}
 
-			return strpos( $account['status'], 'rejected' ) === 0;
+			if ( is_array( $account ) && empty( $account ) ) {
+				// Empty array means no account, so not rejected.
+				return false;
+			}
+
+			return strpos( $account['status'] ?? '', 'rejected' ) === 0;
 		} catch ( Exception $e ) {
 			return $on_error;
 		}

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -409,6 +409,47 @@ class WC_Payments_Account_Test extends WP_UnitTestCase {
 		remove_filter( 'wcpay_dev_mode', '__return_true' );
 	}
 
+	public function test_is_account_rejected_returns_true() {
+		$this->mock_api_client->expects( $this->once() )->method( 'get_account_data' )->willReturn(
+			[
+				'account_id'               => 'acc_test',
+				'live_publishable_key'     => 'pk_test_',
+				'test_publishable_key'     => 'pk_live_',
+				'has_pending_requirements' => true,
+				'current_deadline'         => 12345,
+				'is_live'                  => false,
+				'status'                   => 'rejected.tos',
+			]
+		);
+
+		$this->assertTrue( $this->wcpay_account->is_account_rejected() );
+	}
+
+	public function test_is_account_rejected_returns_false_when_not_rejected() {
+		$this->mock_api_client->expects( $this->once() )->method( 'get_account_data' )->willReturn(
+			[
+				'account_id'               => 'acc_test',
+				'live_publishable_key'     => 'pk_test_',
+				'test_publishable_key'     => 'pk_live_',
+				'has_pending_requirements' => true,
+				'current_deadline'         => 12345,
+				'is_live'                  => false,
+				'status'                   => 'complete',
+			]
+		);
+
+		$this->assertFalse( $this->wcpay_account->is_account_rejected() );
+	}
+
+	public function test_is_account_rejected_returns_false_on_error() {
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_account_data' )
+			->willThrowException( new API_Exception( 'test', 'wcpay_mock', 500 ) );
+
+		$this->assertFalse( $this->wcpay_account->is_account_rejected() );
+	}
+
 	public function test_refresh_account_data_with_empty_cache() {
 		$expected_account = [
 			'account_id'               => 'acc_test',

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -417,7 +417,7 @@ class WC_Payments_Account_Test extends WP_UnitTestCase {
 				'test_publishable_key'     => 'pk_live_',
 				'has_pending_requirements' => true,
 				'current_deadline'         => 12345,
-				'is_live'                  => false,
+				'is_live'                  => true,
 				'status'                   => 'rejected.tos',
 			]
 		);
@@ -433,7 +433,7 @@ class WC_Payments_Account_Test extends WP_UnitTestCase {
 				'test_publishable_key'     => 'pk_live_',
 				'has_pending_requirements' => true,
 				'current_deadline'         => 12345,
-				'is_live'                  => false,
+				'is_live'                  => true,
 				'status'                   => 'complete',
 			]
 		);


### PR DESCRIPTION
See https://github.com/Automattic/woocommerce-payments/pull/3720/files#r799667133

#### Changes proposed in this Pull Request

- Check if the stripe is connected before checking for the rejected status
- On error, always return false, remove the `on_error` arg
- Add some tests

#### Testing instructions

* Unit tests should pass, it's a one line change otherwise, where we always expected `false` as the returned value

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- QA Testing Not Applicable
