### PR TITLE
Hook user/exists endpoint to UI for saving data to platform checkout

### DIFF
--- a/changelog/add-platform-checkout-hook-save-details-UI-to-api-response
+++ b/changelog/add-platform-checkout-hook-save-details-UI-to-api-response
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: update
 Comment: Hook user/exists endpoint to UI for saving information for platform checkout. Functionality currently behind feature flag.
 

--- a/changelog/add-platform-checkout-hook-save-details-UI-to-api-response
+++ b/changelog/add-platform-checkout-hook-save-details-UI-to-api-response
@@ -1,0 +1,5 @@
+Significance: minor
+Type: update
+Comment: Hook user/exists endpoint to UI for saving information for platform checkout. Functionality currently behind feature flag.
+
+

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -93,6 +93,17 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 		)
 			.then( ( response ) => response.json() )
 			.then( ( data ) => {
+				// Dispatch an event after we get the response.
+				const PlatformCheckoutUserCheckEvent = new CustomEvent(
+					'PlatformCheckoutUserCheck',
+					{
+						detail: {
+							isRegisteredUser: data[ 'user-exists' ],
+						},
+					}
+				);
+				window.dispatchEvent( PlatformCheckoutUserCheckEvent );
+
 				if ( data[ 'user-exists' ] ) {
 					openIframe( email );
 				}

--- a/client/components/platform-checkout/hooks/use-platform-checkout-user.js
+++ b/client/components/platform-checkout/hooks/use-platform-checkout-user.js
@@ -27,9 +27,7 @@ const usePlatformCheckoutUser = () => {
 		};
 	}, [] );
 
-	return {
-		isRegisteredUser,
-	};
+	return isRegisteredUser;
 };
 
 export default usePlatformCheckoutUser;

--- a/client/components/platform-checkout/hooks/use-platform-checkout-user.js
+++ b/client/components/platform-checkout/hooks/use-platform-checkout-user.js
@@ -1,6 +1,31 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef, useState } from 'react';
+
 // hook for handling API calls to get and create platform checkout user.
 const usePlatformCheckoutUser = () => {
-	const isRegisteredUser = true;
+	const [ isRegisteredUser, setIsRegisteredUser ] = useState( false );
+	const windowRef = useRef( window );
+
+	useEffect( () => {
+		const handlePlatformCheckoutUserCheck = ( e ) => {
+			setIsRegisteredUser( e.detail.isRegisteredUser );
+		};
+
+		const currentWindowRef = windowRef.current;
+		currentWindowRef.addEventListener(
+			'PlatformCheckoutUserCheck',
+			handlePlatformCheckoutUserCheck
+		);
+
+		return () => {
+			currentWindowRef.removeEventListener(
+				'PlatformCheckoutUserCheck',
+				handlePlatformCheckoutUserCheck
+			);
+		};
+	}, [] );
 
 	return {
 		isRegisteredUser,

--- a/client/components/platform-checkout/save-user/checkout-page-save-user.js
+++ b/client/components/platform-checkout/save-user/checkout-page-save-user.js
@@ -21,7 +21,7 @@ const CheckoutPageSaveUser = () => {
 	const [ isSaveDetailsChecked, setIsSaveDetailsChecked ] = useState( false );
 	// eslint-disable-next-line no-unused-vars
 	const [ phoneNumber, setPhoneNumber ] = useState( '' );
-	const { isRegisteredUser } = usePlatformCheckoutUser();
+	const isRegisteredUser = usePlatformCheckoutUser();
 	const { isWCPayChosen } = useSelectedPaymentMethod();
 
 	if ( ! isWCPayChosen || isRegisteredUser ) {

--- a/client/components/platform-checkout/save-user/test/checkout-page-save-user.test.js
+++ b/client/components/platform-checkout/save-user/test/checkout-page-save-user.test.js
@@ -17,9 +17,7 @@ jest.mock( '../../hooks/use-selected-payment-method', () => jest.fn() );
 
 describe( 'CheckoutPageSaveUser', () => {
 	beforeEach( () => {
-		usePlatformCheckoutUser.mockImplementation( () => ( {
-			isRegisteredUser: false,
-		} ) );
+		usePlatformCheckoutUser.mockImplementation( () => false );
 
 		useSelectedPaymentMethod.mockImplementation( () => ( {
 			isWCPayChosen: true,
@@ -48,9 +46,7 @@ describe( 'CheckoutPageSaveUser', () => {
 	} );
 
 	it( 'should not render checkbox for saving Platform Checkout user when user is already registered', () => {
-		usePlatformCheckoutUser.mockImplementation( () => ( {
-			isRegisteredUser: true,
-		} ) );
+		usePlatformCheckoutUser.mockImplementation( () => true );
 
 		render( <CheckoutPageSaveUser /> );
 		expect(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR creates and dispatches a new custom event when a response is returned from the `user/exists` platform checkout endpoint with the `isRegisteredUser` set to `data[ 'user-exists' ]`. A listener for that event has also been added to the component that allows users to save their data for faster checkout. If the user exists, that section is not shown. Otherwise, it is.

#### Testing instructions

1. Add a product to your cart.
2. Go to the shortcode checkout.
3. Verify that the "Remember your details?" section is shown.
4. Enter an email address that exists on the platform checkout and verify that the section is **_not_** rendered.
4. Enter an email address that **_does not exist_** on the platform checkout and verify that the section **_is_** rendered.