### PR TITLE
Add UPE appearance filter

### DIFF
--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -698,8 +698,8 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		$payment_fields['paymentMethodsConfig']     = $this->get_enabled_payment_method_config();
 		$payment_fields['saveUPEAppearanceNonce']   = wp_create_nonce( 'wcpay_save_upe_appearance_nonce' );
 		$payment_fields['testMode']                 = $this->is_in_test_mode();
-		$payment_fields['upeAppearance']            = get_transient( self::UPE_APPEARANCE_TRANSIENT );
-		$payment_fields['wcBlocksUPEAppearance']    = get_transient( self::WC_BLOCKS_UPE_APPEARANCE_TRANSIENT );
+		$payment_fields['upeAppearance']            = apply_filters( 'wcpay_upe_appearance', get_transient( self::UPE_APPEARANCE_TRANSIENT ) );
+		$payment_fields['wcBlocksUPEAppearance']    = apply_filters( 'wcpay_upe_appearance', get_transient( self::WC_BLOCKS_UPE_APPEARANCE_TRANSIENT ) );
 		$payment_fields['checkoutTitle']            = $this->checkout_title;
 		$payment_fields['cartContainsSubscription'] = $this->is_subscription_item_in_cart();
 		$payment_fields['logPaymentErrorNonce']     = wp_create_nonce( 'wcpay_log_payment_error_nonce' );

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -1571,6 +1571,24 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_upe_appearance_filter() {
+		$expected = [
+			'theme' => 'night',
+		];
+
+		add_filter(
+			'wcpay_upe_appearance',
+			function() use ( $expected ) {
+				return $expected;
+			}
+		);
+
+		$payment_fields = $this->mock_upe_gateway->get_payment_fields_js_config();
+		$this->assertSame( $expected, $payment_fields['upeAppearance'], );
+		$this->assertSame( $expected, $payment_fields['wcBlocksUPEAppearance'], );
+	}
+
+
 	public function maybe_filter_gateway_title_data_provider() {
 		$method_title   = 'WooCommerce Payments';
 		$checkout_title = 'Popular payment methods';


### PR DESCRIPTION
Fixes #3604

#### Changes proposed in this Pull Request
Add `wcpay_upe_appearance` filter for both classic and block based. Apply the filter on the current `get_transient` will load the custom appearance directly, without running the style generation.

Any wrong property provided will be evaluated by Stripe and show a warning log in the browser console, but still loads all the valid ones.

#### Screenshot
<img width="435" alt="Screenshot 2022-06-01 at 11 52 38" src="https://user-images.githubusercontent.com/7670276/171377814-359690f9-672f-4f2d-aade-978bcbd05900.png">

_Result using rules `.Label { color: green }`_

#### Testing instructions

Add the following filter, you can try any other properties [from Stripe's doc](https://stripe.com/docs/elements/appearance-api).
```php
add_filter(
	'wcpay_upe_appearance',
	function() {
		return [
			'theme' => 'night',
		];
	}
);
```

- Having UPE enabled.
- For both classic checkout and block based one.
- Your custom appearance should load correctly.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

- [ ] Update WCPay public documentation.
