### PR TITLE
Fix fatal error by checking for valid order before processing webhook

### DIFF
--- a/changelog/fix-4286-fix-webhook-service-fatal-error
+++ b/changelog/fix-4286-fix-webhook-service-fatal-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes fatal error on payment intent succeeded webhook.

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -361,6 +361,15 @@ class WC_Payments_Webhook_Processing_Service {
 		$charges_data  = $this->read_webhook_property( $event_charges, 'data' );
 		$charge_id     = $this->read_webhook_property( $charges_data[0], 'id' );
 
+		if ( ! $order ) {
+			throw new Invalid_Webhook_Data_Exception(
+				sprintf(
+				/* translators: %1: charge ID */
+					__( 'Could not find order via charge ID: %1$s', 'woocommerce-payments' ),
+					$charge_id
+				)
+			);
+		}
 		// update _charge_id meta if it doesn't exist - happens when maybe_process_upe_redirect fails sometimes.
 		if ( $charge_id && ! $order->get_meta( '_charge_id' ) ) {
 			$order->update_meta_data( '_charge_id', $charge_id );

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -362,13 +362,7 @@ class WC_Payments_Webhook_Processing_Service {
 		$charge_id     = $this->read_webhook_property( $charges_data[0], 'id' );
 
 		if ( ! $order ) {
-			throw new Invalid_Webhook_Data_Exception(
-				sprintf(
-				/* translators: %1: charge ID */
-					__( 'Could not find order via charge ID: %1$s', 'woocommerce-payments' ),
-					$charge_id
-				)
-			);
+			return;
 		}
 		// update _charge_id meta if it doesn't exist - happens when maybe_process_upe_redirect fails sometimes.
 		if ( $charge_id && ! $order->get_meta( '_charge_id' ) ) {


### PR DESCRIPTION
Fixes #4286 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
# Fixing Fatal Errors From Fractured Webhooks

Please read the details within #4286 for more context on the need for this fix. 

If the event body of the `process_webhook_payment_intent_succeeded` webhook event is not associated with a valid order ID for whatever reason, this fix will prevent a fatal error. All other functions within `WC_Payments_Webhook_Processing_Service` already have similar safety nets to handle mysteriously indecipherable orders and with these changes the `process_webhook_payment_intent_succeeded` handler will fall in line by throwing the same `Invalid_Webhook_Data_Exception` if an order is not to be found.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
1. Please pull the changes in this PR.
2. We will need to trigger the webhooks REST endpoint with an event type of `payment_intent.succeeded`. I'm not sure if there is a better way to do this, but I managed it by making a `POST` request to the endpoint using Postman. The target endpoint should be `/wp-json/wc/v3/payments/webhook`. Here is an example of a test request body. All of these fields will be required and the object `id` (here `pi_123`) must not match anything in your orders table.
```json
{
  "id": "evt_123",
  "object": "event",
  "data": {
    "object": {
      "id": "pi_123",
      "object": "payment_intent",
      "charge": "ch_123",
      "status": "processing",
      "invoice": "inv_123",
      "metadata": [],
      "charges": {
          "data": [
              {
                  "id": "ch_123"
              }
          ]
      }
    }
  },
  "type": "payment_intent.succeeded"
```
3. If we make the above request without these changes, the response should be an `internal_server_error` that states that there has been a critical error on the website. However, with the changes we should now be greeted with a marginally friendlier `400` `bad_request` error instead. 
4. Double-check that we threw the correct Exception by checking the WCPay status/error logs. There should be an error printed similar to the following: "ERROR WCPay\Exceptions\Invalid_Webhook_Data_Exception: Could not find order via charge ID: ch_123 in /var/www/html/wp-content/plugins/woocommerce-payments/includes/class-wc-payments-webhook-processing-service.php:365".
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
