### PR TITLE
In-Person Payments: send receipt for Interac payments.

### DIFF
--- a/changelog/fix-4183-send-receipts-for-interac-payments
+++ b/changelog/fix-4183-send-receipts-for-interac-payments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Send receipt for Interac payments.

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -358,7 +358,8 @@ class WC_Payments_Webhook_Processing_Service {
 		$this->order_service->mark_payment_completed( $order, $intent_id, $intent_status, $charge_id );
 
 		// Send the customer a card reader receipt if it's an in person payment type.
-		if ( Payment_Method::CARD_PRESENT === ( $charges_data[0]['payment_method_details']['type'] ?? null ) ) {
+		$payment_method = $charges_data[0]['payment_method_details']['type'] ?? null;
+		if ( Payment_Method::CARD_PRESENT === $payment_method || Payment_Method::INTERAC_PRESENT === $payment_method ) {
 			$merchant_settings = [
 				'business_name' => $this->wcpay_gateway->get_option( 'account_business_name' ),
 				'support_info'  => [


### PR DESCRIPTION
Fixes #4183 

#### Changes proposed in this Pull Request

Enables sending receipts for Interac payments.

#### Testing instructions

* All CI checks shall pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
