### PR TITLE
Update GH Workflow to skip setting up WC Blocks for incompatible WC versions

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -44,12 +44,6 @@ jobs:
         exclude:
           - test_groups: 'blocks'
             test_branches: 'merchant'
-          - woocommerce: '5.2.0'
-            test_groups: 'blocks'
-            test_branches: 'shopper'
-          - woocommerce: '6.1.0'
-            test_groups: 'blocks'
-            test_branches: 'shopper'
 
     name: WC - ${{ matrix.woocommerce }} | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -44,6 +44,12 @@ jobs:
         exclude:
           - test_groups: 'blocks'
             test_branches: 'merchant'
+          - woocommerce: '5.2.0'
+            test_groups: 'blocks'
+            test_branches: 'shopper'
+          - woocommerce: '6.1.0'
+            test_groups: 'blocks'
+            test_branches: 'shopper'
 
     name: WC - ${{ matrix.woocommerce }} | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -60,12 +60,6 @@ jobs:
           SKIP_VERSIONS=('5.2.0' '6.1.0')
           if [[ " ${SKIP_VERSIONS[@]} " =~ " ${E2E_WC_VERSION} " ]]; then
             echo "SKIP_WC_BLOCKS_TESTS=1" >> $GITHUB_ENV
-            if [[
-                $E2E_GROUP == 'wcpay' && $E2E_BRANCH == 'merchant' ||
-                $E2E_GROUP == 'blocks'
-            ]]; then
-                echo "SKIP_E2E_WORKFLOW=1" >> $GITHUB_ENV
-            fi
           fi
 
       # Log workflow configuration

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -63,7 +63,7 @@ jobs:
       # Conditionally skip workflow. Remove/update based on min supported WC version by the blocks checkout plugin.
       - name: Conditionally skip workflow
         run: |
