### PR TITLE
Fix guest session

### DIFF
--- a/changelog/fix-guest-session
+++ b/changelog/fix-guest-session
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix checkout as guest on platform checkout

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -838,6 +838,15 @@ class WC_Payments {
 		if ( $is_platform_checkout_feature_enabled && $is_platform_checkout_enabled ) {
 			add_action( 'wc_ajax_wcpay_init_platform_checkout', [ __CLASS__, 'ajax_init_platform_checkout' ] );
 			add_filter( 'determine_current_user', [ __CLASS__, 'determine_current_user_for_platform_checkout' ] );
+			add_filter(
+				'woocommerce_cookie',
+				function( string $cookie_hash ) {
+					if ( isset( $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) && 0 === (int) $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) {
+						return 'platform_checkout_session';
+					}
+					return $cookie_hash;
+				}
+			);
 			// Disable nonce checks for API calls. TODO This should be changed.
 			add_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
 			add_action( 'woocommerce_checkout_before_customer_details', [ __CLASS__, 'platform_checkout_fields_before_billing_details' ], 10 );
@@ -910,13 +919,6 @@ class WC_Payments {
 		if ( ! isset( $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) || ! is_numeric( $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) ) {
 			return $user;
 		}
-
-		add_filter(
-			'woocommerce_cookie',
-			function( string $cookie_hash ) {
-				return 'platform_checkout_session';
-			}
-		);
 
 		return (int) $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'];
 	}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -838,15 +838,7 @@ class WC_Payments {
 		if ( $is_platform_checkout_feature_enabled && $is_platform_checkout_enabled ) {
 			add_action( 'wc_ajax_wcpay_init_platform_checkout', [ __CLASS__, 'ajax_init_platform_checkout' ] );
 			add_filter( 'determine_current_user', [ __CLASS__, 'determine_current_user_for_platform_checkout' ] );
-			add_filter(
-				'woocommerce_cookie',
-				function( string $cookie_hash ) {
-					if ( isset( $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) && 0 === (int) $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) {
-						return 'platform_checkout_session';
-					}
-					return $cookie_hash;
-				}
-			);
+			add_filter( 'woocommerce_cookie', [ __CLASS__, 'determine_session_cookie_for_platform_checkout' ] );
 			// Disable nonce checks for API calls. TODO This should be changed.
 			add_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
 			add_action( 'woocommerce_checkout_before_customer_details', [ __CLASS__, 'platform_checkout_fields_before_billing_details' ], 10 );
@@ -904,6 +896,20 @@ class WC_Payments {
 
 		Logger::log( $response_body_json );
 		wp_send_json( json_decode( $response_body_json ) );
+	}
+
+	/**
+	 * Tells WC to use platform checkout session cookie if the header is present.
+	 *
+	 * @param string $cookie_hash Default cookie hash.
+	 *
+	 * @return string
+	 */
+	public static function determine_session_cookie_for_platform_checkout( $cookie_hash ) {
+		if ( isset( $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) && 0 === (int) $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) {
+			return 'platform_checkout_session';
+		}
+		return $cookie_hash;
 	}
 
 	/**


### PR DESCRIPTION
###
Fixes platform checkout when customer is not logged into merchant site. 

Something changed in WC or WCPay so the session was initialized before the user was loaded. Therefore we need to register the `woocommerce_cookie` filter earlier in the init process. 

Without this change platform checkout site would say the cart was empty.