### PR TITLE
Register draft order status hooks to stores with platform checkout enabled.

### DIFF
--- a/changelog/fix-platform-checkout-928-draft-order-status
+++ b/changelog/fix-platform-checkout-928-draft-order-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Register draft order status hooks to stores with platform checkout enabled.


### PR DESCRIPTION
Fixes platform checkout #️⃣928.
More context: p1652474214461389-slack-C022WMN88KG

#### Changes proposed in this Pull Request

- Register draft order status hooks to stores with platform checkout enabled.

#### Testing instructions

- Please follow the steps to reproduce from platform checkout issue #️⃣928.
- With the WooCommerce Blocks plugin disabled from the merchant store, make sure the order which is created after redirect has the status "Draft" instead of "Pending payment", whereas in `develop`, you don't have the "Draft" status, unless WooCommerce Blocks is enabled.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_