### PR TITLE
Fix changelog entry with newline.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,8 +24,7 @@
 * Fix - Empty file input to allow the user to select the same file again if there's an error.
 * Fix - Enable card readers branding section.
 * Fix - Enable WooCommerce Blocks checkout to hide option to save payment methods for a non-reusable payment method.
-* Fix - Fix - Using any other payment methods apart from WooCommerce Payments in "Pay for order".
-form triggers validation errors when UPE checkout is enabled.
+* Fix - Using any other payment methods apart from WooCommerce Payments in "Pay for order" form triggers validation errors when UPE checkout is enabled.
 * Fix - Fix an error in refunding In-Person Payments.
 * Fix - Fixed the pricing displayed on Google Pay/ Apple Pay preview for variable subscription products.
 * Fix - Fix placeholders not being injected into the New Receipt email.

--- a/changelog/fix-changelog-4.0.0-newline
+++ b/changelog/fix-changelog-4.0.0-newline
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Just fixing changelog entry format.
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix malformed [changelog entry](https://github.com/Automattic/woocommerce-payments/blob/dd9d319b661427a1d22a5aeab945c23dd429f317/changelog.txt#L27-L28). The changelog entry comes from [this PR](https://github.com/Automattic/woocommerce-payments/pull/4049/files#diff-fe8a0960624868cf0ed34795d9533b72fb5342e8284af9c1986acaa465e92b4bR4-R5).
This problem prevents the [automated release process](https://github.com/Automattic/woocommerce-payments/runs/6071045933?check_suite_focus=true#step:11:81).

To prevent this problem from happening in the future, I filed https://github.com/Automattic/woocommerce-payments/issues/4150.

#### Testing instructions

* Running this command on base branch should fail. Run on on this PR's branch should work.

```
./vendor/bin/changelogger write --use-version="4.1.0-test-1" --release-date=unreleased
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
