### PR TITLE
Fix an issue with sorting by customer currency on analytics > orders

### DIFF
--- a/changelog/dev-fix-analytics-sorting
+++ b/changelog/dev-fix-analytics-sorting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix an issue with sorting by customer currency in Analytics > Orders

--- a/client/multi-currency-analytics/index.js
+++ b/client/multi-currency-analytics/index.js
@@ -55,7 +55,7 @@ addFilter(
 			...tableData.headers,
 			{
 				isNumeric: false,
-				isSortable: true,
+				isSortable: false,
 				key: 'customer_currency',
 				label: __( 'Customer currency', 'woocommerce-payments' ),
 				required: false,


### PR DESCRIPTION
Fixes #4456

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

- Fix an error that occurred when trying to sort by customer currency on the Analytics > Orders page.
- For now we have disabled sorting on this column as it is unsupported, but we can look to re-introduce this in future.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `Analytics > Orders` 
* Verify you cannot sort the table of orders by Customer currency.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
