### PR TITLE
added check to prevent fatal errors when no $order is null

### DIFF
--- a/changelog/fix-4317-fatal-error-on-checkout-without-order
+++ b/changelog/fix-4317-fatal-error-on-checkout-without-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+added check to prevent fatal errors on checkout

--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -23,13 +23,13 @@ class WC_Payments_Order_Success_Page {
 	/**
 	 * Return the WooPay thank you notice when the order was created via WooPay
 	 *
-	 * @param string   $text  the default thank you text.
-	 * @param WC_Order $order the order being shown.
+	 * @param string        $text  the default thank you text.
+	 * @param WC_Order|null $order the order being shown.
 	 *
 	 * @return string
 	 */
 	public function show_woopay_thankyou_notice( $text, $order ) {
-		if ( ! $order->get_meta( 'is_woopay' ) ) {
+		if ( ! $order || ! $order->get_meta( 'is_woopay' ) ) {
 			return $text;
 		}
 


### PR DESCRIPTION
fix #4317 

#### Changes proposed in this Pull Request
This PR adds a check to prevent fatal errors when $order is null. 

#### Testing instructions
- Buy any product and checkout
- You should see no errors and the default success page should show up
- Checkout again but this time using the WooPay
- You should see no errors and the WooPay success page should show up(Green notice and WooPay logo_
- Change [this line](https://github.com/woocommerce/woocommerce/blob/35b58245af09042934d9c726786cb3dfcb246838/plugins/woocommerce/templates/checkout/thankyou.php#L24) to `if(false) {` 
- Repeat the process. Now both times you should only see the default thank you notice and no other message or error.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 