### PR TITLE
Fix StripeLink + WooCommerce Blocks issues

### DIFF
--- a/changelog/fix-stripe-link-woo-blocks
+++ b/changelog/fix-stripe-link-woo-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix compatibility issues with the new WooCommerce Blocks

--- a/client/checkout/blocks/upe-fields.js
+++ b/client/checkout/blocks/upe-fields.js
@@ -118,11 +118,13 @@ const WCPayUPEFields = ( {
 					const setAddress =
 						shippingAddressFields[ key ] === nodeId
 							? customerData.setShippingAddress
-							: customerData.setBillingData;
+							: customerData.setBillingData ||
+							  customerData.setBillingAddress;
 					const customerAddress =
 						shippingAddressFields[ key ] === nodeId
 							? customerData.shippingAddress
-							: customerData.billingData;
+							: customerData.billingData ||
+							  customerData.billingAddress;
 
 					if ( 'line1' === key ) {
 						customerAddress.address_1 = address.address[ key ];
@@ -140,8 +142,15 @@ const WCPayUPEFields = ( {
 						return document.getElementById( 'email' ).value;
 					}
 
-					customerData.billingData.email = getEmail();
-					customerData.setBillingData( customerData.billingData );
+					if ( customerData.billingData ) {
+						customerData.billingData.email = getEmail();
+						customerData.setBillingData( customerData.billingData );
+					} else {
+						customerData.billingAddress.email = getEmail();
+						customerData.setBillingAddress(
+							customerData.billingAddress
+						);
+					}
 				},
 				show_button: ( linkAutofill ) => {
 					jQuery( '#email' )

--- a/client/checkout/blocks/upe-fields.js
+++ b/client/checkout/blocks/upe-fields.js
@@ -35,13 +35,21 @@ const useCustomerData = () => {
 			isInitialized: store.hasFinishedResolution( 'getCartData' ),
 		};
 	} );
-	const { setShippingAddress, setBillingData } = useDispatch( WC_STORE_CART );
+	const {
+		setShippingAddress,
+		setBillingData,
+		setBillingAddress,
+	} = useDispatch( WC_STORE_CART );
 
 	return {
 		isInitialized,
 		billingData: customerData.billingData,
+		// Backward compatibility billingData/billingAddress
+		billingAddress: customerData.billingAddress,
 		shippingAddress: customerData.shippingAddress,
 		setBillingData,
+		// Backward compatibility setBillingData/setBillingAddress
+		setBillingAddress,
 		setShippingAddress,
 	};
 };


### PR DESCRIPTION
Fixes #4475

#### Changes proposed in this Pull Request

This fixes a breaking change introduced in https://github.com/woocommerce/woocommerce-blocks/pull/6369, where new blocks do not work with StripeLink.

The proposed change is to fix this while keeping it backward compatible.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. Clone the woocommerce-blocks repo locally
2. Edit the `docker-compose.override.yml` in this repo to link to `woocommerce-blocks`. Something like this should work
```
version: '3'

services:
    wordpress:
        volumes:
            - ../woocommerce-blocks:/var/www/html/wp-content/plugins/woocommerce-blocks
```
3. Go to local repo for `woocommerce-blocks`, `git checkout 296ccef` (this is the commit where the breaking change was introduced)
4. Go to local repo for `woocommerce-blocks`, install deps `npm i` & `composer install` + run the build `npm run build`.
5. Create a new page in WP Admin (this repo), and add a checkout block via Gutenberg
6. Try to buy something using StripeLink, the address should not work
7. Now get this PR and try again, it should work this time
8. Go to local repo for `woocommerce-blocks`, `git checkout 2f172d251` (this is the commit just before the breaking change was introduced)
9. Go to local repo for `woocommerce-blocks`, install deps `npm i` & `composer install` + run the build `npm run build`.
10. Try to buy something using StripeLink, it should work (backward compatible)


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
