### PR TITLE
[WIP] Unset receipt_email before capturing an intent

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2008,10 +2008,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$metadata_from_intent = $intent->get_metadata(); // mobile app may have set metadata.
 			$metadata_from_order  = $this->get_metadata_from_order( $order, $payment_type );
 			$merged_metadata      = array_merge( (array) $metadata_from_order, (array) $metadata_from_intent ); // prioritize metadata from mobile app.
+			$remove_receipt_email = true;
 
 			$this->payments_api_client->update_intention_metadata(
 				$intent_id,
-				$merged_metadata
+				$merged_metadata,
+				$remove_receipt_email
 			);
 
 			$intent = $this->payments_api_client->capture_intention(

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -338,14 +338,20 @@ class WC_Payments_API_Client {
 	 *
 	 * @param string $intention_id - The ID of the intention to update.
 	 * @param array  $metadata     - Meta data values to be sent along with payment intent creation.
+	 * @param bolean $remove_receipt_email - Whether to remove the receipt_email.
 	 *
 	 * @return WC_Payments_API_Intention
 	 * @throws API_Exception - Exception thrown on intention creation failure.
 	 */
-	public function update_intention_metadata( $intention_id, $metadata ) {
+	public function update_intention_metadata( $intention_id, $metadata, $remove_receipt_email = false ) {
 		$request = [
 			'metadata' => $metadata,
 		];
+
+		if ( $remove_receipt_email ) {
+			// I tried to set this to null but then Stripe did not remove the email.
+			$request['receipt_email'] = '';
+		}
 
 		$response_array = $this->request_with_level3_data( $request, self::INTENTIONS_API . '/' . $intention_id, self::POST );
 


### PR DESCRIPTION
Fixes #4048 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
This is WIP, please feel free to amend this description as you see fit. 

I think it is going in the good direction. As stated in the description of the issue, we need to update the payment intent to remove the `receipt_email` to prevent [Stripe from sending the email on their end](https://stripe.com/docs/receipts#automatically-send-receipts-when-payments-are-successful). 

There is an issue with testing this approach, since Stripe does not send email receipts in Test mode. However, I can see that after this change, the `receipt_email` is set to null in the payment events in Stripe's Dashboard:

**Before this change**

<img width="1451" alt="Screen Shot 2022-04-08 at 18 55 42" src="https://user-images.githubusercontent.com/1553182/162491178-7acbd312-ef3f-43ba-b59f-2857fef052b2.png">

**After this change**

<img width="1451" alt="Screen Shot 2022-04-08 at 18 56 40" src="https://user-images.githubusercontent.com/1553182/162491254-a9324ad5-9c02-4741-b6c0-ee26a8666322.png">

If we trust the Stripe Docs, **there should be no email sent since the `receipt_email` is set to null.** 

**TODOs**

- [ ] Refactor the name of the method to reflect that we are also updating the `receipt_email`
- [ ] Amend / Add unit tests if needed
- [ ] Manual test that emails are not sent?

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You will need to use the mobile emulator or use the capture_charge endpoint to test this

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
