### PR TITLE
Fix capital list formatting

### DIFF
--- a/changelog/fix-3992-fix-table-value-formatting-in-capital-page-table
+++ b/changelog/fix-3992-fix-table-value-formatting-in-capital-page-table
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the number formatting issues in Capital loans page loans list

--- a/client/additional-methods-setup/wizard/README.md
+++ b/client/additional-methods-setup/wizard/README.md
@@ -1,94 +1,129 @@
 # Wizard helpers
+
 Use these components to simplify (hopefully) setting up a wizard.
 
 The components are as follows:
 
 ### `wrapper/context`: `WizardContext`
+
 #### Description:
+
 Contains the data for the wizard. It just uses `React.createContext()`.
 
 #### Attributes:
-- `activeTask`: the identifier of the current tasks
-- `completedTasks`: a key-value-pair of the completed tasks. The key is the task identifier, the value can be a boolean or an object, set through `setCompletedTasks`
-- `setActiveTask`: helper to update the identifier of the current task - useful when navigating the wizard
-- `setCompletedTasks`: helper to update the `completedTasks` attribute
+
+-   `activeTask`: the identifier of the current tasks
+-   `completedTasks`: a key-value-pair of the completed tasks. The key is the task identifier, the value can be a boolean or an object, set through `setCompletedTasks`
+-   `setActiveTask`: helper to update the identifier of the current task - useful when navigating the wizard
+-   `setCompletedTasks`: helper to update the `completedTasks` attribute
 
 #### Example of usage
+
 ```jsx
 const Consumer = () => {
-    const { setActiveTask } = useContext( WizardContext );
-    
-    return <button onClick={ () => setActiveTask( 'task-number-1' ) }>Go to task number 1</button>;
-}
+	const { setActiveTask } = useContext( WizardContext );
+
+	return (
+		<button onClick={ () => setActiveTask( 'task-number-1' ) }>
+			Go to task number 1
+		</button>
+	);
+};
 ```
 
 ### `wrapper/index`: `Wizard`
+
 #### Description:
+
 Implementation of the `WizardContext`. Wrap all your components with this component.  
 By leveraging the `WizardContext` you can instruct this component to update the values of the context provider.
 
 #### props
-- `children`: the React children hierarchy
-- `defaultActiveTask` (recommended): the identifier of the first task that should be marked as active. Do not update this prop after initialization, it will have no effect.
-- `defaultCompletedTasks` (optional): the key-value-pair of the completed tasks. Do not update this prop after initialization, it will have no effect.
+
+-   `children`: the React children hierarchy
+-   `defaultActiveTask` (recommended): the identifier of the first task that should be marked as active. Do not update this prop after initialization, it will have no effect.
+-   `defaultCompletedTasks` (optional): the key-value-pair of the completed tasks. Do not update this prop after initialization, it will have no effect.
 
 #### Example of usage
+
 ```jsx
 const Consumer = () => {
-    return (
-      <WizardTask defaultActiveTask="task-2" defaultCompletedTasks={{'task-1': true}}>
-        <WizardTask id="task-1"><Task1Controls /></WizardTask>
-        <WizardTask id="task-2"><Task2Controls /></WizardTask>
-      </Wizard>
-    );
-}
+	return (
+		<WizardTask
+			defaultActiveTask="task-2"
+			defaultCompletedTasks={ { 'task-1': true } }
+		>
+			<WizardTask id="task-1">
+				<Task1Controls />
+			</WizardTask>
+			<WizardTask id="task-2">
+				<Task2Controls />
+			</WizardTask>
+		</Wizard>
+	);
+};
 ```
 
 ### `task/context`: `WizardTaskContext`
+
 #### Description:
+
 Contains the data for one individual task within the wizard. It just uses `React.createContext()`.
 
 #### Attributes:
-- `isActive`: identifies whether or not the current task is active
-- `setActive`: helper to mark the current task as active
-- `isCompleted`: identifies whether or not the current task has been marked as completed
-- `setCompleted`: helper to mark the current task as completed and (optionally) set the next active task
+
+-   `isActive`: identifies whether or not the current task is active
+-   `setActive`: helper to mark the current task as active
+-   `isCompleted`: identifies whether or not the current task has been marked as completed
+-   `setCompleted`: helper to mark the current task as completed and (optionally) set the next active task
 
 #### Example of usage
