### PR TITLE
Sync changelog.txt and readme.txt.

### DIFF
--- a/changelog/fix-changelog-readme-4.0.0-newline
+++ b/changelog/fix-changelog-readme-4.0.0-newline
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Just syncing readme.txt and changelog.txt.
+
+

--- a/readme.txt
+++ b/readme.txt
@@ -122,8 +122,7 @@ Please note that our support for the checkout block is still experimental and th
 * Fix - Empty file input to allow the user to select the same file again if there's an error.
 * Fix - Enable card readers branding section.
 * Fix - Enable WooCommerce Blocks checkout to hide option to save payment methods for a non-reusable payment method.
-* Fix - Fix - Using any other payment methods apart from WooCommerce Payments in "Pay for order".
-form triggers validation errors when UPE checkout is enabled.
+* Fix - Using any other payment methods apart from WooCommerce Payments in "Pay for order" form triggers validation errors when UPE checkout is enabled.
 * Fix - Fix an error in refunding In-Person Payments.
 * Fix - Fixed the pricing displayed on Google Pay/ Apple Pay preview for variable subscription products.
 * Fix - Fix placeholders not being injected into the New Receipt email.
@@ -201,9 +200,9 @@ form triggers validation errors when UPE checkout is enabled.
 * Dev - Refactor the processing part of Webhook Controller to a separate service.
 * Dev - Remove type "Tweak" from the list of changelog types.
 * Dev - REST API documentation
+* Dev - Skip e2e tests if WC version is 5.0.0 because of WooCommerce Checkout Blocks minimum WC Required version
 * Dev - Unit test support for PHP 8 and upgrade PHPUnit version to 9.5.14
 * Dev - Updated contribution notes (how to add a changelog)
-* Dev - Skip e2e tests if WC version is 5.0.0 because of WooCommerce Checkout Blocks minimum WC Required version
 
 = 3.8.2 - 2022-03-03 =
 * Fix - Fix fatal error when a subscription renews automatically.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I fixed malformed [changelog entry](https://github.com/Automattic/woocommerce-payments/blob/dd9d319b661427a1d22a5aeab945c23dd429f317/changelog.txt#L27-L28) with this PR: https://github.com/Automattic/woocommerce-payments/pull/4149.

I forgot to sync readme. Hence, this PR.

#### Testing instructions

Make sure the changelog part of `readme.txt` is exactly the same as `changelog.txt`.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)