### PR TITLE
Add tracking for enabling and disabling platform checkout

### DIFF
--- a/changelog/add-platform-checkout-enable-disable-tracking
+++ b/changelog/add-platform-checkout-enable-disable-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add tracking for enabling and disabling platform checkout

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -661,7 +661,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 
 		$is_platform_checkout_enabled = $request->get_param( 'is_platform_checkout_enabled' );
 
-		$this->wcpay_gateway->update_option( 'platform_checkout', $is_platform_checkout_enabled ? 'yes' : 'no' );
+		$this->wcpay_gateway->update_is_platform_checkout_enabled( $is_platform_checkout_enabled );
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1597,6 +1597,19 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Updates whether platform checkout is enabled or disabled.
+	 *
+	 * @param bool $is_platform_checkout_enabled Whether platform checkout should be enabled.
+	 */
+	public function update_is_platform_checkout_enabled( $is_platform_checkout_enabled ) {
+		$current_is_platform_checkout_enabled = 'yes' === $this->get_option( 'platform_checkout', 'no' );
+		if ( $is_platform_checkout_enabled !== $current_is_platform_checkout_enabled ) {
+			wc_admin_record_tracks_event( $is_platform_checkout_enabled ? 'platform_checkout_enabled' : 'platform_checkout_disabled' );
+			$this->update_option( 'platform_checkout', $is_platform_checkout_enabled ? 'yes' : 'no' );
+		}
+	}
+
+	/**
 	 * Init settings for gateways.
 	 */
 	public function init_settings() {


### PR DESCRIPTION
Fixes #3815

See pdpOw2-l8-p2

#### Changes proposed in this Pull Request

#3738 added a setting on the WCPay Settings page to enable and disable platform checkout. This PR records an event in Tracks each time the platform checkout is enabled or disabled.

cc @malithsen in case you'd like to review or have feedback as well.

#### Testing instructions

- In your `wp_options` table, ensure that the `_wcpay_feature_platform_checkout` option is set to `1`.
- In WP Admin, go to **Payments > Settings**.
- Look for the "Platform Checkout" option next to "Express checkouts."
- Enable the checkbox and "Save changes."
- In ~5 minutes, checks the Tracks Live View for an event called `wcadmin_platform_checkout_enabled`.
- Disable the checkbox and "Save changes."
- In ~5 minutes, checks the Tracks Live View for an event called `wcadmin_platform_checkout_enabled`.
- Click "Save changes" again.
- In ~5 minutes, check the Tracks Live View — there shouldn't be any new event, since the setting hasn't changed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
