### PR TITLE
Enable capture terminal payment for succeeded intents

### DIFF
--- a/changelog/update-3764-register-captured-terminal-payment
+++ b/changelog/update-3764-register-captured-terminal-payment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Enable capture terminal payment for succeeded intents

--- a/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
@@ -146,27 +146,27 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 
 		$mock_intent = $this->createMock( WC_Payments_API_Intention::class );
 		$mock_intent
-			->expects( $this->any() )
+			->expects( $this->atLeastOnce() )
 			->method( 'get_status' )
 			->willReturn( 'succeeded' );
 		$mock_intent
-			->expects( $this->any() )
+			->expects( $this->atLeastOnce() )
 			->method( 'get_id' )
 			->willReturn( $this->mock_intent_id );
 		$mock_intent
-			->expects( $this->any() )
+			->expects( $this->once() )
 			->method( 'get_payment_method_id' )
 			->willReturn( 'pm_mock' );
 		$mock_intent
-			->expects( $this->any() )
+			->expects( $this->once() )
 			->method( 'get_customer_id' )
 			->willReturn( 'cus_mock' );
 		$mock_intent
-			->expects( $this->any() )
+			->expects( $this->atLeastOnce() )
 			->method( 'get_charge_id' )
 			->willReturn( 'ch_mock' );
 		$mock_intent
-			->expects( $this->any() )
+			->expects( $this->atLeastOnce() )
 			->method( 'get_currency' )
 			->willReturn( 'mok' );
 
@@ -174,10 +174,6 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'get_intent' )
 			->willReturn( $mock_intent );
-
-		$this->mock_gateway
-			->expects( $this->never() )
-			->method( 'capture_charge' );
 
 		$this->mock_gateway
 			->expects( $this->once() )
@@ -191,6 +187,19 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 				'ch_mock',
 				'mok'
 			);
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'update_order_status_from_intent' )
+			->with(
+				$this->isInstanceOf( WC_Order::class ),
+				$this->mock_intent_id,
+				'succeeded',
+				'ch_mock',
+				'mok'
+			);
+		$this->mock_gateway
+			->expects( $this->never() )
+			->method( 'capture_charge' );
 
 		$request = new WP_REST_Request( 'POST' );
 		$request->set_body_params(
@@ -227,27 +236,27 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 
 		$mock_intent = $this->createMock( WC_Payments_API_Intention::class );
 		$mock_intent
-			->expects( $this->any() )
+			->expects( $this->atLeastOnce() )
 			->method( 'get_status' )
 			->willReturn( 'succeeded' );
 		$mock_intent
-			->expects( $this->any() )
+			->expects( $this->atLeastOnce() )
 			->method( 'get_id' )
 			->willReturn( $this->mock_intent_id );
 		$mock_intent
-			->expects( $this->any() )
+			->expects( $this->once() )
 			->method( 'get_payment_method_id' )
 			->willReturn( 'pm_mock' );
 		$mock_intent
-			->expects( $this->any() )
+			->expects( $this->once() )
 			->method( 'get_customer_id' )
 			->willReturn( 'cus_mock' );
 		$mock_intent
-			->expects( $this->any() )
+			->expects( $this->atLeastOnce() )
 			->method( 'get_charge_id' )
 			->willReturn( 'ch_mock' );
 		$mock_intent
-			->expects( $this->any() )
+			->expects( $this->atLeastOnce() )
 			->method( 'get_currency' )
 			->willReturn( 'mok' );
 
@@ -255,10 +264,6 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'get_intent' )
 			->willReturn( $mock_intent );
-
-		$this->mock_gateway
-			->expects( $this->never() )
-			->method( 'capture_charge' );
 
 		$this->mock_gateway
 			->expects( $this->once() )
@@ -272,6 +277,19 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 				'ch_mock',
 				'mok'
 			);
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'update_order_status_from_intent' )
+			->with(
+				$this->isInstanceOf( WC_Order::class ),
+				$this->mock_intent_id,
+				'succeeded',
+				'ch_mock',
+				'mok'
+			);
+		$this->mock_gateway
+			->expects( $this->never() )
+			->method( 'capture_charge' );
 
 		$request = new WP_REST_Request( 'POST' );
 		$request->set_body_params(

--- a/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
@@ -141,7 +141,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 		$this->assertStringEndsWith( '/wc/v3/payments/readers/receipts/pi_mock', $result_order->get_meta( 'receipt_url' ) );
 	}
 
