### PR TITLE
Check for variables before using them to prevent possible errors during UPE checkout process.

### DIFF
--- a/changelog/fix-3966-possible-fatal-during-upe-checkout
+++ b/changelog/fix-3966-possible-fatal-during-upe-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Check for variables before using them to prevent possible errors during UPE checkout process.

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -656,7 +656,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			Logger::log( 'Error: ' . $e->getMessage() );
 
 			// Confirm our needed variables are set before using them due to there could be a server issue during the get_intent process.
-			$status    = $status ?? 'failed';
+			$status    = $status ?? null;
 			$charge_id = $charge_id ?? null;
 
 			/* translators: localized exception message */

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -655,6 +655,10 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		} catch ( Exception $e ) {
 			Logger::log( 'Error: ' . $e->getMessage() );
 
+			// Confirm our needed variables are set before using them due to there could be a server issue during the get_intent process.
+			$status    = $status ?? 'failed';
+			$charge_id = $charge_id ?? null;
+
 			/* translators: localized exception message */
 			$message = sprintf( __( 'UPE payment failed: %s', 'woocommerce-payments' ), $e->getMessage() );
 			$this->order_service->mark_payment_failed( $order, $intent_id, $status, $charge_id, $message );


### PR DESCRIPTION
Fixes #3966

#### Changes proposed in this Pull Request

* Set values for variables if they already do not exist.

#### Testing instructions

* Tests should pass.

We tried to replicate the issue mentioned in Slack, but we could not, so I am not sure how to manually test this.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _QA Testing Not Applicable_
