### PR TITLE
Add new onboarding flow experiment

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -63,7 +63,7 @@ addFilter(
 				__( 'Onboarding', 'woocommerce-payments' ),
 			],
 			navArgs: {
-				id: 'wc-payments',
+				id: 'wc-payments-onboarding',
 			},
 			capability: 'manage_woocommerce',
 		} );

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -166,18 +166,6 @@ class WC_Payments_Admin {
 				],
 			]
 		);
-		wc_admin_register_page(
-			[
-				'id'       => 'wc-payments-onboarding',
-				'title'    => __( 'Onboarding', 'woocommerce-payments' ),
-				'parent'   => 'wc-payments',
-				'path'     => '/payments/onboarding',
-				'nav_args' => [
-					'parent' => 'wc-payments',
-					'order'  => 10,
-				],
-			]
-		);
 		wp_enqueue_style(
 			'wcpay-admin-css',
 			plugins_url( 'assets/css/admin.css', WCPAY_PLUGIN_FILE ),
@@ -233,6 +221,23 @@ class WC_Payments_Admin {
 			// If the account is rejected, only show the overview page.
 			wc_admin_register_page( $this->admin_child_pages['wc-payments-overview'] );
 			return;
+		}
+
+		if ( WC_Payments_Utils::is_in_onboarding_treatment_mode() && ! $should_render_full_menu ) {
+				wc_admin_register_page(
+					[
+						'id'         => 'wc-payments-onboarding',
+						'title'      => __( 'Onboarding', 'woocommerce-payments' ),
+						'parent'     => 'wc-payments',
+						'path'       => '/payments/onboarding',
+						'capability' => 'manage_woocommerce',
+						'nav_args'   => [
+							'parent' => 'wc-payments',
+						],
+					]
+				);
+				global $submenu;
+				remove_submenu_page( 'wc-admin&path=/payments/connect', 'wc-admin&path=/payments/onboarding' );
 		}
 
 		if ( $should_render_full_menu ) {
@@ -353,19 +358,6 @@ class WC_Payments_Admin {
 					'title'  => __( 'Preview a printed receipt', 'woocommerce-payments' ),
 					'path'   => '/payments/card-readers/preview-receipt',
 
-				]
-			);
-
-			wc_admin_register_page(
-				[
-					'id'       => 'wc-payments-onboarding',
-					'title'    => __( 'Onboarding', 'woocommerce-payments' ),
-					'parent'   => 'wc-payments',
-					'path'     => '/payments/onboarding',
-					'nav_args' => [
-						'parent' => 'wc-payments',
-						'order'  => 10,
-					],
 				]
 			);
 		}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -444,6 +444,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return string URL of the configuration screen for this gateway
 	 */
 	public static function get_settings_url() {
+		if ( WC_Payments_Utils::is_in_onboarding_treatment_mode() ) {
+			return admin_url( 'admin.php?page=wc-admin&path=/payments/onboarding' );
+		}
 		return admin_url( add_query_arg( self::$settings_url_params, 'admin.php' ) );
 	}
 
