### PR TITLE
Fix for E2E error caused by analytics updates

### DIFF
--- a/changelog/fix-e2e-analytics
+++ b/changelog/fix-e2e-analytics
@@ -1,5 +1,4 @@
 Significance: patch
-Type: dev
-Comment: Fix only relates to E2E tests.
+Type: fix
 
-
+Fix for an issue where a console error relating to wcSettings displayed on WooCommerce > Settings page.

--- a/changelog/fix-e2e-analytics
+++ b/changelog/fix-e2e-analytics
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix only relates to E2E tests.
+
+

--- a/client/multi-currency-analytics/index.js
+++ b/client/multi-currency-analytics/index.js
@@ -5,7 +5,8 @@
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
-const customerCurrencies = wcSettings.customerCurrencies.sort( ( a, b ) => {
+const customerCurrencies = wcSettings.customerCurrencies ?? [];
+const customerCurrencyOptions = customerCurrencies.sort( ( a, b ) => {
 	return a.label < b.label ? -1 : 1;
 } );
 
@@ -57,7 +58,7 @@ addFilter(
 				],
 				input: {
 					component: 'SelectControl',
-					options: customerCurrencies,
+					options: customerCurrencyOptions,
 				},
 				allowMultiple: true,
 			},

--- a/client/multi-currency-analytics/index.js
+++ b/client/multi-currency-analytics/index.js
@@ -5,10 +5,13 @@
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
-const customerCurrencies = wcSettings.customerCurrencies ?? [];
-const customerCurrencyOptions = customerCurrencies.sort( ( a, b ) => {
-	return a.label < b.label ? -1 : 1;
-} );
+const getCustomerCurrencies = () => {
+	return (
+		wcSettings.customerCurrencies.sort( ( a, b ) => {
+			return a.label < b.label ? -1 : 1;
+		} ) ?? []
+	);
+};
 
 addFilter(
 	'woocommerce_admin_orders_report_advanced_filters',
@@ -58,7 +61,7 @@ addFilter(
 				],
 				input: {
 					component: 'SelectControl',
-					options: customerCurrencyOptions,
+					options: getCustomerCurrencies(),
 				},
 				allowMultiple: true,
 			},


### PR DESCRIPTION
Fixes #4478 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

- Fix for an error occurring on the settings page introduced in #4441.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- Go to `WooCommerce > Settings` and verify there are no console errors and the page works as expected.
- Go to `Analytics > Orders`, change the `Show` dropdown to `Advanced filters` and add the `Customer Currency` advanced filter. Check that the list is populated (it should contain any customer currencies ever used on your store to complete an order.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
