### PR TITLE
Remove isBrandingEnabled feature flag

### DIFF
--- a/changelog/fix-remove-card-reader-settings-branding-feature-flag
+++ b/changelog/fix-remove-card-reader-settings-branding-feature-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Enable card readers branding section

--- a/client/card-readers/settings/index.tsx
+++ b/client/card-readers/settings/index.tsx
@@ -21,8 +21,6 @@ import AddressDetailsSection from './sections/address-details';
 import BrandingDetailsSection from './sections/branding-details';
 import { getAdminUrl } from 'wcpay/utils';
 
-const isBrandingEnabled = false;
-
 const ReadersSettingsDescription = (): JSX.Element => (
 	<>
 		<h2>{ __( 'Card reader receipts', 'woocommerce-payments' ) }</h2>
@@ -58,7 +56,7 @@ const ReceiptSettings = (): JSX.Element => {
 							/>
 							<ContactsDetailsSection />
 							<AddressDetailsSection />
-							{ isBrandingEnabled && <BrandingDetailsSection /> }
+							<BrandingDetailsSection />
 						</CardBody>
 					</Card>
 				</LoadableSettingsSection>


### PR DESCRIPTION
Fixes #3512

#### Changes proposed in this Pull Request
Remove the `isBrandingEnabled` feature flag

#### Testing instructions

* Navigate to `Payments` -> `Card Readers` page.
* Navigate to `Receipt details`.
* Verify the Logo, icon and color settings are displayed.

<img width="556" alt="Screenshot 2022-04-01 at 15 38 44" src="https://user-images.githubusercontent.com/8667118/161265233-82fedcfd-a718-4215-a766-11e3cae18375.png">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)