### PR TITLE
Add test mode property to platform checkout events

### DIFF
--- a/changelog/update-platform-checkout-events-test-mode
+++ b/changelog/update-platform-checkout-events-test-mode
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Add test_mode property to platform checkout events, behind feature flag
+
+

--- a/includes/class-platform-checkout-tracker.php
+++ b/includes/class-platform-checkout-tracker.php
@@ -110,6 +110,10 @@ class Platform_Checkout_Tracker extends Jetpack_Tracks_Client {
 			$event = self::$prefix . '_' . $event;
 		}
 
+		// Add event property for test mode vs. live mode events.
+		$gateway           = \WC_Payments::get_gateway();
+		$data['test_mode'] = $gateway->is_in_test_mode() ? 1 : 0;
+
 		return $this->tracks_record_event( $user, $event, $data );
 	}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1676,7 +1676,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if ( $is_platform_checkout_enabled !== $current_is_platform_checkout_enabled ) {
 			wc_admin_record_tracks_event(
 				$is_platform_checkout_enabled ? 'platform_checkout_enabled' : 'platform_checkout_disabled',
-				[ 'test_mode' => $this->is_in_test_mode() ]
+				[ 'test_mode' => $this->is_in_test_mode() ? 1 : 0 ]
 			);
 			$this->update_option( 'platform_checkout', $is_platform_checkout_enabled ? 'yes' : 'no' );
 		}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1674,7 +1674,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public function update_is_platform_checkout_enabled( $is_platform_checkout_enabled ) {
 		$current_is_platform_checkout_enabled = 'yes' === $this->get_option( 'platform_checkout', 'no' );
 		if ( $is_platform_checkout_enabled !== $current_is_platform_checkout_enabled ) {
-			wc_admin_record_tracks_event( $is_platform_checkout_enabled ? 'platform_checkout_enabled' : 'platform_checkout_disabled' );
+			wc_admin_record_tracks_event(
+				$is_platform_checkout_enabled ? 'platform_checkout_enabled' : 'platform_checkout_disabled',
+				[ 'test_mode' => $this->is_in_test_mode() ]
+			);
 			$this->update_option( 'platform_checkout', $is_platform_checkout_enabled ? 'yes' : 'no' );
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a `test_mode` property to all platform checkout Tracks events, so that we can more easily filter out test mode / dev mode events when we're interested in looking at live events only.

#### Testing instructions

- In WC Core advanced settings (/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com), be sure "Allow usage of WooCommerce to be tracked" is turned on.
- Go to WCPay settings and toggle the platform checkout setting. After a few minutes, check the Tracks live view for a `wcadmin_platform_checkout_disabled` event from your site. It should have a `test_mode` property that is `1` or `0` depending on whether your site is in test mode or not.
- With platform checkout enabled, as a customer (non-admin user), add a product to your cart and visit the checkout page. After a few minutes, check the Tracks live view for a `woocommerceanalytics_order_checkout_start` event from your site. It should have a `test_mode` property that is `1` or `0` depending on whether your site is in test mode or not.

cc @malithsen 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
