### PR TITLE
E2E - Skip blocks tests against incompatible WC versions

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -51,9 +51,9 @@ jobs:
             test_groups: 'blocks'
             test_branches: 'shopper'
           - wordpress: 'nightly'
-            woocommerce: '5.8.1'
+            woocommerce: '6.0.1'
           - wordpress: 'nightly'
-            woocommerce: '6.4.1'
+            woocommerce: '6.5.1'
           - wordpress: 'nightly'
             woocommerce: 'beta'
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -47,12 +47,15 @@ jobs:
           - woocommerce: '6.0.1'
             test_groups: 'blocks'
             test_branches: 'shopper'
+          - woocommerce: '6.5.1'
+            test_groups: 'blocks'
+            test_branches: 'shopper'
           - wordpress: 'nightly'
-            woocommerce: '5.8.1' 
+            woocommerce: '5.8.1'
           - wordpress: 'nightly'
             woocommerce: '6.4.1'
           - wordpress: 'nightly'
-            woocommerce: 'beta'   
+            woocommerce: 'beta'
 
     name: WC - ${{ matrix.woocommerce }} | WP - ${{ matrix.wordpress }} | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 
@@ -66,7 +69,7 @@ jobs:
       # Conditionally skip WC Blocks tests. Remove/update based on min supported WC version by the blocks checkout plugin.
       - name: Conditionally skip WC Blocks tests
         run: |
-          SKIP_WC_VERSIONS=('6.0.1')
+          SKIP_WC_VERSIONS=('6.0.1' '6.5.1')
           if [[ " ${SKIP_WC_VERSIONS[@]} " =~ " ${E2E_WC_VERSION} " ]]; then
             echo "SKIP_WC_BLOCKS_TESTS=1" >> $GITHUB_ENV
           fi

--- a/changelog/e2e-update-e2e-workflow-wc-versions
+++ b/changelog/e2e-update-e2e-workflow-wc-versions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Exclude blocks tests against incompatible WC versions + exclude specific WC versions for WP nightly tests


### PR DESCRIPTION
Fixes #4480 

#### Changes proposed in this Pull Request

1. Updates the WC versions, against which WooCommerce blocks are incompatible. With the latest WC blocks, minimum supported WC version is `6.6`.
2. Updated the exclusion of tests against WP nightly. Tests against WP nightly are run only against the latest WooCommerce version. Since the other versions weren't excluded, nightly tests were ran against each WC version causing an increase in the number of tests.

#### Testing instructions
* Trigger a new E2E test against this branch from Actions -> E2E tests and confirm that the tests are passing. (There are a few flaky E2E tests, so some could fail. But most of them should pass).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
