### PR TITLE
Fix subscription PM changes.

### DIFF
--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -760,7 +760,19 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		try {
 			$display_tokenization = $this->supports( 'tokenization' ) && ( is_checkout() || is_add_payment_method_page() );
 
-			add_action( 'wp_footer', [ $this, 'enqueue_payment_scripts' ] );
+			/**
+			 * Localizing scripts within shortcodes does not work in WP 5.9,
+			 * but we need `$this->get_payment_fields_js_config` to be called
+			 * before `$this->saved_payment_methods()`.
+			 */
+			$payment_fields = $this->get_payment_fields_js_config();
+			wp_enqueue_script( 'wcpay-upe-checkout' );
+			add_action(
+				'wp_footer',
+				function() use ( $payment_fields ) {
+					wp_localize_script( 'wcpay-upe-checkout', 'wcpay_config', $payment_fields );
+				}
+			);
 
 			$prepared_customer_data = $this->get_prepared_customer_data();
 			if ( ! empty( $prepared_customer_data ) ) {
@@ -836,15 +848,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			</div>
 			<?php
 		}
-	}
-
-	/**
-	 * Enqueues and localizes UPE's checkout scripts.
-	 */
-	public function enqueue_payment_scripts() {
-		$payment_fields = $this->get_payment_fields_js_config();
-		wp_localize_script( 'wcpay-upe-checkout', 'wcpay_config', $payment_fields );
-		wp_enqueue_script( 'wcpay-upe-checkout' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes (only partially) #3771.
Closes https://github.com/Automattic/woocommerce-payments/issues/3765.

#### Changes proposed in this Pull Request

Call `get_payment_fields_js_config()` as early as possible within UPE's `payment_fields` in order to allow newly added PMs to be displayed as saved payment methods, and chosen by JavaScript before the "Change payment method" form gets re-submitted.

More detailed reasoning can be found in the issue.

#### Testing instructions

We need to use the following matrix in order to perform those actions:

- Complete the classic checkout
- Complete checkout through the checkout block.
- Add a new payment method to an existing subscription (new as one that doesn't exist in the database yet, not just a different one)

In combinations of the following scenarios:

- When using a block-based theme (ex. Twenty Twenty-Two) or using a classic theme (ex. Storefront)
- When using UPE fields and when **not** using UPE fields

| UPE | Block-based | Checkout block | Classic | Subscription update |
|-----|-------------|----------------|---------|---------------------|
| 0   | 0           | Yes/No         | Yes/No  | Yes/No              |
| 1   | 0           | Yes/No         | Yes/No  | Yes/No              |
| 0   | 1           | Yes/No         | Yes/No  | Yes/No              |
| 1   | 1           | Yes/No         | Yes/No  | Yes/No              |

- [x] No changelog entries needed, as the previous change is not live yet.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (does not apply)