### PR TITLE
Fix onboarding form country getting reseted

### DIFF
--- a/client/onboarding/tasks/add-business-info-task/index.js
+++ b/client/onboarding/tasks/add-business-info-task/index.js
@@ -27,12 +27,14 @@ const AddBusinessInfoTask = () => {
 	const [ displayStructures, setDisplayStructures ] = useState( false );
 
 	useEffect( () => {
-		setBusinessCountry(
-			businessTypes.find(
-				( country ) => country.key === wcpaySettings.connect.country
-			)
-		);
-	}, [ businessTypes ] );
+		if ( ! businessCountry ) {
+			setBusinessCountry(
+				businessTypes.find(
+					( country ) => country.key === wcpaySettings.connect.country
+				)
+			);
+		}
+	}, [ businessTypes, businessCountry ] );
 
 	const handleBusinessCountryUpdate = ( country ) => {
 		setBusinessCountry( country );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Check if `businessCountry` is not empty before applying the account settings country, to avoid resetting user selected one after context update.

#### Testing instructions
- Select any country other than the default selected one
- Select **Individual** as **Business type**
- Should keep the selected country and not revert to the initial one.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] QA Testing Not Applicable
