### PR TITLE
Update subscriptions-core to `1.7.0`

### DIFF
--- a/changelog/subscriptions-core-1.7.0-pr-103
+++ b/changelog/subscriptions-core-1.7.0-pr-103
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Sets up subscriptions integration with the Mini Cart Block and adds new hook to filter compatible blocks.

--- a/changelog/subscriptions-core-1.7.0-pr-115
+++ b/changelog/subscriptions-core-1.7.0-pr-115
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+When there is only one Shipping Method available in the recurring shipping package, make sure that this method is treated as selected in the current session and the `woocommerce_after_shipping_rate` action runs.

--- a/changelog/subscriptions-core-1.7.0-pr-121
+++ b/changelog/subscriptions-core-1.7.0-pr-121
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Don't anonymize new subscriptions related to old subscriptions via a resubscribe relationship

--- a/changelog/subscriptions-core-1.7.0-pr-125
+++ b/changelog/subscriptions-core-1.7.0-pr-125
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Subscription token notices that appear on the My account > Payment methods page should be translatable.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
       "automattic/jetpack-sync": "1.29.2",
       "automattic/jetpack-tracking": "1.14.1",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "1.6.4"
+      "woocommerce/subscriptions-core": "1.7.0"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "658aa09066087d38fd3f2c8138dac9d3",
+    "content-hash": "5a564ce0a9300ebf87163f7434aba9b5",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1060,16 +1060,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "1.6.4",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "7cdddd4887080595bf08b6e48ba51514ce8c14f5"
+                "reference": "69d33cac5e31fa8130072b2a88ec94689cb1ca91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/7cdddd4887080595bf08b6e48ba51514ce8c14f5",
-                "reference": "7cdddd4887080595bf08b6e48ba51514ce8c14f5",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/69d33cac5e31fa8130072b2a88ec94689cb1ca91",
+                "reference": "69d33cac5e31fa8130072b2a88ec94689cb1ca91",
                 "shasum": ""
             },
             "require": {
@@ -1111,10 +1111,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/1.6.4",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/1.7.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-02-10T00:09:23+00:00"
+            "time": "2022-03-18T05:01:34+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Load newer woocommerce-subscriptions-core's version 1.7.0.
- Added changelog entries from woocommerce-subscriptions-core to the changelog.
- Updated composer.lock as a result of running `composer update woocommerce/subscriptions-core`.

#### Testing instructions

* Checkout this branch.
* [Husky hook should run `composer install`](https://github.com/Automattic/woocommerce-payments/blob/develop/.husky/post-checkout#L8) and your `vendor/woocommerce/subscriptions-core` should be updated to `1.7.0`. Confirm that latest changes from `1.7.0` is present, for example, [vendor/woocommerce/subscriptions-core/changelog.txt is up-to-date](https://github.com/Automattic/woocommerce-subscriptions-core/blob/1.7.0/changelog.txt).


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_

fixes #3974
fixes #3889