### PR TITLE
Modify the pointer content on the "Add new product" page when WCS is not active.

### DIFF
--- a/changelog/update-4098-remove-reference-to-wcs
+++ b/changelog/update-4098-remove-reference-to-wcs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Modify the pointer content on the "Add new product" page when WooCommerce Subscriptions is not active.

--- a/includes/subscriptions/class-wc-payments-subscriptions-onboarding-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-onboarding-handler.php
@@ -42,6 +42,7 @@ class WC_Payments_Subscriptions_Onboarding_Handler {
 		add_action( 'woocommerce_payments_account_refreshed', [ $this, 'account_data_refreshed' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_modal_scripts_and_styles' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_toast_script' ] );
+		add_filter( 'woocommerce_subscriptions_admin_pointer_script_parameters', [ $this, 'filter_admin_pointer_script_parameters' ] );
 
 		$this->account = $account;
 	}
@@ -258,5 +259,23 @@ class WC_Payments_Subscriptions_Onboarding_Handler {
 		);
 
 		wp_enqueue_script( 'wcpay-subscription-product-onboarding-toast' );
+	}
+
+	/**
+	 * Modifies the pointer content found on the "Add new product" page
+	 * when WooCommerce Subscriptions is not active.
+	 *
+	 * @param array $pointer_params Array of strings used on the "Add new product" page.
+	 * @return array Potentially modified array of strings used on the "Add new product" page.
+	 */
+	public function filter_admin_pointer_script_parameters( $pointer_params ) {
+		if ( $this->is_subscriptions_plugin_active() ) {
+			return $pointer_params;
+		}
+
+		// translators: %1$s: <h3> tag, %2$s: </h3> tag, %3$s: <p> tag, %4$s: <em> tag, %5$s: </em> tag, %6$s: <em> tag, %7$s: </em> tag, %7$s: </p> tag.
+		$pointer_params['typePointerContent'] = sprintf( _x( '%1$sChoose Subscription%2$s%3$sWooCommerce Payments adds two new subscription product types - %4$sSimple subscription%5$s and %6$sVariable subscription%7$s.%8$s', 'used in admin pointer script params in javascript as type pointer content', 'woocommerce-payments' ), '<h3>', '</h3>', '<p>', '<em>', '</em>', '<em>', '</em>', '</p>' );
+
+		return $pointer_params;
 	}
 }

--- a/includes/subscriptions/class-wc-payments-subscriptions-onboarding-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-onboarding-handler.php
@@ -273,7 +273,7 @@ class WC_Payments_Subscriptions_Onboarding_Handler {
 			return $pointer_params;
 		}
 
-		// translators: %1$s: <h3> tag, %2$s: </h3> tag, %3$s: <p> tag, %4$s: <em> tag, %5$s: </em> tag, %6$s: <em> tag, %7$s: </em> tag, %7$s: </p> tag.
+		// translators: %1$s: <h3> tag, %2$s: </h3> tag, %3$s: <p> tag, %4$s: <em> tag, %5$s: </em> tag, %6$s: <em> tag, %7$s: </em> tag, %8$s: </p> tag.
 		$pointer_params['typePointerContent'] = sprintf( _x( '%1$sChoose Subscription%2$s%3$sWooCommerce Payments adds two new subscription product types - %4$sSimple subscription%5$s and %6$sVariable subscription%7$s.%8$s', 'used in admin pointer script params in javascript as type pointer content', 'woocommerce-payments' ), '<h3>', '</h3>', '<p>', '<em>', '</em>', '<em>', '</em>', '</p>' );
 
 		return $pointer_params;


### PR DESCRIPTION
Fixes #4098 

#### Changes proposed in this Pull Request

This PR modifies the pointer content found on the "Add new product" page when WooCommerce Subscriptions is not active.

#### Testing instructions

**Scenario 1:** WCS is active (no change)
 
1. Have a WordPress website with WooCommerce Payments installed. WooCommerce Subscriptions **should be installed and activated.**
2. Navigate to `/wp-admin/post-new.php?post_type=product&select_subscription=true&subscription_pointers=true`
3. Observe, the content in the pointer is "The WooCommerce Subscriptions extension adds two new subscription product types - Simple subscription and Variable subscription."

<img width="384" alt="Screen Shot 2022-05-18 at 1 52 35 pm" src="https://user-images.githubusercontent.com/1527164/168953992-84f84cf2-54fd-4787-bbd5-890ae7f4af08.png">

**Scenario 2:** WCS is not active

1. Have a WordPress website with WooCommerce Payments installed. WooCommerce Subscriptions **should not be installed or activated.**
2. Navigate to `/wp-admin/post-new.php?post_type=product&select_subscription=true&subscription_pointers=true`
3. Observe, the content in the pointer is "WooCommerce Payments adds two new subscription product types - Simple subscription and Variable subscription."

<img width="360" alt="Screen Shot 2022-05-18 at 1 53 30 pm" src="https://user-images.githubusercontent.com/1527164/168954061-c77685b6-c401-4abb-94ac-9e3af22a5755.png">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
