### PR TITLE
Allow enabling the platform checkout for subscriptions via an option

### DIFF
--- a/changelog/add-platform-checkout-subscriptions-flag
+++ b/changelog/add-platform-checkout-subscriptions-flag
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Just introducing a feature flag to facilitate the feature development
+
+

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -100,6 +100,15 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Checks whether the platform checkout is elegible for paying for subscriptions.
+	 *
+	 * @return boolean
+	 */
+	public static function is_platform_checkout_subscriptions_enabled() {
+		return '1' === get_option( '_wcpay_feature_platform_checkout_subscriptions_enabled', '0' );
+	}
+
+	/**
 	 * Checks whether documents section is enabled.
 	 *
 	 * @return bool

--- a/includes/platform-checkout/class-platform-checkout-utilities.php
+++ b/includes/platform-checkout/class-platform-checkout-utilities.php
@@ -25,8 +25,8 @@ class Platform_Checkout_Utilities {
 	public function should_enable_platform_checkout( $gateway ) {
 		$is_platform_checkout_eligible = WC_Payments_Features::is_platform_checkout_eligible(); // Feature flag.
 		$is_platform_checkout_enabled  = 'yes' === $gateway->get_option( 'platform_checkout', 'no' );
-		$is_subscription_item_in_cart  = $this->is_subscription_item_in_cart();
+		$disable_for_subscription      = ! WC_Payments_Features::is_platform_checkout_subscriptions_enabled() && $this->is_subscription_item_in_cart();
 
-		return $is_platform_checkout_eligible && $is_platform_checkout_enabled && ! $is_subscription_item_in_cart;
+		return $is_platform_checkout_eligible && $is_platform_checkout_enabled && ! $disable_for_subscription;
 	}
 }


### PR DESCRIPTION
Fixes: No related issue.

#### Changes proposed in this Pull Request

Introduce a feature flag based on wp options to skip disabling the platform checkout for subscriptions.

This is intended to be used with the development tools to facilitate the development of this feature.

#### Testing instructions

(You can test these steps using the option introduced in the PR 71 from the dev tools, using the option introduced there instead of adding and removing the option `_wcpay_feature_platform_checkout_subscriptions_enabled` as described below)

1. Go to your WCPay site and confirm the platform checkout is enabled and working
2. Add a subscription product to your cart
3. Go to the checkout page
  Confirm that the platform checkout is disabled

4. In your DB, go to `wp_options`
5. Create an option named `_wcpay_feature_platform_checkout_subscriptions_enabled` and set it to `1`
6. Reload the checkout page
  Confirm that the platform checkout is now enabled on the checkout page
7. Remove the subscription from the cart and add a regular product. Go to the checkout page
  Confirm that the platform checkout is still showing up
8. Remove the `_wcpay_feature_platform_checkout_subscriptions_enabled` option from `wp_options`
  Confirm that the platform checkout is still showing up on the checkout page

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
