### PR TITLE
Enable the Payments → Overview task list for all merchants

### DIFF
--- a/changelog/update-4457-launch-the-payments-overview-task-list
+++ b/changelog/update-4457-launch-the-payments-overview-task-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add "Things to do" task list to the Payments Overview screen

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -58,7 +58,7 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_account_overview_task_list_enabled() {
-		return get_option( '_wcpay_feature_account_overview_task_list' );
+		return get_option( '_wcpay_feature_account_overview_task_list', '1' );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -11,10 +11,11 @@
 class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 	const FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING = [
-		'_wcpay_feature_upe'                     => 'upe',
-		'_wcpay_feature_upe_settings_preview'    => 'upeSettingsPreview',
-		'_wcpay_feature_customer_multi_currency' => 'multiCurrency',
-		'_wcpay_feature_documents'               => 'documents',
+		'_wcpay_feature_upe'                        => 'upe',
+		'_wcpay_feature_upe_settings_preview'       => 'upeSettingsPreview',
+		'_wcpay_feature_customer_multi_currency'    => 'multiCurrency',
+		'_wcpay_feature_documents'                  => 'documents',
+		'_wcpay_feature_account_overview_task_list' => 'accountOverviewTaskList',
 	];
 
 	public function set_up() {


### PR DESCRIPTION
Resolves code changes as part of #4457

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR makes the **Payments → Overview** `Things to do` task list visible to all new and existing merchants.

The default value for the `_wcpay_feature_account_overview_task_list` feature flag option is set to `'1'`. Sites that have explicitly set the option to `'0'` (e.g. using WCPay Dev Tools) will not see the task list.

Current task list items include:

* ~`update-business-details`: Update WooCommerce Payments business details.~
* ~`reconnect-wpcom-user`: WooCommerce Payments is missing a connected WordPress.com account. Some functionality will be limited without a connected account.~
* ~`force-secure-checkout`: Protect your customers data and increase trustworthiness of your store by forcing HTTPS on checkout pages.~
* `dispute-resolution-task`: *x* disputed payments needs your response.


> **Note**
> Initially, only the `dispute-resolution-task` will be visible. A separate issue ([#4471](https://github.com/Automattic/woocommerce-payments/issues/4471)) has been created to include all tasks listed above.


<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. If using WCPay Dev Tools, clear the `_wcpay_feature_account_overview_task_list` option (`/wp-admin/options.php`).
2. Ensure one or more of the task list items above will be visible.
    * Create a disputed transaction by purchasing a product using the card number `4000000000000259`.
4. Go to **Payments → Overview**.
5. The `Things to do` task list should be visible.

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/3147296/180100667-f98d2341-1cca-47a3-8732-e48949ba36f2.png">


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) Tested on Safari iOS 15.5

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
