### PR TITLE
Fix gathering changelog in the pre-release CI

### DIFF
--- a/.github/workflows/pre-release-publish-on-tag.yaml
+++ b/.github/workflows/pre-release-publish-on-tag.yaml
@@ -116,6 +116,7 @@ jobs:
           VERSION=$(sed -E 's/^([^-]+)-.*/\1/' <<< $TAG)
 
           # Install this dev package to gather changelog entries
+          # Using `global` to avoid including it into the release package
           composer global require automattic/jetpack-changelogger:^3.0.7
 
           # Gather changelog entries

--- a/.github/workflows/pre-release-publish-on-tag.yaml
+++ b/.github/workflows/pre-release-publish-on-tag.yaml
@@ -116,7 +116,7 @@ jobs:
           VERSION=$(sed -E 's/^([^-]+)-.*/\1/' <<< $TAG)
 
           # Install this dev package to gather changelog entries
-          composer global require automattic/jetpack-changelogger
+          composer global require automattic/jetpack-changelogger:^3.0.7
 
           # Gather changelog entries
           if [[ $VERSION == "3.8.0" ]];

--- a/.github/workflows/pre-release-publish-on-tag.yaml
+++ b/.github/workflows/pre-release-publish-on-tag.yaml
@@ -115,13 +115,16 @@ jobs:
           # pick anything before the first dash as a version number
           VERSION=$(sed -E 's/^([^-]+)-.*/\1/' <<< $TAG)
 
+          # Install this dev package to gather changelog entries
+          composer global require automattic/jetpack-changelogger
+
           # Gather changelog entries
           if [[ $VERSION == "3.8.0" ]];
           then
             # Add "--amend" for the cut-off version before moving to Jetpack Changelogger completely.
-            ./vendor/bin/changelogger write --use-version="$VERSION" --release-date=unreleased --amend
+            ~/.composer/vendor/bin/changelogger write --use-version="$VERSION" --release-date=unreleased --amend
           else
-            ./vendor/bin/changelogger write --use-version="$VERSION" --release-date=unreleased
+            ~/.composer/vendor/bin/changelogger write --use-version="$VERSION" --release-date=unreleased
           fi
 
           echo "Picking up changelog for version '$VERSION'..."

--- a/changelog/fix-ci-pre-release-tag-log
+++ b/changelog/fix-ci-pre-release-tag-log
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: This only affects CI.
+
+


### PR DESCRIPTION
Fixes the error in this run: https://github.com/Automattic/woocommerce-payments/runs/5193408662?check_suite_focus=true

```
Extract changelog
...
/home/runner/work/_temp/1240f0c9-7359-46b9-a9af-61d412108967.sh: line 8: ./vendor/bin/changelogger: No such file or directory
Error: Process completed with exit code 127.
``` 

This was caused by my PR #3685 when adding a new package to handle changelog.

Since this workflow runs `npm run build` - [ref](https://github.com/Automattic/woocommerce-payments/blob/560c06a759bc43297786be202050386478f05e40/.github/workflows/pre-release-publish-on-tag.yaml#L103-L103), which then includes only `required` composer packages, not dev package - [ref](https://github.com/Automattic/woocommerce-payments/blob/560c06a759bc43297786be202050386478f05e40/package.json#L20-L20). Hence, the dev package `automattic/jetpack-changelogger` is not included.

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- Install this package `automattic/jetpack-changelogger` as global.
- And then use the global vendor location to run it.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Mostly verify my testing steps and results are reasonable:

- I created a tag `3.8.0-test-pr-3812` to trigger CI action: 

```
git checkout fix/ci-pre-release-tag-log
git tag -a -m 'Test for PR 3812' 3.8.0-test-pr-3812
git push origin 3.8.0-test-pr-3812   
``` 

- CI run: https://github.com/Automattic/woocommerce-payments/actions/runs/1852651087
- Pre-release version is created: https://github.com/Automattic/woocommerce-payments/releases/tag/3.8.0-test-pr-3812

You can create another tag but with a different tag name like `3.8.0-test-pr-3812-second` and check the result again. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Delete this tag `3.8.0-test-pr-3812`.
- [ ] Delete this pre-release version https://github.com/Automattic/woocommerce-payments/releases/tag/3.8.0-test-pr-3812