### PR TITLE
Fix not populated loan variable without account cache 

### DIFF
--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -315,7 +315,11 @@ class WC_Payments_Account {
 	 */
 	public function get_capital() {
 		$account = $this->get_cached_account_data();
-		return ! empty( $account ) && isset( $account['capital'] ) ? $account['capital'] : [];
+		return ! empty( $account ) && isset( $account['capital'] ) && ! empty( $account['capital'] ) ? $account['capital'] : [
+			'loans'             => [],
+			'has_active_loan'   => false,
+			'has_previous_loan' => false,
+		];
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR will fix the bug which is introduced on #3717 that causes the Stripe onboarding CTA page to display "Sorry, you are not allowed to view this page" error, because of a React error. The page doesn't show up because of this error, because the accountLoans property isn't populated when a Stripe account isn't connected, and even it's not populated, the client code tries to read it.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* All tests shall pass.
* Without the fix, go to WCPay dev tools and enable "Force the plugin to act as disconnected from WCPay", then click the "Payments" link on the sidebar. You should get the error mentioned.
* With the fix, do the same and expect to see the Stripe onboarding CTA page.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

QA Testing Not Applicable
