### PR TITLE
Add onboarding requirements component

### DIFF
--- a/client/onboarding/requirements/company.tsx
+++ b/client/onboarding/requirements/company.tsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { groups } from './strings';
+import RequirementGroup from './group';
+import { representative, mapToList, company, companyDetails } from './keymap';
+
+interface CompanyRequirementsProps {
+	keys: string[];
+}
+
+const CompanyDetails = ( { keys }: CompanyRequirementsProps ): JSX.Element => {
+	const details = [];
+
+	if ( keys.some( ( key ) => key.includes( 'owners.' ) ) )
+		details.push( groups.owner );
+	if ( keys.some( ( key ) => key.includes( 'directors.' ) ) )
+		details.push( groups.director );
+	if ( keys.some( ( key ) => key.includes( 'executives.' ) ) )
+		details.push( groups.executive );
+
+	if ( details.length === 0 ) return <></>;
+
+	const headline = `${ groups.company } ${ details.join( ', ' ) }`;
+	const subline = mapToList( keys, companyDetails );
+
+	return (
+		<RequirementGroup
+			icon={ 'user' }
+			headline={ headline }
+			subline={ subline }
+		/>
+	);
+};
+
+const CompanyRequirements = ( {
+	keys,
+}: CompanyRequirementsProps ): JSX.Element => {
+	const companyList = mapToList( keys, company );
+	const representativeList = mapToList( keys, representative );
+
+	return (
+		<>
+			<RequirementGroup
+				icon={ 'institution' }
+				headline={ groups.companyInfo }
+				subline={ companyList }
+			/>
+			<CompanyDetails keys={ keys } />
+			<RequirementGroup
+				icon={ 'user' }
+				headline={ groups.representativeDetails }
+				subline={ representativeList }
+			/>
+			<RequirementGroup
+				icon={ 'credit-card' }
+				headline={ groups.companyBank }
+			/>
+		</>
+	);
+};
+
+export default CompanyRequirements;

--- a/client/onboarding/requirements/company.tsx
+++ b/client/onboarding/requirements/company.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { groups } from './strings';
 import RequirementGroup from './group';
 import { representative, mapToList, company, companyDetails } from './keymap';
