### PR TITLE
Update KYC tracks properties

### DIFF
--- a/changelog/update-kyc-reminder-track-props
+++ b/changelog/update-kyc-reminder-track-props
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update KYC reminder email Tracks properties

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -529,9 +529,22 @@ class WC_Payments_Account {
 		$redirect_param = sanitize_text_field( wp_unslash( $_GET['wcpay-connect-redirect'] ) );
 
 		// Let's record in Tracks merchants returning via the KYC reminder email.
+		if ( 'initial' === $redirect_param ) {
+			$offset      = 1;
+			$description = 'initial';
+		} elseif ( 'second' === $redirect_param ) {
+			$offset      = 3;
+			$description = 'second';
+		} else {
+			$follow_number = in_array( $redirect_param, [ '1', '2', '3', '4' ], true ) ? $redirect_param : '0';
+			// offset is recorded in days, $follow_number maps to the week number.
+			$offset      = (int) $follow_number * 7;
+			$description = 'weekly-' . $follow_number;
+		}
+
 		$track_props = [
-			'type'          => 'initial' === $redirect_param ? 'initial' : 'follow',
-			'follow_number' => in_array( $redirect_param, [ '1', '2', '3', '4' ], true ) ? $redirect_param : '0',
+			'offset'      => $offset,
+			'description' => $description,
 		];
 		wc_admin_record_tracks_event( 'wcpay_kyc_reminder_merchant_returned', $track_props );
 


### PR DESCRIPTION
Fixes #4248 

#### Changes proposed in this Pull Request
Track merchants visiting the Connect page with the special URL param to redirect them to the KYC flow.

These events were originally introduced in #3958. 
Server-side property names of KYC reminder emails were recently updated in 1995-gh-Automattic/woocommerce-payments-server, this PR adjust the client side track event, `wcadmin_wcpay_kyc_reminder_merchant_returned` to match the above changes.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
#### Testing instructions

* Make sure Tracking is enabled in WC options. That's in `{your site}/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`.
* Make your site publicly accessible. `npm run tube:start` would do the trick if your're using Jurassic Tube. I don't recall if this was required but mentioning it just in case

Initial:
* Visit `{website url}/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect&wcpay-connect-redirect=initial` 
* Go to Live Tracks and search `wcadmin_wcpay_kyc_reminder_merchant_returned`
* Wait ~5 minutes after visiting the URL (it could take ~10 mins for the event to show up) 
* Confirm the event has `eventprops [ offset: 1, description: initial ]` in its properties

second:
* Visit `{website url}/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect&wcpay-connect-redirect=second` 
* Go to Live Tracks and search `wcadmin_wcpay_kyc_reminder_merchant_returned`
* Wait ~5 minutes after visiting the URL (it could take ~10 mins for the event to show up) 
* Confirm the event has `eventprops [ offset: 3, description: second ]` in its properties

Follow-ups
* Visit `{website url}/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect&wcpay-connect-redirect={ 1 | 2 | 3 | 4}` 
* Go to Live Tracks and search `wcadmin_wcpay_kyc_reminder_merchant_returned`
* Wait ~5 minutes after visiting the URL (it could take ~10 mins for the event to show up) 
* Confirm the event has `eventprops [ offset: 7 | 14 | 21 | 28, description: weekly-{1|2|3|4} ]` in its properties


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_