### PR TITLE
Remove type "Tweak" from the list of changelog types.

### DIFF
--- a/changelog/fix-3853-deposits-evidence-upload-preview
+++ b/changelog/fix-3853-deposits-evidence-upload-preview
@@ -1,5 +1,5 @@
 Significance: patch
-Type: tweak
+Type: fix
 Comment: Fixing a feature that is not released yet.
 
 

--- a/changelog/tweak-2695-update-grouped-card-icon
+++ b/changelog/tweak-2695-update-grouped-card-icon
@@ -1,4 +1,4 @@
 Significance: patch
-Type: tweak
+Type: update
 
 Update payment methods icons.

--- a/changelog/update-remove-changelog-type-tweak
+++ b/changelog/update-remove-changelog-type-tweak
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove type "Tweak" from the list of changelog types.

--- a/composer.json
+++ b/composer.json
@@ -76,8 +76,7 @@
                 "add": "Add",
                 "fix": "Fix",
                 "update": "Update",
-                "dev": "Dev",
-                "tweak": "Tweak"
+                "dev": "Dev"
             },
             "formatter": {
                 "filename": "bin/class-wcpay-changelog-formatter.php"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a65d27b3182bb27e7cf4175b41c5d8dd",
+    "content-hash": "658aa09066087d38fd3f2c8138dac9d3",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",


### PR DESCRIPTION
See paJDYF-3tQ-p2

#### Changes proposed in this Pull Request

- Remove "Tweak" from `extra.changelogger.type`s in composer.json.
- Update current changelog files using "tweak" as type.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- Run `npm run changelog`. Confirm that: the "tweak" option is no longer offered. 
- Run `./vendor/bin/changelogger write --use-version="3.9.0" --release-date=unreleased` (this is a part of the release process).  
- Confirm that:

1. All current changelog files under folder `/changelog` are deleted
2. File `changelog.txt` gets updated with all entries from the deleted files.


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Not apply. Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_