### PR TITLE
Fix platform checkout iframe positioning

### DIFF
--- a/changelog/fix-platform-checkout-iframe-positioning
+++ b/changelog/fix-platform-checkout-iframe-positioning
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Made change to functionality behind a feature flag and is not yet public.
+
+

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -12,10 +12,13 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 	const parentDiv = platformCheckoutEmailInput.parentNode;
 	spinner.classList.add( 'wc-block-components-spinner' );
 
+	// Make the iframe wrapper.
 	const iframeWrapper = document.createElement( 'div' );
 	iframeWrapper.setAttribute( 'role', 'dialog' );
 	iframeWrapper.setAttribute( 'aria-modal', 'true' );
 	iframeWrapper.classList.add( 'platform-checkout-sms-otp-iframe-wrapper' );
+
+	// Make the iframe.
 	const iframe = document.createElement( 'iframe' );
 	iframe.title = __(
 		'Platform checkout SMS code verification',
@@ -23,6 +26,7 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 	);
 	iframe.classList.add( 'platform-checkout-sms-otp-iframe' );
 
+	// Make the iframe arrow.
 	const iframeArrow = document.createElement( 'span' );
 	iframeArrow.setAttribute( 'aria-hidden', 'true' );
 	iframeArrow.classList.add( 'arrow' );
@@ -49,25 +53,32 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 				getConfig( 'platformCheckoutHost' )
 			);
 		}
+
+		// Prevent scrolling when the iframe is open.
 		document.body.style.overflow = 'hidden';
 	};
 
+	/**
+	 * Handles setting the iframe popover position based on the input field.
+	 * It tries to be positioned at the right of the input field unless the
+	 * window is too narrow, then it sticks 50px from the right edge of the
+	 * screen.
+	 */
 	const setPopoverPosition = () => {
+		// If for some reason the iframe is not loaded, just return.
 		if ( ! iframe ) {
 			return;
 		}
 
+		// If the window width is less than the breakpoint, reset the styles and return.
 		if ( fullScreenModalBreakpoint >= window.innerWidth ) {
 			iframe.style.left = '0';
 			iframe.style.right = '';
 			return;
 		}
 
-		// Get our element rects.
-		let iframeRect = iframe.getBoundingClientRect();
-
-		// Check top position.
-		if ( 0 >= iframeRect.top ) {
+		// Check if the iframe is off the top of the screen and scroll back into view.
+		if ( 0 >= iframe.getBoundingClientRect().top ) {
 			const topOffset = 50;
 			const scrollTop =
 				document.documentElement.scrollTop +
@@ -79,13 +90,15 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 			} );
 		}
 
-		// Update the rects after maybe scrolling.
+		// Get references to the iframe and input field bounding rects.
 		const anchorRect = platformCheckoutEmailInput.getBoundingClientRect();
-		iframeRect = iframe.getBoundingClientRect();
+		const iframeRect = iframe.getBoundingClientRect();
 
+		// Set the iframe top.
 		iframe.style.top =
 			Math.floor( anchorRect.top - iframeRect.height / 2 ) + 'px';
-		// Arrow top is the input top plus half the input height minus the border width.
+
+		// Set the arrow top.
 		iframeArrow.style.top =
 			Math.floor(
 				anchorRect.top +
@@ -97,6 +110,7 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 					)
 			) + 'px';
 
+		// Check if the iframe is off the right edge of the screen. If so, stick it to the right edge of the window.
 		if (
 			50 >=
 			window.innerWidth - ( anchorRect.right + iframeRect.width )
@@ -116,24 +130,31 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 	iframe.addEventListener( 'load', () => {
 		// Set the initial value.
 		iframeHeaderValue = true;
+
 		getWindowSize();
 		window.addEventListener( 'resize', getWindowSize );
+
 		setPopoverPosition();
 		window.addEventListener( 'resize', setPopoverPosition );
+
 		iframe.classList.add( 'open' );
 	} );
+
+	// Add the iframe and iframe arrow to the wrapper.
 	iframeWrapper.insertBefore( iframeArrow, null );
 	iframeWrapper.insertBefore( iframe, null );
 
 	const closeIframe = () => {
-		// debouncedGetWindowSize.cancel();
 		window.removeEventListener( 'resize', getWindowSize );
 		window.removeEventListener( 'resize', setPopoverPosition );
+
 		iframeWrapper.remove();
 		iframe.classList.remove( 'open' );
 		platformCheckoutEmailInput.focus();
+
 		document.body.style.overflow = '';
 	};
+
 	iframeWrapper.addEventListener( 'click', closeIframe );
 
 	const openIframe = ( email ) => {
@@ -142,8 +163,13 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 		) }/sms-otp/?email=${ email }&needsHeader=${
 			fullScreenModalBreakpoint > window.innerWidth
 		}`;
+
+		// Insert the wrapper into the DOM.
 		parentDiv.insertBefore( iframeWrapper, null );
+
 		setPopoverPosition();
+
+		// Focus the iframe.
 		iframe.focus();
 	};
 

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -158,11 +158,16 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 	iframeWrapper.addEventListener( 'click', closeIframe );
 
 	const openIframe = ( email ) => {
+		const urlParams = new URLSearchParams();
+		urlParams.append( 'email', email );
+		urlParams.append(
+			'needsHeader',
+			fullScreenModalBreakpoint > window.innerWidth
+		);
+
 		iframe.src = `${ getConfig(
 			'platformCheckoutHost'
-		) }/sms-otp/?email=${ email }&needsHeader=${
-			fullScreenModalBreakpoint > window.innerWidth
-		}`;
+		) }/sms-otp/?${ urlParams.toString() }`;
 
 		// Insert the wrapper into the DOM.
 		parentDiv.insertBefore( iframeWrapper, null );
