### PR TITLE
Update payment method id order meta after checkout

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1180,6 +1180,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$client_secret = $intent->get_client_secret();
 			$currency      = $intent->get_currency();
 			$next_action   = $intent->get_next_action();
+			// We update the payment method ID server side when it's necessary to clone payment methods,
+			// for example when saving a payment method to a platform customer account. When this happens
+			// we need to make sure the payment method on the order matches the one on the merchant account
+			// not the one on the platform account. The payment method ID is updated on the order further
+			// down.
+			$payment_method = $intent->get_payment_method_id() ?? $payment_method;
 
 			if ( 'requires_action' === $status && $payment_information->is_merchant_initiated() ) {
 				// Allow 3rd-party to trigger some action if needed.


### PR DESCRIPTION
Fixes issue in a different repository, linked to via GitHub internal linking below.

## Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When we create an account through the platform checkout experience (i.e. when a customer ticks **Save my information for faster checkouts**) the payment method ID sent to the server (and thus saved to the order) is a platform payment method. This caused issues, such as the merchant not being able to refund the order used to create the platform checkout account because the payment method in the order meta is not available to the merchant account.

This PR fixes the issue by updating the payment method ID in the order meta to the one returned by the server. That payment method ID is updated whenever a payment method is cloned from the platform account to the merchant account. The default is still whatever payment method is returned from the frontend during the checkout request.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> **Note:** Since this is functionality for the Platform Checkout Experience that hasn't been released yet there will be no testing instructions added to the Release Testing Instructions wiki.

### Reproducing the issue

1. Make sure you have a platform checkout website, a merchant store, and the WCPay server ready somewhere, all running `trunk`/`develop` depending on the repo.
2. Add an item to the cart and go to the **Checkout** page.
3. Use an email address that does not have a platform checkout account associated with it yet.
4. Fill in the customer information and make sure you **tick _Save my information for faster checkouts_**.
5. Add a valid phone number.
6. Click **Place order** to complete the payment.
7. Open wp-admin and go to **WooCommerce > Orders** and find the order you just placed.
8. Try to refund the order.
9. You'll see an error message pop up saying something along the lines of "Payment method `pm_abc123` does not exist", and the refund will fail.

### Testing the fix

1. Make sure you have a platform checkout website, a merchant store, and the WCPay server ready somewhere, the platform checkout website and WCPay server running `trunk`, the merchant store running this branch (`fix/refunds-after-creating-platform-account`).
2. Add an item to the cart and go to the **Checkout** page.
3. Use an email address that does not have a platform checkout account associated with it yet.
4. Fill in the customer information and make sure you **tick _Save my information for faster checkouts_**.
5. Add a valid phone number.
6. Click **Place order** to complete the payment.
7. Open wp-admin and go to **WooCommerce > Orders** and find the order you just placed.
8. Try to refund the order.
9. The refund should succeed.

- Repeat the process, but this time **do not tick _Save my information for faster checkouts_** to make sure refunds for normal refunds still work.
- Disable the Platform Checkout Experience on the merchant store, make an order, and make sure refunds still work.
- Create a new merchant store that hasn't been gated into the Platform Checkout Experience, make an order, and make sure refunds still work.



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
