### PR TITLE
Update subscriptions-core to 2.1.0

### DIFF
--- a/changelog/subscriptions-core-2.1.0
+++ b/changelog/subscriptions-core-2.1.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update subscriptions-core to 2.1.0.

--- a/changelog/subscriptions-core-2.1.0-2
+++ b/changelog/subscriptions-core-2.1.0-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fatal Error caused in rare cases where a subscription line item's quantity is zero during renewal.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
       "automattic/jetpack-sync": "1.30.5",
       "automattic/jetpack-tracking": "1.14.5",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "2.0.0"
+      "woocommerce/subscriptions-core": "2.1.0"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "59e89fea10abc3830b03b5f48e1d62aa",
+    "content-hash": "a51884b9cc5c6841d02e9502bf1efdf1",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1060,16 +1060,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "69ab97d25d8a3fb4c1ac38fb180b39f323af6ac9"
+                "reference": "7eab8aec595c2f511fc9dfdd35d48ac965ae1a37"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/69ab97d25d8a3fb4c1ac38fb180b39f323af6ac9",
-                "reference": "69ab97d25d8a3fb4c1ac38fb180b39f323af6ac9",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/7eab8aec595c2f511fc9dfdd35d48ac965ae1a37",
+                "reference": "7eab8aec595c2f511fc9dfdd35d48ac965ae1a37",
                 "shasum": ""
             },
             "require": {
@@ -1108,10 +1108,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.0.0",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.1.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-05-23T01:00:04+00:00"
+            "time": "2022-06-06T23:53:47+00:00"
         }
     ],
     "packages-dev": [
@@ -5834,5 +5834,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Load newer woocommerce-subscriptions-core's version 2.1.0.
- Added changelog entries from woocommerce-subscriptions-core to the changelog.
- Updated composer.lock as a result of running `composer update woocommerce/subscriptions-core`.

#### Testing instructions

* Checkout this branch.
* [Husky hook should run `composer install`](https://github.com/Automattic/woocommerce-payments/blob/develop/.husky/post-checkout#L8) and your `vendor/woocommerce/subscriptions-core` should be updated to `2.1.0`. Confirm that latest changes from `2.1.0` is present, for example, [vendor/woocommerce/subscriptions-core/changelog.txt is up-to-date](https://github.com/Automattic/woocommerce-subscriptions-core/blob/2.1.0/changelog.txt).


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _Add link here / 'QA Testing Not Applicable'_