### PR TITLE
Add tool for deletion of non-onboarded accounts

### DIFF
--- a/includes/admin/class-wc-payments-admin-sections-overwrite.php
+++ b/includes/admin/class-wc-payments-admin-sections-overwrite.php
@@ -51,7 +51,7 @@ class WC_Payments_Admin_Sections_Overwrite {
 	 * @return bool
 	 */
 	public function is_account_disconnected() {
-		return empty( $this->account->get_cached_account_data() );
+		return ! $this->account->is_account_onboarded();
 	}
 
 	/**

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1292,4 +1292,12 @@ class WC_Payments_Account {
 		$action_time = time() + ( 2 * HOUR_IN_SECONDS );
 		$action_scheduler_service->schedule_job( $action_time, $action_hook );
 	}
+
+	/**
+	 * Deletes Stripe account that hasn't completed onboarding, if any.
+	 */
+	public function delete_non_onboarded_account() {
+		$this->payments_api_client->delete_non_onboarded_account();
+		$this->clear_cache();
+	}
 }

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -127,8 +127,20 @@ class WC_Payments_Account {
 			throw new Exception( __( 'Failed to detect connection status', 'woocommerce-payments' ) );
 		}
 
+		return $this->is_account_onboarded();
+	}
+
+	/**
+	 * Checks if the account has finished onboarding.
+	 *
+	 * @return bool True if the account is onboarded, false otherwise.
+	 */
+	public function is_account_onboarded() {
+		$account = $this->get_cached_account_data();
+
 		// The empty array indicates that account is not connected yet.
-		return [] !== $account;
+		// If non-empty account has no status, can assume already onboarded for legacy reasons.
+		return ! empty( $account ) && ( $account['status'] ?? null ) !== 'onboarding';
 	}
 
 	/**

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -475,7 +475,7 @@ class WC_Payments_Account {
 			update_option( 'wcpay_should_redirect_to_onboarding', false );
 		}
 
-		if ( ! empty( $account ) ) {
+		if ( $this->is_account_onboarded() ) {
 			// Do not redirect if connected.
 			return false;
 		}

--- a/includes/class-wc-payments-status.php
+++ b/includes/class-wc-payments-status.php
@@ -53,6 +53,16 @@ class WC_Payments_Status {
 			'desc'     => __( 'This tool will clear the account cached values used in WooCommerce Payments.', 'woocommerce-payments' ),
 			'callback' => [ $this->account, 'refresh_account_data' ],
 		];
+
+		if ( ! empty( $this->account->get_cached_account_data() ) && ! $this->account->is_account_onboarded() ) {
+			$tools['delete_non_onboarded_wcpay_account'] = [
+				'name'     => __( 'Delete WooCommerce Payments account', 'woocommerce-payments' ),
+				'button'   => __( 'Delete', 'woocommerce-payments' ),
+				'desc'     => __( 'This tool will delete your WooCommerce Payments account and allow account setup to be restarted.', 'woocommerce-payments' ),
+				'callback' => [ $this->account, 'delete_non_onboarded_account' ],
+			];
+		}
+
 		return $tools;
 	}
 

--- a/includes/migrations/class-update-service-data-from-server.php
+++ b/includes/migrations/class-update-service-data-from-server.php
@@ -39,10 +39,9 @@ class Update_Service_Data_From_Server {
 	 * Checks whether it's worth doing the migration.
 	 */
 	public function maybe_migrate() {
-		$account_data = $this->account->get_cached_account_data();
 		// no need to migrate anything, maybe the site is disconnected.
 		// the plugin will eventually fetch new account data.
-		if ( empty( $account_data ) ) {
+		if ( ! $this->account->is_account_onboarded() ) {
 			return;
 		}
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -998,6 +998,13 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Delete Stripe account
+	 */
+	public function delete_non_onboarded_account() {
+		$this->request( [], self::ACCOUNTS_API, self::DELETE, true, true );
+	}
+
+	/**
 	 * Request capability activation from the server
 	 *
 	 * @param   string $capability_id  Capability ID.

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -322,6 +322,42 @@ class WC_Payments_Account_Test extends WP_UnitTestCase {
 		$this->assertFalse( $this->wcpay_account->is_stripe_connected( false ) );
 	}
 
+	public function test_is_account_onboarded_returns_true_if_no_longer_onboarding() {
+		$this->mock_api_client->expects( $this->once() )->method( 'get_account_data' )->will(
+			$this->returnValue(
+				[
+					'account_id' => 'acc_test',
+					'is_live'    => true,
+					'status'     => 'complete',
+				]
+			)
+		);
+
+		$this->assertTrue( $this->wcpay_account->is_account_onboarded() );
+	}
+
+	public function test_is_account_onboarded_returns_true_if_not_finished_onboarding() {
+		$this->mock_api_client->expects( $this->once() )->method( 'get_account_data' )->will(
+			$this->returnValue(
+				[
+					'account_id' => 'acc_test',
+					'is_live'    => true,
+					'status'     => 'onboarding',
+				]
+			)
+		);
+
+		$this->assertFalse( $this->wcpay_account->is_account_onboarded() );
+	}
+
+	public function test_is_account_onboarded_returns_true_if_no_account() {
+		$this->mock_api_client->expects( $this->once() )->method( 'get_account_data' )->will(
+			$this->throwException( new API_Exception( 'test', 'wcpay_account_not_found', 401 ) )
+		);
+
+		$this->assertFalse( $this->wcpay_account->is_account_onboarded() );
+	}
+
 	public function test_get_publishable_key_returns_for_live() {
 		$this->mock_api_client->expects( $this->once() )->method( 'get_account_data' )->will(
 			$this->returnValue(


### PR DESCRIPTION

Depends on 1595-gh-Automattic/woocommerce-payments-server for functionality but can be shipped without it.

#### Changes proposed in this Pull Request

<img width="1133" alt="delete-wcpay-account-tool" src="https://user-images.githubusercontent.com/1867547/153428195-d6f1dbca-bdab-41e9-8ab3-3588de02c167.png">

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With no account linked, navigate to WooCommerce » Status » Tools and verify that "Delete WooCommerce Payments account" tool does not appear
* Initiate onboarding from the setup screen or dev tools (after setting plugin `Version` header above 10.0.0)
* In Stripe's KYC, select business type and country and proceed (after which they are never asked again)
* Return to WP Admin, navigate again to WooCommerce » Status » Tools, and verify that "Delete WooCommerce Payments account" appears
* Can verify that an account is cached at this point, despite onboarding not being completed
  * Can also verify that nothing else is affected by the account cache change in this state
* Action "Delete"
  * Verify redirect to "Finish setup" screen
  * Can verify that no account is cached at this point
* Initiate onboarding again, and verify that business type and country are asked (since it is a new account)

-------------------

- [ ] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_