### PR TITLE
Remove the conditional `completed` and `additionalInfo` attribute for dispute task.

### DIFF
--- a/changelog/fix-4123-dispute-count
+++ b/changelog/fix-4123-dispute-count
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Correctly show the number of disputes that need to be responded in task list.
+Show the correct number of disputes needing a response in the Payments > Overview task list.

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -122,7 +122,7 @@ export const getTasks = ( {
 				_n(
 					'1 disputed payment needs your response',
 					'%s disputed payments need your response',
-					numDisputesNeedingResponse,
+					parseInt( numDisputesNeedingResponse, 10 ),
 					'woocommerce-payments'
 				),
 				numDisputesNeedingResponse

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -122,7 +122,7 @@ export const getTasks = ( {
 				_n(
 					'1 disputed payment needs your response',
 					'%s disputed payments need your response',
-					parseInt( numDisputesNeedingResponse, 10 ),
+					numDisputesNeedingResponse,
 					'woocommerce-payments'
 				),
 				numDisputesNeedingResponse

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -127,11 +127,8 @@ export const getTasks = ( {
 				),
 				numDisputesNeedingResponse
 			),
-			additionalInfo:
-				0 < numDisputesNeedingResponse
-					? __( 'View and respond', 'woocommerce-payments' )
-					: '',
-			completed: 0 === numDisputesNeedingResponse,
+			additionalInfo: __( 'View and respond', 'woocommerce-payments' ),
+			completed: false,
 			isDeletable: true,
 			isDismissable: true,
 			allowSnooze: true,

--- a/client/overview/task-list/test/tasks.js
+++ b/client/overview/task-list/test/tasks.js
@@ -177,6 +177,7 @@ describe( 'getTasks()', () => {
 					completed: false,
 					level: 3,
 					title: '1 disputed payment needs your response',
+					additionalInfo: 'View and respond',
 				} ),
 			] )
 		);
@@ -201,6 +202,7 @@ describe( 'getTasks()', () => {
 					completed: false,
 					level: 3,
 					title: '2000 disputed payments need your response',
+					additionalInfo: 'View and respond',
 				} ),
 			] )
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Addressing [feedbacks](https://github.com/Automattic/woocommerce-payments/pull/4388#pullrequestreview-1030944088) from https://github.com/Automattic/woocommerce-payments/pull/4388, ie:
1. Since dispute task list will only show if there is non-zero disputes needing response and it will not show if there is 0 disputes needing response, the task list is cannot be completed, so I removed the condition for `completed` and `additionalInfo` attribute.
2. Better wording for changelog.

#### Testing instructions

I can't think of a way to test this changes as it's just a cleaner code.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
