### PR TITLE
Display the "Respond by" dispute date in local time

### DIFF
--- a/changelog/fix-4338-dispute-utc-time
+++ b/changelog/fix-4338-dispute-utc-time
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Dates presented in the "Respond by" column on the Payments → Disputes page are displayed in local time rather than UTC time.

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -211,7 +211,7 @@ export const DisputesList = (): JSX.Element => {
 				display: clickable(
 					dateI18n(
 						'M j, Y / g:iA',
-						moment( dispute.due_by ).toISOString()
+						moment.utc( dispute.due_by ).local().toISOString()
 					)
 				),
 			},

--- a/client/disputes/test/__snapshots__/index.tsx.snap
+++ b/client/disputes/test/__snapshots__/index.tsx.snap
@@ -487,7 +487,7 @@ exports[`Disputes list renders correctly 1`] = `
                     href="admin.php?page=wc-admin&path=%2Fpayments%2Fdisputes%2Fdetails&id=dp_asdfghjkl"
                     tabindex="-1"
                   >
-                    Nov 8, 2019 / 2:46AM
+                    Nov 7, 2019 / 9:46PM
                   </a>
                 </td>
               </tr>
@@ -607,7 +607,7 @@ exports[`Disputes list renders correctly 1`] = `
                     href="admin.php?page=wc-admin&path=%2Fpayments%2Fdisputes%2Fdetails&id=dp_zxcvbnm"
                     tabindex="-1"
                   >
-                    Nov 6, 2019 / 11:00PM
+                    Nov 6, 2019 / 6:00PM
                   </a>
                 </td>
               </tr>
@@ -732,7 +732,7 @@ exports[`Disputes list renders correctly 1`] = `
                     href="admin.php?page=wc-admin&path=%2Fpayments%2Fdisputes%2Fdetails&id=dp_rstyuoi"
                     tabindex="-1"
                   >
-                    Nov 8, 2019 / 2:46AM
+                    Nov 7, 2019 / 9:46PM
                   </a>
                 </td>
               </tr>


### PR DESCRIPTION
Fixes #4338

#### Changes proposed in this Pull Request

Changes the dates presented in the "Respond by" column on the **Payments → Disputes** page to be displayed in local time rather than UTC time.

Before | After
--- | ---
<img width="1287" alt="Screen Shot 2022-06-10 at 12 56 38 pm" src="https://user-images.githubusercontent.com/1527164/172982199-49a58c5b-da96-4508-8f0f-cac76c98ea3b.png"> | <img width="1288" alt="Screen Shot 2022-06-10 at 12 57 39 pm" src="https://user-images.githubusercontent.com/1527164/172982227-71c0d8b2-1a56-46f0-b8e5-d77e3bf691d0.png">

#### Testing instructions

1. Make a purchase using a card that will automatically raise a dispute (eg `4000 0000 0000 0259` see more [here](https://woocommerce.com/document/payments/testing/#section-15))
1. Go to **Payments > Disputes** in your WP dashboard.
1. Observe the dates displayed in the "Respond by" column are in local time.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
