### PR TITLE
Add host.docker.internal extra host

### DIFF
--- a/changelog/chore-host-docker-internal-linux
+++ b/changelog/chore-host-docker-internal-linux
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Just a minor change to make development on Linux machines easier. Not relevant for the changelog.
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       - ./docker/wc-payments-php.ini:/usr/local/etc/php/conf.d/wc-payments-php.ini
       - dockerdirectory:/var/www/html/wp-content/plugins/woocommerce-payments/docker
       - ./docker/bin:/var/scripts
+    extra_hosts:
+      - "host.docker.internal:host-gateway"  
   db:
     container_name: woocommerce_payments_mysql
     image: mariadb:10.5.8


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add the extra host `host.docker.internal` to add support for development (communication with a local WCPay server) on Linux.

#### Testing instructions

Using a Linux machine:

1. Try to connect to a local instance of the WCPay server using the address `host.docker.internal:8086`.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
