### PR TITLE
Remove mountUPEElement() because we are creating one for each payment…

### DIFF
--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -422,7 +422,6 @@ jQuery( function ( $ ) {
 					useSetUpIntent
 				);
 			}
-			mountUPEElement( useSetUpIntent );
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/4395

### Description 

We are mounting UPE element for each payment method type (giropay, sepa, etc). The `mountUPEElement( useSetUpIntent );` code returns an error because `useSetUpIntent` is passed in as `paymentMethodType` in the new parameter signature for `mountUPEElement(paymentMethodType, upeDOMElement, isSetupIntent = false)`. 

I don't think we need this line anymore because we are already mounting a UPE element for each of the payment types.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
1.  Checkout an item and then update the order status to "Pending payment". This allows us to click on the "Customer payment page" link. 
![image](https://user-images.githubusercontent.com/572862/180329343-c0ef616d-d7aa-49e9-a74c-e6f4ccb83ddd.png)
2. Click the "Customer payment page" link to open the "Pay for order" page. 
3. You should see the multiple checkout elements without the `Uncaught (in promise) TypeError: upeComponents is undefined` error in console. 
![image](https://user-images.githubusercontent.com/572862/180329483-c0d6120e-fde4-45aa-a916-16cb5a14a90b.png)

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
