### PR TITLE
Fix display of UPE payment methods when manual capture is enabled

### DIFF
--- a/changelog/fix-4382-upe-payment-method-display-with-manual-capture
+++ b/changelog/fix-4382-upe-payment-method-display-with-manual-capture
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correctly show UPE payment methods when UPE is first enabled while manual capture is already enabled

--- a/client/components/payment-methods-checkboxes/payment-method-checkbox.js
+++ b/client/components/payment-methods-checkboxes/payment-method-checkbox.js
@@ -64,13 +64,13 @@ const PaymentMethodCheckbox = ( { onChange, name, checked, fees, status } ) => {
 
 	const [ isManualCaptureEnabled ] = useManualCapture();
 	const paymentMethod = PaymentMethodsMap[ name ];
-	const hasOverlay =
+	const needsOverlay =
 		isManualCaptureEnabled && ! paymentMethod.allows_manual_capture;
 
 	return (
 		<li
 			className={ classNames( 'payment-method-checkbox', {
-				'has-overlay': hasOverlay,
+				overlay: needsOverlay,
 			} ) }
 		>
 			<LoadableCheckboxControl

--- a/client/components/payment-methods-checkboxes/payment-method-checkbox.js
+++ b/client/components/payment-methods-checkboxes/payment-method-checkbox.js
@@ -6,6 +6,7 @@ import React, { useContext, useEffect } from 'react';
 import { Icon, VisuallyHidden } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ import PaymentMethodsMap from '../../payment-methods-map';
 import Pill from '../pill';
 import Tooltip from '../tooltip';
 import './payment-method-checkbox.scss';
+import { useManualCapture } from 'wcpay/data';
 
 const PaymentMethodDescription = ( { name } ) => {
 	const description = PaymentMethodsMap[ name ]?.description;
@@ -60,10 +62,17 @@ const PaymentMethodCheckbox = ( { onChange, name, checked, fees, status } ) => {
 		}
 	}, [ disabled, checked, handleChange ] );
 
+	const [ isManualCaptureEnabled ] = useManualCapture();
 	const paymentMethod = PaymentMethodsMap[ name ];
+	const hasOverlay =
+		isManualCaptureEnabled && ! paymentMethod.allows_manual_capture;
 
 	return (
-		<li className="payment-method-checkbox">
+		<li
+			className={ classNames( 'payment-method-checkbox', {
+				'has-overlay': hasOverlay,
+			} ) }
+		>
 			<LoadableCheckboxControl
 				label={ paymentMethod.label }
 				checked={ checked }

--- a/client/components/payment-methods-checkboxes/payment-method-checkbox.js
+++ b/client/components/payment-methods-checkboxes/payment-method-checkbox.js
@@ -4,7 +4,7 @@
  */
 import React, { useContext, useEffect } from 'react';
 import { Icon, VisuallyHidden } from '@wordpress/components';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -17,7 +17,6 @@ import {
 } from '../../utils/account-fees';
 import LoadableCheckboxControl from 'components/loadable-checkbox';
 import { upeCapabilityStatuses } from 'wcpay/additional-methods-setup/constants';
-import PaymentMethodIcon from '../../settings/payment-method-icon';
 import PaymentMethodsMap from '../../payment-methods-map';
 import Pill from '../pill';
 import Tooltip from '../tooltip';
@@ -61,14 +60,12 @@ const PaymentMethodCheckbox = ( { onChange, name, checked, fees, status } ) => {
 		}
 	}, [ disabled, checked, handleChange ] );
 
