### PR TITLE
Add Multi-Currency compatibility with Points & Rewards plugin

### DIFF
--- a/changelog/add-2848-mc-points-rewards-compat
+++ b/changelog/add-2848-mc-points-rewards-compat
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Multi-Currency compatibility with Points & Rewards plugin.

--- a/includes/multi-currency/Compatibility.php
+++ b/includes/multi-currency/Compatibility.php
@@ -20,6 +20,7 @@ use WCPay\MultiCurrency\Compatibility\WooCommerceProductAddOns;
 use WCPay\MultiCurrency\Compatibility\WooCommerceSubscriptions;
 use WCPay\MultiCurrency\Compatibility\WooCommerceUPS;
 use WCPay\MultiCurrency\Compatibility\WooCommerceDeposits;
+use WCPay\MultiCurrency\Compatibility\WooCommercePointsAndRewards;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -63,6 +64,7 @@ class Compatibility extends BaseCompatibility {
 			$this->compatibility_classes[] = new WooCommerceSubscriptions( $this->multi_currency, $this->utils );
 			$this->compatibility_classes[] = new WooCommerceUPS( $this->multi_currency, $this->utils );
 			$this->compatibility_classes[] = new WooCommerceDeposits( $this->multi_currency, $this->utils );
+			$this->compatibility_classes[] = new WooCommercePointsAndRewards( $this->multi_currency, $this->utils );
 		}
 	}
 

--- a/includes/multi-currency/Compatibility/WooCommercePointsAndRewards.php
+++ b/includes/multi-currency/Compatibility/WooCommercePointsAndRewards.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class WooCommercePreOrders
+ * Class WooCommercePointsAndRewards
  *
  * @package WCPay\MultiCurrency\Compatibility
  */
@@ -65,7 +65,7 @@ class WooCommercePointsAndRewards extends BaseCompatibility {
 		$value  = (float) ( $ratio[1] ?? 0 );
 
 		$rate  = $this->selected_currency->get_rate();
-		$value = (float) $value * $rate;
+		$value = $value * $rate;
 
 		return "$points:$value";
 	}

--- a/includes/multi-currency/Compatibility/WooCommercePointsAndRewards.php
+++ b/includes/multi-currency/Compatibility/WooCommercePointsAndRewards.php
@@ -7,10 +7,26 @@
 
 namespace WCPay\MultiCurrency\Compatibility;
 
