### PR TITLE
Platform Checkout: Removes dependency on script related to express checkout methods.

### DIFF
--- a/changelog/fix-platform-checkout-remove-express-payment-dependency
+++ b/changelog/fix-platform-checkout-remove-express-payment-dependency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Update to platform checkout functionality - feature not yet released.
+
+

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -588,9 +588,9 @@ export default class WCPayAPI {
 
 	initPlatformCheckout() {
 		return this.request(
-			getPaymentRequestAjaxURL( 'init_platform_checkout' ),
+			buildAjaxURL( getConfig( 'wcAjaxUrl' ), 'init_platform_checkout' ),
 			{
-				_wpnonce: getPaymentRequestData( 'nonce' )?.checkout,
+				_wpnonce: getConfig( 'initPlatformCheckoutNonce' ),
 			}
 		);
 	}

--- a/client/checkout/api/test/index.test.js
+++ b/client/checkout/api/test/index.test.js
@@ -3,23 +3,21 @@
  */
 import WCPayAPI from '..';
 import request from 'wcpay/checkout/blocks/request';
-import {
-	getPaymentRequestData,
-	getPaymentRequestAjaxURL,
-} from 'wcpay/payment-request/utils';
+import { buildAjaxURL } from 'wcpay/payment-request/utils';
+import { getConfig } from 'wcpay/utils/checkout';
 
 jest.mock( 'wcpay/checkout/blocks/request', () => jest.fn() );
 jest.mock( 'wcpay/payment-request/utils', () => ( {
-	getPaymentRequestData: jest.fn(),
-	getPaymentRequestAjaxURL: jest.fn(),
+	buildAjaxURL: jest.fn(),
+} ) );
+jest.mock( 'wcpay/utils/checkout', () => ( {
+	getConfig: jest.fn(),
 } ) );
 
 describe( 'WCPayAPI', () => {
 	test( 'initializes platform checkout using expected params', () => {
-		getPaymentRequestAjaxURL.mockReturnValue( 'https://example.org/' );
-		getPaymentRequestData.mockReturnValue( {
-			checkout: 'foo',
-		} );
+		buildAjaxURL.mockReturnValue( 'https://example.org/' );
+		getConfig.mockReturnValue( 'foo' );
 
 		const api = new WCPayAPI( {}, request );
 		api.initPlatformCheckout();

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -623,6 +623,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'createSetupIntentNonce'         => wp_create_nonce( 'wcpay_create_setup_intent_nonce' ),
 			'createPaymentIntentNonce'       => wp_create_nonce( 'wcpay_create_payment_intent_nonce' ),
 			'updatePaymentIntentNonce'       => wp_create_nonce( 'wcpay_update_payment_intent_nonce' ),
+			'initPlatformCheckoutNonce'      => wp_create_nonce( 'wcpay_init_platform_checkout_nonce' ),
 			'genericErrorMessage'            => __( 'There was a problem processing the payment. Please check your email inbox and refresh the page to try again.', 'woocommerce-payments' ),
 			'fraudServices'                  => $this->account->get_fraud_services_config(),
 			'features'                       => $this->supports,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR switches away from using `getPaymentRequestAjaxURL()` when building an AJAX URL to `buildAjaxURL()` because this feature shouldn't rely on express checkout methods being active to function. `getPaymentRequestAjaxURL()` tries to use a global variable that isn't present when express checkout methods are inactive and it was causing a js error.

#### Testing instructions
- Check out this PR.
- Make sure that `Apple Pay / Google Pay` is unchecked in settings.
- Add a product to your cart.
- Go to the shortcode checkout.
- Enter a valid platform checkout email address.
- Complete the SMS OTP challenge.
- There should be no js errors and you should be redirected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : QA Testing Not Applicable
