### PR TITLE
Update subscriptions-core to 2.0.0

### DIFF
--- a/changelog/subscriptions-core-2.0.0
+++ b/changelog/subscriptions-core-2.0.0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update subscriptions-core to 2.0.0.

--- a/changelog/subscriptions-core-2.0.0-1
+++ b/changelog/subscriptions-core-2.0.0-1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+In subscriptions-core source files replace all cases of update_post_meta() where an Order ID is passed to use WC_Order::update_meta_data() instead.

--- a/changelog/subscriptions-core-2.0.0-1
+++ b/changelog/subscriptions-core-2.0.0-1
@@ -1,4 +1,4 @@
 Significance: minor
 Type: dev
 
-In subscriptions-core source files replace all cases of update_post_meta() where an Order ID is passed to use WC_Order::update_meta_data() instead.
+In subscriptions-core source files, replace all cases of update_post_meta() where an Order ID is passed to use WC_Order::update_meta_data() instead.

--- a/changelog/subscriptions-core-2.0.0-2
+++ b/changelog/subscriptions-core-2.0.0-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+In subscriptions-core source files replace code using get_post_type( $order_id ) with WC Data Store get_order_type().

--- a/changelog/subscriptions-core-2.0.0-2
+++ b/changelog/subscriptions-core-2.0.0-2
@@ -1,4 +1,4 @@
 Significance: minor
 Type: dev
 
-In subscriptions-core source files replace code using get_post_type( $order_id ) with WC Data Store get_order_type().
+In subscriptions-core source files, replace code using get_post_type( $order_id ) with WC Data Store get_order_type().

--- a/changelog/subscriptions-core-2.0.0-3
+++ b/changelog/subscriptions-core-2.0.0-3
@@ -1,4 +1,4 @@
 Significance: minor
 Type: dev
 
-Remove the get_post_meta() call from WCS_Post_Meta_Cache_Manager::maybe_update_for_post_change().
+In subscriptions-core source files, replace the get_post_meta() calls in WCS_Post_Meta_Cache_Manager with WC_Order::get_meta().

--- a/changelog/subscriptions-core-2.0.0-3
+++ b/changelog/subscriptions-core-2.0.0-3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove the get_post_meta() call from WCS_Post_Meta_Cache_Manager::maybe_update_for_post_change().

--- a/changelog/subscriptions-core-2.0.0-4
+++ b/changelog/subscriptions-core-2.0.0-4
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update the wcs_get_objects_property() function to prevent calls to get_post_meta() on objects that support calling the get_meta() function.

--- a/changelog/subscriptions-core-2.0.0-5
+++ b/changelog/subscriptions-core-2.0.0-5
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Deprecate the WC_Subscriptions_Order::get_meta() function. Use wcs_get_objects_property( $order, $meta_key, "single", $default ) instead.

--- a/changelog/subscriptions-core-2.0.0-6
+++ b/changelog/subscriptions-core-2.0.0-6
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Retrieving user subscription orders has been updated to use the WooCommerce specific APIs in WC_Subscriptions_Order.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
       "automattic/jetpack-sync": "1.30.5",
       "automattic/jetpack-tracking": "1.14.5",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "1.8.0"
+      "woocommerce/subscriptions-core": "2.0.0"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
       "automattic/jetpack-sync": "1.30.5",
       "automattic/jetpack-tracking": "1.14.5",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "2.0.0"
