### PR TITLE
Bump minimum WC version for 4.4.0 release

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -12,13 +12,13 @@ jobs:
       max-parallel: 10
       matrix:
         # Minimum support version, ..., Latest version, `beta`.
-        woocommerce: [ '5.6.2', '5.7.2', '5.8.1', '5.9.1', '6.0.1', '6.1.2', '6.2.2', '6.3.1', '6.4.1', '6.5.1', 'beta' ]
+        woocommerce: [ '5.8.1', '5.9.1', '6.0.1', '6.1.2', '6.2.2', '6.3.1', '6.4.1', '6.5.1', '6.6.0', 'beta' ]
         wordpress:   [ 'latest' ]
         gutenberg:   [ 'latest' ]
         php:         [ '7.4' ]
         include:
           # Edge case: oldest dependencies compatibility
-          - woocommerce: '5.6.2'
+          - woocommerce: '5.8.1'
             wordpress:   '5.7'
             gutenberg:   '11.4.0' # The latest version supporting WP 5.6.
             php:         '7.1' # Minimum supported PHP version

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast:     false
       matrix:
         # Min WooCommerce | L-2 | L(atest) | beta
-        woocommerce:   [ '5.6.2', '6.3.1', '6.5.1', 'beta' ]
+        woocommerce:   [ '5.8.1', '6.4.1', '6.6.0', 'beta' ]
         wordpress:     [ 'latest' ]
         php:           [ '7.4' ]
         test_groups:   [ 'wcpay', 'subscriptions', 'blocks' ]
@@ -44,7 +44,7 @@ jobs:
         exclude:
           - test_groups: 'blocks'
             test_branches: 'merchant'
-          - woocommerce: '5.6.2'
+          - woocommerce: '5.8.1'
             test_groups: 'blocks'
             test_branches: 'shopper'
 
@@ -60,7 +60,7 @@ jobs:
       # Conditionally skip WC Blocks tests. Remove/update based on min supported WC version by the blocks checkout plugin.
       - name: Conditionally skip WC Blocks tests
         run: |
-          SKIP_WC_VERSIONS=('5.6.2')
+          SKIP_WC_VERSIONS=('5.8.1')
           if [[ " ${SKIP_WC_VERSIONS[@]} " =~ " ${E2E_WC_VERSION} " ]]; then
             echo "SKIP_WC_BLOCKS_TESTS=1" >> $GITHUB_ENV
           fi

--- a/changelog/bump-wc-tested-up-for-wcpay-4-4
+++ b/changelog/bump-wc-tested-up-for-wcpay-4-4
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Bump minimum required version of WooCommerce from 5.6 to 5.8.

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ Our global support team is available to answer questions you may have about WooC
 = Requirements =
 
 * WordPress 5.7 or newer.
-* WooCommerce 6.3 or newer.
+* WooCommerce 6.4 or newer.
 * PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
 
 = Try it now =

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Woo: 5278104:bf3cf30871604e15eec560c962593c1f
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
- * WC requires at least: 5.6
+ * WC requires at least: 5.8
  * WC tested up to: 6.6.0
  * Requires at least: 5.7
  * Requires PHP: 7.0


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

- Bumps the minimum WC versions supported for the upcoming 4.4.0 release in accordance to the L-2 policy (ref: paJDYF-3fF-p2#comment-9727)
- Adds the new WC version 6.6.0 to the `wcpay-e2e-tests` matrix
- Removes newly unsupported WC versions from compatibility tests

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check all minimum WC versions have been updated to 5.8 correctly
* Check all tests are passing

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
