### PR TITLE
E2E environment setup & workflow optimizations

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -82,6 +82,10 @@ jobs:
       - name: Clone WCPay Repository
         uses: actions/checkout@v2
 
+      # Add GH token for authentication
+      - name: Add GH token for authentication
+        run: echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
+
       # PHP setup
       - name: PHP Setup
         uses: shivammathur/setup-php@v2
@@ -132,10 +136,6 @@ jobs:
       - name: Update node dependencies
         if: steps.node-cache.outputs.cache-hit == 'true'
         run: npm update
-
-      # Add GH token for cloning other repos
-      - name: Add GH token for authentication
-        run: echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
 
       # Build WCPay client
       - name: Build WCPay Client

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -156,6 +156,6 @@ jobs:
             name: e2e-screenshots
             path: |
               tests/e2e/screenshots
-              tests/e2e/docker/wp-content/debug.log
+              tests/e2e/docker/wordpress/wp-content/debug.log
             if-no-files-found: ignore
             retention-days: 5

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -142,8 +142,7 @@ jobs:
 
       # Prepare test environment
       - name: Prepare test environment
-        run: |
-          npm run test:e2e-setup
+        run: npm run test:e2e-setup
 
       # Run Tests
       - name: Run E2E Tests

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -16,10 +16,9 @@ env:
   E2E_GH_TOKEN:             ${{ secrets.E2E_GH_TOKEN }}
   CI_USER_TOKEN:            ${{ secrets.CI_USER_TOKEN }}
   WCP_DEV_TOOLS_REPO:       ${{ secrets.WCP_DEV_TOOLS_REPO }}
+  WCP_DEV_TOOLS_BRANCH:     'trunk'
   WCP_SERVER_REPO:          ${{ secrets.WCP_SERVER_REPO }}
   WC_SUBSCRIPTIONS_REPO:    ${{ secrets.WC_SUBSCRIPTIONS_REPO }}
