### PR TITLE
Fix zero based currency subscriptions - use WC_Payments_Utils::prepare_amount() to format price data

### DIFF
--- a/includes/subscriptions/class-wc-payments-subscription-service.php
+++ b/includes/subscriptions/class-wc-payments-subscription-service.php
@@ -269,7 +269,7 @@ class WC_Payments_Subscription_Service {
 		$data = [
 			'currency'            => $currency,
 			'product'             => $wcpay_product_id,
-			'unit_amount_decimal' => round( $unit_amount, wc_get_rounding_precision() ) * 100,
+			'unit_amount_decimal' => WC_Payments_Utils::prepare_amount( $unit_amount, $currency ),
 		];
 
 		if ( $interval && $interval_count ) {
@@ -300,7 +300,7 @@ class WC_Payments_Subscription_Service {
 
 			if ( $discount ) {
 				$data[] = [
-					'amount_off' => $discount * 100,
+					'amount_off' => WC_Payments_Utils::prepare_amount( $discount, $subscription->get_currency() ),
 					'currency'   => $subscription->get_currency(),
 					'duration'   => $duration,
 					// Translators: %s Coupon code.


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

Slack thread: p1654501085183779-slack-CGGCLBN58

When generating price data for subscription (stripe billing objects) we were incorrectly accounting for zero based currencies like Japanese Yen (JPY). The problem code was multiplying all price data sent to Stripe by 100 to convert the price into cents, however this isn't necessary for zero based currencies (see [Stripe API reference](https://stripe.com/docs/currencies#zero-decimal)). 

This PR fixes that by making sure we pass subscription line item data through `WC_Payments_Utils::prepare_amount()`

#### Testing instructions

1. make sure WC Subscriptions (the plugin) is disabled and you're using WC Pay Subscriptions. 
1. Enable multi-currencies in **WooCommerce > Settings > Multi-currency**
2. Add Japanese Yen as a currency. 
3. If you're connected to your local/test WC Pay Server, by default the currency conversion rate may just be 1:1. If this is the case, make sure to change the rate so a conversion occurs. See screenshot below for example. 
5. Purchase a subscription with WC Pay in JPY. 
    - If you purchased the subscription on `trunk` view the subscription in Stripe you should see a 100 x price in Yen.
    - If you purchased the subscription on this branch it should match. 

<img width="1071" alt="Screen Shot 2022-06-06 at 9 14 16 pm" src="https://user-images.githubusercontent.com/8490476/172150494-5db43603-53ac-4fe3-8c90-4d258f546257.png">

<img width="1078" alt="Screen Shot 2022-06-06 at 9 16 32 pm" src="https://user-images.githubusercontent.com/8490476/172150695-96ba2fed-e59c-4d51-a458-da36d5c0bba0.png">

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.