-	public function test_capture_terminal_payment_intent_non_capturable() {
+	public function test_capture_terminal_payment_succeeded_intent() {
 		$order = $this->create_mock_order();
 
 		$mock_intent = $this->createMock( WC_Payments_API_Intention::class );
@@ -149,6 +149,165 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 			->expects( $this->any() )
 			->method( 'get_status' )
 			->willReturn( 'succeeded' );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_id' )
+			->willReturn( $this->mock_intent_id );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_payment_method_id' )
+			->willReturn( 'pm_mock' );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_customer_id' )
+			->willReturn( 'cus_mock' );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_charge_id' )
+			->willReturn( 'ch_mock' );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_currency' )
+			->willReturn( 'mok' );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->willReturn( $mock_intent );
+
+		$this->mock_gateway
+			->expects( $this->never() )
+			->method( 'capture_charge' );
+
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'attach_intent_info_to_order' )
+			->with(
+				$this->isInstanceOf( WC_Order::class ),
+				$this->mock_intent_id,
+				'succeeded',
+				'pm_mock',
+				'cus_mock',
+				'ch_mock',
+				'mok'
+			);
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params(
+			[
+				'order_id'          => $order->get_id(),
+				'payment_intent_id' => $this->mock_intent_id,
+			]
+		);
+
+		$response      = $this->controller->capture_terminal_payment( $request );
+		$response_data = $response->get_data();
+
+		$this->assertSame( 200, $response->status );
+		$this->assertEquals(
+			[
+				'status' => 'succeeded',
+				'id'     => $this->mock_intent_id,
+			],
+			$response_data
+		);
+
+		$result_order = wc_get_order( $order->get_id() );
+		$this->assertSame( 'woocommerce_payments', $result_order->get_payment_method() );
+		$this->assertSame( 'WooCommerce In-Person Payments', $result_order->get_payment_method_title() );
+		$this->assertSame( 'completed', $result_order->get_status() );
+		$this->assertStringEndsWith( '/wc/v3/payments/readers/receipts/' . $this->mock_intent_id, $result_order->get_meta( 'receipt_url' ) );
+	}
+
+	public function test_capture_terminal_payment_completed_order() {
+		// This scenario may occur when `process_webhook_payment_intent_succeeded`
+		// is triggered before the terminal payment is captured in the backend.
+		$order = $this->create_mock_order();
+		$order->update_status( 'completed' );
+
+		$mock_intent = $this->createMock( WC_Payments_API_Intention::class );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_status' )
+			->willReturn( 'succeeded' );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_id' )
+			->willReturn( $this->mock_intent_id );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_payment_method_id' )
+			->willReturn( 'pm_mock' );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_customer_id' )
+			->willReturn( 'cus_mock' );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_charge_id' )
+			->willReturn( 'ch_mock' );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_currency' )
+			->willReturn( 'mok' );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->willReturn( $mock_intent );
+
+		$this->mock_gateway
+			->expects( $this->never() )
+			->method( 'capture_charge' );
+
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'attach_intent_info_to_order' )
+			->with(
+				$this->isInstanceOf( WC_Order::class ),
+				$this->mock_intent_id,
+				'succeeded',
+				'pm_mock',
+				'cus_mock',
+				'ch_mock',
+				'mok'
+			);
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params(
+			[
+				'order_id'          => $order->get_id(),
+				'payment_intent_id' => $this->mock_intent_id,
+			]
+		);
+
+		$response      = $this->controller->capture_terminal_payment( $request );
+		$response_data = $response->get_data();
+
+		$this->assertSame( 200, $response->status );
+		$this->assertEquals(
+			[
+				'status' => 'succeeded',
+				'id'     => $this->mock_intent_id,
+			],
+			$response_data
+		);
+
+		$result_order = wc_get_order( $order->get_id() );
+		$this->assertSame( 'woocommerce_payments', $result_order->get_payment_method() );
+		$this->assertSame( 'WooCommerce In-Person Payments', $result_order->get_payment_method_title() );
+		$this->assertSame( 'completed', $result_order->get_status() );
+		$this->assertStringEndsWith( '/wc/v3/payments/readers/receipts/' . $this->mock_intent_id, $result_order->get_meta( 'receipt_url' ) );
+	}
+
+	public function test_capture_terminal_payment_intent_non_capturable() {
+		$order = $this->create_mock_order();
+
+		$mock_intent = $this->createMock( WC_Payments_API_Intention::class );
+		$mock_intent
+			->expects( $this->any() )
+			->method( 'get_status' )
+			->willReturn( 'requires_payment_method' );
 
 		$this->mock_api_client
 			->expects( $this->once() )


### PR DESCRIPTION
Fixes #3803
Fixes #3764

Interac payments are authorized and captured in a single step on client-side, in which case server-side capturing of intent is not required. But it is still desirable to register such payments on server-side to keep the order data consistent with regular terminal payments.

#### Changes proposed in this Pull Request

Update the `capture_terminal_payment` endpoint to handle "succeeded" payment intents.

#### Testing instructions

REST API

* Create a cash-on-delivery order in the WooCommerce customer-facing site.
* Check the order in WP Admin → WooCommerce → Orders. Its status should be "processing" or "pending payment."
* Create a new payment intent at `https://dashboard.stripe.com/test/connect/accounts/<account_id>/payments/new`.
* Make a POST request to `/payments/orders/<order_id>/capture_terminal_payment` with the intent id from the above step.
* Verify that you receive a 200 response. Before this change, a 409 response was returned.
* Also verify the order status has changed to "completed" in WP Admin and appropriate order notes are captured.

Mobile App

* Verify if an Interac payment is successfully captured in the backend.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests
- [x] Tested on mobile

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
