### PR TITLE
Add ARN to successful refund events in the payment timeline

### DIFF
--- a/changelog/add-4024-arn-successful-refund-timeline
+++ b/changelog/add-4024-arn-successful-refund-timeline
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add ARN (Acquirer Reference Number) to refunds in payment details timeline.

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -650,7 +650,10 @@ const mapEventToTimelineItems = ( event ) => {
 					),
 					'checkmark',
 					'is-success',
-					[ composeFXString( event ) ]
+					[
+						composeFXString( event ),
+						getRefundTrackingDetails( event ),
+					]
 				),
 			];
 		case 'refund_failed':

--- a/client/payment-details/timeline/test/__snapshots__/index.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/index.js.snap
@@ -352,6 +352,7 @@ exports[`PaymentDetailsTimeline renders correctly (with a mocked Timeline compon
                   class="woocommerce-timeline-item__body"
                 >
                   <span />
+                  <span />
                 </div>
               </li>
             </ul>
@@ -482,6 +483,7 @@ exports[`PaymentDetailsTimeline renders correctly (with a mocked Timeline compon
                 <div
                   class="woocommerce-timeline-item__body"
                 >
+                  <span />
                   <span />
                 </div>
               </li>

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -217,6 +217,7 @@ Array [
   Object {
     "body": Array [
       "1,00 EUR → 1,20222 USD: 21,64&nbsp;$ USD",
+      "",
     ],
     "date": 2020-04-04T13:51:06.000Z,
     "headline": "A payment of 18,00&nbsp;€ EUR was successfully refunded.",
@@ -254,6 +255,7 @@ Array [
   Object {
     "body": Array [
       "1,00 EUR → 1,2 USD: 6,00&nbsp;$ USD",
+      "Acquirer Reference Number (ARN) 4785767637658864",
     ],
     "date": 2020-04-03T18:58:01.000Z,
     "headline": "A payment of 5,00&nbsp;€ EUR was successfully refunded.",
@@ -826,6 +828,7 @@ Array [
   Object {
     "body": Array [
       undefined,
+      "Acquirer Reference Number (ARN) 4785767637658864",
     ],
     "date": 2020-04-04T13:51:06.000Z,
     "headline": "A payment of $100.00 USD was successfully refunded.",
@@ -863,6 +866,7 @@ Array [
   Object {
     "body": Array [
       undefined,
+      "",
     ],
     "date": 2020-04-03T18:58:01.000Z,
     "headline": "A payment of $50.00 USD was successfully refunded.",

--- a/client/payment-details/timeline/test/map-events.js
+++ b/client/payment-details/timeline/test/map-events.js
@@ -331,6 +331,8 @@ describe( 'mapTimelineEvents', () => {
 						datetime: 1586008266,
 						deposit: null,
 						type: 'full_refund',
+						acquirer_reference_number_status: 'available',
+						acquirer_reference_number: '4785767637658864',
 					},
 				] )
 			).toMatchSnapshot();
@@ -481,6 +483,8 @@ describe( 'mapTimelineEvents', () => {
 						datetime: 1585940281,
 						deposit: null,
 						type: 'partial_refund',
+						acquirer_reference_number_status: 'available',
+						acquirer_reference_number: '4785767637658864',
 						transaction_details: {
 							customer_amount: 500,
 							customer_currency: 'EUR',


### PR DESCRIPTION
Fixes #4024

#### Changes proposed in this Pull Request
Add refund ARN to payment detail timeline, using the existing `getRefundTrackingDetails` method to include it within `getMainTimelineItem`.

#### Screenshot
<img width="709" alt="Screenshot 2022-05-30 at 15 57 58" src="https://user-images.githubusercontent.com/7670276/171007468-571dcac7-5a11-4b64-a32a-903c480af8b8.png">


#### Testing instructions
- Refund an order (don't forget to have stripe listener running)
- Go to **Payments > Transactions > Your refund**
- You should see the ARN below `A payment of ... was successfully refunded.`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
