### PR TITLE
Update order note format to fix E2E tests

### DIFF
--- a/changelog/fix-e2e-wcpay-merchant-full-refund-test
+++ b/changelog/fix-e2e-wcpay-merchant-full-refund-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Updates refund order note with reason format to fix failing E2E tests.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1500,14 +1500,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$note = sprintf(
 				WC_Payments_Utils::esc_interpolated_html(
 					/* translators: %1: the successfully charged amount, %2: refund id, %3: reason */
-					__( 'A refund of %1$s was successfully processed using WooCommerce Payments (<code>%2$s</code>). Reason: %3$s', 'woocommerce-payments' ),
+					__( 'A refund of %1$s was successfully processed using WooCommerce Payments. Reason: %2$s. (<code>%3$s</code>)', 'woocommerce-payments' ),
 					[
 						'code' => '<code>',
 					]
 				),
 				WC_Payments_Explicit_Price_Formatter::get_explicit_price( wc_price( $amount, [ 'currency' => $currency ] ), $order ),
-				$refund['id'],
-				$reason
+				$reason,
+				$refund['id']
 			);
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With the merge of #3965, E2E tests related to refunding orders started failing - https://github.com/Automattic/woocommerce-payments/actions/runs/2057115854

This was caused by a change in the order note format. For order notes with reason, the updated format includes the `refund_id` between the note and the reason causing the tests to fail. This PR updates the order note format to include `refund_id` after the reason so the tests doesn't fail.

Sample order note format introduced in #3965:

```
A refund of $18.00 USD was successfully processed using WooCommerce Payments (re_3KibMc2EmsPMSjPc11jybK6P). Reason: No longer wanted
```

Updated order note format in this PR:

```
A refund of $18.00 USD was successfully processed using WooCommerce Payments. Reason: No longer wanted. (re_3KibcH2EmsPMSjPc0EmYmqCg)
```

#### Testing instructions

* Switch to the branch `fix/e2e-wcpay-merchant-full-refund-test`.
* Create a new order from front-end
* Fully refund the order from WP-ADMIN and confirm that the order note added includes the WCPay refund id - re_xxxxxxxxxxxxxxxxxxxxxxxx in the order note format mentioned above.
* Try running the E2E tests against this branch from Actions -> WCPay E2E Tests -> Run workflow and confirm that the tests are passing. Created a job for reference - https://github.com/Automattic/woocommerce-payments/actions/runs/2057835975

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
