### PR TITLE
Fix `is_platform_payment_method` flag on blocks checkout

### DIFF
--- a/changelog/fix-is-platform-payment-method-flag
+++ b/changelog/fix-is-platform-payment-method-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix `is_platform_payment_method` flag on blocks checkout

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -818,7 +818,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				<div id="wcpay-card-element"></div>
 				<div id="wcpay-errors" role="alert"></div>
 				<input id="wcpay-payment-method" type="hidden" name="wcpay-payment-method" />
-
+				<input type="hidden" name="wcpay-is-platform-payment-method" value="<?php echo esc_attr( $this->should_use_stripe_platform_on_checkout_page() ); ?>" />
 			<?php
 			if ( $this->is_saved_cards_enabled() ) {
 				$force_save_payment = ( $display_tokenization && ! apply_filters( 'wc_payments_display_save_payment_method_checkbox', $display_tokenization ) ) || is_add_payment_method_page();
@@ -1093,7 +1093,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			$payment_methods = WC_Payments::get_gateway()->get_payment_method_ids_enabled_at_checkout( null, true );
 
-			if ( ! $payment_information->is_using_saved_payment_method() && $this->should_use_stripe_platform_on_checkout_page() ) {
+			// Make sure the payment method being charged was created in the platform.
+			if (
+				! $payment_information->is_using_saved_payment_method() &&
+				$this->should_use_stripe_platform_on_checkout_page() &&
+				// This flag is useful to differentiate between PRB, blocks and shortcode checkout, since this endpoint is being used for all of them.
+				! empty( $_POST['wcpay-is-platform-payment-method'] ) && // phpcs:ignore WordPress.Security.NonceVerification
+				filter_var( $_POST['wcpay-is-platform-payment-method'], FILTER_VALIDATE_BOOLEAN ) // phpcs:ignore WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+			) {
 				// This payment method was created under the platform account.
 				$additional_api_parameters['is_platform_payment_method'] = 'true';
 			}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -704,6 +704,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			! WC_Payments_Features::is_upe_enabled() &&
 			is_checkout() &&
 			! has_block( 'woocommerce/checkout' ) &&
+			! is_wc_endpoint_url( 'order-pay' ) &&
 			! WC()->cart->is_empty()
 		) {
 			$cart_total = WC_Payments_Utils::prepare_amount( WC()->cart->get_total( '' ), get_woocommerce_currency() );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -1081,6 +1081,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->method( 'should_use_stripe_platform_on_checkout_page' )
 			->willReturn( true );
 
+		$_POST['wcpay-is-platform-payment-method'] = 1;
+
 		// Arrange: Return a successful response from create_and_confirm_intention().
 		$intent = new WC_Payments_API_Intention(
 			'pi_123',


### PR DESCRIPTION
In #3762 we introduced platform payment methods in the shortcode checkout when the platform checkout is enabled.

More specifically in https://github.com/Automattic/woocommerce-payments/commit/7847fbfcb5e3efa18dd3c7d3fefbf1777943173f, I did some cleanup and removed a server-side check to see if a given payment method was created in the platform, but that ended up breaking the blocks and PRB checkout (when platform checkout is enabled) since both use the same `process_payment_for_order`, and I didn't anticipate that `$this->should_use_stripe_platform_on_checkout_page()` would be `true` for blocks.

Even though we have this check: `is_checkout() && ! has_block( 'woocommerce/checkout' )`, it will return `true` for the endpoint triggered from the blocks checkout.

Unfortunately, the requests coming from payment request button (express checkout), blocks and shortcode, are too similar to make use of any logic to differentiate between these types of checkouts, and let the server know which type of payment method is being used.

So the solution to this was to add an input field with the return from `$this->should_use_stripe_platform_on_checkout_page()`.

Additionally, this PR also fixes the "pay for order" page.

#### Changes proposed in this Pull Request

- Prevent Stripe JS from being initialized as platform on order-pay page: `is_wc_endpoint_url( 'order-pay' )`.
- Add form field `wcpay-is-platform-payment-method` to differentiate requests coming from blocks, shortcode and PRB.

#### Testing instructions

Note: This PR works with the `trunk` branch of the server.

- Re-build JS from this branch `npm start`.
- Make sure **Settings > Express checkouts > Platform checkout** is enabled.
- Notice shortcode, blocks and payment request button checkouts work.
- Notice the "pay for order" page works:
  - Go to wp-admin.
  - Go to **WooCommerce > Orders > Add order**.
  - Add an item to the order, and click "Create".
  - Click "Customer payment page →".
  - Checkout with a new card.
- Extra: Notice UPE still works.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] QA Testing Not Applicable
