### PR TITLE
Update subscriptions-core to `1.8.0`

### DIFF
--- a/changelog/subscriptions-core-1.8.0
+++ b/changelog/subscriptions-core-1.8.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Switch to global functions to remove deprecation warnings originating from WooCommerce Blocks.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
       "automattic/jetpack-sync": "1.29.2",
       "automattic/jetpack-tracking": "1.14.1",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "1.7.0"
+      "woocommerce/subscriptions-core": "1.8.0"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a564ce0a9300ebf87163f7434aba9b5",
+    "content-hash": "ad8383dabdc5b25391d7d6a26314eef0",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1060,16 +1060,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "69d33cac5e31fa8130072b2a88ec94689cb1ca91"
+                "reference": "20d0604af2431cde345ba73d19aa0b2c3f86c81f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/69d33cac5e31fa8130072b2a88ec94689cb1ca91",
-                "reference": "69d33cac5e31fa8130072b2a88ec94689cb1ca91",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/20d0604af2431cde345ba73d19aa0b2c3f86c81f",
+                "reference": "20d0604af2431cde345ba73d19aa0b2c3f86c81f",
                 "shasum": ""
             },
             "require": {
@@ -1111,10 +1111,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/1.7.0",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/1.8.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-03-18T05:01:34+00:00"
+            "time": "2022-04-05T00:00:20+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Load newer woocommerce-subscriptions-core's version 1.8.0.
- Added changelog entries from woocommerce-subscriptions-core to the changelog.
- Updated composer.lock as a result of running `composer update woocommerce/subscriptions-core`.

#### Testing instructions

* Checkout this branch.
* [Husky hook should run `composer install`](https://github.com/Automattic/woocommerce-payments/blob/develop/.husky/post-checkout#L8) and your `vendor/woocommerce/subscriptions-core` should be updated to `1.8.0`. Confirm that latest changes from `1.8.0` is present, for example, [vendor/woocommerce/subscriptions-core/changelog.txt is up-to-date](https://github.com/Automattic/woocommerce-subscriptions-core/blob/1.8.0/changelog.txt).


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_

fixes #4004 