### PR TITLE
Prevent expensive JOINs when there aren't multiple currencies used

### DIFF
--- a/changelog/update-reduce-expensive-queries
+++ b/changelog/update-reduce-expensive-queries
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Prevent expensive JOIN queries in Multi-Currency analytics if the store has never used Multi-Currency.

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -66,32 +66,16 @@ class Analytics {
 
 		add_filter( 'woocommerce_analytics_update_order_stats_data', [ $this, 'update_order_stats_data' ], self::PRIORITY_LATEST, 2 );
 
-		// If we aren't making a REST request, return before adding these filters.
+		// If we aren't making a REST request, or no multi currency orders exist in the merchant's store,
+		// return before adding these filters.
 		if ( ! WC()->is_rest_api_request() || ! $this->has_multi_currency_orders() ) {
 			return;
-
 		}
 
 		$this->set_sql_replacements();
 
 		add_filter( 'woocommerce_analytics_clauses_select', [ $this, 'filter_select_clauses' ], self::PRIORITY_LATE, 2 );
 		add_filter( 'woocommerce_analytics_clauses_join', [ $this, 'filter_join_clauses' ], self::PRIORITY_LATE, 2 );
-	}
-
-	public function has_multi_currency_orders() {
-		global $wpdb;
-		$query = <<<EOD
-			SELECT COUNT(DISTINCT `meta_value`) as `count`
-			FROM `{$wpdb->postmeta}`
-			INNER JOIN `{$wpdb->posts}` ON (`{$wpdb->postmeta}`.`post_id` = `{$wpdb->posts}`.`id`)
-			WHERE `{$wpdb->posts}`.`post_type` = 'order'
-				AND `meta_key` = '_order_currency'
-				AND `meta_value` <> ''
-				AND `meta_value` <> NULL;
-			EOD;
-
-		$currencies = intval( $wpdb->get_var( $query ) );
-		return $currencies > 1;
 	}
 
 	/**
@@ -346,6 +330,32 @@ class Analytics {
 	 */
 	private function generate_case_when( string $variable, string $then, string $else ): string {
 		return "CASE WHEN {$variable} IS NOT NULL THEN {$then} ELSE {$else} END";
+	}
+
+	/**
+	 * Perform an SQL query to determine whether Multi Currency has ever been used on this store,
+	 * by checking how many orders are in the database where an exchange currency rate has been stored.
+	 *
+	 * @return bool
+	 */
+	private function has_multi_currency_orders() {
+		global $wpdb;
+
+		$orders = intval(
+			$wpdb->get_var(
+				"
+				SELECT
+					COUNT(DISTINCT orders.ID)
+				FROM
+					{$wpdb->posts} AS orders
+				INNER JOIN
+					{$wpdb->postmeta} order_meta ON order_meta.post_id = orders.ID
+					AND order_meta.meta_key = '_wcpay_multi_currency_order_exchange_rate';
+				"
+			)
+		);
+
+		return $orders > 0;
 	}
 
 	/**

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -346,12 +346,11 @@ class Analytics {
 			$wpdb->get_var(
 				"
 				SELECT
-					COUNT(DISTINCT orders.ID)
+					COUNT(post_id)
 				FROM
-					{$wpdb->posts} AS orders
-				INNER JOIN
-					{$wpdb->postmeta} order_meta ON order_meta.post_id = orders.ID
-					AND order_meta.meta_key = '_wcpay_multi_currency_order_exchange_rate';
+					{$wpdb->postmeta}
+				WHERE
+					meta_key = '_wcpay_multi_currency_order_exchange_rate';
 				"
 			)
 		);

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -68,6 +68,7 @@ class Analytics {
 
 		// If we aren't making a REST request, or no multi currency orders exist in the merchant's store,
 		// return before adding these filters.
+
 		if ( ! WC()->is_rest_api_request() || ! $this->has_multi_currency_orders() ) {
 			return;
 		}

--- a/tests/unit/multi-currency/test-class-analytics.php
+++ b/tests/unit/multi-currency/test-class-analytics.php
@@ -29,11 +29,19 @@ class WCPay_Multi_Currency_Analytics_Tests extends WP_UnitTestCase {
 	private $mock_multi_currency;
 
 	/**
+	 * Mock orders.
+	 *
+	 * @var array An array of order ids.
+	 */
+	private $mock_orders = [];
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
 		parent::set_up();
 
+		$this->add_mock_order_with_meta();
 		$this->set_is_admin( true );
 		$this->set_is_rest_request( true );
 		add_filter(
@@ -42,7 +50,6 @@ class WCPay_Multi_Currency_Analytics_Tests extends WP_UnitTestCase {
 				return true;
 			}
 		);
-
 		// Add manage_woocommerce capability to user.
 		$cb = $this->create_can_manage_woocommerce_cap_override( true );
 		add_filter( 'user_has_cap', $cb );
@@ -51,6 +58,14 @@ class WCPay_Multi_Currency_Analytics_Tests extends WP_UnitTestCase {
 		$this->analytics           = new Analytics( $this->mock_multi_currency );
 
 		remove_filter( 'user_has_cap', $cb );
+	}
+
+	/**
+	 * Post-test tear down.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		$this->delete_mock_orders();
 	}
 
 	/**
@@ -314,5 +329,31 @@ class WCPay_Multi_Currency_Analytics_Tests extends WP_UnitTestCase {
 
 			return $allcaps;
 		};
+	}
+
+	/**
+	 * This will create a mock order with the appropriate Multi-Currency meta data.
+	 */
+	private function add_mock_order_with_meta() {
+		$order_id = wp_insert_post(
+			[
+				'post_type'   => 'shop_order',
+				'post_status' => 'wc-processing',
+			]
+		);
+
+		update_post_meta( $order_id, '_wcpay_multi_currency_order_exchange_rate', 0.5353 );
+		update_post_meta( $order_id, '_payment_method', 'stripe' );
+		update_post_meta( $order_id, '_order_total', 12.64 );
+		update_post_meta( $order_id, '_order_currency', 'EUR' );
+
+		// Add to the array of mock order IDs so we can delete it later.
+		$this->mock_orders[] = $order_id;
+	}
+
+	private function delete_mock_orders() {
+		foreach ( $this->mock_orders as $order_id ) {
+			wp_delete_post( $order_id, true );
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Prevent expensive JOINs when there aren't multiple currencies used

Looks up the number of currencies that have been used on this site. If
there are more than 1, we need to reflect that in the analytics.
Otherwise we should avoid the expensive JOINs.

See #4280

#### Testing instructions (updated by @dmallory42)

Checking the MC Analytics work when a MC order has been made

- On a site where you have previously made a multi-currency order, go to the analytics section and verify (either using step debugging, or query monitor to view the queries that are being run) to ensure that when the `Analytics` code is initialised, it does *not* return at [this point](https://github.com/Automattic/woocommerce-payments/blob/a4b6b377ab64fe0e389f74bfbfd142b7193a3979/includes/multi-currency/Analytics.php#L72). 
- Make an order with a multi-currency, and view the analytics for today to ensure that the order appears, and the figures (converted into your store default currency) look sensible.

Checking Analytics still loads when no MC order has been made

- Edit the `has_multi_currency_orders` function to return false, then check again - this time , the initialisation of MC Analytics should return early, before adding the filters. Check the analytics and verify that nothing is broken, all pages load without errors etc. (note that the total figures *may* be incorrect in this case, because the filters were not added and the store has MC orders, in prod this should not happen since we'd only return early if there are no MC orders).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
