### PR TITLE
Fix/3970 show currencies based on store country

### DIFF
--- a/changelog/fix-3970-show-currencies-based-on-store-country
+++ b/changelog/fix-3970-show-currencies-based-on-store-country
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show currencies based on store country currency

--- a/client/components/account-status/account-fees/test/index.js
+++ b/client/components/account-status/account-fees/test/index.js
@@ -17,6 +17,9 @@ describe( 'AccountFees', () => {
 	beforeEach( () => {
 		global.wcpaySettings = {
 			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
 			currencyData: {
 				US: {
 					code: 'USD',
@@ -73,6 +76,8 @@ describe( 'AccountFees', () => {
 	} );
 
 	test( 'renders non-USD base fee', () => {
+		global.wcpaySettings.connect.country = 'FR';
+
 		const { container: accountFees } = renderAccountFees( [
 			{
 				payment_method: 'card',
@@ -124,6 +129,8 @@ describe( 'AccountFees', () => {
 	} );
 
 	test( 'renders discounted non-USD base fee', () => {
+		global.wcpaySettings.connect.country = 'UK';
+
 		const { container: accountFees } = renderAccountFees( [
 			{
 				payment_method: 'card',

--- a/client/components/account-status/test/index.js
+++ b/client/components/account-status/test/index.js
@@ -14,6 +14,9 @@ describe( 'AccountStatus', () => {
 	beforeEach( () => {
 		global.wcpaySettings = {
 			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'FR',
+			},
 			currencyData: {
 				FR: {
 					code: 'EUR',

--- a/client/components/active-loan-summary/test/index.js
+++ b/client/components/active-loan-summary/test/index.js
@@ -21,6 +21,19 @@ describe( 'Active loan summary', () => {
 			accountLoans: {
 				loans: [ 'flxln_123456|active' ],
 			},
+			connect: {
+				country: 'US',
+			},
+			currencyData: {
+				US: {
+					code: 'USD',
+					symbol: '$',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+			},
 		};
 	} );
 	afterEach( () => {

--- a/client/components/deposits-information/test/index.js
+++ b/client/components/deposits-information/test/index.js
@@ -75,6 +75,9 @@ describe( 'Deposits information', () => {
 	beforeEach( () => {
 		global.wcpaySettings = {
 			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'FR',
+			},
 			currencyData: {
 				FR: {
 					code: 'EUR',

--- a/client/deposits/details/test/index.js
+++ b/client/deposits/details/test/index.js
@@ -32,6 +32,19 @@ describe( 'Deposit overview', () => {
 		jest.clearAllMocks();
 		global.wcpaySettings = {
 			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
+			currencyData: {
+				US: {
+					code: 'USD',
+					symbol: '$',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+			},
 		};
 	} );
 

--- a/client/deposits/instant-deposits/test/index.js
+++ b/client/deposits/instant-deposits/test/index.js
@@ -43,7 +43,22 @@ const mockZeroInstantBalance = {
 describe( 'Instant deposit button and modal', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		global.wcpaySettings = { zeroDecimalCurrencies: [] };
+		global.wcpaySettings = {
+			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
+			currencyData: {
+				US: {
+					code: 'USD',
+					symbol: '$',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+			},
+		};
 	} );
 
 	test( 'button renders correctly with zero balance', () => {

--- a/client/deposits/list/test/index.js
+++ b/client/deposits/list/test/index.js
@@ -55,7 +55,22 @@ describe( 'Deposits list', () => {
 		// the query string is preserved across tests, so we need to reset it
 		updateQueryString( {}, '/', {} );
 
-		global.wcpaySettings = { zeroDecimalCurrencies: [] };
+		global.wcpaySettings = {
+			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
+			currencyData: {
+				US: {
+					code: 'USD',
+					symbol: '$',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+			},
+		};
 	} );
 
 	// this also covers structural test for single currency.

--- a/client/disputes/details/test/index.tsx
+++ b/client/disputes/details/test/index.tsx
@@ -21,6 +21,19 @@ const mockUseDispute = useDispute as jest.MockedFunction< typeof useDispute >;
 declare const global: {
 	wcpaySettings: {
 		zeroDecimalCurrencies: string[];
+		connect: {
+			country: string;
+		};
+		currencyData: {
+			[ key: string ]: {
+				code: string;
+				symbol: string;
+				symbolPosition: string;
+				thousandSeparator: string;
+				decimalSeparator: string;
+				precision: number;
+			};
+		};
 	};
 };
 
@@ -28,6 +41,19 @@ describe( 'Dispute details screen', () => {
 	beforeEach( () => {
 		global.wcpaySettings = {
 			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
+			currencyData: {
+				US: {
+					code: 'USD',
+					symbol: '$',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+			},
 		};
 	} );
 

--- a/client/disputes/evidence/test/index.js
+++ b/client/disputes/evidence/test/index.js
@@ -170,6 +170,19 @@ describe( 'Dispute evidence page', () => {
 	beforeEach( () => {
 		global.wcpaySettings = {
 			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
+			currencyData: {
+				US: {
+					code: 'USD',
+					symbol: '$',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+			},
 		};
 	} );
 

--- a/client/disputes/info/test/index.tsx
+++ b/client/disputes/info/test/index.tsx
@@ -16,6 +16,19 @@ import { Charge } from 'wcpay/types/charges';
 declare const global: {
 	wcpaySettings: {
 		zeroDecimalCurrencies: string[];
+		connect: {
+			country: string;
+		};
+		currencyData: {
+			[ key: string ]: {
+				code: string;
+				symbol: string;
+				symbolPosition: string;
+				thousandSeparator: string;
+				decimalSeparator: string;
+				precision: number;
+			};
+		};
 	};
 };
 
@@ -23,6 +36,19 @@ describe( 'Dispute info', () => {
 	beforeEach( () => {
 		global.wcpaySettings = {
 			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
+			currencyData: {
+				US: {
+					code: 'USD',
+					symbol: '$',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+			},
 		};
 	} );
 

--- a/client/disputes/test/index.tsx
+++ b/client/disputes/test/index.tsx
@@ -22,6 +22,19 @@ import {
 declare const global: {
 	wcpaySettings: {
 		zeroDecimalCurrencies: string[];
+		connect: {
+			country: string;
+		};
+		currencyData: {
+			[ key: string ]: {
+				code: string;
+				symbol: string;
+				symbolPosition: string;
+				thousandSeparator: string;
+				decimalSeparator: string;
+				precision: number;
+			};
+		};
 	};
 };
 
@@ -115,6 +128,19 @@ describe( 'Disputes list', () => {
 	beforeEach( () => {
 		global.wcpaySettings = {
 			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
+			currencyData: {
+				US: {
+					code: 'USD',
+					symbol: '$',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+			},
 		};
 	} );
 

--- a/client/multi-currency/single-currency-settings/test/index.test.js
+++ b/client/multi-currency/single-currency-settings/test/index.test.js
@@ -144,7 +144,22 @@ const getContainer = () => {
 describe( 'Single currency settings screen', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		global.wcpaySettings = { zeroDecimalCurrencies: [] };
+		global.wcpaySettings = {
+			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
+			currencyData: {
+				US: {
+					code: 'USD',
+					symbol: '$',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+			},
+		};
 	} );
 
 	test( 'Page renders correctly', () => {

--- a/client/payment-details/readers/test/index.js
+++ b/client/payment-details/readers/test/index.js
@@ -39,6 +39,19 @@ describe( 'RenderPaymentCardReaderChargeDetails', () => {
 
 		global.wcpaySettings = {
 			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
+			currencyData: {
+				US: {
+					code: 'USD',
+					symbol: '$',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+			},
 		};
 	} );
 

--- a/client/payment-details/summary/test/index.js
+++ b/client/payment-details/summary/test/index.js
@@ -55,6 +55,9 @@ describe( 'PaymentDetailsSummary', () => {
 		global.wcpaySettings = {
 			isSubscriptionsActive: false,
 			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
 			currencyData: {
 				US: {
 					code: 'USD',

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -33,13 +33,13 @@ Array [
   },
   Object {
     "body": Array [
-      "1,00 EUR → 1.19944 USD: $21.59 USD",
+      "1.00 EUR → 1.19944 USD: $21.59 USD",
       "Fee (2.9% + $0.30): $-0.62",
       undefined,
       "Net deposit: $20.97 USD",
     ],
     "date": 2020-04-01T14:37:54.000Z,
-    "headline": "A payment of 18,00&nbsp;€ EUR was successfully charged.",
+    "headline": "A payment of €18.00 EUR was successfully charged.",
     "icon": <t
       className="is-success"
       icon="checkmark"
@@ -82,13 +82,13 @@ Array [
   },
   Object {
     "body": Array [
-      "1,00 EUR → 1.19944 USD: $21.59 USD",
-      "Fee: 0,52&nbsp;€",
+      "1.00 EUR → 1.19944 USD: $21.59 USD",
+      "Fee: €0.52",
       undefined,
       "Net deposit: $20.97 USD",
     ],
     "date": 2020-04-01T14:37:54.000Z,
-    "headline": "A payment of 18,00&nbsp;€ EUR was successfully charged.",
+    "headline": "A payment of €18.00 EUR was successfully charged.",
     "icon": <t
       className="is-success"
       icon="checkmark"
@@ -112,8 +112,8 @@ Array [
   },
   Object {
     "body": Array [
-      "Disputed amount: 18,00&nbsp;€",
-      "1,00 EUR → 1.2 USD: $21.60 USD",
+      "Disputed amount: €18.00",
+      "1.00 EUR → 1.2 USD: $21.60 USD",
       "Fee: $15.00",
     ],
     "date": 2020-04-02T02:06:14.000Z,
@@ -207,7 +207,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-04T13:51:06.000Z,
-    "headline": "$21.64 USD will be deducted from a future deposit.",
+    "headline": "21,64&nbsp;$ USD will be deducted from a future deposit.",
     "icon": <t
       className=""
       icon="minus"
@@ -216,7 +216,7 @@ Array [
   },
   Object {
     "body": Array [
-      "1,00 EUR → 1.20222 USD: $21.64 USD",
+      "1,00 EUR → 1,20222 USD: 21,64&nbsp;$ USD",
     ],
     "date": 2020-04-04T13:51:06.000Z,
     "headline": "A payment of 18,00&nbsp;€ EUR was successfully refunded.",
@@ -244,7 +244,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-03T18:58:01.000Z,
-    "headline": "$6.00 USD will be deducted from a future deposit.",
+    "headline": "6,00&nbsp;$ USD will be deducted from a future deposit.",
     "icon": <t
       className=""
       icon="minus"
@@ -253,7 +253,7 @@ Array [
   },
   Object {
     "body": Array [
-      "1,00 EUR → 1.2 USD: $6.00 USD",
+      "1,00 EUR → 1,2 USD: 6,00&nbsp;$ USD",
     ],
     "date": 2020-04-03T18:58:01.000Z,
     "headline": "A payment of 5,00&nbsp;€ EUR was successfully refunded.",

--- a/client/payment-details/timeline/test/index.js
+++ b/client/payment-details/timeline/test/index.js
@@ -21,6 +21,9 @@ describe( 'PaymentDetailsTimeline', () => {
 				paymentTimeline: true,
 			},
 			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
 			currencyData: {
 				US: {
 					code: 'USD',

--- a/client/payment-details/timeline/test/map-events.js
+++ b/client/payment-details/timeline/test/map-events.js
@@ -9,6 +9,9 @@ describe( 'mapTimelineEvents', () => {
 		jest.clearAllMocks();
 		global.wcpaySettings = {
 			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
 			currencyData: {
 				US: {
 					code: 'USD',
@@ -452,6 +455,8 @@ describe( 'mapTimelineEvents', () => {
 		} );
 
 		test( 'formats partial_refund events', () => {
+			global.wcpaySettings.connect.country = 'FR';
+
 			expect(
 				mapTimelineEvents( [
 					{
@@ -474,6 +479,8 @@ describe( 'mapTimelineEvents', () => {
 		} );
 
 		test( 'formats full_refund events', () => {
+			global.wcpaySettings.connect.country = 'FR';
+
 			expect(
 				mapTimelineEvents( [
 					{

--- a/client/transactions/list/test/converted-amount.tsx
+++ b/client/transactions/list/test/converted-amount.tsx
@@ -13,6 +13,19 @@ import ConvertedAmount from '../converted-amount';
 declare const global: {
 	wcpaySettings: {
 		zeroDecimalCurrencies: string[];
+		connect: {
+			country: string;
+		};
+		currencyData: {
+			[ key: string ]: {
+				code: string;
+				symbol: string;
+				symbolPosition: string;
+				thousandSeparator: string;
+				decimalSeparator: string;
+				precision: number;
+			};
+		};
 	};
 };
 
@@ -20,6 +33,19 @@ describe( 'ConvertedAmount', () => {
 	beforeEach( () => {
 		global.wcpaySettings = {
 			zeroDecimalCurrencies: [],
+			connect: {
+				country: 'US',
+			},
+			currencyData: {
+				US: {
+					code: 'USD',
+					symbol: '$',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+			},
 		};
 	} );
 

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -70,6 +70,9 @@ declare const global: {
 		};
 		zeroDecimalCurrencies: string[];
 		currentUserEmail: string;
+		connect: {
+			country: string;
+		};
 		currencyData: {
 			[ key: string ]: {
 				code: string;
@@ -164,6 +167,9 @@ describe( 'Transactions list', () => {
 			isSubscriptionsActive: false,
 			zeroDecimalCurrencies: [],
 			currentUserEmail: 'mock@example.com',
+			connect: {
+				country: 'US',
+			},
 			currencyData: {
 				US: {
 					code: 'USD',

--- a/client/utils/currency/index.js
+++ b/client/utils/currency/index.js
@@ -37,17 +37,25 @@ export const formatCurrencyName = ( currencyCode ) =>
  * @return {Currency|null} Currency object
  */
 export const getCurrency = ( currencyCode, baseCurrencyCode = null ) => {
-	const { currencyData } = wcpaySettings;
+	const {
+		currencyData,
+		connect: { country = 'US' },
+	} = wcpaySettings;
 
 	const currency = find( currencyData, { code: currencyCode.toUpperCase() } );
 	if ( currency ) {
 		if (
-			null !== baseCurrencyCode &&
-			baseCurrencyCode.toUpperCase() !== currencyCode.toUpperCase()
+			( null !== baseCurrencyCode &&
+				baseCurrencyCode.toUpperCase() !==
+					currencyCode.toUpperCase() ) ||
+			currencyData[ country ]
 		) {
-			const baseCurrency = find( currencyData, {
-				code: baseCurrencyCode.toUpperCase(),
-			} );
+			const baseCurrency = baseCurrencyCode
+				? find( currencyData, {
+						code: baseCurrencyCode.toUpperCase(),
+				  } )
+				: currencyData[ country ];
+
 			if ( baseCurrency ) {
 				currency.decimalSeparator = baseCurrency.decimalSeparator;
 				currency.thousandSeparator = baseCurrency.thousandSeparator;

--- a/client/utils/currency/test/index.js
+++ b/client/utils/currency/test/index.js
@@ -13,6 +13,9 @@ describe( 'Currency utilities', () => {
 		jest.clearAllMocks();
 		global.wcpaySettings = {
 			zeroDecimalCurrencies: [ 'vnd', 'jpy' ],
+			connect: {
+				country: 'US',
+			},
 			currencyData: {
 				US: {
 					code: 'USD',
@@ -81,11 +84,11 @@ describe( 'Currency utilities', () => {
 
 	test.each`
 		source                                   | target                                 | expected
-		${ { currency: 'EUR', amount: 1242 } }   | ${ { currency: 'USD', amount: 1484 } } | ${ '1,00 EUR → 1.19485 USD: $14.84 USD' }
+		${ { currency: 'EUR', amount: 1242 } }   | ${ { currency: 'USD', amount: 1484 } } | ${ '1.00 EUR → 1.19485 USD: $14.84 USD' }
 		${ { currency: 'CHF', amount: 1500 } }   | ${ { currency: 'USD', amount: 1675 } } | ${ '1.00 CHF → 1.11667 USD: $16.75 USD' }
 		${ { currency: 'GBP', amount: 1800 } }   | ${ { currency: 'USD', amount: 2439 } } | ${ '1.00 GBP → 1.355 USD: $24.39 USD' }
 		${ { currency: 'INR', amount: 131392 } } | ${ { currency: 'USD', amount: 1779 } } | ${ '1.00 INR → 0.01354 USD: $17.79 USD' }
-		${ { currency: 'RUB', amount: 136746 } } | ${ { currency: 'USD', amount: 1777 } } | ${ '1,00 RUB → 0.012995 USD: $17.77 USD' }
+		${ { currency: 'RUB', amount: 136746 } } | ${ { currency: 'USD', amount: 1777 } } | ${ '1.00 RUB → 0.012995 USD: $17.77 USD' }
 		${ { currency: 'JPY', amount: 1894 } }   | ${ { currency: 'USD', amount: 1786 } } | ${ '1 JPY → 0.00943 USD: $17.86 USD' }
 	`(
 		'format FX string $source.currency -> $target.currency',


### PR DESCRIPTION
Fixes #3970

#### Changes proposed in this Pull Request

* Show the currencies on WooCommerce Payments based on the Country setting on WC Core, this way we can show the currencies in the right format.

See #3948 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

We change to change the settings on WC Core to a country that uses a different way to format currencies.

* Open WC Payments Overview.
* If the store country is US, the currency symbol should be on the left side using , as thousand separator.
* Access WooCommerce > Settings.
* Change the Country to France.
* Open WC Payments Overview.
* The currency symbol should be showing on the right ride, using a space as thousand separator.

<img width="703" alt="Screen Shot 2022-03-15 at 10 03 21 PM" src="https://user-images.githubusercontent.com/1693223/158496443-c8441909-a2cc-4d10-b6a1-f2a5cf10f623.png">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
