### PR TITLE
Update function call and declarations to remove unused arguments and parameters

### DIFF
--- a/changelog/update-remove-unused-function-arguments
+++ b/changelog/update-remove-unused-function-arguments
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Removed some unusued function parameter and arguments.
+
+

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -178,7 +178,7 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 			// Store receipt generation URL for mobile applications in order meta-data.
 			$order->add_meta_data( 'receipt_url', get_rest_url( null, sprintf( '%s/payments/readers/receipts/%s', $this->namespace, $intent->get_id() ) ) );
 			// Actualize order status.
-			$this->order_service->mark_terminal_payment_completed( $order, $intent_id, $result['status'], $charge_id );
+			$this->order_service->mark_terminal_payment_completed( $order, $intent_id, $result['status'] );
 
 			return rest_ensure_response(
 				[

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2219,7 +2219,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$charge    = $intent->get_charge();
 			$charge_id = ! empty( $charge ) ? $charge->get_id() : null;
 
-			$this->order_service->mark_payment_capture_cancelled( $order, $intent->get_id(), $status, $charge_id );
+			$this->order_service->mark_payment_capture_cancelled( $order, $intent->get_id(), $status );
 			return;
 		} elseif ( ! empty( $error_message ) ) {
 			$note = sprintf(

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -145,7 +145,7 @@ class WC_Payments_Order_Service {
 			return;
 		}
 
-		$this->add_payment_started_note( $order, $intent_id, $charge_id );
+		$this->add_payment_started_note( $order, $intent_id );
 		$this->complete_order_processing( $order, $intent_status );
 	}
 

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -221,11 +221,10 @@ class WC_Payments_Order_Service {
 	 * @param WC_Order $order         Order object.
 	 * @param string   $intent_id     The ID of the intent associated with this order.
 	 * @param string   $intent_status The status of the intent related to this order.
-	 * @param string   $charge_id     The charge ID related to the intent/order.
 	 *
 	 * @return void
 	 */
-	public function mark_payment_capture_cancelled( $order, $intent_id, $intent_status, $charge_id ) {
+	public function mark_payment_capture_cancelled( $order, $intent_id, $intent_status ) {
 		if ( ! $this->order_prepared_for_processing( $order, $intent_id ) ) {
 			return;
 		}
@@ -305,11 +304,10 @@ class WC_Payments_Order_Service {
 	 * @param WC_Order $order         Order object.
 	 * @param string   $intent_id     The ID of the intent associated with this order.
 	 * @param string   $intent_status The status of the intent related to this order.
-	 * @param string   $charge_id     The charge ID related to the intent/order.
 	 *
 	 * @return void
 	 */
-	public function mark_terminal_payment_completed( $order, $intent_id, $intent_status, $charge_id ) {
+	public function mark_terminal_payment_completed( $order, $intent_id, $intent_status ) {
 		$this->update_order_status( $order, self::STATUS_COMPLETED, $intent_id );
 		$this->complete_order_processing( $order, $intent_status );
 	}
@@ -467,11 +465,10 @@ class WC_Payments_Order_Service {
 	 *
 	 * @param WC_Order $order     Order object.
 	 * @param string   $intent_id The ID of the intent associated with this order.
-	 * @param string   $charge_id The charge ID related to the intent/order.
 	 *
 	 * @return void
 	 */
-	private function add_payment_started_note( $order, $intent_id, $charge_id ) {
+	private function add_payment_started_note( $order, $intent_id ) {
 		$note = sprintf(
 			WC_Payments_Utils::esc_interpolated_html(
 				/* translators: %1: the authorized amount, %2: transaction ID of the payment */

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -231,7 +231,7 @@ class WC_Payments_Order_Service {
 		}
 
 		$this->update_order_status( $order, self::STATUS_CANCELLED );
-		$this->add_capture_cancelled_note( $order, $intent_id, $charge_id );
+		$this->add_capture_cancelled_note( $order );
 		$this->complete_order_processing( $order, $intent_status );
 	}
 

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -425,7 +425,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$order_status  = 'cancelled'; // WooCommerce uses double 'l'.
 
 		// Act: Attempt to mark the payment/order expired/cancelled.
-		$this->order_service->mark_payment_capture_cancelled( $this->order, $this->intent_id, $intent_status, $this->charge_id );
+		$this->order_service->mark_payment_capture_cancelled( $this->order, $this->intent_id, $intent_status );
 
 		// Assert: Check to make sure the intent_status meta was set.
 		$this->assertEquals( $intent_status, $this->order->get_meta( '_intention_status' ) );
@@ -538,7 +538,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$order_status  = 'completed';
 
 		// Act: Attempt to mark the payment/order complete.
-		$this->order_service->mark_terminal_payment_completed( $this->order, $this->intent_id, $intent_status, $this->charge_id );
+		$this->order_service->mark_terminal_payment_completed( $this->order, $this->intent_id, $intent_status );
 
 		// Assert: Check to make sure the intent_status meta was set.
 		$this->assertEquals( $intent_status, $this->order->get_meta( '_intention_status' ) );


### PR DESCRIPTION
Fixes #4347

#### Changes proposed in this Pull Request

1. The `add_capture_cancelled_note` function accepts one argument, but the function call provides three arguments. This PR removes the two unused arguments from the function call.

2. The `mark_payment_capture_cancelled`, `mark_terminal_payment_completed`, and `add_payment_started_note` functions include the `$charge_id` parameter, but it is not used inside the function. This PR removed the parameter from all three functions.

#### Testing instructions
- Unit tests should pass.
- Check if other functions use the `$charge_id` parameter.

-------------------

- [x]  Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
