### PR TITLE
Add "Needs Response" disputes page filter option

### DIFF
--- a/changelog/add-4124-disputes-display-needs-response-filter-option
+++ b/changelog/add-4124-disputes-display-needs-response-filter-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Disputes page: add a new filter option to the Show dropdown for displaying disputes awaiting a response.

--- a/client/data/disputes/hooks.ts
+++ b/client/data/disputes/hooks.ts
@@ -16,6 +16,7 @@ import type {
 	DisputesSummary,
 } from 'wcpay/types/disputes';
 import { STORE_NAME } from '../constants';
+import { disputeNeedsResponseStatuses } from 'wcpay/disputes/filters/config';
 
 export const useDispute = (
 	id: string
@@ -57,6 +58,7 @@ export const useDisputes = ( {
 	date_before: dateBefore,
 	date_after: dateAfter,
 	date_between: dateBetween,
+	filter,
 	status_is: statusIs,
 	status_is_not: statusIsNot,
 	orderby: orderBy,
@@ -65,6 +67,11 @@ export const useDisputes = ( {
 	useSelect(
 		( select ) => {
 			const { getDisputes, isResolving } = select( STORE_NAME );
+
+			const search =
+				filter === 'needs_response'
+					? disputeNeedsResponseStatuses
+					: undefined;
 
 			const query = {
 				paged: Number.isNaN( parseInt( paged ?? '', 10 ) )
@@ -82,6 +89,7 @@ export const useDisputes = ( {
 					dateBetween.sort( ( a, b ) =>
 						moment( a ).diff( moment( b ) )
 					),
+				search,
 				statusIs,
 				statusIsNot,
 				orderBy: orderBy || 'created',
@@ -101,6 +109,7 @@ export const useDisputes = ( {
 			dateBefore,
 			dateAfter,
 			JSON.stringify( dateBetween ),
+			filter,
 			statusIs,
 			statusIsNot,
 			orderBy,
@@ -116,12 +125,18 @@ export const useDisputesSummary = ( {
 	date_before: dateBefore,
 	date_after: dateAfter,
 	date_between: dateBetween,
+	filter,
 	status_is: statusIs,
 	status_is_not: statusIsNot,
 }: Query ): DisputesSummary =>
 	useSelect(
 		( select ) => {
 			const { getDisputesSummary, isResolving } = select( STORE_NAME );
+
+			const search =
+				filter === 'needs_response'
+					? disputeNeedsResponseStatuses
+					: undefined;
 
 			const query = {
 				paged: Number.isNaN( parseInt( paged ?? '', 10 ) )
@@ -135,6 +150,7 @@ export const useDisputesSummary = ( {
 				dateBefore,
 				dateAfter,
 				dateBetween,
+				search,
 				statusIs,
 				statusIsNot,
 			};
@@ -152,6 +168,7 @@ export const useDisputesSummary = ( {
 			dateBefore,
 			dateAfter,
 			JSON.stringify( dateBetween ),
+			filter,
 			statusIs,
 			statusIsNot,
 		]

--- a/client/data/disputes/hooks.ts
+++ b/client/data/disputes/hooks.ts
@@ -3,8 +3,9 @@
 /**
  * External dependencies
  */
+import { useEffect, useState } from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
-import type { Query } from '@woocommerce/navigation';
+import { getQuery, Query, updateQueryString } from '@woocommerce/navigation';
 import moment from 'moment';
 
 /**
@@ -173,3 +174,32 @@ export const useDisputesSummary = ( {
 			statusIsNot,
 		]
 	);
+
+export const useDisputesFilterSelection = ( {
+	disputesSummary,
+	isLoading,
+}: DisputesSummary ): void => {
+	// Keep track if 'all' filter has been viewed.
+	const [ allFilterViewed, setAllFilterViewed ] = useState( false );
+
+	// Select 'all' filter if summary returns 0 disputes needing response.
+	// If 'all' filter has been viewed, 'needs_response' filter can be selected.
+	useEffect( () => {
+		if (
+			false === allFilterViewed &&
+			'needs_response' === getQuery().filter &&
+			false === isLoading &&
+			0 === disputesSummary.count
+		) {
+			updateQueryString( { filter: undefined } );
+			setAllFilterViewed( true );
+		}
+	}, [ disputesSummary, isLoading, allFilterViewed ] );
+
+	// Update state if 'all' or undefined filter is present in query.
+	useEffect( () => {
+		if ( [ 'all', undefined ].includes( getQuery().filter ) ) {
+			setAllFilterViewed( true );
+		}
+	}, [] );
+};

--- a/client/data/disputes/hooks.ts
+++ b/client/data/disputes/hooks.ts
@@ -3,9 +3,8 @@
 /**
  * External dependencies
  */
-import { useEffect, useState } from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { getQuery, Query, updateQueryString } from '@woocommerce/navigation';
+import type { Query } from '@woocommerce/navigation';
 import moment from 'moment';
 
 /**
@@ -174,32 +173,3 @@ export const useDisputesSummary = ( {
 			statusIsNot,
 		]
 	);
-
-export const useDisputesFilterSelection = ( {
-	disputesSummary,
-	isLoading,
-}: DisputesSummary ): void => {
-	// Keep track if 'all' filter has been viewed.
-	const [ allFilterViewed, setAllFilterViewed ] = useState( false );
-
-	// Select 'all' filter if summary returns 0 disputes needing response.
-	// If 'all' filter has been viewed, 'needs_response' filter can be selected.
-	useEffect( () => {
-		if (
-			false === allFilterViewed &&
-			'needs_response' === getQuery().filter &&
-			false === isLoading &&
-			0 === disputesSummary.count
-		) {
-			updateQueryString( { filter: undefined } );
-			setAllFilterViewed( true );
-		}
-	}, [ disputesSummary, isLoading, allFilterViewed ] );
-
-	// Update state if 'all' or undefined filter is present in query.
-	useEffect( () => {
-		if ( [ 'all', undefined ].includes( getQuery().filter ) ) {
-			setAllFilterViewed( true );
-		}
-	}, [] );
-};

--- a/client/data/disputes/hooks.ts
+++ b/client/data/disputes/hooks.ts
@@ -16,7 +16,7 @@ import type {
 	DisputesSummary,
 } from 'wcpay/types/disputes';
 import { STORE_NAME } from '../constants';
-import { disputeNeedsResponseStatuses } from 'wcpay/disputes/filters/config';
+import { disputeAwaitingResponseStatuses } from 'wcpay/disputes/filters/config';
 
 export const useDispute = (
 	id: string
@@ -69,8 +69,8 @@ export const useDisputes = ( {
 			const { getDisputes, isResolving } = select( STORE_NAME );
 
 			const search =
-				filter === 'needs_response'
-					? disputeNeedsResponseStatuses
+				filter === 'awaiting_response'
+					? disputeAwaitingResponseStatuses
 					: undefined;
 
 			const query = {
@@ -134,8 +134,8 @@ export const useDisputesSummary = ( {
 			const { getDisputesSummary, isResolving } = select( STORE_NAME );
 
 			const search =
-				filter === 'needs_response'
-					? disputeNeedsResponseStatuses
+				filter === 'awaiting_response'
+					? disputeAwaitingResponseStatuses
 					: undefined;
 
 			const query = {

--- a/client/data/disputes/resolvers.js
+++ b/client/data/disputes/resolvers.js
@@ -29,6 +29,7 @@ const formatQueryFilters = ( query ) => ( {
 		formatDateValue( query.dateBetween[ 0 ] ),
 		formatDateValue( query.dateBetween[ 1 ], true ),
 	],
+	search: query.search,
 	status_is: query.statusIs,
 	status_is_not: query.statusIsNot,
 } );

--- a/client/disputes/filters/config.ts
+++ b/client/disputes/filters/config.ts
@@ -30,6 +30,11 @@ const disputesStatusOptions = Object.entries( displayStatus )
 		return el != null;
 	} );
 
+export const disputeNeedsResponseStatuses = [
+	'needs_response',
+	'warning_needs_response',
+];
+
 export const filters: [ DisputesFilterType, DisputesFilterType ] = [
 	{
 		label: __( 'Dispute currency', 'woocommerce-payments' ),

--- a/client/disputes/filters/config.ts
+++ b/client/disputes/filters/config.ts
@@ -76,6 +76,10 @@ export const filters: [ DisputesFilterType, DisputesFilterType ] = [
 		showFilters: () => true,
 		filters: [
 			{
+				label: __( 'Need response', 'woocommerce-payments' ),
+				value: 'needs_response',
+			},
+			{
 				label: __( 'All disputes', 'woocommerce-payments' ),
 				value: 'all',
 			},

--- a/client/disputes/filters/config.ts
+++ b/client/disputes/filters/config.ts
@@ -30,7 +30,7 @@ const disputesStatusOptions = Object.entries( displayStatus )
 		return el != null;
 	} );
 
-export const disputeNeedsResponseStatuses = [
+export const disputeAwaitingResponseStatuses = [
 	'needs_response',
 	'warning_needs_response',
 ];
@@ -77,7 +77,7 @@ export const filters: [ DisputesFilterType, DisputesFilterType ] = [
 		filters: [
 			{
 				label: __( 'Needs response', 'woocommerce-payments' ),
-				value: 'needs_response',
+				value: 'awaiting_response',
 			},
 			{
 				label: __( 'All disputes', 'woocommerce-payments' ),

--- a/client/disputes/filters/config.ts
+++ b/client/disputes/filters/config.ts
@@ -76,7 +76,7 @@ export const filters: [ DisputesFilterType, DisputesFilterType ] = [
 		showFilters: () => true,
 		filters: [
 			{
-				label: __( 'Need response', 'woocommerce-payments' ),
+				label: __( 'Needs response', 'woocommerce-payments' ),
 				value: 'needs_response',
 			},
 			{

--- a/client/disputes/filters/test/__snapshots__/index.tsx.snap
+++ b/client/disputes/filters/test/__snapshots__/index.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Disputes filters when filtering by status should render all statuses 1`] = `
+exports[`Disputes filters: Advanced when filtering by status should render all statuses 1`] = `
 HTMLOptionsCollection [
   <option
     value="warning_needs_response"

--- a/client/disputes/filters/test/index.tsx
+++ b/client/disputes/filters/test/index.tsx
@@ -24,6 +24,32 @@ function addCurrencyFilter( filter: string ) {
 	user.click( screen.getByRole( 'button', { name: filter } ) );
 }
 
+describe( 'Disputes filters: Needs response', () => {
+	test( 'selecting the Needs response filter adds query param', () => {
+		updateQueryString( {}, '/', {} );
+		render( <DisputesFilters /> );
+		expect( getQuery().filter ).toEqual( undefined );
+
+		// Select the Needs response filter.
+		user.click( screen.getByRole( 'button', { name: /All disputes/i } ) );
+		user.click( screen.getByRole( 'button', { name: /Needs response/i } ) );
+		expect( getQuery().filter ).toEqual( 'awaiting_response' );
+	} );
+
+	test( 'when filter query param is awaiting_response, the Needs response filter option is selected', () => {
+		updateQueryString( { filter: 'awaiting_response' }, '/', {} );
+		render( <DisputesFilters /> );
+
+		// All disputes filter option should not be selected.
+		expect(
+			screen.queryByRole( 'button', { name: /All disputes/i } )
+		).toBeNull();
+
+		// Needs response filter option should be selected.
+		screen.getByRole( 'button', { name: /Needs response/i } );
+	} );
+} );
+
 describe( 'Disputes filters: Advanced', () => {
 	beforeEach( () => {
 		// the query string is preserved across tests, so we need to reset it

--- a/client/disputes/filters/test/index.tsx
+++ b/client/disputes/filters/test/index.tsx
@@ -24,7 +24,7 @@ function addCurrencyFilter( filter: string ) {
 	user.click( screen.getByRole( 'button', { name: filter } ) );
 }
 
-describe( 'Disputes filters', () => {
+describe( 'Disputes filters: Advanced', () => {
 	beforeEach( () => {
 		// the query string is preserved across tests, so we need to reset it
 		updateQueryString( {}, '/', {} );

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -22,11 +22,7 @@ import { useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies.
  */
-import {
-	useDisputes,
-	useDisputesFilterSelection,
-	useDisputesSummary,
-} from 'data/index';
+import { useDisputes, useDisputesSummary } from 'data/index';
 import OrderLink from 'components/order-link';
 import DisputeStatusChip from 'components/dispute-status-chip';
 import ClickableCell from 'components/clickable-cell';
@@ -143,11 +139,6 @@ export const DisputesList = (): JSX.Element => {
 	const { disputesSummary, isLoading: isSummaryLoading } = useDisputesSummary(
 		getQuery()
 	);
-
-	useDisputesFilterSelection( {
-		disputesSummary,
-		isLoading: isSummaryLoading,
-	} );
 
 	const headers = getHeaders( getQuery().orderby );
 	const totalRows = disputesSummary.count || 0;

--- a/client/disputes/index.tsx
+++ b/client/disputes/index.tsx
@@ -22,7 +22,11 @@ import { useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies.
  */
-import { useDisputes, useDisputesSummary } from 'data/index';
+import {
+	useDisputes,
+	useDisputesFilterSelection,
+	useDisputesSummary,
+} from 'data/index';
 import OrderLink from 'components/order-link';
 import DisputeStatusChip from 'components/dispute-status-chip';
 import ClickableCell from 'components/clickable-cell';
@@ -139,6 +143,11 @@ export const DisputesList = (): JSX.Element => {
 	const { disputesSummary, isLoading: isSummaryLoading } = useDisputesSummary(
 		getQuery()
 	);
+
+	useDisputesFilterSelection( {
+		disputesSummary,
+		isLoading: isSummaryLoading,
+	} );
 
 	const headers = getHeaders( getQuery().orderby );
 	const totalRows = disputesSummary.count || 0;

--- a/client/transactions/declarations.d.ts
+++ b/client/transactions/declarations.d.ts
@@ -121,6 +121,7 @@ declare module '@woocommerce/navigation' {
 		status_is_not?: string;
 		document_id?: string;
 		document_type?: string;
+		filter?: string;
 	}
 
 	const onQueryChange: unknown;

--- a/includes/admin/class-wc-rest-payments-disputes-controller.php
+++ b/includes/admin/class-wc-rest-payments-disputes-controller.php
@@ -170,6 +170,7 @@ class WC_REST_Payments_Disputes_Controller extends WC_Payments_REST_Controller {
 				'created_before'  => $request->get_param( 'date_before' ),
 				'created_after'   => $request->get_param( 'date_after' ),
 				'created_between' => $request->get_param( 'date_between' ),
+				'search'          => $request->get_param( 'search' ),
 				'status_is'       => $request->get_param( 'status_is' ),
 				'status_is_not'   => $request->get_param( 'status_is_not' ),
 			],


### PR DESCRIPTION
Partially fixes #4124

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

* A "Needs response" filter is added to the "Show" dropdown on the **Payments → Disputes** page.
* When selected, disputes with the status `needs_response` or `warning_needs_response` are displayed.
* This filter can be selected on page load if the `filter=awaiting_response` query param is provided.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/3147296/174949554-bab1f951-ccc1-4f1c-9928-b4da918bfce1.png">

Filtering by multiple dispute `status` values is achieved with the WCPay-server disputes API `search` query param added in 2127-gh-Automattic/woocommerce-payments-server

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout the WCPay-server branch: `add/2124-disputes-endpoints-allow-filtering-by-multiple-status` (2127-gh-Automattic/woocommerce-payments-server) and start the local WCPay-server environment with `npm start`.
2. Checkout this WCPay client branch and build JS bundles with `npm run build:client` or `npm start`
3. In your local WCPay (client) store, create disputed purchases with various statuses, including [`needs_response`, `warning_needs_response`, `lost`]:
   * Create a `warning_needs_response` disputed purchase with the card: `4000000000005423`.
   * Create a `needs_response` disputed purchase with the card: `4000000000000259`.
   * Create a `lost` disputed purchase with the card: `4000000000000259` and **Accept** the dispute as merchant.
4. View the **Payments → Disputes** page in wp-admin.
5. The "Show" dropdown should have "All disputes" selected and include the "Needs response" option at the top:
   <img width="400" alt="image" src="https://user-images.githubusercontent.com/3147296/174949554-bab1f951-ccc1-4f1c-9928-b4da918bfce1.png">
6. Selecting the "Needs response" option will:
   - trigger new network GET requests: `disputes` and `disputes/summary`
   - once resolved, the disputes table will only show disputes needing a response (*Needs Response* or *Inquiry: Needs Response*)
7. Manually **removing** the `filter=awaiting_response` query param from the browser URL bar and hitting `return` will select the "All disputes" filter on page load.
8. Manually **adding** the `filter=awaiting_response` query param to the browser URL bar and hitting `return` will select the "Needs response filter on page load.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.