### PR TITLE
Add how to write good manual test instructions to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,4 +47,4 @@ We often create a blank page ahead of time for the next release.
 If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
 -->
 
-- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_
+- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_


### PR DESCRIPTION
This PR adds a link to our wiki on [how to write good manual testing scenarios](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) to the PR template. 

This was discussed in paJDYF-3Ab-p2 after GlobalStep could not test the plugin because they did not have access to a P2

## Testing Instructions
Make sure the PR template has a link to our wiki on [how to write good manual testing scenarios](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) to the PR template. 