-	const label = useMemo( () => <PaymentMethodIcon name={ name } showName />, [
-		name,
-	] );
+	const paymentMethod = PaymentMethodsMap[ name ];
 
 	return (
 		<li className="payment-method-checkbox">
 			<LoadableCheckboxControl
-				label={ label }
+				label={ paymentMethod.label }
 				checked={ checked }
 				disabled={ disabled }
 				onChange={ ( state ) => {
@@ -76,9 +73,18 @@ const PaymentMethodCheckbox = ( { onChange, name, checked, fees, status } ) => {
 				} }
 				delayMsOnCheck={ 1500 }
 				delayMsOnUncheck={ 0 }
+				hideLabel={ true }
+				isAllowingManualCapture={ paymentMethod.allows_manual_capture }
 			/>
+			<div className={ 'woocommerce-payments__payment-method-icon' }>
+				{ paymentMethod.icon() }
+			</div>
 			<div className={ 'payment-method-checkbox__pills' }>
 				<div className={ 'payment-method-checkbox__pills-left' }>
+					<span className="payment-method-checkbox__label">
+						{ paymentMethod.label }
+					</span>
+
 					{ upeCapabilityStatuses.PENDING_APPROVAL === status && (
 						<Tooltip
 							content={ __(
@@ -104,7 +110,7 @@ const PaymentMethodCheckbox = ( { onChange, name, checked, fees, status } ) => {
 										'information. Follow the instructions sent by our partner Stripe to %s.',
 									'woocommerce-payments'
 								),
-								label,
+								paymentMethod.label,
 								wcpaySettings?.accountEmail ?? ''
 							) }
 						>

--- a/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
+++ b/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
@@ -68,6 +68,10 @@
 		}
 	}
 
+	&__label {
+		text-transform: initial;
+	}
+
 	&__info {
 		> * {
 			margin: 0;

--- a/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
+++ b/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
@@ -94,7 +94,7 @@
 		}
 	}
 
-	&.has-overlay {
+	&.overlay {
 		position: relative;
 		&::after {
 			content: '';

--- a/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
+++ b/client/components/payment-methods-checkboxes/payment-method-checkbox.scss
@@ -93,6 +93,23 @@
 			word-wrap: normal;
 		}
 	}
+
+	&.has-overlay {
+		position: relative;
+		&::after {
+			content: '';
+			position: absolute;
+			// adds some spacing for the borders, so that they're not part of the opacity
+			top: 1px;
+			bottom: 1px;
+			// ensures that the info icon isn't part of the opacity
+			left: 55px;
+			right: 0;
+			background: #fff;
+			opacity: 0.5;
+			pointer-events: none;
+		}
+	}
 }
 
 .woocommerce-payments__payment-method-icon {

--- a/client/components/payment-methods-checkboxes/test/index.js
+++ b/client/components/payment-methods-checkboxes/test/index.js
@@ -19,13 +19,13 @@ describe( 'PaymentMethodsCheckboxes', () => {
 		const handleChange = jest.fn();
 
 		const upeMethods = [
-			[ 'Bancontact', true ],
-			[ 'EPS', false ],
+			[ 'bancontact', true ],
+			[ 'eps', false ],
 			[ 'giropay', false ],
-			[ 'iDEAL', false ],
-			[ 'Przelewy24 (P24)', false ],
-			[ 'SEPA Direct Debit', false ],
-			[ 'Sofort', false ],
+			[ 'ideal', false ],
+			[ 'p24', false ],
+			[ 'sepa_debit', false ],
+			[ 'sofort', false ],
 		];
 
 		render(
@@ -75,22 +75,14 @@ describe( 'PaymentMethodsCheckboxes', () => {
 
 		expect( handleChange ).toHaveBeenNthCalledWith(
 			1,
-			'Bancontact',
+			'bancontact',
 			false
 		);
 		expect( handleChange ).toHaveBeenNthCalledWith( 3, 'giropay', true );
-		expect( handleChange ).toHaveBeenNthCalledWith( 4, 'iDEAL', true );
-		expect( handleChange ).toHaveBeenNthCalledWith(
-			5,
-			'Przelewy24 (P24)',
-			true
-		);
-		expect( handleChange ).toHaveBeenNthCalledWith(
-			6,
-			'SEPA Direct Debit',
-			true
-		);
-		expect( handleChange ).toHaveBeenNthCalledWith( 7, 'Sofort', true );
+		expect( handleChange ).toHaveBeenNthCalledWith( 4, 'ideal', true );
+		expect( handleChange ).toHaveBeenNthCalledWith( 5, 'p24', true );
+		expect( handleChange ).toHaveBeenNthCalledWith( 6, 'sepa_debit', true );
+		expect( handleChange ).toHaveBeenNthCalledWith( 7, 'sofort', true );
 		jest.useRealTimers();
 	} );
 

--- a/client/components/payment-methods-list/payment-method.js
+++ b/client/components/payment-methods-list/payment-method.js
@@ -37,7 +37,7 @@ const PaymentMethod = ( {
 	const { accountFees } = useContext( WCPaySettingsContext );
 	const [ isManualCaptureEnabled ] = useManualCapture();
 
-	const hasOverlay = isManualCaptureEnabled && ! isAllowingManualCapture;
+	const needsOverlay = isManualCaptureEnabled && ! isAllowingManualCapture;
 
 	const handleChange = ( newStatus ) => {
 		if ( newStatus ) {
@@ -51,7 +51,7 @@ const PaymentMethod = ( {
 			className={ classNames(
 				'payment-method',
 				{ 'has-icon-border': 'card' !== id },
-				{ 'has-overlay': hasOverlay },
+				{ overlay: needsOverlay },
 				className
 			) }
 		>

--- a/client/components/payment-methods-list/payment-method.scss
+++ b/client/components/payment-methods-list/payment-method.scss
@@ -104,7 +104,7 @@
 		box-shadow: 0 0 0 1px #ddd;
 	}
 
-	&.has-overlay {
+	&.overlay {
 		position: relative;
 		&::after {
 			content: '';


### PR DESCRIPTION
Fixes #4382 

#### Changes proposed in this Pull Request

Manage correctly the UPE payment methods display when it has to be visually hidden and UPE just got enabled.

The Payment > Settings page already manages that display (see https://github.com/Automattic/woocommerce-payments/pull/4245) but we missed the initial page shown when we first enable UPE.

That means:
- we show the right text in the tooltip
- we display the logo and name of each payment method
- we add an overlay to make it clear that the payment methods won't be available right away

### Manual capture enabled / UPE being enabled:

Before:
![image](https://user-images.githubusercontent.com/28830738/176697505-61f75d05-a17f-4033-b343-c173f3d0085c.png)

After:
![image](https://user-images.githubusercontent.com/28830738/176694473-2f21e73b-6cad-459b-a93e-2155c0f5d862.png)

### Manual capture enabled / UPE being enabled with payment methods pending verification/activation

Before:
![image](https://user-images.githubusercontent.com/28830738/176699364-92ecf137-474a-42a8-afb0-067b5a94aa95.png)

After:
![image](https://user-images.githubusercontent.com/28830738/176699667-b8de6e05-c83f-47b9-9116-0c6805b48782.png)

#### Testing instructions

- Go to Payment > Settings and enable manual capture
- Click on "Enable in your store" to enable UPE
- You should see the name and logo of each payment method, and the corresponding tooltip attached to the warning sign also shows the right name

In `client/components/payment-methods-checkboxes/payment-method-checkbox.js`, add `status = upeCapabilityStatuses.PENDING_VERIFICATION;` line 67 to simulate that the UPE methods are pending activation.

If you follow the same steps as above, the display should also be correct (check the tooltip attached to "Pending activation").

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
