### PR TITLE
E2E - Fix failing dispute tests

### DIFF
--- a/changelog/e2e-fix-dispute-tests
+++ b/changelog/e2e-fix-dispute-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fixes E2E dispute test flow

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-losing.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-losing.spec.js
@@ -88,18 +88,6 @@ describe( 'Disputes > Submit losing dispute', () => {
 
 		// Accept the dispute
 		await merchantWCP.openAcceptDispute();
-		await page.waitForSelector(
-			'div.components-snackbar > .components-snackbar__content'
-		);
-
-		// Verify the dispute has been accepted properly
-		await expect( page ).toMatchElement(
-			'div.components-snackbar > .components-snackbar__content',
-			{
-				text:
-					'You have accepted the dispute for order #' + orderId + '.',
-			}
-		);
 
 		// If webhooks are not received, the dispute status won't be updated in the dispute list page resulting in test failure.
 		// Workaround - Open dispute details page again and check status.

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
@@ -141,17 +141,6 @@ describe( 'Disputes > Submit winning dispute', () => {
 			page.waitForNavigation( { waitUntil: 'networkidle0' } ),
 			uiLoaded(),
 		] );
-		await page.waitForSelector(
-			'div.components-snackbar > .components-snackbar__content'
-		);
-
-		// Verify the dispute has been challenged properly
-		await expect( page ).toMatchElement(
-			'div.components-snackbar > .components-snackbar__content',
-			{
-				text: 'Evidence submitted!',
-			}
-		);
 
 		// If webhooks are not received, the dispute status won't be updated in the dispute list page resulting in test failure.
 		// Workaround - Open dispute details page again and check status.


### PR DESCRIPTION
Fixes #4487 

#### Changes proposed in this Pull Request

Based on the changed introduced by #4458, there was some changes to the dispute flow. 

Previously dispute tests were looking for the accept/challenge notification to appear after redirecting to WCPay disputes page. Now, the notification is displayed before redirect and the redirect is triggered at the same time or just before the notification is displayed preventing puppeteer to read the notification content (refer to video on #4458).

Hence, I've modified the tests to skip checking for notification. However the tests will continue to check for dispute status to confirm whether the dispute is accepted/challenged.

#### Testing instructions

* Trigger a new test against this branch via Actions -> E2E Tests. I've created a reference test here - https://github.com/Automattic/woocommerce-payments/actions/runs/2733871946
* Confirm that WCPay - Merchant tests are passing.
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**
- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
