### PR TITLE
KYC connect onboarding prefill

### DIFF
--- a/client/onboarding/index.js
+++ b/client/onboarding/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { Card, CardBody } from '@wordpress/components';
 
 /**
@@ -17,6 +17,8 @@ import SetupCompleteTask from './tasks/setup-complete-task';
 import './index.scss';
 
 const OnboardingPage = () => {
+	const [ selectedData, setSelectedData ] = useState();
+
 	return (
 		<Card
 			size="large"
@@ -26,10 +28,10 @@ const OnboardingPage = () => {
 				<Wizard defaultActiveTask="complete-business-info">
 					<WizardTaskList>
 						<WizardTask id="complete-business-info">
-							<AddBusinessInfoTask />
+							<AddBusinessInfoTask onChange={ setSelectedData } />
 						</WizardTask>
 						<WizardTask id="setup-complete">
-							<SetupCompleteTask />
+							<SetupCompleteTask args={ selectedData } />
 						</WizardTask>
 					</WizardTaskList>
 				</Wizard>

--- a/client/onboarding/tasks/add-business-info-task/index.js
+++ b/client/onboarding/tasks/add-business-info-task/index.js
@@ -17,7 +17,7 @@ import { useBusinessTypes } from 'data/onboarding';
 import RequiredVerificationInfo from './required-verification-info';
 import strings from '../../strings';
 
-const AddBusinessInfoTask = () => {
+const AddBusinessInfoTask = ( { onChange } ) => {
 	const { isCompleted, setCompleted } = useContext( WizardTaskContext );
 	const { businessTypes, isLoading } = useBusinessTypes();
 
@@ -33,6 +33,14 @@ const AddBusinessInfoTask = () => {
 			)
 		);
 	}, [ businessTypes ] );
+
+	useEffect( () => {
+		onChange( {
+			country: businessCountry?.key,
+			type: businessType?.key,
+			structure: businessStructure?.key,
+		} );
+	}, [ businessCountry, businessType, businessStructure, onChange ] );
 
 	const handleBusinessCountryUpdate = ( country ) => {
 		setBusinessCountry( country );

--- a/client/onboarding/tasks/add-business-info-task/test/index.js
+++ b/client/onboarding/tasks/add-business-info-task/test/index.js
@@ -66,6 +66,9 @@ const businessTypes = [
 	},
 ];
 
+const renderTask = () =>
+	render( <AddBusinessInfoTask onChange={ () => {} } /> );
+
 describe( 'AddBusinessInfoTask', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -82,7 +85,7 @@ describe( 'AddBusinessInfoTask', () => {
 			isLoading: true,
 		} );
 
-		const { container: task } = render( <AddBusinessInfoTask /> );
+		const { container: task } = renderTask();
 		expect( task ).toMatchSnapshot();
 	} );
 
@@ -92,7 +95,7 @@ describe( 'AddBusinessInfoTask', () => {
 			isLoading: false,
 		} );
 
-		const { container: task } = render( <AddBusinessInfoTask /> );
+		const { container: task } = renderTask();
 		expect( task ).toMatchSnapshot();
 	} );
 
@@ -107,7 +110,7 @@ describe( 'AddBusinessInfoTask', () => {
 			isLoading: false,
 		} );
 
-		const { container: task } = render( <AddBusinessInfoTask /> );
+		const { container: task } = renderTask();
 
 		user.click( screen.getByRole( 'button', { name: /country/i } ) );
 		user.click(
@@ -146,7 +149,7 @@ describe( 'AddBusinessInfoTask', () => {
 			isLoading: false,
 		} );
 
-		const { container: task } = render( <AddBusinessInfoTask /> );
+		const { container: task } = renderTask();
 
 		user.click( screen.getByRole( 'button', { name: /country/i } ) );
 		user.click(

--- a/client/onboarding/tasks/setup-complete-task/index.js
+++ b/client/onboarding/tasks/setup-complete-task/index.js
@@ -6,13 +6,16 @@
 import React, { useContext } from 'react';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 
 import WizardTaskItem from 'additional-methods-setup/wizard/task-item';
 import WizardTaskContext from 'additional-methods-setup/wizard/task/context';
 
-const SetupCompleteTask = () => {
+const SetupCompleteTask = ( { args } ) => {
 	const { connectUrl } = wcpaySettings;
 	const { setCompleted } = useContext( WizardTaskContext );
+
+	const url = addQueryArgs( connectUrl, { prefill: args } );
 
 	return (
 		<WizardTaskItem
@@ -25,7 +28,7 @@ const SetupCompleteTask = () => {
 			<div className="wcpay-onboarding-setup-complete-task__buttons">
 				{ /* Todo: pass the selected form parameters to the onboarding. */ }
 				<Button
