### PR TITLE
Hide Platform Checkout iframe on browser back button

### DIFF
--- a/changelog/fix-4364-hide-platform-checkout-iframe-on-browser-back-button
+++ b/changelog/fix-4364-hide-platform-checkout-iframe-on-browser-back-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide Platform Checkout iframe on browser back button.

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -164,13 +164,16 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 	iframeWrapper.insertBefore( iframeArrow, null );
 	iframeWrapper.insertBefore( iframe, null );
 
-	const closeIframe = () => {
+	const closeIframe = ( focus = true ) => {
 		window.removeEventListener( 'resize', getWindowSize );
 		window.removeEventListener( 'resize', setPopoverPosition );
 
 		iframeWrapper.remove();
 		iframe.classList.remove( 'open' );
-		platformCheckoutEmailInput.focus();
+
+		if ( focus ) {
+			platformCheckoutEmailInput.focus();
+		}
 
 		document.body.style.overflow = '';
 	};
@@ -259,24 +262,39 @@ export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 
 	// Prevent show platform checkout iframe if the page comes from
 	// the back button on platform checkout itself.
-	const searchParams = new URLSearchParams( window.location.search );
+	window.addEventListener( 'pageshow', function ( event ) {
+		// Detect browser back button.
+		const historyTraversal =
+			event.persisted ||
+			( 'undefined' !== typeof performance &&
+				'back_forward' ===
+					performance.getEntriesByType( 'navigation' )[ 0 ].type );
 
-	if ( 'true' !== searchParams.get( 'skip_platform_checkout' ) ) {
-		// Check the initial value of the email input and trigger input validation.
-		if ( validateEmail( platformCheckoutEmailInput.value ) ) {
-			platformCheckoutLocateUser( platformCheckoutEmailInput.value );
+		const searchParams = new URLSearchParams( window.location.search );
+
+		if (
+			! historyTraversal &&
+			'true' !== searchParams.get( 'skip_platform_checkout' )
+		) {
+			// Check the initial value of the email input and trigger input validation.
+			if ( validateEmail( platformCheckoutEmailInput.value ) ) {
+				platformCheckoutLocateUser( platformCheckoutEmailInput.value );
+			}
+		} else {
+			searchParams.delete( 'skip_platform_checkout' );
+
+			let { pathname } = window.location;
+
+			if ( '' !== searchParams.toString() ) {
+				pathname += '?' + searchParams.toString();
+			}
+
+			history.replaceState( null, null, pathname );
+
+			// Safari needs to close iframe with this.
+			closeIframe( false );
 		}
-	} else {
-		searchParams.delete( 'skip_platform_checkout' );
-
-		let { pathname } = window.location;
-
-		if ( '' !== searchParams.toString() ) {
-			pathname += '?' + searchParams.toString();
-		}
-
-		history.replaceState( null, null, pathname );
-	}
+	} );
 
 	platformCheckoutEmailInput.addEventListener( 'input', ( e ) => {
 		const email = e.currentTarget.value;


### PR DESCRIPTION
Fixes #4364

#### Changes proposed in this Pull Request

* Hide Platform Checkout iframe when go back using browser back button.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Buy something on merchant site.
* Checkout with Platform Checkout.
* Go back using browser button.
* The Platform Checkout iframe should not show.
* Do the same steps using Safari because it does not close the iframe automatically and open it again after call `/exists` as occur on other browsers.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
