### PR TITLE
Include WordPress nightly build into E2E tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         # Min WooCommerce | L-2 | L(atest) | beta
         woocommerce:   [ '5.8.1', '6.4.1', '6.6.0', 'beta' ]
-        wordpress:     [ 'latest' ]
+        wordpress:     [ 'latest', 'nightly' ]
         php:           [ '7.4' ]
         test_groups:   [ 'wcpay', 'subscriptions', 'blocks' ]
         test_branches: [ 'merchant', 'shopper' ]

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -48,10 +48,11 @@ jobs:
             test_groups: 'blocks'
             test_branches: 'shopper'
           - wordpress: 'nightly'
-        include:
+            woocommerce: '5.8.1' 
           - wordpress: 'nightly'
-            woocommerce: 'beta'
-      
+            woocommerce: '6.4.1'
+          - wordpress: 'nightly'
+            woocommerce: 'beta'   
 
     name: WC - ${{ matrix.woocommerce }} | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -54,7 +54,7 @@ jobs:
           - wordpress: 'nightly'
             woocommerce: 'beta'   
 
-    name: WC - ${{ matrix.woocommerce }} | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
+    name: WC - ${{ matrix.woocommerce }} | WP - ${{ matrix.wordpress }} | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 
     env:
       E2E_WP_VERSION: ${{ matrix.wordpress }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -47,6 +47,11 @@ jobs:
           - woocommerce: '5.8.1'
             test_groups: 'blocks'
             test_branches: 'shopper'
+          - wordpress: 'nightly'
+        include:
+          - wordpress: 'nightly'
+            woocommerce: 'beta'
+      
 
     name: WC - ${{ matrix.woocommerce }} | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast:     false
       matrix:
         # Min WooCommerce | L-2 | L(atest) | beta
-        woocommerce:   [ '5.8.1', '6.4.1', '6.6.0', 'beta' ]
+        woocommerce:   [ '5.8.1', '6.4.1', 'latest', 'beta' ]
         wordpress:     [ 'latest', 'nightly' ]
         php:           [ '7.4' ]
         test_groups:   [ 'wcpay', 'subscriptions', 'blocks' ]

--- a/changelog/e2e-include-wp-prelease-version
+++ b/changelog/e2e-include-wp-prelease-version
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Included prelease version of WordPress into E2E tests


### PR DESCRIPTION
Fixes #3885

#### Changes proposed in this Pull Request

This PR adds nightly build or prerelease version of WordPress into E2E tests to catch possible issues for upcomming releases

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure to all E2E tests pass
* Make sure that WP nightly builds are included into E2E tests

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
