### PR TITLE
Show WooPay error message

### DIFF
--- a/changelog/fix-4157-show-woopay-error-message
+++ b/changelog/fix-4157-show-woopay-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show WooPay error message.


### PR DESCRIPTION
Fixes #4157

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

* Show an error message when some error occur while contacting WooPay.

<img width="395" alt="Screen Shot 2022-06-27 at 7 55 48 PM" src="https://user-images.githubusercontent.com/1693223/176050335-38f6d2ff-1d51-4a33-aa72-8fb78cdbd53a.png">

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Force an error on the `/wp-json/platform-checkout/v1/user/exists` endpoint.
* Type a valid e-mail, the error message should be shown.
* Remove the forced error.
* Remove a letter from the e-mail address and add it again to hide the error message and show the iframe.
* Force an error on the `/wp-json/platform-checkout/v1/init` endpoint.
* Type the SMS OTP code.
* The error message should be shown and close the iframe automatically.
* Remove a letter from the e-mail address and add it again to hide the error message and show the iframe.
* Close the iframe.
* Force the offline mode on browser DevTools.
* The error message should be shown.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
