### PR TITLE
Change the URL separators to underscore

### DIFF
--- a/client/data/capital/resolvers.ts
+++ b/client/data/capital/resolvers.ts
@@ -20,7 +20,7 @@ import { ApiError, Summary } from './types';
  * Retrieve all deposits' overviews from the deposits API.
  */
 export function* getActiveLoanSummary(): unknown {
-	const path = `${ NAMESPACE }/capital/active-loan-summary`;
+	const path = `${ NAMESPACE }/capital/active_loan_summary`;
 
 	try {
 		const result = yield apiFetch( { path } );

--- a/client/data/capital/test/resolvers.js
+++ b/client/data/capital/test/resolvers.js
@@ -33,7 +33,7 @@ describe( 'getActiveLoanSummary resolver', () => {
 	beforeEach( () => {
 		generator = getActiveLoanSummary();
 		expect( generator.next().value ).toEqual(
-			apiFetch( { path: '/wc/v3/payments/capital/active-loan-summary' } )
+			apiFetch( { path: '/wc/v3/payments/capital/active_loan_summary' } )
 		);
 	} );
 

--- a/includes/admin/class-wc-rest-payments-capital-controller.php
+++ b/includes/admin/class-wc-rest-payments-capital-controller.php
@@ -25,7 +25,7 @@ class WC_REST_Payments_Capital_Controller extends WC_Payments_REST_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/active-loan-summary',
+			'/' . $this->rest_base . '/active_loan_summary',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_active_loan_summary' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a small PR changing the word separators from `-` to `_` in the URL to get the loan summary.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tests should pass. 
* The loan summary will still be visible for those having an active loan.

-------------------

- [x] Added changelog entries to both `readme.txt` and `changelog.txt` (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

QA Testing Not Applicable
