### PR TITLE
Update transaction details link to use Payment Intent ID instead of Charge ID

### DIFF
--- a/changelog/update-3122-links
+++ b/changelog/update-3122-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update transaction details link to use Payment Intent ID instead of Charge ID

--- a/client/data/transactions/hooks.ts
+++ b/client/data/transactions/hooks.ts
@@ -44,6 +44,7 @@ export interface Transaction {
 		interval_from: string;
 		interval_to: string;
 	};
+	payment_intent_id?: string;
 }
 
 interface Transactions {

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -211,7 +211,10 @@ export const TransactionsList = (
 	const totalRows = transactionsSummary.count || 0;
 	const rows = transactions.map( ( txn ) => {
 		const detailsURL =
-			getDetailsURL( txn.charge_id, 'transactions' ) +
+			getDetailsURL(
+				txn.payment_intent_id || txn.charge_id,
+				'transactions'
+			) +
 			'&transaction_id=' +
 			txn.transaction_id +
 			'&transaction_type=' +

--- a/client/transactions/list/test/__snapshots__/index.tsx.snap
+++ b/client/transactions/list/test/__snapshots__/index.tsx.snap
@@ -485,7 +485,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     Jan 2, 2020 / 12:46PM
@@ -497,7 +497,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     Refund
@@ -509,7 +509,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     $10.00
@@ -521,7 +521,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     $-0.50
@@ -533,7 +533,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     $9.50
@@ -555,7 +555,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     <span
@@ -585,7 +585,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     Jan 4, 2020 / 11:22PM
@@ -597,7 +597,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     Charge
@@ -609,7 +609,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     <div
@@ -643,7 +643,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     $-0.50
@@ -655,7 +655,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     $14.50
@@ -677,7 +677,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     <span
@@ -1193,7 +1193,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     Jan 2, 2020 / 12:46PM
@@ -1205,7 +1205,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     Refund
@@ -1217,7 +1217,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     $10.00
@@ -1229,7 +1229,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     $-0.50
@@ -1241,7 +1241,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     $9.50
@@ -1263,7 +1263,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     <span
@@ -1293,7 +1293,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     Jan 4, 2020 / 11:22PM
@@ -1305,7 +1305,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     Charge
@@ -1317,7 +1317,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     <div
@@ -1351,7 +1351,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     $-0.50
@@ -1363,7 +1363,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     $14.50
@@ -1385,7 +1385,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     <span
@@ -1883,7 +1883,7 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     Jan 4, 2020 / 11:22PM
@@ -1895,7 +1895,7 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     Charge
@@ -1907,7 +1907,7 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     <div
@@ -1941,7 +1941,7 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     $-0.50
@@ -1953,7 +1953,7 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     $14.50
@@ -1975,7 +1975,7 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     <span
@@ -2537,7 +2537,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     Jan 2, 2020 / 12:46PM
@@ -2549,7 +2549,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     Refund
@@ -2561,7 +2561,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     $10.00
@@ -2573,7 +2573,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     $-0.50
@@ -2585,7 +2585,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     $9.50
@@ -2617,7 +2617,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     <span
@@ -2647,7 +2647,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     Jan 4, 2020 / 11:22PM
@@ -2659,7 +2659,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     Charge
@@ -2671,7 +2671,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     <div
@@ -2705,7 +2705,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     $-0.50
@@ -2717,7 +2717,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     $14.50
@@ -2742,7 +2742,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     <span
@@ -3300,7 +3300,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     Jan 2, 2020 / 12:46PM
@@ -3312,7 +3312,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     Refund
@@ -3324,7 +3324,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     $10.00
@@ -3336,7 +3336,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     $-0.50
@@ -3348,7 +3348,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     $9.50
@@ -3370,7 +3370,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     <span
@@ -3400,7 +3400,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     Jan 4, 2020 / 11:22PM
@@ -3412,7 +3412,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     Charge
@@ -3424,7 +3424,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     <div
@@ -3458,7 +3458,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     $-0.50
@@ -3470,7 +3470,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     $14.50
@@ -3492,7 +3492,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     <span
@@ -4050,7 +4050,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     Jan 2, 2020 / 12:46PM
@@ -4062,7 +4062,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     Refund
@@ -4074,7 +4074,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     $10.00
@@ -4086,7 +4086,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     $-0.50
@@ -4098,7 +4098,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     $9.50
@@ -4120,7 +4120,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j23w39dsajda&transaction_id=txn_j23jda9JJa&transaction_type=refund"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_j23jda9JJa&transaction_type=refund"
                     tabindex="-1"
                   >
                     <span
@@ -4150,7 +4150,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     Jan 4, 2020 / 11:22PM
@@ -4162,7 +4162,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     Charge
@@ -4174,7 +4174,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     <div
@@ -4208,7 +4208,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     $-0.50
@@ -4220,7 +4220,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     $14.50
@@ -4242,7 +4242,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                   <a
                     class="woocommerce-table__clickable-cell"
                     data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=ch_j239jda&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_mock&transaction_id=txn_oa9kaKaa8&transaction_type=charge"
                     tabindex="-1"
                   >
                     <span

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -112,6 +112,7 @@ const getMockTransactions: () => Transaction[] = () => [
 		risk_level: 0,
 		deposit_id: undefined,
 		loan_id: undefined,
+		payment_intent_id: 'pi_mock',
 	},
 	{
 		transaction_id: 'txn_oa9kaKaa8',
@@ -138,6 +139,7 @@ const getMockTransactions: () => Transaction[] = () => [
 		risk_level: 2,
 		deposit_id: 'po_mock',
 		loan_id: 'flxln_mock',
+		payment_intent_id: 'pi_mock',
 	},
 ];
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2693,33 +2693,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return string
 	 */
 	public function get_transaction_url( $order ) {
-		$charge_id         = $order->get_meta( '_charge_id', true );
-		$payment_intent_id = $order->get_meta( '_intent_id', true );
+		$intent_id = $order->get_meta( '_intent_id', true );
+		$charge_id = $order->get_meta( '_charge_id', true );
 
-		$id = ! empty( $payment_intent_id ) ? $payment_intent_id : $charge_id;
-
-		return $this->compose_transaction_url( $id );
-	}
-
-	/**
-	 * Composes url for transaction details page.
-	 *
-	 * @param  string $id Payment intent id or charge id.
-	 * @return string     Transaction details page url.
-	 */
-	protected function compose_transaction_url( $id ) {
-		if ( empty( $id ) ) {
-			return '';
-		}
-
-		return add_query_arg(
-			[
-				'page' => 'wc-admin',
-				'path' => '/payments/transactions/details',
-				'id'   => $id,
-			],
-			admin_url( 'admin.php' )
-		);
+		return WC_Payments_Utils::compose_transaction_url( $intent_id, $charge_id );
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2693,18 +2693,22 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return string
 	 */
 	public function get_transaction_url( $order ) {
-		$charge_id = $order->get_meta( '_charge_id' );
-		return $this->compose_transaction_url( $charge_id );
+		$charge_id         = $order->get_meta( '_charge_id', true );
+		$payment_intent_id = $order->get_meta( '_intent_id', true );
+
+		$id = ! empty( $payment_intent_id ) ? $payment_intent_id : $charge_id;
+
+		return $this->compose_transaction_url( $id );
 	}
 
 	/**
 	 * Composes url for transaction details page.
 	 *
-	 * @param  string $charge_id Charge id.
-	 * @return string            Transaction details page url.
+	 * @param  string $id Payment intent id or charge id.
+	 * @return string     Transaction details page url.
 	 */
-	protected function compose_transaction_url( $charge_id ) {
-		if ( empty( $charge_id ) ) {
+	protected function compose_transaction_url( $id ) {
+		if ( empty( $id ) ) {
 			return '';
 		}
 
@@ -2712,7 +2716,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			[
 				'page' => 'wc-admin',
 				'path' => '/payments/transactions/details',
-				'id'   => $charge_id,
+				'id'   => $id,
 			],
 			admin_url( 'admin.php' )
 		);

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -58,7 +58,7 @@ class WC_Payments_Order_Service {
 			return;
 		}
 
-		$note = $this->generate_payment_success_note( $charge_id, $this->get_order_amount( $order ) );
+		$note = $this->generate_payment_success_note( $intent_id, $charge_id, $this->get_order_amount( $order ) );
 
 		if ( $this->order_note_exists( $order, $note ) ) {
 			return;
@@ -380,13 +380,14 @@ class WC_Payments_Order_Service {
 	/**
 	 * Get content for the success order note.
 	 *
+	 * @param string $intent_id        The payment intent ID related to the intent/order.
 	 * @param string $charge_id        The charge ID related to the intent/order.
 	 * @param string $formatted_amount The formatted order total.
 	 *
 	 * @return string Note content.
 	 */
-	private function generate_payment_success_note( $charge_id, $formatted_amount ) {
-		$transaction_url = $this->compose_transaction_url( $charge_id );
+	private function generate_payment_success_note( $intent_id, $charge_id, $formatted_amount ) {
+		$transaction_url = WC_Payments_Utils::compose_transaction_url( $intent_id, $charge_id );
 
 		return sprintf(
 			WC_Payments_Utils::esc_interpolated_html(
@@ -398,7 +399,7 @@ class WC_Payments_Order_Service {
 				]
 			),
 			$formatted_amount,
-			$charge_id
+			WC_Payments_Utils::get_transaction_url_id( $intent_id, $charge_id )
 		);
 	}
 
@@ -413,7 +414,7 @@ class WC_Payments_Order_Service {
 	 * @return string Note content.
 	 */
 	private function generate_payment_failure_note( $intent_id, $charge_id, $message, $formatted_amount ) {
-		$transaction_url = $this->compose_transaction_url( $charge_id );
+		$transaction_url = WC_Payments_Utils::compose_transaction_url( $intent_id, $charge_id );
 		$note            = sprintf(
 			WC_Payments_Utils::esc_interpolated_html(
 				/* translators: %1: the authorized amount, %2: transaction ID of the payment */
@@ -424,7 +425,7 @@ class WC_Payments_Order_Service {
 				]
 			),
 			$formatted_amount,
-			$intent_id
+			WC_Payments_Utils::get_transaction_url_id( $intent_id, $charge_id )
 		);
 
 		if ( ! empty( $message ) ) {
@@ -444,7 +445,7 @@ class WC_Payments_Order_Service {
 	 * @return void
 	 */
 	private function add_payment_authorized_note( $order, $intent_id, $charge_id ) {
-		$transaction_url = $this->compose_transaction_url( $charge_id );
+		$transaction_url = WC_Payments_Utils::compose_transaction_url( $intent_id, $charge_id );
 		$note            = sprintf(
 			WC_Payments_Utils::esc_interpolated_html(
 				/* translators: %1: the authorized amount, %2: transaction ID of the payment */
@@ -455,7 +456,7 @@ class WC_Payments_Order_Service {
 				]
 			),
 			$this->get_order_amount( $order ),
-			$intent_id
+			WC_Payments_Utils::get_transaction_url_id( $intent_id, $charge_id )
 		);
 
 		$order->add_order_note( $note );
@@ -497,7 +498,7 @@ class WC_Payments_Order_Service {
 	 * @return void
 	 */
 	private function add_capture_success_note( $order, $intent_id, $charge_id ) {
-		$transaction_url = $this->compose_transaction_url( $charge_id );
+		$transaction_url = WC_Payments_Utils::compose_transaction_url( $intent_id, $charge_id );
 		$note            = sprintf(
 			WC_Payments_Utils::esc_interpolated_html(
 				/* translators: %1: the successfully charged amount, %2: transaction ID of the payment */
@@ -508,7 +509,7 @@ class WC_Payments_Order_Service {
 				]
 			),
 			$this->get_order_amount( $order ),
-			$charge_id
+			WC_Payments_Utils::get_transaction_url_id( $intent_id, $charge_id )
 		);
 
 		$order->add_order_note( $note );
@@ -525,7 +526,7 @@ class WC_Payments_Order_Service {
 	 * @return void
 	 */
 	private function add_capture_failed_note( $order, $intent_id, $charge_id, $message ) {
-		$transaction_url = $this->compose_transaction_url( $charge_id );
+		$transaction_url = WC_Payments_Utils::compose_transaction_url( $intent_id, $charge_id );
 		$note            = sprintf(
 			WC_Payments_Utils::esc_interpolated_html(
 				/* translators: %1: the authorized amount, %2: transaction ID of the payment */
@@ -536,7 +537,7 @@ class WC_Payments_Order_Service {
 				]
 			),
 			$this->get_order_amount( $order ),
-			$intent_id
+			WC_Payments_Utils::get_transaction_url_id( $intent_id, $charge_id )
 		);
 
 		if ( ! empty( $message ) ) {
@@ -555,7 +556,7 @@ class WC_Payments_Order_Service {
 	 * @return string Note content.
 	 */
 	private function generate_capture_expired_note( $intent_id, $charge_id ) {
-		$transaction_url = $this->compose_transaction_url( $charge_id );
+		$transaction_url = WC_Payments_Utils::compose_transaction_url( $intent_id, $charge_id );
 
 		return sprintf(
 			WC_Payments_Utils::esc_interpolated_html(
@@ -566,7 +567,7 @@ class WC_Payments_Order_Service {
 					'a'      => ! empty( $transaction_url ) ? '<a href="' . $transaction_url . '" target="_blank" rel="noopener noreferrer">' : '<code>',
 				]
 			),
-			$intent_id
+			WC_Payments_Utils::get_transaction_url_id( $intent_id, $charge_id )
 		);
 
 	}
@@ -629,28 +630,6 @@ class WC_Payments_Order_Service {
 				]
 			),
 			$status
-		);
-	}
-
-	/**
-	 * Composes url for transaction details page.
-	 *
-	 * @param string $charge_id Charge id.
-	 *
-	 * @return string Transaction details page url.
-	 */
-	private function compose_transaction_url( $charge_id ) {
-		if ( empty( $charge_id ) ) {
-			return '';
-		}
-
-		return add_query_arg(
-			[
-				'page' => 'wc-admin',
-				'path' => '/payments/transactions/details',
-				'id'   => $charge_id,
-			],
-			admin_url( 'admin.php' )
 		);
 	}
 

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -600,13 +600,28 @@ class WC_Payments_Utils {
 	}
 
 	/**
+	 * Returns the correct id to be used on the transaction URL
+	 * The Payment Intent ID is prioritized and it fallbacks to the charge ID
+	 *
+	 * @param string $intent_id Payment intent ID.
+	 * @param string $charge_id Charge ID.
+	 *
+	 * @return string
+	 */
+	public static function get_transaction_url_id( $intent_id, $charge_id ) {
+		return ! empty( $intent_id ) ? $intent_id : $charge_id;
+	}
+
+	/**
 	 * Composes url for transaction details page.
 	 *
-	 * @param  string $charge_id Charge id.
-	 * @return string            Transaction details page url.
+	 * @param string $intent_id Payment Intent ID.
+	 * @param string $charge_id Charge ID.
+	 *
+	 * @return string Transaction details page url.
 	 */
-	public static function compose_transaction_url( $charge_id ) {
-		if ( empty( $charge_id ) ) {
+	public static function compose_transaction_url( $intent_id, $charge_id ) {
+		if ( empty( $charge_id ) && empty( $intent_id ) ) {
 			return '';
 		}
 
@@ -614,7 +629,7 @@ class WC_Payments_Utils {
 			[
 				'page' => 'wc-admin',
 				'path' => '/payments/transactions/details',
-				'id'   => $charge_id,
+				'id'   => self::get_transaction_url_id( $intent_id, $charge_id ),
 			],
 			admin_url( 'admin.php' )
 		);

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -678,7 +678,9 @@ class WC_Payments_API_Client {
 			foreach ( $transactions['data'] as &$transaction ) {
 				foreach ( $orders_with_charge_ids as $order_with_charge_id ) {
 					if ( $order_with_charge_id['charge_id'] === $transaction['charge_id'] && ! empty( $transaction['charge_id'] ) ) {
-						$transaction['order'] = $this->build_order_info( $order_with_charge_id['order'] );
+						$order                            = $order_with_charge_id['order'];
+						$transaction['order']             = $this->build_order_info( $order );
+						$transaction['payment_intent_id'] = $order->get_meta( '_intent_id' );
 					}
 				}
 			}

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -130,7 +130,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
 		$this->assertStringContainsString( 'Pending payment to Processing', $notes[1]->content );
 		$this->assertStringContainsString( 'successfully charged</strong> using WooCommerce Payments', $notes[0]->content );
-		$this->assertStringContainsString( '/payments/transactions/details&id=py_123" target="_blank" rel="noopener noreferrer">py_123', $notes[0]->content );
+		$this->assertStringContainsString( '/payments/transactions/details&id=pi_123" target="_blank" rel="noopener noreferrer">pi_123', $notes[0]->content );
 
 		// Assert: Check that the order was unlocked.
 		$this->assertFalse( get_transient( 'wcpay_processing_intent_' . $this->order->get_id() ) );
@@ -162,7 +162,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
 		$this->assertStringContainsString( 'Pending payment to Failed', $notes[1]->content );
 		$this->assertStringContainsString( 'failed</strong> using WooCommerce Payments', $notes[0]->content );
-		$this->assertStringContainsString( '/payments/transactions/details&id=py_123" target="_blank" rel="noopener noreferrer">pi_123', $notes[0]->content );
+		$this->assertStringContainsString( '/payments/transactions/details&id=pi_123" target="_blank" rel="noopener noreferrer">pi_123', $notes[0]->content );
 		$this->assertStringContainsString( 'This is the test failed message.', $notes[0]->content );
 
 		// Assert: Check that the order was unlocked.
@@ -235,7 +235,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
 		$this->assertStringContainsString( 'Pending payment to On hold', $notes[1]->content );
 		$this->assertStringContainsString( 'authorized</strong> using WooCommerce Payments', $notes[0]->content );
-		$this->assertStringContainsString( '/payments/transactions/details&id=py_123" target="_blank" rel="noopener noreferrer">pi_123', $notes[0]->content );
+		$this->assertStringContainsString( '/payments/transactions/details&id=pi_123" target="_blank" rel="noopener noreferrer">pi_123', $notes[0]->content );
 
 		// Assert: Check that the order was unlocked.
 		$this->assertFalse( get_transient( 'wcpay_processing_intent_' . $this->order->get_id() ) );
@@ -328,7 +328,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
 		$this->assertStringContainsString( 'Pending payment to Processing', $notes[1]->content );
 		$this->assertStringContainsString( 'successfully captured</strong> using WooCommerce Payments', $notes[0]->content );
-		$this->assertStringContainsString( '/payments/transactions/details&id=py_123" target="_blank" rel="noopener noreferrer">py_123', $notes[0]->content );
+		$this->assertStringContainsString( '/payments/transactions/details&id=pi_123" target="_blank" rel="noopener noreferrer">pi_123', $notes[0]->content );
 
 		// Assert: Check that the order was unlocked.
 		$this->assertFalse( get_transient( 'wcpay_processing_intent_' . $this->order->get_id() ) );
@@ -353,7 +353,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		// Assert: Check that the notes were updated.
 		$notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
 		$this->assertStringContainsString( 'failed</strong> to complete using WooCommerce Payments', $notes[0]->content );
-		$this->assertStringContainsString( '/payments/transactions/details&id=py_123" target="_blank" rel="noopener noreferrer">pi_123', $notes[0]->content );
+		$this->assertStringContainsString( '/payments/transactions/details&id=pi_123" target="_blank" rel="noopener noreferrer">pi_123', $notes[0]->content );
 
 		// Assert: Check that the order was unlocked.
 		$this->assertFalse( get_transient( 'wcpay_processing_intent_' . $this->order->get_id() ) );
@@ -378,7 +378,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		// Assert: Check that the notes were updated.
 		$notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
 		$this->assertStringContainsString( 'failed</strong> to complete using WooCommerce Payments', $notes[0]->content );
-		$this->assertStringContainsString( '/payments/transactions/details&id=py_123" target="_blank" rel="noopener noreferrer">pi_123', $notes[0]->content );
+		$this->assertStringContainsString( '/payments/transactions/details&id=pi_123" target="_blank" rel="noopener noreferrer">pi_123', $notes[0]->content );
 
 		// Assert: Check that the order was unlocked.
 		$this->assertFalse( get_transient( 'wcpay_processing_intent_' . $this->order->get_id() ) );
@@ -405,7 +405,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
 		$this->assertStringContainsString( 'Pending payment to Cancelled', $notes[1]->content );
 		$this->assertStringContainsString( 'Payment authorization has <strong>expired</strong>', $notes[0]->content );
-		$this->assertStringContainsString( '/payments/transactions/details&id=py_123" target="_blank" rel="noopener noreferrer">pi_123', $notes[0]->content );
+		$this->assertStringContainsString( '/payments/transactions/details&id=pi_123" target="_blank" rel="noopener noreferrer">pi_123', $notes[0]->content );
 
 		// Assert: Check that the order was unlocked.
 		$this->assertFalse( get_transient( 'wcpay_processing_intent_' . $this->order->get_id() ) );


### PR DESCRIPTION
Fixes #3122

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
Update transaction details link to use Payment Intent ID instead of Charge ID

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR updates the links that lead to the transaction details page in order to use primarily the Payment Intent ID instead of the Charge ID. This change aims to prevent an unnecessary redirect on the transaction details page.

Pages affected:
- Transactions list
- Order details
  - Link on "Order details" box
  - Link on "Order notes" box

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Perform an order on your test shop
- **Transactions List**
  - Open **Payments > Transactions**
  - Click on the transaction that you have just made
  - It should have an `pi_` identifier on the URL and load the transaction details without a redirect
- **Order details**
  - Open **WooCommerce > Orders**
  - Open on the order that you have just made
  - **Order details box (1)**
    - Click on the Payment Intent id link
    - It should have an `pi_` identifier on the URL and load the transaction details without a redirect
  - **Order notes box (2)** 
    - Click on the Payment Intent id link 
    - It should have a `pi_` identifier on the URL and load the transaction details without a redirect

![image](https://user-images.githubusercontent.com/16882226/180241245-f3b8f5a2-0066-4513-a33b-bc17d21f1c2e.png)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
