### PR TITLE
E2E - Update GH workflow to fix compatibility with WC 4.8.0

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -56,11 +56,18 @@ jobs:
       E2E_BRANCH: ${{ matrix.test_branches }}
 
     steps:
-      # Set conditional ENV Variables
-      - name: Set conditional variables
-        if: ${{ matrix.woocommerce == '4.8.0' }}
+      # Conditionally skip workflow. Remove/update based on min supported WC version.
+      - name: Conditionally skip workflow
         run: |
-          echo "SKIP_WC_BLOCKS_TESTS=1" >> $GITHUB_ENV
+          if [[ $E2E_WC_VERSION == '4.8.0' ]]; then
+            echo "SKIP_WC_BLOCKS_TESTS=1" >> $GITHUB_ENV
+            if [[
+                $E2E_GROUP == 'wcpay' && $E2E_BRANCH == 'merchant' ||
+                $E2E_GROUP == 'blocks'
+            ]]; then
+                echo "SKIP_E2E_WORKFLOW=1" >> $GITHUB_ENV
+            fi
+          fi
 
       # Log workflow configuration
       - name: Workflow Configuration

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -44,8 +44,6 @@ jobs:
         exclude:
           - test_groups: 'blocks'
             test_branches: 'merchant'
-          - woocommerce: '4.8.0'
-            test_groups: 'blocks'
 
     name: WC - ${{ matrix.woocommerce }} | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 
@@ -155,11 +153,13 @@ jobs:
         run: npm run test:e2e
 
       # Archive screenshots if any
-      - name: Archive e2e test screenshots
+      - name: Archive e2e test screenshots & logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
             name: e2e-screenshots
-            path: tests/e2e/screenshots
+            path: |
+              tests/e2e/screenshots
+              tests/e2e/docker/wp-content/debug.log
             if-no-files-found: ignore
             retention-days: 5

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -71,6 +71,7 @@ jobs:
 
       # Log workflow configuration
       - name: Workflow Configuration
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: |
           echo "WordPress version: ${{ matrix.wordpress }}"
           echo "WooCommerce version: ${{ matrix.woocommerce }}"
@@ -80,34 +81,40 @@ jobs:
 
       # Clone Repo
       - name: Clone WCPay Repository
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/checkout@v2
 
       # Use node version from .nvmrc
       - name: Setup NodeJS
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/setup-node@v2
         with:
           node-version-file: '.nvmrc'
 
       # Dependency caching
       - name: Add composer to cache
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/cache@v2
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
 
       - name: Add vendor directory to cache
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/cache@v2
         with:
           path: vendor/
           key:  ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
 
       - name: Add NPM directory to cache
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/cache@v2
         with:
           path: ~/.npm/
           key:  ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
 
       - name: Add node_modules to cache
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/cache@v2
         with:
           path: node_modules/
@@ -115,6 +122,7 @@ jobs:
 
       # PHP setup
       - name: PHP Setup
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -124,6 +132,7 @@ jobs:
 
       # Prepare testing dependencies
       - name: Prepare testing dependencies
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: |
           echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
           sudo systemctl start mysql.service
@@ -131,15 +140,18 @@ jobs:
 
       # Build WCPay client
       - name: Build WCPay Client
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: npm ci && npm run build:client
 
       # Prepare test environment
       - name: Prepare test environment
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: |
           npm run test:e2e-setup
 
       # Run Tests
       - name: Run E2E Tests
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: npm run test:e2e
 
       # Archive screenshots if any

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -44,6 +44,8 @@ jobs:
         exclude:
           - test_groups: 'blocks'
             test_branches: 'merchant'
+          - woocommerce: '4.8.0'
+            test_groups: 'blocks'
 
     name: WC - ${{ matrix.woocommerce }} | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -54,6 +54,12 @@ jobs:
       E2E_BRANCH: ${{ matrix.test_branches }}
 
     steps:
+      # Set conditional ENV Variables
+      - name: Set conditional variables
+        if: ${{ matrix.woocommerce == '4.8.0' }}
+        run: |
+          echo "SKIP_WC_BLOCKS_TESTS=1" >> $GITHUB_ENV
+
       # Log workflow configuration
       - name: Workflow Configuration
         run: |

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -148,6 +148,12 @@ fi
 echo "Updating the WordPress database..."
 cli wp core update-db --quiet
 
+# Disable displaying errors & log to file with WP_DEBUG when DEBUG flag is not present or false.
+if [[ "$DEBUG" != true ]]; then
+	cli wp config set WP_DEBUG_DISPLAY false --raw
+	cli wp config set WP_DEBUG_LOG true --raw
+fi
+
 echo "Updating permalink structure"
 cli wp rewrite structure '/%postname%/'
 


### PR DESCRIPTION
### Problem

WooCommerce 4.8.0 has compatibility issues with WooCommerce Blocks package (#3862) causing the E2E pipeline to fail. Since we install the latest version of WooCommerce blocks package during E2E environment setup, we need to update the workflow to skip specific tests based on the WooCommerce version.

### Changes proposed in this Pull Request

Introduces a new step on GH workflow to add environment variable `SKIP_E2E_WORKFLOW` based on test versions and configured rest of the steps to check for the same. If present, the steps will be skipped marking the test as successful in GH actions.

For WC 4.8.0, WCPay - Merchant & Blocks - Merchant tests are skipped. Also during setup, WC Blocks package won't be installed.

Additionally, `WP_DEBUG` errors causes problems with tests on WC 4.8.0. To fix this problem, `WP_DEBUG_DISPLAY` is set to `false` & `WP_DEBUG_LOG` is set to `true` when `DEBUG` flag is not present. The workflow is also configured to upload `debug.log` as an artifact.

### Testing changes

* Trigger a  new E2E Test against this branch from Actions tab. Reference Job - https://github.com/Automattic/woocommerce-payments/actions/runs/1920915076
* Confirm that `WC - 4.8.0 | wcpay - merchant` & `WC - 4.8.0 | blocks - shopper` tests passes but steps are skipped.
* Confirm that rest of the tests for WC 4.8.0 are passing (requires #3848 to be merged). Reference Job - https://github.com/Automattic/woocommerce-payments/actions/runs/1920522059