### PR TITLE
Fix price on Payment Request pop-ups for tax inclusive pricing

### DIFF
--- a/changelog/fix-4431-tax-inclusive-payment-request
+++ b/changelog/fix-4431-tax-inclusive-payment-request
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: It is a fix for patching a bug caused in PR #4366
+
+

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -207,6 +207,12 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 */
 	public function get_product_price( $product ) {
 		$product_price = $product->get_price();
+
+		//If prices should include tax, add it in 
+		if(! $this->prices_exclude_tax()) {
+			$product_price = wc_get_price_including_tax( $product );
+		}
+
 		// Add subscription sign-up fees to product price.
 		if ( 'subscription' === $product->get_type() && class_exists( 'WC_Subscriptions_Product' ) ) {
 			$product_price = $product->get_price() + WC_Subscriptions_Product::get_sign_up_fee( $product );


### PR DESCRIPTION
Fixes #4431

#### Changes proposed in this Pull Request

When prices are set to display as tax inclusive (_woocommerce_tax_display_cart_), use tax inclusive price in Payment Request pop-up on product page.

#### Testing instructions
- Set up different Tax configurations under WooCommerce > Settings > Tax
- Confirm that the pricing displayed in Apple Pay and GPay pop-ups are aligned with that shown on Cart.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Not relevant - Covered with tests (or have a good reason not to test in description ☝️)
- [x] Not relevant - Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-4.5.0#validate-pricing-display-on-payment-request-pop-ups
- [x] Not relevant - Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
