### PR TITLE
Fix preview print receipt functionality

### DIFF
--- a/changelog/fix-4056-preview-print-receipt-functionality
+++ b/changelog/fix-4056-preview-print-receipt-functionality
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Card Readers: Preview receipt functionality

--- a/client/card-readers/preview-receipt/receipt.tsx
+++ b/client/card-readers/preview-receipt/receipt.tsx
@@ -20,9 +20,13 @@ import {
 } from '../../data';
 import { FetchReceiptPayload } from 'wcpay/types/card-readers';
 
+interface PreviewReceiptHtmlContent {
+	html_content: string;
+}
+
 async function fetchReceiptHtml(
 	payload: FetchReceiptPayload
-): Promise< string > {
+): Promise< PreviewReceiptHtmlContent > {
 	const path = '/wc/v3/payments/readers/receipts/preview';
 	return apiFetch( { path, data: payload, method: 'post' } );
 }
@@ -56,7 +60,7 @@ const PreviewReceipt = (): JSX.Element => {
 
 				if ( ! didCancel && data ) {
 					setIsLoading( false );
-					setReceiptHtml( data );
+					setReceiptHtml( data.html_content );
 				}
 			} catch ( error ) {
 				setIsLoading( false );


### PR DESCRIPTION
Fixes #4056 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to Payments -> Card Readers page -> Receipt details.
* Click the "Preview a printed receipt" link.
* Check that the preview is generated correctly, like in the screenshot below

<img width="1255" alt="Screen Shot 2022-03-30 at 15 30 44" src="https://user-images.githubusercontent.com/1553182/160846376-fdb9a524-02c8-4f15-974d-da0bb93f2ba4.png">


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) :  QA Testing Not Applicable
