### PR TITLE
add docs about updating siteurl with ngrok tunnel

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -41,5 +41,7 @@ ngrok http 8082
 
 You will see it give a forwarding address like this one:
  http://e0747cffd8a3.ngrok.io
+ 
+You may need to set your `siteurl` and `home` `wp_option`s to the new url. You can do this with phpMyAdmin or WP-CLI.
 
 Visit the `<url>` , login and setup WCPay.

--- a/docker/README.md
+++ b/docker/README.md
@@ -42,6 +42,6 @@ ngrok http 8082
 You will see it give a forwarding address like this one:
  http://e0747cffd8a3.ngrok.io
  
-You may need to set your `siteurl` and `home` `wp_option`s to the new url. You can do this with phpMyAdmin or WP-CLI.
+You may need to temporarily set your `siteurl` and `home` `wp_option`s to the new url. You can do this with phpMyAdmin or WP-CLI.
 
 Visit the `<url>` , login and setup WCPay.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a line to the dev readme about `siteurl` and `home` options. When using a tunnel (e.g. ngrok), I believe these need to be updated (temporarily) to the tunnel url.

I hit this when regenerating my local environment, so I figured it might block others in future. 

#### Testing instructions

Read through the readme – check if it's helpful and clear 😁 
