### PR TITLE
Fix terminal location creation when site title is missing

### DIFF
--- a/changelog/fix-4305-terminal-location-creation
+++ b/changelog/fix-4305-terminal-location-creation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix terminal location creation if site title is missing

--- a/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
+++ b/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
@@ -145,6 +145,9 @@ class WC_REST_Payments_Terminal_Locations_Controller extends WC_Payments_REST_Co
 		try {
 			// Check the existing locations to see if one of them matches the store.
 			$name = get_bloginfo();
+			if ( empty( $name ) ) {
+				$name = get_home_url();
+			}
 			foreach ( $this->fetch_locations() as $location ) {
 				if (
 					$location['display_name'] === $name


### PR DESCRIPTION
Fixes #4305

#### Changes proposed in this Pull Request

The `payments/terminal/locations` endpoint uses the site title for the `display_name` property for the location. If the site has no  title, attempting to get the store terminal location fails. This PR falls back to the site URL as the `display_name` if there is no site title to use.

#### Testing instructions

- In **Settings > General**, set the **Site Title** field to empty and then **Save Changes**.
- Make a `GET` request to `/wp-json/wc/v3/payments/terminal/locations/store`.
- Verify that the location object you get back has a `display_name` set to the site's URL.
- In **Settings > General**, set the **Site Title** to a non-empty string.
- Make another `GET` request to `/wp-json/wc/v3/payments/terminal/locations/store`.
- Verify that the location object you get back has a `display_name` set to the site's title.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
