### PR TITLE
Add support for direct document access

### DIFF
--- a/changelog/add-s1838-document-direct-link
+++ b/changelog/add-s1838-document-direct-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Feature behind the documents feature flag. Will be announced when the documents feature is released.

--- a/client/documents/list/index.tsx
+++ b/client/documents/list/index.tsx
@@ -125,13 +125,15 @@ export const DocumentsList = (): JSX.Element => {
 	] = useState< {
 		documentId: Document[ 'document_id' ];
 		type: Document[ 'type' ];
+		newTab: boolean;
 	} | null >( null );
 
 	const handleDocumentDownload = (
 		documentId: Document[ 'document_id' ],
-		type: Document[ 'type' ]
+		type: Document[ 'type' ],
+		newTab: boolean
 	): boolean => {
-		setInterruptedDownloadDocument( { documentId, type } );
+		setInterruptedDownloadDocument( { documentId, type, newTab } );
 
 		if ( 'vat_invoice' === type ) {
 			if ( ! wcpaySettings.accountStatus.hasSubmittedVatData ) {
@@ -144,10 +146,14 @@ export const DocumentsList = (): JSX.Element => {
 	};
 
 	const downloadDocument = useCallback(
-		( documentId: Document[ 'document_id' ], type: Document[ 'type' ] ) => {
+		(
+			documentId: Document[ 'document_id' ],
+			type: Document[ 'type' ],
+			newTab = true
+		) => {
 			const url = getDocumentUrl( documentId );
-			if ( handleDocumentDownload( documentId, type ) ) {
-				window.open( url, '_blank' );
+			if ( handleDocumentDownload( documentId, type, newTab ) ) {
+				window.open( url, newTab ? '_blank' : '_self' );
 			}
 		},
 		[]
@@ -161,7 +167,8 @@ export const DocumentsList = (): JSX.Element => {
 		if ( interruptedDownloadDocument ) {
 			downloadDocument(
 				interruptedDownloadDocument.documentId,
-				interruptedDownloadDocument.type
+				interruptedDownloadDocument.type,
+				interruptedDownloadDocument.newTab
 			);
 		}
 	};
@@ -176,7 +183,8 @@ export const DocumentsList = (): JSX.Element => {
 		if ( requestedDocumentID && requestedDocumentType ) {
 			downloadDocument(
 				requestedDocumentID,
-				requestedDocumentType as Document[ 'type' ]
+				requestedDocumentType as Document[ 'type' ],
+				false
 			);
 		}
 	}, [ requestedDocumentID, requestedDocumentType, downloadDocument ] );

--- a/client/documents/list/index.tsx
+++ b/client/documents/list/index.tsx
@@ -166,6 +166,21 @@ export const DocumentsList = (): JSX.Element => {
 		}
 	};
 
+	// Check if the page view is requesting a specific document and trigger its download.
+	const {
+		document_id: requestedDocumentID,
+		document_type: requestedDocumentType,
+	} = getQuery();
+
+	useEffect( () => {
+		if ( requestedDocumentID && requestedDocumentType ) {
+			downloadDocument(
+				requestedDocumentID,
+				requestedDocumentType as Document[ 'type' ]
+			);
+		}
+	}, [ requestedDocumentID, requestedDocumentType, downloadDocument ] );
+
 	const columnsToDisplay = getColumns();
 
 	const totalRows = documentsSummary.count || 0;

--- a/client/documents/list/index.tsx
+++ b/client/documents/list/index.tsx
@@ -3,12 +3,13 @@
 /**
  * External dependencies
  */
-import React, { MouseEvent, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { dateI18n } from '@wordpress/date';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import moment from 'moment';
 import { TableCard, TableCardColumn } from '@woocommerce/components';
 import { onQueryChange, getQuery } from '@woocommerce/navigation';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -119,31 +120,49 @@ export const DocumentsList = (): JSX.Element => {
 	const [ isVatFormModalOpen, setVatFormModalOpen ] = useState( false );
 
 	const [
-		clickedDownloadLink,
-		setClickedDownloadLink,
-	] = useState< HTMLElement | null >( null );
+		interruptedDownloadDocument,
+		setInterruptedDownloadDocument,
+	] = useState< {
+		documentId: Document[ 'document_id' ];
+		type: Document[ 'type' ];
+	} | null >( null );
 
-	const handleDocumentDownload = async (
-		document: Document,
-		event: MouseEvent
-	) => {
-		setClickedDownloadLink( event.currentTarget as HTMLElement );
+	const handleDocumentDownload = (
+		documentId: Document[ 'document_id' ],
+		type: Document[ 'type' ]
+	): boolean => {
+		setInterruptedDownloadDocument( { documentId, type } );
 
-		if ( 'vat_invoice' === document.type ) {
+		if ( 'vat_invoice' === type ) {
 			if ( ! wcpaySettings.accountStatus.hasSubmittedVatData ) {
 				setVatFormModalOpen( true );
-				event.preventDefault();
+				return false;
 			}
 		}
+
+		return true;
 	};
+
+	const downloadDocument = useCallback(
+		( documentId: Document[ 'document_id' ], type: Document[ 'type' ] ) => {
+			const url = getDocumentUrl( documentId );
+			if ( handleDocumentDownload( documentId, type ) ) {
+				window.open( url, '_blank' );
+			}
+		},
+		[]
+	);
 
 	const onVatFormCompleted = () => {
 		setVatFormModalOpen( false );
 		// Set the flag to true so that the user can download the document without refreshing the page.
 		wcpaySettings.accountStatus.hasSubmittedVatData = true;
-		// Fire the click event again, once the VAT details have been submitted.
-		if ( clickedDownloadLink ) {
-			clickedDownloadLink.click();
+		// Attempt to download the previous document, once the VAT details have been submitted.
+		if ( interruptedDownloadDocument ) {
+			downloadDocument(
+				interruptedDownloadDocument.documentId,
+				interruptedDownloadDocument.type
+			);
 		}
 	};
 
@@ -174,17 +193,17 @@ export const DocumentsList = (): JSX.Element => {
 			download: {
 				value: getDocumentUrl( document.document_id ),
 				display: (
-					<a
-						href={ getDocumentUrl( document.document_id ) }
-						rel="noopener noreferrer"
-						target="_blank"
-						style={ { display: 'inline' } }
-						onClick={ ( event ) =>
-							handleDocumentDownload( document, event )
+					<Button
+						isLink
+						onClick={ () =>
+							downloadDocument(
+								document.document_id,
+								document.type
+							)
 						}
 					>
 						{ __( 'Download', 'woocommerce-payments' ) }
-					</a>
+					</Button>
 				),
 			},
 		};

--- a/client/documents/list/test/__snapshots__/index.tsx.snap
+++ b/client/documents/list/test/__snapshots__/index.tsx.snap
@@ -241,14 +241,12 @@ exports[`Documents list renders correctly 1`] = `
                 <td
                   class="woocommerce-table__item is-numeric"
                 >
-                  <a
-                    href="https://site.com/wp-json/wc/v3/payments/documents/test_document_123456?_wpnonce=random_wp_rest_nonce"
-                    rel="noopener noreferrer"
-                    style="display: inline;"
-                    target="_blank"
+                  <button
+                    class="components-button is-link"
+                    type="button"
                   >
                     Download
-                  </a>
+                  </button>
                 </td>
               </tr>
               <tr>
@@ -271,14 +269,12 @@ exports[`Documents list renders correctly 1`] = `
                 <td
                   class="woocommerce-table__item is-numeric"
                 >
-                  <a
-                    href="https://site.com/wp-json/wc/v3/payments/documents/test_document_654321?_wpnonce=random_wp_rest_nonce"
-                    rel="noopener noreferrer"
-                    style="display: inline;"
-                    target="_blank"
+                  <button
+                    class="components-button is-link"
+                    type="button"
                   >
                     Download
-                  </a>
+                  </button>
                 </td>
               </tr>
             </tbody>
@@ -549,14 +545,12 @@ exports[`Documents list renders table summary only when the documents summary da
                 <td
                   class="woocommerce-table__item is-numeric"
                 >
-                  <a
-                    href="https://site.com/wp-json/wc/v3/payments/documents/test_document_123456?_wpnonce=random_wp_rest_nonce"
-                    rel="noopener noreferrer"
-                    style="display: inline;"
-                    target="_blank"
+                  <button
+                    class="components-button is-link"
+                    type="button"
                   >
                     Download
-                  </a>
+                  </button>
                 </td>
               </tr>
               <tr>
@@ -579,14 +573,12 @@ exports[`Documents list renders table summary only when the documents summary da
                 <td
                   class="woocommerce-table__item is-numeric"
                 >
-                  <a
-                    href="https://site.com/wp-json/wc/v3/payments/documents/test_document_654321?_wpnonce=random_wp_rest_nonce"
-                    rel="noopener noreferrer"
-                    style="display: inline;"
-                    target="_blank"
+                  <button
+                    class="components-button is-link"
+                    type="button"
                   >
                     Download
-                  </a>
+                  </button>
                 </td>
               </tr>
             </tbody>

--- a/client/documents/list/test/index.tsx
+++ b/client/documents/list/test/index.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import * as React from 'react';
-import { createEvent, fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
 

--- a/client/documents/list/test/index.tsx
+++ b/client/documents/list/test/index.tsx
@@ -166,6 +166,8 @@ describe( 'Document download button', () => {
 
 	describe( 'for VAT invoices', () => {
 		beforeEach( () => {
+			window.open = jest.fn();
+
 			mockUseDocuments.mockReturnValue( {
 				documents: [
 					{
@@ -203,16 +205,18 @@ describe( 'Document download button', () => {
 
 				render( <DocumentsList /> );
 
-				downloadButton = screen.getByRole( 'link', {
+				downloadButton = screen.getByRole( 'button', {
 					name: 'Download',
 				} );
 			} );
 
 			it( 'should download the document ', () => {
-				const clickEvent = createEvent.click( downloadButton );
-				fireEvent( downloadButton, clickEvent );
+				user.click( downloadButton );
 
-				expect( clickEvent.defaultPrevented ).toBe( false );
+				expect( window.open ).toHaveBeenCalledWith(
+					'https://site.com/wp-json/wc/v3/payments/documents/vat_invoice_123456?_wpnonce=random_wp_rest_nonce',
+					'_blank'
+				);
 			} );
 		} );
 
@@ -224,16 +228,15 @@ describe( 'Document download button', () => {
 
 				render( <DocumentsList /> );
 
-				downloadButton = screen.getByRole( 'link', {
+				downloadButton = screen.getByRole( 'button', {
 					name: 'Download',
 				} );
 			} );
 
 			it( 'should not download the document', () => {
-				const clickEvent = createEvent.click( downloadButton );
-				fireEvent( downloadButton, clickEvent );
+				user.click( downloadButton );
 
-				expect( clickEvent.defaultPrevented ).toBe( true );
+				expect( window.open ).not.toHaveBeenCalled();
 			} );
 
 			it( 'should open the VAT form modal', () => {
@@ -250,16 +253,8 @@ describe( 'Document download button', () => {
 			} );
 
 			describe( 'after the VAT details are submitted', () => {
-				const mockButtonOnClick = jest.fn();
-
 				beforeEach( () => {
 					user.click( downloadButton );
-
-					// Add a mock button onclick handler to assert that it's been called a second time.
-					downloadButton.addEventListener(
-						'click',
-						mockButtonOnClick
-					);
 
 					user.click( screen.getByText( 'Complete' ) );
 				} );
@@ -276,8 +271,11 @@ describe( 'Document download button', () => {
 					).toBe( true );
 				} );
 
-				it( 'should automatically click on the download button', () => {
-					expect( mockButtonOnClick ).toHaveBeenCalled();
+				it( 'should automatically download the document', () => {
+					expect( window.open ).toHaveBeenCalledWith(
+						'https://site.com/wp-json/wc/v3/payments/documents/vat_invoice_123456?_wpnonce=random_wp_rest_nonce',
+						'_blank'
+					);
 				} );
 			} );
 		} );

--- a/client/documents/list/test/index.tsx
+++ b/client/documents/list/test/index.tsx
@@ -307,7 +307,7 @@ describe( 'Direct document download', () => {
 		expect( window.open ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should download the document if document type and ID are in the query', () => {
+	it( 'should download the document in the same tab if document type and ID are in the query', () => {
 		updateQueryString(
 			{ document_id: 'vat_invoice_123456', document_type: 'vat_invoice' },
 			'/',
@@ -318,7 +318,7 @@ describe( 'Direct document download', () => {
 
 		expect( window.open ).toHaveBeenCalledWith(
 			'https://site.com/wp-json/wc/v3/payments/documents/vat_invoice_123456?_wpnonce=random_wp_rest_nonce',
-			'_blank'
+			'_self'
 		);
 	} );
 } );

--- a/client/documents/list/test/index.tsx
+++ b/client/documents/list/test/index.tsx
@@ -6,7 +6,7 @@
 import * as React from 'react';
 import { createEvent, fireEvent, render, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
-import { getQuery } from '@woocommerce/navigation';
+import { getQuery, updateQueryString } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -279,5 +279,46 @@ describe( 'Document download button', () => {
 				} );
 			} );
 		} );
+	} );
+} );
+
+describe( 'Direct document download', () => {
+	beforeEach( () => {
+		window.open = jest.fn();
+
+		global.wcpaySettings = {
+			accountStatus: { hasSubmittedVatData: true },
+		};
+	} );
+
+	it( 'should not download the document if document type is missing', () => {
+		updateQueryString( { document_id: 'vat_invoice_123456' }, '/', {} );
+
+		render( <DocumentsList /> );
+
+		expect( window.open ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not download the document if document ID is missing', () => {
+		updateQueryString( { document_type: 'vat_invoice' }, '/', {} );
+
+		render( <DocumentsList /> );
+
+		expect( window.open ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should download the document if document type and ID are in the query', () => {
+		updateQueryString(
+			{ document_id: 'vat_invoice_123456', document_type: 'vat_invoice' },
+			'/',
+			{}
+		);
+
+		render( <DocumentsList /> );
+
+		expect( window.open ).toHaveBeenCalledWith(
+			'https://site.com/wp-json/wc/v3/payments/documents/vat_invoice_123456?_wpnonce=random_wp_rest_nonce',
+			'_blank'
+		);
 	} );
 } );

--- a/client/transactions/declarations.d.ts
+++ b/client/transactions/declarations.d.ts
@@ -119,6 +119,8 @@ declare module '@woocommerce/navigation' {
 		search?: string[];
 		status_is?: string;
 		status_is_not?: string;
+		document_id?: string;
+		document_type?: string;
 	}
 
 	const onQueryChange: unknown;


### PR DESCRIPTION
Fixes 1838-gh-Automattic/woocommerce-payments-server

#### Changes proposed in this Pull Request

This PR modifies the document download button to use a helper method and window.open instead of relying on the
`<a>` href property to open the document. This is useful to tidy up the retry mechanism and also to allow documents to be downloaded without having a button on the page.

It also adds a handler to the documents list that will automatically download a document, or go through the VAT validation process, if `document_id` and `document_type` are present in the query string. This is used to create a direct link from the new document email to the actual report.

Direct links will attempt to be opened in the current tab. However, depending on the content-disposition header, files might be automatically downloaded. In such cases, the current page will remain the documents list.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To be tested in conjunction with 1926-gh-Automattic/woocommerce-payments-server.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_