### PR TITLE
Display notices when redirecting to platform checkout is in progress/fails

### DIFF
--- a/client/components/platform-checkout/index.tsx
+++ b/client/components/platform-checkout/index.tsx
@@ -4,15 +4,18 @@
 import React from 'react';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
 import interpolateComponents from 'interpolate-components';
 
 /**
  * Internal dependencies
  */
 import { getConfig } from 'utils/checkout';
+import './style.scss';
 
 interface apiResponse {
 	url: Location;
+	result?: string;
 }
 
 interface wcpayApi {
@@ -24,8 +27,39 @@ interface platformCheckoutButtonProps {
 	api: wcpayApi;
 }
 
+const SuccessNotice = () => {
+	return (
+		<Notice
+			status="success"
+			isDismissible={ false }
+			className="init-platform-checkout-notice"
+		>
+			{ __(
+				'Redirecting to platform checkout. Please wait…',
+				'woocommerce-payments'
+			) }
+		</Notice>
+	);
+};
+
+const ErrorNotice = () => {
+	return (
+		<Notice
+			status="error"
+			isDismissible={ false }
+			className="init-platform-checkout-notice"
+		>
+			{ __(
+				'An error occurred while redirecting to platform checkout. Please try again.',
+				'woocommerce-payments'
+			) }
+		</Notice>
+	);
+};
+
 const PlatformCheckout = ( { isStatic, api }: platformCheckoutButtonProps ) => {
 	const [ isLoading, setIsLoading ] = useState( false );
+	const [ responseStatus, setResponseStatus ] = useState( '' );
 
 	const buttonContent = (
 		<span>
@@ -46,13 +80,20 @@ const PlatformCheckout = ( { isStatic, api }: platformCheckoutButtonProps ) => {
 	const onClick = () => {
 		setIsLoading( true );
 		api.initPlatformCheckout().then( ( response ) => {
-			window.location = response.url;
+			if ( response?.result === 'success' ) {
+				window.location = response.url;
+				setResponseStatus( 'success' );
+			} else {
+				setResponseStatus( 'error' );
+			}
 			setIsLoading( false );
 		} );
 	};
 
 	return (
 		<>
+			{ responseStatus === 'success' && <SuccessNotice /> }
+			{ responseStatus === 'error' && <ErrorNotice /> }
 			<button
 				onClick={ onClick }
 				type="button"

--- a/client/components/platform-checkout/style.scss
+++ b/client/components/platform-checkout/style.scss
@@ -1,0 +1,5 @@
+.init-platform-checkout-notice {
+	&#{&} {
+		margin: 0 0 15px 0;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If clicking the "Buy now with platform checkout" button triggers an invalid response from the back-end, the customer gets redirected to `http://example.org/undefined`. The changes proposed in this PR prevent the redirection and cause displaying an error.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Break the AJAX response by adding the following code above [this line](https://github.com/Automattic/woocommerce-payments/blob/8e1cd1871f8f57f766f96a20fce9778ac8e6755e/includes/class-wc-payments.php#L863):
   ```php
   wp_send_json( [ 'foo' => 'bar' ] );
   ```
1. See the redirection error after clicking the "Buy now with platform checkout" button.
1. Remove the above code.
1. See the redirection succees message after clicking the button.

#### Screenshots

Before clicking:

![Markup on 2022-03-11 at 19:21:12](https://user-images.githubusercontent.com/1759681/157928131-a7c2b23a-4ea9-490b-bedb-9e3f6c5a5a74.png)

On error:

![Markup on 2022-03-11 at 19:21:24](https://user-images.githubusercontent.com/1759681/157928167-28ea1d45-3375-42ec-9a27-fe8d1dfc6305.png)

On success:

![Markup on 2022-03-11 at 19:21:33](https://user-images.githubusercontent.com/1759681/157928193-3ffc69b5-7bfc-41dc-949a-00bbdda3e8f7.png)

