### PR TITLE
In-Person Payments: fix an error in store location endpoint when blog name is empty

### DIFF
--- a/changelog/fix-4305-ipp-failure-in-store-location-endpoint
+++ b/changelog/fix-4305-ipp-failure-in-store-location-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix default terminal location creation for store when blog name is empty.

--- a/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
+++ b/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
@@ -144,18 +144,19 @@ class WC_REST_Payments_Terminal_Locations_Controller extends WC_Payments_REST_Co
 
 		try {
 			// Check the existing locations to see if one of them matches the store.
-			$name = get_bloginfo();
+			// Originally we picked `get_bloginfo` for generating names, but later switched to `site_url` for max immutability.
+			$possible_names = [ get_bloginfo(), site_url() ];
 			foreach ( $this->fetch_locations() as $location ) {
-				if (
-					$location['display_name'] === $name
-					&& count( array_intersect( $location['address'], $location_address ) ) === count( $location_address )
-				) {
-					return rest_ensure_response( $this->extract_location_fields( $location ) );
+				if ( in_array( $location['display_name'], $possible_names, true ) ) {
+					$matching_address_fields = array_intersect( $location['address'], $location_address );
+					if ( count( $matching_address_fields ) === count( $location_address ) ) {
+						return rest_ensure_response( $this->extract_location_fields( $location ) );
+					}
 				}
 			}
 
 			// If the location is missing, Create a new one and actualize the transient.
-			$location = $this->api_client->create_terminal_location( $name, $location_address );
+			$location = $this->api_client->create_terminal_location( site_url(), $location_address );
 			$this->reload_locations();
 
 			return rest_ensure_response( $this->extract_location_fields( $location ) );

--- a/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
+++ b/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
@@ -145,7 +145,8 @@ class WC_REST_Payments_Terminal_Locations_Controller extends WC_Payments_REST_Co
 		try {
 			// Check the existing locations to see if one of them matches the store.
 			// Originally we picked `get_bloginfo` for generating names, but later switched to `site_url` for max immutability.
-			$possible_names = [ get_bloginfo(), site_url() ];
+			$store_hostname = str_replace( [ 'https://', 'http://' ], '', get_site_url() );
+			$possible_names = [ get_bloginfo(), $store_hostname ];
 			foreach ( $this->fetch_locations() as $location ) {
 				if ( in_array( $location['display_name'], $possible_names, true ) ) {
 					$matching_address_fields = array_intersect( $location['address'], $location_address );
@@ -156,7 +157,7 @@ class WC_REST_Payments_Terminal_Locations_Controller extends WC_Payments_REST_Co
 			}
 
 			// If the location is missing, Create a new one and actualize the transient.
-			$location = $this->api_client->create_terminal_location( site_url(), $location_address );
+			$location = $this->api_client->create_terminal_location( $store_hostname, $location_address );
 			$this->reload_locations();
 
 			return rest_ensure_response( $this->extract_location_fields( $location ) );

--- a/tests/unit/admin/test-class-wc-rest-payments-terminal-locations-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-terminal-locations-controller.php
@@ -50,7 +50,7 @@ class WC_REST_Payments_Terminal_Locations_Controller_Test extends WP_UnitTestCas
 		$this->location   = [
 			'id'           => 'tml_XXXXXX',
 			'livemode'     => true,
-			'display_name' => get_bloginfo(),
+			'display_name' => str_replace( [ 'https://', 'http://' ], '', get_site_url() ),
 			'address'      => [
 				'city'        => WC()->countries->get_base_city(),
 				'country'     => WC()->countries->get_base_country(),


### PR DESCRIPTION
Fixes #4305 

#### Changes proposed in this Pull Request

Re-work location name generation towards a more reliable approach.

#### Testing instructions

* Change blog name in WordPress settings
* Follow test instructions from https://github.com/Automattic/woocommerce-payments/pull/2830

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.