### PR TITLE
Add  has_started_onboarding front-end facing 

### DIFF
--- a/changelog/feat-has_started_onboarding_endpoint
+++ b/changelog/feat-has_started_onboarding_endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add has_started_onboarding endpoint

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1753,7 +1753,7 @@ class WC_Payments_API_Client {
 	 * @param bool   $use_user_token   - If true, the request will be signed with the user token rather than blog token. Defaults to false.
 	 * @param bool   $raw_response     - If true, the raw response will be returned. Defaults to false.
 	 *
-	 * @return array
+	 * @return mixed
 	 * @throws API_Exception - If the account ID hasn't been set.
 	 */
 	protected function request( $params, $api, $method, $is_site_specific = true, $use_user_token = false, bool $raw_response = false ) {

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -922,6 +922,23 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Get status of onboarding
+	 *
+	 * @return boolean Has onboarding started
+	 *
+	 * @throws API_Exception - Error contacting the API.
+	 */
+	public function has_onboarding_started() {
+		return (bool) $this->request(
+			[
+				'test_mode' => WC_Payments::get_gateway()->is_in_dev_mode(), // only send a test mode request if in dev mode.
+			],
+			self::ACCOUNTS_API . '/has_onboarding_started',
+			self::GET
+		);
+	}
+
+	/**
 	 * Retrieve a file details via API.
 	 *
 	 * @param string $file_id - API file id.


### PR DESCRIPTION
Front-end for 1859-gh-Automattic/woocommerce-payments-server
Already merged on WPCOM with D78119-code


#### Changes proposed in this Pull Request

Adds API_Client::has_onboarding_started()

#### Testing instructions

See D78119-code