### PR TITLE
Fix woocommerce_order_actions when order is empty

### DIFF
--- a/changelog/tweak-2704-check-order-on-woocommerce_order_actions
+++ b/changelog/tweak-2704-check-order-on-woocommerce_order_actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix bug when woocommerce_order_actions is called by a plugin or custom code.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -17,6 +17,7 @@ use WCPay\Constants\Payment_Initiated_By;
 use WCPay\Constants\Payment_Capture_Type;
 use WCPay\Tracker;
 use WCPay\Payment_Methods\UPE_Payment_Gateway;
+use WC_Order;
 
 /**
  * Gateway class for WooCommerce Payments
@@ -1856,6 +1857,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public function add_order_actions( $actions ) {
 		global $theorder;
 
+		if ( ! is_object( $theorder ) ) {
+			$theorder = new WC_Order();
+		}
+
 		if ( $this->id !== $theorder->get_payment_method() ) {
 			return $actions;
 		}
@@ -1868,6 +1873,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'capture_charge'       => __( 'Capture charge', 'woocommerce-payments' ),
 			'cancel_authorization' => __( 'Cancel authorization', 'woocommerce-payments' ),
 		];
+
+		// Clear the dummy order.
+		$theorder = null;
 
 		return array_merge( $new_actions, $actions );
 	}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -17,7 +17,6 @@ use WCPay\Constants\Payment_Initiated_By;
 use WCPay\Constants\Payment_Capture_Type;
 use WCPay\Tracker;
 use WCPay\Payment_Methods\UPE_Payment_Gateway;
-use WC_Order;
 
 /**
  * Gateway class for WooCommerce Payments

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1857,7 +1857,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		global $theorder;
 
 		if ( ! is_object( $theorder ) ) {
-			$theorder = new WC_Order();
+			return $actions;
 		}
 
 		if ( $this->id !== $theorder->get_payment_method() ) {
@@ -1872,9 +1872,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'capture_charge'       => __( 'Capture charge', 'woocommerce-payments' ),
 			'cancel_authorization' => __( 'Cancel authorization', 'woocommerce-payments' ),
 		];
-
-		// Clear the dummy order.
-		$theorder = null;
 
 		return array_merge( $new_actions, $actions );
 	}


### PR DESCRIPTION
Fixes #2704

#### Changes proposed in this Pull Request

* Fix fatal error when `woocommerce_order_actions` is called by a plugin or custom code without an order.

See 1017-gh-woocommerce/automatewoo and 1031-gh-woocommerce/automatewoo for more information.

#### Testing instructions

To test it we will need to add `do_action( 'woocommerce_order_actions', [] );` to the theme functions.php file, or create a new plugin that call `woocommerce_order_actions`.

* Create a `dummy-plugin` folder on the `wp-content/plugins`.
* Create a `dummy-plugin.php` file.
* Add this content to the file:

```php
<?php

/**
 * Plugin Name:       My Basics Plugin
 */

do_action( 'woocommerce_order_actions', [] );
```

* Enable the plugin on WordPress admin.
* Without these modifications, it will throw a error and not allow to enable the plugin.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
