### PR TITLE
Platform checkout: Remove WooCommerce Blocks plugin dependency

### DIFF
--- a/changelog/fix-platform-checkout-inject-payments-api
+++ b/changelog/fix-platform-checkout-inject-payments-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Inject Payments API into Blocks Package to remove dependency on the Blocks plugin for the platform checkout.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -935,6 +935,22 @@ class WC_Payments {
 					}
 				}
 			);
+
+			// This injects the payments API into core, so the WooCommerce Blocks plugin is not necessary.
+			// The payments API is currently only available in feature builds (with flag `WC_BLOCKS_IS_FEATURE_PLUGIN`).
+			// We should remove this once it's available in core by default.
+			if ( ! defined( 'WC_BLOCKS_IS_FEATURE_PLUGIN' ) && class_exists( 'Automattic\WooCommerce\Blocks\Payments\Api' ) ) {
+				$blocks_package_container = Automattic\WooCommerce\Blocks\Package::container();
+				$blocks_package_container->register(
+					Automattic\WooCommerce\Blocks\Payments\Api::class,
+					function ( $container ) {
+						$payment_method_registry = $container->get( Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry::class );
+						$asset_data_registry     = $container->get( Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class );
+						return new Automattic\WooCommerce\Blocks\Payments\Api( $payment_method_registry, $asset_data_registry );
+					}
+				);
+				$blocks_package_container->get( Automattic\WooCommerce\Blocks\Payments\Api::class );
+			}
 		}
 	}
 


### PR DESCRIPTION
Context: p1650319227659789-slack-C022WMN88KG

#### Changes proposed in this Pull Request

This injects the necessary payments API classes only available behind constant `WC_BLOCKS_IS_FEATURE_PLUGIN`, so they're available in core for the platform checkout.

#### Testing instructions

* Make sure the WooCommerce Blocks plugin is disabled.
* As a shopper, add a product to the cart.
* Proceed to checkout and enter a platform checkout user email.
* Proceed with the platform checkout, and ensure you're redirected back to the "Order received" page.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_