### PR TITLE
Check payment method before updating payment method title

### DIFF
--- a/changelog/fix-4428-woocommerce-payments-override-stripe
+++ b/changelog/fix-4428-woocommerce-payments-override-stripe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Check payment method before updating payment method title

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -378,7 +378,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 	 * @return  void
 	 */
 	public function add_order_meta( $order_id, $posted_data ) {
-		if ( empty( $_POST['payment_request_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( empty( $_POST['payment_request_type'] ) || ! isset( $_POST['payment_method'] ) || 'woocommerce_payments' !== $_POST['payment_method'] ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
 


### PR DESCRIPTION
Fixes #4428 

#### Changes proposed in this Pull Request
Check if there is a payment request and check if the payment method is not WooCommerce payments before updating the payment method title


#### Screenshots
*Before*
<img width="349" alt="Screen Shot 2022-07-28 at 4 44 13 PM" src="https://user-images.githubusercontent.com/56378160/181659120-a36a77da-6268-4997-acf2-bb09975e9043.png">


*After*
<img width="210" alt="Screen Shot 2022-07-28 at 4 44 39 PM" src="https://user-images.githubusercontent.com/56378160/181659132-c4cab33b-a771-44ff-b080-228acdabefed.png">

#### Testing instructions
1. WC + WC Pay test site.
1. Also install Stripe and set it up in test mode.
1. Enable Apple/Google Pay in both WooCommerce Payment and Stripe gateways.
1. On a product page, place a test order using the Stripe payment request button.
1. Verify the test transaction shows in your Stripe account.
1. Inside the WooCommerce order, check the payment method shown Google Pay(Stripe) as shown in the screenshot.

Note: If you run into this issue asked where you can't checkout without your first and last name while checking out with Stripe Google Pay, adding the below code can solve the problem.

```
add_filter( 'woocommerce_checkout_fields', 'customize_woo_checkout_fields' );
  
function customize_woo_checkout_fields( $fields ) {
    unset( $fields['billing']['billing_first_name'] );
    unset( $fields['billing']['billig_last_name'] );
   
    return $fields;
}
```

*

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [X] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
