### PR TITLE
Remove the slide in animation from the dispute task item on Payments > Overview

### DIFF
--- a/changelog/issue-4461
+++ b/changelog/issue-4461
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: This task item was hidden by a feature flag so there's no effective change by this PR
+
+

--- a/client/overview/task-list/index.js
+++ b/client/overview/task-list/index.js
@@ -175,7 +175,6 @@ const TaskList = ( { overviewTasksVisibility, tasks } ) => {
 			</CardHeader>
 			<CardBody>
 				<CollapsibleList
-					animation="slide-right"
 					collapsed={ false }
 					show={ 5 }
 					collapseLabel={ __( 'Hide tasks', 'woocommerce-payments' ) }


### PR DESCRIPTION
Fixes #4461 

#### Changes proposed in this Pull Request

This PR removes the slide in from left animation on the task items in the Payments > Overview task list.

This is the animation being referred to: 
![Screen Recording 7-20-2022 at 2 08 PM](https://user-images.githubusercontent.com/8490476/180106871-b0ff3209-6d5f-4852-805f-b46fffcac288.gif)


#### Testing instructions

* Purchase a product with a disputed payment method. (eg `4000000000000259`).
* Go to **Payments > Overview** in your admin dashboard. 
* While the page is generated, pay attention to the task list items when they animate in. 
     * On `develop` they will animate slide in from the left. 
     * On this branch, the task list grows in (vertically down) but the tasks don't animate at all. 

**After:** 
![](https://user-images.githubusercontent.com/8490476/180107697-bb8105db-b997-4d5b-b05b-0334195dde80.gif)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
