### PR TITLE
Fix IPP email receipt removes custom email settings

### DIFF
--- a/changelog/fix-ipp-email-receipt-removes-custom-email-settings
+++ b/changelog/fix-ipp-email-receipt-removes-custom-email-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed non-working emails customization setting page caused by WCPay.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -285,7 +285,7 @@ class WC_Payments {
 		self::$remote_note_service                 = new WC_Payments_Remote_Note_Service( WC_Data_Store::load( 'admin-note' ) );
 		self::$action_scheduler_service            = new WC_Payments_Action_Scheduler_Service( self::$api_client );
 		self::$fraud_service                       = new WC_Payments_Fraud_Service( self::$api_client, self::$customer_service, self::$account );
-		self::$in_person_payments_receipts_service = new WC_Payments_In_Person_Payments_Receipts_Service( WC()->mailer() );
+		self::$in_person_payments_receipts_service = new WC_Payments_In_Person_Payments_Receipts_Service();
 		self::$localization_service                = new WC_Payments_Localization_Service();
 		self::$failed_transaction_rate_limiter     = new Session_Rate_Limiter( Session_Rate_Limiter::SESSION_KEY_DECLINED_CARD_REGISTRY, 5, 10 * MINUTE_IN_SECONDS );
 		self::$order_service                       = new WC_Payments_Order_Service();

--- a/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
+++ b/includes/in-person-payments/class-wc-payments-in-person-payments-receipts-service.php
@@ -13,23 +13,6 @@ defined( 'ABSPATH' ) || exit;
 class WC_Payments_In_Person_Payments_Receipts_Service {
 
 	/**
-	 * WC_Emails instance.
-	 *
-	 * @var WC_Emails
-	 */
-	private $mailer;
-
-	/**
-	 * __construct
-	 *
-	 * @param  WC_Emails $mailer instance.
-	 * @return void
-	 */
-	public function __construct( WC_Emails $mailer ) {
-		$this->mailer = $mailer;
-	}
-
-	/**
 	 * Renders the receipt template.
 	 *
 	 * @param  array    $settings Merchant settings.
@@ -95,7 +78,7 @@ class WC_Payments_In_Person_Payments_Receipts_Service {
 	 * @return void
 	 */
 	public function send_customer_ipp_receipt_email( WC_Order $order, array $merchant_settings, array $charge ) {
-		$email_receipt = $this->mailer->get_emails()['WC_Payments_Email_IPP_Receipt'];
+		$email_receipt = WC()->mailer()->get_emails()['WC_Payments_Email_IPP_Receipt'];
 		if ( $email_receipt instanceof WC_Payments_Email_IPP_Receipt ) {
 			$email_receipt->trigger( $order, $merchant_settings, $charge );
 		}

--- a/tests/unit/in-person-payments/test-class-wc-payments-in-person-payments-receipts-service.php
+++ b/tests/unit/in-person-payments/test-class-wc-payments-in-person-payments-receipts-service.php
@@ -40,9 +40,7 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 	public function set_up() {
 		parent::set_up();
 
-		$this->mock_emails = $this->createMock( WC_Emails::class );
-
-		$this->receipts_service = new WC_Payments_In_Person_Payments_Receipts_Service( $this->mock_emails );
+		$this->receipts_service = new WC_Payments_In_Person_Payments_Receipts_Service();
 	}
 
 	public function test_get_receipt_markup_is_EMV_compliant() {
@@ -94,35 +92,6 @@ class WC_Payments_In_Person_Payments_Receipts_Service_Test extends WP_UnitTestCa
 		$this->expectException( \RuntimeException::class );
 		$this->expectExceptionMessage( $expected_message );
 		$this->receipts_service->get_receipt_markup( $input_settings, $mock_order, [] );
-	}
-
-	public function test_send_customer_receipt_email_success() {
-		require WCPAY_ABSPATH . 'includes/emails/class-wc-payments-email-ipp-receipt.php';
-		$mock_receipt_email = $this->createMock( WC_Payments_Email_IPP_Receipt::class );
-		$mock_order         = WC_Helper_Order::create_order();
-		$mock_charge        = [
-			'amount_captured'        => 10,
-			'order'                  => [
-				'number' => $mock_order->get_id(),
-			],
-			'payment_method_details' => [
-				'card_present' => [
-					'brand'   => 'test',
-					'last4'   => 'Test',
-					'receipt' => [
-						'application_preferred_name' => 'Test',
-						'dedicated_file_name'        => 'Test 42',
-						'account_type'               => 'Test',
-					],
-				],
-			],
-		];
-
-		$this->mock_emails->expects( $this->once() )->method( 'get_emails' )->willReturn( [ 'WC_Payments_Email_IPP_Receipt' => $mock_receipt_email ] );
-
-		$mock_receipt_email->expects( $this->once() )->method( 'trigger' )->with( $mock_order, $this->mock_settings, $mock_charge );
-
-		$this->receipts_service->send_customer_ipp_receipt_email( $mock_order, $this->mock_settings, $mock_charge );
 	}
 
 	public function provide_settings_validation_data() {


### PR DESCRIPTION
Fixes #4167 & #4182 

#### Changes proposed in this Pull Request
The inclusion of the IPP New receipt email in v4.0.0 is causing problems with other plugins that provide custom emails. The issue is caused because the WC_Emails mailer was initialized when the WCPay plugin is loaded, not allowing other plugins to attach their hooks to register their emails.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This PR fixes two different issues that were documented in #4167 & #4182. 

**Test Customizing a new OSM template**
* Start with a WC test site with WC Pay installed and active
* Install and activate [Order Status Manager](https://woocommerce.com/products/woocommerce-order-status-manager/). 
* Go to WooCommerce > Settings > Order Status > Emails.
* Create an example email template there.
* Once you save, click Customize Email. 
* Check that you are directed to the customization page (please check screenshot below)
* Check that you are able to update and save the customized email


<img width="1318" alt="Screen Shot 2022-04-26 at 13 09 59" src="https://user-images.githubusercontent.com/1553182/165287703-6ec81cb7-129b-41b6-9790-de30b69efaab.png">

-------------------
**Test all templates are available**
* Use test site created in the above section
* Install and activate latest WooCommerce Subscriptions + WooCommerce Subscriptions Gifting 
* Go to WooCommerce > Settings > Emails 
* Check that the email templates created by WooCommerce Subscriptions Gifting are listed 
* Check that the email created in Test Customizing a new OSM template section is listed
* Check the the New Receipt template is listed (see screenshot below)

<img width="1318" alt="Screen Shot 2022-04-26 at 13 18 48" src="https://user-images.githubusercontent.com/1553182/165289153-d38195c3-f8fc-433b-b9f4-e09dcb1457f9.png">


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : 'QA Testing Not Applicable'