### PR TITLE
Platform Checkout settings responsiveness

### DIFF
--- a/changelog/fix-4337-platform-checkout-settings-responsive
+++ b/changelog/fix-4337-platform-checkout-settings-responsive
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Platform Checkout settings responsive.
+Platform Checkout settings responsiveness.

--- a/changelog/fix-4337-platform-checkout-settings-responsive
+++ b/changelog/fix-4337-platform-checkout-settings-responsive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Platform Checkout settings responsive.

--- a/client/settings/express-checkout-settings/index.js
+++ b/client/settings/express-checkout-settings/index.js
@@ -37,7 +37,14 @@ const methods = {
 								'woocommerce-payments'
 							) }
 						</p>
-						<div style={ { marginTop: 50 } }>
+					</>
+				),
+			},
+			{
+				section: 'appearance',
+				description: () => (
+					<>
+						<div>
 							<h2>{ __( 'Checkout appearance' ) }</h2>
 						</div>
 					</>

--- a/client/settings/express-checkout-settings/platform-checkout-preview.js
+++ b/client/settings/express-checkout-settings/platform-checkout-preview.js
@@ -18,8 +18,7 @@ export default ( { storeName, storeLogo, ...props } ) => {
 	return (
 		<>
 			<svg
-				width="680"
-				height="33"
+				width="100%"
 				viewBox="0 0 680 33"
 				fill="none"
 				xmlns="http://www.w3.org/2000/svg"
@@ -30,8 +29,7 @@ export default ( { storeName, storeLogo, ...props } ) => {
 				<circle cx="34" cy="17" r="3" fill="#DCDCDE" />
 			</svg>
 			<svg
-				width="680"
-				height="261"
+				width="100%"
 				viewBox="0 0 680 261"
 				fill="none"
 				xmlns="http://www.w3.org/2000/svg"

--- a/client/settings/express-checkout-settings/platform-checkout-settings.js
+++ b/client/settings/express-checkout-settings/platform-checkout-settings.js
@@ -20,7 +20,7 @@ import {
 
 const CUSTOM_MESSAGE_MAX_LENGTH = 100;
 
-const PlatformCheckoutSettings = () => {
+const PlatformCheckoutSettings = ( { section } ) => {
 	const [
 		isPlatformCheckoutEnabled,
 		updateIsPlatformCheckoutEnabled,
@@ -38,69 +38,84 @@ const PlatformCheckoutSettings = () => {
 
 	return (
 		<div className="platform-checkout-settings">
-			<Card>
-				<CardBody>
-					<CheckboxControl
-						checked={ isPlatformCheckoutEnabled }
-						onChange={ updateIsPlatformCheckoutEnabled }
-						label={ __( 'Enable WooPay', 'woocommerce-payments' ) }
-						help={ __(
-							'When enabled, customers will be able to checkout using WooPay',
-							'woocommerce-payments'
-						) }
-					/>
-				</CardBody>
-			</Card>
-			<Card style={ { marginTop: 12 } }>
-				<div className="platform-checkout-settings__preview">
-					<PlatformCheckoutPreview
-						storeName={ wcSettings.siteTitle }
-						storeLogo={ platformCheckoutStoreLogo }
-					></PlatformCheckoutPreview>
-					<div className="platform-checkout-settings__preview-fade"></div>
-				</div>
-				<CardBody>
-					<div className="platform-checkout-settings__custom-message-wrapper">
-						<h4>
-							{ __(
-								'Store logo on checkout',
+			{ 'general' === section && (
+				<Card>
+					<CardBody>
+						<CheckboxControl
+							checked={ isPlatformCheckoutEnabled }
+							onChange={ updateIsPlatformCheckoutEnabled }
+							label={ __(
+								'Enable WooPay',
 								'woocommerce-payments'
 							) }
-						</h4>
-						<PlatformCheckoutFileUpload
-							fieldKey="woopay-store-logo"
-							accept="image/png, image/jpeg"
-							disabled={ false }
 							help={ __(
-								'Use a custom logo to WooPay if the one taken from your store doesn’t look right.' +
-									' For best results, upload a high-resolution horizontal image with white or transparent background.',
+								'When enabled, customers will be able to checkout using WooPay',
 								'woocommerce-payments'
 							) }
-							purpose="business_logo"
-							fileID={ platformCheckoutStoreLogo }
-							updateFileID={ setPlatformCheckoutStoreLogo }
 						/>
+					</CardBody>
+				</Card>
+			) }
+
+			{ 'appearance' === section && (
+				<Card style={ { marginTop: 12 } }>
+					<div className="platform-checkout-settings__preview">
+						<PlatformCheckoutPreview
+							storeName={ wcSettings.siteTitle }
+							storeLogo={ platformCheckoutStoreLogo }
+						></PlatformCheckoutPreview>
+						<div className="platform-checkout-settings__preview-fade"></div>
 					</div>
-					<div className="platform-checkout-settings__custom-message-wrapper">
-						<h4>
-							{ __( 'Custom message', 'woocommerce-payments' ) }
-						</h4>
-						<TextControl
-							help={ __(
-								'Inform your customers about the return, refund, and exchange policy, or include any other useful' +
-									' message. Note that you can add plain text and links, but not images.',
-								'woocommerce-payments'
-							) }
-							value={ platformCheckoutCustomMessage }
-							onChange={ setPlatformCheckoutCustomMessage }
-							maxLength={ CUSTOM_MESSAGE_MAX_LENGTH }
-						/>
-						<span className="input-help-text" aria-hidden="true">
-							{ `${ platformCheckoutCustomMessage.length } / ${ CUSTOM_MESSAGE_MAX_LENGTH }` }
-						</span>
-					</div>
-				</CardBody>
-			</Card>
+					<CardBody>
+						<div className="platform-checkout-settings__custom-message-wrapper">
+							<h4>
+								{ __(
+									'Store logo on checkout',
+									'woocommerce-payments'
+								) }
+							</h4>
+							<PlatformCheckoutFileUpload
+								fieldKey="woopay-store-logo"
+								accept="image/png, image/jpeg"
+								disabled={ false }
+								help={ __(
+									'Use a custom logo to WooPay if the one taken from your store doesn’t look right.' +
+										' For best results, upload a high-resolution horizontal image' +
+										' with white or transparent background.',
+									'woocommerce-payments'
+								) }
+								purpose="business_logo"
+								fileID={ platformCheckoutStoreLogo }
+								updateFileID={ setPlatformCheckoutStoreLogo }
+							/>
+						</div>
+						<div className="platform-checkout-settings__custom-message-wrapper">
+							<h4>
+								{ __(
+									'Custom message',
+									'woocommerce-payments'
+								) }
+							</h4>
+							<TextControl
+								help={ __(
+									'Inform your customers about the return, refund, and exchange policy, or include any other useful' +
+										' message. Note that you can add plain text and links, but not images.',
+									'woocommerce-payments'
+								) }
+								value={ platformCheckoutCustomMessage }
+								onChange={ setPlatformCheckoutCustomMessage }
+								maxLength={ CUSTOM_MESSAGE_MAX_LENGTH }
+							/>
+							<span
+								className="input-help-text"
+								aria-hidden="true"
+							>
+								{ `${ platformCheckoutCustomMessage.length } / ${ CUSTOM_MESSAGE_MAX_LENGTH }` }
+							</span>
+						</div>
+					</CardBody>
+				</Card>
+			) }
 		</div>
 	);
 };

--- a/client/settings/express-checkout-settings/test/platform-checkout-settings.test.js
+++ b/client/settings/express-checkout-settings/test/platform-checkout-settings.test.js
@@ -66,16 +66,6 @@ describe( 'PlatformCheckoutSettings', () => {
 		const [ enableCheckbox ] = screen.queryAllByRole( 'checkbox' );
 
 		expect( enableCheckbox ).toBeInTheDocument();
-
-		// confirm settings headings
-		expect(
-			screen.queryByRole( 'heading', { name: 'Custom message' } )
-		).toBeInTheDocument();
-
-		// confirm radio button groups displayed
-		const customMessageTextbox = screen.queryByRole( 'textbox' );
-
-		expect( customMessageTextbox ).toBeInTheDocument();
 	} );
 
 	it( 'triggers the hooks when the enable setting is being interacted with', () => {
@@ -108,7 +98,17 @@ describe( 'PlatformCheckoutSettings', () => {
 			)
 		);
 
-		render( <PlatformCheckoutSettings section="general" /> );
+		render( <PlatformCheckoutSettings section="appearance" /> );
+
+		// confirm settings headings
+		expect(
+			screen.queryByRole( 'heading', { name: 'Custom message' } )
+		).toBeInTheDocument();
+
+		// confirm radio button groups displayed
+		const customMessageTextbox = screen.queryByRole( 'textbox' );
+
+		expect( customMessageTextbox ).toBeInTheDocument();
 
 		expect(
 			updatePlatformCheckoutCustomMessageHandler


### PR DESCRIPTION
Fixes #4337

#### Changes proposed in this Pull Request

* Makes the Platform Checkout settings preview SVG be responsive to work better on mobile devices.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access WCPay settings.
* On Platform Checkout, click on `Customize`.
* Simulate a mobile device on browser DevTools.
* The page should not break and the sections should be better separated.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
