### PR TITLE
Drop `wordpress-element` package

### DIFF
--- a/changelog/remove-709-wordpress-element
+++ b/changelog/remove-709-wordpress-element
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Drop an old dependency
+
+

--- a/client/account-status-settings/index.js
+++ b/client/account-status-settings/index.js
@@ -5,7 +5,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 import moment from 'moment';
-import { __experimentalCreateInterpolateElement as createInterpolateElement } from 'wordpress-element';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/client/components/deposits-status/index.js
+++ b/client/components/deposits-status/index.js
@@ -6,7 +6,7 @@
 import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
 import GridiconNotice from 'gridicons/dist/notice';
 import { __ } from '@wordpress/i18n';
-import { __experimentalCreateInterpolateElement as createInterpolateElement } from 'wordpress-element';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/client/connect-account-page/strings.js
+++ b/client/connect-account-page/strings.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { __experimentalCreateInterpolateElement as createInterpolateElement } from 'wordpress-element';
+import { createInterpolateElement } from '@wordpress/element';
 
 export default {
 	button: __( 'Finish setup', 'woocommerce-payments' ),

--- a/client/deposits/instant-deposits/modal.js
+++ b/client/deposits/instant-deposits/modal.js
@@ -5,7 +5,7 @@
  */
 import { Button, Modal } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { __experimentalCreateInterpolateElement as createInterpolateElement } from 'wordpress-element';
+import { createInterpolateElement } from '@wordpress/element';
 import { formatCurrency, formatExplicitCurrency } from 'utils/currency';
 
 /**

--- a/client/deposits/utils/index.js
+++ b/client/deposits/utils/index.js
@@ -4,7 +4,7 @@
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 import moment from 'moment';
-import { __experimentalCreateInterpolateElement as createInterpolateElement } from 'wordpress-element';
+import { createInterpolateElement } from '@wordpress/element';
 
 const formatDate = ( format, date ) =>
 	dateI18n(

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -8,7 +8,7 @@ import Gridicon from 'gridicons';
 import { __, sprintf } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
 import moment from 'moment';
-import { __experimentalCreateInterpolateElement as createInterpolateElement } from 'wordpress-element';
+import { createInterpolateElement } from '@wordpress/element';
 import { Link } from '@woocommerce/components';
 
 /**

--- a/client/subscription-product-onboarding/modal.js
+++ b/client/subscription-product-onboarding/modal.js
@@ -4,8 +4,11 @@
 import React from 'react';
 
 import { Button, Icon, Modal } from '@wordpress/components';
-import { __experimentalCreateInterpolateElement as createInterpolateElement } from 'wordpress-element';
-import { useEffect, useState } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	useEffect,
+	useState,
+} from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import { removeQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';

--- a/client/subscriptions-empty-state/index.js
+++ b/client/subscriptions-empty-state/index.js
@@ -3,9 +3,12 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { render, useEffect, useState } from '@wordpress/element';
-
-import { __experimentalCreateInterpolateElement as createInterpolateElement } from 'wordpress-element';
+import {
+	createInterpolateElement,
+	render,
+	useEffect,
+	useState,
+} from '@wordpress/element';
 import { Button } from '@wordpress/components';
 
 import wcpayTracks from '../tracks';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1300,6 +1300,7 @@
       "version": "7.13.17",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz",
       "integrity": "sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -10657,6 +10658,7 @@
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.12.2.tgz",
       "integrity": "sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
@@ -27117,7 +27119,8 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -31884,18 +31887,6 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
-    },
-    "wordpress-element": {
-      "version": "npm:@wordpress/element@2.11.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-      "integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-      "requires": {
-        "@babel/runtime": "^7.8.3",
-        "@wordpress/escape-html": "^1.7.0",
-        "lodash": "^4.17.15",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0"
-      }
     },
     "worker-farm": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -69,8 +69,7 @@
     "debug": "^4.1.1",
     "interpolate-components": "^1.1.1",
     "intl-tel-input": "^17.0.15",
-    "lodash": "^4.17.14",
-    "wordpress-element": "npm:@wordpress/element@2.11.0"
+    "lodash": "^4.17.14"
   },
   "devDependencies": {
     "@automattic/color-studio": "2.3.1",


### PR DESCRIPTION
Fixes #709

#### Changes proposed in this Pull Request
Drop `wordpress-element` in favor of `@wordpress/element` and update all affected code.

Our minimum WordPress version is now 5.7 and includes `@wordpress/element@2.19.1` that already exports `createInterpolateElement`. So we can replace all the `__experimentalCreateInterpolateElement ` calls with it. And stop bundling it.

#### Testing instructions
- Checkout the branch and run `npm run start`
- Any of the affected components that use `createInterpolateElement` should render without issues. For example: deposit status, connect account page, account status settings, etc.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