+
 ```jsx
 const Consumer = () => {
-  const { setActiveTask } = useContext( WizardContext );
-  const { isActive, isCompleted, setCompleted } = useContext( WizardTaskContext );
-    
-    return (
-      <div className={ classNames({'id-active': isActive, 'is-completed': isCompleted })}>
-        <button onClick={ () => setCompleted( true, 'task-number-2' ) }>
-          Mark current task complete and go to task number 2
-        </button>
-        <button onClick={ () => setActiveTask( 'task-number-3' ) }>
-          Go to task number 3
-        </button>
-      </div>
-    );
-}
+	const { setActiveTask } = useContext( WizardContext );
+	const { isActive, isCompleted, setCompleted } = useContext(
+		WizardTaskContext
+	);
+
+	return (
+		<div
+			className={ classNames( {
+				'id-active': isActive,
+				'is-completed': isCompleted,
+			} ) }
+		>
+			<button onClick={ () => setCompleted( true, 'task-number-2' ) }>
+				Mark current task complete and go to task number 2
+			</button>
+			<button onClick={ () => setActiveTask( 'task-number-3' ) }>
+				Go to task number 3
+			</button>
+		</div>
+	);
+};
 ```
 
 ### `task/index`: `WizardTask`
+
 #### Description:
+
 Implementation of the `WizardTaskContext`. Wrap the componentry of one individual task with this component.  
 By leveraging the `WizardTaskContext` you can instruct the `WizardTask` to update the values of the context provider.
 
 #### props
-- `children`: the React children hierarchy
-- `id` (required): the identifier of this task
+
+-   `children`: the React children hierarchy
+-   `id` (required): the identifier of this task
 
 #### Example of usage
+
 ```jsx
 const Task1 = () => {
-    return (
-      <WizardTask id="task-1">
-        <Task1Controls />
-      </WizardTask>
-    );
-}
+	return (
+		<WizardTask id="task-1">
+			<Task1Controls />
+		</WizardTask>
+	);
+};
 ```

--- a/client/capital/index.tsx
+++ b/client/capital/index.tsx
@@ -22,6 +22,7 @@ import Chip from 'components/chip';
 import { useLoans } from 'wcpay/data';
 
 import './style.scss';