+import { joinWithConjunction } from 'utils/strings';
 
 interface CompanyRequirementsProps {
 	keys: string[];
@@ -26,7 +27,7 @@ const CompanyDetails = ( { keys }: CompanyRequirementsProps ): JSX.Element => {
 
 	if ( details.length === 0 ) return <></>;
 
-	const headline = `${ groups.company } ${ details.join( ', ' ) }`;
+	const headline = `${ groups.company } ${ joinWithConjunction( details ) }`;
 	const subline = mapToList( keys, companyDetails );
 
 	return (

--- a/client/onboarding/requirements/company.tsx
+++ b/client/onboarding/requirements/company.tsx
@@ -18,12 +18,10 @@ interface CompanyRequirementsProps {
 const CompanyDetails = ( { keys }: CompanyRequirementsProps ): JSX.Element => {
 	const details = [];
 
-	if ( keys.some( ( key ) => key.includes( 'owners.' ) ) )
-		details.push( groups.owner );
-	if ( keys.some( ( key ) => key.includes( 'directors.' ) ) )
-		details.push( groups.director );
-	if ( keys.some( ( key ) => key.includes( 'executives.' ) ) )
-		details.push( groups.executive );
+	const keysList = keys.join();
+	if ( keysList.includes( 'owners.' ) ) details.push( groups.owner );
+	if ( keysList.includes( 'directors.' ) ) details.push( groups.director );
+	if ( keysList.includes( 'executives.' ) ) details.push( groups.executive );
 
 	if ( details.length === 0 ) return <></>;
 

--- a/client/onboarding/requirements/group.tsx
+++ b/client/onboarding/requirements/group.tsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+
+interface RequirementGroupProps {
+	icon: string;
+	headline: string;
+	subline?: string;
+}
+
+const RequirementGroup = ( {
+	icon,
+	headline,
+	subline,
+}: RequirementGroupProps ): JSX.Element => {
+	return (
+		<div>
+			<p>
+				<Gridicon icon={ icon } /> { headline }
+			</p>
+			{ subline && <pre>{ subline }</pre> }
+		</div>
+	);
+};
+
+export default RequirementGroup;

--- a/client/onboarding/requirements/group.tsx
+++ b/client/onboarding/requirements/group.tsx
@@ -7,6 +7,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import './style.scss';
 
 interface RequirementGroupProps {
 	icon: string;
@@ -20,11 +21,10 @@ const RequirementGroup = ( {
 	subline,
 }: RequirementGroupProps ): JSX.Element => {
 	return (
-		<div>
-			<p>
-				<Gridicon icon={ icon } /> { headline }
-			</p>
-			{ subline && <pre>{ subline }</pre> }
+		<div className="onboarding__requirement-group">
+			<Gridicon icon={ icon } size={ 18 } />
+			<div className="headline">{ headline }</div>
+			{ subline && <div className="subline">{ subline }</div> }
 		</div>
 	);
 };

--- a/client/onboarding/requirements/index.tsx
+++ b/client/onboarding/requirements/index.tsx
@@ -6,8 +6,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { groups } from './strings';
 import IndividualRequirements from './individual';
+import CompanyRequirements from './company';
 
 interface RequirementsProps {
 	type: 'individual' | 'company' | 'non_profit';
@@ -17,71 +17,11 @@ interface RequirementsProps {
 const Requirements = ( { type, keys }: RequirementsProps ): JSX.Element => {
 	const isIndividual = type === 'individual';
 
-	return isIndividual ? <IndividualRequirements keys={ keys } /> : <></>; // TODO: Company
+	return isIndividual ? (
+		<IndividualRequirements keys={ keys } />
+	) : (
+		<CompanyRequirements keys={ keys } />
+	);
 };
 
 export default Requirements;
-
-/*
-Individual
-==========
-"individual.address.city",
-"individual.address.line1",
-"individual.address.postal_code",
-"individual.address.state",
-"individual.dob.day",
-"individual.dob.month",
-"individual.dob.year",
-"individual.email",
-"individual.first_name",
-"individual.id_number",
-"individual.last_name",
-"individual.phone",
-"individual.ssn_last_4",
-"individual.verification.document",
-
-Company
-=======
-"representative.address.city",
-"representative.address.line1",
-"representative.address.postal_code",
-"representative.address.state",
-"representative.dob.day",
-"representative.dob.month",
-"representative.dob.year",
-"representative.email",
-"representative.first_name",
-"representative.id_number",
-"representative.last_name",
-"representative.phone",
-"representative.relationship.executive",
-"representative.relationship.title",
-"representative.ssn_last_4",
-"representative.verification.document",
-"company.address.city",
-"company.address.line1",
-"company.address.postal_code",
-"company.address.state",
-"company.name",
-"company.owners_provided",
-"company.phone",
-"company.tax_id",
-"owners.address.city",
-"owners.address.line1",
-"owners.address.postal_code",
-"owners.address.state",
-"owners.dob.day",
-"owners.dob.month",
-"owners.dob.year",
-"owners.email",
-"owners.first_name",
-"owners.id_number",
-"owners.last_name",
-"owners.phone",
-"owners.ssn_last_4",
-"owners.verification.document",
-
-directors.first_name
-
-executives.first_name
-*/

--- a/client/onboarding/requirements/index.tsx
+++ b/client/onboarding/requirements/index.tsx
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { groups } from './strings';
+import IndividualRequirements from './individual';
+
+interface RequirementsProps {
+	type: 'individual' | 'company' | 'non_profit';
+	keys: string[];
+}
+
+const Requirements = ( { type, keys }: RequirementsProps ): JSX.Element => {
+	const isIndividual = type === 'individual';
+
+	return isIndividual ? <IndividualRequirements keys={ keys } /> : <></>; // TODO: Company
+};
+
+export default Requirements;
+
+/*
+Individual
+==========
+"individual.address.city",
+"individual.address.line1",
+"individual.address.postal_code",
+"individual.address.state",
+"individual.dob.day",
+"individual.dob.month",
+"individual.dob.year",
+"individual.email",
+"individual.first_name",
+"individual.id_number",
+"individual.last_name",
+"individual.phone",
+"individual.ssn_last_4",
+"individual.verification.document",
+
+Company
+=======
+"representative.address.city",
+"representative.address.line1",
+"representative.address.postal_code",
+"representative.address.state",
+"representative.dob.day",
+"representative.dob.month",
+"representative.dob.year",
+"representative.email",
+"representative.first_name",
+"representative.id_number",
+"representative.last_name",
+"representative.phone",
+"representative.relationship.executive",
+"representative.relationship.title",
+"representative.ssn_last_4",
+"representative.verification.document",
+"company.address.city",
+"company.address.line1",
+"company.address.postal_code",
+"company.address.state",
+"company.name",
+"company.owners_provided",
+"company.phone",
+"company.tax_id",
+"owners.address.city",
+"owners.address.line1",
+"owners.address.postal_code",
+"owners.address.state",
+"owners.dob.day",
+"owners.dob.month",
+"owners.dob.year",
+"owners.email",
+"owners.first_name",
+"owners.id_number",
+"owners.last_name",
+"owners.phone",
+"owners.ssn_last_4",
+"owners.verification.document",
+
+directors.first_name
+
+executives.first_name
+*/

--- a/client/onboarding/requirements/individual.tsx
+++ b/client/onboarding/requirements/individual.tsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { groups, requirements } from './strings';
+import RequirementGroup from './group';
+import { individual, mapToList, taxKeys } from './keymap';
+
+interface IndividualRequirementsProps {
+	keys: string[];
+}
+
+const IndividualRequirements = ( {
+	keys,
+}: IndividualRequirementsProps ): JSX.Element => {
+	const personalList = mapToList( keys, individual );
+	const hasTax = keys.some( ( key ) => taxKeys.includes( key ) );
+
+	return (
+		<>
+			<RequirementGroup
+				icon={ 'user' }
+				headline={ groups.personalDetails }
+				subline={ personalList }
+			/>
+			{ hasTax && (
+				<RequirementGroup
+					icon={ 'institution' }
+					headline={ groups.taxInfo }
+					subline={ requirements.ssn }
+				/>
+			) }
+			<RequirementGroup
+				icon={ 'credit-card' }
+				headline={ groups.bankDetails }
+			/>
+		</>
+	);
+};
+
+export default IndividualRequirements;

--- a/client/onboarding/requirements/individual.tsx
+++ b/client/onboarding/requirements/individual.tsx
@@ -6,8 +6,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { groups, requirements } from './strings';
 import RequirementGroup from './group';
+import { groups, requirements } from './strings';
 import { individual, mapToList, individualTaxKeys } from './keymap';
 
 interface IndividualRequirementsProps {

--- a/client/onboarding/requirements/individual.tsx
+++ b/client/onboarding/requirements/individual.tsx
@@ -8,7 +8,7 @@ import React from 'react';
  */
 import { groups, requirements } from './strings';
 import RequirementGroup from './group';
-import { individual, mapToList, taxKeys } from './keymap';
+import { individual, mapToList, individualTaxKeys } from './keymap';
 
 interface IndividualRequirementsProps {
 	keys: string[];
@@ -18,7 +18,7 @@ const IndividualRequirements = ( {
 	keys,
 }: IndividualRequirementsProps ): JSX.Element => {
 	const personalList = mapToList( keys, individual );
-	const hasTax = keys.some( ( key ) => taxKeys.includes( key ) );
+	const hasTax = keys.some( ( key ) => individualTaxKeys.includes( key ) );
 
 	return (
 		<>

--- a/client/onboarding/requirements/keymap.tsx
+++ b/client/onboarding/requirements/keymap.tsx
@@ -16,14 +16,51 @@ export const individual: KeyMap = {
 	'individual.nationality': requirements.nationality,
 };
 
-export const taxKeys = [ 'individual.ssn_last_4', 'individual.id_number' ];
+export const individualTaxKeys = [
+	'individual.ssn_last_4',
+	'individual.id_number',
+];
+
+export const representative: KeyMap = {
+	'representative.first_name': requirements.name,
+	'representative.dob.day': requirements.dob,
+	'representative.address.line1': requirements.address,
+	'representative.email': requirements.email,
+	'representative.phone': requirements.phone,
+	'representative.nationality': requirements.nationality,
+	'representative.id_number': requirements.ssn,
+};
+
+export const company: KeyMap = {
+	'company.name': requirements.name,
+	'company.address.line1': requirements.address,
+	'company.phone': requirements.phone,
+	'company.tax_id': requirements.taxId,
+	'company.registration_number': requirements.registrationNumber,
+};
+
+export const companyDetails: KeyMap = {
+	'owners.first_name': requirements.name,
+	'owners.dob.day': requirements.dob,
+	'owners.address.line1': requirements.address,
+	'owners.email': requirements.email,
+	'owners.id_number': requirements.ssn,
+	'directors.first_name': requirements.name,
+	'directors.dob.day': requirements.dob,
+	'directors.address.line1': requirements.address,
+	'directors.email': requirements.email,
+	'executives.first_name': requirements.name,
+	'executives.dob.day': requirements.dob,
+	'executives.address.line1': requirements.address,
+	'executives.email': requirements.email,
+};
 
 export const mapToList = ( keys: string[], map: KeyMap ): string => {
-	const list = [];
+	const list = new Set();
 
 	for ( const key in map ) {
-		if ( keys.includes( key ) ) list.push( individual[ key ] );
+		if ( keys.includes( key ) ) list.add( map[ key ] );
 	}
 
-	return list.join( ', ' );
+	return Array.from( list ).join( ', ' );
 };

--- a/client/onboarding/requirements/keymap.tsx
+++ b/client/onboarding/requirements/keymap.tsx
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { joinWithConjunction } from 'utils/strings';
 import { requirements } from './strings';
 
 interface KeyMap {
@@ -56,11 +57,11 @@ export const companyDetails: KeyMap = {
 };
 
 export const mapToList = ( keys: string[], map: KeyMap ): string => {
-	const list = new Set();
+	const list: Set< string > = new Set();
 
 	for ( const key in map ) {
 		if ( keys.includes( key ) ) list.add( map[ key ] );
 	}
 
-	return Array.from( list ).join( ', ' );
+	return joinWithConjunction( Array.from( list ) );
 };

--- a/client/onboarding/requirements/keymap.tsx
+++ b/client/onboarding/requirements/keymap.tsx
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import { requirements } from './strings';
+
+interface KeyMap {
+	[ key: string ]: string;
+}
+
+export const individual: KeyMap = {
+	'individual.first_name': requirements.name,
+	'individual.dob.day': requirements.dob,
+	'individual.address.line1': requirements.address,
+	'individual.email': requirements.email,
+	'individual.phone': requirements.phone,
+	'individual.nationality': requirements.nationality,
+};
+
+export const taxKeys = [ 'individual.ssn_last_4', 'individual.id_number' ];
+
+export const mapToList = ( keys: string[], map: KeyMap ): string => {
+	const list = [];
+
+	for ( const key in map ) {
+		if ( keys.includes( key ) ) list.push( individual[ key ] );
+	}
+
+	return list.join( ', ' );
+};

--- a/client/onboarding/requirements/strings.tsx
+++ b/client/onboarding/requirements/strings.tsx
@@ -7,8 +7,12 @@ export const groups = {
 	personalDetails: __( 'Personal details', 'woocommerce-payments' ),
 	taxInfo: __( 'Tax information', 'woocommerce-payments' ),
 	companyInfo: __( 'Company information', 'woocommerce-payments' ),
-	companyOwner: __(
-		'Company owner, director and executive details',
+	company: __( 'Company', 'woocommerce-payments' ),
+	owner: __( 'owner', 'woocommerce-payments' ),
+	director: __( 'director', 'woocommerce-payments' ),
+	executive: __( 'executive', 'woocommerce-payments' ),
+	representativeDetails: __(
+		'Representative details',
 		'woocommerce-payments'
 	),
 	bankDetails: __( 'Bank account details', 'woocommerce-payments' ),
@@ -23,4 +27,9 @@ export const requirements = {
 	phone: __( 'phone', 'woocommerce-payments' ),
 	nationality: __( 'nationality', 'woocommerce-payments' ),
 	ssn: __( 'Social Security Number (SSN)', 'woocommerce-payments' ),
+	taxId: __( 'Company Tax ID', 'woocommerce-payments' ),
+	registrationNumber: __(
+		'Company Registration Number',
+		'woocommerce-payments'
+	),
 };

--- a/client/onboarding/requirements/strings.tsx
+++ b/client/onboarding/requirements/strings.tsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const groups = {
+	personalDetails: __( 'Personal details', 'woocommerce-payments' ),
+	taxInfo: __( 'Tax information', 'woocommerce-payments' ),
+	companyInfo: __( 'Company information', 'woocommerce-payments' ),
+	companyOwner: __(
+		'Company owner, director and executive details',
+		'woocommerce-payments'
+	),
+	bankDetails: __( 'Bank account details', 'woocommerce-payments' ),
+	companyBank: __( 'Company bank account details', 'woocommerce-payments' ),
+};
+
+export const requirements = {
+	name: __( 'name', 'woocommerce-payments' ),
+	dob: __( 'date of birth', 'woocommerce-payments' ),
+	address: __( 'address', 'woocommerce-payments' ),
+	email: __( 'email', 'woocommerce-payments' ),
+	phone: __( 'phone', 'woocommerce-payments' ),
+	nationality: __( 'nationality', 'woocommerce-payments' ),
+	ssn: __( 'Social Security Number (SSN)', 'woocommerce-payments' ),
+};

--- a/client/onboarding/requirements/style.scss
+++ b/client/onboarding/requirements/style.scss
@@ -1,0 +1,27 @@
+.onboarding__requirement-group {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	column-gap: $gap-smaller;
+	align-items: center;
+	margin: $gap-smaller;
+
+	svg {
+		background-color: $studio-purple-0;
+		border-radius: 4px;
+		fill: $studio-purple-60;
+		padding: 2px;
+	}
+
+	.headline {
+		color: $gray-900;
+	}
+
+	.subline {
+		grid-column: 2;
+		font-size: $helptext-font-size;
+		color: $gray-700;
+		&::first-letter {
+			text-transform: capitalize;
+		}
+	}
+}

--- a/client/utils/strings.tsx
+++ b/client/utils/strings.tsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ *	Joins a list using commas plus `and` or the translated word.
+ *  Example: [a, b, c] => `a, b and c`.
+ *
+ * @param {string[]} list of strings to join
+ * @return {string} joined list with a conjunction
+ */
+export const joinWithConjunction = ( list: string[] ): string => {
+	const commaSeparated = list.join( ', ' );
+	return commaSeparated.replace(
+		/\,(?=[^,]*$)/,
+		__( ' and', 'woocommerce-payments' )
+	);
+};


### PR DESCRIPTION
Fixes #3978

#### Changes proposed in this Pull Request
-

#### Testing instructions
You'll need to manually place the component somewhere to be able to test it, using something like:
```jsx
const keys = ['individual.first_name'...]; // Stripe requirements keys from the server response.
const type = 'individual'; // Company type from the onboarding form.

<Requirements type={type} keys={keys} />
```
- Try with different combinations of keys.
- Should show the required verifications details according to the provided Figma design.

#### Screenshots
| AU:company:private_partnership | SG:individual |
|-|-|
|<img width="313" alt="Screenshot 2022-03-22 at 12 21 49" src="https://user-images.githubusercontent.com/7670276/159471030-f4d68582-1837-4fe5-bbcf-3eed3af94c2f.png">|<img width="377" alt="Screenshot 2022-03-22 at 12 23 06" src="https://user-images.githubusercontent.com/7670276/159471036-710f1651-c433-4036-aa1a-f3e2bb5241b5.png">|

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**
- QA Testing Not Applicable
