### PR TITLE
Ignore cache expiry check when checking platform_checkout eligibility

### DIFF
--- a/changelog/fix-cache-lookup-platform-checkout-eligibility
+++ b/changelog/fix-cache-lookup-platform-checkout-eligibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix platform checkout eligibility check through ajax requests

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -94,10 +94,7 @@ class Database_Cache {
 	public function get( string $key, bool $force = false ) {
 		$cache_contents = get_option( $key );
 		if ( is_array( $cache_contents ) && array_key_exists( 'data', $cache_contents ) ) {
-			if ( true === $force ) {
-				return $cache_contents['data'];
-			}
-			if ( $this->is_expired( $key, $cache_contents ) ) {
+			if ( ! $force && $this->is_expired( $key, $cache_contents ) ) {
 				return null;
 			}
 

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -87,12 +87,16 @@ class Database_Cache {
 	 * Gets a value from the cache.
 	 *
 	 * @param string $key The key to look for.
+	 * @param bool   $force if set return from the cache without checking for expiry.
 	 *
 	 * @return mixed The cache contents.
 	 */
-	public function get( string $key ) {
+	public function get( string $key, bool $force = false ) {
 		$cache_contents = get_option( $key );
 		if ( is_array( $cache_contents ) && array_key_exists( 'data', $cache_contents ) ) {
+			if ( true === $force ) {
+				return $cache_contents['data'];
+			}
 			if ( $this->is_expired( $key, $cache_contents ) ) {
 				return null;
 			}

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -87,7 +87,7 @@ class Database_Cache {
 	 * Gets a value from the cache.
 	 *
 	 * @param string $key The key to look for.
-	 * @param bool   $force if set return from the cache without checking for expiry.
+	 * @param bool   $force If set, return from the cache without checking for expiry.
 	 *
 	 * @return mixed The cache contents.
 	 */

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -94,7 +94,8 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_platform_checkout_eligible() {
-		$account = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY );
+		// read directly from cache, ignore cache expiration check.
+		$account = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
 		return is_array( $account ) && ( $account['platform_checkout_eligible'] ?? false );
 	}
 


### PR DESCRIPTION
Fixes #4214 

#### Changes proposed in this Pull Request

Introduce an optional argument to database cache `get` method to ignore the expiry check. This is utilized when determining the platform checkout eligibility.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. To make it easier to reproduce, set `$ttl = MINUTE_IN_SECONDS` in this [line](https://github.com/Automattic/woocommerce-payments/blob/1b6827884c53767f43c51057a174c56098f29d99/includes/class-database-cache.php#L281) 
2. As a customer, add a product to the cart
3. Go to the checkout page
4. Enter an email address that is already registered to platform checkout
5. Open dev tools network tab and look for `admin-ajax` requests
6. When the OTP iframe opens, notice that the `admin-ajax` request to track `platform_checkout_otp_prompt_start` returns a 200 response.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
