### PR TITLE
Add a namespace to Session_Rate_Limiter

### DIFF
--- a/changelog/fix-rate-limiter-namespace
+++ b/changelog/fix-rate-limiter-namespace
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Minor code cleanup
+
+

--- a/includes/class-session-rate-limiter.php
+++ b/includes/class-session-rate-limiter.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Payments
  */
 
+namespace WCPay;
+
 defined( 'ABSPATH' ) || exit; // block direct access.
 
 /**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -19,6 +19,7 @@ use WCPay\Constants\Payment_Capture_Type;
 use WCPay\Tracker;
 use WCPay\Payment_Methods\UPE_Payment_Gateway;
 use WCPay\Platform_Checkout\Platform_Checkout_Utilities;
+use WCPay\Session_Rate_Limiter;
 
 /**
  * Gateway class for WooCommerce Payments

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -24,6 +24,7 @@ use WCPay\Payment_Methods\Ideal_Payment_Method;
 use WCPay\Payment_Methods\Eps_Payment_Method;
 use WCPay\Platform_Checkout_Tracker;
 use WCPay\Platform_Checkout\Platform_Checkout_Utilities;
+use WCPay\Session_Rate_Limiter;
 
 /**
  * Main class for the WooCommerce Payments extension. Its responsibility is to initialize the extension.

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -15,6 +15,7 @@ use WCPay\Exceptions\Add_Payment_Method_Exception;
 use WCPay\Logger;
 use WCPay\Payment_Information;
 use WCPay\Constants\Payment_Type;
+use WCPay\Session_Rate_Limiter;
 use WC_Payment_Gateway_WCPay;
 use WC_Payments_Account;
 use WC_Payments_Action_Scheduler_Service;
@@ -25,7 +26,6 @@ use WC_Payments_Token_Service;
 use WC_Payment_Token_CC;
 use WC_Payments;
 use WC_Payments_Utils;
-use Session_Rate_Limiter;
 
 use Exception;
 use WCPay\Exceptions\Amount_Too_Small_Exception;

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -17,6 +17,7 @@ use WCPay\Payment_Methods\Sofort_Payment_Method;
 use WCPay\Payment_Methods\P24_Payment_Method;
 use WCPay\Payment_Methods\Ideal_Payment_Method;
 use WCPay\Payment_Methods\Sepa_Payment_Method;
+use WCPay\Session_Rate_Limiter;
 
 /**
  * WC_REST_Payments_Settings_Controller_Test unit tests.

--- a/tests/unit/admin/test-class-wc-rest-payments-tos-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-tos-controller.php
@@ -6,6 +6,7 @@
  */
 
 use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Session_Rate_Limiter;
 
 /**
  * WC_REST_Payments_Tos_Controller unit tests.

--- a/tests/unit/admin/test-class-wc-rest-upe-flag-toggle-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-upe-flag-toggle-controller.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Payments\Tests
  */
 
+use WCPay\Session_Rate_Limiter;
+
 /**
  * WC_REST_UPE_Flag_Toggle_Controller unit tests.
  */

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -15,6 +15,7 @@ use WCPay\Exceptions\Connection_Exception;
 use WCPay\Exceptions\Process_Payment_Exception;
 use WCPay\Logger;
 use WCPay\MultiCurrency\Currency;
+use WCPay\Session_Rate_Limiter;
 
 use WC_Payment_Gateway_WCPay;
 use WC_Payments_Account;
@@ -34,7 +35,6 @@ use WC_Subscriptions_Cart;
 use WP_UnitTestCase;
 use WP_User;
 use Exception;
-use Session_Rate_Limiter;
 
 /**
  * Overriding global function within namespace for testing

--- a/tests/unit/test-class-session-rate-limiter.php
+++ b/tests/unit/test-class-session-rate-limiter.php
@@ -7,6 +7,7 @@
 
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Exceptions\API_Exception;
+use WCPay\Session_Rate_Limiter;
 
 /**
  * WC_Payments_Fraud_Service unit tests.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Payments\Tests
  */
 
+use WCPay\Session_Rate_Limiter;
+
 /**
  * WC_Payment_Gateway_WCPay unit tests.
  */

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -7,6 +7,7 @@
 
 use WCPay\Exceptions\API_Exception;
 use WCPay\Exceptions\Connection_Exception;
+use WCPay\Session_Rate_Limiter;
 
 // Need to use WC_Mock_Data_Store.
 require_once dirname( __FILE__ ) . '/helpers/class-wc-mock-wc-data-store.php';

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-payment-method-order-note.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-payment-method-order-note.php
@@ -6,6 +6,7 @@
  */
 
 use WCPay\Exceptions\API_Exception;
+use WCPay\Session_Rate_Limiter;
 
 /**
  * WC_Payment_Gateway_WCPay unit tests.
@@ -97,7 +98,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Payment_Method_Order_Note_Test exte
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->mock_session_rate_limiter = $this->getMockBuilder( 'Session_Rate_Limiter' )
+		$this->mock_session_rate_limiter = $this->getMockBuilder( Session_Rate_Limiter::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Payments\Tests
  */
 
+use WCPay\Session_Rate_Limiter;
+
 /**
  * WC_Payment_Gateway_WCPay unit tests.
  */

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -6,6 +6,7 @@
  */
 
 use WCPay\Exceptions\API_Exception;
+use WCPay\Session_Rate_Limiter;
 
 /**
  * WC_Payment_Gateway_WCPay unit tests.
@@ -97,7 +98,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->mock_session_rate_limiter = $this->getMockBuilder( 'Session_Rate_Limiter' )
+		$this->mock_session_rate_limiter = $this->getMockBuilder( Session_Rate_Limiter::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -12,6 +12,7 @@ use WCPay\Constants\Payment_Type;
 use WCPay\Exceptions\Process_Payment_Exception;
 use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
 use WCPay\Payment_Information;
+use WCPay\Session_Rate_Limiter;
 
 // Need to use WC_Mock_Data_Store.
 require_once dirname( __FILE__ ) . '/helpers/class-wc-mock-wc-data-store.php';

--- a/tests/unit/test-class-wc-payments-payment-request-button-handler.php
+++ b/tests/unit/test-class-wc-payments-payment-request-button-handler.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Payments\Tests
  */
 
+use WCPay\Session_Rate_Limiter;
+
 /**
  * WC_Payments_Payment_Request_Button_Handler_Test class.
  */


### PR DESCRIPTION
Noticed that `Session_Rate_Limiter` has no namespace and isn't prefixed with `WC_Payments_`. If any other plugin on a site declares a class with a similar name, it could lead to some nasty errors.

#### Changes proposed in this Pull Request

Add a `WCPay` namespace to the class, update the files that use it.

#### Testing instructions

* Process a payment - it should succeed
* Unit tests should pass
* Verify that all files that use `Session_Rate_Limiter` now import it at the top of the file as `WCPay\Session_Rate_Limiter`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
