### PR TITLE
Check for file access in domain verification before throwing a warning

### DIFF
--- a/changelog/fix-3899
+++ b/changelog/fix-3899
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Additional checks for domain verification file operations to prevent throwing Warnings on hosts that do not allow for suppression with `@`

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -129,7 +129,7 @@ class WC_Payments_Apple_Pay_Registration {
 	 * Verify domain upon plugin update only in case the domain association file has changed.
 	 */
 	public function verify_domain_on_update() {
-		if ( ! $this->is_hosted_domain_association_file_up_to_date() ) {
+		if ( $this->is_enabled() && ! $this->is_hosted_domain_association_file_up_to_date() ) {
 			$this->verify_domain_if_configured();
 		}
 	}
@@ -141,10 +141,13 @@ class WC_Payments_Apple_Pay_Registration {
 	 * @return bool Whether file is up to date or not.
 	 */
 	private function is_hosted_domain_association_file_up_to_date() {
+		$fullpath = untrailingslashit( ABSPATH ) . '/' . self::DOMAIN_ASSOCIATION_FILE_DIR . '/' . self::DOMAIN_ASSOCIATION_FILE_NAME;
+		if ( ! file_exists( $fullpath ) ) {
+			return false;
+		}
 		// Contents of domain association file from plugin dir.
 		$new_contents = @file_get_contents( WCPAY_ABSPATH . '/' . self::DOMAIN_ASSOCIATION_FILE_NAME ); // @codingStandardsIgnoreLine
 		// Get file contents from local path and remote URL and check if either of which matches.
-		$fullpath        = untrailingslashit( ABSPATH ) . '/' . self::DOMAIN_ASSOCIATION_FILE_DIR . '/' . self::DOMAIN_ASSOCIATION_FILE_NAME;
 		$local_contents  = @file_get_contents( $fullpath ); // @codingStandardsIgnoreLine
 		$url             = get_site_url() . '/' . self::DOMAIN_ASSOCIATION_FILE_DIR . '/' . self::DOMAIN_ASSOCIATION_FILE_NAME;
 		$response        = @wp_remote_get( $url ); // @codingStandardsIgnoreLine


### PR DESCRIPTION
Upon setting up WooCommerce Payments, it tries to read from a missing file, generating errors like these:

```
b>[Suppressed] Warning</b>: file_get_contents(/home/wpcom/public_html/.well-known/apple-developer-merchantid-domain-association): failed to open stream: No such file or directory in <b>/home/wpcom/public_html/wp-content/plugins/woocommerce-payments/woocommerce-payments-3.6.1/includes/class-wc-payments-apple-pay-registration.php</b> on line <b>148</b><br />
[test-payment.tumblr.com/wp-json/wc/tumblrpay/v1/provision]<br />
[/plugins/woocommerce-payments/woocommerce-payments-3.6.1/includes/class-wc-payments-apple-pay-registration.php:148 file_get_contents(), /plugins/woocommerce-payments/woocommerce-payments-3.6.1/includes/class-wc-payments-apple-pay-registration.php:132 is_hosted_domain_association_file_up_to_date(), wp-includes/class-wp-hook.php:307 verify_domain_on_update(), wp-includes/class-wp-hook.php:331 apply_filters(''), wp-includes/plugin.php:474 do_action(Array), /plugins/woocommerce-payments/woocommerce-payments-3.6.1/includes/class-wc-payments.php:697 do_action('woocommerce_woocommerce_payments_updated'), /plugins/tumblrpay-plugin/tumblrpay-backend-site.php:205 install_actions(), /plugins/tumblrpay-plugin/endpoints/tumblrpay-provisioning-endpoint.php:85 TumblrPay\Tumblrpay_Backend_Site\create(), wp-includes/rest-api/class-wp-rest-server.php:1141 create_subsite(), wp-includes/rest-api/class-wp-rest-server.php:988 respond_to_request(), wp-includes/rest-api/class-wp-rest-server.php:414 dispatch(), wp-includes/rest-api.php:395 serve_request(), wp-includes/class-wp-hook.php:307 rest_api_loaded(), wp-includes/class-wp-hook.php:331 apply_filters(''), wp-includes/plugin.php:522 do_action(Array), wp-includes/class-wp.php:396 do_action_ref_array(), wp-includes/class-wp.php:758 parse_request(), wp-includes/functions.php:1361 main(), wp-blog-header.php:16 wp(), index.php:17 require('wp-blog-header.php')]
```

This line passes empty state:

https://github.com/Automattic/woocommerce-payments/blob/ab60ad2e73c2c8a4a070c64704a9225f26958c6d/includes/class-wc-payments-apple-pay-registration.php#L328


Which forces this line to read from an empty file:

https://github.com/Automattic/woocommerce-payments/blob/ab60ad2e73c2c8a4a070c64704a9225f26958c6d/includes/class-wc-payments-apple-pay-registration.php#L148

This PR does a following check:
- only checks the domain verification file if payment request is actually enabled
- checks for `file_exists`
