### PR TITLE
Add VAT details form when downloading invoice

### DIFF
--- a/changelog/add-3934-vat-data-form
+++ b/changelog/add-3934-vat-data-form
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Feature behind the documents feature flag. Will be announced when the documents feature is released.
+
+

--- a/client/documents/list/index.tsx
+++ b/client/documents/list/index.tsx
@@ -118,15 +118,32 @@ export const DocumentsList = (): JSX.Element => {
 
 	const [ isVatFormModalOpen, setVatFormModalOpen ] = useState( false );
 
-	const handleDocumentDownload = (
+	const [
+		clickedDownloadLink,
+		setClickedDownloadLink,
+	] = useState< HTMLElement | null >( null );
+
+	const handleDocumentDownload = async (
 		document: Document,
 		event: MouseEvent
 	) => {
+		setClickedDownloadLink( event.currentTarget as HTMLElement );
+
 		if ( 'vat_invoice' === document.type ) {
 			if ( ! wcpaySettings.accountStatus.hasSubmittedVatData ) {
 				setVatFormModalOpen( true );
 				event.preventDefault();
 			}
+		}
+	};
+
+	const onVatFormCompleted = () => {
+		setVatFormModalOpen( false );
+		// Set the flag to true so that the user can download the document without refreshing the page.
+		wcpaySettings.accountStatus.hasSubmittedVatData = true;
+		// Fire the click event again, once the VAT details have been submitted.
+		if ( clickedDownloadLink ) {
+			clickedDownloadLink.click();
 		}
 	};
 
@@ -220,7 +237,7 @@ export const DocumentsList = (): JSX.Element => {
 			<VatFormModal
 				isModalOpen={ isVatFormModalOpen }
 				setModalOpen={ setVatFormModalOpen }
-				onCompleted={ () => ( {} ) }
+				onCompleted={ onVatFormCompleted }
 			/>
 		</Page>
 	);

--- a/client/documents/list/index.tsx
+++ b/client/documents/list/index.tsx
@@ -220,6 +220,7 @@ export const DocumentsList = (): JSX.Element => {
 			<VatFormModal
 				isModalOpen={ isVatFormModalOpen }
 				setModalOpen={ setVatFormModalOpen }
+				onCompleted={ () => ( {} ) }
 			/>
 		</Page>
 	);

--- a/client/documents/list/test/index.tsx
+++ b/client/documents/list/test/index.tsx
@@ -14,11 +14,15 @@ import { getQuery } from '@woocommerce/navigation';
 import { DocumentsList } from '../';
 import { useDocuments, useDocumentsSummary } from 'data/index';
 import type { Document } from 'data/documents/hooks';
+import { mocked } from 'ts-jest/utils';
+import VatForm from 'wcpay/vat/form';
 
 jest.mock( 'data/index', () => ( {
 	useDocuments: jest.fn(),
 	useDocumentsSummary: jest.fn(),
 } ) );
+
+jest.mock( 'wcpay/vat/form', () => jest.fn() );
 
 const mockUseDocuments = useDocuments as jest.MockedFunction<
 	typeof useDocuments
@@ -175,6 +179,20 @@ describe( 'Document download button', () => {
 				isLoading: false,
 				documentsError: undefined,
 			} );
+
+			mocked( VatForm ).mockImplementation( ( { onCompleted } ) => (
+				<button
+					onClick={ () =>
+						onCompleted(
+							'123456789',
+							'Test company',
+							'Test address'
+						)
+					}
+				>
+					Complete
+				</button>
+			) );
 		} );
 
 		describe( 'if VAT data has been submitted', () => {
@@ -229,6 +247,38 @@ describe( 'Document download button', () => {
 				expect(
 					screen.getByRole( 'dialog', { name: 'VAT details' } )
 				).toBeVisible();
+			} );
+
+			describe( 'after the VAT details are submitted', () => {
+				const mockButtonOnClick = jest.fn();
+
+				beforeEach( () => {
+					user.click( downloadButton );
+
+					// Add a mock button onclick handler to assert that it's been called a second time.
+					downloadButton.addEventListener(
+						'click',
+						mockButtonOnClick
+					);
+
+					user.click( screen.getByText( 'Complete' ) );
+				} );
+
+				it( 'should close the modal', () => {
+					expect(
+						screen.queryByRole( 'dialog', { name: 'VAT details' } )
+					).toBeNull();
+				} );
+
+				it( 'should set the hasSubmittedVatData flag to true', () => {
+					expect(
+						wcpaySettings.accountStatus.hasSubmittedVatData
+					).toBe( true );
+				} );
+
+				it( 'should automatically click on the download button', () => {
+					expect( mockButtonOnClick ).toHaveBeenCalled();
+				} );
 			} );
 		} );
 	} );

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -10,6 +10,7 @@ declare const wcpaySettings: {
 	accountStatus: {
 		error?: boolean;
 		status?: string;
+		country?: string;
 		hasSubmittedVatData?: boolean;
 	};
 	accountLoans: {

--- a/client/vat/form-modal/index.tsx
+++ b/client/vat/form-modal/index.tsx
@@ -25,8 +25,6 @@ const VatFormModal = ( {
 	return isModalOpen ? (
 		<Modal
 			title={ __( 'VAT details', 'woocommerce-payments' ) }
-			isDismissible={ false }
-			shouldCloseOnClickOutside={ true }
 			onRequestClose={ () => setModalOpen( false ) }
 		>
 			<VatForm onCompleted={ onCompleted } />

--- a/client/vat/form-modal/index.tsx
+++ b/client/vat/form-modal/index.tsx
@@ -11,13 +11,16 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import VatForm from '../form';
+import { VatFormOnCompleted } from '../types';
 
 const VatFormModal = ( {
 	isModalOpen,
 	setModalOpen,
+	onCompleted,
 }: {
 	isModalOpen: boolean;
 	setModalOpen: ( value: boolean ) => void;
+	onCompleted: VatFormOnCompleted;
 } ): JSX.Element | null => {
 	return isModalOpen ? (
 		<Modal
@@ -26,7 +29,7 @@ const VatFormModal = ( {
 			shouldCloseOnClickOutside={ true }
 			onRequestClose={ () => setModalOpen( false ) }
 		>
-			<VatForm />
+			<VatForm onCompleted={ onCompleted } />
 		</Modal>
 	) : null;
 };

--- a/client/vat/form-modal/index.tsx
+++ b/client/vat/form-modal/index.tsx
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import VatForm from '../form';
 
 const VatFormModal = ( {
 	isModalOpen,
@@ -25,7 +26,7 @@ const VatFormModal = ( {
 			shouldCloseOnClickOutside={ true }
 			onRequestClose={ () => setModalOpen( false ) }
 		>
-			<p>VAT Form</p>
+			<VatForm />
 		</Modal>
 	) : null;
 };

--- a/client/vat/form-modal/test/__snapshots__/index.tsx.snap
+++ b/client/vat/form-modal/test/__snapshots__/index.tsx.snap
@@ -24,6 +24,24 @@ exports[`VAT form modal should render the VAT Form 1`] = `
           VAT details
         </h1>
       </div>
+      <button
+        aria-label="Close dialog"
+        class="components-button has-icon"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          role="img"
+          size="24"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"
+          />
+        </svg>
+      </button>
     </div>
     <p>
       VAT Form

--- a/client/vat/form-modal/test/index.tsx
+++ b/client/vat/form-modal/test/index.tsx
@@ -22,7 +22,11 @@ describe( 'VAT form modal', () => {
 
 	it( 'should render when isModalOpen is true', () => {
 		render(
-			<VatFormModal isModalOpen={ true } setModalOpen={ () => ( {} ) } />
+			<VatFormModal
+				isModalOpen={ true }
+				setModalOpen={ () => ( {} ) }
+				onCompleted={ () => ( {} ) }
+			/>
 		);
 		expect(
 			screen.getByRole( 'dialog', { name: 'VAT details' } )
@@ -31,7 +35,11 @@ describe( 'VAT form modal', () => {
 
 	it( 'should not render when isModalOpen is false', () => {
 		render(
-			<VatFormModal isModalOpen={ false } setModalOpen={ () => ( {} ) } />
+			<VatFormModal
+				isModalOpen={ false }
+				setModalOpen={ () => ( {} ) }
+				onCompleted={ () => ( {} ) }
+			/>
 		);
 		expect(
 			screen.queryByRole( 'dialog', { name: 'VAT details' } )
@@ -40,7 +48,11 @@ describe( 'VAT form modal', () => {
 
 	it( 'should render the VAT Form', () => {
 		render(
-			<VatFormModal isModalOpen={ true } setModalOpen={ () => ( {} ) } />
+			<VatFormModal
+				isModalOpen={ true }
+				setModalOpen={ () => ( {} ) }
+				onCompleted={ () => ( {} ) }
+			/>
 		);
 		expect(
 			screen.getByRole( 'dialog', { name: 'VAT details' } )

--- a/client/vat/form-modal/test/index.tsx
+++ b/client/vat/form-modal/test/index.tsx
@@ -5,13 +5,21 @@
  */
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { mocked } from 'ts-jest/utils';
 
 /**
  * Internal dependencies
  */
 import VatFormModal from '..';
+import VatForm from '../../form';
+
+jest.mock( '../../form', () => jest.fn() );
 
 describe( 'VAT form modal', () => {
+	beforeEach( () => {
+		mocked( VatForm ).mockReturnValue( <p>VAT Form</p> );
+	} );
+
 	it( 'should render when isModalOpen is true', () => {
 		render(
 			<VatFormModal isModalOpen={ true } setModalOpen={ () => ( {} ) } />

--- a/client/vat/form-modal/test/index.tsx
+++ b/client/vat/form-modal/test/index.tsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import user from '@testing-library/user-event';
 import React from 'react';
 import { mocked } from 'ts-jest/utils';
 
@@ -57,5 +58,32 @@ describe( 'VAT form modal', () => {
 		expect(
 			screen.getByRole( 'dialog', { name: 'VAT details' } )
 		).toMatchSnapshot();
+	} );
+
+	it( 'should close when clicking on the dismiss button', () => {
+		let isModalOpen = true;
+		const setModalOpen = ( value: boolean ) => ( isModalOpen = value );
+		const { rerender } = render(
+			<VatFormModal
+				isModalOpen={ isModalOpen }
+				setModalOpen={ setModalOpen }
+				onCompleted={ () => ( {} ) }
+			/>
+		);
+
+		user.click( screen.getByRole( 'button', { name: 'Close dialog' } ) );
+
+		// The isModalOpen prop should have changed, so we need to force a rerender.
+		rerender(
+			<VatFormModal
+				isModalOpen={ isModalOpen }
+				setModalOpen={ setModalOpen }
+				onCompleted={ () => ( {} ) }
+			/>
+		);
+
+		expect(
+			screen.queryByRole( 'dialog', { name: 'VAT details' } )
+		).toBeNull();
 	} );
 } );

--- a/client/vat/form/index.tsx
+++ b/client/vat/form/index.tsx
@@ -4,21 +4,25 @@
  * External dependencies
  */
 import React, { useState } from 'react';
+import Wizard from 'wcpay/additional-methods-setup/wizard/wrapper';
 import WizardTask from 'wcpay/additional-methods-setup/wizard/task';
 import WizardTaskList from 'wcpay/additional-methods-setup/wizard/task-list';
-import Wizard from 'wcpay/additional-methods-setup/wizard/wrapper';
 
 /**
  * Internal dependencies
  */
+import { VatFormOnCompleted } from '../types';
+import { CompanyDataTask } from './tasks/company-data-task';
 import { VatNumberTask } from './tasks/vat-number-task';
 
-const VatForm = (): JSX.Element => {
-	/* eslint-disable @typescript-eslint/no-unused-vars */
+const VatForm = ( {
+	onCompleted,
+}: {
+	onCompleted: VatFormOnCompleted;
+} ): JSX.Element => {
 	const [ vatNumber, setVatNumber ] = useState< string | null >( null );
 	const [ name, setName ] = useState< string >( '' );
 	const [ address, setAddress ] = useState< string >( '' );
-	/* eslint-enable @typescript-eslint/no-unused-vars */
 
 	const onVatNumberCompleted = (
 		newVatNumber: string | null,
@@ -30,11 +34,27 @@ const VatForm = (): JSX.Element => {
 		setAddress( companyAddress );
 	};
 
+	const onCompanyDataCompleted = (
+		companyVatNumber: string | null,
+		companyName: string,
+		companyAddress: string
+	): void => {
+		onCompleted( companyVatNumber, companyName, companyAddress );
+	};
+
 	return (
 		<Wizard defaultActiveTask="vat-number">
 			<WizardTaskList>
 				<WizardTask id="vat-number">
 					<VatNumberTask onCompleted={ onVatNumberCompleted } />
+				</WizardTask>
+				<WizardTask id="company-data">
+					<CompanyDataTask
+						onCompleted={ onCompanyDataCompleted }
+						vatNumber={ vatNumber }
+						placeholderCompanyName={ name }
+						placeholderCompanyAddress={ address }
+					/>
 				</WizardTask>
 			</WizardTaskList>
 		</Wizard>

--- a/client/vat/form/index.tsx
+++ b/client/vat/form/index.tsx
@@ -1,0 +1,44 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import React, { useState } from 'react';
+import WizardTask from 'wcpay/additional-methods-setup/wizard/task';
+import WizardTaskList from 'wcpay/additional-methods-setup/wizard/task-list';
+import Wizard from 'wcpay/additional-methods-setup/wizard/wrapper';
+
+/**
+ * Internal dependencies
+ */
+import { VatNumberTask } from './tasks/vat-number-task';
+
+const VatForm = (): JSX.Element => {
+	/* eslint-disable @typescript-eslint/no-unused-vars */
+	const [ vatNumber, setVatNumber ] = useState< string | null >( null );
+	const [ name, setName ] = useState< string >( '' );
+	const [ address, setAddress ] = useState< string >( '' );
+	/* eslint-enable @typescript-eslint/no-unused-vars */
+
+	const onVatNumberCompleted = (
+		newVatNumber: string | null,
+		companyName: string,
+		companyAddress: string
+	): void => {
+		setVatNumber( newVatNumber );
+		setName( companyName );
+		setAddress( companyAddress );
+	};
+
+	return (
+		<Wizard defaultActiveTask="vat-number">
+			<WizardTaskList>
+				<WizardTask id="vat-number">
+					<VatNumberTask onCompleted={ onVatNumberCompleted } />
+				</WizardTask>
+			</WizardTaskList>
+		</Wizard>
+	);
+};
+
+export default VatForm;

--- a/client/vat/form/style.scss
+++ b/client/vat/form/style.scss
@@ -1,0 +1,4 @@
+.components-notice.vat-number-error {
+	margin: 0;
+	margin-top: 15px;
+}

--- a/client/vat/form/tasks/company-data-task.tsx
+++ b/client/vat/form/tasks/company-data-task.tsx
@@ -3,7 +3,12 @@
 /**
  * External dependencies
  */
-import { Button, Notice, TextControl } from '@wordpress/components';
+import {
+	Button,
+	Notice,
+	TextareaControl,
+	TextControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import React, { useContext, useEffect, useState } from 'react';
 import CollapsibleBody from 'wcpay/additional-methods-setup/wizard/collapsible-body';
@@ -100,7 +105,7 @@ export const CompanyDataTask = ( {
 					onChange={ setCompanyName }
 				/>
 
-				<TextControl
+				<TextareaControl
 					label={ __( 'Address', 'woocommerce-payments' ) }
 					value={ companyAddress }
 					onChange={ setCompanyAddress }

--- a/client/vat/form/tasks/company-data-task.tsx
+++ b/client/vat/form/tasks/company-data-task.tsx
@@ -1,0 +1,130 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { Button, Notice, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import React, { useContext, useEffect, useState } from 'react';
+import CollapsibleBody from 'wcpay/additional-methods-setup/wizard/collapsible-body';
+import WizardTaskItem from 'wcpay/additional-methods-setup/wizard/task-item';
+import WizardTaskContext from 'wcpay/additional-methods-setup/wizard/task/context';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import {
+	VatError,
+	VatFormOnCompleted,
+	VatSaveDetails,
+	VatSaveDetailsResult,
+} from '../../types';
+
+export const CompanyDataTask = ( {
+	onCompleted,
+	vatNumber,
+	placeholderCompanyName,
+	placeholderCompanyAddress,
+}: {
+	onCompleted: VatFormOnCompleted;
+	vatNumber: string | null;
+	placeholderCompanyName: string;
+	placeholderCompanyAddress: string;
+} ): JSX.Element => {
+	const { setCompleted } = useContext( WizardTaskContext );
+
+	const [ saveDetailsError, setSaveDetailsError ] = useState< string | null >(
+		null
+	);
+	const [ isLoading, setLoading ] = useState< boolean >( false );
+
+	const [ companyName, setCompanyName ] = useState< string >( '' );
+	const [ companyAddress, setCompanyAddress ] = useState< string >( '' );
+
+	// Update placeholder values when props change.
+	useEffect( () => {
+		setCompanyName( placeholderCompanyName );
+		setCompanyAddress( placeholderCompanyAddress );
+	}, [ placeholderCompanyName, placeholderCompanyAddress ] );
+
+	const isConfirmButtonDisabled =
+		companyName.trim() === '' || companyAddress.trim() === '';
+
+	const submit = async () => {
+		try {
+			setLoading( true );
+
+			const details: VatSaveDetails = {
+				name: companyName,
+				address: companyAddress,
+			};
+
+			if ( vatNumber !== null ) {
+				details.vat_number = vatNumber;
+			}
+
+			const savedDetails = await apiFetch< VatSaveDetailsResult >( {
+				path: '/wc/v3/payments/vat',
+				method: 'POST',
+				data: details,
+			} );
+
+			setLoading( false );
+
+			setCompleted( true, 'vat-submitted' );
+			onCompleted(
+				savedDetails.vat_number,
+				savedDetails.name,
+				savedDetails.address
+			);
+		} catch ( error ) {
+			setLoading( false );
+			setSaveDetailsError( ( error as VatError ).message );
+		}
+	};
+
+	return (
+		<WizardTaskItem
+			index={ 2 }
+			title={ __(
+				'Confirm your business details',
+				'woocommerce-payments'
+			) }
+			className={ null }
+		>
+			<CollapsibleBody className={ null }>
+				<TextControl
+					label={ __( 'Business name', 'woocommerce-payments' ) }
+					value={ companyName }
+					onChange={ setCompanyName }
+				/>
+
+				<TextControl
+					label={ __( 'Address', 'woocommerce-payments' ) }
+					value={ companyAddress }
+					onChange={ setCompanyAddress }
+				/>
+
+				<Button
+					isPrimary
+					disabled={ isConfirmButtonDisabled || isLoading }
+					isBusy={ isLoading }
+					onClick={ submit }
+				>
+					{ __( 'Confirm', 'woocommerce-payments' ) }
+				</Button>
+
+				{ saveDetailsError && (
+					<Notice
+						status="error"
+						isDismissible={ false }
+						className="vat-number-error"
+					>
+						{ saveDetailsError }
+					</Notice>
+				) }
+			</CollapsibleBody>
+		</WizardTaskItem>
+	);
+};

--- a/client/vat/form/tasks/vat-number-task.tsx
+++ b/client/vat/form/tasks/vat-number-task.tsx
@@ -1,0 +1,159 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import {
+	Button,
+	CheckboxControl,
+	Notice,
+	TextControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import React, { useContext, useState } from 'react';
+import CollapsibleBody from 'wcpay/additional-methods-setup/wizard/collapsible-body';
+import WizardTaskItem from 'wcpay/additional-methods-setup/wizard/task-item';
+import WizardTaskContext from 'wcpay/additional-methods-setup/wizard/task/context';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { VatError, VatFormOnCompleted, VatValidationResult } from '../../types';
+import '../style.scss';
+
+const getVatPrefix = () => {
+	switch ( wcpaySettings.accountStatus.country ) {
+		case 'GR':
+			return 'EL ';
+		case 'CH':
+			return 'CHE ';
+		default:
+			return `${ wcpaySettings.accountStatus.country } `;
+	}
+};
+
+export const VatNumberTask = ( {
+	onCompleted,
+}: {
+	onCompleted: VatFormOnCompleted;
+} ): JSX.Element => {
+	const { setCompleted } = useContext( WizardTaskContext );
+
+	const [ vatValidationError, setVatValidationError ] = useState<
+		string | null
+	>( null );
+	const [ isLoading, setLoading ] = useState< boolean >( false );
+
+	const [ isVatRegistered, setVatRegistered ] = useState< boolean >( false );
+	const [ vatNumber, setVatNumber ] = useState< string >( '' );
+
+	const vatNumberPrefix = getVatPrefix();
+
+	const isVatButtonDisabled =
+		isVatRegistered && vatNumber.trimEnd() === vatNumberPrefix.trimEnd();
+
+	// Reset VAT number to default value if prefix is changed.
+	if ( ! vatNumber.startsWith( vatNumberPrefix ) ) {
+		setVatNumber( vatNumberPrefix );
+	}
+
+	const submit = async () => {
+		const normalizedVatNumber = isVatRegistered
+			? vatNumber.replace( vatNumberPrefix, '' )
+			: null;
+
+		let companyName = '';
+		let companyAddress = '';
+
+		setVatValidationError( '' );
+
+		try {
+			if ( null !== normalizedVatNumber ) {
+				setLoading( true );
+
+				const validationResult = await apiFetch< VatValidationResult >(
+					{
+						path: `/wc/v3/payments/vat/${ encodeURI(
+							normalizedVatNumber
+						) }`,
+					}
+				);
+
+				setLoading( false );
+
+				companyName = validationResult.name ?? '';
+				companyAddress = validationResult.address ?? '';
+			}
+
+			setCompleted( true, 'company-data' );
+			onCompleted( normalizedVatNumber, companyName, companyAddress );
+		} catch ( error ) {
+			setLoading( false );
+			setVatValidationError( ( error as VatError ).message );
+		}
+	};
+
+	return (
+		<WizardTaskItem
+			index={ 1 }
+			title={ __(
+				'Update your VAT information',
+				'woocommerce-payments'
+			) }
+			className={ null }
+		>
+			<p className="wcpay-wizard-task__description-element">
+				{ __(
+					'VAT information saved on this page will be applied to all of your account’s receipts.',
+					'woocommerce-payments'
+				) }
+			</p>
+
+			<CollapsibleBody className={ null }>
+				<CheckboxControl
+					checked={ isVatRegistered }
+					onChange={ setVatRegistered }
+					label={ __(
+						'I’m registered for a VAT number',
+						'woocommerce-payments'
+					) }
+					help={ __(
+						'If your sales exceed the VAT threshold for your country, you’re required to register for a VAT number.',
+						'woocommerce-payments'
+					) }
+				/>
+				{ isVatRegistered && (
+					<TextControl
+						label={ __( 'VAT Number', 'woocommerce-payments' ) }
+						help={ __(
+							'This is 8 to 12 digits with your country code prefix, for example DE 123456789.',
+							'woocommerce-payments'
+						) }
+						value={ vatNumber }
+						onChange={ setVatNumber }
+					/>
+				) }
+
+				<Button
+					isPrimary
+					disabled={ isVatButtonDisabled || isLoading }
+					isBusy={ isLoading }
+					onClick={ submit }
+				>
+					{ __( 'Continue', 'woocommerce-payments' ) }
+				</Button>
+
+				{ vatValidationError && (
+					<Notice
+						status="error"
+						isDismissible={ false }
+						className="vat-number-error"
+					>
+						{ vatValidationError }
+					</Notice>
+				) }
+			</CollapsibleBody>
+		</WizardTaskItem>
+	);
+};

--- a/client/vat/form/test/index.tsx
+++ b/client/vat/form/test/index.tsx
@@ -1,0 +1,173 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import React from 'react';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import VatForm from '..';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
+
+const waitForVatValidationRequest = async ( vatNumber: string ) => {
+	return waitFor( () => {
+		expect( mockApiFetch ).toHaveBeenCalledWith( {
+			path: `/wc/v3/payments/vat/${ vatNumber }`,
+		} );
+	} );
+};
+
+declare const global: {
+	wcpaySettings: {
+		accountStatus: {
+			country: string;
+		};
+	};
+};
+
+const countries = [
+	[ 'GB', 'GB' ],
+	[ 'DE', 'DE' ],
+	[ 'GR', 'EL' ],
+	[ 'CH', 'CHE' ],
+];
+
+describe( 'VAT form', () => {
+	it.each( countries )(
+		'should display the right prefix for country %s',
+		( country, expectedPrefix ) => {
+			global.wcpaySettings = {
+				accountStatus: { country: country },
+			};
+
+			render( <VatForm /> );
+
+			user.click(
+				screen.getByLabelText( 'I’m registered for a VAT number' )
+			);
+
+			expect(
+				screen.getByRole( 'textbox', { name: 'VAT Number' } )
+			).toHaveValue( `${ expectedPrefix } ` );
+		}
+	);
+} );
+
+describe( 'VAT form', () => {
+	beforeEach( () => {
+		global.wcpaySettings = {
+			accountStatus: { country: 'GB' },
+		};
+
+		render( <VatForm /> );
+	} );
+
+	it( 'should display a check box to select if registered for VAT', () => {
+		screen.getByLabelText( 'I’m registered for a VAT number' );
+	} );
+
+	it( 'should start with the first task active', () => {
+		expect( screen.getByRole( 'list' ).firstChild ).toHaveClass(
+			'is-active'
+		);
+		expect( screen.getByRole( 'list' ).firstChild ).not.toHaveClass(
+			'is-completed'
+		);
+	} );
+
+	describe( 'when not registered for VAT', () => {
+		it( 'should enable the Continue button', () => {
+			expect( screen.getByText( 'Continue' ) ).toBeEnabled();
+		} );
+
+		it( 'should proceed to the company-data step when submitted', () => {
+			user.click( screen.getByText( 'Continue' ) );
+
+			expect( screen.getByRole( 'list' ).firstChild ).toHaveClass(
+				'is-completed'
+			);
+		} );
+	} );
+
+	describe( 'when registered for VAT', () => {
+		beforeEach( () => {
+			user.click(
+				screen.getByLabelText( 'I’m registered for a VAT number' )
+			);
+		} );
+
+		it( 'should disable the Continue button', () => {
+			expect( screen.getByText( 'Continue' ) ).toBeDisabled();
+		} );
+
+		it( 'should not allow the prefix to be removed', () => {
+			const input = screen.getByRole( 'textbox', { name: 'VAT Number' } );
+
+			user.clear( input );
+			// Due to the way clear works, we need to "simulate" a keypress with
+			// user.type to fire a change event.
+			user.type( input, ' ' );
+
+			expect( input ).toHaveValue( 'GB ' );
+		} );
+
+		describe( 'after filling a VAT number', () => {
+			beforeEach( () => {
+				user.type(
+					screen.getByRole( 'textbox', { name: 'VAT Number' } ),
+					'123456789'
+				);
+			} );
+
+			it( 'should enable the Continue button', () => {
+				expect( screen.getByText( 'Continue' ) ).toBeEnabled();
+			} );
+
+			it( 'should display an error message when an invalid VAT number is submitted', async () => {
+				mockApiFetch.mockRejectedValue(
+					new Error( 'The provided VAT number failed validation' )
+				);
+
+				user.click( screen.getByText( 'Continue' ) );
+
+				await waitForVatValidationRequest( '123456789' );
+
+				expect( screen.getByRole( 'list' ).firstChild ).not.toHaveClass(
+					'is-completed'
+				);
+
+				// This will fail if no notices are in the document, and will pass if one or more are found.
+				// The "more" part is needed because notices are added twice to the document due to a11y.
+				screen.getAllByText(
+					'The provided VAT number failed validation'
+				);
+			} );
+
+			it( 'should proceed to the company-data step when a valid VAT number is submitted', async () => {
+				mockApiFetch.mockResolvedValue( {
+					address: 'Test address',
+					country_code: 'GB',
+					name: 'Test company',
+					valid: true,
+					vat_number: '123456789',
+				} );
+
+				user.click( screen.getByText( 'Continue' ) );
+
+				await waitForVatValidationRequest( '123456789' );
+
+				expect( screen.getByRole( 'list' ).firstChild ).toHaveClass(
+					'is-completed'
+				);
+			} );
+		} );
+	} );
+} );

--- a/client/vat/types.d.ts
+++ b/client/vat/types.d.ts
@@ -1,0 +1,18 @@
+export interface VatValidationResult {
+	address: string | null;
+	country_code: string;
+	name: string | null;
+	valid: boolean;
+	vat_number: string;
+}
+
+export type VatFormOnCompleted = (
+	vatNumber: string | null,
+	companyName: string,
+	companyAddress: string
+) => void;
+
+export interface VatError {
+	code: string;
+	message: string;
+}

--- a/client/vat/types.d.ts
+++ b/client/vat/types.d.ts
@@ -6,6 +6,18 @@ export interface VatValidationResult {
 	vat_number: string;
 }
 
+export interface VatSaveDetails {
+	vat_number?: string;
+	name: string;
+	address: string;
+}
+
+export interface VatSaveDetailsResult {
+	vat_number: string | null;
+	name: string;
+	address: string;
+}
+
 export type VatFormOnCompleted = (
 	vatNumber: string | null,
 	companyName: string,

--- a/includes/admin/class-wc-rest-payments-vat-controller.php
+++ b/includes/admin/class-wc-rest-payments-vat-controller.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Class WC_REST_Payments_VAT_Controller
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+use WCPay\Exceptions\API_Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST controller for vat.
+ */
+class WC_REST_Payments_VAT_Controller extends WC_Payments_REST_Controller {
+
+	/**
+	 * Endpoint path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'payments/vat';
+
+	/**
+	 * Configure REST API routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<vat_number>[\w\.\%]+)',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'validate_vat' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				'methods'             => WP_REST_Server::EDITABLE,
+				'args'                => [
+					'vat_number' => [
+						'type'     => 'string',
+						'required' => false,
+					],
+					'name'       => [
+						'type'     => 'string',
+						'required' => true,
+					],
+					'address'    => [
+						'type'     => 'string',
+						'required' => true,
+					],
+				],
+				'callback'            => [ $this, 'save_vat_details' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+	}
+
+	/**
+	 * Validate VAT number to respond with via API.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public function validate_vat( $request ) {
+		$vat_number = $request->get_param( 'vat_number' );
+		return $this->forward_request( 'validate_vat', [ $vat_number ] );
+	}
+
+	/**
+	 * Save VAT details and respond via API.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public function save_vat_details( $request ) {
+		$vat_number = $request->get_param( 'vat_number' );
+		$name       = $request->get_param( 'name' );
+		$address    = $request->get_param( 'address' );
+		return $this->forward_request( 'save_vat_details', [ $vat_number, $name, $address ] );
+	}
+}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -179,6 +179,7 @@ class WC_Payments_Account {
 
 		return [
 			'email'               => $account['email'] ?? '',
+			'country'             => $account['country'] ?? 'US',
 			'status'              => $account['status'],
 			'paymentsEnabled'     => $account['payments_enabled'],
 			'depositsStatus'      => $account['deposits_status'],

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -710,6 +710,10 @@ class WC_Payments {
 			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-documents-controller.php';
 			$documents_controller = new WC_REST_Payments_Documents_Controller( self::$api_client );
 			$documents_controller->register_routes();
+
+			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-vat-controller.php';
+			$vat_controller = new WC_REST_Payments_VAT_Controller( self::$api_client );
+			$vat_controller->register_routes();
 		}
 	}
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -60,6 +60,7 @@ class WC_Payments_API_Client {
 	const CAPITAL_API                  = 'capital';
 	const WEBHOOK_FETCH_API            = 'webhook/failed_events';
 	const DOCUMENTS_API                = 'documents';
+	const VAT_API                      = 'vat';
 
 	/**
 	 * Common keys in API requests/responses that we might want to redact.
@@ -1822,6 +1823,42 @@ class WC_Payments_API_Client {
 	 */
 	public function get_document( $document_id ) {
 		return $this->request( [], self::DOCUMENTS_API . '/' . $document_id, self::GET, true, false, true );
+	}
+
+	/**
+	 * Validates a VAT number on the server and returns the full response.
+	 *
+	 * @param string $vat_number The VAT number.
+	 *
+	 * @return array HTTP response on success.
+	 *
+	 * @throws API_Exception - If not connected or request failed.
+	 */
+	public function validate_vat( $vat_number ) {
+		return $this->request( [], self::VAT_API . '/' . $vat_number, self::GET );
+	}
+
+	/**
+	 * Saves the VAT details on the server and returns the full response.
+	 *
+	 * @param string $vat_number The VAT number.
+	 * @param string $name       The company's name.
+	 * @param string $address    The company's address.
+	 *
+	 * @return array HTTP response on success.
+	 *
+	 * @throws API_Exception - If not connected or request failed.
+	 */
+	public function save_vat_details( $vat_number, $name, $address ) {
+		return $this->request(
+			[
+				'vat_number' => $vat_number,
+				'name'       => $name,
+				'address'    => $address,
+			],
+			self::VAT_API,
+			self::POST
+		);
 	}
 
 	/**

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1850,7 +1850,7 @@ class WC_Payments_API_Client {
 	 * @throws API_Exception - If not connected or request failed.
 	 */
 	public function save_vat_details( $vat_number, $name, $address ) {
-		return $this->request(
+		$response = $this->request(
 			[
 				'vat_number' => $vat_number,
 				'name'       => $name,
@@ -1859,6 +1859,10 @@ class WC_Payments_API_Client {
 			self::VAT_API,
 			self::POST
 		);
+
+		WC_Payments::get_account_service()->refresh_account_data();
+
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3934 

#### Changes proposed in this Pull Request

This PR builds on top of #4140, adding the actual VAT details form to the modal. The form is composed of two steps: in the first, we ask merchants for their VAT number — in case they have one — and validate it; in the second step we use the data we were able to get when validating the VAT number to ask for the company name and address.

Merchants are able to submit the details without specifying a VAT number, but business name and address are required. Once the details are stored in the server, the `hasSubmittedVatData` flag is set to true on the client to allow invoices to be downloaded without requiring a page refresh. The account cache is also refreshed in the background, so that the new status is reflected right away, instead of having to wait for an automatic refresh.

As soon as the form is submitted and the flag is updated, merchants will be redirected to the invoice document, without having to click on Download a second time. Further downloads should be processed directly, without asking for the details again.

#### Testing instructions

_We don't have a way to validate VAT numbers for some countries, like the US. In these cases, an error will be displayed when attempting to validate it. Merchants should be able to proceed without informing a VAT number in such cases._

_If using an account from the UK, the local server and sandbox will use a test API. You can find valid VAT numbers to test it [here](https://github.com/hmrc/vat-registered-companies-api/blob/main/public/api/conf/1.0/test-data/vrn.csv)._

_If using an account from the EU, the VIES production service will be used, so you'll need to use a real VAT number._

* Apply this PR's branch and 1803-gh-Automattic/woocommerce-payments-server on your local server or sandbox
* Create a new `vat_invoice` for your account if you don't have one by running the following command
    ```
    wp wcpay add_document_for_account {Your account id} vat_invoice --date="2022-03-01" --period_from="2022-02-01 00:00:00" --period_to="2022-02-28 23:59:59"
    ```
* Navigate to the documents list and click on the download button for the VAT invoice
    * Make sure a modal pops up with the VAT details form
    * Check "I’m registered for a VAT number" and make sure your account's country prefix is used in the input
        * Input an invalid VAT number, click on Continue, and assert that a notice is displayed with the error
        * Input a valid VAT number, click on Continue, and assert that the form proceeds to the next step with the details from the VAT check
            * Modify or keep the placeholder values for business name and address and click on Confirm
            * Make sure the form is submitted correctly and the document is downloaded automatically
            * Check the account_meta table on the server to make sure the data was saved correctly
* Remove the VAT details from the server and clear the account cache on the client
    * Navigate to the documents list and click on the download button for the VAT invoice
    * Click on Continue without checking "I’m registered for a VAT number"
        * Make sure the Confirm button is disabled until a business name and address are provided
    * Provide a business name and address and click on Confirm
        * Make sure the form is submitted correctly and the document is downloaded automatically 
        * Check the account_meta table on the server to make sure the data was saved correctly

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
