### PR TITLE
Add 'moduleNameMapper' in e2e jest config

### DIFF
--- a/tests/e2e/config/jest.config.js
+++ b/tests/e2e/config/jest.config.js
@@ -56,6 +56,9 @@ const testConfig = useE2EJestConfig( {
 		__dirname,
 		'../config/jest-custom-sequencer.js'
 	),
+	moduleNameMapper: {
+		'^iti/utils$': '<rootDir>/node_modules/intl-tel-input/build/js/utils',
+	},
 } );
 
 module.exports = testConfig;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

E2E tests are failing because in the test environment this `iti/utils` module is not found. This has been used in [this line](https://github.com/Automattic/woocommerce-payments/blob/develop/client/components/platform-checkout/save-user/phone-number-input.js#L13).

Added `moduleNameMapper` in `jest.config.js` file for e2e tests to map the module's location.