### PR TITLE
Use Jetpack connection to make session init request

### DIFF
--- a/changelog/platform-jetpack-session-init
+++ b/changelog/platform-jetpack-session-init
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update session init request to platform checkout to use Jetpack Connection.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1019,8 +1019,29 @@ class WC_Payments {
 			],
 		];
 
-		$response_array     = Automattic\Jetpack\Connection\Client::remote_request( $args, wp_json_encode( $body ) );
-		$response_body_json = wp_remote_retrieve_body( $response_array );
+		/**
+		 * Suppress psalm error from Jetpack Connection namespacing WP_Error.
+		 *
+		 * @psalm-suppress UndefinedDocblockClass
+		 */
+		$response = Automattic\Jetpack\Connection\Client::remote_request( $args, wp_json_encode( $body ) );
+
+		if ( is_wp_error( $response ) || ! is_array( $response ) ) {
+			Logger::error( 'HTTP_REQUEST_ERROR ' . var_export( $response, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+			// phpcs:ignore
+			/**
+			 * @psalm-suppress UndefinedDocblockClass
+			 */
+			$message = sprintf(
+				// translators: %1: original error message.
+				__( 'Http request failed. Reason: %1$s', 'woocommerce-payments' ),
+				$response->get_error_message()
+			);
+			// Respond with same message platform would respond with on failure.
+			$response_body_json = wp_json_encode( [ 'result' => 'failure' ] );
+		} else {
+			$response_body_json = wp_remote_retrieve_body( $response );
+		}
 
 		Logger::log( $response_body_json );
 		wp_send_json( json_decode( $response_body_json ) );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1019,7 +1019,7 @@ class WC_Payments {
 			],
 		];
 
-		$response_array     = wp_remote_request( $url, $args );
+		$response_array     = Automattic\Jetpack\Connection\Client::remote_request( $args, wp_json_encode( $body ) );
 		$response_body_json = wp_remote_retrieve_body( $response_array );
 
 		Logger::log( $response_body_json );


### PR DESCRIPTION
The goal of this PR is to use the Jetpack Connection to make requests to the platform checkout session init. This will allow us to better validate the requesting store when initializing a platform checkout.

I decided to use the existing `Automattic\Jetpack\Connection\Client::remote_request` already being used in `WC_Payments_Http::make_request` and even borrowed the error logging within it. The only hurdle I encountered was with a Psalm error. I ended up suppressing it as I believe the error is actually caused by Jetpack Connection though I wasn't clear on why `WC_Payments_Http::make_request` did not have the same error. The error was:
```
UndefinedDocblockClass - includes/class-wc-payments.php:1022:15 - Docblock-defined class, interface or enum named Automattic\Jetpack\Connection\WP_Error does not exist (see https://psalm.dev/200)
```

If I'm understanding the error correctly, this is being caused by the `Automattic\Jetpack\Connection\Client::remote_request` doc block returning just `WP_Error` instead of `\WP_Error`. If this is incorrect and this is something we should address instead of suppressing let me know.

I have tested this with a successful response from the platform, a failed response from the platform, and a `WP_Error` triggered by the request and all cases were handled properly. For the error case, I added some additional logging and just return the basic failed response message for now. This is an area for future enhancement, but this logging could prove useful as we roll out this feature.