### PR TITLE
Add paymentMethodType to isUsingSavedPaymentMethod function for UPE

### DIFF
--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -663,12 +663,17 @@ jQuery( function ( $ ) {
 	/**
 	 * Checks if the customer is using a saved payment method.
 	 *
+	 * @param {string} paymentMethodType Stripe payment method type ID.
 	 * @return {boolean} Boolean indicating whether or not a saved payment method is being used.
 	 */
-	function isUsingSavedPaymentMethod() {
+	function isUsingSavedPaymentMethod( paymentMethodType ) {
+		const paymentMethodSelector =
+			'#wc-woocommerce_payments_' +
+			paymentMethodType +
+			'-payment-token-new';
 		return (
-			$( '#wc-woocommerce_payments-payment-token-new' ).length &&
-			! $( '#wc-woocommerce_payments-payment-token-new' ).is( ':checked' )
+			$( paymentMethodSelector ).length &&
+			! $( paymentMethodSelector ).is( ':checked' )
 		);
 	}
 
@@ -729,8 +734,8 @@ jQuery( function ( $ ) {
 		.map( ( method ) => `checkout_place_order_${ method }` )
 		.join( ' ' );
 	$( 'form.checkout' ).on( checkoutEvents, function () {
-		if ( ! isUsingSavedPaymentMethod() ) {
-			const paymentMethodType = getSelectedGatewayPaymentMethod();
+		const paymentMethodType = getSelectedGatewayPaymentMethod();
+		if ( ! isUsingSavedPaymentMethod( paymentMethodType ) ) {
 			const paymentIntentId =
 				gatewayUPEComponents[ paymentMethodType ].paymentIntentId;
 			if ( isUPEEnabled && paymentIntentId ) {
@@ -764,7 +769,11 @@ jQuery( function ( $ ) {
 
 	// Handle the Pay for Order form if WooCommerce Payments is chosen.
 	$( '#order_review' ).on( 'submit', () => {
-		if ( ! isUsingSavedPaymentMethod() && isWCPayChosen() ) {
+		const paymentMethodType = getSelectedGatewayPaymentMethod();
+		if (
+			! isUsingSavedPaymentMethod( paymentMethodType ) &&
+			isWCPayChosen()
+		) {
 			if ( isChangingPayment ) {
 				handleUPEAddPayment( $( '#order_review' ) );
 				return false;


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/4397

#### Changes proposed in this Pull Request
This PR changes `isUsingSavedPaymentMethod()` signature. It now takes a `paymentMethodType` parameter to determine which payment method to check against. Otherwise, it will always check the credit card's one.

#### Testing instructions
1. Enable "multi-currency" and add "Euro" to the currency list (http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=wcpay_multi_currency)
2. Go to WCPay settings, enable UPE, and enable a few of the payment methods:
![image](https://user-images.githubusercontent.com/572862/181127307-ef1ef6d6-a071-4183-936a-3c2962f9e89f.png)
3. Go to your local server and listen to webhook events. Ping me if you need help setting this up. This is used to listen to Stripe's webhooks and update our localhost:8082's order statuses.
4. Checkout an item but set currency to "EUR":
![image](https://user-images.githubusercontent.com/572862/181127481-67207baa-09ec-43f2-ab30-81d07452e2c0.png)
5. Scroll down and look for a UPE payment method, I tested with SEPA and Sofort. You can find the test card number on Stripe's doc:
![image](https://user-images.githubusercontent.com/572862/181127546-402c0ba5-74ad-4b6f-a2e0-412355ea60b6.png)
6. Click place order and you should get an "Order received" page.
7. Go to Stripe's dashboard and look up this payment intent (pi_xyzxyzxyzxyz). Check the currency received there. It should say "EUR" and looks something like this:
![image](https://user-images.githubusercontent.com/572862/181127764-ff9f1d6b-80ec-477f-bac6-073e9987cadf.png)

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
