### PR TITLE
Added mode check on order tracking

### DIFF
--- a/changelog/fix-1453-switch-test-live-mode-issue
+++ b/changelog/fix-1453-switch-test-live-mode-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed issue with order tracking when mode is changed

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1071,6 +1071,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$payment_method = $payment_information->get_payment_method();
 		$order->update_meta_data( '_payment_method_id', $payment_method );
 		$order->update_meta_data( '_stripe_customer_id', $customer_id );
+		$order->update_meta_data( '_order_env', $this->is_in_test_mode() ? 'test' : 'prod' );
 
 		// In case amount is 0 and we're not saving the payment method, we won't be using intents and can confirm the order payment.
 		if ( ! $payment_needed && ! $save_payment_method_to_store ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1071,7 +1071,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$payment_method = $payment_information->get_payment_method();
 		$order->update_meta_data( '_payment_method_id', $payment_method );
 		$order->update_meta_data( '_stripe_customer_id', $customer_id );
-		$order->update_meta_data( '_order_env', $this->is_in_test_mode() ? 'test' : 'prod' );
+		$order->update_meta_data( '_wcpay_mode', $this->is_in_test_mode() ? 'test' : 'prod' );
 
 		// In case amount is 0 and we're not saving the payment method, we won't be using intents and can confirm the order payment.
 		if ( ! $payment_needed && ! $save_payment_method_to_store ) {

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -89,6 +89,16 @@ class WC_Payments_Action_Scheduler_Service {
 		if ( empty( $payment_method ) ) {
 			return false;
 		}
+		$order_env = $order->get_meta( '_order_env' );
+
+		if ( $order_env ) {
+			$current_env = $this->payments_api_client->is_in_test_mode() ? 'test' : 'prod';
+			if ( $current_env !== $order_env ) {
+				// If env. doesn't match make sure to stop order tracking to prevent order tracking issues.
+				// False will be returned so maybe next crons will have correct envs.
+				return false;
+			}
+		}
 
 		// Send the order data to the Payments API to track it.
 		$response = $this->payments_api_client->track_order(
@@ -97,6 +107,7 @@ class WC_Payments_Action_Scheduler_Service {
 				[
 					'_payment_method_id'  => $payment_method,
 					'_stripe_customer_id' => $order->get_meta( '_stripe_customer_id' ),
+					'_order_env'          => $order_env,
 				]
 			),
 			$is_update

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -89,13 +89,13 @@ class WC_Payments_Action_Scheduler_Service {
 		if ( empty( $payment_method ) ) {
 			return false;
 		}
-		$order_env = $order->get_meta( '_order_env' );
+		$order_mode = $order->get_meta( '_wcpay_mode' );
 
-		if ( $order_env ) {
-			$current_env = $this->payments_api_client->is_in_test_mode() ? 'test' : 'prod';
-			if ( $current_env !== $order_env ) {
-				// If env. doesn't match make sure to stop order tracking to prevent order tracking issues.
-				// False will be returned so maybe next crons will have correct envs.
+		if ( $order_mode ) {
+			$current_mode = $this->payments_api_client->is_in_test_mode() ? 'test' : 'prod';
+			if ( $current_mode !== $order_mode ) {
+				// If mode doesn't match make sure to stop order tracking to prevent order tracking issues.
+				// False will be returned so maybe future crons will have correct mode.
 				return false;
 			}
 		}
@@ -107,7 +107,7 @@ class WC_Payments_Action_Scheduler_Service {
 				[
 					'_payment_method_id'  => $payment_method,
 					'_stripe_customer_id' => $order->get_meta( '_stripe_customer_id' ),
-					'_order_env'          => $order_env,
+					'_wcpay_mode'         => $order_mode,
 				]
 			),
 			$is_update

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -327,7 +327,7 @@ class WC_Payments_API_Client {
 			// Only update the payment_method_types if we have a reference to the payment type the customer selected.
 			$request['payment_method_types'] = [ $selected_upe_payment_type ];
 		}
-		if ( $payment_country && ! WC_Payments::get_gateway()->is_in_dev_mode() ) {
+		if ( $payment_country && ! $this->is_in_dev_mode() ) {
 			// Do not update on dev mode, Stripe tests cards don't return the appropriate country.
 			$request['payment_country'] = $payment_country;
 		}
@@ -1049,7 +1049,7 @@ class WC_Payments_API_Client {
 	public function get_account_data() {
 		return $this->request(
 			[
-				'test_mode' => WC_Payments::get_gateway()->is_in_dev_mode(), // only send a test mode request if in dev mode.
+				'test_mode' => $this->is_in_dev_mode(), // only send a test mode request if in dev mode.
 			],
 			self::ACCOUNTS_API,
 			self::GET
@@ -1066,7 +1066,7 @@ class WC_Payments_API_Client {
 	public function get_platform_checkout_eligibility() {
 		return $this->request(
 			[
-				'test_mode' => WC_Payments::get_gateway()->is_in_dev_mode(), // only send a test mode request if in dev mode.
+				'test_mode' => $this->is_in_dev_mode(), // only send a test mode request if in dev mode.
 			],
 			self::PLATFORM_CHECKOUT_API,
 			self::GET
@@ -1130,7 +1130,7 @@ class WC_Payments_API_Client {
 				'return_url'          => $return_url,
 				'business_data'       => $business_data,
 				'site_data'           => $site_data,
-				'create_live_account' => ! WC_Payments::get_gateway()->is_in_dev_mode(),
+				'create_live_account' => ! $this->is_in_dev_mode(),
 				'actioned_notes'      => $actioned_notes,
 			]
 		);
@@ -1192,7 +1192,7 @@ class WC_Payments_API_Client {
 		return $this->request(
 			[
 				'redirect_url' => $redirect_url,
-				'test_mode'    => WC_Payments::get_gateway()->is_in_dev_mode(), // only send a test mode request if in dev mode.
+				'test_mode'    => $this->is_in_dev_mode(), // only send a test mode request if in dev mode.
 			],
 			self::ACCOUNTS_API . '/login_links',
 			self::POST,
@@ -1866,6 +1866,24 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Return is client in dev mode.
+	 *
+	 * @return bool
+	 */
+	public function is_in_dev_mode() {
+		return WC_Payments::get_gateway()->is_in_dev_mode();
+	}
+
+	/**
+	 * Return is client in test mode.
+	 *
+	 * @return bool
+	 */
+	public function is_in_test_mode() {
+		return WC_Payments::get_gateway()->is_in_test_mode();
+	}
+
+	/**
 	 * Send the request to the WooCommerce Payment API
 	 *
 	 * @param array  $params           - Request parameters to send as either JSON or GET string. Defaults to test_mode=1 if either in dev or test mode, 0 otherwise.
@@ -1883,7 +1901,7 @@ class WC_Payments_API_Client {
 		$params = wp_parse_args(
 			$params,
 			[
-				'test_mode' => WC_Payments::get_gateway()->is_in_test_mode(),
+				'test_mode' => $this->is_in_test_mode(),
 			]
 		);
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -236,7 +236,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->withConsecutive(
 				[ '_payment_method_id', 'pm_mock' ],
 				[ '_stripe_customer_id', $customer_id ],
-				[ '_order_env', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod' ],
+				[ '_wcpay_mode', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod' ],
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', $charge_id ],
 				[ '_intention_status', $status ],
@@ -420,7 +420,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->withConsecutive(
 				[ '_payment_method_id', 'pm_mock' ],
 				[ '_stripe_customer_id', $customer_id ],
-				[ '_order_env', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod' ],
+				[ '_wcpay_mode', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod' ],
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', $charge_id ],
 				[ '_intention_status', $status ],
@@ -797,7 +797,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->withConsecutive(
 				[ '_payment_method_id', 'pm_mock' ],
 				[ '_stripe_customer_id', $customer_id ],
-				[ '_order_env', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod' ],
+				[ '_wcpay_mode', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod' ],
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', $charge_id ],
 				[ '_intention_status', $status ],
@@ -915,7 +915,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 			->withConsecutive(
 				[ '_payment_method_id', 'pm_mock' ],
 				[ '_stripe_customer_id', $customer_id ],
-				[ '_order_env', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod' ],
+				[ '_wcpay_mode', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod' ],
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', '' ],
 				[ '_intention_status', $status ],

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -231,11 +231,12 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		// There's an issue open for that here:
 		// https://github.com/sebastianbergmann/phpunit/issues/4026.
 		$mock_order
-			->expects( $this->exactly( 9 ) )
+			->expects( $this->exactly( 10 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
 				[ '_payment_method_id', 'pm_mock' ],
 				[ '_stripe_customer_id', $customer_id ],
+				[ '_order_env', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod' ],
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', $charge_id ],
 				[ '_intention_status', $status ],
@@ -414,11 +415,12 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		// There's an issue open for that here:
 		// https://github.com/sebastianbergmann/phpunit/issues/4026.
 		$mock_order
-			->expects( $this->exactly( 9 ) )
+			->expects( $this->exactly( 10 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
 				[ '_payment_method_id', 'pm_mock' ],
 				[ '_stripe_customer_id', $customer_id ],
+				[ '_order_env', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod' ],
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', $charge_id ],
 				[ '_intention_status', $status ],
@@ -790,11 +792,12 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		// There's an issue open for that here:
 		// https://github.com/sebastianbergmann/phpunit/issues/4026.
 		$mock_order
-			->expects( $this->exactly( 9 ) )
+			->expects( $this->exactly( 10 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
 				[ '_payment_method_id', 'pm_mock' ],
 				[ '_stripe_customer_id', $customer_id ],
+				[ '_order_env', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod' ],
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', $charge_id ],
 				[ '_intention_status', $status ],
@@ -907,11 +910,12 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		// There's an issue open for that here:
 		// https://github.com/sebastianbergmann/phpunit/issues/4026.
 		$mock_order
-			->expects( $this->exactly( 8 ) )
+			->expects( $this->exactly( 9 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
 				[ '_payment_method_id', 'pm_mock' ],
 				[ '_stripe_customer_id', $customer_id ],
+				[ '_order_env', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod' ],
 				[ '_intent_id', $intent_id ],
 				[ '_charge_id', '' ],
 				[ '_intention_status', $status ],

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2148,7 +2148,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$order->set_payment_method( 'woocommerce_payments' );
 		$order->update_meta_data( '_payment_method_id', 'pm_123' );
-		$order->update_meta_data( '_order_env', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod' );
+		$order->update_meta_data( '_wcpay_mode', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod' );
 		$order->delete_meta_data( '_new_order_tracking_complete' );
 
 		$this->mock_action_scheduler_service

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2148,6 +2148,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$order->set_payment_method( 'woocommerce_payments' );
 		$order->update_meta_data( '_payment_method_id', 'pm_123' );
+		$order->update_meta_data( '_order_env', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod' );
 		$order->delete_meta_data( '_new_order_tracking_complete' );
 
 		$this->mock_action_scheduler_service

--- a/tests/unit/test-class-wc-payments-action-scheduler-service.php
+++ b/tests/unit/test-class-wc-payments-action-scheduler-service.php
@@ -41,7 +41,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$order->add_meta_data( '_payment_method_id', 'pm_131535132531', true );
 		$order->add_meta_data( '_stripe_customer_id', 'cu_123', true );
-		$order->add_meta_data( '_order_env', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod', true );
+		$order->add_meta_data( '_wcpay_mode', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod', true );
 		$order->save_meta_data();
 
 		$this->mock_api_client->expects( $this->once() )
@@ -74,7 +74,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$order->add_meta_data( '_payment_method_id', 'pm_131535132531', true );
 		$order->add_meta_data( '_stripe_customer_id', 'cu_123', true );
-		$order->add_meta_data( '_order_env', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod', true );
+		$order->add_meta_data( '_wcpay_mode', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod', true );
 		$order->save_meta_data();
 
 		$this->mock_api_client->expects( $this->once() )
@@ -89,7 +89,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$order->add_meta_data( '_payment_method_id', 'pm_13153513253', true );
 		$order->add_meta_data( '_stripe_customer_id', 'cu_123', true );
-		$order->add_meta_data( '_order_env', 'foo', true ); // Random value so we are sure that env will be changed.
+		$order->add_meta_data( '_wcpay_mode', 'foo', true ); // Random value so we are sure that env will be changed.
 		$order->save_meta_data();
 
 		$this->mock_api_client->expects( $this->never() )
@@ -129,7 +129,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 			[
 				'_payment_method_id'  => $order->get_meta( '_payment_method_id' ),
 				'_stripe_customer_id' => $order->get_meta( '_stripe_customer_id' ),
-				'_order_env'          => WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod',
+				'_wcpay_mode'         => WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod',
 			]
 		);
 	}

--- a/tests/unit/test-class-wc-payments-action-scheduler-service.php
+++ b/tests/unit/test-class-wc-payments-action-scheduler-service.php
@@ -41,6 +41,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$order->add_meta_data( '_payment_method_id', 'pm_131535132531', true );
 		$order->add_meta_data( '_stripe_customer_id', 'cu_123', true );
+		$order->add_meta_data( '_order_env', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod', true );
 		$order->save_meta_data();
 
 		$this->mock_api_client->expects( $this->once() )
@@ -73,6 +74,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$order->add_meta_data( '_payment_method_id', 'pm_131535132531', true );
 		$order->add_meta_data( '_stripe_customer_id', 'cu_123', true );
+		$order->add_meta_data( '_order_env', WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod', true );
 		$order->save_meta_data();
 
 		$this->mock_api_client->expects( $this->once() )
@@ -81,6 +83,19 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 			->willReturn( [ 'result' => 'success' ] );
 
 		$this->assertTrue( $this->action_scheduler_service->track_update_order_action( $order->get_id() ) );
+	}
+
+	public function test_track_update_order_action_will_not_track_order_if_env_is_changed() {
+		$order = WC_Helper_Order::create_order();
+		$order->add_meta_data( '_payment_method_id', 'pm_13153513253', true );
+		$order->add_meta_data( '_stripe_customer_id', 'cu_123', true );
+		$order->add_meta_data( '_order_env', 'foo', true ); // Random value so we are sure that env will be changed.
+		$order->save_meta_data();
+
+		$this->mock_api_client->expects( $this->never() )
+			->method( 'track_order' );
+
+		$this->action_scheduler_service->track_update_order_action( $order->get_id() );
 	}
 
 	public function test_track_update_order_action_with_no_payment_method() {
@@ -114,6 +129,7 @@ class WC_Payments_Action_Scheduler_Service_Test extends WP_UnitTestCase {
 			[
 				'_payment_method_id'  => $order->get_meta( '_payment_method_id' ),
 				'_stripe_customer_id' => $order->get_meta( '_stripe_customer_id' ),
+				'_order_env'          => WC_Payments::get_gateway()->is_in_test_mode() ? 'test' : 'prod',
 			]
 		);
 	}


### PR DESCRIPTION
Fixes #4194

#### Changes proposed in this Pull Request

<!--
Title: Check for environment when order is tracked and prevent tracking if environment is changed
-->

When mode is changed on Stripe (from test to prod and vice versa), the order tracking becomes invalid because orders are linked to specific mode (production or test). Order tracking is a scheduled job and changing mode can cause scenarios where the order is invalid because it is related to an entirely different mode with own payment methods and orders (on Stripe). This PR fixes it by adding a metadata value to order that will tell in what environment or mode the order has been created.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. Create new order (subscription is the best since it creates recurring orders)
2. Switch WooCommerce Payments mode
3. Check crons and make sure that order tracking for previous order is not scheduled or will not trigger an error

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
