### PR TITLE
Update WC_Payments_API_Intention and WC_Payments_API_Charge constructors

### DIFF
--- a/changelog/update-3122-payment-intent
+++ b/changelog/update-3122-payment-intent
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update WC_Payments_API_Intention to receive an instance of WC_Payments_API_Change instead of multiple charge-related fields.

--- a/changelog/update-3122-payment-intent
+++ b/changelog/update-3122-payment-intent
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Update WC_Payments_API_Intention to receive an instance of WC_Payments_API_Change instead of multiple charge-related fields.
+Refactor WC_Payments_API_Intention to receive an instance of WC_Payments_API_Change instead of multiple charge-related fields.

--- a/includes/admin/class-wc-rest-payments-charges-controller.php
+++ b/includes/admin/class-wc-rest-payments-charges-controller.php
@@ -50,17 +50,7 @@ class WC_REST_Payments_Charges_Controller extends WC_Payments_REST_Controller {
 			return rest_ensure_response( new WP_Error( 'wcpay_get_charge', $e->getMessage() ) );
 		}
 
-		$raw_details     = $charge['billing_details']['address'];
-		$billing_details = [];
-
-		$billing_details['city']      = ( ! empty( $raw_details['city'] ) ) ? $raw_details['city'] : '';
-		$billing_details['country']   = ( ! empty( $raw_details['country'] ) ) ? $raw_details['country'] : '';
-		$billing_details['address_1'] = ( ! empty( $raw_details['line1'] ) ) ? $raw_details['line1'] : '';
-		$billing_details['address_2'] = ( ! empty( $raw_details['line2'] ) ) ? $raw_details['line2'] : '';
-		$billing_details['postcode']  = ( ! empty( $raw_details['postal_code'] ) ) ? $raw_details['postal_code'] : '';
-		$billing_details['state']     = ( ! empty( $raw_details['state'] ) ) ? $raw_details['state'] : '';
-
-		$charge['billing_details']['formatted_address'] = WC()->countries->get_formatted_address( $billing_details );
+		$charge['billing_details'] = WC_Payments_Utils::get_formatted_billing_details( $charge );
 
 		return rest_ensure_response( $charge );
 	}

--- a/includes/admin/class-wc-rest-payments-charges-controller.php
+++ b/includes/admin/class-wc-rest-payments-charges-controller.php
@@ -50,7 +50,17 @@ class WC_REST_Payments_Charges_Controller extends WC_Payments_REST_Controller {
 			return rest_ensure_response( new WP_Error( 'wcpay_get_charge', $e->getMessage() ) );
 		}
 
-		$charge['billing_details'] = WC_Payments_Utils::get_formatted_billing_details( $charge );
+		$raw_details     = $charge['billing_details']['address'];
+		$billing_details = [];
+
+		$billing_details['city']      = ( ! empty( $raw_details['city'] ) ) ? $raw_details['city'] : '';
+		$billing_details['country']   = ( ! empty( $raw_details['country'] ) ) ? $raw_details['country'] : '';
+		$billing_details['address_1'] = ( ! empty( $raw_details['line1'] ) ) ? $raw_details['line1'] : '';
+		$billing_details['address_2'] = ( ! empty( $raw_details['line2'] ) ) ? $raw_details['line2'] : '';
+		$billing_details['postcode']  = ( ! empty( $raw_details['postal_code'] ) ) ? $raw_details['postal_code'] : '';
+		$billing_details['state']     = ( ! empty( $raw_details['state'] ) ) ? $raw_details['state'] : '';
+
+		$charge['billing_details']['formatted_address'] = WC()->countries->get_formatted_address( $billing_details );
 
 		return rest_ensure_response( $charge );
 	}

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -134,7 +134,8 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 			$order->set_payment_method_title( __( 'WooCommerce In-Person Payments', 'woocommerce-payments' ) );
 			$intent_id     = $intent->get_id();
 			$intent_status = $intent->get_status();
