### PR TITLE
Fix error in refunding in-person payments

### DIFF
--- a/changelog/fix-4100-ipp-refund-error
+++ b/changelog/fix-4100-ipp-refund-error
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix error in refunding in-person payments
+Fix an error in refunding In-Person Payments

--- a/changelog/fix-4100-ipp-refund-error
+++ b/changelog/fix-4100-ipp-refund-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix error in refunding in-person payments

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -176,7 +176,7 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 			// Store receipt generation URL for mobile applications in order meta-data.
 			$order->add_meta_data( 'receipt_url', get_rest_url( null, sprintf( '%s/payments/readers/receipts/%s', $this->namespace, $intent->get_id() ) ) );
 			// Actualize order status.
-			$this->order_service->mark_terminal_payment_completed( $order, $intent_id, $intent_status, $charge_id );
+			$this->order_service->mark_terminal_payment_completed( $order, $intent_id, $result['status'], $charge_id );
 
 			return rest_ensure_response(
 				[


### PR DESCRIPTION
Fixes #4100

#### Changes proposed in this Pull Request

Update the `capture_terminal_payment` endpoint to use the correct intent status while marking the payment as completed. In the current state, all completed orders have their `_intention_status` meta key set as "requires_capture" when it should be "succeeded". This leads to undesired behavior such as error in refunding IPP orders.

#### Testing instructions

1. Create a new order in WooCommerce with “Cash on delivery” as the payment method.
2. Create a payment intent in Stripe Dashboard at `https://dashboard.stripe.com/test/connect/accounts/<account_id>/payments/new`. Make sure to have the “Capture funds later” option selected under “Manually enter card information.”
3. Make a POST request to `/payments/orders/<order_id>/capture_terminal_payment` using the intent id from step 2. Refer the [docs](https://github.com/woocommerce/woocommerce/wiki/Getting-started-with-the-REST-API) to set up authorization correctly.
4. Go to the order details page in WP Admin and refund the order.
5. Ensure that the order gets refunded successfully.
6. Before this change, you would get an alert dialog with the error "This payment is not captured yet. To cancel this order, please go to...".

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (does not apply)
- [x] Tested on mobile

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