@@ -2693,6 +2696,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return string Connection URL.
 	 */
 	public function get_connection_url() {
+		if ( WC_Payments_Utils::is_in_onboarding_treatment_mode() ) {
+			return;
+		}
 		return html_entity_decode( WC_Payments_Account::get_connect_url( 'WCADMIN_PAYMENT_TASK' ) );
 	}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2697,7 +2697,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	public function get_connection_url() {
 		if ( WC_Payments_Utils::is_in_onboarding_treatment_mode() ) {
-			return;
+			// Configure step button will show `Set up` instead of `Connect`.
+			return '';
 		}
 		return html_entity_decode( WC_Payments_Account::get_connect_url( 'WCADMIN_PAYMENT_TASK' ) );
 	}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -560,7 +560,9 @@ class WC_Payments_Account {
 		if ( isset( $_GET['wcpay-connect'] ) && check_admin_referer( 'wcpay-connect' ) ) {
 			$wcpay_connect_param = sanitize_text_field( wp_unslash( $_GET['wcpay-connect'] ) );
 
-			if ( 'WCADMIN_PAYMENT_TASK' === $wcpay_connect_param && WC_Payments_Utils::is_in_onboarding_treatment_mode() ) {
+			$from_wc_admin_task       = 'WCADMIN_PAYMENT_TASK' === $wcpay_connect_param;
+			$from_wc_pay_connect_page = false !== strpos( wp_get_referer(), 'path=%2Fpayments%2Fconnect' );
+			if ( ( $from_wc_admin_task || $from_wc_pay_connect_page ) && WC_Payments_Utils::is_in_onboarding_treatment_mode() ) {
 				$this->redirect_to( admin_url( 'admin.php?page=wc-admin&path=/payments/onboarding' ) );
 			}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -560,6 +560,10 @@ class WC_Payments_Account {
 		if ( isset( $_GET['wcpay-connect'] ) && check_admin_referer( 'wcpay-connect' ) ) {
 			$wcpay_connect_param = sanitize_text_field( wp_unslash( $_GET['wcpay-connect'] ) );
 
+			if ( 'WCADMIN_PAYMENT_TASK' === $wcpay_connect_param && WC_Payments_Utils::is_in_onboarding_treatment_mode() ) {
+				$this->redirect_to( admin_url( 'admin.php?page=wc-admin&path=/payments/onboarding' ) );
+			}
+
 			// Hide menu notification badge upon starting setup.
 			update_option( 'wcpay_menu_badge_hidden', 'yes' );
 

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -619,4 +619,23 @@ class WC_Payments_Utils {
 			admin_url( 'admin.php' )
 		);
 	}
+
+	/**
+	 * Check to see if the current user is in onboarding experiment treatment mode.
+	 *
+	 * @return bool
+	 */
+	public static function is_in_onboarding_treatment_mode() {
+		if ( ! isset( $_COOKIE['tk_ai'] ) ) {
+			return false;
+		}
+
+		$abtest = new \WCPay\Experimental_Abtest(
+			sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ),
+			'woocommerce',
+			'yes' === get_option( 'woocommerce_allow_tracking' )
+		);
+
+		return 'treatment' === $abtest->get_variation( 'woo_wcpayments_tasklist_click_introducing_select_business_type_202203_v1' );
+	}
 }


### PR DESCRIPTION
Fixes #3793, Fixes #4036

#### Changes proposed in this Pull Request
All of these new changes only affect users under treatment mode in the `woo_wcpayments_tasklist_click_introducing_select_business_type_202203_v1` experiment.

- Add static method `is_in_onboarding_treatment_mode` to `WC_Payments_Utils` to check whether the user is in treatment mode.
- Show `Set up` instead of `connect` in the installation process and redirect to the onboarding flow rather than Stripe KYC.
- Redirect `Get paid with WooCommerce Payments` task and payments connect page to the onboarding flow rather than Stripe KYC.
- Hide onboarding page from menu and allow access to it only before onboard and under treatment mode.

#### Testing instructions
ℹ️  To test this experiment you'll need a site without a connected account. And disable `Enable API request redirection` in WC Pay Dev to be able to connect to Explat platform.

**Set up payments Task**
_You can force it to show by editing `is_complete()` and `can_view()` in `/wp-content/plugins/woocommerce/packages/woocommerce-admin/src/Features/OnboardingTasks/Tasks/Payments.php`_
- Disable **WooCommerce Payments** plugin.
- Go to **WP Admin > WooCommerce > Home**.
- Click on **Set up payments** task.
- Click on **Finish setup** in WooCommerce Payments.
- **Control**:
  - Should display a wizard with **Connect** button.
  - Click on  it should redirect to Stripe KYC flow.
- **Treatment**:
  - Should display a wizard with... **Set up** button.
  - Click on it should redirect to the onboarding page.

**Get paid with WooCommerce Payments Task**
_You can force it to show by editing `is_complete()` and `can_view()` in `/wp-content/plugins/woocommerce/packages/woocommerce-admin/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php`_
- Go to **WP Admin > WooCommerce > Home**.
- Click on **Get paid with WooCommerce Payments**
- Should redirect to:
  - **Control** – Stripe KYC flow.
  - **Treatment** –  Onboarding page.

**Payments Menu**
- Go to **WP Admin > Payments**.
- Click on **Finish setup** in WooCommerce Payments.
- Should redirect to:
  - **Control** – Stripe KYC flow.
  - **Treatment** –  Onboarding page.

**Onboarding Page**
- Going through the previous tests in treatment mode should allow you to access the onboarding page. And also going directly to `/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fonboarding`.
- Should not be able to access it in control mode and after onboarding an account.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] QA Testing Not Applicable
