### PR TITLE
Update currencies modal height

### DIFF
--- a/changelog/fix-4491-currencies-modal-height
+++ b/changelog/fix-4491-currencies-modal-height
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update currencies modal height

--- a/client/components/confirmation-modal/styles.scss
+++ b/client/components/confirmation-modal/styles.scss
@@ -6,6 +6,8 @@
 
 	// to ensure that the separator extends all the way, even with different versions of Gutenberg
 	.components-modal__content {
+		display: flex;
+		flex-direction: column;
 		padding: 0 $grid-unit-30 $grid-unit-30;
 	}
 

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/style.scss
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/style.scss
@@ -172,8 +172,6 @@
 
 	&__content {
 		overflow-y: scroll;
-		min-height: 350px;
-		max-height: 350px;
 		flex: 1;
 		display: flex;
 		flex-direction: column;

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/style.scss
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/style.scss
@@ -177,6 +177,7 @@
 		flex-direction: column;
 		margin: 0 -#{$grid-unit-30} -#{$grid-unit-30} 0;
 		padding-left: 4px;
+		max-height: 350px;
 	}
 
 	&__search {

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/style.scss
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/style.scss
@@ -172,8 +172,8 @@
 
 	&__content {
 		overflow-y: scroll;
-		min-height: 240px;
-		max-height: 240px;
+		min-height: 350px;
+		max-height: 350px;
 		flex: 1;
 		display: flex;
 		flex-direction: column;

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/style.scss
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/style.scss
@@ -172,8 +172,8 @@
 
 	&__content {
 		overflow-y: scroll;
-		min-height: 350px;
-		max-height: 350px;
+		min-height: 240px;
+		max-height: 240px;
 		flex: 1;
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
Fixes #4491 

#### Changes proposed in this Pull Request

This PR changes the currencies modal height so the footer, as well as the search input box, can be seen at a first sight at any resolution.

#### Videos
*Before*
https://user-images.githubusercontent.com/56378160/181353092-c74fbb0e-158a-4fb2-b9bf-f430c069c3ba.mov

*After*
https://user-images.githubusercontent.com/56378160/181350340-79b9a4b2-9537-4524-82e6-652458c7910c.mov


#### Testing instructions
1. Go to Payments - Settings - Multi-currency
1. Click on the "Add currencies" button
1. Open your browser dev tools and modify the resolution to 1400x720 and any other sizes
1. See the "Update selected" button and the search input box render in the currencies modal.


*

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [X] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
