### PR TITLE
Add a check for if the SMS OTP iframe modal is off the bottom of the screen.

### DIFF
--- a/changelog/fix-4108-sms-otp-modal-off-screen
+++ b/changelog/fix-4108-sms-otp-modal-off-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure platform checkout SMS OTP iframe modal is always visible.

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -84,8 +84,18 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 			return;
 		}
 
-		// Check if the iframe is off the top of the screen and scroll back into view.
-		if ( 0 >= iframe.getBoundingClientRect().top ) {
+		/**
+		 * If the iframe is off the top of the screen
+		 * OR the iframe is off the bottom of the screen
+		 * scroll the window so the iframe is in view.
+		 */
+		if (
+			0 >= iframe.getBoundingClientRect().top ||
+			0 >=
+				window.innerHeight -
+					iframe.getBoundingClientRect().height +
+					iframe.getBoundingClientRect().top
+		) {
 			const topOffset = 50;
 			const scrollTop =
 				document.documentElement.scrollTop +


### PR DESCRIPTION
Fixes #4108

#### Changes proposed in this Pull Request
We had an existing check for the SMS OTP modal being off the top edge of the screen, but not for the bottom. This PR introduces that check.

#### Testing instructions

1. Check out this PR and build the assets.
2. Go to the shortcode checkout page on a store configured to use the platform checkout.
3. Adjust your browser window to be about 1000x600 and make sure the email field is near the bottom of the screen.
4. Enter a valid platform checkout email address.
5. Verify that when the SMS OTP modal pops up, the window adjusts its scroll position to show the entire modal.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