+use WCPay\MultiCurrency\Currency;
+
 /**
  * Class that controls Multi Currency Compatibility with WooCommerce Points & Rewards Plugin.
  */
 class WooCommercePointsAndRewards extends BaseCompatibility {
+
+	/**
+	 * Default Currency Code.
+	 *
+	 * @var string
+	 */
+	private $default_currency_code;
+
+	/**
+	 * Selected Currency Code.
+	 *
+	 * @var Currency
+	 */
+	private $selected_currency;
 
 	/**
 	 * Init the class.
@@ -20,14 +36,6 @@ class WooCommercePointsAndRewards extends BaseCompatibility {
 	protected function init() {
 		// Add needed filters if Points & Rewards is active and it's not an admin request.
 		if ( is_admin() || ! class_exists( 'WC_Points_Rewards' ) ) {
-			return;
-		}
-
-		$default_currency  = $this->multi_currency->get_default_currency();
-		$selected_currency = $this->multi_currency->get_selected_currency();
-
-		// Skip it if selected currency and default store currency match.
-		if ( $default_currency->code === $selected_currency->code ) {
 			return;
 		}
 
@@ -42,6 +50,11 @@ class WooCommercePointsAndRewards extends BaseCompatibility {
 	 * @return string Converted points ratio.
 	 */
 	public function convert_points_ratio( string $ratio = '' ): string {
+		// Skip conversion if selected and default currencies are the same.
+		if ( $this->selected_and_default_currency_match() ) {
+			return $ratio;
+		}
+
 		// Skip conversion on discount to avoid doing it twice.
 		if ( $this->utils->is_call_in_backtrace( [ 'WC_Points_Rewards_Discount->get_discount_data' ] ) ) {
 			return $ratio;
@@ -51,9 +64,25 @@ class WooCommercePointsAndRewards extends BaseCompatibility {
 		$points = (float) ( $ratio[0] ?? 0 );
 		$value  = (float) ( $ratio[1] ?? 0 );
 
-		$selected_currency = $this->multi_currency->get_selected_currency();
-		$value             = (float) $value * $selected_currency->get_rate();
+		$rate  = $this->selected_currency->get_rate();
+		$value = (float) $value * $rate;
 
 		return "$points:$value";
+	}
+
+	/**
+	 * Whether the selected and default currency are the same.
+	 *
+	 * @return boolean
+	 */
+	private function selected_and_default_currency_match(): bool {
+		if ( empty( $this->default_currency_code ) ) {
+			$this->default_currency_code = $this->multi_currency->get_default_currency()->get_code();
+		}
+		if ( empty( $this->selected_currency ) ) {
+			$this->selected_currency = $this->multi_currency->get_selected_currency();
+		}
+
+		return $this->default_currency_code === $this->selected_currency->get_code();
 	}
 }

--- a/includes/multi-currency/Compatibility/WooCommercePointsAndRewards.php
+++ b/includes/multi-currency/Compatibility/WooCommercePointsAndRewards.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Class WooCommercePreOrders
+ *
+ * @package WCPay\MultiCurrency\Compatibility
+ */
+
+namespace WCPay\MultiCurrency\Compatibility;
+
+/**
+ * Class that controls Multi Currency Compatibility with WooCommerce Points & Rewards Plugin.
+ */
+class WooCommercePointsAndRewards extends BaseCompatibility {
+
+	/**
+	 * Init the class.
+	 *
+	 * @return  void
+	 */
+	protected function init() {
+		// Add needed filters if Points & Rewards is active and it's not an admin request.
+		if ( is_admin() || ! class_exists( 'WC_Points_Rewards' ) ) {
+			return;
+		}
+
+		$default_currency  = $this->multi_currency->get_default_currency();
+		$selected_currency = $this->multi_currency->get_selected_currency();
+
+		// Skip it if selected currency and default store currency match.
+		if ( $default_currency->code === $selected_currency->code ) {
+			return;
+		}
+
+		add_filter( 'option_wc_points_rewards_earn_points_ratio', [ $this, 'convert_points_ratio' ], 50 );
+		add_filter( 'option_wc_points_rewards_redeem_points_ratio', [ $this, 'convert_points_ratio' ], 50 );
+	}
+
+	/**
+	 * Converts points ratio applying selected currency rate to the monetary value.
+	 *
+	 * @param string $ratio Store currency points ratio.
+	 * @return string Converted points ratio.
+	 */
+	public function convert_points_ratio( string $ratio = '' ): string {
+		// Skip conversion on discount to avoid doing it twice.
+		if ( $this->utils->is_call_in_backtrace( [ 'WC_Points_Rewards_Discount->get_discount_data' ] ) ) {
+			return $ratio;
+		}
+
+		$ratio  = explode( ':', $ratio );
+		$points = (float) ( $ratio[0] ?? 0 );
+		$value  = (float) ( $ratio[1] ?? 0 );
+
+		$selected_currency = $this->multi_currency->get_selected_currency();
+		$value             = (float) $value * $selected_currency->get_rate();
+
+		return "$points:$value";
+	}
+}

--- a/tests/unit/helpers/class-wc-helper-points-and-rewards.php
+++ b/tests/unit/helpers/class-wc-helper-points-and-rewards.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Points & Rewards helpers.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * Class WC_Points_Rewards.
+ *
+ * This helper class should ONLY be used for unit tests!.
+ */
+class WC_Points_Rewards {
+
+}

--- a/tests/unit/multi-currency/compatibility/test-class-woocommerce-points-and-rewards.php
+++ b/tests/unit/multi-currency/compatibility/test-class-woocommerce-points-and-rewards.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Class WCPay_Multi_Currency_WooCommercePointsAndRewards_Tests
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\MultiCurrency\Compatibility\WooCommercePointsAndRewards;
+use WCPay\MultiCurrency\MultiCurrency;
+use WCPay\MultiCurrency\Utils;
+use WCPay\MultiCurrency\Currency;
+
+/**
+ * WCPay\MultiCurrency\Compatibility\WooCommercePointsAndRewards unit tests.
+ */
+class WCPay_Multi_Currency_WooCommercePointsAndRewards_Tests extends WCPAY_UnitTestCase {
+
+	/**
+	 * Mock WCPay\MultiCurrency\MultiCurrency.
+	 *
+	 * @var WCPay\MultiCurrency\MultiCurrency|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_multi_currency;
+
+	/**
+	 * Mock WCPay\MultiCurrency\Utils.
+	 *
+	 * @var WCPay\MultiCurrency\Utils|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_utils;
+
+	/**
+	 * WCPay\MultiCurrency\Compatibility\WooCommercePointsAndRewards instance.
+	 *
+	 * @var WCPay\MultiCurrency\Compatibility\WooCommercePointsAndRewards
+	 */
+	private $wc_points_rewards;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->mock_multi_currency = $this->createMock( MultiCurrency::class );
+		$this->mock_utils          = $this->createMock( Utils::class );
+
+		$this->wc_points_rewards = new WooCommercePointsAndRewards( $this->mock_multi_currency, $this->mock_utils );
+	}
+
+	/**
+	 * @dataProvider filters_provider
+	 */
+	public function test_registers_woocommerce_filters_properly( $filter, $function_name ) {
+		$this->mock_multi_currency
+			->expects( $this->once() )
+			->method( 'get_selected_currency' )
+			->willReturn( new Currency( 'EUR' ) );
+		$this->wc_points_rewards = new WooCommercePointsAndRewards( $this->mock_multi_currency, $this->mock_utils );
+
+		$priority = has_filter( $filter, [ $this->wc_points_rewards, $function_name ] );
+		$this->assertGreaterThan(
+			10,
+			$priority,
+			"Filter '$filter' was not registered with '$function_name' with a priority higher than the default."
+		);
+	}
+
+	public function filters_provider() {
+		return [
+			[ 'option_wc_points_rewards_earn_points_ratio', 'convert_points_ratio' ],
+			[ 'option_wc_points_rewards_redeem_points_ratio', 'convert_points_ratio' ],
+		];
+	}
+
+	/**
+	 * @dataProvider points_ratio_provider
+	 */
+	public function test_convert_points_ratio( $backtrace, $rate, $ratio, $converted_ratio ) {
+		$this->mock_utils
+			->expects( $this->once() )
+			->method( 'is_call_in_backtrace' )
+			->willReturnCallback(
+				function ( $with ) use ( $backtrace ) {
+					return $with === $backtrace;
+				}
+			);
+
+		$this->mock_multi_currency
+			->expects( $backtrace ? $this->never() : $this->once() )
+			->method( 'get_selected_currency' )
+			->willReturn( new Currency( 'EUR', $rate ) );
+
+		$this->assertEquals( $converted_ratio, $this->wc_points_rewards->convert_points_ratio( $ratio ) );
+	}
+
+	public function points_ratio_provider() {
+		return [
+			[ [ 'WC_Points_Rewards_Discount->get_discount_data' ], 0, '1:1', '1:1' ],
+			[ null, 0, '', '0:0' ],
+			[ null, 0, '1', '1:0' ],
+			[ null, 0.5, '1:1', '1:0.5' ],
+			[ null, 2, '1:1.23', '1:2.46' ],
+			[ null, 20, '1:10', '1:200' ],
+		];
+	}
+
+}


### PR DESCRIPTION
Fixes #2848 

#### Changes proposed in this Pull Request
- Hook into earn and redeem points ratios and adjust them by currency rate to ensure it matches the store currency.
- Skip conversion on `WC_Points_Rewards_Discount->get_discount_data` to avoid making it twice, as we're already doing it for coupons in MC.
- As we might have rounding and/or charming enabled for a currency. The reward calculation could be higher after conversion and this is expected. The customer will receive points based on store currency after formatting rules are applied. E.g. with `1:1` earn ratio and EUR rate of `1` plus rounding of `10`.
  - `$15 USD` will be `15 points`
  - `€20 EUR` will be `20 points`

I've initially thought of applying filters to prices, but Points & Rewards doesn't have enough filters to do it right. And using points ratio looks like a cleaner solution which also simplifies double conversion issues.

#### Testing instructions
You'll need [WooCommerce Points and Rewards](https://woocommerce.com/products/woocommerce-points-and-rewards/) plugin.

**WooCommerce**
- **Settings**
  - **General**
    - **Currency**: `United States (US) dollar $`
    - **Number of decimals**: `2`
  - **Multi-currency**
    - **Euro** (€ EUR) 
      - **Exchange rate**: `Manual`
      - **Manual rate**: `0.91`
      - **Price rounding**: `1.00 (recommended)`
      - **Charm pricing**: `none`
    - **Icelandic króna** (kr. ISK)
      - **Exchange rate**: `Manual`
      - **Manual rate**: `133.16
      - **Price rounding**: `1.00 (recommended)`
      - **Charm pricing**: `none`
  - **Points & Rewards**
    - **Earn Points Conversion Rate**: `1`  **Points  =  $**: `1`
    - **Earn Points Rounding Mode**: `Round to nearest integer`
    - **Redemption Conversion Rate**: `10`  **Points  =  $**: `1`

**Store**
- Add a `$99 USD` product to cart and go there.
- The `Complete your order and earn X Points...` message should match:
  - **USD**: `99`
  - **EUR**:  `100`
  - **ISK**: `99`
- Place an order to obtain 99 points.
- Add any product to cart and go there.
- The `Use X Points for a Y discount...` message should match:
  - **USD**: `99 Points for a $9.90`
  - **EUR**: `100 Points for a 9,01 €` Yes, it shows more points, but It's something from the plugin rounding behavior. Not related with the compatibility.
  - **ISK**: `99 Points for a 1.318 kr.`
- Set up`Points earned` in a product
  - For a value of `20` it should reward with `20 points` no matter which currency is selected.
  - For a value of `100%` or `50%` the reward should match the converted numbers mentioned previously.
- Being in the cart press `Apply Discount`
- `Points redemption` in cart totals should match the previously shown discount.
- Remove it, and apply again but in the checkout page.
- Should be applied correctly too.

**REST API**
- Install `WooCommerce Blocks` plugin if you don't have it already.
- Get a key from **WooCommerce > Settings > Advanced > REST API**
- Make a GET request to `https://wcpay.test/wp-json/wc/store/v1/cart?consumer_key=ck_123&consumer_secret=cs_123` using your key
- Look for `extensions['points-and-rewards']`
- The values should be converted like in the store.

#### Screenshots

| USD | EUR | ISK |
| - | - | - |
|<img width="803" alt="Screenshot 2022-07-21 at 12 52 33" src="https://user-images.githubusercontent.com/7670276/180197308-00d11835-d5ae-46be-aa86-4c6a3589cb4a.png">|<img width="806" alt="Screenshot 2022-07-21 at 12 52 53" src="https://user-images.githubusercontent.com/7670276/180197310-0e50c809-c3d2-4daa-b15c-74abe84d7459.png">|<img width="803" alt="Screenshot 2022-07-21 at 12 53 04" src="https://user-images.githubusercontent.com/7670276/180197314-55b02660-69e7-4591-b974-27a045dc5cbf.png">|

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
