### PR TITLE
Fix for a few missing or mislabelled strings

### DIFF
--- a/client/onboarding/tasks/add-business-info-task/index.js
+++ b/client/onboarding/tasks/add-business-info-task/index.js
@@ -27,12 +27,14 @@ const AddBusinessInfoTask = () => {
 	const [ displayStructures, setDisplayStructures ] = useState( false );
 
 	useEffect( () => {
-		setBusinessCountry(
-			businessTypes.find(
-				( country ) => country.key === wcpaySettings.connect.country
-			)
-		);
-	}, [ businessTypes ] );
+		if ( ! businessCountry ) {
+			setBusinessCountry(
+				businessTypes.find(
+					( country ) => country.key === wcpaySettings.connect.country
+				)
+			);
+		}
+	}, [ businessTypes, businessCountry ] );
 
 	const handleBusinessCountryUpdate = ( country ) => {
 		setBusinessCountry( country );

--- a/client/onboarding/translations/structures.tsx
+++ b/client/onboarding/translations/structures.tsx
@@ -56,6 +56,14 @@ const businessStructureStrings: StructureKeyMap = {
 		private_corporation: __( 'Corporation', 'woocommerce-payments' ),
 		sole_proprietorship: __( 'Sole trader', 'woocommerce-payments' ),
 		private_partnership: __( 'Partnership', 'woocommerce-payments' ),
+		incorporated_non_profit: __(
+			'Incorporated non-profit',
+			'woocommerce-payments'
+		),
+		unincorporated_non_profit: __(
+			'Unincorporated non-profit',
+			'woocommerce-payments'
+		),
 	},
 	SG: {
 		sole_proprietorship: __(
@@ -95,7 +103,7 @@ const businessStructureStrings: StructureKeyMap = {
 			'Unincorporated non-profit',
 			'woocommerce-payments'
 		),
-		government_unit: __( 'Government unit', 'woocommerce-payments' ),
+		governmental_unit: __( 'Governmental unit', 'woocommerce-payments' ),
 		government_instrumentality: __(
 			'Government instrumentality proprietorship',
 			'woocommerce-payments'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

This issue fixes a few cases where translatable strings were either missing or mislabelled.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- On the new onboarding page, select the following countries: `United States`, `Australia`, `New Zealand`, `Singapore`, `Hong Kong`
- For each country, select all possible business types, and check that the dropdown for structures doesn't have any empty selects (where no label appears).

Note that some country/type combos will not have any structures. In this case, the structure select dropdown won't appear.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
