### PR TITLE
Use Database_Cache in MultiCurrency class

### DIFF
--- a/changelog/add-db-cache-currency
+++ b/changelog/add-db-cache-currency
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update currency rate cache mechanism

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit; // block direct access.
 class Database_Cache {
 	const ACCOUNT_KEY        = 'wcpay_account_data';
 	const BUSINESS_TYPES_KEY = 'wcpay_business_types_data';
+	const CURRENCIES_KEY     = 'wcpay_multi_currency_cached_currencies';
 
 	/**
 	 * Refresh disabled flag, controlling the behaviour of the get_or_add function.
@@ -250,6 +251,10 @@ class Database_Cache {
 					// Non-admin requests should always refresh only after 24h since the last fetch.
 					$ttl = DAY_IN_SECONDS;
 				}
+				break;
+			case self::CURRENCIES_KEY:
+				// Refresh the errored currencies quickly, otherwise cache for 6h.
+				$ttl = $cache_contents['errored'] ? 2 * MINUTE_IN_SECONDS : 6 * HOUR_IN_SECONDS;
 				break;
 			case self::BUSINESS_TYPES_KEY:
 				// Cache business types for a week.

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Payments\Tests
  */
 
+use WCPay\Database_Cache;
 use WCPay\Exceptions\API_Exception;
 use WCPay\MultiCurrency\MultiCurrency;
 use WCPay\MultiCurrency\Utils;
@@ -15,10 +16,8 @@ use WCPay\MultiCurrency\SettingsOnboardCta;
  * WCPay\MultiCurrency\MultiCurrency unit tests.
  */
 class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
-	const LOGGED_IN_USER_ID               = 1;
-	const ENABLED_CURRENCIES_OPTION       = 'wcpay_multi_currency_enabled_currencies';
-	const CACHED_CURRENCIES_OPTION        = 'wcpay_multi_currency_cached_currencies';
-	const CURRENCY_RETRIEVAL_ERROR_OPTION = 'wcpay_multi_currency_retrieval_error';
+	const LOGGED_IN_USER_ID         = 1;
+	const ENABLED_CURRENCIES_OPTION = 'wcpay_multi_currency_enabled_currencies';
 
 	/**
 	 * Mock enabled currencies.
@@ -82,6 +81,13 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 	 */
 	private $mock_localization_service;
 
+	/**
+	 * Mock of Database_Cache.
+	 *
+	 * @var Database_Cache;
+	 */
+	private $mock_database_cache;
+
 	public function set_up() {
 		parent::set_up();
 
@@ -101,7 +107,6 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 			'expires'    => $this->timestamp_for_testing + DAY_IN_SECONDS,
 		];
 
-		update_option( self::CACHED_CURRENCIES_OPTION, $this->mock_cached_currencies );
 		update_option( self::ENABLED_CURRENCIES_OPTION, $this->mock_enabled_currencies );
 
 		$this->init_multi_currency();
@@ -118,7 +123,6 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		wp_set_current_user( 0 );
 
 		$this->remove_currency_settings_mock( 'GBP', [ 'price_charm', 'price_rounding', 'manual_rate', 'exchange_rate' ] );
-		delete_option( self::CACHED_CURRENCIES_OPTION );
 		delete_option( self::ENABLED_CURRENCIES_OPTION );
 		update_option( 'wcpay_multi_currency_enable_auto_currency', 'no' );
 
@@ -558,6 +562,9 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		$mock_api_client->method( 'is_server_connected' )->willReturn( false );
 
 		$this->init_multi_currency( $mock_api_client );
+
+		$this->mock_database_cache->method( 'get' )->willReturn( $this->mock_cached_currencies );
+
 		$this->assertEquals(
 			$this->mock_cached_currencies,
 			$this->multi_currency->get_cached_currencies()
@@ -565,16 +572,19 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_get_cached_currencies_with_account_rejected() {
-		update_option( self::CACHED_CURRENCIES_OPTION, null );
+		$this->mock_database_cache
+			->expects( $this->once() )
+			->method( 'get' )
+			->willReturn( null );
 
 		$this->mock_account
 			->expects( $this->once() )
 			->method( 'is_account_rejected' )
 			->willReturn( true );
 
-		$this->mock_api_client
+		$this->mock_database_cache
 			->expects( $this->never() )
-			->method( 'get_currency_rates' );
+			->method( 'get_or_add' );
 
 		$this->assertEquals(
 			null,
@@ -582,34 +592,26 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_get_expired_cached_currencies_with_server_retrieval_error() {
-		$currency_cache            = $this->mock_cached_currencies;
-		$currency_cache['expires'] = strtotime( 'yesterday' );
-
-		update_option( self::CACHED_CURRENCIES_OPTION, $currency_cache );
-
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_currency_rates' )
-			->willThrowException( new API_Exception( 'Error connecting to server', 'API_ERROR', 500 ) );
-
-		$this->assertEquals(
-			$currency_cache,
-			$this->multi_currency->get_cached_currencies()
-		);
-	}
-
-	public function test_get_cached_currencies_with_valid_cached_data() {
-		update_option( self::CACHED_CURRENCIES_OPTION, $this->mock_cached_currencies );
-
-		$this->assertEquals(
-			$this->mock_cached_currencies,
-			$this->multi_currency->get_cached_currencies()
-		);
-	}
-
 	public function test_get_cached_currencies_fetches_from_server() {
-		delete_option( self::CACHED_CURRENCIES_OPTION );
+		$get_or_add_call_count = 1;
+		$mock_database_cache   = $this->createMock( Database_Cache::class );
+		$mock_database_cache
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_or_add' )
+			->willReturnCallback(
+				function ( $key, $generator, $validator ) use ( &$get_or_add_call_count ) {
+					if ( 1 === $get_or_add_call_count ) {
+						// Call that happens inside the init function in MultiCurrency, still use cached data.
+						$get_or_add_call_count++;
+						return $this->mock_cached_currencies;
+					} else {
+						// Second call from get_cached_currencies below.
+						return $generator();
+					}
+				}
+			);
+
+		$this->init_multi_currency( null, true, null, $mock_database_cache );
 
 		$currency_from = get_woocommerce_currency();
 		$currencies_to = get_woocommerce_currencies();
@@ -630,30 +632,6 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 			$this->mock_available_currencies,
 			$result['currencies']
 		);
-
-		// Assert that the cache was correctly set.
-		$cached_data = get_option( self::CACHED_CURRENCIES_OPTION );
-		$this->assertTrue( is_array( $cached_data ) );
-		$this->assertArrayHasKey( 'currencies', $cached_data );
-		$this->assertArrayHasKey( 'updated', $cached_data );
-		$this->assertEquals(
-			$this->mock_available_currencies,
-			$result['currencies']
-		);
-	}
-
-	public function test_get_cached_currencies_handles_api_exception() {
-		delete_option( self::CACHED_CURRENCIES_OPTION );
-
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_currency_rates' )
-			->willThrowException( new API_Exception( 'Error connecting to server', 'API_ERROR', 500 ) );
-
-		$this->assertNull( $this->multi_currency->get_cached_currencies() );
-
-		// Assert that the cache was correctly set with the error expiration time.
-		$this->assertEquals( time() + MINUTE_IN_SECONDS, get_option( self::CURRENCY_RETRIEVAL_ERROR_OPTION ) );
 	}
 
 	public function test_storefront_integration_init_with_compatible_themes() {
@@ -743,6 +721,7 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 
 	public function test_get_cached_currencies_with_no_stripe_connection() {
 		$this->init_multi_currency( null, false );
+		$this->mock_database_cache->method( 'get' )->willReturn( $this->mock_cached_currencies );
 		$this->assertEquals(
 			$this->mock_cached_currencies,
 			$this->multi_currency->get_cached_currencies()
@@ -892,7 +871,7 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 		}
 	}
 
-	private function init_multi_currency( $mock_api_client = null, $wcpay_account_connected = true, $mock_account = null ) {
+	private function init_multi_currency( $mock_api_client = null, $wcpay_account_connected = true, $mock_account = null, $mock_database_cache = null ) {
 		$this->mock_api_client = $this->createMock( WC_Payments_API_Client::class );
 
 		$this->mock_account = $mock_account ?? $this->createMock( WC_Payments_Account::class );
@@ -911,7 +890,15 @@ class WCPay_Multi_Currency_Tests extends WP_UnitTestCase {
 			]
 		);
 
-		$this->multi_currency = new MultiCurrency( $mock_api_client ?? $this->mock_api_client, $this->mock_account, $this->mock_localization_service );
+		$this->mock_database_cache = $this->createMock( Database_Cache::class );
+		$this->mock_database_cache->method( 'get_or_add' )->willReturn( $this->mock_cached_currencies );
+
+		$this->multi_currency = new MultiCurrency(
+			$mock_api_client ?? $this->mock_api_client,
+			$this->mock_account,
+			$this->mock_localization_service,
+			$mock_database_cache ?? $this->mock_database_cache
+		);
 		$this->multi_currency->init_widgets();
 		$this->multi_currency->init();
 	}

--- a/tests/unit/test-class-wc-payments-explicit-price-formatter.php
+++ b/tests/unit/test-class-wc-payments-explicit-price-formatter.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Payments\Tests
  */
 
+use WCPay\Database_Cache;
 use WCPay\MultiCurrency\MultiCurrency;
 
 /**
@@ -12,10 +13,8 @@ use WCPay\MultiCurrency\MultiCurrency;
  */
 class WC_Payments_Explicit_Price_Formatter_Test extends WP_UnitTestCase {
 
-	const LOGGED_IN_USER_ID               = 1;
-	const ENABLED_CURRENCIES_OPTION       = 'wcpay_multi_currency_enabled_currencies';
-	const CACHED_CURRENCIES_OPTION        = 'wcpay_multi_currency_cached_currencies';
-	const CURRENCY_RETRIEVAL_ERROR_OPTION = 'wcpay_multi_currency_retrieval_error';
+	const LOGGED_IN_USER_ID         = 1;
+	const ENABLED_CURRENCIES_OPTION = 'wcpay_multi_currency_enabled_currencies';
 
 	/**
 	 * Mock enabled currencies.
@@ -79,6 +78,13 @@ class WC_Payments_Explicit_Price_Formatter_Test extends WP_UnitTestCase {
 	 */
 	private $mock_localization_service;
 
+	/**
+	 * Mock of Database_Cache.
+	 *
+	 * @var Database_Cache;
+	 */
+	private $mock_database_cache;
+
 	public function set_up() {
 		parent::set_up();
 
@@ -98,7 +104,6 @@ class WC_Payments_Explicit_Price_Formatter_Test extends WP_UnitTestCase {
 			'expires'    => $this->timestamp_for_testing + DAY_IN_SECONDS,
 		];
 
-		update_option( self::CACHED_CURRENCIES_OPTION, $this->mock_cached_currencies );
 		update_option( self::ENABLED_CURRENCIES_OPTION, $this->mock_enabled_currencies );
 
 		$this->init_multi_currency();
@@ -116,7 +121,6 @@ class WC_Payments_Explicit_Price_Formatter_Test extends WP_UnitTestCase {
 		wp_set_current_user( 0 );
 
 		$this->remove_currency_settings_mock( 'GBP', [ 'price_charm', 'price_rounding', 'manual_rate', 'exchange_rate' ] );
-		delete_option( self::CACHED_CURRENCIES_OPTION );
 		delete_option( self::ENABLED_CURRENCIES_OPTION );
 		update_option( 'wcpay_multi_currency_enable_auto_currency', 'no' );
 
@@ -241,7 +245,10 @@ class WC_Payments_Explicit_Price_Formatter_Test extends WP_UnitTestCase {
 			]
 		);
 
-		$this->multi_currency = new MultiCurrency( $mock_api_client ?? $this->mock_api_client, $this->mock_account, $this->mock_localization_service );
+		$this->mock_database_cache = $this->createMock( Database_Cache::class );
+		$this->mock_database_cache->method( 'get_or_add' )->willReturn( $this->mock_cached_currencies );
+
+		$this->multi_currency = new MultiCurrency( $mock_api_client ?? $this->mock_api_client, $this->mock_account, $this->mock_localization_service, $this->mock_database_cache );
 		$this->multi_currency->init();
 
 		WC_Payments_Explicit_Price_Formatter::set_multi_currency_instance( $this->multi_currency );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Migrates the currency rates fetch to be cached using `Database_Cache` rather than custom code

#### Testing instructions

- Unit tests should pass 
- Tail `wp-content/uploads/wc-logs/woocommerce-payments-<date>...log` in your client WordPress install
- `DELETE FROM wp_options WHERE option_name='wcpay_multi_currency_cached_currencies'`
- Navigate to `WooCommerce > Settings > Multi-Currency`
- The currency rates should be there and not have a value of 1
- `SELECT * FROM wp_options WHERE option_name='wcpay_multi_currency_cached_currencies'`
- The option should be found
- All throughout only one request for the currency rates should be logged in the tailed log file

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _'QA Testing Not Applicable'_
