### PR TITLE
Fix the plural string used in the disputes task list

### DIFF
--- a/changelog/fix-plural-disputes-task-list
+++ b/changelog/fix-plural-disputes-task-list
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This task list was added in this version, this commit simply fixes a grammatical in it.
+
+

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -27,6 +27,7 @@ declare const wcpaySettings: {
 	zeroDecimalCurrencies: string[];
 	restUrl: string;
 	shouldUseExplicitPrice: boolean;
+	numDisputesNeedingResponse: string;
 };
 
 declare const wcTracks: any;

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -33,8 +33,9 @@ const OverviewPage = () => {
 		wpcomReconnectUrl,
 		featureFlags: { accountOverviewTaskList },
 		needsHttpsSetup,
-		numDisputesNeedingResponse,
 	} = wcpaySettings;
+	const numDisputesNeedingResponse =
+		parseInt( wcpaySettings.numDisputesNeedingResponse, 10 ) || 0;
 	const { isLoading: settingsIsLoading, settings } = useSettings();
 
 	const tasksUnsorted = getTasks( {

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -122,7 +122,7 @@ export const getTasks = ( {
 				_n(
 					'1 disputed payment needs your response',
 					'%s disputed payments need your response',
-					numDisputesNeedingResponse,
+					parseInt( numDisputesNeedingResponse, 10 ),
 					'woocommerce-payments'
 				),
 				numDisputesNeedingResponse

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -122,7 +122,7 @@ export const getTasks = ( {
 				_n(
 					'1 disputed payment needs your response',
 					'%s disputed payments need your response',
-					parseInt( numDisputesNeedingResponse, 10 ),
+					numDisputesNeedingResponse,
 					'woocommerce-payments'
 				),
 				numDisputesNeedingResponse

--- a/client/overview/task-list/test/tasks.js
+++ b/client/overview/task-list/test/tasks.js
@@ -157,6 +157,7 @@ describe( 'getTasks()', () => {
 
 		expect( actual ).toEqual( [] );
 	} );
+
 	it( 'should include the dispute resolution task', () => {
 		const numDisputesNeedingResponse = 1;
 		const actual = getTasks( {
@@ -175,6 +176,31 @@ describe( 'getTasks()', () => {
 					key: 'dispute-resolution-task',
 					completed: false,
 					level: 3,
+					title: '1 disputed payment needs your response',
+				} ),
+			] )
+		);
+	} );
+
+	it( 'should include the dispute resolution task with multiple disputes', () => {
+		const numDisputesNeedingResponse = 2000;
+		const actual = getTasks( {
+			accountStatus: {
+				status: 'restricted_soon',
+				currentDeadline: 1620857083,
+				pastDue: false,
+				accountLink: 'http://example.com',
+			},
+			numDisputesNeedingResponse,
+		} );
+
+		expect( actual ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					key: 'dispute-resolution-task',
+					completed: false,
+					level: 3,
+					title: '2000 disputed payments need your response',
 				} ),
 			] )
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This was originally fixed in https://github.com/Automattic/woocommerce-payments/pull/4414, however due to a recent change in https://github.com/Automattic/woocommerce-payments/pull/4388 the number of disputes is now a string and passing '1' into `_n()` apparently returns the plural string.

This PR fixes this issue by parsing the string into an int.

#### Testing instructions

1. Make a purchase using a disputed card number. eg `4000000000000259` ([ref](https://stripe.com/docs/testing#disputes)) 
3. Go to the **Payments → Overview** admin screen.
4. Note that the dispute task list now says: 
     - "1 disputed **payment** needs your response" 
     - Before (on develop) it would read "1 disputed **payments** need your response" ([screenshot](https://user-images.githubusercontent.com/8490476/180371369-7cb66353-4911-4da3-9368-7049ddf09a29.png)) 
2. Make a second purchase using a disputed card number. eg `4000000000000259`.
3. Go to the **Payments → Overview** admin screen and confirm the plural string's grammar is correct. 

Both screenshots have been taken on this branch: 

<img width="730" alt="Screen Shot 2022-07-22 at 3 48 59 pm" src="https://user-images.githubusercontent.com/8490476/180371763-681a24ee-3d5e-4947-a3cc-b2340c82f854.png">

<img width="719" alt="Screen Shot 2022-07-22 at 3 49 30 pm" src="https://user-images.githubusercontent.com/8490476/180371850-6326346d-d869-46ea-9f79-9fabcb8c9364.png">


-------------------
- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