-			$charge_id     = $intent->get_charge_id();
+			$charge        = $intent->get_charge();
+			$charge_id     = $charge ? $charge->get_id() : null;
 			$this->gateway->attach_intent_info_to_order(
 				$order,
 				$intent_id,

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2133,7 +2133,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		Tracker::track_admin( 'wcpay_merchant_captured_auth' );
 
 		// There is a possibility of the intent being null, so we need to get the charge_id safely.
-		$charge_id = ! empty( $intent ) ? $intent->get_charge()->get_id() : $order->get_meta( '_charge_id' );
+		$charge    = ! empty( $intent ) ? $intent->get_charge() : null;
+		$charge_id = ! empty( $charge ) ? $charge->get_id() : $order->get_meta( '_charge_id' );
 
 		$this->attach_exchange_info_to_order( $order, $charge_id );
 
@@ -2188,7 +2189,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		if ( 'canceled' === $status ) {
-			$this->order_service->mark_payment_capture_cancelled( $order, $intent->get_id(), $status, $intent->get_charge()->get_id() );
+			$charge    = $intent->get_charge();
+			$charge_id = ! empty( $charge ) ? $charge->get_id() : null;
+
+			$this->order_service->mark_payment_capture_cancelled( $order, $intent->get_id(), $status, $charge_id );
 			return;
 		} elseif ( ! empty( $error_message ) ) {
 			$note = sprintf(
@@ -2369,7 +2373,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				// An exception is thrown if an intent can't be found for the given intent ID.
 				$intent    = $this->payments_api_client->get_intent( $intent_id );
 				$status    = $intent->get_status();
-				$charge_id = $intent->get_charge()->get_id();
+				$charge    = $intent->get_charge();
+				$charge_id = ! empty( $charge ) ? $charge->get_id() : null;
 
 				$this->attach_exchange_info_to_order( $order, $charge_id );
 				$this->attach_intent_info_to_order( $order, $intent_id, $status, $intent->get_payment_method_id(), $intent->get_customer_id(), $charge_id, $intent->get_currency() );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1190,7 +1190,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			$intent_id     = $intent->get_id();
 			$status        = $intent->get_status();
-			$charge_id     = $intent->get_charge_id();
+			$charge        = $intent->get_charge();
+			$charge_id     = $charge ? $charge->get_id() : null;
 			$client_secret = $intent->get_client_secret();
 			$currency      = $intent->get_currency();
 			$next_action   = $intent->get_next_action();
@@ -1285,7 +1286,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		if ( $payment_needed ) {
-			$payment_method_details = $intent->get_payment_method_details();
+			$payment_method_details = $intent->get_charge()->get_payment_method_details();
 			$payment_method_type    = $payment_method_details ? $payment_method_details['type'] : null;
 
 			if ( $order->get_meta( 'is_woopay' ) && 'card' === $payment_method_type && isset( $payment_method_details['card']['last4'] ) ) {
@@ -2130,7 +2131,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		Tracker::track_admin( 'wcpay_merchant_captured_auth' );
 
 		// There is a possibility of the intent being null, so we need to get the charge_id safely.
-		$charge_id = ! empty( $intent ) ? $intent->get_charge_id() : $order->get_meta( '_charge_id' );
+		$charge_id = ! empty( $intent ) ? $intent->get_charge()->get_id() : $order->get_meta( '_charge_id' );
 
 		$this->attach_exchange_info_to_order( $order, $charge_id );
 
@@ -2185,7 +2186,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		if ( 'canceled' === $status ) {
-			$this->order_service->mark_payment_capture_cancelled( $order, $intent->get_id(), $status, $intent->get_charge_id() );
+			$this->order_service->mark_payment_capture_cancelled( $order, $intent->get_id(), $status, $intent->get_charge()->get_id() );
 			return;
 		} elseif ( ! empty( $error_message ) ) {
 			$note = sprintf(
@@ -2366,7 +2367,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				// An exception is thrown if an intent can't be found for the given intent ID.
 				$intent    = $this->payments_api_client->get_intent( $intent_id );
 				$status    = $intent->get_status();
-				$charge_id = $intent->get_charge_id();
+				$charge_id = $intent->get_charge()->get_id();
 
 				$this->attach_exchange_info_to_order( $order, $charge_id );
 				$this->attach_intent_info_to_order( $order, $intent_id, $status, $intent->get_payment_method_id(), $intent->get_customer_id(), $charge_id, $intent->get_currency() );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1286,7 +1286,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		if ( $payment_needed ) {
-			$payment_method_details = $intent->get_charge()->get_payment_method_details();
+			$charge                 = $intent ? $intent->get_charge() : null;
+			$payment_method_details = $charge ? $charge->get_payment_method_details() : [];
 			$payment_method_type    = $payment_method_details ? $payment_method_details['type'] : null;
 
 			if ( $order->get_meta( 'is_woopay' ) && 'card' === $payment_method_type && isset( $payment_method_details['card']['last4'] ) ) {
@@ -1636,7 +1637,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		} elseif ( $order->meta_exists( '_intent_id' ) ) {
 			$payment_intent_id      = $order->get_meta( '_intent_id', true );
 			$payment_intent         = $this->payments_api_client->get_intent( $payment_intent_id );
-			$payment_method_details = $payment_intent ? $payment_intent->get_payment_method_details() : [];
+			$charge                 = $payment_intent ? $payment_intent->get_charge() : null;
+			$payment_method_details = $charge ? $charge->get_payment_method_details() : [];
 		}
 
 		return $payment_method_details['type'] ?? 'unknown';

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -790,31 +790,4 @@ class WC_Payments_Utils {
 
 		return $formatted_amount;
 	}
-
-	/**
-	 * Adds the formatted_address field to the billing_details object.
-	 *
-	 * @param WC_Payments_API_Charge $charge Original charge object.
-	 *
-	 * @return WC_Payments_API_Charge Charge object with the formatted_address field.
-	 */
-	public static function get_formatted_billing_details( $charge ) {
-		if ( empty( $charge['billing_details'] ) ) {
-			return [];
-		}
-
-		$raw_details     = $charge['billing_details']['address'];
-		$billing_details = [];
-
-		$billing_details['city']      = ( ! empty( $raw_details['city'] ) ) ? $raw_details['city'] : '';
-		$billing_details['country']   = ( ! empty( $raw_details['country'] ) ) ? $raw_details['country'] : '';
-		$billing_details['address_1'] = ( ! empty( $raw_details['line1'] ) ) ? $raw_details['line1'] : '';
-		$billing_details['address_2'] = ( ! empty( $raw_details['line2'] ) ) ? $raw_details['line2'] : '';
-		$billing_details['postcode']  = ( ! empty( $raw_details['postal_code'] ) ) ? $raw_details['postal_code'] : '';
-		$billing_details['state']     = ( ! empty( $raw_details['state'] ) ) ? $raw_details['state'] : '';
-
-		$charge['billing_details']['formatted_address'] = WC()->countries->get_formatted_address( $billing_details );
-
-		return $charge['billing_details'];
-	}
 }

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -791,4 +791,30 @@ class WC_Payments_Utils {
 		return $formatted_amount;
 	}
 
+	/**
+	 * Adds the formatted_address field to the billing_details object.
+	 *
+	 * @param WC_Payments_API_Charge $charge Original charge object.
+	 *
+	 * @return WC_Payments_API_Charge Charge object with the formatted_address field.
+	 */
+	public static function get_formatted_billing_details( $charge ) {
+		if ( empty( $charge['billing_details'] ) ) {
+			return [];
+		}
+
+		$raw_details     = $charge['billing_details']['address'];
+		$billing_details = [];
+
+		$billing_details['city']      = ( ! empty( $raw_details['city'] ) ) ? $raw_details['city'] : '';
+		$billing_details['country']   = ( ! empty( $raw_details['country'] ) ) ? $raw_details['country'] : '';
+		$billing_details['address_1'] = ( ! empty( $raw_details['line1'] ) ) ? $raw_details['line1'] : '';
+		$billing_details['address_2'] = ( ! empty( $raw_details['line2'] ) ) ? $raw_details['line2'] : '';
+		$billing_details['postcode']  = ( ! empty( $raw_details['postal_code'] ) ) ? $raw_details['postal_code'] : '';
+		$billing_details['state']     = ( ! empty( $raw_details['state'] ) ) ? $raw_details['state'] : '';
+
+		$charge['billing_details']['formatted_address'] = WC()->countries->get_formatted_address( $billing_details );
+
+		return $charge['billing_details'];
+	}
 }

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -465,9 +465,10 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 				$intent_id              = $updated_payment_intent->get_id();
 				$intent_status          = $updated_payment_intent->get_status();
 				$payment_method         = $updated_payment_intent->get_payment_method_id();
-				$payment_method_details = $updated_payment_intent->get_payment_method_details();
+				$charge                 = $updated_payment_intent->get_charge();
+				$payment_method_details = $charge ? $charge->get_payment_method_details() : [];
 				$payment_method_type    = $payment_method_details ? $payment_method_details['type'] : null;
-				$charge_id              = $updated_payment_intent->get_charge_id();
+				$charge_id              = $charge ? $charge->get_id() : null;
 
 				/**
 				 * Attach the intent and exchange info to the order before doing the redirect, just in case the redirect
@@ -475,7 +476,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 				 * the redirect completes.
 				 */
 				$this->attach_intent_info_to_order( $order, $intent_id, $intent_status, $payment_method, $customer_id, $charge_id, $currency );
-				$this->attach_exchange_info_to_order( $order, $updated_payment_intent->get_charge_id() );
+				$this->attach_exchange_info_to_order( $order, $charge_id );
 				$this->set_payment_method_title_for_order( $order, $payment_method_type, $payment_method_details );
 				$this->update_order_status_from_intent( $order, $intent_id, $intent_status, $charge_id );
 
@@ -600,10 +601,11 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 				$intent                 = $this->payments_api_client->get_intent( $intent_id );
 				$client_secret          = $intent->get_client_secret();
 				$status                 = $intent->get_status();
-				$charge_id              = $intent->get_charge_id();
+				$charge                 = $intent->get_charge();
+				$charge_id              = $charge ? $charge->get_id() : null;
 				$currency               = $intent->get_currency();
 				$payment_method_id      = $intent->get_payment_method_id();
-				$payment_method_details = $intent->get_payment_method_details();
+				$payment_method_details = $charge ? $charge->get_payment_method_details() : [];
 				$payment_method_type    = $payment_method_details ? $payment_method_details['type'] : null;
 				$error                  = $intent->get_last_payment_error();
 			} else {

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -252,13 +252,15 @@ class WC_Payments_Invoice_Service {
 			return;
 		}
 
+		$charge = $intent_object->get_charge();
+
 		$this->gateway->attach_intent_info_to_order(
 			$order,
 			$intent_id,
 			$intent_object->get_status(),
 			$intent_object->get_payment_method_id(),
 			$intent_object->get_customer_id(),
-			$intent_object->get_charge_id(),
+			$charge ? $charge->get_id() : null,
 			$intent_object->get_currency()
 		);
 	}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2258,39 +2258,19 @@ class WC_Payments_API_Client {
 	 * De-serialize a charge array into a charge object
 	 *
 	 * @param array $charge_array - The charge array to de-serialize.
-	 * @param array $intention_array - The intention array to de-serialize.
 	 *
 	 * @return WC_Payments_API_Charge
 	 * @throws API_Exception - Unable to deserialize charge array.
 	 */
-	private function deserialize_charge_object_from_array( array $charge_array, array $intention_array = [] ) {
+	private function deserialize_charge_object_from_array( array $charge_array ) {
 		// TODO: Throw an exception if the response array doesn't contain mandatory properties.
 		$created = new DateTime();
 		$created->setTimestamp( $charge_array['created'] );
-
-		$charge_array    = $this->add_order_info_to_object( $charge_array['id'], $charge_array );
-		$billing_details = WC_Payments_Utils::get_formatted_billing_details( $charge_array );
-		$customer        = empty( $intention_array ) ? $intention_array['customer'] ?? $charge_array['customer'] ?? null : null;
-		$payment_method  = empty( $intention_array ) ? $intention_array['payment_method'] ?? $intention_array['source'] ?? null : null;
 
 		$charge = new WC_Payments_API_Charge(
 			$charge_array['id'],
 			$charge_array['amount'],
 			$created,
-			$charge_array['balance_transaction'] ?? null,
-			$charge_array['application_fee_amount'] ?? null,
-			$billing_details,
-			$charge_array['currency'] ?? null,
-			$customer,
-			$charge_array['disputed'] ?? false,
-			$charge_array['dispute'] ?? null,
-			$charge_array['order'] ?? null,
-			$charge_array['outcome'] ?? null,
-			$charge_array['refunded'] ?? false,
-			$charge_array['refunds'] ?? null,
-			$charge_array['paydown'] ?? null,
-			$charge_array['payment_intent'] ?? null,
-			$payment_method,
 			$charge_array['payment_method_details'] ?? []
 		);
 
@@ -2321,7 +2301,7 @@ class WC_Payments_API_Client {
 		$customer           = $intention_array['customer'] ?? $charge_array['customer'] ?? null;
 		$payment_method     = $intention_array['payment_method'] ?? $intention_array['source'] ?? null;
 
-		$charge = ! empty( $charge_array ) ? self::deserialize_charge_object_from_array( $charge_array, $intention_array ) : null;
+		$charge = ! empty( $charge_array ) ? self::deserialize_charge_object_from_array( $charge_array ) : null;
 
 		$intent = new WC_Payments_API_Intention(
 			$intention_array['id'],

--- a/includes/wc-payment-api/models/class-wc-payments-api-charge.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-charge.php
@@ -43,104 +43,6 @@ class WC_Payments_API_Charge {
 	private $captured;
 
 	/**
-	 * Object that describes the impact of this charge on the account balance
-	 *
-	 * @var array
-	 */
-	private $balance_transaction;
-
-	/**
-	 * Fee amount
-	 *
-	 * @var int|null
-	 */
-	private $application_fee_amount;
-
-	/**
-	 * Billing information associated with the payment method at the time of the transaction
-	 *
-	 * @var array
-	 */
-	private $billing_details;
-
-	/**
-	 * Charge currency
-	 *
-	 * @var string|null
-	 */
-	private $currency;
-
-	/**
-	 * Customer id
-	 *
-	 * @var string|null
-	 */
-	private $customer;
-
-	/**
-	 * Flag indicated whether the charge has been disputed or not
-	 *
-	 * @var bool
-	 */
-	private $disputed;
-
-	/**
-	 * Dispute data
-	 *
-	 * @var array|null
-	 */
-	private $dispute;
-
-	/**
-	 * Order data
-	 *
-	 * @var array|null
-	 */
-	private $order;
-
-	/**
-	 * Details of whether and why the payment was accepted
-	 *
-	 * @var array|null
-	 */
-	private $outcome;
-
-	/**
-	 * Flag indicated whether the charge has been refunded or not
-	 *
-	 * @var bool
-	 */
-	private $refunded;
-
-	/**
-	 * Refund data
-	 *
-	 * @var array|null
-	 */
-	private $refunds;
-
-	/**
-	 * Paydown data
-	 *
-	 * @var array|null
-	 */
-	private $paydown;
-
-	/**
-	 * Payment intent id
-	 *
-	 * @var string|null
-	 */
-	private $payment_intent;
-
-	/**
-	 * Payment method id
-	 *
-	 * @var string|null
-	 */
-	private $payment_method;
-
-	/**
 	 * Payment method details object
 	 *
 	 * @var array
@@ -150,62 +52,20 @@ class WC_Payments_API_Charge {
 	/**
 	 * WC_Payments_API_Charge constructor.
 	 *
-	 * @param string       $id                     - ID of the charge.
-	 * @param integer      $amount                 - Amount charged.
-	 * @param DateTime     $created                - Time charge created.
-	 * @param array        $balance_transaction    - Object that describes the impact of this charge on the account balance.
-	 * @param integer|null $application_fee_amount - Fee amount.
-	 * @param array        $billing_details        - Billing information associated with the payment method at the time of the transaction.
-	 * @param string|null  $currency               - Charge currency.
-	 * @param string|null  $customer               - Customer id.
-	 * @param bool         $disputed               - Flag indicated whether the charge has been disputed or not.
-	 * @param array|null   $dispute                - Dispute data.
-	 * @param array|null   $order                  - Order data.
-	 * @param array|null   $outcome                - Details of whether and why the payment was accepted.
-	 * @param bool         $refunded               - Flag indicated whether the charge has been refunded or not.
-	 * @param array|null   $refunds                - Refund data.
-	 * @param array|null   $paydown                - Paydown data.
-	 * @param string|null  $payment_intent         - Payment intent id.
-	 * @param string|null  $payment_method         - Payment method id.
-	 * @param array        $payment_method_details - Payment method details object.
+	 * @param string   $id                     - ID of the charge.
+	 * @param integer  $amount                 - Amount charged.
+	 * @param DateTime $created                - Time charge created.
+	 * @param array    $payment_method_details - Payment method details object.
 	 */
 	public function __construct(
 		$id,
 		$amount,
 		DateTime $created,
-		$balance_transaction = null,
-		$application_fee_amount = null,
-		$billing_details = [],
-		$currency = null,
-		$customer = null,
-		$disputed = false,
-		$dispute = null,
-		$order = null,
-		$outcome = null,
-		$refunded = false,
-		$refunds = null,
-		$paydown = null,
-		$payment_intent = null,
-		$payment_method = null,
 		$payment_method_details = []
 	) {
 		$this->id                     = $id;
 		$this->amount                 = $amount;
 		$this->created                = $created;
-		$this->balance_transaction    = $balance_transaction;
-		$this->application_fee_amount = $application_fee_amount;
-		$this->billing_details        = $billing_details;
-		$this->currency               = strtoupper( $currency );
-		$this->customer               = $customer;
-		$this->disputed               = $disputed;
-		$this->dispute                = $dispute;
-		$this->order                  = $order;
-		$this->outcome                = $outcome;
-		$this->refunded               = $refunded;
-		$this->refunds                = $refunds;
-		$this->paydown                = $paydown;
-		$this->payment_intent         = $payment_intent;
-		$this->payment_method         = $payment_method;
 		$this->payment_method_details = $payment_method_details;
 
 		// Set default properties.
@@ -255,132 +115,6 @@ class WC_Payments_API_Charge {
 	 */
 	public function set_captured( $captured ) {
 		$this->captured = $captured;
-	}
-
-	/**
-	 * Returns the balance transaction object associated with this charge
-	 *
-	 * @return integer|null
-	 */
-	public function get_balance_transaction() {
-		return $this->balance_transaction;
-	}
-
-	/**
-	 * Returns the application fee amount of this charge
-	 *
-	 * @return integer|null
-	 */
-	public function get_application_fee_amount() {
-		return $this->application_fee_amount;
-	}
-
-	/**
-	 * Returns the billing details object associated with this charge
-	 *
-	 * @return array|null
-	 */
-	public function get_billing_details() {
-		return $this->billing_details;
-	}
-
-	/**
-	 * Returns the currency of this charge
-	 *
-	 * @return string|null
-	 */
-	public function get_currency() {
-		return $this->currency;
-	}
-
-	/**
-	 * Returns the customer object associated with this charge
-	 *
-	 * @return array|null
-	 */
-	public function get_customer() {
-		return $this->customer;
-	}
-
-	/**
-	 * Returns the boolean indicating if the charge has been disputed
-	 *
-	 * @return bool
-	 */
-	public function get_disputed() {
-		return $this->disputed;
-	}
-
-	/**
-	 * Returns the dispute object associated with this charge
-	 *
-	 * @return array|null
-	 */
-	public function get_dispute() {
-		return $this->dispute;
-	}
-
-	/**
-	 * Returns the order object associated with this charge
-	 *
-	 * @return array|null
-	 */
-	public function get_order() {
-		return $this->order;
-	}
-
-	/**
-	 * Returns the outcome object associated with this charge
-	 *
-	 * @return array|null
-	 */
-	public function get_outcome() {
-		return $this->outcome;
-	}
-
-	/**
-	 * Returns the boolean indicating if the charge has been refunded
-	 *
-	 * @return bool
-	 */
-	public function get_refunded() {
-		return $this->refunded;
-	}
-
-	/**
-	 * Returns the refund object associated with this charge
-	 *
-	 * @return array|null
-	 */
-	public function get_refunds() {
-		return $this->refunds;
-	}
-
-	/**
-	 * Returns the paydown object associated with this charge
-	 *
-	 * @return array|null
-	 */
-	public function get_paydown() {
-		return $this->paydown;
-	}
-
-	/**
-	 * Returns the payment intent ID associated with this charge
-	 *
-	 * @return string
-	 */
-	public function get_payment_intent() {
-		return $this->payment_intent;
-	}
-
-	/**
-	 * Returns the payment method ID associated with this charge
-	 *
-	 * @return string
-	 */
-	public function get_payment_method() {
-		return $this->payment_method;
 	}
 
 	/**

--- a/includes/wc-payment-api/models/class-wc-payments-api-charge.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-charge.php
@@ -43,16 +43,170 @@ class WC_Payments_API_Charge {
 	private $captured;
 
 	/**
+	 * Object that describes the impact of this charge on the account balance
+	 *
+	 * @var array
+	 */
+	private $balance_transaction;
+
+	/**
+	 * Fee amount
+	 *
+	 * @var int|null
+	 */
+	private $application_fee_amount;
+
+	/**
+	 * Billing information associated with the payment method at the time of the transaction
+	 *
+	 * @var array
+	 */
+	private $billing_details;
+
+	/**
+	 * Charge currency
+	 *
+	 * @var string|null
+	 */
+	private $currency;
+
+	/**
+	 * Customer id
+	 *
+	 * @var string|null
+	 */
+	private $customer;
+
+	/**
+	 * Flag indicated whether the charge has been disputed or not
+	 *
+	 * @var bool
+	 */
+	private $disputed;
+
+	/**
+	 * Dispute data
+	 *
+	 * @var array|null
+	 */
+	private $dispute;
+
+	/**
+	 * Order data
+	 *
+	 * @var array|null
+	 */
+	private $order;
+
+	/**
+	 * Details of whether and why the payment was accepted
+	 *
+	 * @var array|null
+	 */
+	private $outcome;
+
+	/**
+	 * Flag indicated whether the charge has been refunded or not
+	 *
+	 * @var bool
+	 */
+	private $refunded;
+
+	/**
+	 * Refund data
+	 *
+	 * @var array|null
+	 */
+	private $refunds;
+
+	/**
+	 * Paydown data
+	 *
+	 * @var array|null
+	 */
+	private $paydown;
+
+	/**
+	 * Payment intent id
+	 *
+	 * @var string|null
+	 */
+	private $payment_intent;
+
+	/**
+	 * Payment method id
+	 *
+	 * @var string|null
+	 */
+	private $payment_method;
+
+	/**
+	 * Payment method details object
+	 *
+	 * @var array
+	 */
+	private $payment_method_details;
+
+	/**
 	 * WC_Payments_API_Charge constructor.
 	 *
-	 * @param string   $id      - ID of the charge.
-	 * @param integer  $amount  - Amount charged.
-	 * @param DateTime $created - Time charge created.
+	 * @param string       $id                     - ID of the charge.
+	 * @param integer      $amount                 - Amount charged.
+	 * @param DateTime     $created                - Time charge created.
+	 * @param array        $balance_transaction    - Object that describes the impact of this charge on the account balance.
+	 * @param integer|null $application_fee_amount - Fee amount.
+	 * @param array        $billing_details        - Billing information associated with the payment method at the time of the transaction.
+	 * @param string|null  $currency               - Charge currency.
+	 * @param string|null  $customer               - Customer id.
+	 * @param bool         $disputed               - Flag indicated whether the charge has been disputed or not.
+	 * @param array|null   $dispute                - Dispute data.
+	 * @param array|null   $order                  - Order data.
+	 * @param array|null   $outcome                - Details of whether and why the payment was accepted.
+	 * @param bool         $refunded               - Flag indicated whether the charge has been refunded or not.
+	 * @param array|null   $refunds                - Refund data.
+	 * @param array|null   $paydown                - Paydown data.
+	 * @param string|null  $payment_intent         - Payment intent id.
+	 * @param string|null  $payment_method         - Payment method id.
+	 * @param array        $payment_method_details - Payment method details object.
 	 */
-	public function __construct( $id, $amount, DateTime $created ) {
-		$this->id      = $id;
-		$this->amount  = $amount;
-		$this->created = $created;
+	public function __construct(
+		$id,
+		$amount,
+		DateTime $created,
+		$balance_transaction = null,
+		$application_fee_amount = null,
+		$billing_details = [],
+		$currency = null,
+		$customer = null,
+		$disputed = false,
+		$dispute = null,
+		$order = null,
+		$outcome = null,
+		$refunded = false,
+		$refunds = null,
+		$paydown = null,
+		$payment_intent = null,
+		$payment_method = null,
+		$payment_method_details = []
+	) {
+		$this->id                     = $id;
+		$this->amount                 = $amount;
+		$this->created                = $created;
+		$this->balance_transaction    = $balance_transaction;
+		$this->application_fee_amount = $application_fee_amount;
+		$this->billing_details        = $billing_details;
+		$this->currency               = strtoupper( $currency );
+		$this->customer               = $customer;
+		$this->disputed               = $disputed;
+		$this->dispute                = $dispute;
+		$this->order                  = $order;
+		$this->outcome                = $outcome;
+		$this->refunded               = $refunded;
+		$this->refunds                = $refunds;
+		$this->paydown                = $paydown;
+		$this->payment_intent         = $payment_intent;
+		$this->payment_method         = $payment_method;
+		$this->payment_method_details = $payment_method_details;
 
 		// Set default properties.
 		$this->captured = false;
@@ -101,5 +255,140 @@ class WC_Payments_API_Charge {
 	 */
 	public function set_captured( $captured ) {
 		$this->captured = $captured;
+	}
+
+	/**
+	 * Returns the balance transaction object associated with this charge
+	 *
+	 * @return integer|null
+	 */
+	public function get_balance_transaction() {
+		return $this->balance_transaction;
+	}
+
+	/**
+	 * Returns the application fee amount of this charge
+	 *
+	 * @return integer|null
+	 */
+	public function get_application_fee_amount() {
+		return $this->application_fee_amount;
+	}
+
+	/**
+	 * Returns the billing details object associated with this charge
+	 *
+	 * @return array|null
+	 */
+	public function get_billing_details() {
+		return $this->billing_details;
+	}
+
+	/**
+	 * Returns the currency of this charge
+	 *
+	 * @return string|null
+	 */
+	public function get_currency() {
+		return $this->currency;
+	}
+
+	/**
+	 * Returns the customer object associated with this charge
+	 *
+	 * @return array|null
+	 */
+	public function get_customer() {
+		return $this->customer;
+	}
+
+	/**
+	 * Returns the boolean indicating if the charge has been disputed
+	 *
+	 * @return bool
+	 */
+	public function get_disputed() {
+		return $this->disputed;
+	}
+
+	/**
+	 * Returns the dispute object associated with this charge
+	 *
+	 * @return array|null
+	 */
+	public function get_dispute() {
+		return $this->dispute;
+	}
+
+	/**
+	 * Returns the order object associated with this charge
+	 *
+	 * @return array|null
+	 */
+	public function get_order() {
+		return $this->order;
+	}
+
+	/**
+	 * Returns the outcome object associated with this charge
+	 *
+	 * @return array|null
+	 */
+	public function get_outcome() {
+		return $this->outcome;
+	}
+
+	/**
+	 * Returns the boolean indicating if the charge has been refunded
+	 *
+	 * @return bool
+	 */
+	public function get_refunded() {
+		return $this->refunded;
+	}
+
+	/**
+	 * Returns the refund object associated with this charge
+	 *
+	 * @return array|null
+	 */
+	public function get_refunds() {
+		return $this->refunds;
+	}
+
+	/**
+	 * Returns the paydown object associated with this charge
+	 *
+	 * @return array|null
+	 */
+	public function get_paydown() {
+		return $this->paydown;
+	}
+
+	/**
+	 * Returns the payment intent ID associated with this charge
+	 *
+	 * @return string
+	 */
+	public function get_payment_intent() {
+		return $this->payment_intent;
+	}
+
+	/**
+	 * Returns the payment method ID associated with this charge
+	 *
+	 * @return string
+	 */
+	public function get_payment_method() {
+		return $this->payment_method;
+	}
+
+	/**
+	 * Returns the payment method details associated with this charge
+	 *
+	 * @return array
+	 */
+	public function get_payment_method_details() {
+		return $this->payment_method_details;
 	}
 }

--- a/includes/wc-payment-api/models/class-wc-payments-api-intention.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-intention.php
@@ -41,13 +41,6 @@ class WC_Payments_API_Intention {
 	private $status;
 
 	/**
-	 * The ID of charge associated with intention
-	 *
-	 * @var string
-	 */
-	private $charge_id;
-
-	/**
 	 * The client secret of the intention
 	 *
 	 * @var string
@@ -90,11 +83,11 @@ class WC_Payments_API_Intention {
 	private $last_payment_error;
 
 	/**
-	 * The payment method details of the charge
+	 * The latest charge object
 	 *
-	 * @var array
+	 * @var WC_Payments_API_Charge
 	 */
-	private $payment_method_details;
+	private $charge;
 
 	/**
 	 * Set of key-value pairs that can be useful for storing
@@ -107,19 +100,18 @@ class WC_Payments_API_Intention {
 	/**
 	 * WC_Payments_API_Intention constructor.
 	 *
-	 * @param string      $id                     - ID of the intention.
-	 * @param integer     $amount                 - Amount charged.
-	 * @param string      $currency               - The currency of the intention.
-	 * @param string|null $customer_id            - Stripe ID of the customer.
-	 * @param string|null $payment_method_id      - Stripe ID of the payment method.
-	 * @param DateTime    $created                - Time charge created.
-	 * @param string      $status                 - Intention status.
-	 * @param string      $charge_id              - ID of charge associated with intention.
-	 * @param string      $client_secret          - The client secret of the intention.
-	 * @param array       $next_action            - An array containing information for next action to take.
-	 * @param array       $last_payment_error     - An array containing details of any errors.
-	 * @param array       $payment_method_details - An array containing payment method details of associated charge.
-	 * @param array       $metadata               - An array containing additional metadata of associated charge or order.
+	 * @param string                 $id                 - ID of the intention.
+	 * @param integer                $amount             - Amount charged.
+	 * @param string                 $currency           - The currency of the intention.
+	 * @param string|null            $customer_id        - Stripe ID of the customer.
+	 * @param string|null            $payment_method_id  - Stripe ID of the payment method.
+	 * @param DateTime               $created            - Time charge created.
+	 * @param string                 $status             - Intention status.
+	 * @param string                 $client_secret      - The client secret of the intention.
+	 * @param WC_Payments_API_Charge $charge             - An array containing payment method details of associated charge.
+	 * @param array                  $next_action        - An array containing information for next action to take.
+	 * @param array                  $last_payment_error - An array containing details of any errors.
+	 * @param array                  $metadata           - An array containing additional metadata of associated charge or order.
 	 */
 	public function __construct(
 		$id,
@@ -129,26 +121,24 @@ class WC_Payments_API_Intention {
 		$payment_method_id,
 		DateTime $created,
 		$status,
-		$charge_id,
 		$client_secret,
+		$charge = null,
 		$next_action = [],
 		$last_payment_error = [],
-		$payment_method_details = [],
 		$metadata = []
 	) {
-		$this->id                     = $id;
-		$this->amount                 = $amount;
-		$this->created                = $created;
-		$this->status                 = $status;
-		$this->charge_id              = $charge_id;
-		$this->client_secret          = $client_secret;
-		$this->currency               = strtoupper( $currency );
-		$this->next_action            = $next_action;
-		$this->last_payment_error     = $last_payment_error;
-		$this->customer_id            = $customer_id;
-		$this->payment_method_id      = $payment_method_id;
-		$this->payment_method_details = $payment_method_details;
-		$this->metadata               = $metadata;
+		$this->id                 = $id;
+		$this->amount             = $amount;
+		$this->created            = $created;
+		$this->status             = $status;
+		$this->client_secret      = $client_secret;
+		$this->currency           = strtoupper( $currency );
+		$this->next_action        = $next_action;
+		$this->last_payment_error = $last_payment_error;
+		$this->customer_id        = $customer_id;
+		$this->payment_method_id  = $payment_method_id;
+		$this->charge             = $charge;
+		$this->metadata           = $metadata;
 	}
 
 	/**
@@ -185,15 +175,6 @@ class WC_Payments_API_Intention {
 	 */
 	public function get_status() {
 		return $this->status;
-	}
-
-	/**
-	 * Returns the charge ID associated with this intention
-	 *
-	 * @return string
-	 */
-	public function get_charge_id() {
-		return $this->charge_id;
 	}
 
 	/**
@@ -251,12 +232,12 @@ class WC_Payments_API_Intention {
 	}
 
 	/**
-	 * Returns the payment method details from the charge of this intention
+	 * Returns the charge associated with this intention
 	 *
-	 * @return array
+	 * @return WC_Payments_API_Charge
 	 */
-	public function get_payment_method_details() {
-		return $this->payment_method_details;
+	public function get_charge() {
+		return $this->charge;
 	}
 
 	/**

--- a/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
@@ -43,12 +43,17 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * @var string
 	 */
-	private $mock_intent_id = 'pi_xxxxxxxxxxxxx';
+	private $mock_intent_id = 'pi_mock';
 
 	/**
 	 * @var string
 	 */
-	private $mock_charge_id = 'ch_yyyyyyyyyyyyy';
+	private $mock_charge_id = 'ch_mock';
+
+	/**
+	 * @var integer
+	 */
+	private $mock_charge_created = 1653076178;
 
 	public function set_up() {
 		parent::set_up();
@@ -70,33 +75,8 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 	}
 
 	public function test_capture_terminal_payment_success() {
-		$order = $this->create_mock_order();
-
-		$mock_intent = $this->createMock( WC_Payments_API_Intention::class );
-		$mock_intent
-			->expects( $this->any() )
-			->method( 'get_status' )
-			->willReturn( 'requires_capture' );
-		$mock_intent
-			->expects( $this->any() )
-			->method( 'get_id' )
-			->willReturn( 'pi_mock' );
-		$mock_intent
-			->expects( $this->any() )
-			->method( 'get_payment_method_id' )
-			->willReturn( 'pm_mock' );
-		$mock_intent
-			->expects( $this->any() )
-			->method( 'get_customer_id' )
-			->willReturn( 'cus_mock' );
-		$mock_intent
-			->expects( $this->any() )
-			->method( 'get_charge_id' )
-			->willReturn( 'ch_mock' );
-		$mock_intent
-			->expects( $this->any() )
-			->method( 'get_currency' )
-			->willReturn( 'mok' );
+		$order       = $this->create_mock_order();
+		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
 		$this->mock_api_client
 			->expects( $this->once() )
@@ -119,12 +99,12 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 			->method( 'attach_intent_info_to_order' )
 			->with(
 				$this->isInstanceOf( WC_Order::class ),
-				'pi_mock',
+				$this->mock_intent_id,
 				'requires_capture',
 				'pm_mock',
 				'cus_mock',
-				'ch_mock',
-				'mok'
+				$this->mock_charge_id,
+				'USD'
 			);
 
 		$request = new WP_REST_Request( 'POST' );
@@ -151,37 +131,12 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'woocommerce_payments', $result_order->get_payment_method() );
 		$this->assertEquals( 'WooCommerce In-Person Payments', $result_order->get_payment_method_title() );
 		$this->assertEquals( 'completed', $result_order->get_status() );
-		$this->assertStringEndsWith( '/wc/v3/payments/readers/receipts/pi_mock', $result_order->get_meta( 'receipt_url' ) );
+		$this->assertStringEndsWith( '/wc/v3/payments/readers/receipts/' . $this->mock_intent_id, $result_order->get_meta( 'receipt_url' ) );
 	}
 
 	public function test_capture_terminal_payment_succeeded_intent() {
-		$order = $this->create_mock_order();
-
-		$mock_intent = $this->createMock( WC_Payments_API_Intention::class );
-		$mock_intent
-			->expects( $this->atLeastOnce() )
-			->method( 'get_status' )
-			->willReturn( 'succeeded' );
-		$mock_intent
-			->expects( $this->atLeastOnce() )
-			->method( 'get_id' )
-			->willReturn( $this->mock_intent_id );
-		$mock_intent
-			->expects( $this->once() )
-			->method( 'get_payment_method_id' )
-			->willReturn( 'pm_mock' );
-		$mock_intent
-			->expects( $this->once() )
-			->method( 'get_customer_id' )
-			->willReturn( 'cus_mock' );
-		$mock_intent
-			->expects( $this->atLeastOnce() )
-			->method( 'get_charge_id' )
-			->willReturn( 'ch_mock' );
-		$mock_intent
-			->expects( $this->atLeastOnce() )
-			->method( 'get_currency' )
-			->willReturn( 'mok' );
+		$order       = $this->create_mock_order();
+		$mock_intent = WC_Helper_Intention::create_intention();
 
 		$this->mock_api_client
 			->expects( $this->once() )
@@ -197,8 +152,8 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 				'succeeded',
 				'pm_mock',
 				'cus_mock',
-				'ch_mock',
-				'mok'
+				$this->mock_charge_id,
+				'USD'
 			);
 		$this->mock_gateway
 			->expects( $this->once() )
@@ -246,31 +201,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 		$order = $this->create_mock_order();
 		$order->update_status( 'completed' );
 
-		$mock_intent = $this->createMock( WC_Payments_API_Intention::class );
-		$mock_intent
-			->expects( $this->atLeastOnce() )
-			->method( 'get_status' )
-			->willReturn( 'succeeded' );
-		$mock_intent
-			->expects( $this->atLeastOnce() )
-			->method( 'get_id' )
-			->willReturn( $this->mock_intent_id );
-		$mock_intent
-			->expects( $this->once() )
-			->method( 'get_payment_method_id' )
-			->willReturn( 'pm_mock' );
-		$mock_intent
-			->expects( $this->once() )
-			->method( 'get_customer_id' )
-			->willReturn( 'cus_mock' );
-		$mock_intent
-			->expects( $this->atLeastOnce() )
-			->method( 'get_charge_id' )
-			->willReturn( 'ch_mock' );
-		$mock_intent
-			->expects( $this->atLeastOnce() )
-			->method( 'get_currency' )
-			->willReturn( 'mok' );
+		$mock_intent = WC_Helper_Intention::create_intention();
 
 		$this->mock_api_client
 			->expects( $this->once() )
@@ -286,8 +217,8 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 				'succeeded',
 				'pm_mock',
 				'cus_mock',
-				'ch_mock',
-				'mok'
+				$this->mock_charge_id,
+				'USD'
 			);
 		$this->mock_gateway
 			->expects( $this->once() )
@@ -332,11 +263,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 	public function test_capture_terminal_payment_intent_non_capturable() {
 		$order = $this->create_mock_order();
 
-		$mock_intent = $this->createMock( WC_Payments_API_Intention::class );
-		$mock_intent
-			->expects( $this->any() )
-			->method( 'get_status' )
-			->willReturn( 'requires_payment_method' );
+		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
 
 		$this->mock_api_client
 			->expects( $this->once() )
@@ -409,11 +336,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 	public function test_capture_terminal_payment_error_when_capturing() {
 		$order = $this->create_mock_order();
 
-		$mock_intent = $this->createMock( WC_Payments_API_Intention::class );
-		$mock_intent
-			->expects( $this->any() )
-			->method( 'get_status' )
-			->willReturn( 'requires_capture' );
+		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
 		$this->mock_api_client
 			->expects( $this->once() )
@@ -454,11 +377,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 	public function test_capture_terminal_payment_error_invalid_arguments() {
 		$order = $this->create_mock_order();
 
-		$mock_intent = $this->createMock( WC_Payments_API_Intention::class );
-		$mock_intent
-			->expects( $this->any() )
-			->method( 'get_status' )
-			->willReturn( 'requires_capture' );
+		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
 		$this->mock_api_client
 			->expects( $this->once() )
@@ -958,10 +877,12 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 	}
 
 	private function create_mock_order() {
+		$charge = $this->create_charge_object();
+
 		$order = WC_Helper_Order::create_order();
 		$order->set_transaction_id( $this->mock_intent_id );
 		$order->update_meta_data( '_intent_id', $this->mock_intent_id );
-		$order->update_meta_data( '_charge_id', $this->mock_charge_id );
+		$order->update_meta_data( '_charge_id', $charge->get_id() );
 		$order->update_meta_data( '_intention_status', 'requires_capture' );
 		$order->update_status( 'on-hold' );
 		return $order;
@@ -1026,5 +947,12 @@ class WC_REST_Payments_Orders_Controller_Test extends WP_UnitTestCase {
 		$request->set_param( 'capture_method', 'invalid_val' );
 
 		$this->controller->get_terminal_intent_capture_method( $request );
+	}
+
+	private function create_charge_object() {
+		$created = new DateTime();
+		$created->setTimestamp( $this->mock_charge_created );
+
+		return new WC_Payments_API_Charge( $this->mock_charge_id, 1500, $created );
 	}
 }

--- a/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
@@ -252,7 +252,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 	public function test_generate_print_receipt() {
 		$order = WC_Helper_Order::create_order();
 
-		$payment_intent = $this->mock_payment_intent();
+		$payment_intent = WC_Helper_Intention::create_intention();
 
 		$charge = $this->mock_charge( $order->get_id() );
 
@@ -263,13 +263,13 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'get_intent' )
-			->with( '42' )
+			->with( 'pi_mock' )
 			->willReturn( $payment_intent );
 
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'get_charge' )
-			->with( $payment_intent->get_charge_id() )
+			->with( 'ch_mock' )
 			->willReturn( $charge );
 
 		$this->mock_wcpay_gateway
@@ -284,7 +284,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 			->willReturn( $receipt );
 
 		$request = new WP_REST_Request( 'GET' );
-		$request->set_param( 'payment_intent_id', 42 );
+		$request->set_param( 'payment_intent_id', 'pi_mock' );
 
 		$response = $this->controller->generate_print_receipt( $request );
 
@@ -418,8 +418,8 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'get_intent' )
-			->with( '42' )
-			->willReturn( $this->mock_payment_intent( 'processing' ) );
+			->with( 'pi_mock' )
+			->willReturn( WC_Helper_Intention::create_intention( [ 'status' => 'processing' ] ) );
 
 		$this->mock_api_client
 			->expects( $this->never() )
@@ -434,7 +434,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 			->method( 'get_receipt_markup' );
 
 		$request = new WP_REST_Request( 'GET' );
-		$request->set_param( 'payment_intent_id', 42 );
+		$request->set_param( 'payment_intent_id', 'pi_mock' );
 
 		$response = $this->controller->generate_print_receipt( $request );
 
@@ -448,7 +448,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'get_intent' )
-			->with( '42' )
+			->with( 'pi_mock' )
 			->willThrowException( new API_Exception( 'Something bad happened', 'test error', 500 ) );
 
 		$this->mock_api_client
@@ -464,7 +464,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 			->method( 'get_receipt_markup' );
 
 		$request = new WP_REST_Request( 'GET' );
-		$request->set_param( 'payment_intent_id', 42 );
+		$request->set_param( 'payment_intent_id', 'pi_mock' );
 
 		$response = $this->controller->generate_print_receipt( $request );
 
@@ -475,20 +475,20 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 	}
 
 	public function test_generate_print_receipt_order_not_found(): void {
-		$payment_intent = $this->mock_payment_intent();
+		$payment_intent = WC_Helper_Intention::create_intention();
 
 		$charge = $this->mock_charge( '42' );
 
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'get_intent' )
-			->with( '42' )
+			->with( 'pi_mock' )
 			->willReturn( $payment_intent );
 
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'get_charge' )
-			->with( $payment_intent->get_charge_id() )
+			->with( 'ch_mock' )
 			->willReturn( $charge );
 
 		$this->mock_wcpay_gateway
@@ -500,7 +500,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 			->method( 'get_receipt_markup' );
 
 		$request = new WP_REST_Request( 'GET' );
-		$request->set_param( 'payment_intent_id', 42 );
+		$request->set_param( 'payment_intent_id', 'pi_mock' );
 
 		$response = $this->controller->generate_print_receipt( $request );
 
@@ -513,20 +513,20 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 	public function test_generate_print_receipt_handle_settings_exception(): void {
 		$order = WC_Helper_Order::create_order();
 
-		$payment_intent = $this->mock_payment_intent();
+		$payment_intent = WC_Helper_Intention::create_intention();
 
 		$charge = $this->mock_charge( $order->get_id() );
 
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'get_intent' )
-			->with( '42' )
+			->with( 'pi_mock' )
 			->willReturn( $payment_intent );
 
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'get_charge' )
-			->with( $payment_intent->get_charge_id() )
+			->with( 'ch_mock' )
 			->willReturn( $charge );
 
 		$this->mock_wcpay_gateway
@@ -539,7 +539,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 			->method( 'get_receipt_markup' );
 
 		$request = new WP_REST_Request( 'GET' );
-		$request->set_param( 'payment_intent_id', 42 );
+		$request->set_param( 'payment_intent_id', 'pi_mock' );
 
 		$response = $this->controller->generate_print_receipt( $request );
 
@@ -552,7 +552,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 	public function test_generate_print_receipt_handle_receipt_service_exception(): void {
 		$order = WC_Helper_Order::create_order();
 
-		$payment_intent = $this->mock_payment_intent();
+		$payment_intent = WC_Helper_Intention::create_intention();
 
 		$charge = $this->mock_charge( $order->get_id() );
 
@@ -561,13 +561,13 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'get_intent' )
-			->with( '42' )
+			->with( 'pi_mock' )
 			->willReturn( $payment_intent );
 
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'get_charge' )
-			->with( $payment_intent->get_charge_id() )
+			->with( 'ch_mock' )
 			->willReturn( $charge );
 
 		$this->mock_wcpay_gateway
@@ -582,7 +582,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 			->willThrowException( new Exception( 'Something bad' ) );
 
 		$request = new WP_REST_Request( 'GET' );
-		$request->set_param( 'payment_intent_id', 42 );
+		$request->set_param( 'payment_intent_id', 'pi_mock' );
 
 		$response = $this->controller->generate_print_receipt( $request );
 
@@ -590,20 +590,6 @@ class WC_REST_Payments_Reader_Controller_Test extends WP_UnitTestCase {
 		$data = $response->get_error_data();
 		$this->assertArrayHasKey( 'status', $data );
 		$this->assertSame( 500, $data['status'] );
-	}
-
-	private function mock_payment_intent( $status = 'succeeded' ): WC_Payments_API_Intention {
-		return new WC_Payments_API_Intention(
-			'42',
-			42,
-			'USD',
-			'42',
-			'42',
-			new DateTime(),
-			$status,
-			'42',
-			'secret'
-		);
 	}
 
 	private function mock_charge( string $order_id ): array {

--- a/tests/unit/helpers/class-wc-helper-intention.php
+++ b/tests/unit/helpers/class-wc-helper-intention.php
@@ -39,20 +39,6 @@ class WC_Helper_Intention {
 			$charge_data['id'],
 			$charge_data['amount'],
 			$charge_data['created'],
-			null,
-			null,
-			[],
-			null,
-			null,
-			false,
-			null,
-			null,
-			null,
-			false,
-			null,
-			null,
-			null,
-			null,
 			$charge_data['payment_method_details']
 		);
 	}

--- a/tests/unit/helpers/class-wc-helper-intention.php
+++ b/tests/unit/helpers/class-wc-helper-intention.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Intention helpers.
+ *
+ * @package WooCommerce/Tests
+ */
+
+/**
+ * Class WC_Helper_Intention.
+ *
+ * This helper class should ONLY be used for unit tests!.
+ */
+class WC_Helper_Intention {
+	/**
+	 * Create a charge.
+	 *
+	 * @param array $data Data to override defaults.
+	 *
+	 * @return WC_Payments_API_Charge
+	 */
+	public static function create_charge( $data = [] ) {
+		$charge_data = wp_parse_args(
+			$data,
+			[
+				'id'                     => 'ch_mock',
+				'created'                => new DateTime( '2022-05-20 19:05:38' ),
+				'amount'                 => 5000,
+				'payment_method_details' => [
+					'type' => 'card',
+					'card' => [
+						'network' => 'visa',
+						'funding' => 'credit',
+					],
+				],
+			]
+		);
+
+		return new WC_Payments_API_Charge(
+			$charge_data['id'],
+			$charge_data['amount'],
+			$charge_data['created'],
+			null,
+			null,
+			[],
+			null,
+			null,
+			false,
+			null,
+			null,
+			null,
+			false,
+			null,
+			null,
+			null,
+			null,
+			$charge_data['payment_method_details']
+		);
+	}
+
+	/**
+	 * Create a payment intent.
+	 *
+	 * @param array $data Data to override defaults.
+	 *
+	 * @return WC_Payments_API_Intention
+	 */
+	public static function create_intention( $data = [] ) {
+		$intent_data = wp_parse_args(
+			$data,
+			[
+				'id'                 => 'pi_mock',
+				'amount'             => 5000,
+				'currency'           => 'usd',
+				'customer_id'        => 'cus_mock',
+				'payment_method_id'  => 'pm_mock',
+				'status'             => 'succeeded',
+				'client_secret'      => 'cs_mock',
+				'charge'             => [],
+				'created'            => new DateTime( '2022-05-20 19:05:38' ),
+				'next_action'        => [],
+				'last_payment_error' => [],
+				'metadata'           => [],
+			]
+		);
+
+		$intention = new WC_Payments_API_Intention(
+			$intent_data['id'],
+			$intent_data['amount'],
+			$intent_data['currency'],
+			$intent_data['customer_id'],
+			$intent_data['payment_method_id'],
+			$intent_data['created'],
+			$intent_data['status'],
+			$intent_data['client_secret'],
+			self::create_charge( $intent_data['charge'] ),
+			$intent_data['next_action'],
+			$intent_data['last_payment_error'],
+			$intent_data['metadata']
+		);
+
+		return $intention;
+	}
+}

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -21,13 +21,13 @@ use WC_Payment_Gateway_WCPay;
 use WC_Payments_Account;
 use WC_Payments_Action_Scheduler_Service;
 use WC_Payments_API_Client;
-use WC_Payments_API_Intention;
 use WC_Payments_Customer_Service;
 use WC_Payments_Token_Service;
 use WC_Payments_Order_Service;
 use WC_Payments;
 use WC_Customer;
 use WC_Helper_Order;
+use WC_Helper_Intention;
 use WC_Helper_Token;
 use WC_Payments_Utils;
 use WC_Subscriptions;
@@ -270,7 +270,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$product_item        = current( $order->get_items( 'line_item' ) );
 		$intent_id           = 'pi_mock';
 		$user                = '';
-		$customer_id         = 'cus_12345';
+		$customer_id         = 'cus_mock';
 		$save_payment_method = true;
 
 		$this->set_cart_contains_subscription_items( false );
@@ -293,7 +293,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 				5000,
 				'usd',
 				true,
-				'cus_12345',
+				'cus_mock',
 				[
 					'customer_name'  => 'Jeroen Sormani',
 					'customer_email' => 'admin@example.org',
@@ -341,7 +341,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$product_item              = current( $order->get_items( 'line_item' ) );
 		$intent_id                 = 'pi_mock';
 		$user                      = '';
-		$customer_id               = 'cus_12345';
+		$customer_id               = 'cus_mock';
 		$save_payment_method       = true;
 		$selected_upe_payment_type = 'giropay';
 
@@ -365,7 +365,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 				5000,
 				'usd',
 				true,
-				'cus_12345',
+				'cus_mock',
 				[
 					'customer_name'  => 'Jeroen Sormani',
 					'customer_email' => 'admin@example.org',
@@ -418,7 +418,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->mock_upe_gateway->expects( $this->once() )
 			->method( 'manage_customer_details_for_order' )
 			->will(
-				$this->returnValue( [ '', 'cus_12345' ] )
+				$this->returnValue( [ '', 'cus_mock' ] )
 			);
 
 		$this->mock_customer_service
@@ -433,7 +433,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 				5000,
 				'usd',
 				false,
-				'cus_12345',
+				'cus_mock',
 				[
 					'customer_name'  => 'Jeroen Sormani',
 					'customer_email' => 'admin@example.org',
@@ -479,7 +479,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	public function test_create_payment_intent_uses_order_amount_if_order() {
 		$order    = WC_Helper_Order::create_order();
 		$order_id = $order->get_id();
-		$intent   = new WC_Payments_API_Intention( 'pi_mock', 5000, 'usd', null, null, new \DateTime(), 'requires_payment_method', null, 'client_secret_123' );
+		$intent   = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_intention' )
@@ -494,7 +494,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	public function test_create_payment_intent_defaults_to_automatic_capture() {
 		$order    = WC_Helper_Order::create_order();
 		$order_id = $order->get_id();
-		$intent   = new WC_Payments_API_Intention( 'pi_mock', 5000, 'usd', null, null, new \DateTime(), 'requires_payment_method', null, 'client_secret_123' );
+		$intent   = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_intention' )
@@ -514,7 +514,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	public function test_create_payment_intent_with_automatic_capture() {
 		$order    = WC_Helper_Order::create_order();
 		$order_id = $order->get_id();
-		$intent   = new WC_Payments_API_Intention( 'pi_mock', 5000, 'usd', null, null, new \DateTime(), 'requires_payment_method', null, 'client_secret_123' );
+		$intent   = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
 		$this->mock_upe_gateway->settings['manual_capture'] = 'no';
 		$this->mock_api_client
 			->expects( $this->once() )
@@ -535,7 +535,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	public function test_create_payment_intent_with_manual_capture() {
 		$order    = WC_Helper_Order::create_order();
 		$order_id = $order->get_id();
-		$intent   = new WC_Payments_API_Intention( 'pi_mock', 5000, 'usd', null, null, new \DateTime(), 'requires_payment_method', null, 'client_secret_123' );
+		$intent   = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
 		$this->mock_upe_gateway->settings['manual_capture'] = 'yes';
 		$this->mock_api_client
 			->expects( $this->once() )
@@ -559,7 +559,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->mock_customer_service
 			->expects( $this->once() )
 			->method( 'get_customer_id_by_user_id' )
-			->will( $this->returnValue( 'cus_12345' ) );
+			->will( $this->returnValue( 'cus_mock' ) );
 
 		$this->mock_customer_service
 			->expects( $this->never() )
@@ -568,7 +568,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_setup_intention' )
-			->with( 'cus_12345', [ 'card' ] )
+			->with( 'cus_mock', [ 'card' ] )
 			->willReturn(
 				[
 					'id'            => 'seti_mock',
@@ -619,35 +619,9 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	public function test_process_payment_returns_correct_redirect_url() {
 		$order                         = WC_Helper_Order::create_order();
 		$order_id                      = $order->get_id();
-		$_POST['wc_payment_intent_id'] = 'pi_abc123';
-		$intent_status                 = 'processing';
-		$charge_id                     = 'ch_mock';
-		$client_secret                 = 'cs_mock';
-		$customer_id                   = 'cus_mock';
-		$intent_id                     = 'pi_mock';
-		$payment_method_id             = 'pm_mock';
-		$payment_method_details        = [
-			'type' => 'card',
-			'card' => [
-				'network' => 'visa',
-				'funding' => 'credit',
-			],
-		];
+		$_POST['wc_payment_intent_id'] = 'pi_mock';
 
-		$payment_intent = new WC_Payments_API_Intention(
-			$intent_id,
-			$order->get_total(),
-			$order->get_currency(),
-			$customer_id,
-			$payment_method_id,
-			new \DateTime( 'NOW' ),
-			$intent_status,
-			$charge_id,
-			$client_secret,
-			[],
-			[],
-			$payment_method_details
-		);
+		$payment_intent = WC_Helper_Intention::create_intention( [ 'status' => 'processing' ] );
 
 		$this->mock_api_client
 			->expects( $this->once() )
@@ -675,35 +649,9 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$gateway_id                    = UPE_Payment_Gateway::GATEWAY_ID;
 		$save_payment_param            = "wc-$gateway_id-new-payment-method";
 		$_POST[ $save_payment_param ]  = 'yes';
-		$_POST['wc_payment_intent_id'] = 'pi_abc123';
-		$intent_status                 = 'processing';
-		$charge_id                     = 'ch_mock';
-		$client_secret                 = 'cs_mock';
-		$customer_id                   = 'cus_mock';
-		$intent_id                     = 'pi_mock';
-		$payment_method_id             = 'pm_mock';
-		$payment_method_details        = [
-			'type' => 'card',
-			'card' => [
-				'network' => 'visa',
-				'funding' => 'credit',
-			],
-		];
+		$_POST['wc_payment_intent_id'] = 'pi_mock';
 
-		$payment_intent = new WC_Payments_API_Intention(
-			$intent_id,
-			$order->get_total(),
-			$order->get_currency(),
-			$customer_id,
-			$payment_method_id,
-			new \DateTime( 'NOW' ),
-			$intent_status,
-			$charge_id,
-			$client_secret,
-			[],
-			[],
-			$payment_method_details
-		);
+		$payment_intent = WC_Helper_Intention::create_intention( [ 'status' => 'processing' ] );
 
 		$this->mock_api_client
 			->expects( $this->once() )
@@ -728,35 +676,9 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	public function test_process_subscription_payment_passes_save_payment_method() {
 		$order                         = WC_Helper_Order::create_order();
 		$order_id                      = $order->get_id();
-		$_POST['wc_payment_intent_id'] = 'pi_abc123';
-		$intent_status                 = 'processing';
-		$charge_id                     = 'ch_mock';
-		$client_secret                 = 'cs_mock';
-		$customer_id                   = 'cus_mock';
-		$intent_id                     = 'pi_mock';
-		$payment_method_id             = 'pm_mock';
-		$payment_method_details        = [
-			'type' => 'card',
-			'card' => [
-				'network' => 'visa',
-				'funding' => 'credit',
-			],
-		];
+		$_POST['wc_payment_intent_id'] = 'pi_mock';
 
-		$payment_intent = new WC_Payments_API_Intention(
-			$intent_id,
-			$order->get_total(),
-			$order->get_currency(),
-			$customer_id,
-			$payment_method_id,
-			new \DateTime( 'NOW' ),
-			$intent_status,
-			$charge_id,
-			$client_secret,
-			[],
-			[],
-			$payment_method_details
-		);
+		$payment_intent = WC_Helper_Intention::create_intention( [ 'status' => 'processing' ] );
 
 		$this->mock_api_client
 			->expects( $this->once() )
@@ -812,38 +734,17 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	}
 
 	public function test_process_redirect_payment_intent_processing() {
-		$order                  = WC_Helper_Order::create_order();
-		$order_id               = $order->get_id();
-		$save_payment_method    = false;
-		$user                   = wp_get_current_user();
-		$intent_status          = 'processing';
-		$charge_id              = 'ch_mock';
-		$client_secret          = 'cs_mock';
-		$customer_id            = 'cus_mock';
-		$intent_id              = 'pi_mock';
-		$payment_method_id      = 'pm_mock';
-		$payment_method_details = [
-			'type' => 'card',
-			'card' => [
-				'network' => 'visa',
-				'funding' => 'credit',
-			],
-		];
+		$order               = WC_Helper_Order::create_order();
+		$order_id            = $order->get_id();
+		$save_payment_method = false;
+		$user                = wp_get_current_user();
+		$intent_status       = 'processing';
+		$charge_id           = 'ch_mock';
+		$customer_id         = 'cus_mock';
+		$intent_id           = 'pi_mock';
+		$payment_method_id   = 'pm_mock';
 
-		$payment_intent = new WC_Payments_API_Intention(
-			$intent_id,
-			$order->get_total(),
-			$order->get_currency(),
-			$customer_id,
-			$payment_method_id,
-			new \DateTime( 'NOW' ),
-			$intent_status,
-			$charge_id,
-			$client_secret,
-			[],
-			[],
-			$payment_method_details
-		);
+		$payment_intent = WC_Helper_Intention::create_intention( [ 'status' => $intent_status ] );
 
 		$this->mock_upe_gateway->expects( $this->once() )
 			->method( 'manage_customer_details_for_order' )
@@ -880,38 +781,17 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	}
 
 	public function test_process_redirect_payment_intent_succeded() {
-		$order                  = WC_Helper_Order::create_order();
-		$order_id               = $order->get_id();
-		$save_payment_method    = false;
-		$user                   = wp_get_current_user();
-		$intent_status          = 'succeeded';
-		$charge_id              = 'ch_mock';
-		$client_secret          = 'cs_mock';
-		$customer_id            = 'cus_mock';
-		$intent_id              = 'pi_mock';
-		$payment_method_id      = 'pm_mock';
-		$payment_method_details = [
-			'type' => 'card',
-			'card' => [
-				'network' => 'visa',
-				'funding' => 'credit',
-			],
-		];
+		$order               = WC_Helper_Order::create_order();
+		$order_id            = $order->get_id();
+		$save_payment_method = false;
+		$user                = wp_get_current_user();
+		$intent_status       = 'succeeded';
+		$charge_id           = 'ch_mock';
+		$customer_id         = 'cus_mock';
+		$intent_id           = 'pi_mock';
+		$payment_method_id   = 'pm_mock';
 
-		$payment_intent = new WC_Payments_API_Intention(
-			$intent_id,
-			$order->get_total(),
-			$order->get_currency(),
-			$customer_id,
-			$payment_method_id,
-			new \DateTime( 'NOW' ),
-			$intent_status,
-			$charge_id,
-			$client_secret,
-			[],
-			[],
-			$payment_method_details
-		);
+		$payment_intent = WC_Helper_Intention::create_intention( [ 'status' => $intent_status ] );
 
 		$this->mock_upe_gateway->expects( $this->once() )
 			->method( 'manage_customer_details_for_order' )
@@ -941,23 +821,16 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	}
 
 	public function test_process_redirect_setup_intent_succeded() {
-		$order                  = WC_Helper_Order::create_order();
-		$order_id               = $order->get_id();
-		$save_payment_method    = true;
-		$user                   = wp_get_current_user();
-		$intent_status          = 'succeeded';
-		$client_secret          = 'cs_mock';
-		$customer_id            = 'cus_mock';
-		$intent_id              = 'si_mock';
-		$payment_method_id      = 'pm_mock';
-		$token                  = WC_Helper_Token::create_token( $payment_method_id );
-		$payment_method_details = [
-			'type' => 'card',
-			'card' => [
-				'network' => 'visa',
-				'funding' => 'credit',
-			],
-		];
+		$order               = WC_Helper_Order::create_order();
+		$order_id            = $order->get_id();
+		$save_payment_method = true;
+		$user                = wp_get_current_user();
+		$intent_status       = 'succeeded';
+		$client_secret       = 'cs_mock';
+		$customer_id         = 'cus_mock';
+		$intent_id           = 'si_mock';
+		$payment_method_id   = 'pm_mock';
+		$token               = WC_Helper_Token::create_token( $payment_method_id );
 
 		$order->set_shipping_total( 0 );
 		$order->set_shipping_tax( 0 );
@@ -1011,39 +884,18 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	}
 
 	public function test_process_redirect_payment_save_payment_token() {
-		$order                  = WC_Helper_Order::create_order();
-		$order_id               = $order->get_id();
-		$save_payment_method    = true;
-		$user                   = wp_get_current_user();
-		$intent_status          = 'processing';
-		$charge_id              = 'ch_mock';
-		$client_secret          = 'cs_mock';
-		$customer_id            = 'cus_mock';
-		$intent_id              = 'pi_mock';
-		$payment_method_id      = 'pm_mock';
-		$token                  = WC_Helper_Token::create_token( $payment_method_id );
-		$payment_method_details = [
-			'type' => 'card',
-			'card' => [
-				'network' => 'visa',
-				'funding' => 'credit',
-			],
-		];
+		$order               = WC_Helper_Order::create_order();
+		$order_id            = $order->get_id();
+		$save_payment_method = true;
+		$user                = wp_get_current_user();
+		$intent_status       = 'processing';
+		$charge_id           = 'ch_mock';
+		$customer_id         = 'cus_mock';
+		$intent_id           = 'pi_mock';
+		$payment_method_id   = 'pm_mock';
+		$token               = WC_Helper_Token::create_token( $payment_method_id );
 
-		$payment_intent = new WC_Payments_API_Intention(
-			$intent_id,
-			$order->get_total(),
-			$order->get_currency(),
-			$customer_id,
-			$payment_method_id,
-			new \DateTime( 'NOW' ),
-			$intent_status,
-			$charge_id,
-			$client_secret,
-			[],
-			[],
-			$payment_method_details
-		);
+		$payment_intent = WC_Helper_Intention::create_intention( [ 'status' => $intent_status ] );
 
 		$this->mock_upe_gateway->expects( $this->once() )
 			->method( 'manage_customer_details_for_order' )
@@ -1387,7 +1239,13 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$order->save();
 
 		set_transient( 'wcpay_minimum_amount_usd', '50', DAY_IN_SECONDS );
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 50, 'usd', null, null, new \DateTime(), 'requires_payment_method', null, 'client_secret_123' );
+
+		$intent = WC_Helper_Intention::create_intention(
+			[
+				'status' => 'requires_payment_method',
+				'amount' => 50,
+			]
+		);
 
 		$this->mock_api_client
 			->expects( $this->once() )
@@ -1405,7 +1263,12 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$order->set_total( 0.45 );
 		$order->save();
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 50, 'usd', null, null, new \DateTime(), 'requires_payment_method', null, 'client_secret_123' );
+		$intent = WC_Helper_Intention::create_intention(
+			[
+				'status' => 'requires_payment_method',
+				'amount' => 50,
+			]
+		);
 
 		$this->mock_api_client
 			->expects( $this->exactly( 2 ) )
@@ -1423,7 +1286,7 @@ class UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->set_get_upe_enabled_payment_method_statuses_return_value();
 
 		$result = $this->mock_upe_gateway->create_payment_intent( $order->get_id() );
-		$this->assertsame( 'client_secret_123', $result['client_secret'] );
+		$this->assertsame( 'cs_mock', $result['client_secret'] );
 	}
 
 	public function test_process_payment_rejects_with_cached_minimum_acount() {

--- a/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
@@ -304,17 +304,7 @@ class WC_Payments_Invoice_Service_Test extends WP_UnitTestCase {
 		$mock_order = WC_Helper_Order::create_order();
 		$intent_id  = 'pi_paymentIntentID';
 
-		$intent = new WC_Payments_API_Intention(
-			$intent_id,
-			'10',
-			'USD',
-			'customer_id',
-			'payment_method_id',
-			new DateTime(),
-			'succeeded', // Intent status.
-			'charge_id',
-			'client_secret'
-		);
+		$intent = WC_Helper_Intention::create_intention();
 
 		$this->mock_api_client
 			->expects( $this->once() )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
@@ -166,7 +166,7 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$this->mock_wcs_order_contains_subscription( false );
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, 'usd', 'cus_1234', 'pm_56789', new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
+		$intent = WC_Helper_Intention::create_intention();
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_and_confirm_intention' )
@@ -203,7 +203,7 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$this->mock_wcs_order_contains_subscription( true );
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, 'usd', 'cus_1234', 'pm_56789', new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
+		$intent = WC_Helper_Intention::create_intention();
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_and_confirm_intention' )
@@ -239,7 +239,7 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WP_UnitTestCase {
 		);
 		$order->add_payment_token( $this->token );
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, 'usd', 'cus_1234', 'pm_56789', new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
+		$intent = WC_Helper_Intention::create_intention();
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_and_confirm_intention' )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -164,11 +164,10 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	 */
 	public function test_intent_status_success() {
 		// Arrange: Reusable data.
-		$intent_id   = 'pi_123';
-		$charge_id   = 'ch_123';
-		$customer_id = 'cu_123';
+		$intent_id   = 'pi_mock';
+		$charge_id   = 'ch_mock';
+		$customer_id = 'cus_mock';
 		$status      = 'succeeded';
-		$secret      = 'client_secret_123';
 		$order_id    = 123;
 		$total       = 12.23;
 
@@ -204,17 +203,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$mock_cart = $this->createMock( 'WC_Cart' );
 
 		// Arrange: Return a successful response from create_and_confirm_intention().
-		$intent = new WC_Payments_API_Intention(
-			$intent_id,
-			1500,
-			'usd',
-			$customer_id,
-			'pm_mock',
-			new DateTime(),
-			$status,
-			$charge_id,
-			$secret
-		);
+		$intent = WC_Helper_Intention::create_intention();
+
 		$this->mock_api_client
 			->expects( $this->any() )
 			->method( 'create_and_confirm_intention' )
@@ -276,12 +266,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	 */
 	public function test_intent_status_success_logged_out_user() {
 		// Arrange: Reusable data.
-		$intent_id = 'pi_123';
-		$charge_id = 'ch_123';
-		$status    = 'succeeded';
-		$secret    = 'client_secret_123';
-		$order_id  = 123;
-		$total     = 12.23;
+		$order_id = 123;
+		$total    = 12.23;
 
 		// Arrange: Create an order to test with.
 		$mock_order = $this->createMock( 'WC_Order' );
@@ -310,17 +296,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$mock_cart = $this->createMock( 'WC_Cart' );
 
 		// Arrange: Return a successful response from create_and_confirm_intention().
-		$intent = new WC_Payments_API_Intention(
-			$intent_id,
-			1500,
-			'usd',
-			'cus_12345',
-			'pm_12345',
-			new DateTime(),
-			$status,
-			$charge_id,
-			$secret
-		);
+		$intent = WC_Helper_Intention::create_intention();
+
 		$this->mock_api_client
 			->expects( $this->any() )
 			->method( 'create_and_confirm_intention' )
@@ -353,11 +330,10 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	 */
 	public function test_intent_status_requires_capture() {
 		// Arrange: Reusable data.
-		$intent_id   = 'pi_123';
-		$charge_id   = 'ch_123';
-		$customer_id = 'cu_123';
+		$intent_id   = 'pi_mock';
+		$charge_id   = 'ch_mock';
+		$customer_id = 'cus_mock';
 		$status      = 'requires_capture';
-		$secret      = 'client_secret_123';
 		$order_id    = 123;
 		$total       = 12.23;
 
@@ -388,17 +364,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$mock_cart = $this->createMock( 'WC_Cart' );
 
 		// Arrange: Return a 'requires_capture' response from create_and_confirm_intention().
-		$intent = new WC_Payments_API_Intention(
-			$intent_id,
-			1500,
-			'usd',
-			$customer_id,
-			'pm_mock',
-			new DateTime(),
-			$status,
-			$charge_id,
-			$secret
-		);
+		$intent = WC_Helper_Intention::create_intention( [ 'status' => $status ] );
+
 		$this->mock_api_client
 			->expects( $this->any() )
 			->method( 'create_and_confirm_intention' )
@@ -730,11 +697,11 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	 */
 	public function test_intent_status_requires_action() {
 		// Arrange: Reusable data.
-		$intent_id   = 'pi_123';
-		$charge_id   = 'ch_123';
-		$customer_id = 'cu_123';
+		$intent_id   = 'pi_mock';
+		$charge_id   = 'ch_mock';
+		$customer_id = 'cus_mock';
 		$status      = 'requires_action';
-		$secret      = 'client_secret_123';
+		$secret      = 'cs_mock';
 		$order_id    = 123;
 		$total       = 12.23;
 
@@ -765,17 +732,8 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$mock_cart = $this->createMock( 'WC_Cart' );
 
 		// Arrange: Return a 'requires_action' response from create_and_confirm_intention().
-		$intent = new WC_Payments_API_Intention(
-			$intent_id,
-			1500,
-			'usd',
-			$customer_id,
-			'pm_mock',
-			new DateTime(),
-			$status,
-			$charge_id,
-			$secret
-		);
+		$intent = WC_Helper_Intention::create_intention( [ 'status' => $status ] );
+
 		$this->mock_api_client
 			->expects( $this->any() )
 			->method( 'create_and_confirm_intention' )
@@ -848,10 +806,10 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	 */
 	public function test_setup_intent_status_requires_action() {
 		// Arrange: Reusable data.
-		$intent_id   = 'pi_123';
-		$customer_id = 'cu_123';
+		$intent_id   = 'pi_mock';
+		$customer_id = 'cus_mock';
 		$status      = 'requires_action';
-		$secret      = 'client_secret_123';
+		$secret      = 'cs_mock';
 		$order_id    = 123;
 		$total       = 0;
 		$currency    = 'USD';
@@ -963,7 +921,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	public function test_saved_card_at_checkout() {
 		$order = WC_Helper_Order::create_order();
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, 'usd', 'cus_1234', 'pm_56789', new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
+		$intent = WC_Helper_Intention::create_intention();
 
 		$this->mock_api_client
 			->expects( $this->any() )
@@ -985,7 +943,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	public function test_not_saved_card_at_checkout() {
 		$order = WC_Helper_Order::create_order();
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, 'usd', 'cus_1234', 'pm_56789', new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
+		$intent = WC_Helper_Intention::create_intention();
 
 		$this->mock_api_client
 			->expects( $this->any() )
@@ -1003,7 +961,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	public function test_does_not_update_new_payment_method() {
 		$order = WC_Helper_Order::create_order();
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, 'usd', 'cus_1234', 'pm_56789', new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
+		$intent = WC_Helper_Intention::create_intention();
 
 		$this->mock_api_client
 			->expects( $this->any() )
@@ -1022,7 +980,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 
 		$order = WC_Helper_Order::create_order();
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, 'usd', 'cus_1234', 'pm_56789', new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
+		$intent = WC_Helper_Intention::create_intention();
 
 		$this->mock_api_client
 			->expects( $this->any() )
@@ -1047,7 +1005,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 	public function test_save_payment_method_to_platform() {
 		$order = WC_Helper_Order::create_order();
 
-		$intent = new WC_Payments_API_Intention( 'pi_mock', 1500, 'usd', 'cus_1234', 'pm_56789', new DateTime(), 'succeeded', 'ch_mock', 'client_secret_123' );
+		$intent = WC_Helper_Intention::create_intention();
 
 		$_POST['save_user_in_platform_checkout'] = 'true';
 
@@ -1096,17 +1054,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WP_UnitTestCase {
 		$_POST['wcpay-is-platform-payment-method'] = 1;
 
 		// Arrange: Return a successful response from create_and_confirm_intention().
-		$intent = new WC_Payments_API_Intention(
-			'pi_123',
-			1500,
-			'usd',
-			'cu_123',
-			'pm_mock',
-			new DateTime(),
-			'succeeded',
-			'ch_123',
-			'client_secret_123'
-		);
+		$intent = WC_Helper_Intention::create_intention();
 
 		// Assert: API is called with additional flag.
 		$this->mock_api_client

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
@@ -374,7 +374,9 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WP_UnitTestCase {
 		$this->mock_api_client
 			->method( 'get_intent' )
 			->with( $intent_id )
-			->willReturn( WC_Helper_Intention::create_intention( [ 'charge' => [ 'payment_method_details' => [ 'type' => 'interac_present' ] ] ] ) );
+			->willReturn(
+				WC_Helper_Intention::create_intention( [ 'charge' => [ 'payment_method_details' => [ 'type' => 'interac_present' ] ] ] )
+			);
 
 		$this->mock_api_client
 			->expects( $this->once() )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
@@ -360,8 +360,8 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WP_UnitTestCase {
 	}
 
 	public function test_process_refund_interac_present_without_payment_method_id_meta() {
-		$intent_id = 'pi_xxxxxxxxxxxxx';
-		$charge_id = 'ch_yyyyyyyyyyyyy';
+		$intent_id = 'pi_mock';
+		$charge_id = 'ch_mock';
 
 		$order = WC_Helper_Order::create_order();
 		$order->update_meta_data( '_intent_id', $intent_id );
@@ -374,22 +374,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WP_UnitTestCase {
 		$this->mock_api_client
 			->method( 'get_intent' )
 			->with( $intent_id )
-			->willReturn(
-				new WC_Payments_API_Intention(
-					$intent_id,
-					5000,
-					'usd',
-					1,
-					'pm_zzzzzzzz',
-					new DateTime(),
-					'succeeded',
-					$charge_id,
-					'client_secret',
-					[],
-					[],
-					[ 'type' => 'interac_present' ]
-				)
-			);
+			->willReturn( WC_Helper_Intention::create_intention( [ 'charge' => [ 'payment_method_details' => [ 'type' => 'interac_present' ] ] ] ) );
 
 		$this->mock_api_client
 			->expects( $this->once() )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -106,17 +106,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WP_Uni
 
 		wp_set_current_user( self::USER_ID );
 
-		$this->payment_intent = new WC_Payments_API_Intention(
-			self::PAYMENT_INTENT_ID,
-			1500,
-			'usd',
-			'cus_12345',
-			'pm_12345',
-			new DateTime(),
-			'succeeded',
-			self::CHARGE_ID,
-			''
-		);
+		$this->payment_intent = WC_Helper_Intention::create_intention();
 
 		$this->mock_api_client = $this->getMockBuilder( 'WC_Payments_API_Client' )
 			->disableOriginalConstructor()

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -227,19 +227,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WP_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'create_and_confirm_intention' )
 			->with( $this->anything(), $this->anything(), self::PAYMENT_METHOD_ID, self::CUSTOMER_ID, $this->anything(), false, false, $this->anything(), $this->anything(), true )
-			->willReturn(
-				new WC_Payments_API_Intention(
-					self::PAYMENT_INTENT_ID,
-					1500,
-					'usd',
-					'cus_12345',
-					'pm_12345',
-					new DateTime(),
-					'succeeded',
-					self::CHARGE_ID,
-					''
-				)
-			);
+			->willReturn( WC_Helper_Intention::create_intention() );
 
 		$this->wcpay_gateway->scheduled_subscription_payment( $renewal_order->get_total(), $renewal_order );
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -159,7 +159,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_attach_exchange_info_to_order_with_no_conversion() {
-		$charge_id = 'ch_yyyyyyyyyyyyy';
+		$charge_id = 'ch_mock';
 
 		$order = WC_Helper_Order::create_order();
 		$order->update_meta_data( '_charge_id', $charge_id );
@@ -178,7 +178,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_attach_exchange_info_to_order_with_different_account_currency_no_conversion() {
-		$charge_id = 'ch_yyyyyyyyyyyyy';
+		$charge_id = 'ch_mock';
 
 		$order = WC_Helper_Order::create_order();
 		$order->update_meta_data( '_charge_id', $charge_id );
@@ -197,7 +197,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_attach_exchange_info_to_order_with_zero_decimal_order_currency() {
-		$charge_id = 'ch_yyyyyyyyyyyyy';
+		$charge_id = 'ch_mock';
 
 		$order = WC_Helper_Order::create_order();
 		$order->update_meta_data( '_charge_id', $charge_id );
@@ -230,7 +230,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_attach_exchange_info_to_order_with_different_order_currency() {
-		$charge_id = 'ch_yyyyyyyyyyyyy';
+		$charge_id = 'ch_mock';
 
 		$order = WC_Helper_Order::create_order();
 		$order->update_meta_data( '_charge_id', $charge_id );
@@ -691,8 +691,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_capture_charge_success() {
-		$intent_id = 'pi_xxxxxxxxxxxxx';
-		$charge_id = 'ch_yyyyyyyyyyyyy';
+		$intent_id = 'pi_mock';
+		$charge_id = 'ch_mock';
 
 		$order = WC_Helper_Order::create_order();
 		$order->set_transaction_id( $intent_id );
@@ -701,17 +701,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_intention_status', 'requires_capture' );
 		$order->update_status( 'on-hold' );
 
-		$mock_intent = new WC_Payments_API_Intention(
-			$intent_id,
-			1500,
-			$order->get_currency(),
-			'cus_12345',
-			'pm_12345',
-			new DateTime(),
-			'requires_capture',
-			$charge_id,
-			'...'
-		);
+		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
 		$this->mock_api_client->expects( $this->once() )->method( 'get_intent' )->with( $intent_id )->will(
 			$this->returnValue( $mock_intent )
@@ -720,19 +710,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			$this->returnValue( $mock_intent )
 		);
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->returnValue(
-				new WC_Payments_API_Intention(
-					$intent_id,
-					1500,
-					$order->get_currency(),
-					'cus_12345',
-					'pm_12345',
-					new DateTime(),
-					'succeeded',
-					$charge_id,
-					'...'
-				)
-			)
+			$this->returnValue( WC_Helper_Intention::create_intention() )
 		);
 
 		$this->mock_wcpay_account
@@ -767,8 +745,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_capture_charge_success_non_usd() {
-		$intent_id = 'pi_xxxxxxxxxxxxx';
-		$charge_id = 'ch_yyyyyyyyyyyyy';
+		$intent_id = 'pi_mock';
+		$charge_id = 'ch_mock';
 
 		$order = WC_Helper_Order::create_order();
 		$order->set_transaction_id( $intent_id );
@@ -777,16 +755,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_intention_status', 'requires_capture' );
 		$order->update_status( 'on-hold' );
 
-		$mock_intent = new WC_Payments_API_Intention(
-			$intent_id,
-			1500,
-			'eur',
-			'cus_12345',
-			'pm_12345',
-			new DateTime(),
-			'requires_capture',
-			$charge_id,
-			'...'
+		$mock_intent = WC_Helper_Intention::create_intention(
+			[
+				'status'   => 'requires_capture',
+				'currency' => 'eur',
+			]
 		);
 
 		$this->mock_api_client->expects( $this->once() )->method( 'get_intent' )->with( $intent_id )->will(
@@ -796,19 +769,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			$this->returnValue( $mock_intent )
 		);
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->returnValue(
-				new WC_Payments_API_Intention(
-					$intent_id,
-					1500,
-					'eur',
-					'cus_12345',
-					'pm_12345',
-					new DateTime(),
-					'succeeded',
-					$charge_id,
-					'...'
-				)
-			)
+			$this->returnValue( WC_Helper_Intention::create_intention( [ 'currency' => 'eur' ] ) )
 		);
 
 		$this->mock_wcpay_account
@@ -845,8 +806,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_capture_charge_failure() {
-		$intent_id = 'pi_xxxxxxxxxxxxx';
-		$charge_id = 'ch_yyyyyyyyyyyyy';
+		$intent_id = 'pi_mock';
+		$charge_id = 'ch_mock';
 
 		$order = WC_Helper_Order::create_order();
 		$order->set_transaction_id( $intent_id );
@@ -855,17 +816,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_intention_status', 'requires_capture' );
 		$order->update_status( 'on-hold' );
 
-		$mock_intent = new WC_Payments_API_Intention(
-			$intent_id,
-			1500,
-			$order->get_currency(),
-			'cus_12345',
-			'pm_12345',
-			new DateTime(),
-			'requires_capture',
-			$charge_id,
-			'...'
-		);
+		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
+
 		$this->mock_api_client->expects( $this->once() )->method( 'get_intent' )->with( $intent_id )->will(
 			$this->returnValue( $mock_intent )
 		);
@@ -873,19 +825,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			$this->returnValue( $mock_intent )
 		);
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->returnValue(
-				new WC_Payments_API_Intention(
-					$intent_id,
-					1500,
-					$order->get_currency(),
-					'cus_12345',
-					'pm_12345',
-					new DateTime(),
-					'requires_capture',
-					$charge_id,
-					'...'
-				)
-			)
+			$this->returnValue( $mock_intent )
 		);
 
 		$this->mock_wcpay_account
@@ -919,8 +859,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_capture_charge_failure_non_usd() {
-		$intent_id = 'pi_xxxxxxxxxxxxx';
-		$charge_id = 'ch_yyyyyyyyyyyyy';
+		$intent_id = 'pi_mock';
+		$charge_id = 'ch_mock';
 
 		$order = WC_Helper_Order::create_order();
 		$order->set_transaction_id( $intent_id );
@@ -930,17 +870,13 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_status( 'on-hold' );
 		$order->set_currency( 'EUR' );
 
-		$mock_intent = new WC_Payments_API_Intention(
-			$intent_id,
-			1500,
-			'eur',
-			'cus_12345',
-			'pm_12345',
-			new DateTime(),
-			'requires_capture',
-			$charge_id,
-			'...'
+		$mock_intent = WC_Helper_Intention::create_intention(
+			[
+				'status'   => 'requires_capture',
+				'currency' => 'eur',
+			]
 		);
+
 		$this->mock_api_client->expects( $this->once() )->method( 'get_intent' )->with( $intent_id )->will(
 			$this->returnValue( $mock_intent )
 		);
@@ -948,19 +884,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			$this->returnValue( $mock_intent )
 		);
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->returnValue(
-				new WC_Payments_API_Intention(
-					$intent_id,
-					1500,
-					'eur',
-					'cus_12345',
-					'pm_12345',
-					new DateTime(),
-					'requires_capture',
-					$charge_id,
-					'...'
-				)
-			)
+			$this->returnValue( $mock_intent )
 		);
 
 		$this->mock_wcpay_account
@@ -996,8 +920,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_capture_charge_api_failure() {
-		$intent_id = 'pi_xxxxxxxxxxxxx';
-		$charge_id = 'ch_yyyyyyyyyyyyy';
+		$intent_id = 'pi_mock';
+		$charge_id = 'ch_mock';
 
 		$order = WC_Helper_Order::create_order();
 		$order->set_transaction_id( $intent_id );
@@ -1006,17 +930,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_intention_status', 'requires_capture' );
 		$order->update_status( 'on-hold' );
 
-		$mock_intent = new WC_Payments_API_Intention(
-			$intent_id,
-			1500,
-			'usd',
-			'cus_12345',
-			'pm_12345',
-			new DateTime(),
-			'requires_capture',
-			$charge_id,
-			'...'
-		);
+		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
 		$this->mock_api_client->expects( $this->atLeastOnce() )->method( 'get_intent' )->with( $intent_id )->will(
 			$this->returnValue( $mock_intent )
@@ -1060,8 +974,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_capture_charge_api_failure_non_usd() {
-		$intent_id = 'pi_xxxxxxxxxxxxx';
-		$charge_id = 'ch_yyyyyyyyyyyyy';
+		$intent_id = 'pi_mock';
+		$charge_id = 'ch_mock';
 
 		$order = WC_Helper_Order::create_order();
 		$order->set_transaction_id( $intent_id );
@@ -1071,16 +985,11 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_status( 'on-hold' );
 		WC_Payments_Utils::set_order_intent_currency( $order, 'EUR' );
 
-		$mock_intent = new WC_Payments_API_Intention(
-			$intent_id,
-			1500,
-			'jpy',
-			'cus_12345',
-			'pm_12345',
-			new DateTime(),
-			'requires_capture',
-			$charge_id,
-			'...'
+		$mock_intent = WC_Helper_Intention::create_intention(
+			[
+				'status'   => 'requires_capture',
+				'currency' => 'jpy',
+			]
 		);
 
 		$this->mock_api_client->expects( $this->atLeastOnce() )->method( 'get_intent' )->with( $intent_id )->will(
@@ -1127,8 +1036,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_capture_charge_expired() {
-		$intent_id = 'pi_xxxxxxxxxxxxx';
-		$charge_id = 'ch_yyyyyyyyyyyyy';
+		$intent_id = 'pi_mock';
+		$charge_id = 'ch_mock';
 
 		$order = WC_Helper_Order::create_order();
 		$order->set_transaction_id( $intent_id );
@@ -1137,17 +1046,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_intention_status', 'requires_capture' );
 		$order->update_status( 'on-hold' );
 
-		$mock_intent = new WC_Payments_API_Intention(
-			$intent_id,
-			1500,
-			'usd',
-			'cus_12345',
-			'pm_12345',
-			new DateTime(),
-			'canceled',
-			$charge_id,
-			'...'
-		);
+		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'canceled' ] );
 
 		$this->mock_api_client->expects( $this->atLeastOnce() )->method( 'get_intent' )->with( $intent_id )->will(
 			$this->returnValue( $mock_intent )
@@ -1189,8 +1088,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_capture_charge_metadata() {
-		$intent_id = 'pi_xxxxxxxxxxxxx';
-		$charge_id = 'ch_yyyyyyyyyyyyy';
+		$intent_id = 'pi_mock';
+		$charge_id = 'ch_mock';
 
 		$order = WC_Helper_Order::create_order();
 		$order->set_transaction_id( $intent_id );
@@ -1199,23 +1098,17 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_intention_status', 'requires_capture' );
 		$order->update_status( 'on-hold' );
 
-		$mock_intent     = new WC_Payments_API_Intention(
-			$intent_id,
-			1500,
-			$order->get_currency(),
-			'cus_12345',
-			'pm_12345',
-			new DateTime(),
-			'requires_capture',
-			$charge_id,
-			'...',
-			[],
-			[],
-			[],
+		$charge = $this->create_charge_object();
+
+		$mock_intent = WC_Helper_Intention::create_intention(
 			[
-				'customer_name' => 'Test',
+				'status'   => 'requires_capture',
+				'metadata' => [
+					'customer_name' => 'Test',
+				],
 			]
 		);
+
 		$merged_metadata = [
 			'customer_name'  => 'Test',
 			'customer_email' => $order->get_billing_email(),
@@ -1233,19 +1126,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			$this->returnValue( $mock_intent )
 		);
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->returnValue(
-				new WC_Payments_API_Intention(
-					$intent_id,
-					1500,
-					$order->get_currency(),
-					'cus_12345',
-					'pm_12345',
-					new DateTime(),
-					'succeeded',
-					$charge_id,
-					'...'
-				)
-			)
+			$this->returnValue( WC_Helper_Intention::create_intention() )
 		);
 
 		$this->mock_wcpay_account
@@ -1279,8 +1160,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_capture_charge_without_level3() {
-		$intent_id = 'pi_xxxxxxxxxxxxx';
-		$charge_id = 'ch_yyyyyyyyyyyyy';
+		$intent_id = 'pi_mock';
+		$charge_id = 'ch_mock';
 
 		$order = WC_Helper_Order::create_order();
 		$order->set_transaction_id( $intent_id );
@@ -1289,17 +1170,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_intention_status', 'requires_capture' );
 		$order->update_status( 'on-hold' );
 
-		$mock_intent = new WC_Payments_API_Intention(
-			$intent_id,
-			1500,
-			$order->get_currency(),
-			'cus_12345',
-			'pm_12345',
-			new DateTime(),
-			'requires_capture',
-			$charge_id,
-			'...'
-		);
+		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
 		$this->mock_api_client->expects( $this->once() )->method( 'get_intent' )->with( $intent_id )->will(
 			$this->returnValue( $mock_intent )
@@ -1308,19 +1179,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			$this->returnValue( $mock_intent )
 		);
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->returnValue(
-				new WC_Payments_API_Intention(
-					$intent_id,
-					1500,
-					$order->get_currency(),
-					'cus_12345',
-					'pm_12345',
-					new DateTime(),
-					'succeeded',
-					$charge_id,
-					'...'
-				)
-			)
+			$this->returnValue( WC_Helper_Intention::create_intention() )
 		);
 
 		$this->mock_wcpay_account
@@ -1354,8 +1213,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_cancel_authorization_handles_api_exception_when_canceling() {
-		$intent_id = 'pi_xxxxxxxxxxxxx';
-		$charge_id = 'ch_yyyyyyyyyyyyy';
+		$intent_id = 'pi_mock';
+		$charge_id = 'ch_mock';
 
 		$order = WC_Helper_Order::create_order();
 		$order->set_transaction_id( $intent_id );
@@ -1373,17 +1232,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'get_intent' )
 			->willReturn(
-				new WC_Payments_API_Intention(
-					$intent_id,
-					1500,
-					'usd',
-					'cus_12345',
-					'pm_12345',
-					new DateTime(),
-					'canceled',
-					$charge_id,
-					'...'
-				)
+				WC_Helper_Intention::create_intention( [ 'status' => 'canceled' ] )
 			);
 
 		$this->wcpay_gateway->cancel_authorization( $order );
@@ -1400,8 +1249,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_cancel_authorization_handles_all_api_exceptions() {
-		$intent_id = 'pi_xxxxxxxxxxxxx';
-		$charge_id = 'ch_yyyyyyyyyyyyy';
+		$intent_id = 'pi_mock';
+		$charge_id = 'ch_mock';
 
 		$order = WC_Helper_Order::create_order();
 		$order->set_transaction_id( $intent_id );
@@ -1977,8 +1826,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			->setMethods( [ 'update_meta_data', 'save' ] )
 			->getMock();
 
-		$intent_id      = 'pi_xxxxxxxxxxxxx';
-		$charge_id      = 'ch_yyyyyyyyyyyyy';
+		$intent_id      = 'pi_mock';
+		$charge_id      = 'ch_mock';
 		$customer_id    = 'cus_12345';
 		$payment_method = 'woocommerce_payments';
 		$intent_status  = 'succeeded';
@@ -2003,8 +1852,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			->method( 'get_data_store' )
 			->willReturn( new \WC_Mock_WC_Data_Store() );
 
-		$intent_id     = 'pi_xxxxxxxxxxxxx';
-		$charge_id     = 'ch_yyyyyyyyyyyyy';
+		$intent_id     = 'pi_mock';
+		$charge_id     = 'ch_mock';
 		$intent_status = 'succeeded';
 
 		$order->expects( $this->once() )->method( 'payment_complete' )->with( $intent_id );
@@ -2024,8 +1873,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 			->method( 'get_data_store' )
 			->willReturn( new \WC_Mock_WC_Data_Store() );
 
-		$intent_id     = 'pi_xxxxxxxxxxxxx';
-		$charge_id     = 'ch_yyyyyyyyyyyyy';
+		$intent_id     = 'pi_mock';
+		$charge_id     = 'ch_mock';
 		$intent_status = 'succeeded';
 
 		$order
@@ -2037,8 +1886,8 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 	}
 
 	public function test_create_intent_success() {
-		$intent_id       = 'pi_xxxxxxxxxxxxx';
-		$charge_id       = 'ch_yyyyyyyyyyyyy';
+		$intent_id       = 'pi_mock';
+		$charge_id       = 'ch_mock';
 		$payment_methods = [ 'card_present' ];
 		$capture_method  = 'manual';
 
@@ -2046,19 +1895,7 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		$order->update_status( 'on-hold' );
 
 		$this->mock_api_client->expects( $this->once() )->method( 'create_intention' )->will(
-			$this->returnValue(
-				new WC_Payments_API_Intention(
-					$intent_id,
-					1500,
-					$order->get_currency(),
-					'cus_12345',
-					'pm_12345',
-					new DateTime(),
-					'requires_payment_method',
-					$charge_id,
-					'...'
-				)
-			)
+			$this->returnValue( WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] ) )
 		);
 
 		$result = $this->wcpay_gateway->create_intent( $order, $payment_methods, $capture_method );
@@ -2167,5 +2004,12 @@ class WC_Payment_Gateway_WCPay_Test extends WP_UnitTestCase {
 		Fraud_Prevention_Service::set_instance( $fraud_prevention_service_mock );
 
 		return $fraud_prevention_service_mock;
+	}
+
+	private function create_charge_object() {
+		$created = new DateTime();
+		$created->setTimestamp( $this->mock_charge_created );
+
+		return new WC_Payments_API_Charge( $this->mock_charge_id, 1500, $created );
 	}
 }


### PR DESCRIPTION
Partially fixes #3122

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

Update `WC_Payments_API_Intention` and `WC_Payments_API_Charge` constructors

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Updates `WC_Payments_API_Intention` to receive a `WC_Payments_API_Charge` instance instead of multiple arguments, and updates `WC_Payments_API_Charge` to hold the payment method details. It will be used in the next PR to retrieve the Intention data from the REST API.

Discussion around the best way to store the charge data inside WC_Payments_API_Intention:
p1654178662338959-slack-C0208C3BXHP

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This change shouldn't require more testing as it just changes how the classes are used internally. All unit tests were fixed and are passing.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.