### PR TITLE
Fix single currency settings page error.

### DIFF
--- a/changelog/fix-4042-single-currency-page-error-in-trunk
+++ b/changelog/fix-4042-single-currency-page-error-in-trunk
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix single currency settings page error.

--- a/client/multi-currency/single-currency-settings/index.js
+++ b/client/multi-currency/single-currency-settings/index.js
@@ -54,14 +54,6 @@ const SingleCurrencySettings = () => {
 		? currencies.available[ currency ]
 		: {};
 
-	// Polyfill for window.wcpaySettings.zeroDecimalCurrencies.
-	// It's needed for wcpay/currency/utils library to format currencies correctly.
-	window.wcpaySettings = window.wcpaySettings || {
-		zeroDecimalCurrencies: Object.values( currencies.available )
-			.filter( ( currencyInfo ) => currencyInfo.is_zero_decimal )
-			.map( ( currencyInfo ) => currencyInfo.code ),
-	};
-
 	const targetCurrencyRoundingOptions = targetCurrency.is_zero_decimal
 		? zeroDecimalCurrencyRoundingOptions
 		: decimalCurrencyRoundingOptions;

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -324,6 +324,8 @@ class MultiCurrency {
 		// Output the settings JS and CSS only on the settings page.
 		if ( 'wcpay_multi_currency' === $current_tab ) {
 			$this->register_admin_scripts();
+			wp_enqueue_script( 'WCPAY_ADMIN_SETTINGS' );
+			wp_enqueue_style( 'WCPAY_ADMIN_SETTINGS' );
 			wp_enqueue_script( 'WCPAY_MULTI_CURRENCY_SETTINGS' );
 			wp_enqueue_style( 'WCPAY_MULTI_CURRENCY_SETTINGS' );
 		}


### PR DESCRIPTION
Fixes #4042 

#### Changes proposed in this Pull Request

* Load the `WCPAY_ADMIN_SETTINGS` assets on the Multi-Currency settings page(s).
* Remove polyfill for zero decimal currencies, since it will no longer be needed.

#### Testing instructions

1. Navigate to WooCommerce > Settings > Multi-Currency.
2. If you do not have any additional currencies, click _Add currencies_ and add a currency.
3. Click _manage_ to update a single currency's settings.
4. Page no longer errors out.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
