### PR TITLE
Payment Request Button - Do not set WC session cookie and HTML container on the product page if not enabled

### DIFF
--- a/changelog/fix-4084-prb-caching-product-page
+++ b/changelog/fix-4084-prb-caching-product-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Payment Request Button - Do not set WC session cookie and HTML container on the product page if not enabled.

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -150,8 +150,10 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 * @return void
 	 */
 	public function set_session() {
+		// Don't set session cookies on product pages to allow for caching when payment request
+		// buttons are disabled. But keep cookies if there is already an active WC session in place.
 		if (
-			! ( $this->is_product() && $this->is_available_at( 'product' ) )
+			! ( $this->is_product() && $this->should_show_payment_request_button() )
 			|| ( isset( WC()->session ) && WC()->session->has_session() )
 		) {
 			return;

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -150,7 +150,10 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 * @return void
 	 */
 	public function set_session() {
-		if ( ! $this->is_product() || ( isset( WC()->session ) && WC()->session->has_session() ) ) {
+		if (
+			! ( $this->is_product() && $this->is_available_at( 'product' ) )
+			|| ( isset( WC()->session ) && WC()->session->has_session() )
+		) {
 			return;
 		}
 

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -662,6 +662,9 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 * Display the payment request button.
 	 */
 	public function display_payment_request_button_html() {
+		if ( ! $this->should_show_payment_request_button() ) {
+			return;
+		}
 		?>
 		<div id="wcpay-payment-request-wrapper" style="clear:both;padding-top:1.5em;display:none;">
 			<div id="wcpay-payment-request-button">
@@ -675,6 +678,9 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 * Display payment request button separator.
 	 */
 	public function display_payment_request_button_separator_html() {
+		if ( ! $this->should_show_payment_request_button() ) {
+			return;
+		}
 		?>
 		<p id="wcpay-payment-request-button-separator" style="margin-top:1.5em;text-align:center;display:none;">&mdash; <?php esc_html_e( 'OR', 'woocommerce-payments' ); ?> &mdash;</p>
 		<?php


### PR DESCRIPTION
Fixes #4084 

TL;DR: The VIP platform uses Varnish HTTP cache with cookie exceptions, such as `wp_woocommerce_session_*`. [Src](https://docs.wpvip.com/technical-references/caching/cookies/#:~:text=A%20WooCommerce%20session%20cookie).

That prevents product pages from being cached, even though express checkouts might be disabled for product pages.

#### Changes proposed in this Pull Request

- Do not set session cookie if product page is not enabled under settings.
- Check if HTML wrapper and separator should be displayed, [similar to Stripe extension](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/a8e04bcb4fd30d2a69b92067e10b4ace13849f0d/includes/payment-methods/class-wc-stripe-payment-request.php#L809) - this was probably ignored when customizable button locations was introduced.

#### Testing instructions

With Google Pay configured in your browser:

1. Make sure your site uses HTTPS.
2. As a merchant, make sure "Express checkouts" is enabled under the WCPay settings.
3. Under **"Express checkouts > Apple Pay / Google Pay"**, click "Customize".
4. Uncheck "Product page" and click "Save changes".
5. As a guest, navigate to a product page and remove all cookies (you can use a browser extension such as [EditThisCookie](https://chrome.google.com/webstore/detail/editthiscookie/fngmhnnpilhplaeedifhccceomclgfbg?hl=pt-BR), or **Chrome DevTools > Application > Cookie**).
6. Refresh the product page, and ensure the `wp_woocommerce_session_*` cookie is not created.
7. As a merchant, enable "Apple Pay / Google Pay" on the product page.
8. As a guest, navigate to a product page and ensure the `wp_woocommerce_session_*` cookie was created.
9. Proceed with Google Pay checkout and make sure it works.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
