### PR TITLE
Fix missing `customer_id` on platform checkout

### DIFF
--- a/changelog/as-fix-missing-customer_id
+++ b/changelog/as-fix-missing-customer_id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing customer_id on platform checkout

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -812,6 +812,17 @@ class WC_Payments {
 	}
 
 	/**
+	 * Sets the customer service instance. This is needed only for tests.
+	 *
+	 * @param WC_Payments_Customer_Service $customer_service_class Instance of WC_Payments_Customer_Service.
+	 *
+	 * @return void
+	 */
+	public static function set_customer_service( WC_Payments_Customer_Service $customer_service_class ) {
+		self::$customer_service = $customer_service_class;
+	}
+
+	/**
 	 * Registers the payment method with the blocks registry.
 	 *
 	 * @param Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry The registry.
@@ -942,7 +953,7 @@ class WC_Payments {
 		if ( null === $customer_id ) {
 			// create customer.
 			$customer_data = WC_Payments_Customer_Service::map_customer_data( null, new WC_Customer( $user->ID ) );
-			self::$customer_service->create_customer_for_user( $user, $customer_data );
+			$customer_id   = self::$customer_service->create_customer_for_user( $user, $customer_data );
 		}
 
 		$account_id = self::get_account_service()->get_stripe_account_id();

--- a/tests/unit/test-class-wc-payments.php
+++ b/tests/unit/test-class-wc-payments.php
@@ -91,7 +91,7 @@ class WC_Payments_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'woocommerce_rest_missing_nonce', $response->get_data()['code'] );
 	}
 
-	public function test_ajax_init_platform_checkout_sends_correct_data() {
+	public function test_ajax_init_platform_checkout_sends_correct_customer_id() {
 		// Necessary in order to prevent die from being called.
 		define( 'DOING_AJAX', true );
 


### PR DESCRIPTION
Fixes platform checkout issue 822

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Assigns the recently created customer Id to `$customer_id`. It seems that was the initial intention.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To reproduce the error you'll need to run the following steps while using the `dev` branch for the WC Payments plugin on your merchant store.

- You need to log in on the platform first with your customer account.
- Delete all cookies on the **merchant store** (while still logged on the platform).
- Add at least a product to the cart.
- Go to the checkout page.
- Enter your customer email.
- Enter the code (00000) in the popup.
- Click the "Place Order" button
- You'll see the error banner and the error in the log.

To test the fix:

Run the same steps above but in the end you'll see no error and no error should be logged.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_