### PR TITLE
Pass capture_method preference to platform store

### DIFF
--- a/changelog/fix-platform-capture-method
+++ b/changelog/fix-platform-capture-method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Pass capture method preference to platform store

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1039,6 +1039,7 @@ class WC_Payments {
 				'store_api_url'     => self::get_store_api_url(),
 				'account_id'        => $account_id,
 				'test_mode'         => self::get_gateway()->is_in_test_mode(),
+				'capture_method'    => empty( self::get_gateway()->get_option( 'manual_capture' ) ) || 'no' === self::get_gateway()->get_option( 'manual_capture' ) ? 'automattic' : 'manual',
 			],
 			'user_session'         => isset( $_REQUEST['user_session'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['user_session'] ) ) : null,
 		];

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1039,7 +1039,7 @@ class WC_Payments {
 				'store_api_url'     => self::get_store_api_url(),
 				'account_id'        => $account_id,
 				'test_mode'         => self::get_gateway()->is_in_test_mode(),
-				'capture_method'    => empty( self::get_gateway()->get_option( 'manual_capture' ) ) || 'no' === self::get_gateway()->get_option( 'manual_capture' ) ? 'automattic' : 'manual',
+				'capture_method'    => empty( self::get_gateway()->get_option( 'manual_capture' ) ) || 'no' === self::get_gateway()->get_option( 'manual_capture' ) ? 'automatic' : 'manual',
 			],
 			'user_session'         => isset( $_REQUEST['user_session'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['user_session'] ) ) : null,
 		];


### PR DESCRIPTION
Fixes 953-gh-Automattic/woopay

#### Changes proposed in this Pull Request
Pass in merchant's capture method preference ('automatic' or 'manual') to the platform store, so that platform store can honor it. 
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a breakpoint [here](https://github.com/Automattic/woocommerce-payments/blob/f525c3b91c43967174908cddcf97a9346d6f1d4f/includes/class-wc-payments.php#L1046)
* As a merchant go to Payments -> Settings
* Make sure "Issue an authorization on checkout, and capture later" is unchecked, and save changes.
![Screen Shot 2022-05-31 at 8 47 34 AM](https://user-images.githubusercontent.com/6216000/171189265-8526534b-7e86-4122-b82a-67ff63f897ac.png)
* Checkout a product as a registered platform checkout merchant.
* Notice the value of the `capture_method` when the above breakpoint is reached, it should be 'automatic'.
* Back in the settings screen, check the  "Issue an authorization on checkout, and capture later" checkbox.
* Go through checkout process again and `capture_method` should now be set to 'manual'.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.