### PR TITLE
Deprecate the create customer endpoint

### DIFF
--- a/changelog/update-3953-deprecate-create-customer-endpoint
+++ b/changelog/update-3953-deprecate-create-customer-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Deprecate the create customer endpoint

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -193,10 +193,13 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 	/**
 	 * Returns customer id from order. Create or update customer if needed.
 	 *
+	 * @deprecated 3.9.0
+	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_customer( $request ) {
+		wc_deprecated_function( __FUNCTION__, '3.9.0' );
 		try {
 			$order_id = $request['order_id'];
 

--- a/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
@@ -852,9 +852,6 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 		$this->assertSame( 'cus_new', $result_order->get_meta( '_stripe_customer_id' ) );
 	}
 
-	/**
-	 * @expectedDeprecated create_customer
-	 */
 	public function test_create_terminal_intent_success() {
 		$order = $this->create_mock_order();
 

--- a/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
@@ -543,6 +543,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 		$this->assertEquals( 404, $data['status'] );
 	}
 
+	/**
+	 * @expectedDeprecated create_customer
+	 */
 	public function test_create_customer_invalid_order_id() {
 		$request = new WP_REST_Request( 'POST' );
 		$request->set_body_params(
@@ -559,6 +562,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 		$this->assertEquals( 404, $data['status'] );
 	}
 
+	/**
+	 * @expectedDeprecated create_customer
+	 */
 	public function test_create_customer_from_order_guest_without_customer_id() {
 		$order         = WC_Helper_Order::create_order( 0 );
 		$customer_data = WC_Payments_Customer_Service::map_customer_data( $order );
@@ -625,6 +631,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @expectedDeprecated create_customer
+	 */
 	public function test_create_customer_from_order_guest_with_customer_id() {
 		$order         = WC_Helper_Order::create_order( 0 );
 		$customer_data = WC_Payments_Customer_Service::map_customer_data( $order );
@@ -675,6 +684,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 		$this->assertSame( 'cus_guest', $result_order->get_meta( '_stripe_customer_id' ) );
 	}
 
+	/**
+	 * @expectedDeprecated create_customer
+	 */
 	public function test_create_customer_from_order_non_guest_with_customer_id() {
 		$order         = WC_Helper_Order::create_order();
 		$customer_data = WC_Payments_Customer_Service::map_customer_data( $order );
@@ -716,6 +728,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 		$this->assertSame( 'cus_exist', $result_order->get_meta( '_stripe_customer_id' ) );
 	}
 
+	/**
+	 * @expectedDeprecated create_customer
+	 */
 	public function test_create_customer_from_order_with_invalid_status() {
 		$order = WC_Helper_Order::create_order();
 		$order->set_status( 'completed' );
@@ -748,6 +763,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 		$this->assertEquals( 400, $data['status'] );
 	}
 
+	/**
+	 * @expectedDeprecated create_customer
+	 */
 	public function test_create_customer_from_order_non_guest_with_customer_id_from_order_meta() {
 		$order         = WC_Helper_Order::create_order();
 		$customer_data = WC_Payments_Customer_Service::map_customer_data( $order );
@@ -790,6 +808,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 		$this->assertSame( 'cus_exist', $result_order->get_meta( '_stripe_customer_id' ) );
 	}
 
+	/**
+	 * @expectedDeprecated create_customer
+	 */
 	public function test_create_customer_from_order_non_guest_without_customer_id() {
 		$order         = WC_Helper_Order::create_order();
 		$customer_data = WC_Payments_Customer_Service::map_customer_data( $order );
@@ -831,6 +852,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 		$this->assertSame( 'cus_new', $result_order->get_meta( '_stripe_customer_id' ) );
 	}
 
+	/**
+	 * @expectedDeprecated create_customer
+	 */
 	public function test_create_terminal_intent_success() {
 		$order = $this->create_mock_order();
 


### PR DESCRIPTION
Fixes #3953

#### Changes proposed in this Pull Request

The `/<order_id>/create_customer` endpoint, which is used by the mobile app with in-person payments, has been marked as deprecated since it is no longer required to collect L2/L3 data (#3898).

Deprecation has been done as per the guidelines here:  
https://developer.woocommerce.com/2017/01/17/deprecation-in-woocommerce-core/

#### Testing instructions

* Review the deprecated markers in code.
* Verify that the endpoint still works. (we want to maintain backward compatibility)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (does not apply)
- [ ] Tested on mobile

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
