### PR TITLE
Fix lodash dependency in webpack

### DIFF
--- a/changelog/fix-lodash-dependency-in-bundle
+++ b/changelog/fix-lodash-dependency-in-bundle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix JavaScript error in blocks checkout and Customizer.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -118,7 +118,6 @@ const webpackConfig = {
 			requestToExternal( request ) {
 				switch ( request ) {
 					case '@wordpress/components':
-					case 'lodash':
 						return null;
 					case '@woocommerce/components':
 						return [ 'wc', 'components' ];
@@ -135,7 +134,6 @@ const webpackConfig = {
 			requestToHandle( request ) {
 				switch ( request ) {
 					case '@wordpress/components':
-					case 'lodash':
 						return null;
 					case '@woocommerce/components':
 						return 'wc-components';


### PR DESCRIPTION
Fixes issue from https://github.com/Automattic/woocommerce-payments/pull/3736, thread: p1646282869889049-slack-CGGCLBN58

#### Changes proposed in this Pull Request

- Remove `case` for lodash in webpack.config.js.

#### Testing instructions

* Run `npm start` and check the blocks checkout page with a media block, or the customizer page.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_