### PR TITLE
Revert "Product version bump update"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Payments Changelog ***
 
-= 4.4.0 - 2022-07-06 =
+= 4.4.0 - 2022-xx-xx =
 * Add - Add handler for authenticated server links
 * Add - Add platform checkout order status sync webhooks
 * Add - Display a badge indicating the number of disputes which need a response in Payments > Disputes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-payments",
-  "version": "4.4.0",
+  "version": "4.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-payments",
-  "version": "4.4.0",
+  "version": "4.3.0",
   "main": "webpack.config.js",
   "author": "Automattic",
   "license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, payment, payment request, credit card, automattic
 Requires at least: 5.7
 Tested up to: 6.0
 Requires PHP: 7.0
-Stable tag: 4.4.0
+Stable tag: 4.3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -98,7 +98,7 @@ Please note that our support for the checkout block is still experimental and th
 
 == Changelog ==
 
-= 4.4.0 - 2022-07-06 =
+= 4.4.0 - 2022-xx-xx =
 * Add - Add handler for authenticated server links
 * Add - Add platform checkout order status sync webhooks
 * Add - Display a badge indicating the number of disputes which need a response in Payments > Disputes

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -12,7 +12,7 @@
  * WC tested up to: 6.6.0
  * Requires at least: 5.7
  * Requires PHP: 7.0
- * Version: 4.4.0
+ * Version: 4.3.0
  *
  * @package WooCommerce\Payments
  */


### PR DESCRIPTION
During the release process, there was an issue that caused the script timeout.
This PR reverts the changes made mid-way through the release process so we try again.

Internal slack thread: p1657063407341979-slack-CGGCLBN58