-  WC_ACTION_SCHEDULER_REPO: ${{ secrets.WC_ACTION_SCHEDULER_REPO }}
-  WC_BLOCKS_REPO:           ${{ secrets.WC_BLOCKS_REPO }}
   E2E_BLOG_ID:              ${{ secrets.E2E_BLOG_ID }}
   E2E_BLOG_TOKEN:           ${{ secrets.E2E_BLOG_TOKEN }}
   E2E_USER_TOKEN:           ${{ secrets.E2E_USER_TOKEN }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -123,12 +123,12 @@ jobs:
 
       # Install composer dependencies if not present on cache
       - name: Install composer dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
+        if: ${{ steps.composer-cache.outputs.cache-hit == false }}
         run: composer install --no-progress
 
       # Install node dependencies if not present on cache
       - name: Install node dependencies
-        if: steps.node-cache.outputs.cache-hit != 'true'
+        if: ${{ steps.node-cache.outputs.cache-hit == false }}
         run: npm ci
 
       # Build WCPay client

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -132,11 +132,9 @@ jobs:
           extensions:  mysql
           coverage:    none
 
-      # Prepare testing dependencies
-      - name: Prepare testing dependencies
-        run: |
-          echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
-          sudo systemctl start mysql.service
+      # Add GH token for cloning other repos
+      - name: Add GH token for authentication
+        run: echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
 
       # Build WCPay client
       - name: Build WCPay Client

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -13,20 +13,20 @@ on:
   workflow_dispatch:
 
 env:
-  E2E_GH_TOKEN:             ${{ secrets.E2E_GH_TOKEN }}
-  CI_USER_TOKEN:            ${{ secrets.CI_USER_TOKEN }}
-  WCP_DEV_TOOLS_REPO:       ${{ secrets.WCP_DEV_TOOLS_REPO }}
-  WCP_DEV_TOOLS_BRANCH:     'trunk'
-  WCP_SERVER_REPO:          ${{ secrets.WCP_SERVER_REPO }}
-  WC_SUBSCRIPTIONS_REPO:    ${{ secrets.WC_SUBSCRIPTIONS_REPO }}
-  E2E_BLOG_ID:              ${{ secrets.E2E_BLOG_ID }}
-  E2E_BLOG_TOKEN:           ${{ secrets.E2E_BLOG_TOKEN }}
-  E2E_USER_TOKEN:           ${{ secrets.E2E_USER_TOKEN }}
-  E2E_RETEST:               1
-  WC_E2E_SCREENSHOTS:       1
-  E2E_SLACK_CHANNEL:        ${{ secrets.E2E_SLACK_CHANNEL }}
-  E2E_SLACK_TOKEN:          ${{ secrets.E2E_SLACK_TOKEN }}
-  E2E_USE_LOCAL_SERVER:     false
+  E2E_GH_TOKEN:          ${{ secrets.E2E_GH_TOKEN }}
+  CI_USER_TOKEN:         ${{ secrets.CI_USER_TOKEN }}
+  WCP_DEV_TOOLS_REPO:    ${{ secrets.WCP_DEV_TOOLS_REPO }}
+  WCP_DEV_TOOLS_BRANCH:  'trunk'
+  WCP_SERVER_REPO:       ${{ secrets.WCP_SERVER_REPO }}
+  WC_SUBSCRIPTIONS_REPO: ${{ secrets.WC_SUBSCRIPTIONS_REPO }}
+  E2E_BLOG_ID:           ${{ secrets.E2E_BLOG_ID }}
+  E2E_BLOG_TOKEN:        ${{ secrets.E2E_BLOG_TOKEN }}
+  E2E_USER_TOKEN:        ${{ secrets.E2E_USER_TOKEN }}
+  E2E_RETEST:            1
+  WC_E2E_SCREENSHOTS:    1
+  E2E_SLACK_CHANNEL:     ${{ secrets.E2E_SLACK_CHANNEL }}
+  E2E_SLACK_TOKEN:       ${{ secrets.E2E_SLACK_TOKEN }}
+  E2E_USE_LOCAL_SERVER:  false
 
 jobs:
   wcpay-e2e-tests:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -27,6 +27,7 @@ env:
   WC_E2E_SCREENSHOTS:       1
   E2E_SLACK_CHANNEL:        ${{ secrets.E2E_SLACK_CHANNEL }}
   E2E_SLACK_TOKEN:          ${{ secrets.E2E_SLACK_TOKEN }}
+  E2E_USE_LOCAL_SERVER:     false
 
 jobs:
   wcpay-e2e-tests:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -95,6 +95,10 @@ jobs:
           extensions:  mysql
           coverage:    none
 
+      # Composer setup
+      - name: Composer Setup
+        run: composer self-update 2.0.6
+
       # Use node version from .nvmrc
       - name: Setup NodeJS
         uses: actions/setup-node@v2
@@ -120,7 +124,7 @@ jobs:
       # Install composer dependencies if not present on cache
       - name: Install composer dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
-        run: composer self-update 2.0.6 && composer install --no-progress
+        run: composer install --no-progress
 
       # Update composer dependencies if using cache
       - name: Update composer dependencies

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -145,10 +145,10 @@ jobs:
 
       # Archive screenshots if any
       - name: Archive e2e test screenshots & logs
-        if: ${{ always() }}
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
-            name: e2e-screenshots
+            name: e2e-screenshots-logs
             path: |
               tests/e2e/screenshots
               tests/e2e/docker/wordpress/wp-content/debug.log

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -126,20 +126,10 @@ jobs:
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer install --no-progress
 
-      # Update composer dependencies if using cache
-      - name: Update composer dependencies
-        if: steps.composer-cache.outputs.cache-hit == 'true'
-        run: composer update
-
       # Install node dependencies if not present on cache
       - name: Install node dependencies
         if: steps.node-cache.outputs.cache-hit != 'true'
         run: npm ci
-
-      # Update node dependencies if using cache
-      - name: Update node dependencies
-        if: steps.node-cache.outputs.cache-hit == 'true'
-        run: npm update
 
       # Build WCPay client
       - name: Build WCPay Client

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -81,6 +81,15 @@ jobs:
       - name: Clone WCPay Repository
         uses: actions/checkout@v2
 
+      # PHP setup
+      - name: PHP Setup
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools:       composer
+          extensions:  mysql
+          coverage:    none
+
       # Use node version from .nvmrc
       - name: Setup NodeJS
         uses: actions/setup-node@v2
@@ -122,15 +131,6 @@ jobs:
       - name: Update node dependencies
         if: steps.node-cache.outputs.cache-hit == 'true'
         run: npm update
-
-      # PHP setup
-      - name: PHP Setup
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          tools:       composer
-          extensions:  mysql
-          coverage:    none
 
       # Add GH token for cloning other repos
       - name: Add GH token for authentication

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -138,7 +138,7 @@ jobs:
 
       # Build WCPay client
       - name: Build WCPay Client
-        run: npm ci && npm run build:client
+        run: npm run build:client
 
       # Prepare test environment
       - name: Prepare test environment

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -87,30 +87,41 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      # Dependency caching
-      - name: Add composer to cache
+      # Cache composer dependencies
+      - name: Cache composer dependencies
+        id: composer-cache
         uses: actions/cache@v2
         with:
-          path: ~/.cache/composer/
-          key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-
-      - name: Add vendor directory to cache
-        uses: actions/cache@v2
-        with:
-          path: vendor/
+          path: ./vendor
           key:  ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
 
-      - name: Add NPM directory to cache
+      # Cache node dependencies
+      - name: Cache node dependencies
+        id: node-cache
         uses: actions/cache@v2
         with:
-          path: ~/.npm/
-          key:  ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
-
-      - name: Add node_modules to cache
-        uses: actions/cache@v2
-        with:
-          path: node_modules/
+          path: ./node_modules
           key:  ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+
+      # Install composer dependencies if not present on cache
+      - name: Install composer dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer self-update 2.0.6 && composer install --no-progress
+
+      # Update composer dependencies if using cache
+      - name: Update composer dependencies
+        if: steps.composer-cache.outputs.cache-hit == 'true'
+        run: composer update
+
+      # Install node dependencies if not present on cache
+      - name: Install node dependencies
+        if: steps.node-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      # Update node dependencies if using cache
+      - name: Update node dependencies
+        if: steps.node-cache.outputs.cache-hit == 'true'
+        run: npm update
 
       # PHP setup
       - name: PHP Setup
@@ -126,7 +137,6 @@ jobs:
         run: |
           echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
           sudo systemctl start mysql.service
-          composer self-update 2.0.6 && composer install --no-progress
 
       # Build WCPay client
       - name: Build WCPay Client

--- a/changelog/e2e-setup-gh-actions-enable-server-instance
+++ b/changelog/e2e-setup-gh-actions-enable-server-instance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+E2E environment setup & workflow optimizations

--- a/tests/e2e/env/down.sh
+++ b/tests/e2e/env/down.sh
@@ -11,7 +11,7 @@ fi
 step "Stopping client containers"
 docker-compose -f $E2E_ROOT/env/docker-compose.yml down
 
-if [[ -z $CI && "$E2E_USE_LOCAL_SERVER" != false ]]; then
+if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 	step "Stopping server containers"
 	docker-compose -f $E2E_ROOT/deps/wcp-server/docker-compose.yml down
 fi

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -252,8 +252,8 @@ if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 	echo "Setting Jetpack blog_id"
 	cli wp wcpay_dev set_blog_id "$BLOG_ID"
 
-	echo "Refresh WCPay Account Cache"
-	cli wp wcpay_dev refresh_account_cache
+	echo "Refresh WCPay Account Data"
+	cli wp wcpay_dev refresh_account_data
 else
 	echo "Setting Jetpack blog_id"
 	cli wp wcpay_dev set_blog_id "$BLOG_ID" --blog_token="$E2E_BLOG_TOKEN" --user_token="$E2E_USER_TOKEN"

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -248,6 +248,9 @@ if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 
 	echo "Setting Jetpack blog_id"
 	cli wp wcpay_dev set_blog_id "$BLOG_ID"
+
+	echo "Refresh WCPay Account Cache"
+	cli wp wcpay_dev refresh_account_cache
 else
 	echo "Disabling WPCOM requests proxy"
 	cli wp option update wcpaydev_proxy 0

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -78,6 +78,12 @@ if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 
 	step "Configuring server with stripe account"
 	"$SERVER_PATH"/local/bin/link-account.sh "$BLOG_ID" "$E2E_WCPAY_STRIPE_ACCOUNT_ID" test 1 1
+
+	if [[ -n $CI ]]; then
+		step "Disable Xdebug on server container"
+		docker exec "$SERVER_CONTAINER" \
+		sh -c 'echo "#zend_extension=xdebug" > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && echo "Xdebug disabled."'
+	fi
 fi
 
 cd "$cwd"

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -238,6 +238,9 @@ fi
 echo "Activating dev tools plugin"
 cli wp plugin activate "$DEV_TOOLS_DIR"
 
+echo "Disabling WPCOM requests proxy"
+cli wp option update wcpaydev_proxy 0
+
 if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 	echo "Setting redirection to local server"
 	# host.docker.internal is not available in linux. Use ip address for docker0 interface to redirect requests from container.
@@ -252,9 +255,6 @@ if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 	echo "Refresh WCPay Account Cache"
 	cli wp wcpay_dev refresh_account_cache
 else
-	echo "Disabling WPCOM requests proxy"
-	cli wp option update wcpaydev_proxy 0
-
 	echo "Setting Jetpack blog_id"
 	cli wp wcpay_dev set_blog_id "$BLOG_ID" --blog_token="$E2E_BLOG_TOKEN" --user_token="$E2E_USER_TOKEN"
 fi

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -31,7 +31,7 @@ SITE_URL=$WP_URL
 
 # Setup WCPay local server instance.
 # Only if E2E_USE_LOCAL_SERVER is present & equals to true.
-if [[ -z $CI && "$E2E_USE_LOCAL_SERVER" != false ]]; then
+if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 	if [[ $FORCE_E2E_DEPS_SETUP || ! -d "$SERVER_PATH" ]]; then
 		step "Fetching server (branch ${WCP_SERVER_BRANCH-trunk})"
 
@@ -222,7 +222,7 @@ fi
 echo "Activating dev tools plugin"
 cli wp plugin activate "$DEV_TOOLS_DIR"
 
-if [[ -z $CI && "$E2E_USE_LOCAL_SERVER" != false ]]; then
+if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 	echo "Setting redirection to local server"
 	# host.docker.internal is not available in linux. Use ip address for docker0 interface to redirect requests from container.
 	if [[ -n $CI ]]; then

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -109,6 +109,12 @@ if [[ -z $CI ]]; then
 	docker-compose -f "$E2E_ROOT"/env/docker-compose.yml up --build --force-recreate -d phpMyAdmin
 fi
 
+if [[ -n $CI ]]; then
+	step "Disabling Xdebug on client container"
+	docker exec "$CLIENT_CONTAINER" \
+	sh -c 'echo "#zend_extension=xdebug" > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && echo "Xdebug disabled."'
+fi
+
 echo
 step "Setting up CLIENT site"
 

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -64,7 +64,7 @@ if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 	redirect_output docker-compose -f docker-compose.yml -f docker-compose.e2e.yml up --build --force-recreate -d
 
 	# Get WordPress instance port number from running containers, and print a debug line to show if it works.
-	WP_LISTEN_PORT=$(docker ps | grep woocommerce_payments_server_wordpress_e2e | sed -En "s/.*0:([0-9]+).*/\1/p")
+	WP_LISTEN_PORT=$(docker ps | grep "$SERVER_CONTAINER" | sed -En "s/.*0:([0-9]+).*/\1/p")
 	echo "WordPress instance listening on port ${WP_LISTEN_PORT}"
 
 	if [[ -n $CI ]]; then

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -83,6 +83,10 @@ if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 		step "Disable Xdebug on server container"
 		docker exec "$SERVER_CONTAINER" \
 		sh -c 'echo "#zend_extension=xdebug" > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && echo "Xdebug disabled."'
+
+		step "Starting webhook listener in background"
+		docker-compose exec -d -u www-data wordpress \
+		stripe listen --api-key "$E2E_WCPAY_STRIPE_TEST_SECRET_KEY" --forward-to http://localhost/wp-json/wpcom/v2/wcpay/webhook/dev
 	fi
 fi
 

--- a/tests/e2e/env/shared.sh
+++ b/tests/e2e/env/shared.sh
@@ -6,9 +6,10 @@ export WCP_ROOT=$cwd
 export E2E_ROOT="$cwd/tests/e2e"
 export WP_URL="localhost:8084"
 export SERVER_PATH="$E2E_ROOT/deps/wcp-server"
+export SERVER_CONTAINER="woocommerce_payments_server_wordpress_e2e"
 export DEV_TOOLS_DIR="wcp-dev-tools"
 export DEV_TOOLS_PATH="$E2E_ROOT/deps/$DEV_TOOLS_DIR"
-export WP_CONTAINER="wcp_e2e_wordpress"
+export CLIENT_CONTAINER="wcp_e2e_wordpress"
 
 step() {
 	echo
@@ -27,12 +28,12 @@ redirect_output() {
 # https://hub.docker.com/_/wordpress#running-as-an-arbitrary-user
 cli()
 {
-	redirect_output docker run -i --rm --user xfs --volumes-from "$WP_CONTAINER" --network container:"$WP_CONTAINER" wordpress:cli "$@"
+	redirect_output docker run -i --rm --user xfs --volumes-from "$CLIENT_CONTAINER" --network container:"$CLIENT_CONTAINER" wordpress:cli "$@"
 }
 
 # Function to log WP-CLI output without redirecting the output to /dev/null.
 # Works even when the DEBUG flag is unset or set to false
 cli_debug()
 {
-	docker run -i --rm --user xfs --volumes-from "$WP_CONTAINER" --network container:"$WP_CONTAINER" wordpress:cli "$@"
+	docker run -i --rm --user xfs --volumes-from "$CLIENT_CONTAINER" --network container:"$CLIENT_CONTAINER" wordpress:cli "$@"
 }

--- a/tests/e2e/env/up.sh
+++ b/tests/e2e/env/up.sh
@@ -11,7 +11,7 @@ fi
 step "Starting client containers"
 docker-compose -f "$E2E_ROOT/env/docker-compose.yml" start
 
-if [[ -z $CI && "$E2E_USE_LOCAL_SERVER" != false ]]; then
+if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 	step "Starting server containers"
 	docker-compose -f "$E2E_ROOT/deps/wcp-server/docker-compose.yml" start
 fi


### PR DESCRIPTION
Fixes #4260 

#### Problem

As part of previous optimizations to E2E environment setup to improve performance, a check against the environment variable `$CI` (which will always return true if ran inside GitHub actions) was added to prevent spinning up a server instance inside GitHub actions.

However, this caused a problem with setting up E2E tests inside WooCommerce Payments Server, which require spinning up a server instance inside docker. This PR fixes this problem with some additional optimizations.

#### Changes proposed in this Pull Request

* Enables the E2E setup script to allow creating server instance inside GitHub actions.
* Fixes composer & node dependency caching - The workflow wasn't making use of the GitHub Actions cache utility because it always triggers a clean install of the node packages. This behavior was fixed by running clean install only when cache is not available.
* Improved performance with caching. Without cache - **23 minutes** | With cache - **13 minutes**
* Removed MySQL service start command since we already have a DB instance running inside docker.
* Split-up dependency installation & client build to 2 different steps to calculate time required to finish each task.
* Modified uploading screenshots & logs only when the test fails
* Fixed path to `debug.log` for uploading screenshots & logs.
* Added CLI command to refresh account data after linking a Stripe account while using a server instance inside docker. (Requires this 61-gh-Automattic/woocommerce-payments-dev-tools  to be merged)
* Explicitly disables Xdebug on server & client instances

#### Testing instructions

* On GitHub actions, trigger a new workflow against this branch. If any job fails, try re-running the failed tests and it should go away. There is still some flakiness present with the tests.
* Confirm whether the workflow makes uses of cache. If using cache [these](https://d.pr/i/RO90K6+) steps would be skipped. If cache is not present, the skipped steps will run. Reference job - https://github.com/Automattic/woocommerce-payments/runs/6494575098?check_suite_focus=true
* Confirm test suite speed. With cache it should be around 13 minutes. Without cache it would be around 23 minutes.
* Confirm that the server instance is not created for tests on WCPay repo.

**Running E2E tests locally** 

* Checkout this branch, cleanup existing E2E environment if present and follow instructions on https://github.com/Automattic/woocommerce-payments/tree/develop/tests/e2e to setup a new environment.
* Confirm that a local server instance can be created (Note: Requires this 61-gh-Automattic/woocommerce-payments-dev-tools to be merged)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_