### PR TITLE
Bump WC minimum supported version for 3.8.0 release

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -11,13 +11,13 @@ jobs:
       fail-fast:    false
       max-parallel: 10
       matrix:
-        woocommerce: [ '4.6.0', '4.7.0', '4.8.0', '4.9.0', '5.0.0', '5.1.0', '5.2.0', '5.3.0', '5.4.0', '5.5.0', '5.6.0', '5.7.0', '5.8.0', '5.9.0', '6.0.0', '6.1.0', '6.1.1', '6.2.0-rc.1']
+        woocommerce: [ '4.7.0', '4.8.0', '4.9.0', '5.0.0', '5.1.0', '5.2.0', '5.3.0', '5.4.0', '5.5.0', '5.6.0', '5.7.0', '5.8.0', '5.9.0', '6.0.0', '6.1.0', '6.1.1', '6.2.0' ]
         wordpress:   [ 'latest' ]
         gutenberg:   [ 'latest' ]
         php:         [ '7.4' ]
         include:
           # Edge case: oldest dependencies compatibility
-          - woocommerce: '4.6.0'
+          - woocommerce: '4.7.0'
             wordpress:   '5.7'
             gutenberg:   '11.4.0' # The latest version supporting WP 5.6.
             php:         '7.1' # TODO This should be 7.0. Pending to fix in issue #2970.

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast:     false
       matrix:
         # Min WooCommerce | L-2 | L(atest) | beta
-        woocommerce:   [ '4.6.0', '5.9.0', '6.1.1', 'beta' ]
+        woocommerce:   [ '4.7.0', '6.0.0', '6.2.0', 'beta' ]
         wordpress:     [ 'latest' ]
         php:           [ '7.4' ]
         test_groups:   [ 'wcpay', 'subscriptions', 'blocks' ]

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   WP_VERSION:        latest
-  WC_VERSION: 5.7.0  # the min supported version as per L-2 policy
+  WC_VERSION: 6.0.0  # the min supported version as per L-2 policy
   GUTENBERG_VERSION: latest
 
 jobs:

--- a/changelog/dev-bump-minimum-versions-3-8-0
+++ b/changelog/dev-bump-minimum-versions-3-8-0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Bump minimum required version of WooCommerce from 4.6 to 4.7.

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ Our global support team is available to answer questions you may have about WooC
 = Requirements =
 
 * WordPress 5.7 or newer.
-* WooCommerce 5.9 or newer.
+* WooCommerce 4.7 or newer.
 * PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
 
 = Try it now =

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,8 +8,8 @@
  * Woo: 5278104:bf3cf30871604e15eec560c962593c1f
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
- * WC requires at least: 4.6
- * WC tested up to: 6.1.1
+ * WC requires at least: 4.7
+ * WC tested up to: 6.2.0
  * Requires at least: 5.7
  * Requires PHP: 7.0
  * Version: 3.7.0


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Bump WC from 4.6.0 to 4.7.0 (still long way behind L-2 on 6.0.0).
- Fixed readme.txt which was inconsistent with plugin header.
- Fixed php-lint-test.yml which was inconsistent with L-2.

No WP updates to catch up on.

#### Testing instructions

* Please check the CI tests in the GH workflows.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)