### PR TITLE
Card testing: rework errors handling.

### DIFF
--- a/changelog/update-1833-card-testing-errors-handling
+++ b/changelog/update-1833-card-testing-errors-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Card testing: rework card errors handling.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -895,7 +895,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			if ( $fraud_prevention_service->is_enabled() && ! $fraud_prevention_service->verify_token( $_POST['wcpay-fraud-prevention-token'] ?? null ) ) {
 				throw new Process_Payment_Exception(
-					__( 'Your payment was not processed.', 'woocommerce-payments' ),
+					__( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-payments' ),
 					'fraud_prevention_enabled'
 				);
 			}

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -422,7 +422,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 				// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				if ( $fraud_prevention_service->is_enabled() && ! $fraud_prevention_service->verify_token( $_POST['wcpay-fraud-prevention-token'] ?? null ) ) {
 					throw new Process_Payment_Exception(
-						__( 'Your payment was not processed.', 'woocommerce-payments' ),
+						__( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-payments' ),
 						'fraud_prevention_enabled'
 					);
 				}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2107,17 +2107,14 @@ class WC_Payments_API_Client {
 					$response_code
 				);
 			} elseif ( isset( $response_body['error'] ) ) {
-				if ( isset( $response_body['error']['decline_code'] ) && 'fraudulent' === $response_body['error']['decline_code'] ) {
-					$fraud_prevention_service = Fraud_Prevention_Service::get_instance();
-					if ( $fraud_prevention_service->is_enabled() ) {
-						$fraud_prevention_service->regenerate_token();
-						WC()->session->set( 'reload_checkout', true );
-					}
-				}
+				$this->maybe_act_on_fraud_prevention( $response_body['error']['decline_code'] ?? '' );
+
 				$error_code    = $response_body['error']['code'] ?? $response_body['error']['type'] ?? null;
 				$error_message = $response_body['error']['message'] ?? null;
 				$error_type    = $response_body['error']['type'] ?? null;
 			} elseif ( isset( $response_body['code'] ) ) {
+				$this->maybe_act_on_fraud_prevention( $response_body['code'] );
+
 				$error_code    = $response_body['code'];
 				$error_message = $response_body['message'];
 			} else {
@@ -2133,6 +2130,25 @@ class WC_Payments_API_Client {
 
 			Logger::error( "$error_message ($error_code)" );
 			throw new API_Exception( $message, $error_code, $response_code, $error_type );
+		}
+	}
+
+	/**
+	 * If error code indicates fraudulent activity, trigger fraud prevention measures.
+	 *
+	 * @param string $error_code Error code.
+	 *
+	 * @return void
+	 */
+	private function maybe_act_on_fraud_prevention( string $error_code ) {
+		// Might be flagged by Stripe Radar or WCPay card testing prevention services.
+		$is_fraudulent = 'fraudulent' === $error_code || 'wcpay_card_testing_prevention' === $error_code;
+		if ( $is_fraudulent ) {
+			$fraud_prevention_service = Fraud_Prevention_Service::get_instance();
+			if ( $fraud_prevention_service->is_enabled() ) {
+				$fraud_prevention_service->regenerate_token();
+				// Here we tried triggering checkout refresh, but it clashes with AJAX handling.
+			}
 		}
 	}
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2384,7 +2384,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			->willReturn( true );
 
 		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'Your payment was not processed.' );
+		$this->expectExceptionMessage( "We're not able to process this payment. Please refresh the page and try again." );
 		$this->wcpay_gateway->process_payment( $order->get_id() );
 	}
 
@@ -2407,7 +2407,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$_POST['wcpay-fraud-prevention-token'] = 'incorrect-token';
 
 		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'Your payment was not processed.' );
+		$this->expectExceptionMessage( "We're not able to process this payment. Please refresh the page and try again." );
 		$this->wcpay_gateway->process_payment( $order->get_id() );
 	}
 


### PR DESCRIPTION
Fixes 1833-gh-Automattic/woocommerce-payments-server

#### Changes proposed in this Pull Request

* Rework errors handling related to card testing.

#### Testing instructions

* Regular payments (succeeded or errored shall pass)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_