### PR TITLE
Allow redirecting to Stripe's KYC given a URL query param

### DIFF
--- a/changelog/add-stripe-onboarding-redirection
+++ b/changelog/add-stripe-onboarding-redirection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Redirect merchants to the onboarding flow when a URL parameter is present

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -45,6 +45,7 @@ class WC_Payments_Account {
 
 		add_action( 'admin_init', [ $this, 'maybe_handle_onboarding' ] );
 		add_action( 'admin_init', [ $this, 'maybe_redirect_to_onboarding' ], 11 ); // Run this after the WC setup wizard and onboarding redirection logic.
+		add_action( 'admin_init', [ $this, 'maybe_redirect_to_wcpay_connect' ], 12 ); // Run this after the redirect to onboarding logic.
 		add_action( 'woocommerce_payments_account_refreshed', [ $this, 'handle_instant_deposits_inbox_note' ] );
 		add_action( 'woocommerce_payments_account_refreshed', [ $this, 'handle_loan_approved_inbox_note' ] );
 		add_action( self::INSTANT_DEPOSITS_REMINDER_ACTION, [ $this, 'handle_instant_deposits_inbox_reminder' ] );
@@ -470,6 +471,47 @@ class WC_Payments_Account {
 		// Redirect if not connected.
 		$this->redirect_to_onboarding_page();
 		return true;
+	}
+
+	/**
+	 * Redirects to the wcpay-connect URL, which then redirects to the KYC flow.
+	 *
+	 * This URL is used by the KYC reminder email. We can't take the merchant
+	 * directly to the wcpay-connect URL because it's nonced, and the
+	 * nonce will likely be expired by the time the user follows the link.
+	 * That's why we need this middleman instead.
+	 */
+	public function maybe_redirect_to_wcpay_connect() {
+		if ( wp_doing_ajax() || ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
+		$params = [
+			'page' => 'wc-admin',
+			'path' => '/payments/connect',
+		];
+
+		// We're not in the onboarding page, don't redirect.
+		if ( count( $params ) !== count( array_intersect_assoc( $_GET, $params ) ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
+		// We could use a value for this parameter for tracking the email that brought the user here.
+		if ( isset( $_GET['wcpay-connect-redirect'] ) ) {
+
+			// Take the user to the 'wcpay-connect' URL.
+			// We handle creating and redirecting to the account link there.
+			$connect_url = add_query_arg(
+				[
+					'wcpay-connect' => '1',
+					'_wpnonce'      => wp_create_nonce( 'wcpay-connect' ),
+				],
+				admin_url( 'admin.php' )
+			);
+
+			wp_safe_redirect( $connect_url );
+			exit;
+		}
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -199,6 +199,60 @@ class WC_Payments_Account_Test extends WP_UnitTestCase {
 		$this->assertFalse( WC_Payments_Account::is_on_boarding_disabled() );
 	}
 
+	public function test_maybe_redirect_to_wcpay_connect_do_redirect() {
+		// Test as an admin user.
+		wp_set_current_user( 1 );
+
+		// Set the redirection parameter.
+		$_GET['wcpay-connect-redirect'] = 1;
+
+		// Mock WC_Payments_Account without redirect_to to prevent headers already sent error.
+		$mock_wcpay_account = $this->getMockBuilder( WC_Payments_Account::class )
+			->setMethods( [ 'redirect_to' ] )
+			->setConstructorArgs( [ $this->mock_api_client ] )
+			->getMock();
+
+		$mock_wcpay_account->expects( $this->once() )->method( 'redirect_to' );
+
+		$this->assertTrue( $mock_wcpay_account->maybe_redirect_to_wcpay_connect() );
+	}
+
+	public function test_maybe_redirect_to_wcpay_connect_unauthorized_user() {
+		// Test as an editor user.
+		$editor_user = $this->factory()->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $editor_user );
+
+		$this->assertFalse( $this->wcpay_account->maybe_redirect_to_wcpay_connect() );
+	}
+
+	public function test_maybe_redirect_to_wcpay_connect_doing_ajax() {
+		// Test as an admin user.
+		wp_set_current_user( 1 );
+
+		// Set the redirection parameter.
+		$_GET['wcpay-connect-redirect'] = 1;
+
+		// Simulate we're in an AJAX request.
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		$this->assertFalse( $this->wcpay_account->maybe_redirect_to_wcpay_connect() );
+
+		// Cleaning up.
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+	}
+
+	public function test_maybe_redirect_to_wcpay_connect_wrong_page() {
+		// Test as an admin user.
+		wp_set_current_user( 1 );
+
+		// Set the redirection parameter.
+		$_GET['wcpay-connect-redirect'] = 1;
+
+		$_GET['path'] = '/payments/overview';
+
+		$this->assertFalse( $this->wcpay_account->maybe_redirect_to_wcpay_connect() );
+	}
+
 	public function test_try_is_stripe_connected_returns_true_when_connected() {
 		$this->mock_api_client->expects( $this->once() )->method( 'get_account_data' )->will(
 			$this->returnValue(


### PR DESCRIPTION
Fixes #3700 

#### Changes proposed in this Pull Request

Allow redirecting to Stripe's KYC given a URL query param.

This PR allows taking merchants to Stripe's KYC flow when they go to `{yoursite.com}/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect&wcpay-connect-redirect=1`. This is used by the KYC reminder email to take merchants back to the onboarding process. This approach was discussed in pdkmC9-7P-p2#comment-203

#### Testing instructions

Disconnect your site from any WCPay account it's connected to
* On Dev tools, make sure "Dev mode" and "Force onboarding" are enabled
* Click on "Reonboard" and don't complete the flow
* On Dev tools, disable "Force onboarding" (we want to connect the account we just initiated the flow with, not a new one)

Test case: Redirection happy path
* Go to `{yoursite.com}/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect&wcpay-connect-redirect=1`
* Confirm you're redirected to Stripe's KYC flow
* Complete the KYC flow
* Confirm you're redirected to your site's Overview page, and that an account now shows up as connected

Test case: Redirection when an account is already connected
* After following the happy path, go to `{yoursite.com}/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect&wcpay-connect-redirect=1`
* Confirm you're redirected to the Overview page, which would be displaying the data of the previously connected account

Test case: Redirection as a logged-out authorized user
* Disconnect your site from any WCPay account it's connected to
* Log out
* Go to `{yoursite.com}/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect&wcpay-connect-redirect=1`
* You should be redirected to WP login page
* Log in with an Administrator user (or any that can `manage_woocommerce`)
* Confirm you're redirected to Stripe's KYC flow
* Complete the KYC flow
* Confirm you're redirected to your site's Overview page, and that an account now shows up as connected

Test case: Redirection with a non-authorized user
* Disconnect your site from any WCPay account it's connected to
* Log out
* Go to `{yoursite.com}/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect&wcpay-connect-redirect=1`
* You should be redirected to WP login page
* Log in with an Editor user (or any that can't `manage_woocommerce` and has access to WP Dashboard)
* Confirm you see a "Sorry, you are not allowed to access this page." message

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_