### PR TITLE
Add more logging info when sending requests to WooCommerce Payments server

### DIFF
--- a/changelog/add-3998-more-data-logging
+++ b/changelog/add-3998-more-data-logging
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add more logging info when sending requests to WooCommerce Payments server.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1878,6 +1878,19 @@ class WC_Payments_API_Client {
 			}
 		}
 
+		$env                    = [];
+		$env['WP_User']         = is_user_logged_in() ? wp_get_current_user()->user_login : 'Guest (non logged-in user)';
+		$env['HTTP_REFERER']    = sanitize_text_field( wp_unslash( $_SERVER['HTTP_REFERER'] ?? '--' ) );
+		$env['HTTP_USER_AGENT'] = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '--' ) );
+		$env['REQUEST_URI']     = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '--' ) );
+		$env['DOING_AJAX']      = defined( 'DOING_AJAX' ) && DOING_AJAX;
+		$env['DOING_CRON']      = defined( 'DOING_CRON' ) && DOING_CRON;
+		$env['WP_CLI']          = defined( 'WP_CLI' ) && WP_CLI;
+		Logger::log(
+			'ENVIRONMENT: '
+			. var_export( $env, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		);
+
 		Logger::log( "REQUEST $method $redacted_url" );
 		Logger::log(
 			'HEADERS: '

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -1536,7 +1536,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 		return [
 			'delete' => [
 				[ [ 'client_secret' => 'some-secret' ], 'abc', 'DELETE' ],
-				3,
+				4,
 				[
 					$this->anything(),
 					$this->callback( $string_should_not_include_secret ),
@@ -1548,7 +1548,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 			],
 			'get'    => [
 				[ [ 'client_secret' => 'some-secret' ], 'abc', 'GET' ],
-				3,
+				4,
 				[
 					$this->anything(),
 					$this->callback( $string_should_not_include_secret ),
@@ -1560,7 +1560,7 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 			],
 			'post'   => [
 				[ [ 'client_secret' => 'some-secret' ], 'abc', 'POST' ],
-				4,
+				5,
 				[
 					$this->anything(),
 					$this->callback( $string_should_not_include_secret ),


### PR DESCRIPTION
Fixes #3998

#### Changes proposed in this Pull Request

- Capture more env info and log them info for this method `WC_Payments_API_Client::request` ,

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your local dev.
* Try to do checkout as a guest, and visit admin pages WP Admin > Payments. This is to trigger requests from your dev site to WCPay Server.
* Look for the latest log file created by WCPay under `wp-content/uploads/wc-uploads`.
* Expect: see `INFO ENVIRONMENT` like the screenshot below. 

![Markup on 2022-04-20 at 15:42:26](https://user-images.githubusercontent.com/10045087/164188703-d812afc1-c62e-4860-abc2-dca37ff81564.png)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] ~Covered with tests~ (or have a good reason not to test in description ☝️)
- [x] ~Tested on mobile~ (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] No need for this simple change. ~Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_~
