### PR TITLE
Fixes small typo in changelog entry introduced in PR #4336

### DIFF
--- a/changelog/update-3122-payment-intent
+++ b/changelog/update-3122-payment-intent
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Refactor WC_Payments_API_Intention to receive an instance of WC_Payments_API_Change instead of multiple charge-related fields.
+Refactor WC_Payments_API_Intention to receive an instance of WC_Payments_API_Charge instead of multiple charge-related fields.


### PR DESCRIPTION
When creating the `4.4.0-test-2` package and tag, I noticed a small typo in one of the changelog entries `_Change` class name should be `_Charge`.

This PR fixes that.

```diff
- Refactor WC_Payments_API_Intention to receive an instance of WC_Payments_API_Change instead of multiple charge-related fields.
+ Refactor WC_Payments_API_Intention to receive an instance of WC_Payments_API_Charge instead of multiple charge-related fields.
```
