### PR TITLE
Remove test_document document type.

### DIFF
--- a/changelog/dev-1837-remove-test-document-type
+++ b/changelog/dev-1837-remove-test-document-type
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Removed test_document document type that was used for testing.
+
+

--- a/client/data/documents/hooks.ts
+++ b/client/data/documents/hooks.ts
@@ -14,7 +14,7 @@ import { STORE_NAME } from '../constants';
 export interface Document {
 	document_id: string;
 	date: string;
-	type: 'test_document' | 'vat_invoice';
+	type: 'vat_invoice';
 	period_from: string;
 	period_to: string;
 }

--- a/client/data/documents/test/reducer.js
+++ b/client/data/documents/test/reducer.js
@@ -11,16 +11,16 @@ describe( 'Documents reducer tests', () => {
 	const mockQuery = { paged: '2', perPage: '50' };
 	const mockDocuments = [
 		{
-			document_id: 'test_doc_12345',
+			document_id: 'vat_invoice_12345',
 			date: '2022-03-15 12:00:00',
-			type: 'test_document',
+			type: 'vat_invoice',
 			period_from: '2022-03-01 00:00:00',
 			period_to: '2022-03-31 23:59:59',
 		},
 		{
-			document_id: 'test_doc_54321',
+			document_id: 'vat_invoice_54321',
 			date: '2022-02-15 12:00:00',
-			type: 'test_document',
+			type: 'vat_invoice',
 			period_from: '2022-02-01 00:00:00',
 			period_to: '2022-02-28 23:59:59',
 		},

--- a/client/data/documents/test/selectors.js
+++ b/client/data/documents/test/selectors.js
@@ -17,16 +17,16 @@ describe( 'Documents selectors', () => {
 	const mockQuery = { paged: '2', perPage: '50' };
 	const mockDocuments = [
 		{
-			document_id: 'test_doc_12345',
+			document_id: 'vat_invoice_12345',
 			date: '2022-03-15 12:00:00',
-			type: 'test_document',
+			type: 'vat_invoice',
 			period_from: '2022-03-01 00:00:00',
 			period_to: '2022-03-31 23:59:59',
 		},
 		{
-			document_id: 'test_doc_54321',
+			document_id: 'vat_invoice_54321',
 			date: '2022-02-15 12:00:00',
-			type: 'test_document',
+			type: 'vat_invoice',
 			period_from: '2022-02-01 00:00:00',
 			period_to: '2022-02-28 23:59:59',
 		},

--- a/client/documents/filters/test/__snapshots__/index.tsx.snap
+++ b/client/documents/filters/test/__snapshots__/index.tsx.snap
@@ -3,11 +3,6 @@
 exports[`Documents filters when filtering by type should render all types 1`] = `
 HTMLOptionsCollection [
   <option
-    value="test_document"
-  >
-    Test Document
-  </option>,
-  <option
     value="vat_invoice"
   >
     VAT Invoice

--- a/client/documents/filters/test/index.tsx
+++ b/client/documents/filters/test/index.tsx
@@ -107,11 +107,11 @@ describe( 'Documents filters', () => {
 			// need to include $ in name, otherwise "Select a document type filter" is also matched.
 			user.selectOptions(
 				screen.getByRole( 'combobox', { name: /document type$/i } ),
-				'test_document'
+				'vat_invoice'
 			);
 			user.click( screen.getByRole( 'link', { name: /Filter/ } ) );
 
-			expect( getQuery().type_is ).toEqual( 'test_document' );
+			expect( getQuery().type_is ).toEqual( 'vat_invoice' );
 		} );
 
 		test( 'should filter by is_not', () => {
@@ -120,11 +120,11 @@ describe( 'Documents filters', () => {
 			// need to include $ in name, otherwise "Select a document type filter" is also matched.
 			user.selectOptions(
 				screen.getByRole( 'combobox', { name: /document type$/i } ),
-				'test_document'
+				'vat_invoice'
 			);
 			user.click( screen.getByRole( 'link', { name: /Filter/ } ) );
 
-			expect( getQuery().type_is_not ).toEqual( 'test_document' );
+			expect( getQuery().type_is_not ).toEqual( 'vat_invoice' );
 		} );
 	} );
 } );

--- a/client/documents/list/index.tsx
+++ b/client/documents/list/index.tsx
@@ -63,26 +63,6 @@ const getColumns = (): Column[] =>
 
 const getDocumentDescription = ( document: Document ) => {
 	switch ( document.type ) {
-		case 'test_document':
-			if ( document.period_from && document.period_to ) {
-				return sprintf(
-					__(
-						'This is a test document for %s to %s',
-						'woocommerce-payments'
-					),
-					dateI18n(
-						'M j, Y',
-						moment.utc( document.period_from ).toISOString(),
-						'utc'
-					),
-					dateI18n(
-						'M j, Y',
-						moment.utc( document.period_to ).toISOString(),
-						'utc'
-					)
-				);
-			}
-			return __( 'This is a test document', 'woocommerce-payments' );
 		case 'vat_invoice':
 			if ( document.period_from && document.period_to ) {
 				return sprintf(

--- a/client/documents/list/test/__snapshots__/index.tsx.snap
+++ b/client/documents/list/test/__snapshots__/index.tsx.snap
@@ -231,18 +231,18 @@ exports[`Documents list renders correctly 1`] = `
                 <td
                   class="woocommerce-table__item is-left-aligned"
                 >
-                  Test Document
+                  VAT Invoice
                 </td>
                 <td
                   class="woocommerce-table__item"
                 >
-                  This is a test document
+                  VAT invoice without proper period dates
                 </td>
                 <td
                   class="woocommerce-table__item is-numeric"
                 >
                   <a
-                    href="https://site.com/wp-json/wc/v3/payments/documents/test_document_123456?_wpnonce=random_wp_rest_nonce"
+                    href="https://site.com/wp-json/wc/v3/payments/documents/vat_invoice_123456?_wpnonce=random_wp_rest_nonce"
                     rel="noopener noreferrer"
                     style="display: inline;"
                     target="_blank"
@@ -261,18 +261,18 @@ exports[`Documents list renders correctly 1`] = `
                 <td
                   class="woocommerce-table__item is-left-aligned"
                 >
-                  Test Document
+                  VAT Invoice
                 </td>
                 <td
                   class="woocommerce-table__item"
                 >
-                  This is a test document
+                  VAT invoice without proper period dates
                 </td>
                 <td
                   class="woocommerce-table__item is-numeric"
                 >
                   <a
-                    href="https://site.com/wp-json/wc/v3/payments/documents/test_document_654321?_wpnonce=random_wp_rest_nonce"
+                    href="https://site.com/wp-json/wc/v3/payments/documents/vat_invoice_654321?_wpnonce=random_wp_rest_nonce"
                     rel="noopener noreferrer"
                     style="display: inline;"
                     target="_blank"
@@ -539,18 +539,18 @@ exports[`Documents list renders table summary only when the documents summary da
                 <td
                   class="woocommerce-table__item is-left-aligned"
                 >
-                  Test Document
+                  VAT Invoice
                 </td>
                 <td
                   class="woocommerce-table__item"
                 >
-                  This is a test document
+                  VAT invoice without proper period dates
                 </td>
                 <td
                   class="woocommerce-table__item is-numeric"
                 >
                   <a
-                    href="https://site.com/wp-json/wc/v3/payments/documents/test_document_123456?_wpnonce=random_wp_rest_nonce"
+                    href="https://site.com/wp-json/wc/v3/payments/documents/vat_invoice_123456?_wpnonce=random_wp_rest_nonce"
                     rel="noopener noreferrer"
                     style="display: inline;"
                     target="_blank"
@@ -569,18 +569,18 @@ exports[`Documents list renders table summary only when the documents summary da
                 <td
                   class="woocommerce-table__item is-left-aligned"
                 >
-                  Test Document
+                  VAT Invoice
                 </td>
                 <td
                   class="woocommerce-table__item"
                 >
-                  This is a test document
+                  VAT invoice without proper period dates
                 </td>
                 <td
                   class="woocommerce-table__item is-numeric"
                 >
                   <a
-                    href="https://site.com/wp-json/wc/v3/payments/documents/test_document_654321?_wpnonce=random_wp_rest_nonce"
+                    href="https://site.com/wp-json/wc/v3/payments/documents/vat_invoice_654321?_wpnonce=random_wp_rest_nonce"
                     rel="noopener noreferrer"
                     style="display: inline;"
                     target="_blank"

--- a/client/documents/list/test/index.tsx
+++ b/client/documents/list/test/index.tsx
@@ -38,16 +38,16 @@ declare const global: {
 
 const getMockDocuments: () => Document[] = () => [
 	{
-		document_id: 'test_document_123456',
+		document_id: 'vat_invoice_123456',
 		date: '2020-01-02 17:46:02',
-		type: 'test_document',
+		type: 'vat_invoice',
 		period_from: '',
 		period_to: '',
 	},
 	{
-		document_id: 'test_document_654321',
+		document_id: 'vat_invoice_654321',
 		date: '2020-01-05 04:22:59',
-		type: 'test_document',
+		type: 'vat_invoice',
 		period_from: '',
 		period_to: '',
 	},

--- a/client/documents/strings.ts
+++ b/client/documents/strings.ts
@@ -7,6 +7,5 @@ import { __ } from '@wordpress/i18n';
 
 // Mapping of transaction types to display string.
 export const displayType = {
-	test_document: __( 'Test Document', 'woocommerce-payments' ),
 	vat_invoice: __( 'VAT Invoice', 'woocommerce-payments' ),
 };

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -1662,9 +1662,9 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 			[
 				'data' => [
 					[
-						'document_id' => 'test_document_1',
+						'document_id' => 'vat_invoice_1',
 						'date'        => '2020-01-02 17:46:02',
-						'type'        => 'test_document',
+						'type'        => 'vat_invoice',
 						'period_from' => '2020-01-01 00:00:00',
 						'period_to'   => '2020-01-31 23:59:59',
 					],
@@ -1674,9 +1674,9 @@ class WC_Payments_API_Client_Test extends WP_UnitTestCase {
 
 		$documents = $this->payments_api_client->list_documents();
 
-		$this->assertSame( 'test_document_1', $documents['data'][0]['document_id'] );
+		$this->assertSame( 'vat_invoice_1', $documents['data'][0]['document_id'] );
 		$this->assertSame( '2020-01-02 17:46:02', $documents['data'][0]['date'] );
-		$this->assertSame( 'test_document', $documents['data'][0]['type'] );
+		$this->assertSame( 'vat_invoice', $documents['data'][0]['type'] );
 		$this->assertSame( '2020-01-01 00:00:00', $documents['data'][0]['period_from'] );
 		$this->assertSame( '2020-01-31 23:59:59', $documents['data'][0]['period_to'] );
 	}


### PR DESCRIPTION
Fixes 1837-gh-Automattic/woocommerce-payments-server

#### Changes proposed in this Pull Request

This PR removes the `test_document` type from the code.

#### Testing instructions

* Tests should pass.
* Go to Payments > Documents.
  * You must have to Documents section enabled in the Dev Tools settings.
* Confirm the advanced filters no longer have the _Test Document_ option.
* If you had test documents in your account, they should now list on the page as _Unknown document_.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_