### PR TITLE
Custom email receipt for terminal card reader

### DIFF
--- a/changelog/add-3558-custom-email-receipt-for-terminal-card-reader
+++ b/changelog/add-3558-custom-email-receipt-for-terminal-card-reader
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+In-Person Payments: Custom email for payment receipt

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -353,8 +353,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
 
 		// Init IPP emails.
-		add_filter( 'woocommerce_email_classes', [ $this, 'add_ipp_emails' ] );
-		add_filter( 'woocommerce_email_actions', [ $this, 'add_ipp_email_actions' ] );
+		add_filter( 'woocommerce_email_classes', [ __CLASS__, 'add_ipp_emails' ], 10 );
 	}
 
 	/**
@@ -366,17 +365,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public static function add_ipp_emails( array $email_classes ): array {
 		$email_classes['WC_Payments_Email_IPP_Receipt'] = include __DIR__ . '/emails/class-wc-payments-email-ipp-receipt.php';
 		return $email_classes;
-	}
-
-	/**
-	 * Function add_email_actions
-	 *
-	 * @param array $email_actions the email actions.
-	 * @return array
-	 */
-	public static function add_ipp_email_actions( array $email_actions ): array {
-		$email_actions[] = 'woocommerce_payments_email_ipp_receipt';
-		return $email_actions;
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -351,6 +351,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// Update the current request logged_in cookie after a guest user is created to avoid nonce inconsistencies.
 		add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
+
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -353,8 +353,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
 
 		// Init IPP emails.
-		add_filter( 'woocommerce_email_classes', [ __CLASS__, 'add_ipp_emails' ], 11 );
-		add_filter( 'woocommerce_email_actions', [ __CLASS__, 'add_ipp_email_actions' ], 11 );
+		add_filter( 'woocommerce_email_classes', [ $this, 'add_ipp_emails' ] );
+		add_filter( 'woocommerce_email_actions', [ $this, 'add_ipp_email_actions' ] );
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -351,20 +351,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// Update the current request logged_in cookie after a guest user is created to avoid nonce inconsistencies.
 		add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
-
-		// Init IPP emails.
-		add_filter( 'woocommerce_email_classes', [ __CLASS__, 'add_ipp_emails' ], 10 );
-	}
-
-	/**
-	 * Function add_emails
-	 *
-	 * @param array $email_classes the email classes.
-	 * @return array
-	 */
-	public static function add_ipp_emails( array $email_classes ): array {
-		$email_classes['WC_Payments_Email_IPP_Receipt'] = include __DIR__ . '/emails/class-wc-payments-email-ipp-receipt.php';
-		return $email_classes;
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -352,6 +352,31 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// Update the current request logged_in cookie after a guest user is created to avoid nonce inconsistencies.
 		add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
 
+		// Init IPP emails.
+		add_filter( 'woocommerce_email_classes', [ __CLASS__, 'add_ipp_emails' ], 11 );
+		add_filter( 'woocommerce_email_actions', [ __CLASS__, 'add_ipp_email_actions' ], 11 );
+	}
+
+	/**
+	 * Function add_emails
+	 *
+	 * @param array $email_classes the email classes.
+	 * @return array
+	 */
+	public static function add_ipp_emails( array $email_classes ): array {
+		$email_classes['WC_Payments_Email_IPP_Receipt'] = include __DIR__ . '/emails/class-wc-payments-email-ipp-receipt.php';
+		return $email_classes;
+	}
+
+	/**
+	 * Function add_email_actions
+	 *
+	 * @param array $email_actions the email actions.
+	 * @return array
+	 */
+	public static function add_ipp_email_actions( array $email_actions ): array {
+		$email_actions[] = 'woocommerce_payments_email_ipp_receipt';
+		return $email_actions;
 	}
 
 	/**

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -353,7 +353,7 @@ class WC_Payments_Webhook_Processing_Service {
 		$this->order_service->mark_payment_completed( $order, $intent_id, $intent_status, $charge_id );
 
 		// Send the customer a card reader receipt if it's an in person payment type.
-		if ( \WCPay\Constants\Payment_Method::CARD_PRESENT === ( $charges_data[0]['payment_method_details']['type'] ?? null ) ) {
+		if ( Payment_Method::CARD_PRESENT === ( $charges_data[0]['payment_method_details']['type'] ?? null ) ) {
 			$merchant_settings = [
 				'business_name' => $this->wcpay_gateway->get_option( 'account_business_name' ),
 				'support_info'  => [

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -62,6 +62,13 @@ class WC_Payments_Webhook_Processing_Service {
 	private $receipt_service;
 
 	/**
+	 * WC_Payment_Gateway_WCPay
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private $wcpay_gateway;
+
+	/**
 	 * WC_Payments_Webhook_Processing_Service constructor.
 	 *
 	 * @param WC_Payments_API_Client                          $api_client          WooCommerce Payments API client.
@@ -69,7 +76,8 @@ class WC_Payments_Webhook_Processing_Service {
 	 * @param WC_Payments_Account                             $account             WC_Payments_Account instance.
 	 * @param WC_Payments_Remote_Note_Service                 $remote_note_service WC_Payments_Remote_Note_Service instance.
 	 * @param WC_Payments_Order_Service                       $order_service       WC_Payments_Order_Service instance.
-	 * @param WC_Payments_In_Person_Payments_Receipts_Service $receipt_service       WC_Payments_In_Person_Payments_Receipts_Service instance.
+	 * @param WC_Payments_In_Person_Payments_Receipts_Service $receipt_service     WC_Payments_In_Person_Payments_Receipts_Service instance.
+	 * @param WC_Payment_Gateway_WCPay                        $wcpay_gateway       WC_Payment_Gateway_WCPay instance.
 	 */
 	public function __construct(
 		WC_Payments_API_Client $api_client,
@@ -77,7 +85,8 @@ class WC_Payments_Webhook_Processing_Service {
 		WC_Payments_Account $account,
 		WC_Payments_Remote_Note_Service $remote_note_service,
 		WC_Payments_Order_Service $order_service,
-		WC_Payments_In_Person_Payments_Receipts_Service $receipt_service
+		WC_Payments_In_Person_Payments_Receipts_Service $receipt_service,
+		WC_Payment_Gateway_WCPay $wcpay_gateway
 	) {
 		$this->wcpay_db            = $wcpay_db;
 		$this->account             = $account;
@@ -85,6 +94,7 @@ class WC_Payments_Webhook_Processing_Service {
 		$this->order_service       = $order_service;
 		$this->api_client          = $api_client;
 		$this->receipt_service     = $receipt_service;
+		$this->wcpay_gateway       = $wcpay_gateway;
 	}
 
 	/**
@@ -343,14 +353,13 @@ class WC_Payments_Webhook_Processing_Service {
 		$this->order_service->mark_payment_completed( $order, $intent_id, $intent_status, $charge_id );
 
 		// Send the customer a card reader receipt if it's an in person payment type.
-		if ( array_key_exists( 'payment_method_details', $charges_data[0] ) && 'card_present' === $this->read_webhook_property( $charges_data[0]['payment_method_details'], 'type' ) ) {
-			$wcpay_gateway     = WC_Payments::get_gateway();
+		if ( \WCPay\Constants\Payment_Method::CARD_PRESENT === ( $charges_data[0]['payment_method_details']['type'] ?? null ) ) {
 			$merchant_settings = [
-				'business_name' => $wcpay_gateway->get_option( 'account_business_name' ),
+				'business_name' => $this->wcpay_gateway->get_option( 'account_business_name' ),
 				'support_info'  => [
-					'address' => $wcpay_gateway->get_option( 'account_business_support_address' ),
-					'phone'   => $wcpay_gateway->get_option( 'account_business_support_phone' ),
-					'email'   => $wcpay_gateway->get_option( 'account_business_support_email' ),
+					'address' => $this->wcpay_gateway->get_option( 'account_business_support_address' ),
+					'phone'   => $this->wcpay_gateway->get_option( 'account_business_support_phone' ),
+					'email'   => $this->wcpay_gateway->get_option( 'account_business_support_email' ),
 				],
 			];
 			$this->receipt_service->send_customer_ipp_receipt_email( $order, $merchant_settings, $charges_data[0] );

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -344,7 +344,16 @@ class WC_Payments_Webhook_Processing_Service {
 
 		// Send the customer a card reader receipt if it's an in person payment type.
 		if ( array_key_exists( 'payment_method_details', $charges_data[0] ) && 'card_present' === $this->read_webhook_property( $charges_data[0]['payment_method_details'], 'type' ) ) {
-			$this->receipt_service->send_customer_ipp_receipt_email( $order, $charges_data[0] );
+			$wcpay_gateway     = WC_Payments::get_gateway();
+			$merchant_settings = [
+				'business_name' => $wcpay_gateway->get_option( 'account_business_name' ),
+				'support_info'  => [
+					'address' => $wcpay_gateway->get_option( 'account_business_support_address' ),
+					'phone'   => $wcpay_gateway->get_option( 'account_business_support_phone' ),
+					'email'   => $wcpay_gateway->get_option( 'account_business_support_email' ),
+				],
+			];
+			$this->receipt_service->send_customer_ipp_receipt_email( $order, $merchant_settings, $charges_data[0] );
 		}
 	}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -266,7 +266,7 @@ class WC_Payments {
 		self::$fraud_service                       = new WC_Payments_Fraud_Service( self::$api_client, self::$customer_service, self::$account );
 		self::$localization_service                = new WC_Payments_Localization_Service();
 		self::$failed_transaction_rate_limiter     = new Session_Rate_Limiter( Session_Rate_Limiter::SESSION_KEY_DECLINED_CARD_REGISTRY, 5, 10 * MINUTE_IN_SECONDS );
-		self::$in_person_payments_receipts_service = new WC_Payments_In_Person_Payments_Receipts_Service();
+		self::$in_person_payments_receipts_service = new WC_Payments_In_Person_Payments_Receipts_Service( WC()->mailer() );
 		self::$order_service                       = new WC_Payments_Order_Service();
 		self::$webhook_processing_service          = new WC_Payments_Webhook_Processing_Service( self::$api_client, self::$db_helper, self::$account, self::$remote_note_service, self::$order_service, self::$in_person_payments_receipts_service );
 		self::$webhook_reliability_service         = new WC_Payments_Webhook_Reliability_Service( self::$api_client, self::$action_scheduler_service, self::$webhook_processing_service );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -266,8 +266,6 @@ class WC_Payments {
 		self::$localization_service                = new WC_Payments_Localization_Service();
 		self::$failed_transaction_rate_limiter     = new Session_Rate_Limiter( Session_Rate_Limiter::SESSION_KEY_DECLINED_CARD_REGISTRY, 5, 10 * MINUTE_IN_SECONDS );
 		self::$order_service                       = new WC_Payments_Order_Service();
-		self::$webhook_processing_service          = new WC_Payments_Webhook_Processing_Service( self::$api_client, self::$db_helper, self::$account, self::$remote_note_service, self::$order_service, self::$in_person_payments_receipts_service );
-		self::$webhook_reliability_service         = new WC_Payments_Webhook_Reliability_Service( self::$api_client, self::$action_scheduler_service, self::$webhook_processing_service );
 
 		$card_class = CC_Payment_Gateway::class;
 		$upe_class  = UPE_Payment_Gateway::class;
@@ -293,6 +291,9 @@ class WC_Payments {
 		} else {
 			self::$card_gateway = new $card_class( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service, self::$failed_transaction_rate_limiter, self::$order_service );
 		}
+
+		self::$webhook_processing_service  = new WC_Payments_Webhook_Processing_Service( self::$api_client, self::$db_helper, self::$account, self::$remote_note_service, self::$order_service, self::$in_person_payments_receipts_service, self::$card_gateway );
+		self::$webhook_reliability_service = new WC_Payments_Webhook_Reliability_Service( self::$api_client, self::$action_scheduler_service, self::$webhook_processing_service );
 
 		self::maybe_register_platform_checkout_hooks();
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -347,32 +347,6 @@ class WC_Payments {
 
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ __CLASS__, 'set_plugin_activation_timestamp' ] );
-
-		// Init Emails. TODO check if this is the right place to do it.
-		add_filter( 'woocommerce_email_classes', [ __CLASS__, 'add_emails' ], 11 );
-		add_filter( 'woocommerce_email_actions', [ __CLASS__, 'add_email_actions' ], 11 );
-	}
-
-	/**
-	 * Function add_emails
-	 *
-	 * @param array $email_classes the email classes.
-	 * @return array
-	 */
-	public static function add_emails( array $email_classes ): array {
-		$email_classes['WC_Payments_Email_IPP_Receipt'] = include __DIR__ . '/emails/class-wc-payments-email-ipp-receipt.php';
-		return $email_classes;
-	}
-
-	/**
-	 * Function add_email_actions
-	 *
-	 * @param array $email_actions the email actions.
-	 * @return array
-	 */
-	public static function add_email_actions( array $email_actions ): array {
-		$email_actions[] = 'woocommerce_payments_email_ipp_receipt';
-		return $email_actions;
 	}
 
 	/**

--- a/includes/emails/class-wc-payments-email-ipp-receipt.php
+++ b/includes/emails/class-wc-payments-email-ipp-receipt.php
@@ -108,13 +108,11 @@ if ( ! class_exists( 'WC_Payments_Email_IPP_Receipt' ) ) :
 			$this->merchant_settings = $merchant_settings;
 			$this->charge            = $charge;
 
-			if ( 'true' !== $email_already_sent ) {
-				if ( $this->is_enabled() && $this->get_recipient() ) {
-					$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+			if ( 'true' !== $email_already_sent && $this->is_enabled() && $this->get_recipient() ) {
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
 
-					$order->update_meta_data( '_new_receipt_email_sent', 'true' );
-					$order->save();
-				}
+				$order->update_meta_data( '_new_receipt_email_sent', 'true' );
+				$order->save();
 			}
 
 			$this->restore_locale();
@@ -236,7 +234,6 @@ if ( ! class_exists( 'WC_Payments_Email_IPP_Receipt' ) ) :
 		/**
 		 * Default content to show below main email content.
 		 *
-		 * @since 3.7.0
 		 * @return string
 		 */
 		public function get_default_additional_content(): string {

--- a/includes/emails/class-wc-payments-email-ipp-receipt.php
+++ b/includes/emails/class-wc-payments-email-ipp-receipt.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * Class WC_Payments_Email_IPP_Receipt file
+ *
+ * @package WooCommerce\Emails
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'WC_Payments_Email_IPP_Receipt' ) ) :
+
+	/**
+	 * In Person Payments Receipt Email.
+	 *
+	 * An email sent to the customer when a new order is paid for with a card reader.
+	 *
+	 * @class       WC_Payments_Email_IPP_Receipt
+	 * @version     2.0.0
+	 * @package     WooCommerce\Classes\Emails
+	 * @extends     WC_Email
+	 */
+	class WC_Payments_Email_IPP_Receipt extends WC_Email {
+
+		/**
+		 * Merchant settings
+		 *
+		 * @var array
+		 */
+		public $merchant_settings = [];
+
+		/**
+		 * Charge
+		 *
+		 * @var array
+		 */
+		public $charge = [];
+
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id             = 'new_receipt';
+			$this->customer_email = true;
+			$this->title          = __( 'New receipt', 'woocommerce-payments' );
+			$this->description    = __( 'New receipt emails are sent to customers when a new order is paid for with a card reader.', 'woocommerce-payments' );
+			$this->template_base  = WCPAY_ABSPATH . 'templates/';
+			$this->template_html  = 'emails/customer-ipp-receipt.php';
+			$this->template_plain = 'emails/plain/customer-ipp-receipt.php';
+			$this->placeholders   = [
+				'{order_date}'   => '',
+				'{order_number}' => '',
+			];
+
+			// Content hooks.
+			add_action( 'woocommerce_payments_email_ipp_receipt_store_details', [ $this, 'store_details' ], 10, 2 );
+			add_action( 'woocommerce_payments_email_ipp_receipt_compliance_details', [ $this, 'compliance_details' ], 10, 2 );
+
+			// Triggers for this email.
+			add_action( 'woocommerce_payments_email_ipp_receipt_notification', [ $this, 'trigger' ], 10, 3 );
+
+			// Call parent constructor.
+			parent::__construct();
+		}
+
+		/**
+		 * Get email subject.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_subject(): string {
+			return __( 'Your {site_title} Receipt', 'woocommerce-payments' );
+		}
+
+		/**
+		 * Get email heading.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_heading(): string {
+			return __( 'Your receipt for order: #{order_number}', 'woocommerce-payments' );
+		}
+
+		/**
+		 * Trigger the sending of this email.
+		 *
+		 * @param WC_Order $order The order instance.
+		 * @param array    $merchant_settings The merchant settings data.
+		 * @param array    $charge The charge data.
+		 */
+		public function trigger( WC_Order $order, array $merchant_settings, array $charge ) {
+			$this->setup_locale();
+			$email_already_sent = false;
+
+			if ( is_a( $order, 'WC_Order' ) ) {
+				$this->object                         = $order;
+				$this->recipient                      = $this->object->get_billing_email();
+				$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
+				$this->placeholders['{order_number}'] = $this->object->get_order_number();
+
+				$email_already_sent = $order->get_meta( '_new_receipt_email_sent' );
+			}
+
+			if ( $merchant_settings ) {
+				$this->merchant_settings = $merchant_settings;
+			}
+
+			if ( $charge ) {
+				$this->charge = $charge;
+			}
+
+			if ( 'true' === $email_already_sent ) {
+				return;
+			}
+
+			if ( $this->is_enabled() && $this->get_recipient() ) {
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+
+				$order->update_meta_data( '_new_receipt_email_sent', 'true' );
+				$order->save();
+			}
+
+			$this->restore_locale();
+		}
+
+		/**
+		 * Get content html.
+		 *
+		 * @return string
+		 */
+		public function get_content_html(): string {
+			return wc_get_template_html(
+				$this->template_html,
+				[
+					'order'              => $this->object,
+					'merchant_settings'  => $this->merchant_settings,
+					'charge'             => $this->charge,
+					'email_heading'      => $this->get_heading(),
+					'additional_content' => $this->get_additional_content(),
+					'sent_to_admin'      => false,
+					'plain_text'         => false,
+					'email'              => $this,
+				],
+				'',
+				WCPAY_ABSPATH . 'templates/'
+			);
+		}
+
+		/**
+		 * Get content plain.
+		 *
+		 * @return string
+		 */
+		public function get_content_plain(): string {
+			return wc_get_template_html(
+				$this->template_plain,
+				[
+					'order'              => $this->object,
+					'merchant_settings'  => $this->merchant_settings,
+					'charge'             => $this->charge,
+					'email_heading'      => $this->get_heading(),
+					'additional_content' => $this->get_additional_content(),
+					'sent_to_admin'      => false,
+					'plain_text'         => true,
+					'email'              => $this,
+				],
+				'',
+				WCPAY_ABSPATH . 'templates/'
+			);
+		}
+
+		/**
+		 * Get store details content html
+		 *
+		 * @param array   $settings The settings.
+		 * @param boolean $plain_text Whether the content type is plain text.
+		 * @return void
+		 */
+		public function store_details( array $settings, bool $plain_text ) {
+			if ( $plain_text ) {
+				wc_get_template(
+					'emails/plain/email-ipp-receipt-store-details.php',
+					[
+						'business_name'   => $settings['business_name'],
+						'support_address' => $settings['support_info']['address'],
+						'support_phone'   => $settings['support_info']['phone'],
+						'support_email'   => $settings['support_info']['email'],
+					],
+					'',
+					WCPAY_ABSPATH . 'templates/'
+				);
+
+			} else {
+				wc_get_template(
+					'emails/email-ipp-receipt-store-details.php',
+					[
+						'business_name'   => $settings['business_name'],
+						'support_address' => $settings['support_info']['address'],
+						'support_phone'   => $settings['support_info']['phone'],
+						'support_email'   => $settings['support_info']['email'],
+					],
+					'',
+					WCPAY_ABSPATH . 'templates/'
+				);
+			}
+		}
+
+		/**
+		 * Get compliance data content html
+		 *
+		 * @param array   $charge The charge.
+		 * @param boolean $plain_text Whether the content type is plain text.
+		 * @return void
+		 */
+		public function compliance_details( array $charge, bool $plain_text ) {
+			if ( $plain_text ) {
+				wc_get_template(
+					'emails/plain/email-ipp-receipt-compliance-details.php',
+					[
+						'payment_method_details' => $charge['payment_method_details']['card_present'],
+						'receipt'                => $charge['payment_method_details']['card_present']['receipt'],
+					],
+					'',
+					WCPAY_ABSPATH . 'templates/'
+				);
+			} else {
+				wc_get_template(
+					'emails/email-ipp-receipt-compliance-details.php',
+					[
+						'payment_method_details' => $charge['payment_method_details']['card_present'],
+						'receipt'                => $charge['payment_method_details']['card_present']['receipt'],
+					],
+					'',
+					WCPAY_ABSPATH . 'templates/'
+				);
+			}
+		}
+
+		/**
+		 * Default content to show below main email content.
+		 *
+		 * @since 3.7.0
+		 * @return string
+		 */
+		public function get_default_additional_content(): string {
+			return __( 'Thanks for using {site_url}!', 'woocommerce-payments' );
+		}
+
+	}
+
+endif;
+
+return new WC_Payments_Email_IPP_Receipt();

