### PR TITLE
Add support for remote inbox notes with actions that have relative admin URLs

### DIFF
--- a/changelog/issue-4350
+++ b/changelog/issue-4350
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Support remote inbox notes with relative admin URLs

--- a/includes/notes/class-wc-payments-remote-note-service.php
+++ b/includes/notes/class-wc-payments-remote-note-service.php
@@ -88,7 +88,7 @@ class WC_Payments_Remote_Note_Service {
 				if ( 'wcpay_settings' === $action['url'] ) {
 					$url = WC_Payment_Gateway_WCPay::get_settings_url();
 				} elseif ( isset( $action['url_is_admin'] ) && (bool) $action['url_is_admin'] ) {
-					$url = admin_url( esc_url( $action['url'] ) );
+					$url = admin_url( $action['url'] );
 				} else {
 					throw new Rest_Request_Exception( 'Invalid note.' );
 				}

--- a/includes/notes/class-wc-payments-remote-note-service.php
+++ b/includes/notes/class-wc-payments-remote-note-service.php
@@ -87,8 +87,8 @@ class WC_Payments_Remote_Note_Service {
 
 				if ( 'wcpay_settings' === $action['url'] ) {
 					$url = WC_Payment_Gateway_WCPay::get_settings_url();
-				} elseif ( isset( $action['url_is_admin'] ) && $action['url_is_admin'] ) {
-					$url = admin_url( $action['url'] );
+				} elseif ( isset( $action['url_is_admin'] ) && (bool) $action['url_is_admin'] ) {
+					$url = admin_url( esc_url( $action['url'] ) );
 				} else {
 					throw new Rest_Request_Exception( 'Invalid note.' );
 				}

--- a/includes/notes/class-wc-payments-remote-note-service.php
+++ b/includes/notes/class-wc-payments-remote-note-service.php
@@ -87,6 +87,8 @@ class WC_Payments_Remote_Note_Service {
 
 				if ( 'wcpay_settings' === $action['url'] ) {
 					$url = WC_Payment_Gateway_WCPay::get_settings_url();
+				} elseif ( isset( $action['url_is_admin'] ) && $action['url_is_admin'] ) {
+					$url = admin_url( $action['url'] );
 				} else {
 					throw new Rest_Request_Exception( 'Invalid note.' );
 				}


### PR DESCRIPTION
Fixes #4350

#### Changes proposed in this Pull Request

This PR adds support to the `wc-payments-remote-note-service` class to receive a remote note with a URL other than just `'wcpay_settings'`. By passing the `'url_is_admin'` param, and a relative URL in the `'url'` param a localised admin URL will be generated. 

This `url_is_admin` param approach has similarities to how the the remote inbox notifcations work. See this section in the docs: [RemoteInboxNotifications/README.md#action](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Admin/RemoteInboxNotifications/README.md#action)

#### Testing instructions
Steps take from: 2151-gh-Automattic/woocommerce-payments-server
**Pre-test set up:**
* Make sure your server is listening for webhooks (Run `npm run listen` in your server directory)
* Checkout the `support_localized_remote_inbox_notes` WooCommerce Payments branch. 
    * _Without this client branch the webhook received will fail due to the url param not being the hardcoded string `wcpay_settings`. This essentially means that sites which don't update to the latest version of WC Payments will not have these notes displayed._ 

**To test:** 
1. Purchase a product with a disputed payment method (`4000000000000259`) 
2. Login to your server (http://localhost:8086/)
    1. Go to **Tools → Cron Events**
    2. Find the newly scheduled cron event for that dispute 
    3. Run that event.
3. View your **WooCommerce → Home** and **Payments → Overview** screens on your WC site and you should have a new inbox notification (see above). 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.