### PR TITLE
Remove Charge request from Transaction Details page

### DIFF
--- a/changelog/update-353-charge
+++ b/changelog/update-353-charge
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove Charge request from Transactions Details page. The Charge data will be retrieved from the Payment Intent request.

--- a/client/data/payment-intents/hooks.ts
+++ b/client/data/payment-intents/hooks.ts
@@ -42,14 +42,8 @@ export const usePaymentIntentWithChargeFallback = (
 
 			const paymentIntent: PaymentIntent = getPaymentIntent( id );
 
-			if ( paymentIntent?.charge?.id ) {
-				const { id: chargeId } = paymentIntent.charge;
-
-				return getChargeData( chargeId, selectors );
-			}
-
 			return {
-				data: {} as Charge,
+				data: paymentIntent?.charge || ( {} as Charge ),
 				error: getPaymentIntentError( id ),
 				isLoading: isResolving( 'getPaymentIntent', [ id ] ),
 			};

--- a/client/data/payment-intents/test/resolvers.ts
+++ b/client/data/payment-intents/test/resolvers.ts
@@ -11,38 +11,23 @@ import { apiFetch, dispatch } from '@wordpress/data-controls';
 import { updatePaymentIntent, updateErrorForPaymentIntent } from '../actions';
 import { getPaymentIntent } from '../resolvers';
 import { PaymentIntent } from '../../../types/payment-intents';
+import { paymentIntentId, paymentIntentMock } from './hooks';
 
 const errorResponse = { code: 'error' };
 
 const paymentIntentResponse: { data: PaymentIntent } = {
-	data: {
-		id: 'pi_test_1',
-		amount: 8903,
-		currency: 'USD',
-		charge: {
-			id: 'ch_test_1',
-			amount: 8903,
-			created: 1656701170,
-			payment_method_details: {
-				card: {},
-				type: 'card',
-			},
-		},
-		created: 1656701169,
-		customer: 'cus_test',
-		metadata: {},
-		payment_method: 'pm_test',
-		status: 'requires_capture',
-	},
+	data: paymentIntentMock,
 };
 
 describe( 'getPaymentIntent resolver', () => {
 	let generator: Generator< unknown >;
 
 	beforeEach( () => {
-		generator = getPaymentIntent( 'pi_test_1' );
+		generator = getPaymentIntent( paymentIntentId );
 		expect( generator.next().value ).toEqual(
-			apiFetch( { path: '/wc/v3/payments/payment_intents/pi_test_1' } )
+			apiFetch( {
+				path: `/wc/v3/payments/payment_intents/${ paymentIntentId }`,
+			} )
 		);
 	} );
 
@@ -73,7 +58,7 @@ describe( 'getPaymentIntent resolver', () => {
 				)
 			);
 			expect( generator.next().value ).toEqual(
-				updateErrorForPaymentIntent( 'pi_test_1', errorResponse )
+				updateErrorForPaymentIntent( paymentIntentId, errorResponse )
 			);
 		} );
 	} );

--- a/client/data/payment-intents/test/selectors.ts
+++ b/client/data/payment-intents/test/selectors.ts
@@ -3,30 +3,8 @@
 /**
  * Internal dependencies
  */
-import { PaymentIntent } from '../../../types/payment-intents';
 import { getPaymentIntent, getPaymentIntentError } from '../selectors';
