### PR TITLE
Fix webhook idempotency (for payment intents)

### DIFF
--- a/changelog/fix-3783-webhook-idempotency
+++ b/changelog/fix-3783-webhook-idempotency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Preventing duplicate order notes and emails by clearing the cache before checking order status.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1270,9 +1270,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			}
 		}
 
+		$this->update_order_status_from_intent( $order, $intent_id, $status, $charge_id );
 		$this->attach_intent_info_to_order( $order, $intent_id, $status, $payment_method, $customer_id, $charge_id, $currency );
 		$this->attach_exchange_info_to_order( $order, $charge_id );
-		$this->update_order_status_from_intent( $order, $intent_id, $status, $charge_id );
 
 		if ( isset( $response ) ) {
 			return $response;

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -721,6 +721,8 @@ class WC_Payments_Order_Service {
 	 * @return boolean True if it has a paid status, false if not.
 	 */
 	private function is_order_paid( $order ) {
+		wp_cache_delete( $order->get_id(), 'posts' );
+
 		// Read the latest order properties from the database to avoid race conditions if webhook was handled during this request.
 		$clone_order = clone $order;
 		$clone_order->get_data_store()->read( $clone_order );


### PR DESCRIPTION
Fixes #3783

### Changes proposed in this Pull Request

Looking at [this comment](https://github.com/automattic/woocommerce-payments/issues/3783#issuecomment-1085215186) from the issue, I noticed that it says "_A payment of $XXX.XX was **started** using WooCommerce Payments_".

**Restoring the payment started note**

Then I looked into our code. This note would only appear if an intent was in the `requires_action` state, and that only happens with 3DS cards, when the authentication overlay comes up. I tried to reproduce the note, but I couldn't get the message to show up. Then I noticed that the `attach_intent_info_to_order` method updates the intent status meta value before `update_order_status_from_intent` has the chance to see if the status should get updated at all, and add the necessary note. That's why https://github.com/Automattic/woocommerce-payments/pull/4278/commits/21ba0c767440e52475b90ab3e69a00b8e7d7a600 is in this PR.

**Busting the cache**

While working on the asynchronous `update_order_status` (required for the payment started note), I noticed that by pausing at certain breakpoints (virtually simulating asynchronous requests), I could get to a state where:

1. One request (ex. the `update_order_status` AJAX call) started and loaded the order.
2. Another request (ex. a webhook) starts in parallel and loads the same order.
3. The first request modifies the order and performs all necessary actions).
4. The second request uses the same loaded order to make decisions, even though the order has already been modified and saved inthe meantime.

This is where it gets interesting. 😄 We already have a few mechanisms, which should have prevented this:

1. `WC_Payments_Order_Service`'s `is_order_locked`, `lock_order_payment`, and `unlock_order_payment` methods are supposed to lock the order for processing before and after updating it. In this case however, the order was locked, processed, and unlocked before the second process could kick in.
2. @htdat's https://github.com/Automattic/woocommerce-payments/pull/3975 should have seen that the order note already exist, and prevented the second process from proceeding. This did not happen for various reasons, which I'll create a separate issue for.
3. `WC_Payments_Order_Service::is_order_paid()` clones the order and reloads it through `$clone_order->get_data_store()->read( $clone_order )`, but that happens to fail as well, because the `read()` method uses `get_post()`. `get_post()` on the other hand uses object cache, which already contains the outdated post available and that fails.

This PR fixes the last point: It performs a `wp_cache_delete()` call before reloading the order. This way the post is freshly loaded from the database, and the second attempt is interrupted.

### Testing instructions

**Preparation and things to keep in mind:**

- Make sure you've got XDebug working for the client.
- Install and setup a mail sniffing plugin like [MailTrap](https://wordpress.org/plugins/mailtrap-for-wp/). It's a free service with a free plugin, which does the job for us.
- Note that the observed behavior should be prevented by [checking for duplicate order notes](https://github.com/Automattic/woocommerce-payments/pull/3975). Within the local Docker environment however, AJAX calls seem to use a different host, adding a small difference to the notes (URL), and circumventing that behavior. If your installation does not exhibit the same behavior, hardcode a `return false` within `WC_Payments_Order_Service::order_note_exists()`.

**Testing steps**

1. Check out this PR.
6. Make sure the server is listening for webhooks (`npm run listen`)
7. Go to `includes/class-wc-payments-order-service.php:724` and comment out the line. This will let you see the issue caused by not purging the cache.
8. In order to slow down execution and control the order of events, add breakpoints to the following lines:
	1. `includes/class-wc-payment-gateway-wcpay.php:2374` (`$this->order_service->mark_payment_completed()`)
	5. `includes/class-wc-payments-webhook-processing-service.php:369` (also `$this->order_service->mark_payment_completed()`)
	6. `includes/class-wc-payments-order-service.php:734` (`return true` statement within `is_order_paid()`)
	7. `includes/class-wc-payments-order-service.php:738` (`return false` statement within `is_order_paid()`)
9. Add a product to the cart, proceed to checkout, and use/enter a 3DS card (found [here](https://stripe.com/docs/testing#authentication-and-setup)). The point here is to force the SCA authentication dialog to show up, so I prefer using `4000 0027 6000 3184`, which always requires authentication.
10. You will see execution paused in `WC_Payments_Order_Service::is_order_paid()` before seeing the SCA modal. That's because we try to immediately create and confirm the intent before receiving the response that it `requires_action`. Let it continue.
11. Next, you will get a couple of parallel requests.
	1. Let the one originating from `WC_Payment_Gateway_WCPay::update_order_status` go through. That should involve resuming execution within the first and last breakpoints, listed above.
	2. Check MailTrap. Even though the webhook request is still paused, you should see 2 emails: one for the merchant, and one for the customer.
	3. Navigate to the order within `wp-admin`. It should already appear as processing, and should have an order note. **By this stage everything is already as it should be**.
	4. Let the second breakpoint from the list go through.
	You will be paused within `WC_Payments_Order_Service::is_order_paid()`, likely on the `return false` statement, which is obviously incorrect.
	8. Check the `$clone_order` object, specifically `->data->status`. Even though we're supposed to be re-reading the order, it will still show `pending`.
	9. Let execution continue.
	10. Once finished, check the order and MailTrap. You will likely see duplicate notes and customer emails.
12. Now to verify that this PR helps, un-comment the line from the 3rd point, and repeat points 5-7. This time `is_order_paid()` should return true, and there should be no duplicate actions 🥳

You can see how this looks in action within this video: p1653133714097669-slack-C01BPL3ALGP

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (this can only be covered by a very complicated E2E test)
- [x] Tested on mobile (does not apply)