### PR TITLE
Make updating existing customer details during checkout async

### DIFF
--- a/changelog/update-manage-customer-details-async
+++ b/changelog/update-manage-customer-details-async
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Make updating existing customer details during checkout async.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -157,10 +157,10 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 			->with( get_current_user_id() )
 			->willReturn( self::CUSTOMER_ID );
 
-		$this->mock_customer_service
-			->expects( $this->once() )
-			->method( 'update_customer_for_user' )
-			->willReturn( self::CUSTOMER_ID );
+		// $this->mock_customer_service
+		// 	->expects( $this->once() )
+		// 	->method( 'update_customer_for_user' )
+		// 	->willReturn( self::CUSTOMER_ID );
 
 		$this->token = WC_Helper_Token::create_token( self::PAYMENT_METHOD_ID, self::USER_ID );
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -157,11 +157,6 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 			->with( get_current_user_id() )
 			->willReturn( self::CUSTOMER_ID );
 
-		// $this->mock_customer_service
-		// 	->expects( $this->once() )
-		// 	->method( 'update_customer_for_user' )
-		// 	->willReturn( self::CUSTOMER_ID );
-
 		$this->token = WC_Helper_Token::create_token( self::PAYMENT_METHOD_ID, self::USER_ID );
 
 		$_POST = [

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -218,11 +218,6 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 			->with( self::USER_ID )
 			->willReturn( self::CUSTOMER_ID );
 
-		// $this->mock_customer_service
-		// 	->expects( $this->once() )
-		// 	->method( 'update_customer_for_user' )
-		// 	->willReturn( self::CUSTOMER_ID );
-
 		$this->mock_api_client
 			->expects( $this->once() )
 			->method( 'create_and_confirm_intention' )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -218,10 +218,10 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 			->with( self::USER_ID )
 			->willReturn( self::CUSTOMER_ID );
 
-		$this->mock_customer_service
-			->expects( $this->once() )
-			->method( 'update_customer_for_user' )
-			->willReturn( self::CUSTOMER_ID );
+		// $this->mock_customer_service
+		// 	->expects( $this->once() )
+		// 	->method( 'update_customer_for_user' )
+		// 	->willReturn( self::CUSTOMER_ID );
 
 		$this->mock_api_client
 			->expects( $this->once() )


### PR DESCRIPTION
Fixes #4490 

#### Changes proposed in this Pull Request
- Make updating existing customer details during checkout async for performance benefits.


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Follow the normal checkout flow(both UPE and non UPE) for an existing customer.
- Ensure there is a scheduled action created as `wcpay_update_customer_with_order_data` in Scheduled Actions (Tools > Scheduled Actions)
- Run the action and ensure there are no errors, additionally check logs to ensure a POST `wcpay/customers/{{customer_id}}` call was made (check WP-Admin > WooCommerce > Status > Logs and there should be a log for WooCommerce Payments with today's date)
- Ensure any UPE and subscription flows are not affected by this change. 
  - Context for subscriptions: p1658831357623559-slack-C02BW3Z8SHK
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.