### PR TITLE
Conditionally add subscription payment gateway features

### DIFF
--- a/changelog/fix-3819-subscriptions-support-flags
+++ b/changelog/fix-3819-subscriptions-support-flags
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Conditionally add subscription payment gateway features.

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -92,19 +92,30 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 			return;
 		}
 
-		array_push(
-			$this->supports,
-			'subscriptions',
+		$payment_gateway_features = [
+			'multiple_subscriptions',
 			'subscription_cancellation',
-			'subscription_suspension',
 			'subscription_reactivation',
-			'subscription_amount_changes',
-			'subscription_date_changes',
-			'subscription_payment_method_change',
-			'subscription_payment_method_change_customer',
-			'subscription_payment_method_change_admin',
-			'multiple_subscriptions'
-		);
+			'subscription_suspension',
+			'subscriptions',
+		];
+
+		if ( $this->is_subscriptions_plugin_active() ) {
+			$payment_gateway_features = array_merge(
+				$payment_gateway_features,
+				[
+					'subscription_amount_changes',
+					'subscription_date_changes',
+					'subscription_payment_method_change_admin',
+					'subscription_payment_method_change_customer',
+					'subscription_payment_method_change',
+				]
+			);
+		} else {
+			$payment_gateway_features[] = 'gateway_scheduled_payments';
+		}
+
+		array_push( $this->supports, $payment_gateway_features );
 
 		add_filter( 'woocommerce_email_classes', [ $this, 'add_emails' ], 20 );
 		add_filter( 'woocommerce_available_payment_gateways', [ $this, 'prepare_order_pay_page' ] );

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -95,6 +95,9 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 		$payment_gateway_features = [
 			'multiple_subscriptions',
 			'subscription_cancellation',
+			'subscription_payment_method_change_admin',
+			'subscription_payment_method_change_customer',
+			'subscription_payment_method_change',
 			'subscription_reactivation',
 			'subscription_suspension',
 			'subscriptions',
@@ -106,16 +109,13 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 				[
 					'subscription_amount_changes',
 					'subscription_date_changes',
-					'subscription_payment_method_change_admin',
-					'subscription_payment_method_change_customer',
-					'subscription_payment_method_change',
 				]
 			);
 		} else {
 			$payment_gateway_features[] = 'gateway_scheduled_payments';
 		}
 
