### PR TITLE
Handle creating an intention when there's a  WooPay subscription

### DIFF
--- a/changelog/add-handle-woopay-subscription-payment
+++ b/changelog/add-handle-woopay-subscription-payment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Pass a parameter when creating an intention when the request comes from the platform checkout and it has a subscription

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1185,6 +1185,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$additional_api_parameters['is_platform_payment_method'] = 'true';
 			}
 
+			// This meta is only set by WooPay.
+			// We want to handle the intention creation differently when there are subscriptions.
+			// We're using simple products on WooPay so the current logic for WCPay subscriptions won't work there.
+			if ( '1' === $order->get_meta( 'has_woopay_subscription' ) ) {
+				$additional_api_parameters['has_woopay_subscription'] = 'true';
+			}
+
 			// The sanitize_user call here is deliberate: it seems the most appropriate sanitization function
 			// for a string that will only contain latin alphanumeric characters and underscores.
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1188,8 +1188,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			// This meta is only set by WooPay.
 			// We want to handle the intention creation differently when there are subscriptions.
 			// We're using simple products on WooPay so the current logic for WCPay subscriptions won't work there.
-			if ( '1' === $order->get_meta( 'has_woopay_subscription' ) ) {
-				$additional_api_parameters['has_woopay_subscription'] = 'true';
+			if ( '1' === $order->get_meta( '_woopay_has_subscription' ) ) {
+				$additional_api_parameters['woopay_has_subscription'] = 'true';
 			}
 
 			// The sanitize_user call here is deliberate: it seems the most appropriate sanitization function


### PR DESCRIPTION
Part of the fix for issue 1166 in the platform checkout.

#### Changes proposed in this Pull Request

When the order has a specific meta, pass a parameter to the request to the server for processing the payment.

This specific meta we're checking for is set by the platform checkout when the order contains a subscription. The parameter we pass to the API request informs of this, so the created payment intent can be used for renewals.

#### Testing instructions

Full testing instructions are on the PR # 1166 in the platform checkout.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.