### PR TITLE
Add client-side server links handler

### DIFF
--- a/changelog/add-4342-client-link-handler
+++ b/changelog/add-4342-client-link-handler
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add handler for authenticated server links

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -54,6 +54,8 @@ const OverviewPage = () => {
 
 	const showLoginError = '1' === queryParams[ 'wcpay-login-error' ];
 	const showLoanOfferError = '1' === queryParams[ 'wcpay-loan-offer-error' ];
+	const showServerLinkError =
+		'1' === queryParams[ 'wcpay-server-link-error' ];
 	const accountRejected =
 		accountStatus.status && accountStatus.status.startsWith( 'rejected' );
 
@@ -112,6 +114,15 @@ const OverviewPage = () => {
 				<Notice status="error" isDismissible={ false }>
 					{ __(
 						'There was a problem redirecting you to the loan offer. Please check that it is not expired and try again.',
+						'woocommerce-payments'
+					) }
+				</Notice>
+			) }
+
+			{ showServerLinkError && (
+				<Notice status="error" isDismissible={ false }>
+					{ __(
+						'There was a problem redirecting you to the requested link. Please check that it is not expired and try again.',
 						'woocommerce-payments'
 					) }
 				</Notice>

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -122,7 +122,7 @@ const OverviewPage = () => {
 			{ showServerLinkError && (
 				<Notice status="error" isDismissible={ false }>
 					{ __(
-						'There was a problem redirecting you to the requested link. Please check that it is not expired and try again.',
+						'There was a problem redirecting you to the requested link. Please check that it is valid and try again.',
 						'woocommerce-payments'
 					) }
 				</Notice>

--- a/client/overview/test/index.js
+++ b/client/overview/test/index.js
@@ -30,7 +30,7 @@ const loanOfferErrorText =
 	'There was a problem redirecting you to the loan offer. Please check that it is not expired and try again.';
 
 const serverLinkErrorText =
-	'There was a problem redirecting you to the requested link. Please check that it is not expired and try again.';
+	'There was a problem redirecting you to the requested link. Please check that it is valid and try again.';
 
 describe( 'Overview page', () => {
 	beforeEach( () => {

--- a/client/overview/test/index.js
+++ b/client/overview/test/index.js
@@ -29,6 +29,9 @@ jest.mock( '@woocommerce/navigation', () => ( { getQuery: jest.fn() } ) );
 const loanOfferErrorText =
 	'There was a problem redirecting you to the loan offer. Please check that it is not expired and try again.';
 
+const serverLinkErrorText =
+	'There was a problem redirecting you to the requested link. Please check that it is not expired and try again.';
+
 describe( 'Overview page', () => {
 	beforeEach( () => {
 		global.wcpaySettings = {
@@ -111,6 +114,37 @@ describe( 'Overview page', () => {
 		expect(
 			container.querySelector( '.wcpay-jetpack-idc-notice' )
 		).toBeVisible();
+	} );
+
+	it( 'Displays the server link redirection error message for query param wcpay-server-link-error=1', () => {
+		getQuery.mockReturnValue( { 'wcpay-server-link-error': '1' } );
+		getTasks.mockReturnValue( [] );
+
+		render( <OverviewPage /> );
+
+		expect(
+			screen.queryByText( ( content, element ) => {
+				return (
+					serverLinkErrorText === content &&
+					! element.classList.contains( 'a11y-speak-region' )
+				);
+			} )
+		).toBeVisible();
+	} );
+
+	it( 'Does not display the server link redirection error message when there the query parameter is not present', () => {
+		getTasks.mockReturnValue( [] );
+
+		render( <OverviewPage /> );
+
+		expect(
+			screen.queryByText( ( content, element ) => {
+				return (
+					serverLinkErrorText === content &&
+					! element.classList.contains( 'a11y-speak-region' )
+				);
+			} )
+		).toBeNull();
 	} );
 
 	it( 'Displays the view loan error message for query param wcpay-loan-offer-error=1', () => {

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -71,6 +71,9 @@ class WC_Payments_Account {
 
 		// Add capital offer redirection.
 		add_action( 'admin_init', [ $this, 'maybe_redirect_to_capital_offer' ] );
+
+		// Add server links handler.
+		add_action( 'admin_init', [ $this, 'maybe_redirect_to_server_link' ] );
 	}
 
 	/**
@@ -425,6 +428,47 @@ class WC_Payments_Account {
 		} catch ( API_Exception $e ) {
 			$error_url = add_query_arg(
 				[ 'wcpay-loan-offer-error' => '1' ],
+				self::get_overview_page_url()
+			);
+
+			$this->redirect_to( $error_url );
+		}
+	}
+
+	/**
+	 * Checks if the request is for the server links handler, and redirects to the link if it's valid.
+	 *
+	 * Only admins are be able to perform this action. The redirect doesn't happen if the request is an AJAX request.
+	 * This method will end execution after the redirect if the user is allowed to view the link and the link is valid.
+	 */
+	public function maybe_redirect_to_server_link() {
+		if ( wp_doing_ajax() ) {
+			return;
+		}
+
+		// Safety check to prevent non-admin users to be redirected to the view offer page.
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
+		// This is an automatic redirection page, used to authenticate users that come from an email link. For this reason
+		// we're not using a nonce. The GET parameter accessed here is just to indicate that we should process the redirection.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['wcpay-link-handler'] ) ) {
+			return;
+		}
+
+		// Get all request arguments to be forwarded and remove the link handler identifier.
+		$args = $_GET;
+		unset( $args['wcpay-link-handler'] );
+
+		try {
+			$link = $this->payments_api_client->get_link( $args );
+
+			$this->redirect_to( $link['url'] );
+		} catch ( API_Exception $e ) {
+			$error_url = add_query_arg(
+				[ 'wcpay-server-link-error' => '1' ],
 				self::get_overview_page_url()
 			);
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -63,6 +63,7 @@ class WC_Payments_API_Client {
 	const WEBHOOK_FETCH_API            = 'webhook/failed_events';
 	const DOCUMENTS_API                = 'documents';
 	const VAT_API                      = 'vat';
+	const LINKS_API                    = 'links';
 
 	/**
 	 * Common keys in API requests/responses that we might want to redact.
@@ -1268,6 +1269,25 @@ class WC_Payments_API_Client {
 				'refresh_url' => $refresh_url,
 			],
 			self::ACCOUNTS_API . '/capital_links',
+			self::POST,
+			true,
+			true
+		);
+	}
+
+	/**
+	 * Get a link's details from the server.
+	 *
+	 * @param array $args The arguments to be sent with the link request.
+	 *
+	 * @return array The link object with an url field.
+	 *
+	 * @throws API_Exception When something goes wrong with the request, or the link is not valid.
+	 */
+	public function get_link( array $args ) {
+		return $this->request(
+			$args,
+			self::LINKS_API,
 			self::POST,
 			true,
 			true

--- a/tests/unit/test-class-wc-payments-account-link.php
+++ b/tests/unit/test-class-wc-payments-account-link.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Class WC_Payments_Account_Server_Links_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\Exceptions\API_Exception;
+use WCPay\Database_Cache;
+
+/**
+ * WC_Payments_Account unit tests for Server Links related methods.
+ */
+class WC_Payments_Account_Server_Links_Test extends WCPAY_UnitTestCase {
+	/**
+	 * System under test.
+	 *
+	 * @var WC_Payments_Account
+	 */
+	private $wcpay_account;
+
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_API_Client|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_api_client;
+
+	/**
+	 * Mock Database_Cache
+	 *
+	 * @var Database_Cache|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_database_cache;
+
+	/**
+	 * Previous user ID.
+	 * @var int
+	 */
+	private $previous_user_id;
+
+	/**
+	 * Mock WC_Payments_Action_Scheduler_Service
+	 *
+	 * @var WC_Payments_Action_Scheduler_Service|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_action_scheduler_service;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->previous_user_id = get_current_user_id();
+		// Set admin as the current user.
+		wp_set_current_user( 1 );
+
+		// Set the request as if the user is requesting to access a server link.
+		add_filter( 'wp_doing_ajax', '__return_false' );
+		$_GET['wcpay-link-handler'] = '';
+
+		$this->mock_api_client = $this->createMock( 'WC_Payments_API_Client' );
+
+		$this->mock_database_cache = $this->createMock( Database_Cache::class );
+
+		$this->mock_action_scheduler_service = $this->createMock( WC_Payments_Action_Scheduler_Service::class );
+
+		// Mock WC_Payments_Account without redirect_to to prevent headers already sent error.
+		$this->wcpay_account = $this->getMockBuilder( WC_Payments_Account::class )
+			->setMethods( [ 'redirect_to' ] )
+			->setConstructorArgs( [ $this->mock_api_client, $this->mock_database_cache, $this->mock_action_scheduler_service ] )
+			->getMock();
+	}
+
+	public function tear_down() {
+		wp_set_current_user( $this->previous_user_id );
+
+		unset( $_GET['wcpay-link-handler'] );
+
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+		remove_filter( 'wp_doing_ajax', '__return_false' );
+
+		parent::tear_down();
+	}
+
+	public function test_maybe_redirect_to_server_link_will_run() {
+		$this->assertNotFalse(
+			has_action( 'admin_init', [ $this->wcpay_account, 'maybe_redirect_to_server_link' ] )
+		);
+	}
+
+	public function test_maybe_redirect_to_server_link_skips_ajax_requests() {
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		$this->mock_api_client->expects( $this->never() )->method( 'get_link' );
+
+		$this->wcpay_account->maybe_redirect_to_server_link();
+	}
+
+	public function test_maybe_redirect_to_server_link_skips_non_admin_users() {
+		wp_set_current_user( 0 );
+
+		$this->mock_api_client->expects( $this->never() )->method( 'get_link' );
+
+		$this->wcpay_account->maybe_redirect_to_server_link();
+	}
+
+	public function test_maybe_redirect_to_server_link_skips_regular_requests() {
+		unset( $_GET['wcpay-link-handler'] );
+
+		$this->mock_api_client->expects( $this->never() )->method( 'get_link' );
+
+		$this->wcpay_account->maybe_redirect_to_server_link();
+	}
+
+	public function test_maybe_redirect_to_server_link_redirects_to_link() {
+		$this->mock_api_client
+			->method( 'get_link' )
+			->willReturn( [ 'url' => 'https://link.url' ] );
+
+		$this->wcpay_account
+			->expects( $this->once() )
+			->method( 'redirect_to' )
+			->with( 'https://link.url' );
+
+		$this->wcpay_account->maybe_redirect_to_server_link();
+	}
+
+	public function test_maybe_redirect_to_server_link_forwards_all_arguments() {
+		$_GET['type']       = 'login_link';
+		$_GET['id']         = 'link_id';
+		$_GET['random_arg'] = 'random_arg';
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_link' )
+			->with(
+				[
+					'type'       => 'login_link',
+					'id'         => 'link_id',
+					'random_arg' => 'random_arg',
+				]
+			)
+			->willReturn( [ 'url' => 'https://link.url' ] );
+
+		$this->wcpay_account->maybe_redirect_to_server_link();
+	}
+
+	public function test_maybe_redirect_to_server_link_redirects_to_overview_on_error() {
+		$this->mock_api_client
+			->method( 'get_link' )
+			->willThrowException( new API_Exception( 'Error: The requested link is invalid.', 'invalid_request_error', 400 ) );
+
+		$this->wcpay_account
+			->expects( $this->once() )
+			->method( 'redirect_to' )
+			->with( 'http://example.org/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Foverview&wcpay-server-link-error=1' );
+
+		$this->wcpay_account->maybe_redirect_to_server_link();
+	}
+}

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -977,7 +977,7 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 					]
 				),
 				true,
-				true // get_capital_links should use user token auth.
+				true // get_link should use user token auth.
 			)
 			->willReturn(
 				[

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -957,6 +957,48 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( [ 'url' => 'https://capital.url' ], $result );
 	}
 
+	public function test_get_link() {
+		$this->mock_http_client
+			->expects( $this->once() )
+			->method( 'remote_request' )
+			->with(
+				$this->callback(
+					function ( $data ): bool {
+						$this->validate_default_remote_request_params( $data, 'https://public-api.wordpress.com/wpcom/v2/sites/%s/wcpay/links', 'POST' );
+						$this->assertSame( 'POST', $data['method'] );
+						return true;
+					}
+				),
+				wp_json_encode(
+					[
+						'test_mode' => false,
+						'type'      => 'login_link',
+						'param'     => 'some_other_param',
+					]
+				),
+				true,
+				true // get_capital_links should use user token auth.
+			)
+			->willReturn(
+				[
+					'body'     => wp_json_encode( [ 'url' => 'https://login.url' ] ),
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+				]
+			);
+
+		$result = $this->payments_api_client->get_link(
+			[
+				'type'  => 'login_link',
+				'param' => 'some_other_param',
+			]
+		);
+
+		$this->assertEquals( [ 'url' => 'https://login.url' ], $result );
+	}
+
 	public function test_add_tos_agreement() {
 		$this->mock_http_client
 			->expects( $this->once() )


### PR DESCRIPTION
Fixes #4342 

#### Changes proposed in this Pull Request

This PR adds a handler for the WC Pay server links, which forwards all parameters to the `get_link` request, enabling us to add new link types without the need for a client update. It also adds an error message when a server link request
fails, by redirecting to the overview page with a `wcpay-server-link-error` query param.

> **Note**: Please check paJDYF-4qh-p2 for more details on the implementation.

> **Note**: The server counterpart is implemented in 2177-gh-Automattic/woocommerce-payments-server.

#### Testing instructions

* Apply 2177-gh-Automattic/woocommerce-payments-server to your local server or sandbox
* Apply this PR to your store's site
* Build the client JS files
* Navigate to `/wp-admin/admin.php?wcpay-link-handler&type=invalid_type`
    * Make sure you're redirected to the overview page and an error notice is displayed
* Navigate to `/wp-admin/admin.php?wcpay-link-handler&type=login_link`
    * Make sure you're redirected to Stripe's express dashboard 
* Open `/wp-admin/admin.php?wcpay-link-handler&type=login_link` in an incognito tab
    * Check that you're prompted for the admin's credentials
    * Enter the credentials and make sure that you're redirected to the express dashboard

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.