### PR TITLE
Fix - Using additional payment methods "Pay for order" form triggers WCPay validation errors

### DIFF
--- a/changelog/fix-pay-for-order-upe-checkout
+++ b/changelog/fix-pay-for-order-upe-checkout
@@ -1,0 +1,5 @@
+Significance: minor
+Type: fix
+
+Fix - Using any other payment methods apart from WooCommerce Payments in "Pay for order" 
+form triggers validation errors when UPE checkout is enabled.

--- a/client/checkout/classic/index.js
+++ b/client/checkout/classic/index.js
@@ -15,6 +15,7 @@ import { getConfig } from 'utils/checkout';
 import { handlePlatformCheckoutEmailInput } from '../platform-checkout/email-input-iframe';
 import WCPayAPI from './../api';
 import enqueueFraudScripts from 'fraud-scripts';
+import { isWCPayChosen } from '../utils/upe';
 
 jQuery( function ( $ ) {
 	enqueueFraudScripts( getConfig( 'fraudServices' ) );
@@ -137,15 +138,6 @@ jQuery( function ( $ ) {
 
 		$.scroll_to_notices( scrollElement );
 		$( document.body ).trigger( 'checkout_error' );
-	};
-
-	/**
-	 * Check if Card payment is being used.
-	 *
-	 * @return {boolean} Boolean indicating whether or not Card payment is being used.
-	 */
-	const isWCPayChosen = function () {
-		return $( '#payment_method_woocommerce_payments' ).is( ':checked' );
 	};
 
 	/**

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -12,7 +12,7 @@ import { getConfig, getCustomGatewayTitle } from 'utils/checkout';
 import WCPayAPI from '../api';
 import enqueueFraudScripts from 'fraud-scripts';
 import { getFontRulesFromPage, getAppearance } from '../upe-styles';
-import { getTerms, getCookieValue } from '../utils/upe';
+import { getTerms, getCookieValue, isWCPayChosen } from '../utils/upe';
 
 jQuery( function ( $ ) {
 	enqueueFraudScripts( getConfig( 'fraudServices' ) );
@@ -732,7 +732,7 @@ jQuery( function ( $ ) {
 
 	// Handle the Pay for Order form if WooCommerce Payments is chosen.
 	$( '#order_review' ).on( 'submit', () => {
-		if ( ! isUsingSavedPaymentMethod() ) {
+		if ( ! isUsingSavedPaymentMethod() && isWCPayChosen() ) {
 			if ( isChangingPayment ) {
 				handleUPEAddPayment( $( '#order_review' ) );
 				return false;

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -26,3 +26,13 @@ export const getTerms = ( paymentMethodsConfig, value = 'always' ) => {
 export const getCookieValue = ( name ) =>
 	document.cookie.match( '(^|;)\\s*' + name + '\\s*=\\s*([^;]+)' )?.pop() ||
 	'';
+
+/**
+ * Check if Card payment is being used.
+ *
+ * @return {boolean} Boolean indicating whether or not Card payment is being used.
+ */
+export const isWCPayChosen = function () {
+	return document.getElementById( 'payment_method_woocommerce_payments' )
+		.checked;
+};


### PR DESCRIPTION
Fixes #3618 

#### Changes proposed in this Pull Request

Using any other payment methods apart from WCPay in "Pay for order" form triggers validation errors when UPE checkout is enabled in WCPay. 

This PR adds a new check for payments via "Pay for order" page to confirm whether WCPay is selected as payment method. With this change, other payment methods can be used without triggering WCPay validation errors.

#### Testing instructions

* Under WooCommerce Settings -> Payments, enable an additional payment gateway, e.g Cash on Delivery
* Create a new manual order from WP-ADMIN & use the `Customer payment page` link to make payment.
* On the "Pay for order" page, pay using Cash on Delivery or the additional payment method you've enabled. Confirm that WooCommerce notice shows up indicating validation failures.
* Checkout the branch `fix/pay-for-order-upe-checkout` and follow the steps above. Confirm that using additional payment methods doesn't trigger WCPay related errors.
* Also try making payment via WCPay (new & saved cards) to confirm that everything works as expected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
