### PR TITLE
Remove _wcpay_feature_card_readers flag

### DIFF
--- a/changelog/add-3512-remove-the-feature-flag-_wcpay_feature_card_readers
+++ b/changelog/add-3512-remove-the-feature-flag-_wcpay_feature_card_readers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Card Readers: remove feature flag

--- a/changelog/add-3512-remove-the-feature-flag-_wcpay_feature_card_readers
+++ b/changelog/add-3512-remove-the-feature-flag-_wcpay_feature_card_readers
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Card Readers: remove feature flag
+Enable card readers section of WCPay admin area

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -22,13 +22,6 @@ class WC_Payments_Admin {
 	const MENU_NOTIFICATION_BADGE = ' <span class="wcpay-menu-badge awaiting-mod count-1"><span class="plugin-count">1</span></span>';
 
 	/**
-	 * Option name used to hide Card Readers page behind a feature flag.
-	 *
-	 * @var string
-	 */
-	const CARD_READERS_FLAG_NAME = '_wcpay_feature_card_readers';
-
-	/**
 	 * Client for making requests to the WooCommerce Payments API.
 	 *
 	 * @var WC_Payments_API_Client
@@ -136,15 +129,6 @@ class WC_Payments_Admin {
 	}
 
 	/**
-	 * Checks whether the Card Readers page is enabled.
-	 *
-	 * @return bool
-	 */
-	public static function is_card_readers_page_enabled() {
-		return '1' === get_option( self::CARD_READERS_FLAG_NAME, '0' );
-	}
-
-	/**
 	 * Add deposits and transactions menus for wcpay_empty_state_preview_mode_v1 experiment's treatment group.
 	 * This code can be removed once we're done with the experiment.
 	 */
@@ -237,7 +221,7 @@ class WC_Payments_Admin {
 		}
 
 		if ( $should_render_full_menu ) {
-			if ( self::is_card_readers_page_enabled() && $this->account->is_card_present_eligible() ) {
+			if ( $this->account->is_card_present_eligible() ) {
 				$this->admin_child_pages['wc-payments-card-readers'] = [
 					'id'       => 'wc-payments-card-readers',
 					'title'    => __( 'Card Readers', 'woocommerce-payments' ),


### PR DESCRIPTION
Fixes #3512

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
Remove the feature flag _wcpay_feature_card_readers
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to WP Admin. Check that 'Card Readers' option shows under Payments menu.
* Navigate to Payments -> Card Readers page
* Check that the page loads with no issues

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : 'QA Testing Not Applicable'
