### PR TITLE
Add has_card_readers_available flag to conditionally display Card readers page

### DIFF
--- a/changelog/add-4190-card-reader-menu-toggle
+++ b/changelog/add-4190-card-reader-menu-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add a new flag to conditionally display the Card Readers page when account has connected card readers.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -226,7 +226,7 @@ class WC_Payments_Admin {
 		}
 
 		if ( $should_render_full_menu ) {
-			if ( $this->account->is_card_present_eligible() ) {
+			if ( $this->account->is_card_present_eligible() && $this->account->has_card_readers_available() ) {
 				$this->admin_child_pages['wc-payments-card-readers'] = [
 					'id'       => 'wc-payments-card-readers',
 					'title'    => __( 'Card Readers', 'woocommerce-payments' ),

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -310,6 +310,16 @@ class WC_Payments_Account {
 	}
 
 	/**
+	 * Get has account connected readers flag
+	 *
+	 * @return bool
+	 */
+	public function has_card_readers_available(): bool {
+		$account = $this->get_cached_account_data();
+		return $account['has_card_readers_available'] ?? false;
+	}
+
+	/**
 	 * Gets the current account fees for rendering on the settings page.
 	 *
 	 * @return array Fees.


### PR DESCRIPTION
Fixes #4190 

#### Changes proposed in this Pull Request
Adding the newly introduced `has_card_readers_available` flag to conditionally display the Card readers page only when there are card readers connected to the account.

#### Testing instructions
- Connect a card reader to your account.
- Clear account cache to force update the account data.
- Verify the `Card readers` page under `Payments` is displayed. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
