### PR TITLE
Fix linter warnings in DepositsList

### DIFF
--- a/changelog/fix-linter-warnings-in-depositslist
+++ b/changelog/fix-linter-warnings-in-depositslist
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Fix linter warnings in DepositsList

--- a/client/deposits/list/index.tsx
+++ b/client/deposits/list/index.tsx
@@ -187,7 +187,7 @@ export const DepositsList = (): JSX.Element => {
 	const downloadable = !! rows.length;
 
 	const onDownload = () => {
-		const { page, path, ...params } = getQuery();
+		const params = getQuery();
 
 		const csvColumns = [
 			{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `DepositsList` React component has a couple of unused destructured variables that are causing GitHub to report linter warnings in unrelated pull requests. This PR fixes the warnings.

<img width="1817" alt="image" src="https://user-images.githubusercontent.com/1288616/162153458-6320feab-886d-49eb-8b62-9313c941b237.png">

#### Testing instructions

* Check that ESLint is not reporting the warnings anymore.
* Verify that the deposits CSV export functionality is not impacted.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (does not apply)
- [ ] Tested on mobile (does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _QA Testing Not Applicable_
