### PR TITLE
CI tests: Fix fetching Woo beta versions

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -186,7 +186,7 @@ install_woocommerce() {
 
 	if [[ $WC_VERSION == 'beta' ]]; then
 		# Get the latest non-trunk version number from the .org repo. This will usually be the latest release, beta, or rc.
-		WC_VERSION=$(curl https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | with_entries(select(.key|match("beta";"i"))) | keys[-1]' --sort-keys)
+		WC_VERSION=$(curl "https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request[slug]=woocommerce" | jq -r '.versions | with_entries(select(.key|match("beta";"i"))) | keys[-1]' --sort-keys)
 	fi
 
 	if [[ -n $INSTALLED_WC_VERSION ]] && [[ $WC_VERSION == 'latest' ]]; then


### PR DESCRIPTION
Fixes 


When working on this PR https://github.com/Automattic/woocommerce-payments/pull/3763, I see that this error for this matrix: [`Environment - WC beta`](https://github.com/Automattic/woocommerce-payments/blob/22dbd7c6c4d01515471c5e299b34538920b84842/.github/workflows/compatibility.yml#L49-L49) like this run https://github.com/Automattic/woocommerce-payments/runs/5135104761?check_suite_focus=true

The last error message in `Run bash bin/run-ci-tests.bash`: 

```
Error: The 'woocommerce' plugin could not be found.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 38439    0 38439    0     0   282k      0 --:--:-- --:--:-- --:--:--  282k
jq: error (at <stdin>:0): null (null) has no keys
Error: Process completed with exit code 5.
``` 

#### Changes proposed in this Pull Request

- Change the endpoint to fetch Woo core versions, then the `versions` property can be fetched again.
- The new endpoint is being used the WP core too https://github.com/WordPress/wordpress-develop/blob/ce3d66c7c9d94671268d5ce51de47cdd3bd9d6c8/src/wp-admin/includes/plugin-install.php#L154

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- See CI tests and confirm that, `[Environment - WC beta]` matrix is no longer failing due to the issue mentioned above.
- 8.0 and 8.1 are failing due to another reason https://github.com/Automattic/woocommerce-payments/issues/3712

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply) - no need as this is related to devs only.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