-					href={ connectUrl }
+					href={ url }
 					isPrimary
 					onClick={ () => setCompleted( true, 'setup-complete' ) }
 				>

--- a/client/onboarding/tasks/setup-complete-task/test/__snapshots__/index.js.snap
+++ b/client/onboarding/tasks/setup-complete-task/test/__snapshots__/index.js.snap
@@ -49,7 +49,7 @@ exports[`SetupCompleteTask renders page 1`] = `
       >
         <a
           class="components-button is-primary"
-          href="/connect"
+          href="/connect?prefill%5Bcountry%5D=US&prefill%5Btype%5D=individual"
         >
           Connect
         </a>

--- a/client/onboarding/tasks/setup-complete-task/test/index.js
+++ b/client/onboarding/tasks/setup-complete-task/test/index.js
@@ -17,7 +17,9 @@ describe( 'SetupCompleteTask', () => {
 			connectUrl: '/connect',
 		};
 
-		const { container: task } = render( <SetupCompleteTask /> );
+		const { container: task } = render(
+			<SetupCompleteTask args={ { country: 'US', type: 'individual' } } />
+		);
 		expect( task ).toMatchSnapshot();
 	} );
 } );

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -805,19 +805,32 @@ class WC_Payments_Account {
 		$current_user = wp_get_current_user();
 		$return_url   = $this->get_onboarding_return_url( $wcpay_connect_from );
 
-		$country = WC()->countries->get_base_country();
+		// Pre-fill from new KYC flow experiment in treatment mode.
+		$prefill         = isset( $_GET['prefill'] ) ? wc_clean( wp_unslash( $_GET['prefill'] ) ) : [];
+		$prefill_country = $prefill['country'] ?? null;
+		$prefill_rest    = [
+			'business_type' => $prefill['type'] ?? null,
+			'company'       => [
+				'structure' => $prefill['structure'] ?? null,
+			],
+		];
+
+		$country = $prefill_country ?? WC()->countries->get_base_country();
 		if ( ! array_key_exists( $country, WC_Payments_Utils::supported_countries() ) ) {
 			$country = null;
 		}
 
 		$onboarding_data = $this->payments_api_client->get_onboarding_data(
 			$return_url,
-			[
-				'email'         => $current_user->user_email,
-				'business_name' => get_bloginfo( 'name' ),
-				'url'           => get_home_url(),
-				'country'       => $country,
-			],
+			array_merge(
+				[
+					'email'         => $current_user->user_email,
+					'business_name' => get_bloginfo( 'name' ),
+					'url'           => get_home_url(),
+					'country'       => $country,
+				],
+				array_filter( $prefill_rest )
+			),
 			[
 				'site_username' => $current_user->user_login,
 			],


### PR DESCRIPTION
#### Changes proposed in this Pull Request
- Add selected form data to connect URL as query arguments under `prefill` array.
- Read those arguments and merge them with our current ones on `get_onboarding_data` call. Taking care of sanitization, preventing any other key to be used and without interfering with our current implementation.

#### Testing instructions

Test it together with 1785-gh-Automattic/woocommerce-payments-server but using this client branch rather than manually editing client code.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- QA Testing Not Applicable