### PR TITLE
add check to prevent fatal errors when $order is null on success page

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -49,3 +49,4 @@ If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
 
 - [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
 - [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
+- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -12,13 +12,13 @@ jobs:
       max-parallel: 10
       matrix:
         # Minimum support version, ..., Latest version, `beta`.
-        woocommerce: [ '5.4.0', '5.5.0', '5.6.0', '5.7.0', '5.8.0', '5.9.0', '6.0.1', '6.1.2', '6.2.2', '6.3.1', '6.4.1', '6.5.1', 'beta' ]
+        woocommerce: [ '5.6.2', '5.7.2', '5.8.1', '5.9.1', '6.0.1', '6.1.2', '6.2.2', '6.3.1', '6.4.1', '6.5.1', 'beta' ]
         wordpress:   [ 'latest' ]
         gutenberg:   [ 'latest' ]
         php:         [ '7.4' ]
         include:
           # Edge case: oldest dependencies compatibility
-          - woocommerce: '5.2.0'
+          - woocommerce: '5.6.2'
             wordpress:   '5.7'
             gutenberg:   '11.4.0' # The latest version supporting WP 5.6.
             php:         '7.1' # Minimum supported PHP version

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -12,7 +12,7 @@ jobs:
       max-parallel: 10
       matrix:
         # Minimum support version, ..., Latest version, `beta`.
-        woocommerce: [ '5.4.0', '5.5.0', '5.6.0', '5.7.0', '5.8.0', '5.9.0', '6.0.1', '6.1.2', '6.2.2', '6.3.1', '6.4.1', '6.5.1' 'beta' ]
+        woocommerce: [ '5.4.0', '5.5.0', '5.6.0', '5.7.0', '5.8.0', '5.9.0', '6.0.1', '6.1.2', '6.2.2', '6.3.1', '6.4.1', '6.5.1', 'beta' ]
         wordpress:   [ 'latest' ]
         gutenberg:   [ 'latest' ]
         php:         [ '7.4' ]

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast:     false
       matrix:
         # Min WooCommerce | L-2 | L(atest) | beta
-        woocommerce:   [ '5.4.0', '6.3.1', '6.5.1', 'beta' ]
+        woocommerce:   [ '5.6.2', '6.3.1', '6.5.1', 'beta' ]
         wordpress:     [ 'latest' ]
         php:           [ '7.4' ]
         test_groups:   [ 'wcpay', 'subscriptions', 'blocks' ]
@@ -44,7 +44,7 @@ jobs:
         exclude:
           - test_groups: 'blocks'
             test_branches: 'merchant'
-          - woocommerce: '5.4.0'
+          - woocommerce: '5.6.2'
             test_groups: 'blocks'
             test_branches: 'shopper'
 
@@ -60,7 +60,7 @@ jobs:
       # Conditionally skip WC Blocks tests. Remove/update based on min supported WC version by the blocks checkout plugin.
       - name: Conditionally skip WC Blocks tests
         run: |
-          SKIP_WC_VERSIONS=('5.4.0')
+          SKIP_WC_VERSIONS=('5.6.2')
           if [[ " ${SKIP_WC_VERSIONS[@]} " =~ " ${E2E_WC_VERSION} " ]]; then
             echo "SKIP_WC_BLOCKS_TESTS=1" >> $GITHUB_ENV
           fi

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   WP_VERSION:        latest
-  WC_VERSION: 6.1.0  # the min supported version as per L-2 policy
+  WC_VERSION: 6.3.0  # the min supported version as per L-2 policy
   GUTENBERG_VERSION: latest
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This is a feature plugin for accepting payments via a WooCommerce-branded paymen
 
 -   WooCommerce
 
+## Version support policy
+
+We adopt the L-2 version support policy for WordPress core strictly, and a loose L-2 policy for WooCommerce. See [more details](./docs/version-support-policy.md).
+
 ## Development
 
 ### Install dependencies & build

--- a/changelog/add-4024-arn-successful-refund-timeline
+++ b/changelog/add-4024-arn-successful-refund-timeline
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add ARN (Acquirer Reference Number) to refunds in payment details timeline.

--- a/changelog/add-version-support-policy
+++ b/changelog/add-version-support-policy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add developer document for "Version Support Policy"

--- a/changelog/apple-pay-folder-wordpress-fix
+++ b/changelog/apple-pay-folder-wordpress-fix
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Verify domain with Apple Pay on websites using alternate folder structure.

--- a/changelog/dev-bump-versions-4-3-0
+++ b/changelog/dev-bump-versions-4-3-0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Bump minimum required version of WooCommerce from 5.4 to 5.6.

--- a/changelog/fix-4239-invalid-email-address
+++ b/changelog/fix-4239-invalid-email-address
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Billing emails containing spaces.

--- a/changelog/fix-4305-ipp-failure-in-store-location-endpoint
+++ b/changelog/fix-4305-ipp-failure-in-store-location-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix default terminal location creation for store when blog name is empty.

--- a/changelog/fix-4317-fatal-error-on-checkout-without-order
+++ b/changelog/fix-4317-fatal-error-on-checkout-without-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+added check to prevent fatal errors on checkout

--- a/changelog/fix-yaml-syntax-error
+++ b/changelog/fix-yaml-syntax-error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: A small fix only.
+
+

--- a/changelog/update-reduce-expensive-queries
+++ b/changelog/update-reduce-expensive-queries
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Prevent expensive JOIN queries in Multi-Currency analytics if the store has never used Multi-Currency.

--- a/client/checkout/blocks/confirm-upe-payment.js
+++ b/client/checkout/blocks/confirm-upe-payment.js
@@ -26,7 +26,10 @@ export default async function confirmUPEPayment(
 			payment_method_data: {
 				billing_details: {
 					name,
-					email: billingData.email || '-',
+					email:
+						'string' === typeof billingData.email
+							? billingData.email.trim()
+							: '-',
 					phone: billingData.phone || '-',
 					address: {
 						country: billingData.country || '-',

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -188,7 +188,10 @@ jQuery( function ( $ ) {
 			name:
 				`${ fields.billing_first_name } ${ fields.billing_last_name }`.trim() ||
 				'-',
-			email: fields.billing_email || '-',
+			email:
+				'string' === typeof fields.billing_email
+					? fields.billing_email.trim()
+					: '-',
 			phone: fields.billing_phone || '-',
 			address: {
 				country: fields.billing_country || '-',

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -650,7 +650,10 @@ const mapEventToTimelineItems = ( event ) => {
 					),
 					'checkmark',
 					'is-success',
-					[ composeFXString( event ) ]
+					[
+						composeFXString( event ),
+						getRefundTrackingDetails( event ),
+					]
 				),
 			];
 		case 'refund_failed':

--- a/client/payment-details/timeline/test/__snapshots__/index.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/index.js.snap
@@ -352,6 +352,7 @@ exports[`PaymentDetailsTimeline renders correctly (with a mocked Timeline compon
                   class="woocommerce-timeline-item__body"
                 >
                   <span />
+                  <span />
                 </div>
               </li>
             </ul>
@@ -482,6 +483,7 @@ exports[`PaymentDetailsTimeline renders correctly (with a mocked Timeline compon
                 <div
                   class="woocommerce-timeline-item__body"
                 >
+                  <span />
                   <span />
                 </div>
               </li>

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -217,6 +217,7 @@ Array [
   Object {
     "body": Array [
       "1,00 EUR → 1,20222 USD: 21,64&nbsp;$ USD",
+      "",
     ],
     "date": 2020-04-04T13:51:06.000Z,
     "headline": "A payment of 18,00&nbsp;€ EUR was successfully refunded.",
@@ -254,6 +255,7 @@ Array [
   Object {
     "body": Array [
       "1,00 EUR → 1,2 USD: 6,00&nbsp;$ USD",
+      "Acquirer Reference Number (ARN) 4785767637658864",
     ],
     "date": 2020-04-03T18:58:01.000Z,
     "headline": "A payment of 5,00&nbsp;€ EUR was successfully refunded.",
@@ -826,6 +828,7 @@ Array [
   Object {
     "body": Array [
       undefined,
+      "Acquirer Reference Number (ARN) 4785767637658864",
     ],
     "date": 2020-04-04T13:51:06.000Z,
     "headline": "A payment of $100.00 USD was successfully refunded.",
@@ -863,6 +866,7 @@ Array [
   Object {
     "body": Array [
       undefined,
+      "",
     ],
     "date": 2020-04-03T18:58:01.000Z,
     "headline": "A payment of $50.00 USD was successfully refunded.",

--- a/client/payment-details/timeline/test/map-events.js
+++ b/client/payment-details/timeline/test/map-events.js
@@ -331,6 +331,8 @@ describe( 'mapTimelineEvents', () => {
 						datetime: 1586008266,
 						deposit: null,
 						type: 'full_refund',
+						acquirer_reference_number_status: 'available',
+						acquirer_reference_number: '4785767637658864',
 					},
 				] )
 			).toMatchSnapshot();
@@ -481,6 +483,8 @@ describe( 'mapTimelineEvents', () => {
 						datetime: 1585940281,
 						deposit: null,
 						type: 'partial_refund',
+						acquirer_reference_number_status: 'available',
+						acquirer_reference_number: '4785767637658864',
 						transaction_details: {
 							customer_amount: 500,
 							customer_currency: 'EUR',

--- a/docs/version-support-policy.md
+++ b/docs/version-support-policy.md
@@ -1,0 +1,18 @@
+# Version Support Policy
+
+We have officially announced the L-2 version support policy for WooCommerce and WordPress core [since May 2021](https://developer.woocommerce.com/2021/05/12/woocommerce-payments-is-adopting-a-new-version-support-policy/).
+
+However, in the practice, we're really enforcing only WordPress core with the `Requires at least` in [`readme.txt`](https://github.com/Automattic/woocommerce-payments/blob/develop/readme.txt) and [`woocommerce-payments.php`](https://github.com/Automattic/woocommerce-payments/blob/develop/woocommerce-payments.php).
+
+For WooCommerce, we are yet to fully support this L-2 policy. The real minimum WooCommerce version can be found on [`woocommerce-payments.php`](https://github.com/Automattic/woocommerce-payments/blob/develop/woocommerce-payments.php) with the `WC requires at least` tag. There are two main reasons for this:
+
+- There is no reliable built-in functionality that prevents a merchant from installing the latest version of WooCommerce Payments (WCPay) with an unsupported WooCommerce version. To deal with this issue, we continue loading WCPay if sites have an active WCPay account, but nudge their owners to upgrade WooCommerce. More details in [this PR](https://github.com/Automattic/woocommerce-payments/pull/3010), which is later refactored to `WC_Payments_Dependency_Service`.
+- Some of our internal consumers are also not yet using the latest version of WooCommerce. See paJDYF-3fF-p2#comment-9591
+
+## What does this policy mean for contributors?
+
+As a contributor to WCPay, you would be mindful when adding new features and functions to your PRs as your code needs to work within proper ranges of WordPress and WooCommerce versions. Although we have [a CI workflow](https://github.com/Automattic/woocommerce-payments/blob/develop/.github/workflows/compatibility.yml) to check the compatibility between WCPay and these ranges, it's still good for contributors to be aware of this policy.
+
+## When will WCPay fully support L-2 for WooCommerce core?
+
+We have no ETA for this yet, and you're recommended to check the current minimum WooCommerce version in the code at the moment of writing your code. That said, we're working on a few approaches to reduce the gap between the real minimum supported version and the L-2 version. paJDYF-3fF-p2

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -66,7 +66,7 @@ class WC_Payments_Apple_Pay_Registration {
 	 * @param WC_Payment_Gateway_WCPay $gateway WooCommerce Payments gateway.
 	 */
 	public function __construct( WC_Payments_API_Client $payments_api_client, WC_Payments_Account $account, WC_Payment_Gateway_WCPay $gateway ) {
-		$this->domain_name             = str_replace( [ 'https://', 'http://' ], '', get_site_url() ); // @codingStandardsIgnoreLine
+		$this->domain_name             = wp_parse_url( get_site_url(), PHP_URL_HOST );
 		$this->apple_pay_verify_notice = '';
 		$this->payments_api_client     = $payments_api_client;
 		$this->account                 = $account;
@@ -356,7 +356,7 @@ class WC_Payments_Apple_Pay_Registration {
 		<div class="notice notice-warning apple-pay-message">
 			<p>
 				<strong><?php echo esc_html( 'Apple Pay:' ); ?></strong>
-				<?php echo esc_html_e( 'Payment request buttons are enabled. To use Apple Pay, please use a live WooCommerce Payments account.', 'woocommerce-payments' ); ?>
+				<?php echo esc_html_e( 'Express checkouts are enabled. To use Apple Pay, please use a live WooCommerce Payments account.', 'woocommerce-payments' ); ?>
 			</p>
 		</div>
 		<?php
@@ -389,14 +389,22 @@ class WC_Payments_Apple_Pay_Registration {
 				'title' => [],
 			],
 		];
-		$payment_request_button_text       = __( 'Payment request button:', 'woocommerce-payments' );
+		$payment_request_button_text       = __( 'Express checkouts:', 'woocommerce-payments' );
 		$verification_failed_without_error = __( 'Apple Pay domain verification failed.', 'woocommerce-payments' );
 		$verification_failed_with_error    = __( 'Apple Pay domain verification failed with the following error:', 'woocommerce-payments' );
-		$check_log_text                    = sprintf(
-			/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-			esc_html__( 'Please check the %1$slogs%2$s for more details on this issue. Debug log must be enabled to see recorded logs.', 'woocommerce-payments' ),
-			'<a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">',
-			'</a>'
+		$check_log_text                    = WC_Payments_Utils::esc_interpolated_html(
+			/* translators: a: Link to the logs page */
+			__( 'Please check the <a>logs</a> for more details on this issue. Debug log must be enabled under <strong>Advanced settings</strong> to see recorded logs.', 'woocommerce-payments' ),
+			[
+				'a'      => '<a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">',
+				'strong' => '<strong>',
+			]
+		);
+		$learn_more_text = WC_Payments_Utils::esc_interpolated_html(
+			__( '<a>Learn more</a>.', 'woocommerce-payments' ),
+			[
+				'a' => '<a href="https://woocommerce.com/document/payments/apple-pay/#triggering-domain-registration" target="_blank">',
+			]
 		);
 
 		?>
@@ -405,11 +413,13 @@ class WC_Payments_Apple_Pay_Registration {
 				<p>
 					<strong><?php echo esc_html( $payment_request_button_text ); ?></strong>
 					<?php echo esc_html( $verification_failed_without_error ); ?>
+					<?php echo $learn_more_text; /* @codingStandardsIgnoreLine */ ?>
 				</p>
 			<?php else : ?>
 				<p>
 					<strong><?php echo esc_html( $payment_request_button_text ); ?></strong>
 					<?php echo esc_html( $verification_failed_with_error ); ?>
+					<?php echo $learn_more_text; /* @codingStandardsIgnoreLine */ ?>
 				</p>
 				<p><i><?php echo wp_kses( make_clickable( esc_html( $this->apple_pay_verify_notice ) ), $allowed_html ); ?></i></p>
 			<?php endif; ?>

--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -23,13 +23,13 @@ class WC_Payments_Order_Success_Page {
 	/**
 	 * Return the WooPay thank you notice when the order was created via WooPay
 	 *
-	 * @param string   $text  the default thank you text.
-	 * @param WC_Order $order the order being shown.
+	 * @param string        $text  the default thank you text.
+	 * @param WC_Order|null $order the order being shown.
 	 *
 	 * @return string
 	 */
 	public function show_woopay_thankyou_notice( $text, $order ) {
-		if ( ! $order->get_meta( 'is_woopay' ) ) {
+		if ( ! $order || ! $order->get_meta( 'is_woopay' ) ) {
 			return $text;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ Our global support team is available to answer questions you may have about WooC
 = Requirements =
 
 * WordPress 5.7 or newer.
-* WooCommerce 6.1 or newer.
+* WooCommerce 6.3 or newer.
 * PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
 
 = Try it now =

--- a/tests/unit/admin/test-class-wc-rest-payments-terminal-locations-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-terminal-locations-controller.php
@@ -50,7 +50,7 @@ class WC_REST_Payments_Terminal_Locations_Controller_Test extends WP_UnitTestCas
 		$this->location   = [
 			'id'           => 'tml_XXXXXX',
 			'livemode'     => true,
-			'display_name' => get_bloginfo(),
+			'display_name' => str_replace( [ 'https://', 'http://' ], '', get_site_url() ),
 			'address'      => [
 				'city'        => WC()->countries->get_base_city(),
 				'country'     => WC()->countries->get_base_country(),

--- a/tests/unit/multi-currency/test-class-analytics.php
+++ b/tests/unit/multi-currency/test-class-analytics.php
@@ -29,11 +29,19 @@ class WCPay_Multi_Currency_Analytics_Tests extends WP_UnitTestCase {
 	private $mock_multi_currency;
 
 	/**
+	 * Mock orders.
+	 *
+	 * @var array An array of order ids.
+	 */
+	private $mock_orders = [];
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
 		parent::set_up();
 
+		$this->add_mock_order_with_meta();
 		$this->set_is_admin( true );
 		$this->set_is_rest_request( true );
 		add_filter(
@@ -42,7 +50,6 @@ class WCPay_Multi_Currency_Analytics_Tests extends WP_UnitTestCase {
 				return true;
 			}
 		);
-
 		// Add manage_woocommerce capability to user.
 		$cb = $this->create_can_manage_woocommerce_cap_override( true );
 		add_filter( 'user_has_cap', $cb );
@@ -51,6 +58,14 @@ class WCPay_Multi_Currency_Analytics_Tests extends WP_UnitTestCase {
 		$this->analytics           = new Analytics( $this->mock_multi_currency );
 
 		remove_filter( 'user_has_cap', $cb );
+	}
+
+	/**
+	 * Post-test tear down.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		$this->delete_mock_orders();
 	}
 
 	/**
@@ -314,5 +329,31 @@ class WCPay_Multi_Currency_Analytics_Tests extends WP_UnitTestCase {
 
 			return $allcaps;
 		};
+	}
+
+	/**
+	 * This will create a mock order with the appropriate Multi-Currency meta data.
+	 */
+	private function add_mock_order_with_meta() {
+		$order_id = wp_insert_post(
+			[
+				'post_type'   => 'shop_order',
+				'post_status' => 'wc-processing',
+			]
+		);
+
+		update_post_meta( $order_id, '_wcpay_multi_currency_order_exchange_rate', 0.5353 );
+		update_post_meta( $order_id, '_payment_method', 'stripe' );
+		update_post_meta( $order_id, '_order_total', 12.64 );
+		update_post_meta( $order_id, '_order_currency', 'EUR' );
+
+		// Add to the array of mock order IDs so we can delete it later.
+		$this->mock_orders[] = $order_id;
+	}
+
+	private function delete_mock_orders() {
+		foreach ( $this->mock_orders as $order_id ) {
+			wp_delete_post( $order_id, true );
+		}
 	}
 }

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,8 +8,8 @@
  * Woo: 5278104:bf3cf30871604e15eec560c962593c1f
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
- * WC requires at least: 5.4
- * WC tested up to: 6.5.1
+ * WC requires at least: 5.6
+ * WC tested up to: 6.6.0
  * Requires at least: 5.7
  * Requires PHP: 7.0
  * Version: 4.2.0


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request
This PR adds a check to prevent fatal errors when $order is null. 

#### Testing instructions
- Buy any product and checkout
- You should see no errors and the default success page should show up
- Checkout again but this time using the WooPay
- You should see no errors and the WooPay success page should show up(Green notice and WooPay logo_
- Change [this line](https://github.com/woocommerce/woocommerce/blob/35b58245af09042934d9c726786cb3dfcb246838/plugins/woocommerce/templates/checkout/thankyou.php#L24) to `if(false) {` 
- Repeat the process. Now both times you should only see the default thank you notice and no other message or error.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 