### PR TITLE
Update payment in renewal order from subscriptions

### DIFF
--- a/changelog/fix-2813-payment-method-copy-subscriptions
+++ b/changelog/fix-2813-payment-method-copy-subscriptions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Copy payment from a subscription to its renewal order when retrying failed renewal payment.

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -144,9 +144,11 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 
 		// Allow store managers to manually set Stripe as the payment method on a subscription.
 		add_filter( 'woocommerce_subscription_payment_meta', [ $this, 'add_subscription_payment_meta' ], 10, 2 );
-		add_filter( 'wcs_copy_payment_meta_to_order', [ $this, 'copy_payment_meta_to_order' ], 10, 3 );
 		add_filter( 'woocommerce_subscription_validate_payment_meta', [ $this, 'validate_subscription_payment_meta' ], 10, 3 );
 		add_action( 'wcs_save_other_payment_meta', [ $this, 'save_meta_in_order_tokens' ], 10, 4 );
+
+		// To make sure payment meta is copied from subscription to order.
+		add_filter( 'wcs_copy_payment_meta_to_order', [ $this, 'append_payment_meta' ], 10, 3 );
 
 		add_filter( 'woocommerce_subscription_note_old_payment_method_title', [ $this, 'get_specific_old_payment_method_title' ], 10, 3 );
 		add_filter( 'woocommerce_subscription_note_new_payment_method_title', [ $this, 'get_specific_new_payment_method_title' ], 10, 3 );
@@ -330,15 +332,14 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 	}
 
 	/**
-	 * Include the payment meta data for wcs_copy_payment_meta_to_order filter, so payment meta data is copied
-	 * from subscription to its related order correctly.
+	 * Append payment meta if order and subscription are using WCPay as payment method and if passed payment meta is an array.
 	 *
 	 * @param array           $payment_meta Associative array of meta data required for automatic payments.
 	 * @param WC_Order        $order        The subscription's related order.
 	 * @param WC_Subscription $subscription The subscription order.
 	 * @return array
 	 */
-	public function copy_payment_meta_to_order( $payment_meta, $order, $subscription ) {
+	public function append_payment_meta( $payment_meta, $order, $subscription ) {
 		if ( $this->id !== $order->get_payment_method() || $this->id !== $subscription->get_payment_method() ) {
 			return $payment_meta;
 		}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -611,6 +611,73 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 		$this->assertFalse( wp_script_is( 'WCPAY_SUBSCRIPTION_EDIT_PAGE', 'enqueued' ) );
 	}
 
+	public function test_append_payment_meta() {
+		$token1 = WC_Helper_Token::create_token( self::PAYMENT_METHOD_ID, self::USER_ID );
+		$token2 = WC_Helper_Token::create_token( self::PAYMENT_METHOD_ID, self::USER_ID );
+
+		$subscription = WC_Helper_Order::create_order( self::USER_ID );
+		$subscription->set_payment_method( $this->wcpay_gateway->id );
+		$subscription->add_payment_token( $token1 );
+
+		$order = WC_Helper_Order::create_order( self::USER_ID );
+		$order->set_payment_method( $this->wcpay_gateway->id );
+		$order->add_payment_token( $token2 );
+
+		$payment_meta1 = $this->wcpay_gateway->append_payment_meta( [], $order, $subscription );
+		$payment_meta2 = $this->wcpay_gateway->append_payment_meta( [ 'some-key' => 'some-value' ], $order, $subscription );
+
+		$this->assertEquals(
+			[
+				'wc_order_tokens' => [
+					'token' => [
+						'label' => 'Saved payment method',
+						'value' => $subscription->get_payment_tokens()[0],
+					],
+				],
+			],
+			$payment_meta1
+		);
+
+		$this->assertEquals(
+			[
+				'some-key'        => 'some-value',
+				'wc_order_tokens' => [
+					'token' => [
+						'label' => 'Saved payment method',
+						'value' => $subscription->get_payment_tokens()[0],
+					],
+				],
+			],
+			$payment_meta2
+		);
+	}
+
+	public function test_append_payment_meta_non_wcpay() {
+		$subscription = WC_Helper_Order::create_order( self::USER_ID );
+
+		$order = WC_Helper_Order::create_order( self::USER_ID );
+		$order->set_payment_method( $this->wcpay_gateway->id );
+
+		$payment_meta = $this->wcpay_gateway->append_payment_meta( [ 'something' ], $order, $subscription );
+
+		$this->assertEquals(
+			[ 'something' ],
+			$payment_meta
+		);
+	}
+
+	public function test_append_payment_meta_invalid_payment_meta() {
+		$subscription = WC_Helper_Order::create_order( self::USER_ID );
+		$order        = WC_Helper_Order::create_order( self::USER_ID );
+
+		$payment_meta = $this->wcpay_gateway->append_payment_meta( 'non-array', $order, $subscription );
+
+		$this->assertEquals(
+			'non-array',
+			$payment_meta
+		);
+	}
+
 	private function mock_wcs_get_subscriptions_for_order( $subscriptions ) {
 		WC_Subscriptions::set_wcs_get_subscriptions_for_order(
 			function ( $order ) use ( $subscriptions ) {


### PR DESCRIPTION
Fixes #2813

#### Changes proposed in this Pull Request

The diff looks unclear but mainly the changes are:
- Pull some code from `add_subscription_payment_meta()` to a new helper function, `get_payment_meta()`.
- Hook to `wcs_copy_payment_meta_to_order` filter.

#### Testing instructions

* Activate WooCommerce Subscriptions.
* Purchase a subscription product with a working test card `4242424242424242`.
* As a buyer, go to My Account > Payment methods > Add payment method.
* Add a 'Decline after attaching' test card `4000000000000341` (from https://stripe.com/docs/testing#declined-payments).
* As an admin (same user account with buyer), edit the subscription from admin, edit the billing details by clicking the pencil icon.
![Screen Shot 2022-06-02 at 13 50 15](https://user-images.githubusercontent.com/73803630/171570433-a9bbe6a0-c097-4ee1-b656-7de15b991cc4.png)
* Change the payment to `4000000000000341` and update the subscription to make that change effective.
![Screen Shot 2022-06-02 at 13 50 25](https://user-images.githubusercontent.com/73803630/171570904-e47aa563-1abe-4bec-a7d0-eb270f70d787.png)
* Choose 'Process a renewal' from the 'Subscriptions actions' box at the top right corner.
* Expect a renewal order created. It will show in the 'Related Orders' box. Its payment should be failed.
* Go to wp-admin > Tools > Scheduled Actions > put in the renewal order id number in the search box.
* Find a pending job called `woocommerce_scheduled_subscription_payment_retry`. Hover on it and there should be a 'Run' link. Click on it.
* Refresh the subscription edit page and expect the renewal order stays failed.
* Change the payment to `4242424242424242` and update the subscription to make that change effective.
* Run again the pending `woocommerce_scheduled_subscription_payment_retry` job for that renewal order.
* Expect the payment for the renewal order to be successful. With base branch, it should stay failed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
