### PR TITLE
Fix the conversion amount in the transaction list

### DIFF
--- a/changelog/fix-3939-incorrect-conversion-in-transaction-list
+++ b/changelog/fix-3939-incorrect-conversion-in-transaction-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the conversion from amount in the transactions list.

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -276,6 +276,7 @@ export const TransactionsList = (
 		const dataType = txn.metadata ? txn.metadata.charge_type : txn.type;
 		const formatAmount = () => {
 			const amount = txn.metadata ? 0 : txn.amount;
+			const fromAmount = txn.customer_amount ? txn.customer_amount : 0;
 
 			return {
 				value: amount / 100,
@@ -283,7 +284,7 @@ export const TransactionsList = (
 					<ConvertedAmount
 						amount={ amount }
 						currency={ currency }
-						fromAmount={ amount }
+						fromAmount={ fromAmount }
 						fromCurrency={ txn.customer_currency.toUpperCase() }
 					/>
 				),


### PR DESCRIPTION
Fixes #3939

#### Changes proposed in this Pull Request

* Update the `fromAmount` in the transactions list to be the amount the conversion was from, meaning the amount the customer paid in their currency.

#### Testing instructions

* Add another currency to your store under WooCommerce > Settings > Multi-Currency.
* Add a product to your cart and go to checkout.
* Change the currency using the currency selector widget.
* Check out.
* View your transactions list and confirm the converted from amount shows correctly.

![Screen Shot 2022-03-10 at 9 29 05 AM](https://user-images.githubusercontent.com/4634416/157671615-f0bab6b4-19ae-43b0-bc88-e051f381a9c3.png)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : QA Testing Not Applicable
