### PR TITLE
Include WCPay's version when making requests to the Platform Checkout

### DIFF
--- a/changelog/add-wcpay-version-to-platform-checkout-requests
+++ b/changelog/add-wcpay-version-to-platform-checkout-requests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Include the WCPay version in the requests to the Platform Checkout

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -184,6 +184,7 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 			'needsHeader',
 			fullScreenModalBreakpoint > window.innerWidth
 		);
+		urlParams.append( 'wcpayVersion', getConfig( 'wcpayVersionNumber' ) );
 
 		iframe.src = `${ getConfig(
 			'platformCheckoutHost'
@@ -210,6 +211,10 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 		const emailExistsQuery = new URLSearchParams();
 		emailExistsQuery.append( 'email', email );
 		emailExistsQuery.append( 'test_mode', !! getConfig( 'testMode' ) );
+		emailExistsQuery.append(
+			'wcpay_version',
+			getConfig( 'wcpayVersionNumber' )
+		);
 
 		fetch(
 			`${ getConfig(

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -672,6 +672,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			'platformCheckoutHost'           => defined( 'PLATFORM_CHECKOUT_FRONTEND_HOST' ) ? PLATFORM_CHECKOUT_FRONTEND_HOST : 'https://pay.woo.com',
 			'platformTrackerNonce'           => wp_create_nonce( 'platform_tracks_nonce' ),
 			'accountIdForIntentConfirmation' => apply_filters( 'wc_payments_account_id_for_intent_confirmation', '' ),
+			'wcpayVersionNumber'             => WCPAY_VERSION_NUMBER,
 		];
 	}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1022,6 +1022,7 @@ class WC_Payments {
 		$store_logo = self::get_gateway()->get_option( 'platform_checkout_store_logo' );
 
 		$body = [
+			'wcpay_version'        => WCPAY_VERSION_NUMBER,
 			'user_id'              => $user->ID,
 			'customer_id'          => $customer_id,
 			'session_nonce'        => wp_create_nonce( 'wc_store_api' ),


### PR DESCRIPTION
Fixes #1013 from Platform Checkout

#### Changes proposed in this Pull Request

Include WCPay's version when making requests to the Platform Checkout.

This PR adds a parameter with the WCPay version to all requests we make to the Platform Checkout.

I evaluated sending it as a header, but we needed to pass this custom header to the `rest_allowed_cors_headers` on the Platform Checkout's end to allow it. I ended up not doing it because it looks like a request param would be enough and would require fewer changes.

#### Testing instructions

* Make sure the platform checkout is enabled in WCPay
* Add a product to the cart and proceed to checkout
* Open the network tab in the browser's dev tools
* Add an email address that exists in the platform checkout
* Look for the request to `/user/exists`
  * Confirm it has a `wcpay_version` parameter with the WCPay version as its value
* Inspect the OTP iframe and look for its `src` attribute
  * Confirm it has a `wcpayVersion` parameter with the WCPay version as its value
* Enter a valid OTP and wait for the redirection
  * Confirm the call to the `init` endpoint includes a `wcpay_version` parameter in its body with the WCPay version as its value. You can check this in the platform checkout's callback for the `/init` endpoint 

Also, please confirm we're not making other requests to the platform checkout. All requests should include this parameter.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
