### PR TITLE
Track document downloaded events

### DIFF
--- a/changelog/add-1791-documents-usage-tracking
+++ b/changelog/add-1791-documents-usage-tracking
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: These changes are behind the documents feature flag and will be reported when the main feature is launched
+
+

--- a/includes/admin/class-wc-rest-payments-documents-controller.php
+++ b/includes/admin/class-wc-rest-payments-documents-controller.php
@@ -100,6 +100,18 @@ class WC_REST_Payments_Documents_Controller extends WC_Payments_REST_Controller 
 			wp_die( esc_html( $message ), '', (int) $e->get_http_code() );
 		}
 
+		// WooCommerce core only includes Tracks in admin, not the REST API, so we need to use this wc_admin method
+		// that includes WC_Tracks in case it's not loaded.
+		if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
+			wc_admin_record_tracks_event(
+				'wcpay_document_downloaded',
+				[
+					'document_id' => $document_id,
+					'mode'        => WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'live',
+				]
+			);
+		}
+
 		// Set the headers to match what was returned from the server.
 		if ( ! headers_sent() ) {
 			nocache_headers();


### PR DESCRIPTION
Fixes 1791-gh-Automattic/woocommerce-payments-server

#### Changes proposed in this Pull Request

This PR uses `wc_admin_record_tracks_event` to register document downloaded events, along with the ID for the requested document and gateway mode.

The change added doesn't use the existing `Tracker` or `WC_Tracks` classes because WooCommerce core only includes Tracks in admin, not the REST API, so it'd be better to use the `wc_admin_record_tracks_event` method that includes `WC_Tracks` in case it's not loaded.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a test document to your account if it doesn't have one yet
* Navigate to the Documents section and click on the "Download" link for a document
* Open the Tracks Live View, filter for `wcadmin_wcpay_document_downloaded`, and make sure an event was registered with the document id and gateway mode
    * _It might take a while for the event to show up in the live view_

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _QA Testing Not Applicable_