### PR TITLE
Accept and manage payments across multiple linked accounts at once

### DIFF
--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -332,7 +332,10 @@ export default class WCPayAPI {
 	initSetupIntent() {
 		return this.request(
 			buildAjaxURL( getConfig( 'wcAjaxUrl' ), 'init_setup_intent' ),
-			{ _ajax_nonce: getConfig( 'createSetupIntentNonce' ) }
+			{
+				wcpay_account_id: getConfig( 'accountId' ),
+				_ajax_nonce: getConfig( 'createSetupIntentNonce' ),
+			}
 		).then( ( response ) => {
 			if ( ! response.success ) {
 				throw response.data.error;
@@ -387,6 +390,7 @@ export default class WCPayAPI {
 			buildAjaxURL( getConfig( 'wcAjaxUrl' ), 'create_payment_intent' ),
 			{
 				wcpay_order_id: orderId,
+				wcpay_account_id: getConfig( 'accountId' ),
 				_ajax_nonce: getConfig( 'createPaymentIntentNonce' ),
 			}
 		)
@@ -432,6 +436,7 @@ export default class WCPayAPI {
 				save_payment_method: savePaymentMethod,
 				wcpay_selected_upe_payment_type: selectedUPEPaymentType,
 				wcpay_payment_country: paymentCountry,
+				wcpay_account_id: getConfig( 'accountId' ),
 				_ajax_nonce: getConfig( 'updatePaymentIntentNonce' ),
 			}
 		)
@@ -494,6 +499,7 @@ export default class WCPayAPI {
 			{
 				...fields,
 				wc_payment_intent_id: paymentIntentId,
+				'wcpay-account': getConfig( 'accountId' ),
 			}
 		)
 			.then( ( response ) => {

--- a/client/checkout/classic/index.js
+++ b/client/checkout/classic/index.js
@@ -297,6 +297,8 @@ jQuery( function ( $ ) {
 		// Populate form with the payment method.
 		$( paymentSelector ).val( id );
 
+		$( '#wcpay-account' ).val( getConfig( 'accountId' ) );
+
 		// Re-submit the form.
 		$form.removeClass( 'processing' ).submit();
 	};

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -644,7 +644,11 @@ jQuery( function ( $ ) {
 		) {
 			const intentId = upePaymentIntentData.split( '-' )[ 1 ];
 			const clientSecret = upePaymentIntentData.split( '-' )[ 2 ];
-			return { intentId, clientSecret };
+			const accountId = upePaymentIntentData.split( '-' )[ 3 ];
+
+			if ( accountId === getConfig( 'accountId' ) ) {
+				return { intentId, clientSecret };
+			}
 		}
 
 		return {};
@@ -659,7 +663,11 @@ jQuery( function ( $ ) {
 		if ( upeSetupIntentData ) {
 			const intentId = upeSetupIntentData.split( '-' )[ 0 ];
 			const clientSecret = upeSetupIntentData.split( '-' )[ 1 ];
-			return { intentId, clientSecret };
+			const accountId = upeSetupIntentData.split( '-' )[ 2 ];
+
+			if ( accountId === getConfig( 'accountId' ) ) {
+				return { intentId, clientSecret };
+			}
 		}
 
 		return {};

--- a/includes/admin/class-wc-payments-rest-controller.php
+++ b/includes/admin/class-wc-payments-rest-controller.php
@@ -61,6 +61,10 @@ class WC_Payments_REST_Controller extends WP_REST_Controller {
 	 * Override this method if custom permissions required.
 	 */
 	public function check_permission() {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$account_id = isset( $_COOKIE['account_id'] ) ? $_COOKIE['account_id'] : null;
+		WC_Payments_Utils::switch_to_account( $account_id );
+
 		return current_user_can( 'manage_woocommerce' );
 	}
 }

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1109,6 +1109,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$account_id = null;
 		}
 		WC_Payments_Utils::switch_to_account( $account_id );
+		$order->update_meta_data( '_wcpay_account_id', $account_id );
+		$order->save_meta_data();
 
 		list( $user, $customer_id ) = $this->manage_customer_details_for_order( $order, $account_id );
 
@@ -2372,6 +2374,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					'order_not_found'
 				);
 			}
+
+			WC_Payments_Utils::switch_to_account( $order->get_meta( '_wcpay_account_id' ) );
 
 			$intent_id          = $order->get_meta( '_intent_id', true );
 			$intent_id_received = isset( $_POST['intent_id'] )

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1559,6 +1559,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		$charge_id = $order->get_meta( '_charge_id', true );
+		WC_Payments_Utils::switch_to_account( $order->get_meta( '_wcpay_account_id' ) );
 
 		try {
 			// If the payment method is Interac, the refund already exists (refunded via Mobile app).

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1105,6 +1105,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// phpcs:ignore WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$account_id = $_POST['wcpay-account'] ?? null;
+		if ( empty( $account_id ) && ! empty( $order->get_meta( '_wcpay_account_id' ) ) ) {
+			$account_id = $order->get_meta( '_wcpay_account_id' );
+		}
 		if ( $account_id === $this->account->get_stripe_account_id() ) {
 			$account_id = null;
 		}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -659,7 +659,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		return [
 			'publishableKey'                 => $this->account->get_publishable_key( $this->is_in_test_mode() ),
 			'testMode'                       => $this->is_in_test_mode(),
-			'accountId'                      => $this->account->get_stripe_account_id(),
+			'accountId'                      => apply_filters( 'wcpay_account_id', $this->account->get_stripe_account_id() ),
 			'ajaxUrl'                        => admin_url( 'admin-ajax.php' ),
 			'wcAjaxUrl'                      => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 			'createSetupIntentNonce'         => wp_create_nonce( 'wcpay_create_setup_intent_nonce' ),

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -863,6 +863,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				<div id="wcpay-card-element"></div>
 				<div id="wcpay-errors" role="alert"></div>
 				<input id="wcpay-payment-method" type="hidden" name="wcpay-payment-method" />
+				<input id="wcpay-account" type="hidden" name="wcpay-account" />
 				<input type="hidden" name="wcpay-is-platform-payment-method" value="<?php echo esc_attr( $this->should_use_stripe_platform_on_checkout_page() ); ?>" />
 			<?php
 			if ( $this->is_saved_cards_enabled() ) {
@@ -1100,6 +1101,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$order_id = $order->get_id();
 		$amount   = $order->get_total();
 		$metadata = $this->get_metadata_from_order( $order, $payment_information->get_payment_type() );
+
+		// phpcs:ignore WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$account_id = $_POST['wcpay-account'] ?? null;
+		WC_Payments_Utils::switch_to_account( $account_id );
 
 		list( $user, $customer_id ) = $this->manage_customer_details_for_order( $order );
 

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -790,4 +790,22 @@ class WC_Payments_Utils {
 
 		return $formatted_amount;
 	}
+
+	/**
+	 * Sets account ID for all API requests to server.
+	 *
+	 * @param string $account_id Account ID to use.
+	 */
+	public static function switch_to_account( $account_id ) {
+		if ( ! empty( $account_id ) ) {
+			add_filter(
+				'wcpay_api_request_params',
+				function( $params ) use ( $account_id ) {
+					$params['account_id'] = $account_id;
+					return $params;
+				}
+			);
+		}
+	}
+
 }

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -440,6 +440,8 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			$account_id = null;
 		}
 		WC_Payments_Utils::switch_to_account( $account_id );
+		$order->update_meta_data( '_wcpay_account_id', $account_id );
+		$order->save_meta_data();
 
 		if ( $payment_intent_id ) {
 			list( $user, $customer_id ) = $this->manage_customer_details_for_order( $order );

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -166,6 +166,10 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 				);
 			}
 
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$account_id = isset( $_POST['wcpay_account_id'] ) ? $_POST['wcpay_account_id'] : null;
+			WC_Payments_Utils::switch_to_account( $account_id );
+
 			$order_id                  = isset( $_POST['wcpay_order_id'] ) ? absint( $_POST['wcpay_order_id'] ) : null;
 			$payment_intent_id         = isset( $_POST['wc_payment_intent_id'] ) ? wc_clean( wp_unslash( $_POST['wc_payment_intent_id'] ) ) : '';
 			$save_payment_method       = isset( $_POST['save_payment_method'] ) ? 'yes' === wc_clean( wp_unslash( $_POST['save_payment_method'] ) ) : false;
@@ -241,13 +245,17 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 				);
 			}
 
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$account_id = isset( $_POST['wcpay_account_id'] ) ? $_POST['wcpay_account_id'] : null;
+			WC_Payments_Utils::switch_to_account( $account_id );
+
 			// If paying from order, we need to get the total from the order instead of the cart.
 			$order_id = isset( $_POST['wcpay_order_id'] ) ? absint( $_POST['wcpay_order_id'] ) : null;
 
-			$response = $this->create_payment_intent( $order_id );
+			$response = $this->create_payment_intent( $order_id, $account_id );
 
 			if ( strpos( $response['id'], 'pi_' ) === 0 ) { // response is a payment intent (could possibly be a setup intent).
-				$this->add_upe_payment_intent_to_session( $response['id'], $response['client_secret'] );
+				$this->add_upe_payment_intent_to_session( $response['id'], $response['client_secret'], $account_id );
 			}
 
 			wp_send_json_success( $response, 200 );
@@ -266,11 +274,12 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	/**
 	 * Creates payment intent using current cart or order and store details.
 	 *
-	 * @param int $order_id The id of the order if intent created from Order.
+	 * @param int         $order_id The id of the order if intent created from Order.
+	 * @param string|null $account_id Account ID, if not default.
 	 *
 	 * @return array
 	 */
-	public function create_payment_intent( $order_id = null ) {
+	public function create_payment_intent( $order_id = null, $account_id ) {
 		$amount   = WC()->cart->get_total( '' );
 		$currency = get_woocommerce_currency();
 		$number   = 0;
@@ -283,7 +292,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 		$converted_amount = WC_Payments_Utils::prepare_amount( $amount, $currency );
 		if ( 1 > $converted_amount ) {
-			return $this->create_setup_intent();
+			return $this->create_setup_intent( $account_id );
 		}
 
 		$minimum_amount = WC_Payments_Utils::get_cached_minimum_amount( $currency );
@@ -345,7 +354,11 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 				);
 			}
 
-			$response = $this->create_setup_intent();
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$account_id = isset( $_POST['wcpay_account_id'] ) ? $_POST['wcpay_account_id'] : null;
+			WC_Payments_Utils::switch_to_account( $account_id );
+
+			$response = $this->create_setup_intent( $account_id );
 
 			$this->add_upe_setup_intent_to_session( $response['id'], $response['client_secret'] );
 
@@ -365,15 +378,17 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	/**
 	 * Creates setup intent without confirmation.
 	 *
+	 * @param string|null $account_id Account ID, if not default.
+	 *
 	 * @return array
 	 */
-	public function create_setup_intent() {
+	public function create_setup_intent( $account_id = null ) {
 		// Determine the customer managing the payment methods, create one if we don't have one already.
 		$user        = wp_get_current_user();
-		$customer_id = $this->customer_service->get_customer_id_by_user_id( $user->ID );
+		$customer_id = $this->customer_service->get_customer_id_by_user_id( $user->ID, $account_id );
 		if ( null === $customer_id ) {
 			$customer_data = WC_Payments_Customer_Service::map_customer_data( null, new \WC_Customer( $user->ID ) );
-			$customer_id   = $this->customer_service->create_customer_for_user( $user, $customer_data );
+			$customer_id   = $this->customer_service->create_customer_for_user( $user, $customer_data, $account_id );
 		}
 
 		$enabled_payment_methods = array_filter( $this->get_upe_enabled_payment_method_ids(), [ $this, 'is_enabled_for_saved_payments' ] );
@@ -418,6 +433,13 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		$payment_type              = $this->is_payment_recurring( $order_id ) ? Payment_Type::RECURRING() : Payment_Type::SINGLE();
 		$save_payment_method       = $payment_type->equals( Payment_Type::RECURRING() ) || ! empty( $_POST[ 'wc-' . static::GATEWAY_ID . '-new-payment-method' ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$payment_country           = ! empty( $_POST['wcpay_payment_country'] ) ? wc_clean( wp_unslash( $_POST['wcpay_payment_country'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$account_id = $_POST['wcpay-account'] ?? null;
+		if ( $account_id === $this->account->get_stripe_account_id() ) {
+			$account_id = null;
+		}
+		WC_Payments_Utils::switch_to_account( $account_id );
 
 		if ( $payment_intent_id ) {
 			list( $user, $customer_id ) = $this->manage_customer_details_for_order( $order );
@@ -590,6 +612,8 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			}
 
 			Logger::log( "Begin processing UPE redirect payment for order $order_id for the amount of {$order->get_total()}" );
+
+			WC_Payments_Utils::switch_to_account( $order->get_meta( '_wcpay_account_id' ) );
 
 			// Get user/customer for order.
 			list( $user, $customer_id ) = $this->manage_customer_details_for_order( $order );
@@ -1161,15 +1185,16 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	 *
 	 * @param string $intent_id     The payment intent id.
 	 * @param string $client_secret The payment intent client secret.
+	 * @param string $account_id Account ID, if not default.
 	 */
-	private function add_upe_payment_intent_to_session( string $intent_id = '', string $client_secret = '' ) {
+	private function add_upe_payment_intent_to_session( string $intent_id = '', string $client_secret = '', string $account_id = '' ) {
 		$cart_hash = 'undefined';
 
 		if ( isset( $_COOKIE['woocommerce_cart_hash'] ) ) {
 			$cart_hash = sanitize_text_field( wp_unslash( $_COOKIE['woocommerce_cart_hash'] ) );
 		}
 
-		$value = $cart_hash . '-' . $intent_id . '-' . $client_secret;
+		$value = $cart_hash . '-' . $intent_id . '-' . $client_secret . '-' . $account_id;
 
 		WC()->session->set( self::KEY_UPE_PAYMENT_INTENT, $value );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Spike demonstrating initial changes needed for partial multiple account support.

Allows setting account ID on checkout via filter, and on dashboard via cookie.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

Use local server with change to "Allow specifying any linked account via request param", and run webhook listener.

First filter account to use at checkout, e.g. to [this spot](https://github.com/Automattic/woocommerce-payments/blob/86dcb9242d4c128463ce1c12ecd09a777c6f86a4/includes/class-wc-payments.php#L389):
```php
add_filter( 'wcpay_account_id', function( $account_id ) {
	if ( get_woocommerce_currency() !== 'USD' ) {
		return 'acct_1JFnoRR0ukO9Psuh'; // or your own account ID
	}

	return $account_id;
} );
```
Then:
- With Multi-Currency configured with USD and EUR
- Check out with USD, and refund
- Verify that these transactions show up on dashboard
- Check out with EUR, and refund
- Set `document.cookie = 'account_id=acct_1JFnoRR0ukO9Psuh; path=/'` from JS console (or your own account ID)
- Verify that these transactions show up on dashboard and that the prior USD ones do not

(Can test with and without the "new checkout experience".)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