+import { getAdminUrl } from 'wcpay/utils';
 
 const columns = [
 	{
@@ -95,7 +96,8 @@ const getRowsData = ( loans: CapitalLoan[] ) =>
 		const clickable = ( children: React.ReactNode ) => (
 			<ClickableCell
 				href={
-					'/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions' +
+					getAdminUrl() +
+					'?page=wc-admin&path=%2Fpayments%2Ftransactions' +
 					'&type=charge&filter=advanced&loan_id_is=' +
 					loan.stripe_loan_id
 				}
@@ -118,7 +120,10 @@ const getRowsData = ( loans: CapitalLoan[] ) =>
 					? loan.amount
 					: loan.amount / 100,
 				display: clickable(
-					formatExplicitCurrency( loan.amount, loan.currency )
+					formatExplicitCurrency(
+						loan.amount,
+						loan.currency.toUpperCase()
+					)
 				),
 			},
 			fee_amount: {
@@ -126,12 +131,17 @@ const getRowsData = ( loans: CapitalLoan[] ) =>
 					? loan.fee_amount
 					: loan.fee_amount / 100,
 				display: clickable(
-					formatExplicitCurrency( loan.fee_amount, loan.currency )
+					formatExplicitCurrency(
+						loan.fee_amount,
+						loan.currency.toUpperCase()
+					)
 				),
 			},
 			withhold_rate: {
 				value: loan.withhold_rate,
-				display: clickable( loan.withhold_rate + '%' ),
+				display: clickable(
+					( loan.withhold_rate * 100 ).toPrecision( 2 ) + '%'
+				),
 			},
 			first_paydown_at: {
 				value: loan.first_paydown_at,

--- a/client/capital/index.tsx
+++ b/client/capital/index.tsx
@@ -20,9 +20,9 @@ import { CapitalLoan } from 'data/capital/types';
 import ClickableCell from 'components/clickable-cell';
 import Chip from 'components/chip';
 import { useLoans } from 'wcpay/data';
+import { getAdminUrl } from 'wcpay/utils';
 
 import './style.scss';
-import { getAdminUrl } from 'wcpay/utils';
 
 const columns = [
 	{
@@ -95,12 +95,13 @@ const getRowsData = ( loans: CapitalLoan[] ) =>
 	loans.map( ( loan ) => {
 		const clickable = ( children: React.ReactNode ) => (
 			<ClickableCell
-				href={
-					getAdminUrl() +
-					'?page=wc-admin&path=%2Fpayments%2Ftransactions' +
-					'&type=charge&filter=advanced&loan_id_is=' +
-					loan.stripe_loan_id
-				}
+				href={ getAdminUrl( {
+					page: 'wc-admin',
+					path: '/payments/transactions',
+					type: 'charge',
+					filter: 'advanced',
+					loan_id_is: loan.stripe_loan_id,
+				} ) }
 			>
 				{ children }
 			</ClickableCell>

--- a/client/capital/index.tsx
+++ b/client/capital/index.tsx
@@ -141,7 +141,7 @@ const getRowsData = ( loans: CapitalLoan[] ) =>
 			withhold_rate: {
 				value: loan.withhold_rate,
 				display: clickable(
-					( loan.withhold_rate * 100 ).toPrecision( 2 ) + '%'
+					+( loan.withhold_rate * 100 ).toFixed( 2 ) + '%'
 				),
 			},
 			first_paydown_at: {

--- a/client/components/active-loan-summary/index.tsx
+++ b/client/components/active-loan-summary/index.tsx
@@ -21,6 +21,7 @@ import { dateI18n } from '@wordpress/date';
 import { formatExplicitCurrency } from 'utils/currency';
 import Loadable from 'components/loadable';
 import { useActiveLoanSummary } from 'wcpay/data';
+import { getAdminUrl } from 'wcpay/utils';
 
 import './style.scss';
 
@@ -153,11 +154,13 @@ const ActiveLoanSummary = (): JSX.Element => {
 					{ getActiveLoanId() && (
 						<Button
 							isLink
-							href={
-								'/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions' +
-								'&type=charge&filter=advanced&loan_id_is=' +
-								getActiveLoanId()
-							}
+							href={ getAdminUrl( {
+								page: 'wc-admin',
+								path: '/payments/transactions',
+								type: 'charge',
+								filter: 'advanced',
+								loan_id_is: getActiveLoanId(),
+							} ) }
 						>
 							{ __(
 								'View transactions',

--- a/client/components/active-loan-summary/test/__snapshots__/index.js.snap
+++ b/client/components/active-loan-summary/test/__snapshots__/index.js.snap
@@ -18,7 +18,7 @@ exports[`Active loan summary renders correctly 1`] = `
       >
         <a
           class="components-button is-link"
-          href="/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=flxln_123456"
+          href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=flxln_123456"
         >
           View transactions
         </a>

--- a/client/components/tooltip/README.md
+++ b/client/components/tooltip/README.md
@@ -3,4 +3,3 @@
 This component exists because the `Tooltip` component within Gutenberg doesn't play nicely when rendered within `Modal`s.
 
 See https://github.com/Automattic/woocommerce-payments/pull/2484
-

--- a/client/data/deposits/test/overviews.fixture.json
+++ b/client/data/deposits/test/overviews.fixture.json
@@ -1,114 +1,114 @@
 {
 	"deposit": {
-			"last_paid": [
-				{
-					"id": "po_...",
-					"date": 1619395200000,
-					"type": "deposit",
-					"amount": 3160,
-					"status": "paid",
-					"bankAccount": " ••••  (USD)",
-					"currency": "usd",
-					"automatic": true,
-					"fee": 0,
-					"fee_percentage": 0,
-					"created": 1619395200
-				},
-				{
-					"id": "po_...",
-					"date": 1619395200000,
-					"type": "deposit",
-					"amount": 1000,
-					"status": "paid",
-					"bankAccount": " ••••  (EUR)",
-					"currency": "eur",
-					"automatic": true,
-					"fee": 0,
-					"fee_percentage": 0,
-					"created": 1619395200
-				}
-			],
-			"next_scheduled": [
-					{
-							"id": "wcpay_estimated_weekly_eur_1622678400",
-							"date": 1622678400000,
-							"type": "deposit",
-							"amount": 3343,
-							"status": "estimated",
-							"bankAccount": null,
-							"currency": "eur",
-							"automatic": true,
-							"fee": 0,
-							"fee_percentage": 0,
-							"created": 1622678400
-					},
-					{
-							"id": "wcpay_estimated_weekly_usd_1622678400",
-							"date": 1622678400000,
-							"type": "deposit",
-							"amount": 1656,
-							"status": "estimated",
-							"bankAccount": null,
-							"currency": "usd",
-							"automatic": true,
-							"fee": 0,
-							"fee_percentage": 0,
-							"created": 1622678400
-					}
-			]
+		"last_paid": [
+			{
+				"id": "po_...",
+				"date": 1619395200000,
+				"type": "deposit",
+				"amount": 3160,
+				"status": "paid",
+				"bankAccount": " ••••  (USD)",
+				"currency": "usd",
+				"automatic": true,
+				"fee": 0,
+				"fee_percentage": 0,
+				"created": 1619395200
+			},
+			{
+				"id": "po_...",
+				"date": 1619395200000,
+				"type": "deposit",
+				"amount": 1000,
+				"status": "paid",
+				"bankAccount": " ••••  (EUR)",
+				"currency": "eur",
+				"automatic": true,
+				"fee": 0,
+				"fee_percentage": 0,
+				"created": 1619395200
+			}
+		],
+		"next_scheduled": [
+			{
+				"id": "wcpay_estimated_weekly_eur_1622678400",
+				"date": 1622678400000,
+				"type": "deposit",
+				"amount": 3343,
+				"status": "estimated",
+				"bankAccount": null,
+				"currency": "eur",
+				"automatic": true,
+				"fee": 0,
+				"fee_percentage": 0,
+				"created": 1622678400
+			},
+			{
+				"id": "wcpay_estimated_weekly_usd_1622678400",
+				"date": 1622678400000,
+				"type": "deposit",
+				"amount": 1656,
+				"status": "estimated",
+				"bankAccount": null,
+				"currency": "usd",
+				"automatic": true,
+				"fee": 0,
+				"fee_percentage": 0,
+				"created": 1622678400
+			}
+		]
 	},
 	"balance": {
-			"pending": [
-					{
-							"amount": 3343,
-							"currency": "eur",
-							"source_types": {
-									"card": 3343
-							}
-					},
-					{
-							"amount": 1656,
-							"currency": "usd",
-							"deposits_count": 2,
-							"source_types": {
-									"card": 1656
-							}
-					}
-			],
-			"available": [
-					{
-							"amount": 2030,
-							"currency": "eur",
-							"source_types": {
-									"card": 0
-							}
-					},
-					{
-							"amount": 0,
-							"currency": "usd",
-							"source_types": {
-									"card": 0
-							}
-					}
-			],
-			"instant": [
-				{
-					"currency": "usd",
-					"amount": 12345,
-					"fee": 185.175,
-					"net": 12159.83,
-					"fee_percentage": 1.5,
-					"transaction_ids": [ "txn_XYZ", "txn_ZXY" ]
+		"pending": [
+			{
+				"amount": 3343,
+				"currency": "eur",
+				"source_types": {
+					"card": 3343
 				}
-			]
+			},
+			{
+				"amount": 1656,
+				"currency": "usd",
+				"deposits_count": 2,
+				"source_types": {
+					"card": 1656
+				}
+			}
+		],
+		"available": [
+			{
+				"amount": 2030,
+				"currency": "eur",
+				"source_types": {
+					"card": 0
+				}
+			},
+			{
+				"amount": 0,
+				"currency": "usd",
+				"source_types": {
+					"card": 0
+				}
+			}
+		],
+		"instant": [
+			{
+				"currency": "usd",
+				"amount": 12345,
+				"fee": 185.175,
+				"net": 12159.83,
+				"fee_percentage": 1.5,
+				"transaction_ids": [ "txn_XYZ", "txn_ZXY" ]
+			}
+		]
 	},
 	"account": {
-			"deposits_enabled": true,
-			"deposits_schedule": {
-					"delay_days": 7,
-					"interval": "weekly",
-					"weekly_anchor": "thursday"
-			},
-			"default_currency": "usd"
+		"deposits_enabled": true,
+		"deposits_schedule": {
+			"delay_days": 7,
+			"interval": "weekly",
+			"weekly_anchor": "thursday"
+		},
+		"default_currency": "usd"
 	}
 }

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -804,11 +804,13 @@ const mapEventToTimelineItems = ( event ) => {
 							{
 								a: (
 									<Link
-										href={
-											'/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions' +
-											'&type=charge&filter=advanced&loan_id_is=' +
-											event.loan_id
-										}
+										href={ getAdminUrl( {
+											page: 'wc-admin',
+											path: '/payments/transactions',
+											type: 'charge',
+											filter: 'advanced',
+											loan_id_is: event.loan_id,
+										} ) }
 									/>
 								),
 							}

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -769,7 +769,7 @@ Array [
       <React.Fragment>
         Loan repayment: 
         <Link
-          href="/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=flxln_1KOKzdR4ByxURRrFX9A65q40"
+          href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=flxln_1KOKzdR4ByxURRrFX9A65q40"
           type="wc-admin"
         >
           Loan flxln_1KOKzdR4ByxURRrFX9A65q40


### PR DESCRIPTION
Fixes #3992

#### Changes proposed in this Pull Request

This PR will fix the following: 

- The withhold rate display from decimal form to the percentage form. 0,015% will become 1,5%. 
- Also it'll fix the admin link issue (doubled /wp-admin/ part) by converting the hardcoded link into `getAdminUrl()` call. 

#### Testing Instructions
- Tests should pass
- The withhold rates should display correctly, matching with the active loan box one.
- When a loan record is clicked, the transactions should be filtered correctly, and refresh the page should open the same transaction list.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : QA Testing Not Applicable
