### PR TITLE
Do not show country code on Platform Checkout opt-in

### DIFF
--- a/changelog/fix-4241-platform-checkout-optin-country-code
+++ b/changelog/fix-4241-platform-checkout-optin-country-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Do not show country code on Platform Checkout opt-in.

--- a/client/components/platform-checkout/save-user/phone-number-input.js
+++ b/client/components/platform-checkout/save-user/phone-number-input.js
@@ -16,7 +16,6 @@ const PhoneNumberInput = ( { handlePhoneNumberChange } ) => {
 		document.getElementById( 'billing_phone' )?.value ?? ''
 	);
 	const [ inputInstance, setInputInstance ] = useState( null );
-	const [ countryCode, setCountryCode ] = useState( null );
 	const [ isValid, setIsValid ] = useState( true );
 
 	const handlePhoneNumberInputChange = ( e ) => {
@@ -82,7 +81,6 @@ const PhoneNumberInput = ( { handlePhoneNumberChange } ) => {
 		);
 
 		const handleCountryChange = () => {
-			setCountryCode( '+' + iti.getSelectedCountryData().dialCode );
 			handlePhoneNumberChange( iti.getNumber() );
 		};
 
@@ -95,7 +93,12 @@ const PhoneNumberInput = ( { handlePhoneNumberChange } ) => {
 				utilsScript: utils,
 			} );
 			setInputInstance( iti );
-			setCountryCode( '+' + iti.getSelectedCountryData().dialCode );
+			setInputValue( ( currentInputValue ) =>
+				currentInputValue.replace(
+					'+' + iti.getSelectedCountryData().dialCode,
+					''
+				)
+			);
 
 			// Focus the phone number input when the component loads.
 			input.focus();
@@ -112,7 +115,7 @@ const PhoneNumberInput = ( { handlePhoneNumberChange } ) => {
 				);
 			}
 		};
-	}, [ handlePhoneNumberChange, setCountryCode ] );
+	}, [ handlePhoneNumberChange ] );
 
 	// Wrapping this in a div instead of a fragment because the library we're using for the phone input
 	// alters the DOM and we'll get warnings about "removing content without using React."
@@ -126,7 +129,7 @@ const PhoneNumberInput = ( { handlePhoneNumberChange } ) => {
 				) }
 				label={ __( 'Mobile phone number', 'woocommerce-payments' ) }
 				name="platform_checkout_user_phone_field[no-country-code]"
-				value={ inputValue.replace( countryCode, '' ) }
+				value={ inputValue }
 				onChange={ handlePhoneNumberInputChange }
 				onBlur={ handlePhoneNumberValidation }
 				className={

--- a/client/components/platform-checkout/save-user/phone-number-input.js
+++ b/client/components/platform-checkout/save-user/phone-number-input.js
@@ -16,6 +16,7 @@ const PhoneNumberInput = ( { handlePhoneNumberChange } ) => {
 		document.getElementById( 'billing_phone' )?.value ?? ''
 	);
 	const [ inputInstance, setInputInstance ] = useState( null );
+	const [ countryCode, setCountryCode ] = useState( null );
 	const [ isValid, setIsValid ] = useState( true );
 
 	const handlePhoneNumberInputChange = ( e ) => {
@@ -93,6 +94,7 @@ const PhoneNumberInput = ( { handlePhoneNumberChange } ) => {
 				utilsScript: utils,
 			} );
 			setInputInstance( iti );
+			setCountryCode( '+' + iti.getSelectedCountryData().dialCode );
 
 			// Focus the phone number input when the component loads.
 			input.focus();
@@ -109,7 +111,7 @@ const PhoneNumberInput = ( { handlePhoneNumberChange } ) => {
 				);
 			}
 		};
-	}, [ handlePhoneNumberChange ] );
+	}, [ handlePhoneNumberChange, setCountryCode ] );
 
 	// Wrapping this in a div instead of a fragment because the library we're using for the phone input
 	// alters the DOM and we'll get warnings about "removing content without using React."
@@ -123,7 +125,7 @@ const PhoneNumberInput = ( { handlePhoneNumberChange } ) => {
 				) }
 				label={ __( 'Mobile phone number', 'woocommerce-payments' ) }
 				name="platform_checkout_user_phone_field[no-country-code]"
-				value={ inputValue }
+				value={ inputValue.replace( countryCode, '' ) }
 				onChange={ handlePhoneNumberInputChange }
 				onBlur={ handlePhoneNumberValidation }
 				className={

--- a/client/components/platform-checkout/save-user/phone-number-input.js
+++ b/client/components/platform-checkout/save-user/phone-number-input.js
@@ -82,6 +82,7 @@ const PhoneNumberInput = ( { handlePhoneNumberChange } ) => {
 		);
 
 		const handleCountryChange = () => {
+			setCountryCode( '+' + iti.getSelectedCountryData().dialCode );
 			handlePhoneNumberChange( iti.getNumber() );
 		};
 


### PR DESCRIPTION
Fixes #4241

#### Changes proposed in this Pull Request

* Prevent show country code text in the Platform Checkout opt-in phone when it's pre-filled, showing only its flag.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable Platform Checkout.
2. On the checkout page billing address, write a phone number starting with + and country code.
3. Opt-in to Platform Checkout.
4. The country code will not show in the opt-in phone field.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
