### PR TITLE
Move the Payments → Overview task list above account details card to improve visibility

### DIFF
--- a/changelog/update-4399-move-payments-overview-task-list
+++ b/changelog/update-4399-move-payments-overview-task-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Move the “Things to do” task list to a more visible position on the Payments Overview screen.

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -125,6 +125,18 @@ const OverviewPage = () => {
 				</ErrorBoundary>
 			) }
 
+			{ !! accountOverviewTaskList &&
+				0 < tasks.length &&
+				! isLoading &&
+				! accountRejected && (
+					<ErrorBoundary>
+						<TaskList
+							tasks={ tasks }
+							overviewTasksVisibility={ overviewTasksVisibility }
+						/>
+					</ErrorBoundary>
+				) }
+
 			<ErrorBoundary>
 				<AccountStatus
 					accountStatus={ wcpaySettings.accountStatus }
@@ -137,18 +149,6 @@ const OverviewPage = () => {
 					<ActiveLoanSummary />
 				</ErrorBoundary>
 			) }
-
-			{ !! accountOverviewTaskList &&
-				0 < tasks.length &&
-				! isLoading &&
-				! accountRejected && (
-					<ErrorBoundary>
-						<TaskList
-							tasks={ tasks }
-							overviewTasksVisibility={ overviewTasksVisibility }
-						/>
-					</ErrorBoundary>
-				) }
 
 			{ ! accountRejected && (
 				<ErrorBoundary>


### PR DESCRIPTION
Fixes #4399

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR moves the **Things to do** task list above the **Account Details** card on the **Payments → Overview** screen to improve the visibility of disputes needing a response.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

1. Using [WCPay Dev Tools](https://github.com/Automattic/woocommerce-payments-dev-tools), ensure the `Enable account overview task list` checkbox is checked.
2. Purchase a product with a disputed payment method (`4000000000000259`).
3. Go to the **Payments → Overview** screen.
4. The **Things to **do task list should be located above the **Account Details**card.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Before**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/3147296/177257459-c78276f8-9f6a-43ba-8f3b-97e3b0557591.png">


**After**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/3147296/177257538-a9cf8f3b-c2c3-40a9-90e0-6f37a1bb06cd.png">


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
