### PR TITLE
Update KYC Optimisation to use the new Cache Logic

### DIFF
--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -13,7 +13,8 @@ defined( 'ABSPATH' ) || exit; // block direct access.
  * A class for caching data as an option in the database.
  */
 class Database_Cache {
-	const ACCOUNT_KEY = 'wcpay_account_data';
+	const ACCOUNT_KEY        = 'wcpay_account_data';
+	const BUSINESS_TYPES_KEY = 'wcpay_business_types_data';
 
 	/**
 	 * Refresh disabled flag, controlling the behaviour of the get_or_add function.
@@ -234,23 +235,30 @@ class Database_Cache {
 	 * @return integer The cache TTL.
 	 */
 	private function get_ttl( string $key, array $cache_contents ): int {
-		// Default to 24h.
-		$ttl = DAY_IN_SECONDS;
-
-		if ( self::ACCOUNT_KEY === $key ) {
-			if ( is_admin() ) {
-				// Fetches triggered from the admin panel should be more frequent.
-				if ( $cache_contents['errored'] ) {
-					// Attempt to refresh the data quickly if the last fetch was an error.
-					$ttl = 2 * MINUTE_IN_SECONDS;
+		switch ( $key ) {
+			case self::ACCOUNT_KEY:
+				if ( is_admin() ) {
+					// Fetches triggered from the admin panel should be more frequent.
+					if ( $cache_contents['errored'] ) {
+						// Attempt to refresh the data quickly if the last fetch was an error.
+						$ttl = 2 * MINUTE_IN_SECONDS;
+					} else {
+						// If the data was fetched successfully, fetch it every 2h.
+						$ttl = 2 * HOUR_IN_SECONDS;
+					}
 				} else {
-					// If the data was fetched successfully, fetch it every 2h.
-					$ttl = 2 * HOUR_IN_SECONDS;
+					// Non-admin requests should always refresh only after 24h since the last fetch.
+					$ttl = DAY_IN_SECONDS;
 				}
-			} else {
-				// Non-admin requests should always refresh only after 24h since the last fetch.
+				break;
+			case self::BUSINESS_TYPES_KEY:
+				// Cache business types for a week.
+				$ttl = WEEK_IN_SECONDS;
+				break;
+			default:
+				// Default to 24h.
 				$ttl = DAY_IN_SECONDS;
-			}
+				break;
 		}
 
 		return apply_filters( 'wcpay_database_cache_ttl', $ttl, $key, $cache_contents );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -289,7 +289,7 @@ class WC_Payments {
 		self::$localization_service                = new WC_Payments_Localization_Service();
 		self::$failed_transaction_rate_limiter     = new Session_Rate_Limiter( Session_Rate_Limiter::SESSION_KEY_DECLINED_CARD_REGISTRY, 5, 10 * MINUTE_IN_SECONDS );
 		self::$order_service                       = new WC_Payments_Order_Service();
-		self::$onboarding_service                  = new WC_Payments_Onboarding_Service( self::$api_client );
+		self::$onboarding_service                  = new WC_Payments_Onboarding_Service( self::$api_client, self::$database_cache );
 
 		$card_class = CC_Payment_Gateway::class;
 		$upe_class  = UPE_Payment_Gateway::class;


### PR DESCRIPTION
Fixes #4126 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

- Update the KYC optimisation to use the `Database_Cache` implemented in #4110.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that you have already got a cached option using the old format (you can do this by visiting the new onboarding flow page on `develop`.
* Checkout this branch, refresh the page.
* Check the option value `wcpay_business_types_data` in the database to ensure that it has been updated to use the new format (it should have the keys `data`, `errored` and `fetched`).
* Reload the page again, verify that the value was fetched from the cache and not the server. (either using step debugging or logging). 
* Test the onboarding selects, ensure all is working as expected.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
