### PR TITLE
Add exception handling to prevent fatal errors when fetching payment methods on the checkout block

### DIFF
--- a/changelog/fix-1566-checkout_block_account_suspended
+++ b/changelog/fix-1566-checkout_block_account_suspended
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add exception handling to prevent fatal error

--- a/changelog/fix-1566-checkout_block_account_suspended
+++ b/changelog/fix-1566-checkout_block_account_suspended
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Add exception handling to prevent fatal error
+Prevent fatal errors when fetching payment methods on the checkout block

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -110,25 +110,30 @@ class WC_Payments_Token_Service {
 			return $tokens;
 		}
 
-		$customer_id = $this->customer_service->get_customer_id_by_user_id( $user_id );
+		try {
+			$customer_id = $this->customer_service->get_customer_id_by_user_id( $user_id );
 
-		if ( null === $customer_id ) {
+			if ( null === $customer_id ) {
+				return $tokens;
+			}
+
+			$stored_tokens = [];
+
+			foreach ( $tokens as $token ) {
+				if ( WC_Payment_Gateway_WCPay::GATEWAY_ID === $token->get_gateway_id() ) {
+					$stored_tokens[ $token->get_token() ] = $token;
+				}
+			}
+
+			$payment_methods = [ [] ];
+			foreach ( WC_Payments::get_gateway()->get_upe_enabled_payment_method_ids() as $type ) {
+				$payment_methods[] = $this->customer_service->get_payment_methods_for_customer( $customer_id, $type );
+			}
+			$payment_methods = array_merge( ...$payment_methods );
+		} catch ( Exception $e ) {
+			Logger::error( 'Failed to fetch payment methods for customer.' . $e );
 			return $tokens;
 		}
-
-		$stored_tokens = [];
-
-		foreach ( $tokens as $token ) {
-			if ( WC_Payment_Gateway_WCPay::GATEWAY_ID === $token->get_gateway_id() ) {
-				$stored_tokens[ $token->get_token() ] = $token;
-			}
-		}
-
-		$payment_methods = [ [] ];
-		foreach ( WC_Payments::get_gateway()->get_upe_enabled_payment_method_ids() as $type ) {
-			$payment_methods[] = $this->customer_service->get_payment_methods_for_customer( $customer_id, $type );
-		}
-		$payment_methods = array_merge( ...$payment_methods );
 
 		// Prevent unnecessary recursion, WC_Payment_Token::save() ends up calling 'woocommerce_get_customer_payment_tokens' in some cases.
 		remove_action( 'woocommerce_get_customer_payment_tokens', [ $this, 'woocommerce_get_customer_payment_tokens' ], 10, 3 );

--- a/tests/unit/test-class-wc-payments-token-service.php
+++ b/tests/unit/test-class-wc-payments-token-service.php
@@ -328,6 +328,21 @@ class WC_Payments_Token_Service_Test extends WP_UnitTestCase {
 		$this->assertEquals( [ new WC_Payment_Token_CC() ], $result );
 	}
 
+	public function test_woocommerce_get_customer_payment_tokens_failed_to_load_payment_methods_for_customer() {
+		$this->mock_customer_service
+			->expects( $this->once() )
+			->method( 'get_customer_id_by_user_id' )
+			->willReturn( 'cus_12345' );
+
+		$this->mock_customer_service
+			->expects( $this->once() )
+			->method( 'get_payment_methods_for_customer' )
+			->willThrowException( new Exception( 'Failed to get payment methods.' ) );
+
+		$result = $this->token_service->woocommerce_get_customer_payment_tokens( [ new WC_Payment_Token_CC() ], 1, 'woocommerce_payments' );
+		$this->assertEquals( [ new WC_Payment_Token_CC() ], $result );
+	}
+
 	private function generate_card_pm_response( $stripe_id ) {
 		return [
 			'type' => Payment_Method::CARD,


### PR DESCRIPTION
Fixes #1566 

#### Changes proposed in this Pull Request

Prevent fatal errors when fetching payment methods on the checkout block

The `get_payment_methods_for_customer` method was causing a fatal error to the application, exposing the stack trace directly to the client. It was caused by the absence of exception handling on the `get_payment_methods_for_customer` method as it rethrows the error to the upper level.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/16882226/169186238-c36a001a-6530-43dc-a6e1-51da97959184.png" alt="Before" />
</td>
<td>
<img src="https://user-images.githubusercontent.com/16882226/169187115-a8d9b854-0fe0-49ad-956a-b40abf06baa1.png" alt="After" />
</td>
</tr>
</table>

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To be able to reproduce this bug you will need to suspend your account:
* Open your account's RC
* Go to the "WooCommerce Payments" section and search for the "Account tool" subsection
* On the dropdown select "Hard Block Account" and then click on "Apply Account Action"
* Clear your account cache on WCPay Dev

After suspending your account, you will need to publish a page using the Checkout Block:
* Install the "WooCommerce Blocks" plugin in case you don't have it installed yet
* Create a new page accessing "Pages > Add new"
* Type `/` in the editor and search by "checkout"
* Add the "Checkout" block and publish the new page

On the store:
* Add a product to your cart
* Access the page that you have just created
* You should see the following error

<img src="https://user-images.githubusercontent.com/16882226/169186238-c36a001a-6530-43dc-a6e1-51da97959184.png" alt="Before" />

In case it doesn't show the error, try to clear the payment methods cache by adding those 2 lines to `includes/class-wc-payments-customer-service.php` at line 212:
```php
	public function get_payment_methods_for_customer( $customer_id, $type = 'card' ) {
		if ( ! $customer_id ) {
			return [];
		}

+		$this->clear_cached_payment_methods_for_user( get_current_user_id() );
+
		$cache_payment_methods = ! WC_Payments::is_network_saved_cards_enabled();
		$cache_key             = Database_Cache::PAYMENT_METHODS_KEY_PREFIX . $customer_id . '_' . $type;
```


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] QA Testing Not Applicable as it may be already in the critical flows
