### PR TITLE
Register only reusable payment methods when adding a payment method

### DIFF
--- a/changelog/fix-4396-filter-reusable-add-payment-methods
+++ b/changelog/fix-4396-filter-reusable-add-payment-methods
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This is a minor fix to a larger PR that is forthcoming.
+
+

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -172,6 +172,8 @@ jQuery( function ( $ ) {
 		const gatewayCardId = getUPEConfig( 'gatewayId' );
 		let selectedGatewayId = null;
 
+		// Handle payment method selection on the Checkout page or Add Payment Method page where class names differ.
+
 		if ( $( 'li.wc_payment_method' ).length ) {
 			selectedGatewayId = $(
 				'li.wc_payment_method input.input-radio:checked'

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -170,11 +170,24 @@ jQuery( function ( $ ) {
 	 */
 	const getSelectedGatewayPaymentMethod = () => {
 		const gatewayCardId = getUPEConfig( 'gatewayId' );
-		const selectedGatewayId = $(
-			'li.wc_payment_method input.input-radio:checked'
-		).attr( 'id' );
+		let selectedGatewayId = null;
+
+		if ( $( 'li.wc_payment_method' ).length ) {
+			selectedGatewayId = $(
+				'li.wc_payment_method input.input-radio:checked'
+			).attr( 'id' );
+		} else if ( $( 'li.woocommerce-PaymentMethod' ).length ) {
+			selectedGatewayId = $(
+				'li.woocommerce-PaymentMethod input.input-radio:checked'
+			).attr( 'id' );
+		}
+
+		if ( 'payment_method_woocommerce_payments' === selectedGatewayId ) {
+			selectedGatewayId = 'payment_method_woocommerce_payments_card';
+		}
 
 		let selectedPaymentMethod = null;
+
 		for ( const paymentMethodType in paymentMethodsConfig ) {
 			if (
 				`payment_method_${ gatewayCardId }_${ paymentMethodType }` ===
@@ -742,15 +755,6 @@ jQuery( function ( $ ) {
 
 	// Handle the add payment method form for WooCommerce Payments.
 	$( 'form#add_payment_method' ).on( 'submit', function () {
-		if (
-			'woocommerce_payments' !==
-			$(
-				"#add_payment_method input:checked[name='payment_method']"
-			).val()
-		) {
-			return;
-		}
-
 		if ( ! $( '#wcpay-setup-intent' ).val() ) {
 			const paymentMethodType = getSelectedGatewayPaymentMethod();
 			const paymentIntentId =

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -422,7 +422,6 @@ jQuery( function ( $ ) {
 					useSetUpIntent
 				);
 			}
-			mountUPEElement( useSetUpIntent );
 		}
 	}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2580,7 +2580,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 *
 	 * @throws Exception - When an error occurs in intent creation.
 	 */
-
 	public function create_intent( WC_Order $order, array $selected_payment_method_type, string $capture_method = 'automatic', array $metadata = [], string $customer_id = null ) {
 		$currency         = strtolower( $order->get_currency() );
 		$converted_amount = WC_Payments_Utils::prepare_amount( $order->get_total(), $currency );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -491,15 +491,27 @@ class WC_Payments {
 	 * @return array The list of payment gateways that will be available, including WooCommerce Payments' Gateway class.
 	 */
 	public static function register_gateway( $gateways ) {
-		$gateways[] = self::$legacy_card_gateway;
+		$gateways[]         = self::$legacy_card_gateway;
+		$reusable_methods[] = self::$legacy_card_gateway;
 
 		if ( WC_Payments_Features::is_upe_enabled() ) {
 			foreach ( self::$card_gateway->get_payment_method_ids_enabled_at_checkout() as $payment_method_id ) {
 				if ( 'card' === $payment_method_id ) {
 					continue;
 				}
-				$upe_gateway = self::get_payment_gateway_by_id( $payment_method_id );
-				$gateways[]  = $upe_gateway;
+				$upe_gateway        = self::get_payment_gateway_by_id( $payment_method_id );
+				$upe_payment_method = self::get_payment_method_by_id( $payment_method_id );
+
+				if ( $upe_payment_method->is_reusable() ) {
+					$reusable_methods[] = $upe_gateway;
+				}
+
+				$gateways[] = $upe_gateway;
+
+			}
+
+			if ( is_add_payment_method_page() ) {
+				return $reusable_methods;
 			}
 		}
 


### PR DESCRIPTION
With multiple gateways being registered, the Add Payment Method page is broken with the error, `This payment method does not support recurring payments.` and new payment methods cannot be added. 

Fixes #4396 

#### Changes proposed in this Pull Request

This ensures that only reusable payment methods are available on the **My Account > Payment Methods > Add Payment Method** page rather than all UPE methods. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. After checking out this branch, run `npm run start`, enable WooPay and the UPE.
2. Enable a few UPE payment methods in the WCPay settings.
3. Add a product to the cart and verify that both the CC and enabled UPE methods are present on checkout
4. Go to **My Account > Payment Methods > Add Payment Method** and verify that no error is present on the page and that a new payment method can be added.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
