### PR TITLE
fix: payment method list icon

### DIFF
--- a/changelog/frosso-patch-1
+++ b/changelog/frosso-patch-1
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: The icon was missing due to a refactor done in https://github.com/Automattic/woocommerce-payments/pull/4035 - seems minor
+
+

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -243,7 +243,7 @@ const PaymentMethods = () => {
 				<CardBody size={ null }>
 					<PaymentMethodsList className="payment-methods__available-methods">
 						{ availableMethods.map(
-							( { id, label, description, Icon } ) => (
+							( { id, label, description, icon: Icon } ) => (
 								<PaymentMethod
 									id={ id }
 									key={ id }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/4050

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

It looks like the icon is broken. Fixing.

Before:
![Screen Shot 2022-03-31 at 10 11 10 AM](https://user-images.githubusercontent.com/273592/161089305-6aacb9ea-9c61-451c-8636-d8da9c4078f8.png)

After:
![Screen Shot 2022-03-31 at 10 11 00 AM](https://user-images.githubusercontent.com/273592/161089328-956f0064-552e-454d-898e-56bad0c58a59.png)

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments
- Icon for payment method is no longer missing

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
