### PR TITLE
Record event for Platform Checkout redirect

### DIFF
--- a/changelog/update-3904-track-platform-checkout-redirect
+++ b/changelog/update-3904-track-platform-checkout-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Record event for Platform Checkout redirect.

--- a/includes/class-platform-checkout-tracker.php
+++ b/includes/class-platform-checkout-tracker.php
@@ -52,6 +52,7 @@ class Platform_Checkout_Tracker extends Jetpack_Tracks_Client {
 		add_action( 'woocommerce_checkout_order_processed', [ $this, 'checkout_order_processed' ] );
 		add_action( 'woocommerce_blocks_checkout_order_processed', [ $this, 'checkout_order_processed' ] );
 		add_action( 'woocommerce_payments_save_user_in_platform_checkout', [ $this, 'must_save_payment_method_to_platform' ] );
+		add_action( 'woocommerce_payments_platform_checkout_redirected', [ $this, 'checkout_redirect' ] );
 	}
 
 	/**
@@ -299,6 +300,15 @@ class Platform_Checkout_Tracker extends Jetpack_Tracks_Client {
 			[
 				'source' => 'checkout',
 			]
+		);
+	}
+
+	/**
+	 * Record a Tracks event that user will be redirected to platform checkout.
+	 */
+	public function checkout_redirect() {
+		$this->maybe_record_event(
+			'platform_checkout_redirect'
 		);
 	}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1075,6 +1075,7 @@ class WC_Payments {
 			// Respond with same message platform would respond with on failure.
 			$response_body_json = wp_json_encode( [ 'result' => 'failure' ] );
 		} else {
+			do_action( 'woocommerce_payments_platform_checkout_redirected' );
 			$response_body_json = wp_remote_retrieve_body( $response );
 		}
 


### PR DESCRIPTION
Fixes #3904

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

* Record a Tracks event when the customer is redirected to Platform Checkout.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout with Platform Checkout.
* In Tracks Live View in about 5 minutes, look for a `woocommerceanalytics_platform_checkout_redirect` event.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
