### PR TITLE
Update to support selection of multiple currencies in analytics

### DIFF
--- a/changelog/add-advanced-filter-analytics
+++ b/changelog/add-advanced-filter-analytics
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for filtering by multiple customer currencies in analytics

--- a/changelog/dev-fix-analytics-sorting
+++ b/changelog/dev-fix-analytics-sorting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix an issue with sorting by customer currency in Analytics > Orders

--- a/client/multi-currency-analytics/index.js
+++ b/client/multi-currency-analytics/index.js
@@ -55,7 +55,7 @@ addFilter(
 			...tableData.headers,
 			{
 				isNumeric: false,
-				isSortable: true,
+				isSortable: false,
 				key: 'customer_currency',
 				label: __( 'Customer currency', 'woocommerce-payments' ),
 				required: false,

--- a/client/multi-currency-analytics/index.js
+++ b/client/multi-currency-analytics/index.js
@@ -9,32 +9,63 @@ const customerCurrencies = wcSettings.customerCurrencies.sort( ( a, b ) => {
 	return a.label < b.label ? -1 : 1;
 } );
 
-const currencyOptions = [
-	{
-		label: __( 'All currencies', 'woocommerce-payments' ),
-		value: 'ALL',
-	},
-	...customerCurrencies,
-];
-
-const addCurrencyFilters = ( filters ) => {
-	return [
-		{
-			label: __( 'Customer currency', 'woocommerce-payments' ),
-			staticParams: [],
-			param: 'currency',
-			showFilters: () => true,
-			defaultValue: 'ALL',
-			filters: [ ...( currencyOptions || [] ) ],
-		},
-		...filters,
-	];
-};
-
 addFilter(
-	'woocommerce_admin_orders_report_filters',
+	'woocommerce_admin_orders_report_advanced_filters',
 	'woocommerce-payments',
-	addCurrencyFilters
+	( advancedFilters ) => {
+		advancedFilters.filters = {
+			currency: {
+				labels: {
+					add: __( 'Customer currency', 'woocommerce-payments' ),
+					remove: __(
+						'Remove customer currency filter',
+						'woocommerce-payments'
+					),
+					rule: __(
+						'Select a customer currency filter match',
+						'woocommerce-payments'
+					),
+					title: __(
+						'{{title}}Customer Currency{{/title}} {{rule /}} {{filter /}}',
+						'woocommerce-payments'
+					),
+					filter: __(
+						'Select a customer currency',
+						'woocommerce-payments'
+					),
+				},
+				rules: [
+					{
+						value: 'is',
+						/* translators: Sentence fragment, logical, "Is" refers to searching for orders matching a chosen currency. */
+						label: __(
+							'Is',
+							'customer currency',
+							'woocommerce-payments'
+						),
+					},
+					{
+						value: 'is_not',
+						// eslint-disable-next-line max-len
+						/* translators: Sentence fragment, logical, "Is Not" refers to searching for orders not matching a chosen currency. */
+						label: __(
+							'Is not',
+							'customer currency',
+							'woocommerce-payments'
+						),
+					},
+				],
+				input: {
+					component: 'SelectControl',
+					options: customerCurrencies,
+				},
+				allowMultiple: true,
+			},
+			...advancedFilters.filters,
+		};
+
+		return advancedFilters;
+	}
 );
 
 addFilter(

--- a/client/multi-currency-analytics/index.js
+++ b/client/multi-currency-analytics/index.js
@@ -49,7 +49,7 @@ addFilter(
 						// eslint-disable-next-line max-len
 						/* translators: Sentence fragment, logical, "Is Not" refers to searching for orders not matching a chosen currency. */
 						label: __(
-							'Is not',
+							'Is Not',
 							'customer currency',
 							'woocommerce-payments'
 						),

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -71,8 +71,8 @@ class Analytics {
 		add_filter( 'woocommerce_analytics_update_order_stats_data', [ $this, 'update_order_stats_data' ], self::PRIORITY_LATEST, 2 );
 
 		// Add filters when the query args are updated.
-		add_filter( 'woocommerce_analytics_orders_query_args', [ $this, 'apply_customer_currency_arg' ] );
-		add_filter( 'woocommerce_analytics_orders_stats_query_args', [ $this, 'apply_customer_currency_arg' ] );
+		add_filter( 'woocommerce_analytics_orders_query_args', [ $this, 'apply_customer_currency_args' ] );
+		add_filter( 'woocommerce_analytics_orders_stats_query_args', [ $this, 'apply_customer_currency_args' ] );
 
 		// If we aren't making a REST request, or no multi currency orders exist in the merchant's store,
 		// return before adding these filters.
@@ -171,13 +171,9 @@ class Analytics {
 	 *
 	 * @return array
 	 */
-	public function apply_customer_currency_arg( $args ): array {
-		$currency = $this->get_customer_currency_from_request();
-		if ( ! is_null( $currency ) ) {
-			$args['currency'] = $currency;
-		}
-
-		return $args;
+	public function apply_customer_currency_args( $args ): array {
+		$currency_args = $this->get_customer_currency_args_from_request();
+		return array_merge( $args, $currency_args );
 	}
 
 	/**
@@ -320,9 +316,15 @@ class Analytics {
 		$prefix       = 'wcpay_multicurrency_';
 		$currency_tbl = $prefix . 'currency_postmeta';
 
-		$currency = $this->get_customer_currency_from_request();
-		if ( ! is_null( $currency ) ) {
-			$clauses[] = "AND {$currency_tbl}.meta_value = '{$currency}'";
+		$currency_args = $this->get_customer_currency_args_from_request();
+		if ( ! empty( $currency_args['currency_is'] ) ) {
+			$currency_is = sprintf( "'%s'", implode( "', '", $currency_args['currency_is'] ) );
+			$clauses[]   = "AND {$currency_tbl}.meta_value IN ({$currency_is})";
+		}
+
+		if ( ! empty( $currency_args['currency_is_not'] ) ) {
+			$currency_is_not = sprintf( "'%s'", implode( "', '", $currency_args['currency_is_not'] ) );
+			$clauses[]       = "AND {$currency_tbl}.meta_value NOT IN ({$currency_is_not})";
 		}
 
 		return apply_filters( MultiCurrency::FILTER_PREFIX . 'filter_where_clauses', $clauses );
@@ -454,16 +456,34 @@ class Analytics {
 	 * Will return null if no currency variable was passed in, otherwise will
 	 * return the currency.
 	 *
-	 * @return string|null
+	 * @return array
 	 */
-	private function get_customer_currency_from_request() {
+	private function get_customer_currency_args_from_request(): array {
+		$fn = function( string $currency ): string {
+			return sanitize_text_field( wp_unslash( $currency ) );
+		};
+
+		$args = [
+			'currency_is'     => [],
+			'currency_is_not' => [],
+		];
+
 		// TODO: Figure out where the nonce is stored.
 		/* phpcs:disable WordPress.Security.NonceVerification */
-		if ( isset( $_GET['currency'] ) ) {
-			return sanitize_text_field( wp_unslash( $_GET['currency'] ) );
+		if ( isset( $_GET['currency_is'] ) ) {
+			/* phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized */
+			$currency_is         = is_array( $_GET['currency_is'] ) ? $_GET['currency_is'] : [ $_GET['currency_is'] ];
+			$args['currency_is'] = array_map( $fn, $currency_is );
 		}
 
-		return null;
+		/* phpcs:disable WordPress.Security.NonceVerification */
+		if ( isset( $_GET['currency_is_not'] ) ) {
+			/* phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized */
+			$currency_is_not         = is_array( $_GET['currency_is_not'] ) ? $_GET['currency_is_not'] : [ $_GET['currency_is_not'] ];
+			$args['currency_is_not'] = array_map( $fn, $currency_is_not );
+		}
+
+		return $args;
 	}
 
 	/**

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -459,29 +459,20 @@ class Analytics {
 	 * @return array
 	 */
 	private function get_customer_currency_args_from_request(): array {
-		$fn = function( string $currency ): string {
-			return sanitize_text_field( wp_unslash( $currency ) );
-		};
-
 		$args = [
 			'currency_is'     => [],
 			'currency_is_not' => [],
 		];
 
-		// TODO: Figure out where the nonce is stored.
 		/* phpcs:disable WordPress.Security.NonceVerification */
-		if ( isset( $_GET['currency_is'] ) ) {
-			/* phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized */
-			$currency_is         = is_array( $_GET['currency_is'] ) ? $_GET['currency_is'] : [ $_GET['currency_is'] ];
-			$args['currency_is'] = array_map( $fn, $currency_is );
+		if ( isset( $_GET['currency_is'] ) && is_array( $_GET['currency_is'] ) ) {
+			$args['currency_is'] = array_map( 'sanitize_text_field', wp_unslash( $_GET['currency_is'] ) );
 		}
 
-		/* phpcs:disable WordPress.Security.NonceVerification */
 		if ( isset( $_GET['currency_is_not'] ) ) {
-			/* phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized */
-			$currency_is_not         = is_array( $_GET['currency_is_not'] ) ? $_GET['currency_is_not'] : [ $_GET['currency_is_not'] ];
-			$args['currency_is_not'] = array_map( $fn, $currency_is_not );
+			$args['currency_is_not'] = array_map( 'sanitize_text_field', wp_unslash( $_GET['currency_is_not'] ) );
 		}
+		/* phpcs:enable WordPress.Security.NonceVerification */
 
 		return $args;
 	}

--- a/tests/unit/multi-currency/test-class-analytics.php
+++ b/tests/unit/multi-currency/test-class-analytics.php
@@ -284,17 +284,91 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 		);
 	}
 
-	public function test_filter_where_clauses_with_currency() {
+	public function test_filter_where_clauses_with_currency_is() {
 		global $wpdb;
 
 		$clauses  = [ "WHERE {$wpdb->prefix}wc_order_stats.order_id = 123" ];
 		$expected = [
 			"WHERE {$wpdb->prefix}wc_order_stats.order_id = 123",
-			"AND wcpay_multicurrency_currency_postmeta.meta_value = 'USD'",
+			"AND wcpay_multicurrency_currency_postmeta.meta_value IN ('USD')",
 		];
 
 		// Simulate a currency being passed in via GET request.
-		$_GET['currency'] = 'USD';
+		$_GET['currency_is'] = 'USD';
+
+		$this->assertEquals(
+			$expected,
+			$this->analytics->filter_where_clauses( $clauses )
+		);
+	}
+
+	public function test_filter_where_clauses_with_multiple_currency_is() {
+		global $wpdb;
+
+		$clauses  = [ "WHERE {$wpdb->prefix}wc_order_stats.order_id = 123" ];
+		$expected = [
+			"WHERE {$wpdb->prefix}wc_order_stats.order_id = 123",
+			"AND wcpay_multicurrency_currency_postmeta.meta_value IN ('USD', 'EUR')",
+		];
+
+		// Simulate a currency being passed in via GET request.
+		$_GET['currency_is'] = [ 'USD', 'EUR' ];
+
+		$this->assertEquals(
+			$expected,
+			$this->analytics->filter_where_clauses( $clauses )
+		);
+	}
+
+	public function test_filter_where_clauses_with_currency_is_not() {
+		global $wpdb;
+
+		$clauses  = [ "WHERE {$wpdb->prefix}wc_order_stats.order_id = 123" ];
+		$expected = [
+			"WHERE {$wpdb->prefix}wc_order_stats.order_id = 123",
+			"AND wcpay_multicurrency_currency_postmeta.meta_value NOT IN ('USD')",
+		];
+
+		// Simulate a currency being passed in via GET request.
+		$_GET['currency_is_not'] = 'USD';
+
+		$this->assertEquals(
+			$expected,
+			$this->analytics->filter_where_clauses( $clauses )
+		);
+	}
+
+	public function test_filter_where_clauses_with_multiple_currency_is_not() {
+		global $wpdb;
+
+		$clauses  = [ "WHERE {$wpdb->prefix}wc_order_stats.order_id = 123" ];
+		$expected = [
+			"WHERE {$wpdb->prefix}wc_order_stats.order_id = 123",
+			"AND wcpay_multicurrency_currency_postmeta.meta_value NOT IN ('USD', 'EUR')",
+		];
+
+		// Simulate a currency being passed in via GET request.
+		$_GET['currency_is_not'] = [ 'USD', 'EUR' ];
+
+		$this->assertEquals(
+			$expected,
+			$this->analytics->filter_where_clauses( $clauses )
+		);
+	}
+
+	public function test_filter_where_clauses_with_multiple_currency_args() {
+		global $wpdb;
+
+		$clauses  = [ "WHERE {$wpdb->prefix}wc_order_stats.order_id = 123" ];
+		$expected = [
+			"WHERE {$wpdb->prefix}wc_order_stats.order_id = 123",
+			"AND wcpay_multicurrency_currency_postmeta.meta_value IN ('GBP')",
+			"AND wcpay_multicurrency_currency_postmeta.meta_value NOT IN ('USD', 'EUR')",
+		];
+
+		// Simulate a currency being passed in via GET request.
+		$_GET['currency_is']     = [ 'GBP' ];
+		$_GET['currency_is_not'] = [ 'USD', 'EUR' ];
 
 		$this->assertEquals(
 			$expected,

--- a/tests/unit/multi-currency/test-class-analytics.php
+++ b/tests/unit/multi-currency/test-class-analytics.php
@@ -294,7 +294,7 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 		];
 
 		// Simulate a currency being passed in via GET request.
-		$_GET['currency_is'] = 'USD';
+		$_GET['currency_is'] = [ 'USD' ];
 
 		$this->assertEquals(
 			$expected,
@@ -330,7 +330,7 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 		];
 
 		// Simulate a currency being passed in via GET request.
-		$_GET['currency_is_not'] = 'USD';
+		$_GET['currency_is_not'] = [ 'USD' ];
 
 		$this->assertEquals(
 			$expected,
@@ -381,7 +381,7 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 		add_filter( 'wcpay_multi_currency_disable_filter_where_clauses', '__return_true' );
 
 		// Nothing should be appended to the clauses array, because the filter is disabled.
-		$_GET['currency'] = 'USD';
+		$_GET['currency_is'] = [ 'USD' ];
 
 		$this->assertEquals( $expected, $this->analytics->filter_where_clauses( $expected ) );
 	}


### PR DESCRIPTION
Fixes #4447 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

- Allow selection of multiple currencies via the advanced filters in analytics.
- Using the existing advanced filters to achieve this, since it is not possible without modification of WC Admin to create our own custom component for this purpose.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make a few orders on your store in various currencies.
* Wait 5 minutes for the cache to update after making the final order.
* Go to `Analytics > Orders`. Verify the page loads. Select the `Advanced filters` option on the `Show` dropdown. Add a single `Customer currency` filter and verify that the orders are filtered correctly to only display those made in that currency, and the totals add up and look sensible.
* Now add another `Customer currency` filter and verify that it now displays orders made in either currency.
* Repeat the same tests, this time using the `Is not` filter to ensure only orders NOT placed in a certain currency appear.

<img width="1006" alt="Screenshot 2022-07-22 at 14 22 24" src="https://user-images.githubusercontent.com/11770181/180448030-18fd62c7-a491-4d12-b8a7-cca6309e67fd.png">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