+      "woocommerce/subscriptions-core": "1.8.0"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e37daa3d7fe1fd81f71ca1b27fa5407c",
+    "content-hash": "59e89fea10abc3830b03b5f48e1d62aa",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1060,30 +1060,27 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "1.8.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "20d0604af2431cde345ba73d19aa0b2c3f86c81f"
+                "reference": "69ab97d25d8a3fb4c1ac38fb180b39f323af6ac9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/20d0604af2431cde345ba73d19aa0b2c3f86c81f",
-                "reference": "20d0604af2431cde345ba73d19aa0b2c3f86c81f",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/69ab97d25d8a3fb4c1ac38fb180b39f323af6ac9",
+                "reference": "69ab97d25d8a3fb4c1ac38fb180b39f323af6ac9",
                 "shasum": ""
             },
             "require": {
                 "composer/installers": "~1.2",
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
                 "dave-liddament/sarb": "^1.1",
-                "doctrine/instantiator": "1.0.5",
-                "phpdocumentor/reflection-docblock": "4.3.4",
-                "phpdocumentor/type-resolver": "0.5.1",
-                "phpunit/phpunit": "^6.0",
+                "phpunit/phpunit": "9.5.14",
                 "woocommerce/woocommerce-sniffs": "0.1.0",
-                "yoast/phpunit-polyfills": "^1.0"
+                "yoast/phpunit-polyfills": "1.0.3"
             },
             "type": "wordpress-plugin",
             "extra": {
@@ -1111,10 +1108,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/1.8.0",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.0.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-04-05T00:00:20+00:00"
+            "time": "2022-05-23T01:00:04+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e37daa3d7fe1fd81f71ca1b27fa5407c",
+    "content-hash": "59e89fea10abc3830b03b5f48e1d62aa",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1060,30 +1060,27 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "1.8.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "20d0604af2431cde345ba73d19aa0b2c3f86c81f"
+                "reference": "69ab97d25d8a3fb4c1ac38fb180b39f323af6ac9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/20d0604af2431cde345ba73d19aa0b2c3f86c81f",
-                "reference": "20d0604af2431cde345ba73d19aa0b2c3f86c81f",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/69ab97d25d8a3fb4c1ac38fb180b39f323af6ac9",
+                "reference": "69ab97d25d8a3fb4c1ac38fb180b39f323af6ac9",
                 "shasum": ""
             },
             "require": {
                 "composer/installers": "~1.2",
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
                 "dave-liddament/sarb": "^1.1",
-                "doctrine/instantiator": "1.0.5",
-                "phpdocumentor/reflection-docblock": "4.3.4",
-                "phpdocumentor/type-resolver": "0.5.1",
-                "phpunit/phpunit": "^6.0",
+                "phpunit/phpunit": "9.5.14",
                 "woocommerce/woocommerce-sniffs": "0.1.0",
-                "yoast/phpunit-polyfills": "^1.0"
+                "yoast/phpunit-polyfills": "1.0.3"
             },
             "type": "wordpress-plugin",
             "extra": {
@@ -1111,10 +1108,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/1.8.0",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.0.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-04-05T00:00:20+00:00"
+            "time": "2022-05-23T01:00:04+00:00"
         }
     ],
     "packages-dev": [
@@ -5837,5 +5834,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "59e89fea10abc3830b03b5f48e1d62aa",
+    "content-hash": "e37daa3d7fe1fd81f71ca1b27fa5407c",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1060,27 +1060,30 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "2.0.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "69ab97d25d8a3fb4c1ac38fb180b39f323af6ac9"
+                "reference": "20d0604af2431cde345ba73d19aa0b2c3f86c81f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/69ab97d25d8a3fb4c1ac38fb180b39f323af6ac9",
-                "reference": "69ab97d25d8a3fb4c1ac38fb180b39f323af6ac9",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/20d0604af2431cde345ba73d19aa0b2c3f86c81f",
+                "reference": "20d0604af2431cde345ba73d19aa0b2c3f86c81f",
                 "shasum": ""
             },
             "require": {
                 "composer/installers": "~1.2",
-                "php": "^7.1"
+                "php": "^7.0"
             },
             "require-dev": {
                 "dave-liddament/sarb": "^1.1",
-                "phpunit/phpunit": "9.5.14",
+                "doctrine/instantiator": "1.0.5",
+                "phpdocumentor/reflection-docblock": "4.3.4",
+                "phpdocumentor/type-resolver": "0.5.1",
+                "phpunit/phpunit": "^6.0",
                 "woocommerce/woocommerce-sniffs": "0.1.0",
-                "yoast/phpunit-polyfills": "1.0.3"
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "wordpress-plugin",
             "extra": {
@@ -1108,10 +1111,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.0.0",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/1.8.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-05-23T01:00:04+00:00"
+            "time": "2022-04-05T00:00:20+00:00"
         }
     ],
     "packages-dev": [
@@ -5834,5 +5837,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Load newer woocommerce-subscriptions-core's version 2.0.0.
- Added changelog entries from woocommerce-subscriptions-core to the changelog.
- Updated composer.lock as a result of running `composer update woocommerce/subscriptions-core`.

#### Testing instructions

* Checkout this branch.
* [Husky hook should run `composer install`](https://github.com/Automattic/woocommerce-payments/blob/develop/.husky/post-checkout#L8) and your `vendor/woocommerce/subscriptions-core` should be updated to `2.0.0`. Confirm that latest changes from `2.0.0` is present, for example, [vendor/woocommerce/subscriptions-core/changelog.txt is up-to-date](https://github.com/Automattic/woocommerce-subscriptions-core/blob/2.0.0/changelog.txt).


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_