### PR TITLE
Fix "Compatibility - WC, WP and PHP" CI failures 

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -55,7 +55,7 @@ jobs:
         woocommerce: [ 'beta' ]
         wordpress:   [ 'latest' ]
         gutenberg:   [ 'latest' ]
-        php:         [ '7.1', '8.0', '8.1' ]
+        php:         [ '7.2', '8.0', '8.1' ]
     env:
       WP_VERSION:        ${{ matrix.wordpress }}
       WC_VERSION:        ${{ matrix.woocommerce }}

--- a/changelog/fix-4169-compaitbility-ci-failures
+++ b/changelog/fix-4169-compaitbility-ci-failures
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix compatility tests with Woo core 6.5.

--- a/changelog/fix-4169-compaitbility-ci-failures
+++ b/changelog/fix-4169-compaitbility-ci-failures
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Fix compatility tests with Woo core 6.5.

--- a/changelog/fix-4169-compatibility-ci-failures
+++ b/changelog/fix-4169-compatibility-ci-failures
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix compatibility tests with Woo core 6.5.

--- a/tests/unit/multi-currency/notes/test-class-note-multi-currency-available-test.php
+++ b/tests/unit/multi-currency/notes/test-class-note-multi-currency-available-test.php
@@ -36,7 +36,15 @@ class Note_Multi_Currency_Available_Test extends WP_UnitTestCase {
 		$this->assertSame( 'wc-payments-notes-multi-currency-available', $actions->name );
 		$this->assertSame( 'Set up now', $actions->label );
 		$this->assertStringStartsWith( 'admin.php?page=wc-admin&path=/payments/multi-currency-setup', $actions->query );
-		$this->assertSame( true, $actions->primary );
+
+		/**
+		 * The $primary property was deprecated from WooCommerce core. Keeping this to maintain the compatibility with old WooCommerce versions.
+		 * @see https://github.com/woocommerce/woocommerce/blob/ff2d7d704a8f72aeb4990811b6972097aa167bea/plugins/woocommerce/src/Admin/Notes/Note.php#L623-L623.
+		 * @see https://github.com/woocommerce/woocommerce-admin/pull/8474
+		 */
+		if ( isset( $actions->primary ) ) {
+			$this->assertSame( true, $actions->primary );
+		}
 	}
 
 

--- a/tests/unit/notes/test-class-wc-payments-notes-additional-payment-methods.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-additional-payment-methods.php
@@ -37,7 +37,15 @@ class WC_Payments_Notes_Additional_Payment_Methods_Test extends WP_UnitTestCase 
 		$this->assertSame( 'wc-payments-notes-additional-payment-methods', $enable_upe_action->name );
 		$this->assertSame( 'Enable on your store', $enable_upe_action->label );
 		$this->assertStringStartsWith( 'http://example.org/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments&action=enable-upe', $enable_upe_action->query );
-		$this->assertSame( true, $enable_upe_action->primary );
+
+		/**
+		 * The $primary property was deprecated from WooCommerce core. Keeping this to maintain the compatibility with old WooCommerce versions.
+		 * @see https://github.com/woocommerce/woocommerce/blob/ff2d7d704a8f72aeb4990811b6972097aa167bea/plugins/woocommerce/src/Admin/Notes/Note.php#L623-L623.
+		 * @see https://github.com/woocommerce/woocommerce-admin/pull/8474
+		 */
+		if ( isset( $enable_upe_action->primary ) ) {
+			$this->assertSame( true, $enable_upe_action->primary );
+		}
 	}
 
 	public function test_get_note_does_not_return_note_when_account_is_not_connected() {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -496,7 +496,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			$this->assertEquals( 'failed', $result_order->get_status() );
 
 			// Assert: Order transaction ID was not set.
-			$this->assertEquals( '', $result_order->get_meta( '_transaction_id' ) );
+			$this->assertEquals( '', $result_order->get_transaction_id() );
 
 			// Assert: Order meta was not updated with charge ID, intention status, or intent ID.
 			$this->assertEquals( '', $result_order->get_meta( '_intent_id' ) );


### PR DESCRIPTION
Fixes #4169

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- Make changes so that they can work for both old, current, and beta Woo core versions.
- See my inline comments to have reference and reasons why I make these changes.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that there is no `Compatibility - WC, WP and PHP` test failure.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] ~Tested on mobile~ (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] No need as this is related to PHP tests only. ~Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_~
