### PR TITLE
Save email in classic checkout

### DIFF
--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -818,6 +818,7 @@ class WC_Payments {
 			add_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
 			add_filter( 'woocommerce_checkout_fields', [ __CLASS__, 'platform_checkout_remove_default_email_field' ], 50 );
 			add_action( 'woocommerce_checkout_before_customer_details', [ __CLASS__, 'platform_checkout_fields_before_billing_details' ], 20 );
+			add_action( 'woocommerce_checkout_update_order_meta', [ __CLASS__, 'platform_checkout_save_email_field' ], 10, 2 );
 		}
 	}
 
@@ -939,4 +940,18 @@ class WC_Payments {
 		echo '</div>';
 		echo '</div>';
 	}
+
+	/**
+	 * Updates an orders email address
+	 *
+	 * @param int $order_id WooCommerce order ID.
+	 */
+	public static function platform_checkout_save_email_field( $order_id ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$billing_email = isset( $_POST['billing_email'] ) ? sanitize_text_field( wp_unslash( $_POST['billing_email'] ) ) : '';
+		if ( ! empty( $billing_email ) ) {
+			update_post_meta( $order_id, '_billing_email', $billing_email );
+		}
+	}
+
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: Save email in classic checkout
-->

Description: A new field was added to move the email address to the top of the checkout page when platform checkout is enabled. The email wasn't being saved to the order. This updates the order meta with the posted email address.


<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

Testing instructions: 

1. Enable platform checkout
2. Add the checkout shortcode to the checkout page - `[woocommerce_checkout]`
3. Purchase a product while logged out to ensure the account email isn't used
4. Open the order from the **WooCommerce > Orders** page and verify that billing email was stored

**Before**
<img src="https://user-images.githubusercontent.com/3473953/154579358-e486ad74-8547-4d28-b1dd-0574436ce43d.png" width="200" />

**After**
<img src="https://user-images.githubusercontent.com/3473953/154579689-9b4e729e-d20b-45c5-a565-4cab0d01a41a.png" width="200" />

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) :QA Testing Not Applicable
