### PR TITLE
Auto redirect a logged in platform user to platform checkout

### DIFF
--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -601,13 +601,18 @@ export default class WCPayAPI {
 		} );
 	}
 
-	initPlatformCheckout( userEmail, platformCheckoutUserSession ) {
+	initPlatformCheckout(
+		userEmail,
+		platformCheckoutUserSession,
+		checkoutFor = ''
+	) {
 		return this.request(
 			buildAjaxURL( getConfig( 'wcAjaxUrl' ), 'init_platform_checkout' ),
 			{
 				_wpnonce: getConfig( 'initPlatformCheckoutNonce' ),
 				email: userEmail,
 				user_session: platformCheckoutUserSession,
+				checkout_for: checkoutFor,
 			}
 		);
 	}

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -275,6 +275,9 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 		platformCheckoutCheckSession().then( ( hasValidUserSession ) => {
 			// Check the initial value of the email input and trigger input validation.
 			if ( hasValidUserSession ) {
+				wcpayTracks.recordUserEvent(
+					wcpayTracks.events.PLATFORM_CHECKOUT_AUTO_REDIRECT
+				);
 				api.initPlatformCheckout( '', hasValidUserSession ).then(
 					( response ) => {
 						if ( 'success' === response.result ) {

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -204,6 +204,20 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 		}
 	} );
 
+	const platformCheckoutCheckSession = () => {
+		return fetch(
+			`${ getConfig(
+				'platformCheckoutHost'
+			) }/wp-json/platform-checkout/v1/user/session`,
+			{
+				credentials: 'include',
+			}
+		)
+			.then( ( response ) => response.json() )
+			.then( ( data ) => data.has_valid_session )
+			.catch( () => false );
+	};
+
 	const platformCheckoutLocateUser = ( email ) => {
 		parentDiv.insertBefore( spinner, platformCheckoutEmailInput );
 
@@ -257,10 +271,16 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 	const searchParams = new URLSearchParams( window.location.search );
 
 	if ( 'true' !== searchParams.get( 'skip_platform_checkout' ) ) {
-		// Check the initial value of the email input and trigger input validation.
-		if ( validateEmail( platformCheckoutEmailInput.value ) ) {
-			platformCheckoutLocateUser( platformCheckoutEmailInput.value );
-		}
+		// Check for session initially.
+		platformCheckoutCheckSession().then( ( hasValidSession ) => {
+			// Check the initial value of the email input and trigger input validation.
+			if (
+				! hasValidSession &&
+				validateEmail( platformCheckoutEmailInput.value )
+			) {
+				platformCheckoutLocateUser( platformCheckoutEmailInput.value );
+			}
+		} );
 	} else {
 		searchParams.delete( 'skip_platform_checkout' );
 

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -214,7 +214,6 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 			}
 		)
 			.then( ( response ) => response.json() )
-			.then( ( data ) => data.platform_checkout_user_session )
 			.catch( () => false );
 	};
 
@@ -272,21 +271,23 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 
 	if ( 'true' !== searchParams.get( 'skip_platform_checkout' ) ) {
 		// Check for session initially.
-		platformCheckoutCheckSession().then( ( hasValidUserSession ) => {
+		platformCheckoutCheckSession().then( ( data ) => {
 			// Check the initial value of the email input and trigger input validation.
-			if ( hasValidUserSession ) {
+			if ( data.platform_checkout_user_session ) {
 				wcpayTracks.recordUserEvent(
 					wcpayTracks.events.PLATFORM_CHECKOUT_AUTO_REDIRECT
 				);
-				api.initPlatformCheckout( '', hasValidUserSession ).then(
-					( response ) => {
-						if ( 'success' === response.result ) {
-							window.location = response.url;
-						} else {
-							closeIframe();
-						}
+				api.initPlatformCheckout(
+					'',
+					data.platform_checkout_user_session,
+					data.checkout_for
+				).then( ( response ) => {
+					if ( 'success' === response.result ) {
+						window.location = response.url;
+					} else {
+						closeIframe();
 					}
-				);
+				} );
 			} else if ( validateEmail( platformCheckoutEmailInput.value ) ) {
 				platformCheckoutLocateUser( platformCheckoutEmailInput.value );
 			}

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -214,7 +214,7 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 			}
 		)
 			.then( ( response ) => response.json() )
-			.then( ( data ) => data.has_valid_session )
+			.then( ( data ) => data.platform_checkout_user_session )
 			.catch( () => false );
 	};
 
@@ -272,12 +272,19 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 
 	if ( 'true' !== searchParams.get( 'skip_platform_checkout' ) ) {
 		// Check for session initially.
-		platformCheckoutCheckSession().then( ( hasValidSession ) => {
+		platformCheckoutCheckSession().then( ( hasValidUserSession ) => {
 			// Check the initial value of the email input and trigger input validation.
-			if (
-				! hasValidSession &&
-				validateEmail( platformCheckoutEmailInput.value )
-			) {
+			if ( hasValidUserSession ) {
+				api.initPlatformCheckout( '', hasValidUserSession ).then(
+					( response ) => {
+						if ( 'success' === response.result ) {
+							window.location = response.url;
+						} else {
+							closeIframe();
+						}
+					}
+				);
+			} else if ( validateEmail( platformCheckoutEmailInput.value ) ) {
 				platformCheckoutLocateUser( platformCheckoutEmailInput.value );
 			}
 		} );

--- a/client/checkout/platform-checkout/style.scss
+++ b/client/checkout/platform-checkout/style.scss
@@ -45,6 +45,17 @@
 	}
 }
 
+.disabled-page {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100vw;
+	height: 100vh;
+	z-index: 99999;
+	background-color: rgba( 117, 117, 117, 0.6 );
+	opacity: 0.5;
+}
+
 @media screen and ( min-width: 768px ) {
 	.platform-checkout-sms-otp-iframe-wrapper {
 		position: fixed;

--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -81,6 +81,7 @@ const events = {
 	PLATFORM_CHECKOUT_OTP_START: 'platform_checkout_otp_prompt_start',
 	PLATFORM_CHECKOUT_OTP_COMPLETE: 'platform_checkout_otp_prompt_complete',
 	PLATFORM_CHECKOUT_OTP_FAILED: 'platform_checkout_otp_prompt_failed',
+	PLATFORM_CHECKOUT_AUTO_REDIRECT: 'platform_checkout_auto_redirect',
 };
 
 export default {

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1005,9 +1005,10 @@ class WC_Payments {
 
 		$session_cookie_name = apply_filters( 'woocommerce_cookie', 'wp_woocommerce_session_' . COOKIEHASH );
 
-		$email       = ! empty( $_POST['email'] ) ? wc_clean( wp_unslash( $_POST['email'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
-		$user        = wp_get_current_user();
-		$customer_id = self::$customer_service->get_customer_id_by_user_id( $user->ID );
+		$platform_user_id = ! empty( $_POST['checkout_for'] ) ? wc_clean( wp_unslash( $_POST['checkout_for'] ) ) : '';
+		$email            = ! empty( $_POST['email'] ) ? wc_clean( wp_unslash( $_POST['email'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+		$user             = wp_get_current_user();
+		$customer_id      = self::$customer_service->get_customer_id_by_user_id( $user->ID );
 		if ( null === $customer_id ) {
 			// create customer.
 			$customer_data = WC_Payments_Customer_Service::map_customer_data( null, new WC_Customer( $user->ID ) );
@@ -1026,6 +1027,7 @@ class WC_Payments {
 			'customer_id'          => $customer_id,
 			'session_nonce'        => wp_create_nonce( 'wc_store_api' ),
 			'email'                => $email,
+			'platform_user_id'     => $platform_user_id,
 			'session_cookie_name'  => $session_cookie_name,
 			'session_cookie_value' => wp_unslash( $_COOKIE[ $session_cookie_name ] ?? '' ), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 			'store_data'           => [


### PR DESCRIPTION
Fixes platform checkout issue 504.

## Description
If a user is already logged in to the platform and lands on a merchant's checkout page having platform checkout enabled, the user should be automatically redirected to the platform checkout page by initiating a valid checkout session.

#### Changes in this Pull Request

- When a user first lands on the checkout page, we are checking for a valid platform checkout login session.
- If a valid login session is present, redirecting the user to the platform. Triggers the OTP flow otherwise.
- Tracking the auto redirect event 
- Sending `platform_user_id` in the `session_init` request which is received in the first response.

### Related issue(s)
#504 

### Steps to test
Steps are mentioned in the other related PR.