### PR TITLE
Update subscriptions-core to `1.6.4`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@
 * Add - UPE payment method - EPS.
 * Fix - Replace uses of is_ajax() with wp_doing_ajax() in subscriptions-core.
 * Improve handling of session data.
+* Fix - When changing the payment method, make sure the subscription total returns $0 when `subscriptions-core` is loaded after the `woocommerce_loaded` action hook.
 
 = 3.6.1 - 2022-01-27 =
 * Fix - Remove packages not compatible with PHP 7.0

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
       "automattic/jetpack-autoloader": "2.10.11",
       "automattic/jetpack-identity-crisis": "0.7.0",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "1.6.3"
+      "woocommerce/subscriptions-core": "1.6.4"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17133e98dfa354883b3b054937d1a0ab",
+    "content-hash": "803256afec087ae60fdadc8bf846d871",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -955,16 +955,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "1.6.3",
+            "version": "1.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "68cbe478e0e21494b93fb0cf3a642157127fd13b"
+                "reference": "7cdddd4887080595bf08b6e48ba51514ce8c14f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/68cbe478e0e21494b93fb0cf3a642157127fd13b",
-                "reference": "68cbe478e0e21494b93fb0cf3a642157127fd13b",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/7cdddd4887080595bf08b6e48ba51514ce8c14f5",
+                "reference": "7cdddd4887080595bf08b6e48ba51514ce8c14f5",
                 "shasum": ""
             },
             "require": {
@@ -1006,10 +1006,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/1.6.3",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/1.6.4",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-02-07T04:58:57+00:00"
+            "time": "2022-02-10T00:09:23+00:00"
         }
     ],
     "packages-dev": [

--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,7 @@ Please note that our support for the checkout block is still experimental and th
 * Add - UPE payment method - EPS.
 * Fix - Replace uses of is_ajax() with wp_doing_ajax() in subscriptions-core.
 * Improve handling of session data.
+* Fix - When changing the payment method, make sure the subscription total returns $0 when `subscriptions-core` is loaded after the `woocommerce_loaded` action hook.
 
 = 3.6.1 - 2022-01-27 =
 * Fix - Remove packages not compatible with PHP 7.0


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Load newer woocommerce-subscriptions-core's version, `1.6.4`.
- Add changes of woocommerce-subscriptions-core to the changelog.
- Updated `composer.lock` as a result of running `composer update woocommerce/subscriptions-core`.

#### Testing instructions

* Checkout this branch.
* [Husky hook should run `composer install`](https://github.com/Automattic/woocommerce-payments/blob/develop/.husky/post-checkout#L8) and your `vendor/woocommerce/subscriptions-core` should be updated to be `1.6.4`. Confirm that [latest changes from `1.6.4`](https://github.com/Automattic/woocommerce-subscriptions-core/commits/1.6.4) is present, for example, [vendor/woocommerce/subscriptions-core/changelog.txt is up-to-date](https://github.com/Automattic/woocommerce-subscriptions-core/blob/1.6.4/changelog.txt).

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

- [ ] Added testing instructions to the [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) (or does not apply)

Closes https://github.com/Automattic/woocommerce-payments/issues/3768.