### PR TITLE
E2E - Optimize setup script to install Action Scheduler & WC Blocks from WordPress.org

### DIFF
--- a/changelog/e2e-optimize-setup-script
+++ b/changelog/e2e-optimize-setup-script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Optimize E2E Setup to install Action Scheduler & WC Blocks from WordPress.org

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -74,15 +74,13 @@ E2E_BLOG_ID='<blog_id>'
 <summary>Installing Plugins</summary>
 <p>
 
-If you wish to run E2E test for WC Subscriptions, Action Scheduler & WC Gutenberg Products Blocks, the following env variables needs to be added to your `local.env` (replace values as required).
+If you wish to run E2E test for WC Subscriptions the following env variables needs to be added to your `local.env` (replace values as required).
 
 For the `E2E_GH_TOKEN`, follow [these instructions to generate a GitHub Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) and assign the `repo` scope to it.
 
 ```
 E2E_GH_TOKEN='githubPersonalAccessToken'
 WC_SUBSCRIPTIONS_REPO='{owner}/{repo}'
-WC_ACTION_SCHEDULER_REPO='{owner}/{repo}'
-WC_BLOCKS_REPO='{owner}/{repo}'
 ```
 
 </p>

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -74,7 +74,7 @@ E2E_BLOG_ID='<blog_id>'
 <summary>Installing Plugins</summary>
 <p>
 
-If you wish to run E2E test for WC Subscriptions the following env variables needs to be added to your `local.env` (replace values as required).
+If you wish to run E2E test for WC Subscriptions, the following env variables needs to be added to your `local.env` (replace values as required).
 
 For the `E2E_GH_TOKEN`, follow [these instructions to generate a GitHub Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) and assign the `repo` scope to it.
 

--- a/tests/e2e/env/docker-compose.yml
+++ b/tests/e2e/env/docker-compose.yml
@@ -19,8 +19,6 @@ services:
       - ${WCP_ROOT}:/var/www/html/wp-content/plugins/woocommerce-payments
       - ${E2E_ROOT}/deps/${DEV_TOOLS_DIR}:/var/www/html/wp-content/plugins/${DEV_TOOLS_DIR}
       - ${E2E_ROOT}/deps/woocommerce-subscriptions:/var/www/html/wp-content/plugins/woocommerce-subscriptions
-      - ${E2E_ROOT}/deps/action-scheduler:/var/www/html/wp-content/plugins/action-scheduler
-      - ${E2E_ROOT}/deps/woo-gutenberg-products-block:/var/www/html/wp-content/plugins/woo-gutenberg-products-block
   db:
     container_name: wcp_e2e_mysql
     image: mariadb:10.5.8

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -266,48 +266,14 @@ fi
 
 if [[ ! ${SKIP_WC_ACTION_SCHEDULER_TESTS} ]]; then
 	echo "Install and activate the latest release of Action Scheduler"
-	cd "$E2E_ROOT"/deps
-
-	LATEST_RELEASE_ASSET_ID=$(curl -H "Authorization: token $E2E_GH_TOKEN" https://api.github.com/repos/"$WC_ACTION_SCHEDULER_REPO"/releases/latest | jq -r '.assets[0].id')
-
-	curl -LJ \
-		-H "Authorization: token $E2E_GH_TOKEN" \
-		-H "Accept: application/octet-stream" \
-		--output action-scheduler.zip \
-		https://api.github.com/repos/"$WC_ACTION_SCHEDULER_REPO"/releases/assets/"$LATEST_RELEASE_ASSET_ID"
-
-	unzip -qq action-scheduler.zip -d action-scheduler-source
-
-	echo "Moving the unzipped plugin files. This may require your admin password"
-	sudo mv action-scheduler-source/action-scheduler/* action-scheduler
-
-	cli wp plugin activate action-scheduler
-
-	rm -rf action-scheduler-source
+	cli wp plugin install action-scheduler --activate
 else
 	echo "Skipping install of Action Scheduler"
 fi
 
 if [[ ! ${SKIP_WC_BLOCKS_TESTS} ]]; then
 	echo "Install and activate the latest release of WooCommerce Blocks"
-	cd "$E2E_ROOT"/deps
-
-	LATEST_RELEASE_ASSET_ID=$(curl -H "Authorization: token $E2E_GH_TOKEN" https://api.github.com/repos/"$WC_BLOCKS_REPO"/releases/latest | jq -r '.assets[0].id')
-
-	curl -LJ \
-		-H "Authorization: token $E2E_GH_TOKEN" \
-		-H "Accept: application/octet-stream" \
-		--output woo-gutenberg-products-block.zip \
-		https://api.github.com/repos/"$WC_BLOCKS_REPO"/releases/assets/"$LATEST_RELEASE_ASSET_ID"
-
-	unzip -qq woo-gutenberg-products-block.zip -d woo-gutenberg-products-block-source
-
-	echo "Moving the unzipped plugin files. This may require your admin password"
-	sudo mv woo-gutenberg-products-block-source/* woo-gutenberg-products-block
-
-	cli wp plugin activate woo-gutenberg-products-block
-
-	rm -rf woo-gutenberg-products-block-source
+	cli wp plugin install woo-gutenberg-products-block --activate
 else
 	echo "Skipping install of WooCommerce Blocks"
 fi


### PR DESCRIPTION
Fixes #4175 

#### Changes proposed in this Pull Request

The changes in this PR was originally part of #4172 and based on p1650536125663419/1649998135.891069-slack-CQ0Q6N62D, it was decided to move these changes as a separate PR.

This PR optimizes the E2E setup script to install Action Scheduler & WC Blocks plugins directly from WordPress.org. Since these plugins are public, we can avoid the hassle of fetching them from GitHub and extracting them to a mapped docker volume.

This PR also updates the E2E docs.

#### Testing instructions

* Run E2E workflow against this branch and confirm that the setup works as expected and the pipeline is green.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Remove unused repo secrets related to the change - @achyuthajoy