### PR TITLE
Add a view and respond subtext to the dispute task on WC → Home

### DIFF
--- a/includes/admin/tasks/class-wc-payments-task-disputes.php
+++ b/includes/admin/tasks/class-wc-payments-task-disputes.php
@@ -66,6 +66,15 @@ class WC_Payments_Task_Disputes extends Task {
 	}
 
 	/**
+	 * Get the additional info.
+	 *
+	 * @return string
+	 */
+	public function get_additional_info() {
+		return __( 'View and respond', 'woocommerce-payments' );
+	}
+
+	/**
 	 * Gets the task's action label.
 	 *
 	 * @return string


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR adds the "View and respond" subtext to the dispute task on the **WC → Home** screen matching the task on **Payments → Overview**. 

**WC → Home**
<img width="727" alt="Screen Shot 2022-07-08 at 2 25 11 pm" src="https://user-images.githubusercontent.com/8490476/177917516-60c5e884-371c-48ec-9e21-c99c4e36aa1b.png">

**Payments → Overview**
<img width="711" alt="Screen Shot 2022-07-08 at 2 34 29 pm" src="https://user-images.githubusercontent.com/8490476/177917537-1a290353-8c27-46b8-891c-cc8fd2d6f8e8.png">

#### Testing instructions

* Purchase a product with a disputed payment method `4000000000000259` 
* Go to **WC → Home** and note the task items
    - The dispute task on `develop` will just include the "x disputed payments need your response"
    - On this branch `add/view_and_respond_to_dispute_task` the task will also include the "View and respond" subtext inline with the one on **Payments → Overview** (see screenshot comparison above).  

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
    - A new change log entry isn't necessary imo as this task was added in https://github.com/Automattic/woocommerce-payments/pull/4418 which I just merged and that change log captures this too. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
