### PR TITLE
Update explicit pricing missing E2E tests

### DIFF
--- a/changelog/fix-explicit-pricing-tests
+++ b/changelog/fix-explicit-pricing-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update missing E2E tests From PR #4383
+
+

--- a/tests/e2e/specs/subscriptions/merchant/merchant-subscriptions-purchase-no-sign-up.spec.js
+++ b/tests/e2e/specs/subscriptions/merchant/merchant-subscriptions-purchase-no-sign-up.spec.js
@@ -88,7 +88,7 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 			await expect( page ).toMatchElement(
 				'li.woocommerce-timeline-item',
 				{
-					text: 'A payment of $9.99 USD was successfully charged.',
+					text: 'A payment of $9.99 was successfully charged.',
 				}
 			);
 		} );

--- a/tests/e2e/specs/subscriptions/merchant/merchant-subscriptions-purchase-sign-up-fee.spec.js
+++ b/tests/e2e/specs/subscriptions/merchant/merchant-subscriptions-purchase-sign-up-fee.spec.js
@@ -86,7 +86,7 @@ describeif( RUN_SUBSCRIPTIONS_TESTS )(
 			await expect( page ).toMatchElement(
 				'li.woocommerce-timeline-item',
 				{
-					text: 'A payment of $11.98 USD was successfully charged.',
+					text: 'A payment of $11.98 was successfully charged.',
 				}
 			);
 		} );

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-full-refund.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-full-refund.spec.js
@@ -95,7 +95,7 @@ describe( 'Order > Full refund', () => {
 
 			// Verify system note was added
 			expect( page ).toMatchElement( '.system-note', {
-				text: `A refund of ${ orderAmount } USD was successfully processed using WooCommerce Payments. Reason: No longer wanted`,
+				text: `A refund of ${ orderAmount } was successfully processed using WooCommerce Payments. Reason: No longer wanted`,
 			} ),
 		] );
 		await takeScreenshot( 'merchant-orders-full-refund_refunded' );
@@ -114,7 +114,7 @@ describe( 'Order > Full refund', () => {
 		// Verify the transaction timeline reflects the refund events
 		await Promise.all( [
 			expect( page ).toMatchElement( 'li.woocommerce-timeline-item', {
-				text: `A payment of ${ orderAmount } USD was successfully refunded.`,
+				text: `A payment of ${ orderAmount } was successfully refunded.`,
 			} ),
 			expect( page ).toMatchElement( 'li.woocommerce-timeline-item', {
 				text: 'Payment status changed to Refunded.',

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-partial-refund.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-partial-refund.spec.js
@@ -183,7 +183,7 @@ describe.each( dataTable )(
 			// Verify the transaction timeline reflects the refund events
 			await Promise.all( [
 				expect( page ).toMatchElement( 'li.woocommerce-timeline-item', {
-					text: `A payment of $${ refundTotalString } USD was successfully refunded.`,
+					text: `A payment of $${ refundTotalString } was successfully refunded.`,
 				} ),
 				expect( page ).toMatchElement( 'li.woocommerce-timeline-item', {
 					text: 'Payment status changed to Partial refund.',


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Update missing E2E tests from PR #4383

#### Testing instructions
E2E tests should pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)