### PR TITLE
Revert "Record event for Platform Checkout redirect"

### DIFF
--- a/changelog/update-3904-track-platform-checkout-redirect
+++ b/changelog/update-3904-track-platform-checkout-redirect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Record event for Platform Checkout redirect.

--- a/includes/class-platform-checkout-tracker.php
+++ b/includes/class-platform-checkout-tracker.php
@@ -52,7 +52,6 @@ class Platform_Checkout_Tracker extends Jetpack_Tracks_Client {
 		add_action( 'woocommerce_checkout_order_processed', [ $this, 'checkout_order_processed' ] );
 		add_action( 'woocommerce_blocks_checkout_order_processed', [ $this, 'checkout_order_processed' ] );
 		add_action( 'woocommerce_payments_save_user_in_platform_checkout', [ $this, 'must_save_payment_method_to_platform' ] );
-		add_action( 'woocommerce_payments_platform_checkout_redirected', [ $this, 'checkout_redirect' ] );
 	}
 
 	/**
@@ -300,15 +299,6 @@ class Platform_Checkout_Tracker extends Jetpack_Tracks_Client {
 			[
 				'source' => 'checkout',
 			]
-		);
-	}
-
-	/**
-	 * Record a Tracks event that user will be redirected to platform checkout.
-	 */
-	public function checkout_redirect() {
-		$this->maybe_record_event(
-			'platform_checkout_redirect'
 		);
 	}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1079,7 +1079,6 @@ class WC_Payments {
 			// Respond with same message platform would respond with on failure.
 			$response_body_json = wp_json_encode( [ 'result' => 'failure' ] );
 		} else {
-			do_action( 'woocommerce_payments_platform_checkout_redirected' );
 			$response_body_json = wp_remote_retrieve_body( $response );
 		}
 


### PR DESCRIPTION
Reverts Automattic/woocommerce-payments#4375

As seen on [this comment](https://github.com/Automattic/woocommerce-payments/issues/3904#issuecomment-1171692469), the PR doesn't not meet the desired approach as the auto redirect is not implement yet.