-		array_push( $this->supports, $payment_gateway_features );
+		$this->supports = array_merge( $this->supports, $payment_gateway_features );
 
 		add_filter( 'woocommerce_email_classes', [ $this, 'add_emails' ], 20 );
 		add_filter( 'woocommerce_available_payment_gateways', [ $this, 'prepare_order_pay_page' ] );

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -110,7 +110,7 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 
 		if ( $this->is_subscriptions_plugin_active() ) {
 			/*
-			 * Subscription amount & date changes or only supported
+			 * Subscription amount & date changes are only supported
 			 * when WooCommerce Subscriptions is active.
 			 */
 			$payment_gateway_features = array_merge(

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -92,6 +92,11 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 			return;
 		}
 
+		/*
+		 * Base set of subscription features to add.
+		 * The WCPay payment gateway supports these feautres
+		 * for both WCPay Subscriptions and WooCommerce Subscriptions.
+		 */
 		$payment_gateway_features = [
 			'multiple_subscriptions',
 			'subscription_cancellation',
@@ -104,6 +109,10 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 		];
 
 		if ( $this->is_subscriptions_plugin_active() ) {
+			/*
+			 * Subscription amount & date changes or only supported
+			 * when WooCommerce Subscriptions is active.
+			 */
 			$payment_gateway_features = array_merge(
 				$payment_gateway_features,
 				[
@@ -112,6 +121,10 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 				]
 			);
 		} else {
+			/*
+			 * The gateway_scheduled_payments feature is only supported
+			 * for WCPay Subscriptions.
+			 */
 			$payment_gateway_features[] = 'gateway_scheduled_payments';
 		}
 

--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -79,10 +79,14 @@ class WC_Payments_Subscription_Service {
 	 */
 	private $supports = [
 		'gateway_scheduled_payments',
-		'subscriptions',
-		'subscription_suspension',
-		'subscription_reactivation',
+		'multiple_subscriptions',
 		'subscription_cancellation',
+		'subscription_payment_method_change_admin',
+		'subscription_payment_method_change_customer',
+		'subscription_payment_method_change',
+		'subscription_reactivation',
+		'subscription_suspension',
+		'subscriptions',
 	];
 
 	/**

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-trait.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-trait.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Class WC_Payment_Gateway_WCPay_Subscriptions_Trait_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * WC_Payment_Gateway_WCPay_Subscriptions_Trait_Test unit tests.
+ */
+class WC_Payment_Gateway_WCPay_Subscriptions_Trait_Test extends WP_UnitTestCase {
+
+	/**
+	 * System under test.
+	 *
+	 * @var WC_Payment_Gateway_WCPay_Subscriptions_Trait|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_wcpay_subscriptions_trait;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->mock_wcpay_subscriptions_trait = $this->getMockForTrait(
+			WC_Payment_Gateway_WCPay_Subscriptions_Trait::class,
+			[],
+			'',
+			true,
+			true,
+			true,
+			[
+				'is_subscriptions_enabled',
+				'is_subscriptions_plugin_active',
+			]
+		);
+
+		$this->mock_wcpay_subscriptions_trait->supports = [];
+		$this->mock_wcpay_subscriptions_trait->id       = 'woocommerce_payments';
+	}
+
+	public function test_maybe_init_subscriptions_with_subscriptions_disabled() {
+		$this->mock_wcpay_subscriptions_trait
+			->method( 'is_subscriptions_enabled' )
+			->willReturn( false );
+
+		$this->mock_wcpay_subscriptions_trait->maybe_init_subscriptions();
+
+		$expected = [];
+
+		$this->assertSame( $expected, $this->mock_wcpay_subscriptions_trait->supports );
+	}
+
+	public function test_maybe_init_subscriptions_with_wcs_enabled() {
+		$this->mock_wcpay_subscriptions_trait
+			->method( 'is_subscriptions_enabled' )
+			->willReturn( true );
+
+		$this->mock_wcpay_subscriptions_trait
+			->method( 'is_subscriptions_plugin_active' )
+			->willReturn( true );
+
+		$this->mock_wcpay_subscriptions_trait->maybe_init_subscriptions();
+
+		$expected = [
+			'multiple_subscriptions',
+			'subscription_cancellation',
+			'subscription_payment_method_change_admin',
+			'subscription_payment_method_change_customer',
+			'subscription_payment_method_change',
+			'subscription_reactivation',
+			'subscription_suspension',
+			'subscriptions',
+			'subscription_amount_changes',
+			'subscription_date_changes',
+		];
+
+		$this->assertSame( $expected, $this->mock_wcpay_subscriptions_trait->supports );
+	}
+
+	public function test_maybe_init_subscriptions_with_wcs_disabled() {
+		$this->mock_wcpay_subscriptions_trait
+			->method( 'is_subscriptions_enabled' )
+			->willReturn( true );
+
+		$this->mock_wcpay_subscriptions_trait
+			->method( 'is_subscriptions_plugin_active' )
+			->willReturn( false );
+
+		$this->mock_wcpay_subscriptions_trait->maybe_init_subscriptions();
+
+		$expected = [
+			'multiple_subscriptions',
+			'subscription_cancellation',
+			'subscription_payment_method_change_admin',
+			'subscription_payment_method_change_customer',
+			'subscription_payment_method_change',
+			'subscription_reactivation',
+			'subscription_suspension',
+			'subscriptions',
+			'gateway_scheduled_payments',
+		];
+
+		$this->assertSame( $expected, $this->mock_wcpay_subscriptions_trait->supports );
+	}
+}


### PR DESCRIPTION
Fixes #3819 

#### Changes proposed in this Pull Request

This PR reduces the [supported payment gateway features](https://woocommerce.github.io/code-reference/classes/WC-Payment-Gateway.html#property_supports) when the WooCommerce Subscriptions plugin is not active.

In particular, the `subscription_amount_changes` and `subscription_date_changes` are only included when WCS is active (as I believe these features do not work with WCPay subscriptions).

And the `gateway_scheduled_payments` feature is included when WCS is not active. I'm not 100% sure about this one but I saw an existing instance of this here → https://github.com/Automattic/woocommerce-payments/blob/32714ed/includes/subscriptions/class-wc-payments-subscription-service.php#L81

All existing subscriptions functionality that is expected to work when WCS is disabled should continue to work with these changes.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
