### PR TITLE
Record wcpay version in platform-checkout Tracks events

### DIFF
--- a/changelog/add-wcpay-version-to-tracks
+++ b/changelog/add-wcpay-version-to-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+record wcpay version in Platform Checkout Tracks events

--- a/includes/class-platform-checkout-tracker.php
+++ b/includes/class-platform-checkout-tracker.php
@@ -111,8 +111,9 @@ class Platform_Checkout_Tracker extends Jetpack_Tracks_Client {
 		}
 
 		// Add event property for test mode vs. live mode events.
-		$gateway           = \WC_Payments::get_gateway();
-		$data['test_mode'] = $gateway->is_in_test_mode() ? 1 : 0;
+		$gateway               = \WC_Payments::get_gateway();
+		$data['test_mode']     = $gateway->is_in_test_mode() ? 1 : 0;
+		$data['wcpay_version'] = get_option( 'woocommerce_woocommerce_payments_version' );
 
 		return $this->tracks_record_event( $user, $event, $data );
 	}


### PR DESCRIPTION
Fixes 1010-gh-Automattic/woopay

#### Changes proposed in this Pull Request

This PR adds a `wcpay_version` property to all platform checkout Tracks events so that we can see which version of WCPay Platform Checkouts merchants are running

#### Testing instructions

- In WC Core advanced settings (/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com), be sure "Allow usage of WooCommerce to be tracked" is turned on.
- Go to WCPay settings and toggle the platform checkout setting. 
- As a customer(non-admin user) add a product to cart and visit the checkout page. In around ~5 minutes `woocommerceanalytics_order_checkout_start` event will show up in Tracks Live view in MC.
- Check the event properties and ensure `wcpay_version` property is present and corresponds to the wcpay version used.  
- Enter an email address of an already registered platform checkout user and wait for the OTP prompt to appear.
- In ~5 minutes check the properties of the `woocommerceanalytics_platform_checkout_otp_prompt_start` Tracks event and ensure `wcpay_version` property is present with the correct version


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.