### PR TITLE
Use inline scripts instead of localizations for checkout

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -732,11 +732,24 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		try {
 			$display_tokenization = $this->supports( 'tokenization' ) && ( is_checkout() || is_add_payment_method_page() );
 
-			add_action( 'wp_footer', [ $this, 'enqueue_payment_scripts' ] );
+			wp_add_inline_script(
+				'WCPAY_CHECKOUT',
+				sprintf(
+					'window.wcpay_config = %s;',
+					wp_json_encode( $this->get_payment_fields_js_config() )
+				)
+			);
+			wp_enqueue_script( 'WCPAY_CHECKOUT' );
 
 			$prepared_customer_data = $this->get_prepared_customer_data();
 			if ( ! empty( $prepared_customer_data ) ) {
-				wp_localize_script( 'WCPAY_CHECKOUT', 'wcpayCustomerData', $prepared_customer_data );
+				wp_add_inline_script(
+					'WCPAY_CHECKOUT',
+					sprintf(
+						'window.wcpayCustomerData = %s;',
+						wp_json_encode( $prepared_customer_data )
+					)
+				);
 			}
 
 			wp_enqueue_style(
@@ -802,14 +815,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			</div>
 			<?php
 		}
-	}
-
-	/**
-	 * Enqueues and localizes WCPay's checkout scripts.
-	 */
-	public function enqueue_payment_scripts() {
-		wp_localize_script( 'WCPAY_CHECKOUT', 'wcpay_config', $this->get_payment_fields_js_config() );
-		wp_enqueue_script( 'WCPAY_CHECKOUT' );
 	}
 
 	/**

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -762,11 +762,23 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 			$payment_fields = $this->get_payment_fields_js_config();
 			wp_enqueue_script( 'wcpay-upe-checkout' );
-			wp_add_inline_script( 'wcpay-upe-checkout', 'wcpay_config=' . wp_json_encode( $payment_fields ) . ';' );
+			wp_add_inline_script(
+				'wcpay-upe-checkout',
+				sprintf(
+					'window.wcpay_config = %s;',
+					wp_json_encode( $payment_fields )
+				)
+			);
 
 			$prepared_customer_data = $this->get_prepared_customer_data();
 			if ( ! empty( $prepared_customer_data ) ) {
-				wp_add_inline_script( 'wcpay-upe-checkout', 'wcpayCustomerData=' . wp_json_encode( $prepared_customer_data ) . ';' );
+				wp_add_inline_script(
+					'wcpay-upe-checkout',
+					sprintf(
+						'window.wcpayCustomerData = %s;',
+						wp_json_encode( $prepared_customer_data )
+					)
+				);
 			}
 
 			wp_enqueue_style(

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -760,11 +760,13 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		try {
 			$display_tokenization = $this->supports( 'tokenization' ) && ( is_checkout() || is_add_payment_method_page() );
 
-			add_action( 'wp_footer', [ $this, 'enqueue_payment_scripts' ] );
+			$payment_fields = $this->get_payment_fields_js_config();
+			wp_enqueue_script( 'wcpay-upe-checkout' );
+			wp_add_inline_script( 'wcpay-upe-checkout', 'wcpay_config=' . wp_json_encode( $payment_fields ) . ';' );
 
 			$prepared_customer_data = $this->get_prepared_customer_data();
 			if ( ! empty( $prepared_customer_data ) ) {
-				wp_localize_script( 'wcpay-upe-checkout', 'wcpayCustomerData', $prepared_customer_data );
+				wp_add_inline_script( 'wcpay-upe-checkout', 'wcpayCustomerData=' . wp_json_encode( $prepared_customer_data ) . ';' );
 			}
 
 			wp_enqueue_style(
@@ -836,15 +838,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			</div>
 			<?php
 		}
-	}
-
-	/**
-	 * Enqueues and localizes UPE's checkout scripts.
-	 */
-	public function enqueue_payment_scripts() {
-		$payment_fields = $this->get_payment_fields_js_config();
-		wp_localize_script( 'wcpay-upe-checkout', 'wcpay_config', $payment_fields );
-		wp_enqueue_script( 'wcpay-upe-checkout' );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Explore `wp_add_inline_script` as a replacement of `wp_localize_script`, and as a fix of Subs' issues.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