-
-const paymentIntentId = 'pi_mock';
-
-const paymentIntentMock: PaymentIntent = {
-	id: paymentIntentId,
-	amount: 8903,
-	currency: 'USD',
-	charge: {
-		id: 'ch_mock',
-		amount: 8903,
-		created: 1656701170,
-		payment_method_details: {
-			card: {},
-			type: 'card',
-		},
-	},
-	created: 1656701169,
-	customer: 'cus_mock',
-	metadata: {},
-	payment_method: 'pm_mock',
-	status: 'requires_capture',
-};
+import { paymentIntentId, paymentIntentMock } from './hooks';
 
 const paymentIntentStateMock = {
 	id: paymentIntentId,

--- a/client/payment-details/summary/test/index.tsx
+++ b/client/payment-details/summary/test/index.tsx
@@ -100,7 +100,7 @@ describe( 'PaymentDetailsSummary', () => {
 		const charge = getBaseCharge();
 		charge.refunded = false;
 		charge.amount_refunded = 1200;
-		charge.refunds.data.push( {
+		charge.refunds?.data.push( {
 			balance_transaction: {
 				amount: -charge.amount_refunded,
 				currency: 'usd',
@@ -114,7 +114,7 @@ describe( 'PaymentDetailsSummary', () => {
 		const charge = getBaseCharge();
 		charge.refunded = true;
 		charge.amount_refunded = 2000;
-		charge.refunds.data.push( {
+		charge.refunds?.data.push( {
 			balance_transaction: {
 				amount: -charge.amount_refunded,
 				currency: 'usd',

--- a/client/payment-details/test/index.tsx
+++ b/client/payment-details/test/index.tsx
@@ -37,71 +37,70 @@ jest.mock( '@wordpress/data', () => ( {
 	useSelect: jest.fn(),
 } ) );
 
+const chargeMock = {
+	id: 'ch_mock',
+	amount: 1500,
+	application_fee_amount: 74,
+	balance_transaction: {
+		amount: 1500,
+		currency: 'usd',
+		fee: 74,
+	},
+	billing_details: {
+		address: {
+			city: 'City',
+			country: 'US',
+			line1: 'Line 1 Street',
+			line2: 'Line 2',
+			postal_code: '99999',
+			state: 'CA',
+		},
+		email: 'email@example.com',
+		name: 'First Name',
+		phone: '1-000-000-0000',
+		formatted_address: 'Line 1 Street<br/>Line 2<br/>City, CA 99999',
+	},
+	captured: true,
+	created: 1655921807,
+	currency: 'usd',
+	customer: 'cus_mock',
+	dispute: null,
+	disputed: false,
+	paid: true,
+	payment_intent: 'pi_mock',
+	payment_method: 'pm_mock',
+	payment_method_details: {
+		card: {
+			brand: 'visa',
+			checks: {
+				address_line1_check: 'pass',
+				address_postal_code_check: 'pass',
+				cvc_check: 'pass',
+			},
+			country: 'US',
+			exp_month: 12,
+			exp_year: 2099,
+			fingerprint: 'fingerprint',
+			funding: 'credit',
+			last4: '4242',
+			network: 'visa',
+		},
+		type: 'card',
+	},
+	refunded: false,
+	refunds: {},
+	status: 'succeeded',
+};
+
 ( useSelect as jest.Mock ).mockImplementation( ( cb ) =>
 	cb(
 		jest.fn().mockReturnValue( {
-			getCharge: jest.fn().mockReturnValue( {
-				id: 'ch_mock',
-				amount: 1500,
-				application_fee_amount: 74,
-				balance_transaction: {
-					amount: 1500,
-					currency: 'usd',
-					fee: 74,
-				},
-				billing_details: {
-					address: {
-						city: 'City',
-						country: 'US',
-						line1: 'Line 1 Street',
-						line2: 'Line 2',
-						postal_code: '99999',
-						state: 'CA',
-					},
-					email: 'email@example.com',
-					name: 'First Name',
-					phone: '1-000-000-0000',
-					formatted_address:
-						'Line 1 Street<br/>Line 2<br/>City, CA 99999',
-				},
-				captured: true,
-				created: 1655921807,
-				currency: 'usd',
-				customer: 'cus_mock',
-				dispute: null,
-				disputed: false,
-				paid: true,
-				payment_intent: 'pi_mock',
-				payment_method: 'pm_mock',
-				payment_method_details: {
-					card: {
-						brand: 'visa',
-						checks: {
-							address_line1_check: 'pass',
-							address_postal_code_check: 'pass',
-							cvc_check: 'pass',
-						},
-						country: 'US',
-						exp_month: 12,
-						exp_year: 2099,
-						fingerprint: 'fingerprint',
-						funding: 'credit',
-						last4: '4242',
-						network: 'visa',
-					},
-					type: 'card',
-				},
-				refunded: false,
-				refunds: {},
-				status: 'succeeded',
-			} ),
+			getCharge: jest.fn().mockReturnValue( chargeMock ),
 			isResolving: jest.fn().mockReturnValue( false ),
 			getChargeError: jest.fn().mockReturnValue( null ),
 			getPaymentIntent: jest.fn().mockReturnValue( {
 				id: 'pi_mock',
-				charge: {
-					id: 'ch_mock',
-				},
+				charge: chargeMock,
 			} ),
 			getPaymentIntentError: jest.fn().mockReturnValue( null ),
 			getTimeline: jest.fn().mockReturnValue( {} ),

--- a/client/style.scss
+++ b/client/style.scss
@@ -111,7 +111,7 @@
 }
 
 .payment-method-details {
-	display: inline-flex;
+	display: flex;
 	align-items: flex-start;
 
 	@media screen and ( max-width: 1023px ) {
@@ -120,6 +120,10 @@
 
 	&__column {
 		flex: 0 0 50%;
+	}
+
+	&-list-item {
+		display: inline-flex;
 	}
 }
 

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -385,7 +385,7 @@ export const TransactionsList = (
 				value: txn.source,
 				display: ! isFinancingType ? (
 					clickable(
-						<span className="payment-method-details">
+						<span className="payment-method-details-list-item">
 							<span
 								className={ `payment-method__brand payment-method__brand--${ txn.source }` }
 							/>

--- a/client/transactions/list/test/__snapshots__/index.tsx.snap
+++ b/client/transactions/list/test/__snapshots__/index.tsx.snap
@@ -587,7 +587,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                     tabindex="-1"
                   >
                     <span
-                      class="payment-method-details"
+                      class="payment-method-details-list-item"
                     >
                       <span
                         class="payment-method__brand payment-method__brand--visa"
@@ -728,7 +728,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                     tabindex="-1"
                   >
                     <span
-                      class="payment-method-details"
+                      class="payment-method-details-list-item"
                     >
                       <span
                         class="payment-method__brand payment-method__brand--mastercard"
@@ -856,7 +856,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                     tabindex="-1"
                   >
                     <span
-                      class="payment-method-details"
+                      class="payment-method-details-list-item"
                     >
                       <span
                         class="payment-method__brand payment-method__brand--visa"
@@ -1468,7 +1468,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                     tabindex="-1"
                   >
                     <span
-                      class="payment-method-details"
+                      class="payment-method-details-list-item"
                     >
                       <span
                         class="payment-method__brand payment-method__brand--visa"
@@ -1609,7 +1609,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                     tabindex="-1"
                   >
                     <span
-                      class="payment-method-details"
+                      class="payment-method-details-list-item"
                     >
                       <span
                         class="payment-method__brand payment-method__brand--mastercard"
@@ -1737,7 +1737,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                     tabindex="-1"
                   >
                     <span
-                      class="payment-method-details"
+                      class="payment-method-details-list-item"
                     >
                       <span
                         class="payment-method__brand payment-method__brand--visa"
@@ -2353,7 +2353,7 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                     tabindex="-1"
                   >
                     <span
-                      class="payment-method-details"
+                      class="payment-method-details-list-item"
                     >
                       <span
                         class="payment-method__brand payment-method__brand--mastercard"
@@ -3030,7 +3030,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                     tabindex="-1"
                   >
                     <span
-                      class="payment-method-details"
+                      class="payment-method-details-list-item"
                     >
                       <span
                         class="payment-method__brand payment-method__brand--visa"
@@ -3174,7 +3174,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                     tabindex="-1"
                   >
                     <span
-                      class="payment-method-details"
+                      class="payment-method-details-list-item"
                     >
                       <span
                         class="payment-method__brand payment-method__brand--mastercard"
@@ -3305,7 +3305,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                     tabindex="-1"
                   >
                     <span
-                      class="payment-method-details"
+                      class="payment-method-details-list-item"
                     >
                       <span
                         class="payment-method__brand payment-method__brand--visa"
@@ -3959,7 +3959,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                     tabindex="-1"
                   >
                     <span
-                      class="payment-method-details"
+                      class="payment-method-details-list-item"
                     >
                       <span
                         class="payment-method__brand payment-method__brand--visa"
@@ -4100,7 +4100,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                     tabindex="-1"
                   >
                     <span
-                      class="payment-method-details"
+                      class="payment-method-details-list-item"
                     >
                       <span
                         class="payment-method__brand payment-method__brand--mastercard"
@@ -4228,7 +4228,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                     tabindex="-1"
                   >
                     <span
-                      class="payment-method-details"
+                      class="payment-method-details-list-item"
                     >
                       <span
                         class="payment-method__brand payment-method__brand--visa"
@@ -4882,7 +4882,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                     tabindex="-1"
                   >
                     <span
-                      class="payment-method-details"
+                      class="payment-method-details-list-item"
                     >
                       <span
                         class="payment-method__brand payment-method__brand--visa"
@@ -5023,7 +5023,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                     tabindex="-1"
                   >
                     <span
-                      class="payment-method-details"
+                      class="payment-method-details-list-item"
                     >
                       <span
                         class="payment-method__brand payment-method__brand--mastercard"
@@ -5151,7 +5151,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                     tabindex="-1"
                   >
                     <span
-                      class="payment-method-details"
+                      class="payment-method-details-list-item"
                     >
                       <span
                         class="payment-method__brand payment-method__brand--visa"

--- a/client/types/charges.d.ts
+++ b/client/types/charges.d.ts
@@ -16,6 +16,7 @@ interface ChargeBillingDetails {
 		postal_code: null | string;
 		state: null | string;
 	};
+	formatted_address?: string;
 }
 
 interface ChargeRefund {
@@ -41,6 +42,13 @@ export interface PaymentMethodDetails {
 		| 'sofort';
 }
 
+export type OutcomeRiskLevel =
+	| 'normal'
+	| 'elevated'
+	| 'highest'
+	| 'not_assessed'
+	| 'unknown';
+
 export interface Charge {
 	id: string;
 	amount: number;
@@ -49,34 +57,30 @@ export interface Charge {
 	application_fee_amount: number;
 	balance_transaction: BalanceTransaction;
 	billing_details: ChargeBillingDetails;
-	captured: boolean;
+	captured?: boolean;
 	created: number;
 	currency: string;
-	dispute?: Dispute;
+	dispute?: null | Dispute;
 	disputed: boolean;
 	order: null | OrderDetails;
 	outcome: null | {
 		network_status: string;
-		reason: string;
-		risk_level:
-			| 'normal'
-			| 'elevated'
-			| 'highest'
-			| 'not_assessed'
-			| 'unknown';
+		reason: null | string;
+		risk_level: OutcomeRiskLevel;
 		risk_score: number;
-		rule: string;
+		rule?: string;
 		seller_message: string;
 		type: string;
 	};
 	paid: boolean;
-	paydown: {
+	paydown: null | {
 		amount: number;
 	};
 	payment_intent: null | string;
+	payment_method: string;
 	payment_method_details: PaymentMethodDetails;
 	refunded: boolean;
-	refunds: ChargeRefunds;
+	refunds: null | ChargeRefunds;
 	status: string;
 }
 

--- a/client/types/payment-intents.d.ts
+++ b/client/types/payment-intents.d.ts
@@ -1,19 +1,12 @@
 /**
  * Internal dependencies
  */
-import { PaymentMethodDetails } from './charges';
-
-export interface PaymentIntentCharge {
-	id: string;
-	amount: number;
-	created: number;
-	payment_method_details: PaymentMethodDetails;
-}
+import { Charge } from './charges';
 
 export interface PaymentIntent {
 	id: string;
 	amount: number;
-	charge: PaymentIntentCharge;
+	charge: Charge;
 	created: number;
 	currency: string;
 	customer: string;

--- a/client/utils/charge/index.ts
+++ b/client/utils/charge/index.ts
@@ -15,8 +15,9 @@ import { Charge, ChargeAmounts } from 'types/charges';
 const failedOutcomeTypes = [ 'issuer_declined', 'invalid' ];
 const blockedOutcomeTypes = [ 'blocked' ];
 
-export const getDisputeStatus = ( dispute: Dispute = <Dispute>{} ): string =>
-	dispute.status || '';
+export const getDisputeStatus = (
+	dispute: null | Dispute = <Dispute>{}
+): string => dispute?.status || '';
 
 export const getChargeOutcomeType = ( charge: Charge = <Charge>{} ): string =>
 	charge.outcome ? charge.outcome.type : '';
@@ -103,15 +104,15 @@ export const getChargeAmounts = ( charge: Charge ): ChargeAmounts => {
 	if ( isChargeRefunded( charge ) ) {
 		// Refund balance_transactions have negative amount.
 		balance.refunded -= sumBy(
-			charge.refunds.data,
+			charge.refunds?.data,
 			'balance_transaction.amount'
 		);
 	}
 
 	if ( isChargeDisputed( charge ) && typeof charge.dispute !== 'undefined' ) {
-		balance.fee += sumBy( charge.dispute.balance_transactions, 'fee' );
+		balance.fee += sumBy( charge.dispute?.balance_transactions, 'fee' );
 		balance.refunded -= sumBy(
-			charge.dispute.balance_transactions,
+			charge.dispute?.balance_transactions,
 			'amount'
 		);
 	}

--- a/includes/admin/class-wc-rest-payments-charges-controller.php
+++ b/includes/admin/class-wc-rest-payments-charges-controller.php
@@ -50,18 +50,6 @@ class WC_REST_Payments_Charges_Controller extends WC_Payments_REST_Controller {
 			return rest_ensure_response( new WP_Error( 'wcpay_get_charge', $e->getMessage() ) );
 		}
 
-		$raw_details     = $charge['billing_details']['address'];
-		$billing_details = [];
-
-		$billing_details['city']      = ( ! empty( $raw_details['city'] ) ) ? $raw_details['city'] : '';
-		$billing_details['country']   = ( ! empty( $raw_details['country'] ) ) ? $raw_details['country'] : '';
-		$billing_details['address_1'] = ( ! empty( $raw_details['line1'] ) ) ? $raw_details['line1'] : '';
-		$billing_details['address_2'] = ( ! empty( $raw_details['line2'] ) ) ? $raw_details['line2'] : '';
-		$billing_details['postcode']  = ( ! empty( $raw_details['postal_code'] ) ) ? $raw_details['postal_code'] : '';
-		$billing_details['state']     = ( ! empty( $raw_details['state'] ) ) ? $raw_details['state'] : '';
-
-		$charge['billing_details']['formatted_address'] = WC()->countries->get_formatted_address( $billing_details );
-
 		return rest_ensure_response( $charge );
 	}
 }

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2328,7 +2328,23 @@ class WC_Payments_API_Client {
 			$charge_array['id'],
 			$charge_array['amount'],
 			$created,
-			$charge_array['payment_method_details'] ?? []
+			$charge_array['payment_method_details'] ?? null,
+			$charge_array['amount_captured'] ?? null,
+			$charge_array['amount_refunded'] ?? null,
+			$charge_array['application_fee_amount'] ?? null,
+			$charge_array['balance_transaction'] ?? null,
+			$charge_array['billing_details'] ?? null,
+			$charge_array['currency'] ?? null,
+			$charge_array['dispute'] ?? null,
+			$charge_array['disputed'] ?? null,
+			$charge_array['order'] ?? null,
+			$charge_array['outcome'] ?? null,
+			$charge_array['paid'] ?? null,
+			$charge_array['paydown'] ?? null,
+			$charge_array['payment_intent'] ?? null,
+			$charge_array['refunded'] ?? null,
+			$charge_array['refunds'] ?? null,
+			$charge_array['status'] ?? null
 		);
 
 		if ( isset( $charge_array['captured'] ) ) {

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2264,17 +2264,21 @@ class WC_Payments_API_Client {
 	 * @return array
 	 */
 	private function add_formatted_address_to_charge_object( array $charge ) : array {
-		$raw_details     = $charge['billing_details']['address'];
-		$billing_details = [];
+		$has_billing_details = isset( $charge['billing_details'] );
 
-		$billing_details['city']      = ( ! empty( $raw_details['city'] ) ) ? $raw_details['city'] : '';
-		$billing_details['country']   = ( ! empty( $raw_details['country'] ) ) ? $raw_details['country'] : '';
-		$billing_details['address_1'] = ( ! empty( $raw_details['line1'] ) ) ? $raw_details['line1'] : '';
-		$billing_details['address_2'] = ( ! empty( $raw_details['line2'] ) ) ? $raw_details['line2'] : '';
-		$billing_details['postcode']  = ( ! empty( $raw_details['postal_code'] ) ) ? $raw_details['postal_code'] : '';
-		$billing_details['state']     = ( ! empty( $raw_details['state'] ) ) ? $raw_details['state'] : '';
+		if ( $has_billing_details ) {
+			$raw_details     = $charge['billing_details']['address'];
+			$billing_details = [];
 
-		$charge['billing_details']['formatted_address'] = WC()->countries->get_formatted_address( $billing_details );
+			$billing_details['city']      = ( ! empty( $raw_details['city'] ) ) ? $raw_details['city'] : '';
+			$billing_details['country']   = ( ! empty( $raw_details['country'] ) ) ? $raw_details['country'] : '';
+			$billing_details['address_1'] = ( ! empty( $raw_details['line1'] ) ) ? $raw_details['line1'] : '';
+			$billing_details['address_2'] = ( ! empty( $raw_details['line2'] ) ) ? $raw_details['line2'] : '';
+			$billing_details['postcode']  = ( ! empty( $raw_details['postal_code'] ) ) ? $raw_details['postal_code'] : '';
+			$billing_details['state']     = ( ! empty( $raw_details['state'] ) ) ? $raw_details['state'] : '';
+
+			$charge['billing_details']['formatted_address'] = WC()->countries->get_formatted_address( $billing_details );
+		}
 
 		return $charge;
 	}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -777,7 +777,9 @@ class WC_Payments_API_Client {
 			return $charge;
 		}
 
-		return $this->add_order_info_to_object( $charge['id'], $charge );
+		$charge = $this->add_additional_info_to_charge( $charge );
+
+		return $charge;
 	}
 
 	/**
@@ -2241,6 +2243,43 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Adds additional info to charge object.
+	 *
+	 * @param array $charge - Charge object.
+	 *
+	 * @return array
+	 */
+	private function add_additional_info_to_charge( array $charge ) : array {
+		$charge = $this->add_order_info_to_object( $charge['id'], $charge );
+		$charge = $this->add_formatted_address_to_charge_object( $charge );
+
+		return $charge;
+	}
+
+	/**
+	 * Adds the formatted address to the Charge object
+	 *
+	 * @param array $charge - Charge object.
+	 *
+	 * @return array
+	 */
+	private function add_formatted_address_to_charge_object( array $charge ) : array {
+		$raw_details     = $charge['billing_details']['address'];
+		$billing_details = [];
+
+		$billing_details['city']      = ( ! empty( $raw_details['city'] ) ) ? $raw_details['city'] : '';
+		$billing_details['country']   = ( ! empty( $raw_details['country'] ) ) ? $raw_details['country'] : '';
+		$billing_details['address_1'] = ( ! empty( $raw_details['line1'] ) ) ? $raw_details['line1'] : '';
+		$billing_details['address_2'] = ( ! empty( $raw_details['line2'] ) ) ? $raw_details['line2'] : '';
+		$billing_details['postcode']  = ( ! empty( $raw_details['postal_code'] ) ) ? $raw_details['postal_code'] : '';
+		$billing_details['state']     = ( ! empty( $raw_details['state'] ) ) ? $raw_details['state'] : '';
+
+		$charge['billing_details']['formatted_address'] = WC()->countries->get_formatted_address( $billing_details );
+
+		return $charge;
+	}
+
+	/**
 	 * Returns a transaction with order information when it exists.
 	 *
 	 * @param  string $charge_id related charge id.
@@ -2324,11 +2363,14 @@ class WC_Payments_API_Client {
 		$created = new DateTime();
 		$created->setTimestamp( $charge_array['created'] );
 
+		$charge_array = $this->add_additional_info_to_charge( $charge_array );
+
 		$charge = new WC_Payments_API_Charge(
 			$charge_array['id'],
 			$charge_array['amount'],
 			$created,
 			$charge_array['payment_method_details'] ?? null,
+			$charge_array['payment_method'] ?? null,
 			$charge_array['amount_captured'] ?? null,
 			$charge_array['amount_refunded'] ?? null,
 			$charge_array['application_fee_amount'] ?? null,

--- a/includes/wc-payment-api/models/class-wc-payments-api-charge.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-charge.php
@@ -50,6 +50,13 @@ class WC_Payments_API_Charge implements \JsonSerializable {
 	private $payment_method_details;
 
 	/**
+	 * Payment method id
+	 *
+	 * @var string|null
+	 */
+	private $payment_method;
+
+	/**
 	 * Amount in cents captured
 	 *
 	 * @var int|null
@@ -168,6 +175,7 @@ class WC_Payments_API_Charge implements \JsonSerializable {
 	 * @param integer     $amount                 - Amount charged.
 	 * @param DateTime    $created                - Time charge created.
 	 * @param array       $payment_method_details - Payment method details object.
+	 * @param string|null $payment_method         - Payment method id.
 	 * @param int|null    $amount_captured        - Amount in cents captured.
 	 * @param int|null    $amount_refunded        - Amount in cents refunded.
 	 * @param int|null    $application_fee_amount - The amount of the application fee requested for the charge.
@@ -190,6 +198,7 @@ class WC_Payments_API_Charge implements \JsonSerializable {
 		$amount,
 		DateTime $created,
 		$payment_method_details = [],
+		$payment_method = null,
 		$amount_captured = null,
 		$amount_refunded = null,
 		$application_fee_amount = null,
@@ -211,6 +220,7 @@ class WC_Payments_API_Charge implements \JsonSerializable {
 		$this->amount                 = $amount;
 		$this->created                = $created;
 		$this->payment_method_details = $payment_method_details;
+		$this->payment_method         = $payment_method;
 		$this->amount_captured        = $amount_captured;
 		$this->amount_refunded        = $amount_refunded;
 		$this->application_fee_amount = $application_fee_amount;
@@ -284,6 +294,15 @@ class WC_Payments_API_Charge implements \JsonSerializable {
 	 */
 	public function get_payment_method_details() {
 		return $this->payment_method_details;
+	}
+
+	/**
+	 * Returns the payment method id associated with this charge
+	 *
+	 * @return array
+	 */
+	public function get_payment_method() {
+		return $this->payment_method;
 	}
 
 	/**
@@ -440,6 +459,7 @@ class WC_Payments_API_Charge implements \JsonSerializable {
 			'amount'                 => $this->get_amount(),
 			'created'                => $this->get_created()->getTimestamp(),
 			'payment_method_details' => $this->get_payment_method_details(),
+			'payment_method'         => $this->get_payment_method(),
 			'amount_captured'        => $this->get_amount_captured(),
 			'amount_refunded'        => $this->get_amount_refunded(),
 			'application_fee_amount' => $this->get_application_fee_amount(),

--- a/includes/wc-payment-api/models/class-wc-payments-api-charge.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-charge.php
@@ -299,7 +299,7 @@ class WC_Payments_API_Charge implements \JsonSerializable {
 	/**
 	 * Returns the payment method id associated with this charge
 	 *
-	 * @return array
+	 * @return string|null
 	 */
 	public function get_payment_method() {
 		return $this->payment_method;

--- a/includes/wc-payment-api/models/class-wc-payments-api-charge.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-charge.php
@@ -50,23 +50,183 @@ class WC_Payments_API_Charge implements \JsonSerializable {
 	private $payment_method_details;
 
 	/**
+	 * Amount in cents captured
+	 *
+	 * @var int|null
+	 */
+	private $amount_captured;
+
+	/**
+	 * Amount in cents refunded
+	 *
+	 * @var int|null
+	 */
+	private $amount_refunded;
+
+	/**
+	 * The amount of the application fee requested for the charge
+	 *
+	 * @var int|null
+	 */
+	private $application_fee_amount;
+
+	/**
+	 * Balance transaction that describes the impact of this charge on the account balance
+	 *
+	 * @var array
+	 */
+	private $balance_transaction;
+
+	/**
+	 * Billing information associated with the payment method at the time of the transaction
+	 *
+	 * @var array
+	 */
+	private $billing_details;
+
+	/**
+	 * Charge currency
+	 *
+	 * @var string|null
+	 */
+	private $currency;
+
+	/**
+	 * Charge dispute object
+	 *
+	 * @var array
+	 */
+	private $dispute;
+
+	/**
+	 * Flag indicating whether the charge has been disputed or not
+	 *
+	 * @var bool|null
+	 */
+	private $disputed;
+
+	/**
+	 * Charge order object
+	 *
+	 * @var array
+	 */
+	private $order;
+
+	/**
+	 * Details about whether the payment was accepted, and why
+	 *
+	 * @var array
+	 */
+	private $outcome;
+
+	/**
+	 * Flag indicating whether the charge has been paid or not
+	 *
+	 * @var bool|null
+	 */
+	private $paid;
+
+	/**
+	 * Charge paydown object
+	 *
+	 * @var array
+	 */
+	private $paydown;
+
+	/**
+	 * Charge payment intent id
+	 *
+	 * @var string|null
+	 */
+	private $payment_intent;
+
+	/**
+	 * Flag indicating whether the charge has been refunded or not
+	 *
+	 * @var bool|null
+	 */
+	private $refunded;
+
+	/**
+	 * Charge refunds object
+	 *
+	 * @var array
+	 */
+	private $refunds;
+
+	/**
+	 * Charge status
+	 *
+	 * @var string|null
+	 */
+	private $status;
+
+	/**
 	 * WC_Payments_API_Charge constructor.
 	 *
-	 * @param string   $id                     - ID of the charge.
-	 * @param integer  $amount                 - Amount charged.
-	 * @param DateTime $created                - Time charge created.
-	 * @param array    $payment_method_details - Payment method details object.
+	 * @param string      $id                     - ID of the charge.
+	 * @param integer     $amount                 - Amount charged.
+	 * @param DateTime    $created                - Time charge created.
+	 * @param array       $payment_method_details - Payment method details object.
+	 * @param int|null    $amount_captured        - Amount in cents captured.
+	 * @param int|null    $amount_refunded        - Amount in cents refunded.
+	 * @param int|null    $application_fee_amount - The amount of the application fee requested for the charge.
+	 * @param array       $balance_transaction    - Balance transaction that describes the impact of this charge on the account balance.
+	 * @param array       $billing_details        - Billing information associated with the payment method at the time of the transaction.
+	 * @param string|null $currency               - Charge currency.
+	 * @param array       $dispute                - Charge dispute object.
+	 * @param bool|null   $disputed               - Flag indicating whether the charge has been disputed or not.
+	 * @param array       $order                  - Charge order object.
+	 * @param array       $outcome                - Details about whether the payment was accepted, and why.
+	 * @param bool|null   $paid                   - Flag indicating whether the charge has been paid or not.
+	 * @param array       $paydown                - Charge paydown object.
+	 * @param string|null $payment_intent         - Charge payment intent id.
+	 * @param bool|null   $refunded               - Flag indicating whether the charge has been refunded or not.
+	 * @param array       $refunds                - Charge refunds object.
+	 * @param string|null $status                 - Charge status.
 	 */
 	public function __construct(
 		$id,
 		$amount,
 		DateTime $created,
-		$payment_method_details = []
+		$payment_method_details = [],
+		$amount_captured = null,
+		$amount_refunded = null,
+		$application_fee_amount = null,
+		$balance_transaction = [],
+		$billing_details = [],
+		$currency = null,
+		$dispute = [],
+		$disputed = null,
+		$order = [],
+		$outcome = [],
+		$paid = null,
+		$paydown = [],
+		$payment_intent = null,
+		$refunded = null,
+		$refunds = [],
+		$status = null
 	) {
 		$this->id                     = $id;
 		$this->amount                 = $amount;
 		$this->created                = $created;
 		$this->payment_method_details = $payment_method_details;
+		$this->amount_captured        = $amount_captured;
+		$this->amount_refunded        = $amount_refunded;
+		$this->application_fee_amount = $application_fee_amount;
+		$this->balance_transaction    = $balance_transaction;
+		$this->billing_details        = $billing_details;
+		$this->currency               = $currency;
+		$this->dispute                = $dispute;
+		$this->disputed               = $disputed;
+		$this->order                  = $order;
+		$this->outcome                = $outcome;
+		$this->paid                   = $paid;
+		$this->paydown                = $paydown;
+		$this->payment_intent         = $payment_intent;
+		$this->refunded               = $refunded;
+		$this->refunds                = $refunds;
+		$this->status                 = $status;
 
 		// Set default properties.
 		$this->captured = false;
@@ -127,6 +287,151 @@ class WC_Payments_API_Charge implements \JsonSerializable {
 	}
 
 	/**
+	 * Returns the amount captured associated with this charge
+	 *
+	 * @return int|null
+	 */
+	public function get_amount_captured() {
+		return $this->amount_captured;
+	}
+
+	/**
+	 * Returns the amount refunded associated with this charge
+	 *
+	 * @return int|null
+	 */
+	public function get_amount_refunded() {
+		return $this->amount_refunded;
+	}
+
+	/**
+	 * Returns the application fee amount associated with this charge
+	 *
+	 * @return int|null
+	 */
+	public function get_application_fee_amount() {
+		return $this->application_fee_amount;
+	}
+
+	/**
+	 * Returns the balance transaction associated with this charge
+	 *
+	 * @return array
+	 */
+	public function get_balance_transaction() {
+		return $this->balance_transaction;
+	}
+
+	/**
+	 * Returns the billing details associated with this charge
+	 *
+	 * @return array
+	 */
+	public function get_billing_details() {
+		return $this->billing_details;
+	}
+
+	/**
+	 * Returns the currency associated with this charge
+	 *
+	 * @return string|null
+	 */
+	public function get_currency() {
+		return $this->currency;
+	}
+
+	/**
+	 * Returns the dispute object associated with this charge
+	 *
+	 * @return array
+	 */
+	public function get_dispute() {
+		return $this->dispute;
+	}
+
+	/**
+	 * Returns the disputed flag associated with this charge
+	 *
+	 * @return bool|null
+	 */
+	public function get_disputed() {
+		return $this->disputed;
+	}
+
+	/**
+	 * Returns the order object associated with this charge
+	 *
+	 * @return array
+	 */
+	public function get_order() {
+		return $this->order;
+	}
+
+	/**
+	 * Returns the outcome object associated with this charge
+	 *
+	 * @return array
+	 */
+	public function get_outcome() {
+		return $this->outcome;
+	}
+
+	/**
+	 * Returns the paid flag associated with this charge
+	 *
+	 * @return bool|null
+	 */
+	public function get_paid() {
+		return $this->paid;
+	}
+
+	/**
+	 * Returns the paydown object associated with this charge
+	 *
+	 * @return array
+	 */
+	public function get_paydown() {
+		return $this->paydown;
+	}
+
+	/**
+	 * Returns the payment intent id associated with this charge
+	 *
+	 * @return string|null
+	 */
+	public function get_payment_intent() {
+		return $this->payment_intent;
+	}
+
+	/**
+	 * Returns the refunded flag associated with this charge
+	 *
+	 * @return bool|null
+	 */
+	public function get_refunded() {
+		return $this->refunded;
+	}
+
+	/**
+	 * Returns the refund object associated with this charge
+	 *
+	 * @return array
+	 */
+	public function get_refunds() {
+		return $this->refunds;
+	}
+
+	/**
+	 * Returns the status associated with this charge
+	 *
+	 * @return string|null
+	 */
+	public function get_status() {
+		return $this->status;
+	}
+
+
+	/**
 	 * Defines which data will be serialized to JSON
 	 */
 	public function jsonSerialize(): array {
@@ -135,6 +440,22 @@ class WC_Payments_API_Charge implements \JsonSerializable {
 			'amount'                 => $this->get_amount(),
 			'created'                => $this->get_created()->getTimestamp(),
 			'payment_method_details' => $this->get_payment_method_details(),
+			'amount_captured'        => $this->get_amount_captured(),
+			'amount_refunded'        => $this->get_amount_refunded(),
+			'application_fee_amount' => $this->get_application_fee_amount(),
+			'balance_transaction'    => $this->get_balance_transaction(),
+			'billing_details'        => $this->get_billing_details(),
+			'currency'               => $this->get_currency(),
+			'dispute'                => $this->get_dispute(),
+			'disputed'               => $this->get_disputed(),
+			'order'                  => $this->get_order(),
+			'outcome'                => $this->get_outcome(),
+			'paid'                   => $this->get_paid(),
+			'paydown'                => $this->get_paydown(),
+			'payment_intent'         => $this->get_payment_intent(),
+			'refunded'               => $this->get_refunded(),
+			'refunds'                => $this->get_refunds(),
+			'status'                 => $this->get_status(),
 		];
 	}
 }


### PR DESCRIPTION
This is the first part of the fix for #353.

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

- Add missing fields to WC_Payments_API_Charge
  - Those fields will be used to populate the transactions details page, removing the requirement of doing 2 requests to fetch all the necessary data
- Remove `Charge` request from `usePaymentIntentWithChargeFallback` hook
- Fix "Payment method" block style

<details>
<summary>Payment method block changes</summary>

<table>
<tr>
<td>
Before
</td>
</tr>
<tr>
<td>
<img width="1039" alt="Before" src="https://user-images.githubusercontent.com/16882226/184360416-c3d1818a-d59a-4dd9-a007-e3c6ca92c45f.png">
</td>
</tr>
<tr>
<td>
After
</td>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/16882226/184360473-9858b153-2f60-4be4-86ab-adf21bf31fba.png" alt="After" />
</td>
</tr>
</table>
</details>

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Sync your `woocommerce-payments-server` to 2339-gh-Automattic/woocommerce-payments-server.
* Perform an order on your test shop
  - Open **Payments > Transactions**
  - Click on the transaction that you have just made
  - It should perform a request to `/wp-json/wc/v3/payments/payment_intents/pi_*` and load the transaction details page without requiring a `/charges` request.
* The unit tests should be passing

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.