-          SKIP_VERSIONS = ('5.2.0' '6.1.0')
+          SKIP_VERSIONS=('5.2.0' '6.1.0')
           if [[ " ${SKIP_VERSIONS[@]} " =~ " ${E2E_WC_VERSION} " ]]; then
             echo "SKIP_WC_BLOCKS_TESTS=1" >> $GITHUB_ENV
             if [[

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -54,8 +54,8 @@ jobs:
       E2E_BRANCH: ${{ matrix.test_branches }}
 
     steps:
-      # Conditionally skip workflow. Remove/update based on min supported WC version by the blocks checkout plugin.
-      - name: Conditionally skip workflow
+      # Conditionally skip WC Blocks tests. Remove/update based on min supported WC version by the blocks checkout plugin.
+      - name: Conditionally skip WC Blocks tests
         run: |
           SKIP_VERSIONS=('5.2.0' '6.1.0')
           if [[ " ${SKIP_VERSIONS[@]} " =~ " ${E2E_WC_VERSION} " ]]; then
@@ -64,7 +64,6 @@ jobs:
 
       # Log workflow configuration
       - name: Workflow Configuration
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: |
           echo "WordPress version: ${{ matrix.wordpress }}"
           echo "WooCommerce version: ${{ matrix.woocommerce }}"
@@ -74,40 +73,34 @@ jobs:
 
       # Clone Repo
       - name: Clone WCPay Repository
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/checkout@v2
 
       # Use node version from .nvmrc
       - name: Setup NodeJS
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/setup-node@v2
         with:
           node-version-file: '.nvmrc'
 
       # Dependency caching
       - name: Add composer to cache
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/cache@v2
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
 
       - name: Add vendor directory to cache
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/cache@v2
         with:
           path: vendor/
           key:  ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
 
       - name: Add NPM directory to cache
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/cache@v2
         with:
           path: ~/.npm/
           key:  ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
 
       - name: Add node_modules to cache
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/cache@v2
         with:
           path: node_modules/
@@ -115,7 +108,6 @@ jobs:
 
       # PHP setup
       - name: PHP Setup
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -125,7 +117,6 @@ jobs:
 
       # Prepare testing dependencies
       - name: Prepare testing dependencies
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: |
           echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
           sudo systemctl start mysql.service
@@ -133,18 +124,15 @@ jobs:
 
       # Build WCPay client
       - name: Build WCPay Client
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: npm ci && npm run build:client
 
       # Prepare test environment
       - name: Prepare test environment
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: |
           npm run test:e2e-setup
 
       # Run Tests
       - name: Run E2E Tests
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: npm run test:e2e
 
       # Archive screenshots if any

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -57,8 +57,8 @@ jobs:
       # Conditionally skip WC Blocks tests. Remove/update based on min supported WC version by the blocks checkout plugin.
       - name: Conditionally skip WC Blocks tests
         run: |
-          SKIP_VERSIONS=('5.2.0' '6.1.0')
-          if [[ " ${SKIP_VERSIONS[@]} " =~ " ${E2E_WC_VERSION} " ]]; then
+          SKIP_WC_VERSIONS=('5.2.0' '6.1.0')
+          if [[ " ${SKIP_WC_VERSIONS[@]} " =~ " ${E2E_WC_VERSION} " ]]; then
             echo "SKIP_WC_BLOCKS_TESTS=1" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -44,6 +44,12 @@ jobs:
         exclude:
           - test_groups: 'blocks'
             test_branches: 'merchant'
+          - woocommerce: '5.2.0'
+            test_groups: 'blocks'
+            test_branches: 'shopper'
+          - woocommerce: '6.1.0'
+            test_groups: 'blocks'
+            test_branches: 'shopper'
 
     name: WC - ${{ matrix.woocommerce }} | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 
@@ -54,22 +60,8 @@ jobs:
       E2E_BRANCH: ${{ matrix.test_branches }}
 
     steps:
-      # Conditionally skip workflow. Remove/update based on min supported WC version by the blocks checkout plugin.
-      - name: Conditionally skip workflow
-        run: |
-          if [[ $E2E_WC_VERSION == '5.2.0' ]]; then
-            echo "SKIP_WC_BLOCKS_TESTS=1" >> $GITHUB_ENV
-            if [[
-                $E2E_GROUP == 'wcpay' && $E2E_BRANCH == 'merchant' ||
-                $E2E_GROUP == 'blocks'
-            ]]; then
-                echo "SKIP_E2E_WORKFLOW=1" >> $GITHUB_ENV
-            fi
-          fi
-
       # Log workflow configuration
       - name: Workflow Configuration
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: |
           echo "WordPress version: ${{ matrix.wordpress }}"
           echo "WooCommerce version: ${{ matrix.woocommerce }}"
@@ -79,40 +71,34 @@ jobs:
 
       # Clone Repo
       - name: Clone WCPay Repository
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/checkout@v2
 
       # Use node version from .nvmrc
       - name: Setup NodeJS
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/setup-node@v2
         with:
           node-version-file: '.nvmrc'
 
       # Dependency caching
       - name: Add composer to cache
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/cache@v2
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
 
       - name: Add vendor directory to cache
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/cache@v2
         with:
           path: vendor/
           key:  ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
 
       - name: Add NPM directory to cache
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/cache@v2
         with:
           path: ~/.npm/
           key:  ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
 
       - name: Add node_modules to cache
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/cache@v2
         with:
           path: node_modules/
@@ -120,7 +106,6 @@ jobs:
 
       # PHP setup
       - name: PHP Setup
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -130,7 +115,6 @@ jobs:
 
       # Prepare testing dependencies
       - name: Prepare testing dependencies
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: |
           echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
           sudo systemctl start mysql.service
@@ -138,18 +122,15 @@ jobs:
 
       # Build WCPay client
       - name: Build WCPay Client
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: npm ci && npm run build:client
 
       # Prepare test environment
       - name: Prepare test environment
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: |
           npm run test:e2e-setup
 
       # Run Tests
       - name: Run E2E Tests
-        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: npm run test:e2e
 
       # Archive screenshots if any

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -60,8 +60,23 @@ jobs:
       E2E_BRANCH: ${{ matrix.test_branches }}
 
     steps:
+      # Conditionally skip workflow. Remove/update based on min supported WC version by the blocks checkout plugin.
+      - name: Conditionally skip workflow
+        run: |
+          SKIP_VERSIONS = ('5.2.0' '6.1.0')
+          if [[ " ${SKIP_VERSIONS[@]} " =~ " ${E2E_WC_VERSION} " ]]; then
+            echo "SKIP_WC_BLOCKS_TESTS=1" >> $GITHUB_ENV
+            if [[
+                $E2E_GROUP == 'wcpay' && $E2E_BRANCH == 'merchant' ||
+                $E2E_GROUP == 'blocks'
+            ]]; then
+                echo "SKIP_E2E_WORKFLOW=1" >> $GITHUB_ENV
+            fi
+          fi
+
       # Log workflow configuration
       - name: Workflow Configuration
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: |
           echo "WordPress version: ${{ matrix.wordpress }}"
           echo "WooCommerce version: ${{ matrix.woocommerce }}"
@@ -71,34 +86,40 @@ jobs:
 
       # Clone Repo
       - name: Clone WCPay Repository
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/checkout@v2
 
       # Use node version from .nvmrc
       - name: Setup NodeJS
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/setup-node@v2
         with:
           node-version-file: '.nvmrc'
 
       # Dependency caching
       - name: Add composer to cache
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/cache@v2
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
 
       - name: Add vendor directory to cache
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/cache@v2
         with:
           path: vendor/
           key:  ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
 
       - name: Add NPM directory to cache
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/cache@v2
         with:
           path: ~/.npm/
           key:  ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
 
       - name: Add node_modules to cache
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: actions/cache@v2
         with:
           path: node_modules/
@@ -106,6 +127,7 @@ jobs:
 
       # PHP setup
       - name: PHP Setup
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -115,6 +137,7 @@ jobs:
 
       # Prepare testing dependencies
       - name: Prepare testing dependencies
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: |
           echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
           sudo systemctl start mysql.service
@@ -122,15 +145,18 @@ jobs:
 
       # Build WCPay client
       - name: Build WCPay Client
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: npm ci && npm run build:client
 
       # Prepare test environment
       - name: Prepare test environment
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: |
           npm run test:e2e-setup
 
       # Run Tests
       - name: Run E2E Tests
+        if: ${{ ! env.SKIP_E2E_WORKFLOW }}
         run: npm run test:e2e
 
       # Archive screenshots if any

--- a/changelog/update-gh-e2e-env-setup
+++ b/changelog/update-gh-e2e-env-setup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update GitHub Actions E2E workflow to skip running WC Blocks tests against incompatible WooCommerce versions.

--- a/tests/e2e/specs/blocks/shopper/shopper-wc-blocks-checkout-failures.spec.js
+++ b/tests/e2e/specs/blocks/shopper/shopper-wc-blocks-checkout-failures.spec.js
@@ -44,6 +44,7 @@ describeif( RUN_WC_BLOCKS_TESTS )(
 
 		afterEach( async () => {
 			// Clear card details for the next test
+			await shopperWCP.openCheckoutWCB();
 			await clearWCBCardDetails();
 		} );
 


### PR DESCRIPTION
Fixes #4173 

#### Changes proposed in this Pull Request

We've recently noticed failures on E2E pipeline (discussion - p1649998135891069-slack-CQ0Q6N62D). The problem was caused due to WooCommerce Checkout Blocks version [support policy](https://developer.woocommerce.com/2021/07/27/announcing-a-change-to-the-woocommerce-blocks-version-support-policy/). The minimum supported WooCommerce version for the latest version of WC Blocks is `6.3`.

Since our E2E tests currently runs against lower WooCommerce versions `5.2.0` and `6.1.0`, installing WC Blocks on these versions causes the tests to fail because checkout blocks will fail to load.

![Screenshot](https://d.pr/i/E78UcI+)

This PR disables setting up WC Blocks on incompatible WC versions, skipping blocks related tests. Also, this PR adds page refresh between running WC Blocks to fix flakiness while reading WC error notices.

#### Testing instructions

* Create a new E2E workflow against this branch from Actions tab. Reference job - https://github.com/Automattic/woocommerce-payments/runs/6107673722?check_suite_focus=true
* Confirm that the pipeline is Green

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_