--- a/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
+++ b/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
@@ -68,6 +68,29 @@ class WC_Payments_In_Person_Payments_Receipts_Service {
 		return ob_get_clean();
 	}
 
+
+	/**
+	 * Send card reader receipt to customer by email
+	 *
+	 * @param  WC_Order $order the order.
+	 * @param  array    $charge the charge.
+	 * @return void
+	 */
+	public function send_customer_ipp_receipt_email( WC_Order $order, array $charge ) {
+		// Send email receipt to the customer.
+		$wcpay_gateway     = WC_Payments::get_gateway();
+		$merchant_settings = [
+			'business_name' => $wcpay_gateway->get_option( 'account_business_name' ),
+			'support_info'  => [
+				'address' => $wcpay_gateway->get_option( 'account_business_support_address' ),
+				'phone'   => $wcpay_gateway->get_option( 'account_business_support_phone' ),
+				'email'   => $wcpay_gateway->get_option( 'account_business_support_email' ),
+			],
+		];
+
+		do_action( 'woocommerce_payments_email_ipp_receipt', $order, $merchant_settings, $charge );
+	}
+
 	/**
 	 * Format line items
 	 *

--- a/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
+++ b/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
@@ -95,7 +95,6 @@ class WC_Payments_In_Person_Payments_Receipts_Service {
 	 * @return void
 	 */
 	public function send_customer_ipp_receipt_email( WC_Order $order, array $merchant_settings, array $charge ) {
-		$this->mailer->init();
 		$email_receipt = $this->mailer->get_emails()['WC_Payments_Email_IPP_Receipt'];
 		if ( $email_receipt instanceof WC_Payments_Email_IPP_Receipt ) {
 			$email_receipt->trigger( $order, $merchant_settings, $charge );

--- a/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
+++ b/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
@@ -13,6 +13,23 @@ defined( 'ABSPATH' ) || exit;
 class WC_Payments_In_Person_Payments_Receipts_Service {
 
 	/**
+	 * WC_Emails instance.
+	 *
+	 * @var WC_Emails
+	 */
+	private $mailer;
+
+	/**
+	 * __construct
+	 *
+	 * @param  WC_Emails $mailer instance.
+	 * @return void
+	 */
+	public function __construct( WC_Emails $mailer ) {
+		$this->mailer = $mailer;
+	}
+
+	/**
 	 * Renders the receipt template.
 	 *
 	 * @param  array    $settings Merchant settings.
@@ -73,22 +90,15 @@ class WC_Payments_In_Person_Payments_Receipts_Service {
 	 * Send card reader receipt to customer by email
 	 *
 	 * @param  WC_Order $order the order.
+	 * @param array    $merchant_settings The merchant settings.
 	 * @param  array    $charge the charge.
 	 * @return void
 	 */
-	public function send_customer_ipp_receipt_email( WC_Order $order, array $charge ) {
-		// Send email receipt to the customer.
-		$wcpay_gateway     = WC_Payments::get_gateway();
-		$merchant_settings = [
-			'business_name' => $wcpay_gateway->get_option( 'account_business_name' ),
-			'support_info'  => [
-				'address' => $wcpay_gateway->get_option( 'account_business_support_address' ),
-				'phone'   => $wcpay_gateway->get_option( 'account_business_support_phone' ),
-				'email'   => $wcpay_gateway->get_option( 'account_business_support_email' ),
-			],
-		];
-
-		do_action( 'woocommerce_payments_email_ipp_receipt', $order, $merchant_settings, $charge );
+	public function send_customer_ipp_receipt_email( WC_Order $order, array $merchant_settings, array $charge ) {
+		$email_receipt = $this->mailer->get_emails()['WC_Payments_Email_IPP_Receipt'];
+		if ( $email_receipt instanceof WC_Payments_Email_IPP_Receipt ) {
+			$email_receipt->trigger( $order, $merchant_settings, $charge );
+		}
 	}
 
 	/**

--- a/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
+++ b/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
@@ -95,6 +95,7 @@ class WC_Payments_In_Person_Payments_Receipts_Service {
 	 * @return void
 	 */
 	public function send_customer_ipp_receipt_email( WC_Order $order, array $merchant_settings, array $charge ) {
+		$this->mailer->init();
 		$email_receipt = $this->mailer->get_emails()['WC_Payments_Email_IPP_Receipt'];
 		if ( $email_receipt instanceof WC_Payments_Email_IPP_Receipt ) {
 			$email_receipt->trigger( $order, $merchant_settings, $charge );

--- a/templates/emails/customer-ipp-receipt.php
+++ b/templates/emails/customer-ipp-receipt.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/customer-ipp-receipt.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce\Payments\Templates\Emails
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/*
+ * @hooked WC_Emails::email_header() Output the email header
+ */
+do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
+
+<?php /* translators: %s: Customer first name */ ?>
+<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce-payments' ), esc_html( $order->get_billing_first_name() ) ); ?></p>
+<?php /* translators: %s: Order number */ ?>
+<p><?php printf( esc_html__( 'This is the receipt for your order #%s:', 'woocommerce-payments' ), esc_html( $order->get_order_number() ) ); ?></p>
+<?php
+/*
+ * @hooked WC_Payments_Email_IPP_Receipt::store_details() Output the store details
+ */
+do_action( 'woocommerce_payments_email_ipp_receipt_store_details', $merchant_settings, $plain_text );
+
+/*
+ * @hooked WC_Emails::order_details() Shows the order details table.
+ * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+ * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+ * @since 2.5.0
+ */
+do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
+
+/*
+ * @hooked WC_Payments_Email_IPP_Receipt::compliance_details() Output receipt compliance details
+ */
+do_action( 'woocommerce_payments_email_ipp_receipt_compliance_details', $charge, $plain_text );
+
+/*
+ * @hooked WC_Emails::order_meta() Shows order meta data.
+ */
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
+}
+
+/*
+ * @hooked WC_Emails::email_footer() Output the email footer
+ */
+do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/email-ipp-receipt-compliance-details.php
+++ b/templates/emails/email-ipp-receipt-compliance-details.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-ipp-receipt-compliance-details.php
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce\Payments\Templates\Emails
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+?>
+
+<div style="margin-bottom: 40px;">
+	<table class="td" cellspacing="0" cellpadding="6" style="width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;" border="1">
+		<tbody>
+			<tr>
+				<th class="td" scope="row" colspan="2">
+					<?php esc_html_e( 'Payment Method', 'woocommerce-payments' ); ?>
+				</th>
+				<td class="td">
+					<div><?php echo esc_html( sprintf( '%s - %s', ucfirst( $payment_method_details['brand'] ), $payment_method_details['last4'] ) ); ?></div>
+				</td>
+			</tr>
+			<tr>
+				<th class="td" scope="row" colspan="2">
+					<?php esc_html_e( 'Application Name', 'woocommerce-payments' ); ?>
+				</th>
+				<td class="td">
+					<div id="application-preferred-name"><?php echo esc_html( ucfirst( $receipt['application_preferred_name'] ) ); ?></div>
+				</td>
+			</tr>
+			<tr>
+				<th class="td" scope="row" colspan="2">
+					<?php esc_html_e( 'AID', 'woocommerce-payments' ); ?>
+				</th>
+				<td class="td">
+					<div id="dedicated-file-name"><?php echo esc_html( ucfirst( $receipt['dedicated_file_name'] ) ); ?></div>
+				</td>
+			</tr>
+			<tr>
+				<th class="td" scope="row" colspan="2">
+					<?php esc_html_e( 'Account Type', 'woocommerce-payments' ); ?>
+				</th>
+				<td class="td">
+					<div id="account-type"><?php echo esc_html( ucfirst( $receipt['account_type'] ) ); ?></div>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+</div>

--- a/templates/emails/email-ipp-receipt-store-details.php
+++ b/templates/emails/email-ipp-receipt-store-details.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/email-ipp-receipt-store-details.php
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce\Payments\Templates\Emails
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+?>
+
+<div style="margin-bottom: 40px;">
+	<table class="td" cellspacing="0" cellpadding="6" style="width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;" border="1">
+		<tbody>
+			<tr>
+				<td>
+					<h1><?php echo esc_html( $business_name ); ?></h1>
+					<?php if ( ! empty( $support_address ) ) { ?>
+						<div><?php echo esc_html( $support_address['line1'] ); ?></div>
+						<div><?php echo esc_html( $support_address['line2'] ); ?></div>
+						<div><?php echo esc_html( implode( ' ', [ $support_address['city'], $support_address['state'], $support_address['postal_code'], $support_address['country'] ] ) ); ?></div>
+						<div><?php echo esc_html( implode( ' ', [ $support_phone, $support_email ] ) ); ?></div>
+						<div><?php echo esc_html( gmdate( 'Y/m/d - H:iA' ) ); ?></div>
+					<?php } ?>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+</div>

--- a/templates/emails/plain/customer-ipp-receipt.php
+++ b/templates/emails/plain/customer-ipp-receipt.php
@@ -25,7 +25,7 @@ echo sprintf( esc_html__( 'Hi %s,', 'woocommerce-payments' ), esc_html( $order->
 /* translators: %s: Order number */
 echo sprintf( esc_html__( 'This is the receipt for your order #%s:', 'woocommerce-payments' ), esc_html( $order->get_order_number() ) ) . "\n\n";
 
-do_action( 'woocommerce_payments_email_receipt_store_details', $merchant_settings, $plain_text );
+do_action( 'woocommerce_payments_email_ipp_receipt_store_details', $merchant_settings, $plain_text );
 
 echo "\n----------------------------------------\n\n";
 
@@ -39,7 +39,7 @@ do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_tex
 
 echo "\n----------------------------------------\n\n";
 
-do_action( 'woocommerce_payments_email_receipt_compliance_details', $charge, $plain_text );
+do_action( 'woocommerce_payments_email_ipp_receipt_compliance_details', $charge, $plain_text );
 
 echo "\n\n----------------------------------------\n\n";
 

--- a/templates/emails/plain/customer-ipp-receipt.php
+++ b/templates/emails/plain/customer-ipp-receipt.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/customer-ipp-receipt.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce\Payments\Templates\Emails\Plain
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
+echo esc_html( wp_strip_all_tags( $email_heading ) );
+echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+/* translators: %s: Customer first name */
+echo sprintf( esc_html__( 'Hi %s,', 'woocommerce-payments' ), esc_html( $order->get_billing_first_name() ) ) . "\n\n";
+/* translators: %s: Order number */
+echo sprintf( esc_html__( 'This is the receipt for your order #%s:', 'woocommerce-payments' ), esc_html( $order->get_order_number() ) ) . "\n\n";
+
+do_action( 'woocommerce_payments_email_receipt_store_details', $merchant_settings, $plain_text );
+
+echo "\n----------------------------------------\n\n";
+
+/*
+ * @hooked WC_Emails::order_details() Shows the order details table.
+ * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+ * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+ * @since 2.5.0
+ */
+do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
+
+echo "\n----------------------------------------\n\n";
+
+do_action( 'woocommerce_payments_email_receipt_compliance_details', $charge, $plain_text );
+
+echo "\n\n----------------------------------------\n\n";
+
+/*
+ * @hooked WC_Emails::order_meta() Shows order meta data.
+ */
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+	echo esc_html( wp_strip_all_tags( wptexturize( $additional_content ) ) );
+	echo "\n\n----------------------------------------\n\n";
+}
+
+echo wp_kses_post( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/templates/emails/plain/email-ipp-receipt-compliance-details.php
+++ b/templates/emails/plain/email-ipp-receipt-compliance-details.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/email-ipp-receipt-compliance-details.php
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce\Payments\Templates\Emails\Plain
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+echo esc_html( sprintf( "%s:\t%s", __( 'Payment Method', 'woocommerce-payments' ), sprintf( '%s - %s', ucfirst( $payment_method_details['brand'] ), $payment_method_details['last4'] ) ) ) . "\n";
+
+echo esc_html( sprintf( "%s:\t%s", __( 'Application Name', 'woocommerce-payments' ), ucfirst( $receipt['application_preferred_name'] ) ) ) . "\n";
+
+echo esc_html( sprintf( "%s:\t%s", __( 'AID', 'woocommerce-payments' ), ucfirst( $receipt['dedicated_file_name'] ) ) ) . "\n";
+
+echo esc_html( sprintf( "%s:\t%s", __( 'Account Type', 'woocommerce-payments' ), ucfirst( $receipt['account_type'] ) ) ) . "\n";

--- a/templates/emails/plain/email-ipp-receipt-store-details.php
+++ b/templates/emails/plain/email-ipp-receipt-store-details.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/email-ipp-receipt-store-details.php
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce\Payments\Templates\Emails\Plain
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+echo "==========\n\n";
+
+echo esc_html( $business_name ) . "\n\n";
+
+echo "==========\n\n";
+
+if ( ! empty( $support_address ) ) {
+	echo esc_html( $support_address['line1'] ) . "\n";
+	echo esc_html( $support_address['line2'] ) . "\n";
+	echo esc_html( implode( ' ', [ $support_address['city'], $support_address['state'], $support_address['postal_code'], $support_address['country'] ] ) ) . "\n";
+	echo esc_html( implode( ' ', [ $support_phone, $support_email ] ) ) . "\n";
+	echo esc_html( gmdate( 'Y-m-d H:iA' ) ) . "\n";
+}

--- a/tests/unit/in-person-payments/test-class-wc-payments-in-person-payments-receipts-service.php
+++ b/tests/unit/in-person-payments/test-class-wc-payments-in-person-payments-receipts-service.php
@@ -34,6 +34,12 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 		parent::set_up();
 
 		$this->receipts_service = new WC_Payments_In_Person_Payments_Receipts_Service();
+		reset_phpmailer_instance();
+	}
+
+	public function tear_down() {
+		reset_phpmailer_instance();
+		parent::tear_down();
 	}
 
 	public function test_get_receipt_markup_is_EMV_compliant() {
@@ -85,6 +91,55 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 		$this->expectException( \RuntimeException::class );
 		$this->expectExceptionMessage( $expected_message );
 		$this->receipts_service->get_receipt_markup( $input_settings, $mock_order, [] );
+	}
+
+	public function test_send_customer_receipt_email_success() {
+		$mock_order  = WC_Helper_Order::create_order();
+		$mock_charge = [
+			'amount_captured'        => 10,
+			'order'                  => [
+				'number' => $mock_order->get_id(),
+			],
+			'payment_method_details' => [
+				'card_present' => [
+					'brand'   => 'test',
+					'last4'   => 'Test',
+					'receipt' => [
+						'application_preferred_name' => 'Test',
+						'dedicated_file_name'        => 'Test 42',
+						'account_type'               => 'Test',
+					],
+				],
+			],
+		];
+
+		$mock_mailer = tests_retrieve_phpmailer_instance();
+
+		$this->receipts_service->send_customer_ipp_receipt_email( $mock_order, $mock_charge );
+
+		$sent_email = $mock_mailer->get_sent();
+
+		$this->assertSame( $mock_order->get_billing_email(), $sent_email->to[0][0] );
+		$this->assertSame( 'Your Test Blog Receipt', $sent_email->subject );
+
+		$doc = new DOMDocument();
+		$doc->loadHTML( $sent_email->body );
+		$this->assertSame( $mock_charge['payment_method_details']['card_present']['receipt']['application_preferred_name'], $doc->getElementById( 'application-preferred-name' )->textContent );
+		$this->assertSame( $mock_charge['payment_method_details']['card_present']['receipt']['dedicated_file_name'], $doc->getElementById( 'dedicated-file-name' )->textContent );
+		$this->assertSame( $mock_charge['payment_method_details']['card_present']['receipt']['account_type'], $doc->getElementById( 'account-type' )->textContent );
+	}
+
+	public function test_send_customer_receipt_email_not_sent_twice() {
+		$mock_order = WC_Helper_Order::create_order();
+		$mock_order->update_meta_data( '_new_receipt_email_sent', 'true' );
+
+		$mock_mailer = tests_retrieve_phpmailer_instance();
+
+		$this->receipts_service->send_customer_ipp_receipt_email( $mock_order, [] );
+
+		$sent_email = $mock_mailer->get_sent();
+
+		$this->assertFalse( $sent_email );
 	}
 
 	public function provide_settings_validation_data() {

--- a/tests/unit/in-person-payments/test-class-wc-payments-in-person-payments-receipts-service.php
+++ b/tests/unit/in-person-payments/test-class-wc-payments-in-person-payments-receipts-service.php
@@ -38,8 +38,8 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 	}
 
 	public function tear_down() {
-		reset_phpmailer_instance();
 		parent::tear_down();
+		reset_phpmailer_instance();
 	}
 
 	public function test_get_receipt_markup_is_EMV_compliant() {
@@ -119,7 +119,7 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 
 		$sent_email = $mock_mailer->get_sent();
 
-		$this->assertSame( $mock_order->get_billing_email(), $sent_email->to[0][0] );
+		$this->assertSame( $mock_order->get_billing_email(), $sent_email->get_recipient( 'to' )->address );
 		$this->assertSame( 'Your Test Blog Receipt', $sent_email->subject );
 
 		$doc = new DOMDocument();

--- a/tests/unit/in-person-payments/test-class-wc-payments-in-person-payments-receipts-service.php
+++ b/tests/unit/in-person-payments/test-class-wc-payments-in-person-payments-receipts-service.php
@@ -16,6 +16,13 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 	private $receipts_service;
 
 	/**
+	 * mock_emails
+	 *
+	 * @var WC_Emails|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_emails;
+
+	/**
 	 * mock_settings
 	 *
 	 * @var array
@@ -33,13 +40,9 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 	public function set_up() {
 		parent::set_up();
 
-		$this->receipts_service = new WC_Payments_In_Person_Payments_Receipts_Service();
-		reset_phpmailer_instance();
-	}
+		$this->mock_emails = $this->createMock( WC_Emails::class );
 
-	public function tear_down() {
-		parent::tear_down();
-		reset_phpmailer_instance();
+		$this->receipts_service = new WC_Payments_In_Person_Payments_Receipts_Service( $this->mock_emails );
 	}
 
 	public function test_get_receipt_markup_is_EMV_compliant() {
@@ -94,8 +97,10 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 	}
 
 	public function test_send_customer_receipt_email_success() {
-		$mock_order  = WC_Helper_Order::create_order();
-		$mock_charge = [
+		require WCPAY_ABSPATH . 'includes/emails/class-wc-payments-email-ipp-receipt.php';
+		$mock_receipt_email = $this->createMock( WC_Payments_Email_IPP_Receipt::class );
+		$mock_order         = WC_Helper_Order::create_order();
+		$mock_charge        = [
 			'amount_captured'        => 10,
 			'order'                  => [
 				'number' => $mock_order->get_id(),
@@ -113,33 +118,11 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 			],
 		];
 
-		$mock_mailer = tests_retrieve_phpmailer_instance();
+		$this->mock_emails->expects( $this->once() )->method( 'get_emails' )->willReturn( [ 'WC_Payments_Email_IPP_Receipt' => $mock_receipt_email ] );
 
-		$this->receipts_service->send_customer_ipp_receipt_email( $mock_order, $mock_charge );
+		$mock_receipt_email->expects( $this->once() )->method( 'trigger' )->with( $mock_order, $this->mock_settings, $mock_charge );
 
-		$sent_email = $mock_mailer->get_sent();
-
-		$this->assertSame( $mock_order->get_billing_email(), $sent_email->get_recipient( 'to' )->address );
-		$this->assertSame( 'Your Test Blog Receipt', $sent_email->subject );
-
-		$doc = new DOMDocument();
-		$doc->loadHTML( $sent_email->body );
-		$this->assertSame( $mock_charge['payment_method_details']['card_present']['receipt']['application_preferred_name'], $doc->getElementById( 'application-preferred-name' )->textContent );
-		$this->assertSame( $mock_charge['payment_method_details']['card_present']['receipt']['dedicated_file_name'], $doc->getElementById( 'dedicated-file-name' )->textContent );
-		$this->assertSame( $mock_charge['payment_method_details']['card_present']['receipt']['account_type'], $doc->getElementById( 'account-type' )->textContent );
-	}
-
-	public function test_send_customer_receipt_email_not_sent_twice() {
-		$mock_order = WC_Helper_Order::create_order();
-		$mock_order->update_meta_data( '_new_receipt_email_sent', 'true' );
-
-		$mock_mailer = tests_retrieve_phpmailer_instance();
-
-		$this->receipts_service->send_customer_ipp_receipt_email( $mock_order, [] );
-
-		$sent_email = $mock_mailer->get_sent();
-
-		$this->assertFalse( $sent_email );
+		$this->receipts_service->send_customer_ipp_receipt_email( $mock_order, $this->mock_settings, $mock_charge );
 	}
 
 	public function provide_settings_validation_data() {

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -698,7 +698,18 @@ class WC_Payments_Webhook_Processing_Service_Test extends WP_UnitTestCase {
 		$this->mock_receipt_service
 			->expects( $this->once() )
 			->method( 'send_customer_ipp_receipt_email' )
-			->with( $mock_order, $this->event_body['data']['object']['charges']['data'][0] );
+			->with(
+				$mock_order,
+				[
+					'business_name' => '',
+					'support_info'  => [
+						'address' => [],
+						'phone'   => '',
+						'email'   => '',
+					],
+				],
+				$this->event_body['data']['object']['charges']['data'][0]
+			);
 
 		// Run the test.
 		$this->webhook_processing_service->process( $this->event_body );


### PR DESCRIPTION
Fixes #3558 

#### Changes proposed in this Pull Request
This PR adds a new custom email that will be delivered to a customer when they pay for an order with a card reader. 
Using the `woocommerce_email_classes` and `woocommerce_email_actions` hooks implemented in `WC_Emails` class we are able to leverage the email capabilities of the WooCommerce plugin.

This email will be triggered by the `payment_intent.suceeded` webhook that is forwarded from the WC Pay Server, whenever the payment intent is marked as sucessful.

The layout of the new email is based on the design of the emails that the customers currently receive when a new order is created.  You can find below screenshots of the html and plain text versions:

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
**HTML version**

<img width="600" alt="Screen Shot 2022-03-30 at 16 45 55" src="https://user-images.githubusercontent.com/1553182/160863088-1cd9994c-b6cf-4353-bc2c-53526f024bb6.png">



**Plain Text version**

```
=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
Your receipt for order: #59
=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

Hi John,

This is the receipt for your order #59:

==========

WooCommerce Payments Dev

==========

60 29th Street
#343
San Francisco California 94110 US
+16267792059 help@mgasca-dev.jurassic.tube
2022-03-23 14:55PM

----------------------------------------

[ORDER #59] (MARCH 21, 2022)

Beanie with Logo X 1 = $18.00


==========

Subtotal:	 $18.00
Shipping:	 Local pickup
Payment method:	 WooCommerce In-Person Payments
Total:	 $18.00

----------------------------------------

Payment Method:	Visa - 0119
Application Name:	
AID:	
Account Type:	Credit


----------------------------------------

Thanks for using mgasca-dev.jurassic.tube!

----------------------------------------

WooCommerce Payments Dev -- Built with WooCommerce
```

#### Managing email settings

The new email settings can be managed from the `WP Admin > WooCommerce > Settings > Emails`:

<img width="1300" alt="Screen Shot 2022-03-25 at 19 44 25" src="https://user-images.githubusercontent.com/1553182/160183327-1e18cf89-d724-474c-9f37-ea38d98415a1.png">

From the details view the merchant can manage settings like the email type, subject, heading, ...

<img width="1312" alt="Screen Shot 2022-03-25 at 19 51 34" src="https://user-images.githubusercontent.com/1553182/160183624-3b0cccf0-ced7-4bee-9737-bdc53971db5f.png">
 

#### Testing instructions
*Prerequisites*
Your local setup is not likely to be configured to send emails. There are plugins that let you see the sent emails, like [WP Mail Logging](https://wordpress.org/plugins/wp-mail-logging/)

- Connect your local WC Pay client and server.
- Create an order with Cash on Delivery as payment method. Please use the proxied url of your local site.
- Start listening for webhooks in your local WC Pay server. You'll need this to trigger the email.
- Use the WooCommerce Mobile App to pay the order. You can follow this great guide to set it up locally: pdjVC1-9M-p2
- After the mobile apps process the payment correctly, go to `WP Admin > Tools > WP Mail Log`
- Check that there is a new entry in the emails table. Clicking on it you can access a preview of the email

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [X] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_