### PR TITLE
Add a filter in get_metadata_from_order

### DIFF
--- a/changelog/add-metadata-filter
+++ b/changelog/add-metadata-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add `wcpay_metadata_from_order` filter which allows for injecting of arbitrary metadata and/or overriding of the `payment_context`

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1266,7 +1266,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			}
 		}
 
-		return $metadata;
+		return apply_filters( 'wcpay_metadata_from_order', $metadata, $order, $payment_type );
 	}
 
 	/**


### PR DESCRIPTION
This PR provides no functional change.

**Changes proposed in this Pull Request**

- Add `wcpay_metadata_from_order` filter which allows for injecting of arbitrary metadata and/or overriding of the payment_context

The change proposed here adds a filter that will be used in the TumblrPay project to pass the information about the type of product being purchased, so the server can apply appropriate fee structure.
We have different fee structures for tips, and subscriptions and currently rely on parsing the product name (SIC!) to detect type of product.
We want a more robust system in place, so we can explicitly pass along the information to the `payment_context` field.