### PR TITLE
Rename financing paydown event "date" to "datetime"

### DIFF
--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -174,7 +174,7 @@ const getFinancingPaydownTimelineItem = ( event, formattedAmount, body ) => {
 	}
 
 	return {
-		date: new Date( event.date * 1000 ),
+		date: new Date( event.datetime * 1000 ),
 		icon: getIcon( 'minus' ),
 		headline,
 		body,

--- a/client/payment-details/timeline/test/map-events.js
+++ b/client/payment-details/timeline/test/map-events.js
@@ -332,7 +332,7 @@ describe( 'mapTimelineEvents', () => {
 				mapTimelineEvents( [
 					{
 						type: 'financing_paydown',
-						date: 1643717044,
+						datetime: 1643717044,
 						amount: -11000,
 						loan_id: 'flxln_1KOKzdR4ByxURRrFX9A65q40',
 					},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The server expects all events to have a "datetime" field to sort them, but the previous implementation used "date". This has been fixed, so this commit updates the client to use the new field.

#### Testing instructions

* Follow the instructions from 1666-gh-Automattic/woocommerce-payments-server and make sure you can see the event date when sent in the new field

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _QA Testing Not Applicable_