### PR TITLE
Allow file upload to select same file after error

### DIFF
--- a/changelog/fix-460-file-upload-does-not-start-selecting-same-file
+++ b/changelog/fix-460-file-upload-does-not-start-selecting-same-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Empty file input to allow the user to select the same file again if there's an error.

--- a/client/components/file-upload/index.tsx
+++ b/client/components/file-upload/index.tsx
@@ -45,7 +45,11 @@ export const FileUploadControl = ( {
 		event: React.MouseEvent< HTMLButtonElement >,
 		openFileDialog: () => void
 	) => {
-		// Get file input next to the button element and clear it's value, allowing to select the same file again in case of connection or general error or need to select it again
+		// Get file input next to the button element and clear it's value,
+		// allowing to select the same file again in case of
+		// connection or general error or just need to select it again.
+		// This workaround is useful until we update @wordpress/components to a
+		// version the supports this: https://github.com/WordPress/gutenberg/issues/39267
 		const fileInput:
 			| HTMLInputElement
 			| null

--- a/client/components/file-upload/index.tsx
+++ b/client/components/file-upload/index.tsx
@@ -41,6 +41,25 @@ export const FileUploadControl = ( {
 		/>
 	);
 
+	const handleButtonClick = (
+		event: React.MouseEvent< HTMLButtonElement >,
+		openFileDialog: () => void
+	) => {
+		// Get file input next to the button element and clear it's value, allowing to select the same file again in case of connection or general error or need to select it again
+		const fileInput:
+			| HTMLInputElement
+			| null
+			| undefined = ( event.target as HTMLButtonElement )
+			.closest( '.components-form-file-upload' )
+			?.querySelector( 'input[type="file"]' );
+
+		if ( fileInput ) {
+			fileInput.value = '';
+		}
+
+		openFileDialog();
+	};
+
 	return (
 		<BaseControl
 			id={ `form-file-upload-base-control-${ field.key }` }
@@ -56,13 +75,6 @@ export const FileUploadControl = ( {
 			</DropZoneProvider>
 			<div className="file-upload">
 				<FormFileUpload
-					id={ `form-file-upload-${ field.key }` }
-					className={ isDone && ! hasError ? 'is-success' : '' }
-					isSecondary
-					isDestructive={ hasError }
-					isBusy={ isLoading }
-					disabled={ disabled || isLoading }
-					icon={ getIcon }
 					accept={ accept }
 					onChange={ (
 						event: React.ChangeEvent< HTMLInputElement >
@@ -72,9 +84,25 @@ export const FileUploadControl = ( {
 							( event.target.files || new FileList() )[ 0 ]
 						);
 					} }
-				>
-					{ __( 'Upload file', 'woocommerce-payments' ) }
-				</FormFileUpload>
+					render={ ( { openFileDialog } ) => (
+						<Button
+							id={ `form-file-upload-${ field.key }` }
+							className={
+								isDone && ! hasError ? 'is-success' : ''
+							}
+							isSecondary
+							isDestructive={ hasError }
+							isBusy={ isLoading }
+							disabled={ disabled || isLoading }
+							icon={ getIcon }
+							onClick={ (
+								event: React.MouseEvent< HTMLButtonElement >
+							) => handleButtonClick( event, openFileDialog ) }
+						>
+							{ __( 'Upload file', 'woocommerce-payments' ) }
+						</Button>
+					) }
+				></FormFileUpload>
 
 				{ hasError ? (
 					<FileUploadError error={ error } />

--- a/client/components/file-upload/test/index.tsx
+++ b/client/components/file-upload/test/index.tsx
@@ -12,6 +12,8 @@ import { render, fireEvent } from '@testing-library/react';
 import { FileUploadControl } from 'components/file-upload';
 import type { DisputeFileUpload } from 'wcpay/types/disputes';
 
+import userEvent from '@testing-library/user-event';
+
 describe( 'FileUploadControl', () => {
 	let props: DisputeFileUpload;
 	const field = {
@@ -84,6 +86,29 @@ describe( 'FileUploadControl', () => {
 		expect( props.onFileChange ).toHaveBeenCalledWith(
 			field.key,
 			fakeFile
+		);
+	} );
+
+	test( 'triggers onFileChange two times when selecting the same file again', async () => {
+		const { container: control } = render(
+			<FileUploadControl { ...props } />
+		);
+
+		const file = new File( [ 'hello' ], 'hello.png', {
+			type: 'image/png',
+		} );
+
+		// Note: FormFileUpload does not associate file input with label so workaround is required to select it.
+		const input = control.querySelector( 'input[type="file"]' );
+		if ( input !== null ) {
+			await userEvent.upload( input, file );
+			await userEvent.upload( input, file );
+		}
+
+		expect( props.onFileChange ).toHaveBeenNthCalledWith(
+			2,
+			field.key,
+			file
 		);
 	} );
 

--- a/client/components/file-upload/test/index.tsx
+++ b/client/components/file-upload/test/index.tsx
@@ -5,14 +5,13 @@
  */
 import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
  */
 import { FileUploadControl } from 'components/file-upload';
 import type { DisputeFileUpload } from 'wcpay/types/disputes';
-
-import userEvent from '@testing-library/user-event';
 
 describe( 'FileUploadControl', () => {
 	let props: DisputeFileUpload;


### PR DESCRIPTION
Fixes #460 

#### Changes proposed in this Pull Request

* Fixes an error that occur when a user upload a file and have some connection or general error, if select the same file again it does not emit the onChange event and the user get stuck until select a different file.

Needed to use a workaround to empty the file input because WordPress/gutenberg#39268 will be implemented on the next Gutenberg release and WCPay still uses the version 5.1.2 of it.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Buy something on a merchant store and [add a payment that generates a dispute](https://woocommerce.com/document/payments/testing/#section-15).
* Access the Transactions section on the left panel and open the latest transaction, if it does not work (this page is always empty to me), open the latest order and click on the "pi_hash" link.

![Screen Shot 2022-03-23 at 9 45 36 PM](https://user-images.githubusercontent.com/1693223/159819835-00949a86-eb8d-4ddc-9351-0e972489db58.png)

* On this page there is a "View dispute" link, click on it.

![Screen Shot 2022-03-23 at 9 47 39 PM](https://user-images.githubusercontent.com/1693223/159820011-7f267fd2-e513-4c3b-82f3-07ef9a34bec4.png)

* Click on "Challenge dispute".
* Change the "Product type".
* The file input button will be on this page.

![Screen Shot 2022-03-23 at 9 49 49 PM](https://user-images.githubusercontent.com/1693223/159820157-3b3b8175-b82c-4d66-94a4-db8b538a559e.png)

* Now we need to make an error occur, to do it, just select a file that is not a PDF/JPG/PNG file.
* Now select the same file again, it will show the loading animation, before this PR the user would get stuck because the onChange event was not called.
* You can also disable the internet on the browser DevTools and try to upload a file, enable the internet again and selected the same file, before this PR the "You are offline" message would be showing until the user select another file.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
