### PR TITLE
Sanitize option key for subscription

### DIFF
--- a/changelog/'Sanitize option key for subscription'
+++ b/changelog/'Sanitize option key for subscription'
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Minor change to how keys are sanitized and saved in database.
+
+

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -125,7 +125,7 @@ class WC_Payments_Product_Service {
 	 * Gets the WC Pay product ID associated with a WC product.
 	 *
 	 * @param string $type The item type to create a product for.
-	 * return string       The item's WCPay product id.
+	 * @return string       The item's WCPay product id.
 	 */
 	public function get_wcpay_product_id_for_item( string $type ) : string {
 		$sanitized_type  = self::sanitize_option_key( $type );
@@ -140,10 +140,10 @@ class WC_Payments_Product_Service {
 	 * Sanitize option key string to replace space with underscore, and remove special characters.
 	 *
 	 * @param string $type Non sanitized input.
-	 * return string       Sanitized output.
+	 * @return string       Sanitized output.
 	 */
 	public static function sanitize_option_key( string $type ) {
-		return sanitize_key( str_replace( ' ', '_', strtolower( trim( $type ) ) ) );
+		return sanitize_key( str_replace( ' ', '_', trim( $type ) ) );
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -128,11 +128,12 @@ class WC_Payments_Product_Service {
 	 * return string       The item's WCPay product id.
 	 */
 	public function get_wcpay_product_id_for_item( string $type ) : string {
-		if ( ! get_option( self::get_wcpay_product_id_option() . '_' . $type ) ) {
-			$this->create_product_for_item_type( $type );
+		$sanitized_type = str_replace( ' ', '_', trim( strtolower( $type ) ) );
+		if ( ! get_option( self::get_wcpay_product_id_option() . '_' . $sanitized_type ) ) {
+			$this->create_product_for_item_type( $sanitized_type );
 		}
 
-		return get_option( self::get_wcpay_product_id_option() . '_' . $type );
+		return get_option( self::get_wcpay_product_id_option() . '_' . $sanitized_type );
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -128,7 +128,7 @@ class WC_Payments_Product_Service {
 	 * return string       The item's WCPay product id.
 	 */
 	public function get_wcpay_product_id_for_item( string $type ) : string {
-		$sanitized_type = str_replace( ' ', '_', trim( strtolower( $type ) ) );
+		$sanitized_type = sanitize_key( str_replace( ' ', '_', trim( strtolower( $type ) ) ) );
 		if ( ! get_option( self::get_wcpay_product_id_option() . '_' . $sanitized_type ) ) {
 			$this->create_product_for_item_type( $sanitized_type );
 		}

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -128,13 +128,22 @@ class WC_Payments_Product_Service {
 	 * return string       The item's WCPay product id.
 	 */
 	public function get_wcpay_product_id_for_item( string $type ) : string {
-		$sanitized_type  = sanitize_key( str_replace( ' ', '_', strtolower( trim( $type ) ) ) );
+		$sanitized_type  = self::sanitize_option_key( $type );
 		$option_key_name = self::get_wcpay_product_id_option() . '_' . $sanitized_type;
 		if ( ! get_option( $option_key_name ) ) {
 			$this->create_product_for_item_type( $sanitized_type );
 		}
-
 		return get_option( $option_key_name );
+	}
+
+	/**
+	 * Sanitize option key string to replace space with underscore, and remove special characters.
+	 *
+	 * @param string $type Non sanitized input.
+	 * return string       Sanitized output.
+	 */
+	public static function sanitize_option_key( string $type ) {
+		return sanitize_key( str_replace( ' ', '_', strtolower( trim( $type ) ) ) );
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-product-service.php
+++ b/includes/subscriptions/class-wc-payments-product-service.php
@@ -128,12 +128,13 @@ class WC_Payments_Product_Service {
 	 * return string       The item's WCPay product id.
 	 */
 	public function get_wcpay_product_id_for_item( string $type ) : string {
-		$sanitized_type = sanitize_key( str_replace( ' ', '_', trim( strtolower( $type ) ) ) );
-		if ( ! get_option( self::get_wcpay_product_id_option() . '_' . $sanitized_type ) ) {
+		$sanitized_type  = sanitize_key( str_replace( ' ', '_', strtolower( trim( $type ) ) ) );
+		$option_key_name = self::get_wcpay_product_id_option() . '_' . $sanitized_type;
+		if ( ! get_option( $option_key_name ) ) {
 			$this->create_product_for_item_type( $sanitized_type );
 		}
 
-		return get_option( self::get_wcpay_product_id_option() . '_' . $sanitized_type );
+		return get_option( $option_key_name );
 	}
 
 	/**

--- a/tests/unit/subscriptions/test-class-wc-payments-product-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-product-service.php
@@ -289,7 +289,6 @@ class WC_Payments_Product_Service_Test extends WCPAY_UnitTestCase {
 	 * Tests for WC_Payments_Product_Service::get_wcpay_product_id_for_item()
 	 */
 	public function test_get_wcpay_product_id_for_item() {
-
 		$this->mock_api_client->expects( $this->once() )
 		->method( 'create_product' )
 		->willReturn(
@@ -305,13 +304,5 @@ class WC_Payments_Product_Service_Test extends WCPAY_UnitTestCase {
 
 		$this->assertFalse( get_option( '_wcpay_product_id_live_Test Tax *&^ name' ) );
 		$this->assertSame( 'product_id_test123', get_option( '_wcpay_product_id_live_test_tax__name' ) );
-	}
-
-	/**
-	 * Tests for WC_Payments_Product_Service::sanitize_option_key()
-	 */
-	public function test_sanitize_option_key() {
-		$test_type = 'Test Tax *&^ name';
-		$this->assertSame( 'test_tax__name', WC_Payments_Product_Service::sanitize_option_key( $test_type ) );
 	}
 }

--- a/tests/unit/subscriptions/test-class-wc-payments-product-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-product-service.php
@@ -274,7 +274,9 @@ class WC_Payments_Product_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( $mock_product_id, $this->product_service->get_wcpay_product_id( $this->mock_product ) );
 	}
 
-
+	/**
+	 * Tests for WC_Payments_Product_Service::get_wcpay_product_id_option()
+	 */
 	public function test_get_wcpay_product_id_option() {
 		$this->assertSame( '_wcpay_product_id_live', WC_Payments_Product_Service::get_wcpay_product_id_option() );
 
@@ -301,9 +303,15 @@ class WC_Payments_Product_Service_Test extends WCPAY_UnitTestCase {
 		$test_type = 'Test Tax *&^ name';
 		$this->product_service->get_wcpay_product_id_for_item( $test_type );
 
-		$this->assertSame( 'test_tax__name', WC_Payments_Product_Service::sanitize_option_key( $test_type ) );
-
 		$this->assertFalse( get_option( '_wcpay_product_id_live_Test Tax *&^ name' ) );
 		$this->assertSame( 'product_id_test123', get_option( '_wcpay_product_id_live_test_tax__name' ) );
+	}
+
+	/**
+	 * Tests for WC_Payments_Product_Service::sanitize_option_key()
+	 */
+	public function test_sanitize_option_key() {
+		$test_type = 'Test Tax *&^ name';
+		$this->assertSame( 'test_tax__name', WC_Payments_Product_Service::sanitize_option_key( $test_type ) );
 	}
 }

--- a/tests/unit/subscriptions/test-class-wc-payments-product-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-product-service.php
@@ -301,6 +301,8 @@ class WC_Payments_Product_Service_Test extends WCPAY_UnitTestCase {
 		$test_type = 'Test Tax *&^ name';
 		$this->product_service->get_wcpay_product_id_for_item( $test_type );
 
+		$this->assertSame( 'test_tax__name', WC_Payments_Product_Service::sanitize_option_key( $test_type ) );
+
 		$this->assertFalse( get_option( '_wcpay_product_id_live_Test Tax *&^ name' ) );
 		$this->assertSame( 'product_id_test123', get_option( '_wcpay_product_id_live_test_tax__name' ) );
 	}

--- a/tests/unit/subscriptions/test-class-wc-payments-product-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-product-service.php
@@ -274,9 +274,7 @@ class WC_Payments_Product_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( $mock_product_id, $this->product_service->get_wcpay_product_id( $this->mock_product ) );
 	}
 
-	/**
-	 * Tests for WC_Payments_Product_Service::get_wcpay_product_id_option()
-	 */
+
 	public function test_get_wcpay_product_id_option() {
 		$this->assertSame( '_wcpay_product_id_live', WC_Payments_Product_Service::get_wcpay_product_id_option() );
 
@@ -286,13 +284,24 @@ class WC_Payments_Product_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
-	 * Tests for WC_Payments_Product_Service::get_wcpay_price_id_option()
+	 * Tests for WC_Payments_Product_Service::get_wcpay_product_id_for_item()
 	 */
-	public function test_get_wcpay_price_id_option() {
-		$this->assertSame( '_wcpay_product_price_id_live', WC_Payments_Product_Service::get_wcpay_price_id_option() );
+	public function test_get_wcpay_product_id_for_item() {
 
-		// set to testmode.
-		WC_Payments::get_gateway()->update_option( 'test_mode', 'yes' );
-		$this->assertSame( '_wcpay_product_price_id_test', WC_Payments_Product_Service::get_wcpay_price_id_option() );
+		$this->mock_api_client->expects( $this->once() )
+		->method( 'create_product' )
+		->willReturn(
+			[
+				'wcpay_product_id' => 'product_id_test123',
+				'wcpay_price_id'   => 'price_test123',
+			]
+		);
+
+		// If type is 'Test Tax *&^ name', the result should be _wcpay_product_id_live_test_tax__name.
+		$test_type = 'Test Tax *&^ name';
+		$this->product_service->get_wcpay_product_id_for_item( $test_type );
+
+		$this->assertFalse( get_option( '_wcpay_product_id_live_Test Tax *&^ name' ) );
+		$this->assertSame( 'product_id_test123', get_option( '_wcpay_product_id_live_test_tax__name' ) );
 	}
 }


### PR DESCRIPTION
Replace spaces with underscores between words in option key names for sub products.

Fixes #4259 

#### Changes proposed in this Pull Request
Sanitize Subscription product option key name before they are saved in DB

Option keys, for example, tax names, are saved as `_wcpay_product_id_Tax name`  instead of `_wcpay_product_id_tax_name`. The PR replaces spaces with underscores, and makes the option name in all small case, before it gets concatenated and saved in the database. 


#### Testing instructions

* Turn taxes on for a WC store
* Add a new tax with a name containing spaces. For example ('Tax for climate')
* Apply the tax to a WC Pay subscriptions product (or leave it on all store products)
* Purchase the product with the tax applied to it
* Verify the wp_options table. There should be a new option called `_wcpay_product_id_test_tax_for_climate` (contains name of the tax with underscore instead of spaces)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (Not applicable)


Post merge
- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : (QA Testing Not Applicable)
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable. - (Not applicable)
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable. - (Not applicable)