### PR TITLE
Fix caching dispute issues after accepting a dispute

### DIFF
--- a/changelog/fix-dispute-caching-after-accept
+++ b/changelog/fix-dispute-caching-after-accept
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix caching issues after accepting a dispute. Resolves issues where the number of disputes needing a response doesn't update after accepting a dispute.

--- a/client/data/disputes/actions.js
+++ b/client/data/disputes/actions.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import { apiFetch, dispatch } from '@wordpress/data-controls';
-import { getHistory } from '@woocommerce/navigation';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -51,7 +50,7 @@ export function* acceptDispute( id ) {
 		yield dispatch( STORE_NAME, 'finishResolution', 'getDispute', [ id ] );
 
 		// Redirect to Disputes list.
-		getHistory().push(
+		window.location.replace(
 			getAdminUrl( {
 				page: 'wc-admin',
 				path: '/payments/disputes',

--- a/client/data/disputes/test/actions.js
+++ b/client/data/disputes/test/actions.js
@@ -4,16 +4,13 @@
  * External dependencies
  */
 import { apiFetch, dispatch } from '@wordpress/data-controls';
-import { getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
 import { acceptDispute, updateDispute } from '../actions';
 
-jest.mock( '@woocommerce/navigation', () => ( {
-	getHistory: jest.fn( () => ( { push: () => {} } ) ),
-} ) );
+window.location.replace = jest.fn();
 
 describe( 'acceptDispute action', () => {
 	const mockDispute = {
@@ -46,7 +43,7 @@ describe( 'acceptDispute action', () => {
 		);
 
 		const noticeAction = generator.next().value;
-		expect( getHistory.mock.calls.length ).toEqual( 1 );
+		expect( window.location.replace ).toHaveBeenCalledTimes( 1 );
 		expect( noticeAction ).toEqual(
 			dispatch(
 				'core/notices',

--- a/client/disputes/evidence/index.js
+++ b/client/disputes/evidence/index.js
@@ -6,7 +6,6 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect, useMemo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { getHistory } from '@woocommerce/navigation';
 import apiFetch from '@wordpress/api-fetch';
 import {
 	Button,
@@ -562,6 +561,7 @@ export default ( { query } ) => {
 		const href = getAdminUrl( {
 			page: 'wc-admin',
 			path: '/payments/disputes',
+			filter: 'awaiting_response',
 		} );
 
 		wcpayTracks.recordEvent(
@@ -594,7 +594,7 @@ export default ( { query } ) => {
 			],
 		} );
 
-		getHistory().push( href );
+		window.location.replace( href );
 	};
 
 	const handleSaveError = ( err, submit ) => {

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -15,6 +15,7 @@ use WCPay\Logger;
 use Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore;
 use WCPay\Payment_Methods\Link_Payment_Method;
 use WCPay\Payment_Methods\CC_Payment_Method;
+use WCPay\Database_Cache;
 
 /**
  * Communicates with WooCommerce Payments API.
@@ -876,6 +877,8 @@ class WC_Payments_API_Client {
 		];
 
 		$dispute = $this->request( $request, self::DISPUTES_API . '/' . $dispute_id, self::POST );
+		// Invalidate the dispute status cache.
+		\WC_Payments::get_database_cache()->delete( Database_Cache::DISPUTE_STATUS_COUNTS_KEY );
 
 		if ( is_wp_error( $dispute ) ) {
 			return $dispute;
@@ -893,6 +896,8 @@ class WC_Payments_API_Client {
 	 */
 	public function close_dispute( $dispute_id ) {
 		$dispute = $this->request( [], self::DISPUTES_API . '/' . $dispute_id . '/close', self::POST );
+		// Invalidate the dispute status cache.
+		\WC_Payments::get_database_cache()->delete( Database_Cache::DISPUTE_STATUS_COUNTS_KEY );
 
 		if ( is_wp_error( $dispute ) ) {
 			return $dispute;


### PR DESCRIPTION
Fixes #4373 

#### Changes proposed in this Pull Request

After accepting a dispute, the user is redirected back to the disputes table. Currently, because of caching issues, the dispute the user just accepted will still appear in the list as needing a response. 
 

To resolve this issue this PR does 2 things:

1. Use a standard JS redirect after accepting the dispute. This replaces the existing `getHistory().push()` call. The `getHistory().push()` approach caused this issue because it just pushes the URL onto the stack with no page load.
2. Delete the status count cache after updating or accepting a dispute. This fixes the notifications badge in the side panel. Without this cache delete, it would wait for the webhook to be received and that will be too late. 


https://user-images.githubusercontent.com/8490476/179916571-af964cc0-e010-4457-8a3b-a3296207f90f.mov


**Note:** You'll notice this in the video and when testing - compared to the current behaviour, the interaction is a little different. After accepting the dispute the page fully reloads on the new Lost dispute screen before the redirect to the list table occurs. 

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a product using a disputed payment method (eg `4000000000000259`)
* Go to **Payments → Disputes**
* Make a mental note of the notifications badge number and the dispute order ID.
* Click on the dispute and accept it.
     * On **`develop`** - You will be redirected to the Disputes list table and the dispute you just accepted (lost) will still show as needs response.
     * On this branch, the notifications badge, and list table should no longer include the dispute you just accepted.

I had some changes to WCPay Server that I thought were necessary to improve this flow, however they don't appear to be necessary. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
