### PR TITLE
added card last 4 to order meta

### DIFF
--- a/changelog/add-save-last4
+++ b/changelog/add-save-last4
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add card last 4 digits to order meta to allow WooPay to send it to the merchant store

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1267,6 +1267,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if ( $payment_needed ) {
 			$payment_method_details = $intent->get_payment_method_details();
 			$payment_method_type    = $payment_method_details ? $payment_method_details['type'] : null;
+
+			if ( $payment_method_details && 'card' === $payment_method_details['type'] ) {
+				$order->add_meta_data( 'last4', $payment_method_details['card']['last4'] );
+				$order->save_meta_data();
+			}
 		} else {
 			$payment_method_details = false;
 			$payment_method_options = isset( $intent['payment_method_options'] ) ? array_keys( $intent['payment_method_options'] ) : null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR adds the card last 4 to the order to allow WooPay to send it to the merchant store. This PR needs to be reviewed alongside with 911-gh-Automattic/woopay and #4232

#### Testing instructions
- Check instructions in 911-gh-Automattic/woopay

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**
- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_