### PR TITLE
Improve visibility of wcpay payment methods fields for dark themes

### DIFF
--- a/changelog/fix-1152-wcpay-checkout-payment-methods-fields-visibility
+++ b/changelog/fix-1152-wcpay-checkout-payment-methods-fields-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve visibility of checkout fields for WCPay payment options on a darker theme

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -2,6 +2,10 @@
 	margin-bottom: 2rem;
 }
 
+.wcpay-card-mounted {
+	background-color: #fff;
+}
+
 /* stylelint-disable-next-line selector-id-pattern */
 #express-payment-method-platform_checkout {
 	width: 100%;


### PR DESCRIPTION
Fixes #1152 

#### Changes proposed in this Pull Request

Make checkout fields usable for darker themes.

Using a darker theme, we cannot distinguish the card number, expiry date, and CCV fields. That makes the checkout form unusable.

Similar to what is done for the Stripe gateway, we now apply a white background to the container class. That has no impact when using light themes, making the fields usable for darker themes.

The base class `wcpay-card-mounted` was already applied to the container but not defined in the relevant CSS file, which is why I added the white background rule to it. I checked, and no other files (upe) from this checkout folder use this class, so there shouldn't be any side effects on other pieces.

Stripe gateway display with a dark theme:
![Screenshot 2022-03-07 at 16 54 58](https://user-images.githubusercontent.com/28830738/157069459-add0bd4a-d8fe-466b-8bb9-6cf8c502ea95.png)

WCPay display with a dark theme before:
![Screenshot 2022-03-07 at 16 53 45](https://user-images.githubusercontent.com/28830738/157069299-ad743a0f-28bc-44fc-8601-61e777c6bb83.png)

WCPay display with a dark theme after:
![Screenshot 2022-03-07 at 16 54 04](https://user-images.githubusercontent.com/28830738/157069315-3f95d961-22af-4677-8d9a-e0784c3f207c.png)

WCPay display with a light theme after:
![Screenshot 2022-03-08 at 09 21 18](https://user-images.githubusercontent.com/28830738/157196016-523eb79d-c1c4-4d32-b1ed-47df5a5dc814.png)

#### Testing instructions

- Install Spice Software Dark theme
- Add a product to the cart and go to the checkout page
- You should be able to distinguish the fields for the WCPay payment options thanks to the white background


- Use a light theme (Storefront for example)
- The WCPay fields for payment options should still be displayed similarly to how it used to be displayed before this change

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