@@ -182,10 +187,13 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 	const platformCheckoutLocateUser = ( email ) => {
 		parentDiv.insertBefore( spinner, platformCheckoutEmailInput );
 
+		const emailParam = new URLSearchParams();
+		emailParam.append( 'email', email );
+
 		fetch(
-			getConfig( 'platformCheckoutHost' ) +
-				'/wp-json/platform-checkout/v1/user/exists?email=' +
-				email
+			`${ getConfig(
+				'platformCheckoutHost'
+			) }/wp-json/platform-checkout/v1/user/exists?${ emailParam.toString() }`
 		)
 			.then( ( response ) => response.json() )
 			.then( ( data ) => {

--- a/client/checkout/platform-checkout/style.scss
+++ b/client/checkout/platform-checkout/style.scss
@@ -32,6 +32,7 @@
 	left: 0;
 	z-index: 355000;
 	border: 0;
+	background: #fff;
 	&.open {
 		top: 0;
 	}
@@ -40,6 +41,7 @@
 @media screen and ( min-width: 768px ) {
 	.platform-checkout-sms-otp-iframe-wrapper {
 		.platform-checkout-sms-otp-iframe {
+			transition: none;
 			height: 90vh;
 			max-height: 520px;
 			position: absolute;
@@ -64,7 +66,7 @@
 			height: 100vh;
 			content: ' ';
 			display: block;
-			z-index: 555;
+			z-index: 355000;
 		}
 		&::after {
 			content: '';
@@ -77,7 +79,7 @@
 			background: transparent;
 			width: 0;
 			height: 0;
-			z-index: 5555;
+			z-index: 355001;
 			border-top: 15px solid transparent;
 			border-bottom: 15px solid transparent;
 			border-right: 15px solid #fff;

--- a/client/checkout/platform-checkout/style.scss
+++ b/client/checkout/platform-checkout/style.scss
@@ -38,44 +38,39 @@
 	}
 }
 
+.platform-checkout-sms-otp-iframe-wrapper {
+	.arrow {
+		position: fixed;
+		top: 100%;
+	}
+}
+
 @media screen and ( min-width: 768px ) {
 	.platform-checkout-sms-otp-iframe-wrapper {
+		position: fixed;
+		background: rgba( 117, 117, 117, 0.6 );
+		top: 0;
+		left: 0;
+		width: 100vw;
+		height: 100vh;
+		content: ' ';
+		display: block;
+		z-index: 355000;
+
 		.platform-checkout-sms-otp-iframe {
 			transition: none;
 			height: 90vh;
 			max-height: 520px;
 			position: absolute;
-			left: min(
-				calc( 100% + 30px ),
-				calc( 85vw - max( 85vw - 100% - 94px, 300px ) )
-			);
-			top: -250px;
-			width: max( calc( 100vw - 100% - 94px ), 300px );
 			max-width: 374px;
 			border-radius: 8px;
-			&.open {
-				top: -45vh;
-			}
+			right: 50px;
+			left: auto;
 		}
-		&::before {
-			position: fixed;
-			background: rgba( 117, 117, 117, 0.6 );
-			top: 0;
-			left: 0;
-			width: 100vw;
-			height: 100vh;
-			content: ' ';
-			display: block;
-			z-index: 355000;
-		}
-		&::after {
-			content: '';
+
+		.arrow {
 			position: absolute;
-			left: calc(
-				min( 100% + 30px, 85vw - max( 85vw - 100% - 94px, 300px ) ) -
-					15px
-			);
-			top: calc( 50% - 15px );
+			right: calc( 15px / 2 );
 			background: transparent;
 			width: 0;
 			height: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR handles positioning the iframe popover positioning. It will position it at the right edge of the email input field unless the iframe window would be < 50px from the right edge of the screen. At that point, it will stick to 50px from the right edge of the screen. If the window is below the mobile breakpoint it resets the `left` and `right` properties and does nothing else. For situations when the position of the email field would cause the iframe popover to be off the top edge of the screen, the window is scrolled down and the `top` property of the iframe popover is adjusted.

#### Testing instructions

1. Add product to cart.
2. Go to checkout.
3. Enter a valid email address from your platform checkout environment.
4. Make sure that as you resize the window that the iframe popover behaves as described above.
