### PR TITLE
E2E - Rewrite dispute tests flow to ignore waiting for webhooks

### DIFF
--- a/changelog/e2e-fix-failing-dispute-tests
+++ b/changelog/e2e-fix-failing-dispute-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update selectors & flow for dispute related tests

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -83,10 +83,6 @@ if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 		step "Disable Xdebug on server container"
 		docker exec "$SERVER_CONTAINER" \
 		sh -c 'echo "#zend_extension=xdebug" > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && echo "Xdebug disabled."'
-
-		step "Starting webhook listener in background"
-		docker-compose exec -d -u www-data wordpress \
-		stripe listen --api-key "$E2E_WCPAY_STRIPE_TEST_SECRET_KEY" --forward-to http://localhost/wp-json/wpcom/v2/wcpay/webhook/dev
 	fi
 fi
 

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-save-for-editing.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-save-for-editing.spec.js
@@ -81,7 +81,7 @@ describe( 'Disputes > Save dispute for editing', () => {
 		await merchantWCP.openChallengeDispute();
 
 		await page.waitForSelector(
-			'div.components-flex.components-card__header.is-size-large',
+			'div.wcpay-dispute-evidence .components-flex.components-card__header.is-size-large',
 			{
 				timeout: 10000,
 			}
@@ -89,7 +89,7 @@ describe( 'Disputes > Save dispute for editing', () => {
 
 		// Verify we're on the challenge dispute page
 		await expect( page ).toMatchElement(
-			'div.components-flex.components-card__header.is-size-large',
+			'div.wcpay-dispute-evidence .components-flex.components-card__header.is-size-large',
 			{
 				text: 'Challenge dispute',
 			}
@@ -108,13 +108,19 @@ describe( 'Disputes > Save dispute for editing', () => {
 			'Offline service'
 		);
 
-		await page.waitForSelector( 'button.components-button.is-secondary', {
-			timeout: 10000,
-		} );
+		await page.waitForSelector(
+			'div.wcpay-dispute-evidence button.components-button.is-secondary',
+			{
+				timeout: 10000,
+			}
+		);
 
-		await expect( page ).toClick( 'button.components-button.is-secondary', {
-			text: 'Save for later',
-		} );
+		await expect( page ).toClick(
+			'div.wcpay-dispute-evidence button.components-button.is-secondary',
+			{
+				text: 'Save for later',
+			}
+		);
 
 		// Re-open the dispute to view the details
 		await merchantWCP.openDisputeDetails( disputeDetailsLink );

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-losing.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-losing.spec.js
@@ -40,12 +40,13 @@ describe( 'Disputes > Submit losing dispute', () => {
 		await merchant.logout();
 	} );
 
-	it( 'should process a losing dispute', async () => {
+	it( 'should process and confirm a losing dispute', async () => {
 		// Pull out and follow the link to avoid working in multiple tabs
 		const paymentDetailsLink = await page.$eval(
 			'p.order_number > a',
 			( anchor ) => anchor.getAttribute( 'href' )
 		);
+
 		await merchantWCP.openPaymentDetails( paymentDetailsLink );
 
 		// Verify we have a dispute for this purchase
@@ -73,13 +74,13 @@ describe( 'Disputes > Submit losing dispute', () => {
 
 		// Verify we're on the view dispute page
 		await expect( page ).toMatchElement(
-			'div.components-card > .components-card__header',
+			'div.wcpay-dispute-details .header-dispute-overview',
 			{
 				text: 'Dispute overview',
 			}
 		);
 		await expect( page ).toMatchElement(
-			'div.components-card > .components-card__header',
+			'div.wcpay-dispute-details .components-card > .components-card__header',
 			{
 				text: 'Dispute: Product not received',
 			}
@@ -100,37 +101,17 @@ describe( 'Disputes > Submit losing dispute', () => {
 			}
 		);
 
-		// Verify Lost status in disputes view
-		await page.waitForSelector( 'span.chip-light' );
-		await expect( page ).toMatchElement( 'span.chip-light', {
-			text: 'Lost',
-		} );
-	} );
-
-	it( 'should verify a dispute has been accepted properly', async () => {
-		// Re-open the dispute to view the details
-		await merchant.goToOrder( orderId );
-
-		// Pull out and follow the link to avoid working in multiple tabs
-		const paymentDetailsLink = await page.$eval(
-			'p.order_number > a',
-			( anchor ) => anchor.getAttribute( 'href' )
-		);
-		await merchantWCP.openPaymentDetails( paymentDetailsLink );
-
-		// Get the link to the dispute details
-		const disputeDetailsElement = await page.$(
-			'[data-testid="view-dispute-button"]'
-		);
-		const disputeDetailsLink = await page.evaluate(
-			( anchor ) => anchor.getAttribute( 'href' ),
-			disputeDetailsElement
-		);
-
-		// Open the dispute details
+		// If webhooks are not received, the dispute status won't be updated in the dispute list page resulting in test failure.
+		// Workaround - Open dispute details page again and check status.
 		await merchantWCP.openDisputeDetails( disputeDetailsLink );
+		await expect( page ).toMatchElement(
+			'div.wcpay-dispute-details .header-dispute-overview',
+			{
+				text: 'Dispute overview',
+			}
+		);
 
-		// Check if buttons are not present anymore since a dispute has been accepted
+		// Confirm buttons are not present anymore since a dispute has been accepted.
 		await expect( page ).not.toMatchElement(
 			'div.components-card > .components-card__footer > a',
 			{
@@ -141,6 +122,17 @@ describe( 'Disputes > Submit losing dispute', () => {
 			'div.components-card > .components-card__footer > button',
 			{
 				text: 'Accept dispute',
+			}
+		);
+
+		// Confirm dispute status is Lost.
+		await page.waitForSelector(
+			'div.wcpay-dispute-details .header-dispute-overview span.chip-light'
+		);
+		await expect( page ).toMatchElement(
+			'div.wcpay-dispute-details .header-dispute-overview span.chip-light',
+			{
+				text: 'Lost',
 			}
 		);
 	} );

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -311,7 +311,9 @@ export const merchantWCP = {
 
 	openChallengeDispute: async () => {
 		await Promise.all( [
-			evalAndClick( 'a.components-button.is-primary' ),
+			evalAndClick(
+				'div.wcpay-dispute-details a.components-button.is-primary'
+			),
 			page.waitForNavigation( { waitUntil: 'networkidle0' } ),
 			uiLoaded(),
 		] );

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -322,7 +322,9 @@ export const merchantWCP = {
 	openAcceptDispute: async () => {
 		await Promise.all( [
 			page.removeAllListeners( 'dialog' ),
-			evalAndClick( 'button.components-button.is-secondary' ),
+			evalAndClick(
+				'div.wcpay-dispute-details button.components-button.is-secondary'
+			),
 			page.on( 'dialog', async ( dialog ) => {
 				await dialog.accept();
 			} ),


### PR DESCRIPTION
Fixes #4367 

#### Changes proposed in this Pull Request

This change is targeted to fix the failing dispute tests on WCPay server.

At the moment, when running E2E tests against a server instance inside docker, dispute related tests times out because the dispute entry won't be present on the disputes page. The dispute entries are created after receiving the webhook event, which is not available inside Github actions.

However, it is still possible to access the dispute via the WCPay transaction link inside the order details page on WP-ADMIN. Hence, I've modified the tests to use this approach instead of waiting for the dispute entry to be created.

#### Testing instructions

* Trigger a new E2E test against this branch on client & confirm that the following tests are passing as expected
 * `merchant-disputes-save-for-editing.spec.js`
 * `merchant-disputes-submit-losing.spec.js`
 * `merchant-disputes-submit-winning.spec.js`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**
- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
