### PR TITLE
Revert "Bump minimum WC version for 4.4.0 release"

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -12,13 +12,13 @@ jobs:
       max-parallel: 10
       matrix:
         # Minimum support version, ..., Latest version, `beta`.
-        woocommerce: [ '5.8.1', '5.9.1', '6.0.1', '6.1.2', '6.2.2', '6.3.1', '6.4.1', '6.5.1', '6.6.0', 'beta' ]
+        woocommerce: [ '5.6.2', '5.7.2', '5.8.1', '5.9.1', '6.0.1', '6.1.2', '6.2.2', '6.3.1', '6.4.1', '6.5.1', 'beta' ]
         wordpress:   [ 'latest' ]
         gutenberg:   [ 'latest' ]
         php:         [ '7.4' ]
         include:
           # Edge case: oldest dependencies compatibility
-          - woocommerce: '5.8.1'
+          - woocommerce: '5.6.2'
             wordpress:   '5.7'
             gutenberg:   '11.4.0' # The latest version supporting WP 5.6.
             php:         '7.1' # Minimum supported PHP version

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast:     false
       matrix:
         # Min WooCommerce | L-2 | L(atest) | beta
-        woocommerce:   [ '5.8.1', '6.4.1', '6.6.0', 'beta' ]
+        woocommerce:   [ '5.6.2', '6.3.1', '6.5.1', 'beta' ]
         wordpress:     [ 'latest' ]
         php:           [ '7.4' ]
         test_groups:   [ 'wcpay', 'subscriptions', 'blocks' ]
@@ -44,7 +44,7 @@ jobs:
         exclude:
           - test_groups: 'blocks'
             test_branches: 'merchant'
-          - woocommerce: '5.8.1'
+          - woocommerce: '5.6.2'
             test_groups: 'blocks'
             test_branches: 'shopper'
 
@@ -60,7 +60,7 @@ jobs:
       # Conditionally skip WC Blocks tests. Remove/update based on min supported WC version by the blocks checkout plugin.
       - name: Conditionally skip WC Blocks tests
         run: |
-          SKIP_WC_VERSIONS=('5.8.1')
+          SKIP_WC_VERSIONS=('5.6.2')
           if [[ " ${SKIP_WC_VERSIONS[@]} " =~ " ${E2E_WC_VERSION} " ]]; then
             echo "SKIP_WC_BLOCKS_TESTS=1" >> $GITHUB_ENV
           fi

--- a/changelog/bump-wc-tested-up-for-wcpay-4-4
+++ b/changelog/bump-wc-tested-up-for-wcpay-4-4
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Bump minimum required version of WooCommerce from 5.6 to 5.8.

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ Our global support team is available to answer questions you may have about WooC
 = Requirements =
 
 * WordPress 5.7 or newer.
-* WooCommerce 6.4 or newer.
+* WooCommerce 6.3 or newer.
 * PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
 
 = Try it now =

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Woo: 5278104:bf3cf30871604e15eec560c962593c1f
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
- * WC requires at least: 5.8
+ * WC requires at least: 5.6
  * WC tested up to: 6.6.0
  * Requires at least: 5.7
  * Requires PHP: 7.0


### PR DESCRIPTION
Reverts Automattic/woocommerce-payments#4360

Some internal services/products are still using WC 5.6 so we cannot bump the version to a minimum of 5.8 yet.
See discussion: p1656485082313449-slack-CGGCLBN58