### PR TITLE
Fix dispute task grammar for multiple disputes and change the redirect when clicked

### DIFF
--- a/changelog/fix-dispute-task-plural-phrasing
+++ b/changelog/fix-dispute-task-plural-phrasing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a grammatical issue in the dispute task on the Payments > Overview screen when there is more than 1 dispute which needs a response.

--- a/changelog/update-dispute-task-redirect
+++ b/changelog/update-dispute-task-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Redirect users to the disputes screen filtered to disputes which need a response when clicking on the Payments > Overview dispute task.

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -134,7 +134,7 @@ export const getTasks = ( {
 			title: sprintf(
 				_n(
 					'1 disputed payment needs your response',
-					'%s disputed payments needs your response',
+					'%s disputed payments need your response',
 					disputesToResolve,
 					'woocommerce-payments'
 				),

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -154,6 +154,7 @@ export const getTasks = ( {
 				window.location.href = getAdminUrl( {
 					page: 'wc-admin',
 					path: '/payments/disputes',
+					filter: 'awaiting_response',
 				} );
 			},
 		},

--- a/client/overview/task-list/test/tasks.js
+++ b/client/overview/task-list/test/tasks.js
@@ -220,7 +220,7 @@ describe( 'getTasks()', () => {
 					key: 'dispute-resolution-task',
 					completed: true,
 					level: 3,
-					title: '2 disputed payments needs your response',
+					title: '2 disputed payments need your response',
 				} ),
 			] )
 		);


### PR DESCRIPTION
Fixes #4413
Part of #4123

#### Changes proposed in this Pull Request

This PR changes the Dispute task on the Payments Overview task list in two minor ways:

1. Fixes a grammatical issue with the plural phrasing when more than 1 dispute needs a response. 
2. When clicked, the user will be directed to the disputes list and only show disputes which need a response.

#### Testing instructions

1. Go to WCPay Dev tools and [enable the "Enable account overview task list" option](https://user-images.githubusercontent.com/8490476/177457548-e173d9b8-74fd-492f-977e-4799a037f785.png). 
2. Make **2** separate purchases using a disputed card number. eg `4000000000000259` ([ref](https://stripe.com/docs/testing#disputes)) 
3. Go to the **Payments → Overview** admin screen.
4. Note that the dispute task list now says: 
     - "2 disputed payments **need** your response" 
     - Before (on develop) it would read "2 disputed payments **needs** your response" ([screenshot](https://user-images.githubusercontent.com/8490476/177468814-8fdc99ac-1305-49c3-ace3-e36c22bc48b8.png)) 
5. Click on the task
     - On develop you would have landed on the disputes list table with all disputes listed.
     - On this branch you will only see the list filtered by disputes which need your response. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
