### PR TITLE
Make hardcoded string translatable

### DIFF
--- a/changelog/fix-translatable-string
+++ b/changelog/fix-translatable-string
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make hardcoded string in the checkout page translatable

--- a/client/components/platform-checkout/save-user/checkout-page-save-user.js
+++ b/client/components/platform-checkout/save-user/checkout-page-save-user.js
@@ -37,7 +37,7 @@ const CheckoutPageSaveUser = () => {
 
 	return (
 		<>
-			<h3>Remember your details?</h3>
+			<h3>{ __( 'Remember your details?', 'woocommerce-payments' ) }</h3>
 			<span>
 				<label htmlFor="save_user_in_platform_checkout">
 					<input


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

This PR makes the "Remember your details?" string we display on the checkout page translatable.

#### Testing instructions

Because it's just making a string translatable, checking out the code and seeing the string shows up on the checkout page without errors would probably be enough.

- Make sure Platform Checkout is enabled
- Add a product to the cart and proceed to check out
- Use an email that's not registered in the Platform Checkout
- Make sure the string "Remember your details?" shows up and there are no errors in the browser console  
![image](https://user-images.githubusercontent.com/41606954/173103659-6beccf67-9130-4386-8d8d-f2522e71a65f.png)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
