### PR TITLE
Add thousand separator to the transactions count

### DIFF
--- a/changelog/fix-page-result-count-formatting
+++ b/changelog/fix-page-result-count-formatting
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Add the thousand separator to the transactions count.
+
+

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -54,9 +54,20 @@ import DownloadButton from 'components/download-button';
 import { getTransactionsCSV } from '../../data/transactions/resolvers';
 import p24BankList from '../../payment-details/payment-method/p24/bank-list';
 
+const siteLang = document.documentElement.lang;
 const siteNumberOptions = {
 	thousandSeparator: ',',
 };
+
+if ( [ 'fr-CA', 'pl-PL', 'fr-FR', 'fr-BE' ].includes( siteLang ) ) {
+	siteNumberOptions.thousandSeparator = ' ';
+} else if (
+	[ 'de-AT', 'nl-BE', 'de-DE', 'it-IT', 'nl', 'es', 'pt-BR' ].includes(
+		siteLang
+	)
+) {
+	siteNumberOptions.thousandSeparator = '.';
+}
 
 const formatStoreNumber = partial( numberFormat, siteNumberOptions );
 interface TransactionsListProps {

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -53,23 +53,6 @@ import wcpayTracks from 'tracks';
 import DownloadButton from 'components/download-button';
 import { getTransactionsCSV } from '../../data/transactions/resolvers';
 import p24BankList from '../../payment-details/payment-method/p24/bank-list';
-
-const siteLang = document.documentElement.lang;
-const siteNumberOptions = {
-	thousandSeparator: ',',
-};
-
-if ( [ 'fr-CA', 'pl-PL', 'fr-FR', 'fr-BE' ].includes( siteLang ) ) {
-	siteNumberOptions.thousandSeparator = ' ';
-} else if (
-	[ 'de-AT', 'nl-BE', 'de-DE', 'it-IT', 'nl', 'es', 'pt-BR' ].includes(
-		siteLang
-	)
-) {
-	siteNumberOptions.thousandSeparator = '.';
-}
-
-const formatStoreNumber = partial( numberFormat, siteNumberOptions );
 interface TransactionsListProps {
 	depositId?: string;
 }
@@ -94,6 +77,28 @@ interface Column extends TableCardColumn {
 	visible?: boolean;
 	cellClassName?: string;
 }
+
+const applyThousandSeparator = ( trxCount: number ) => {
+	const siteLang = document.documentElement.lang;
+	const siteNumberOptions = {
+		thousandSeparator: ',',
+	};
+
+	if ( [ 'fr', 'pl' ].some( ( lang ) => siteLang.startsWith( lang ) ) ) {
+		siteNumberOptions.thousandSeparator = ' ';
+	} else if ( 'de-CH' === siteLang ) {
+		siteNumberOptions.thousandSeparator = "'";
+	} else if (
+		[ 'de', 'nl', 'it', 'es', 'pt' ].some( ( lang ) =>
+			siteLang.startsWith( lang )
+		)
+	) {
+		siteNumberOptions.thousandSeparator = '.';
+	}
+
+	const formattedNumber = partial( numberFormat, siteNumberOptions );
+	return formattedNumber( trxCount );
+};
 
 const getPaymentSourceDetails = ( txn: Transaction ) => {
 	if ( ! txn.source_identifier ) {
@@ -630,7 +635,9 @@ export const TransactionsList = (
 					transactionsSummary.count as number,
 					'woocommerce-payments'
 				),
-				value: `${ formatStoreNumber( transactionsSummary.count ) }`,
+				value: `${ applyThousandSeparator(
+					transactionsSummary.count as number
+				) }`,
 			},
 		];
 

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -619,7 +619,7 @@ export const TransactionsList = (
 					transactionsSummary.count as number,
 					'woocommerce-payments'
 				),
-				value: `${ transactionsSummary.count }`,
+				value: `${ formatStoreNumber( transactionsSummary.count ) }`,
 			},
 		];
 

--- a/client/transactions/list/index.tsx
+++ b/client/transactions/list/index.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { Fragment, useState } from 'react';
-import { uniq } from 'lodash';
+import { uniq, partial } from 'lodash';
 import { useDispatch } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { dateI18n } from '@wordpress/date';
@@ -27,6 +27,8 @@ import {
 	generateCSVFileName,
 } from '@woocommerce/csv-export';
 import apiFetch from '@wordpress/api-fetch';
+import { numberFormat } from '@woocommerce/number';
+
 /**
  * Internal dependencies
  */
@@ -52,6 +54,11 @@ import DownloadButton from 'components/download-button';
 import { getTransactionsCSV } from '../../data/transactions/resolvers';
 import p24BankList from '../../payment-details/payment-method/p24/bank-list';
 
+const siteNumberOptions = {
+	thousandSeparator: ',',
+};
+
+const formatStoreNumber = partial( numberFormat, siteNumberOptions );
 interface TransactionsListProps {
 	depositId?: string;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4596,11 +4596,42 @@
             "regenerator-runtime": "^0.13.4"
           }
         },
+        "@woocommerce/number": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-2.0.0.tgz",
+          "integrity": "sha512-/YFkF0wwYmF0M58wPVrTtFopVwqdsmMAcrgQGnUFIj3JwXQumKR1co99DhDkjJm9vDMYXFTniwKqwvhBxdviSw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime-corejs2": "7.7.4",
+            "locutus": "2.0.11"
+          },
+          "dependencies": {
+            "@babel/runtime-corejs2": {
+              "version": "7.7.4",
+              "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.4.tgz",
+              "integrity": "sha512-hKNcmHQbBSJFnZ82ewYtWDZ3fXkP/l1XcfRtm7c8gHPM/DMecJtFFBEp7KMLZTuHwwb7RfemHdsEnd7L916Z6A==",
+              "dev": true,
+              "requires": {
+                "core-js": "^2.6.5",
+                "regenerator-runtime": "^0.13.2"
+              }
+            }
+          }
+        },
         "core-js": {
           "version": "2.6.12",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
           "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
           "dev": true
+        },
+        "locutus": {
+          "version": "2.0.11",
+          "resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz",
+          "integrity": "sha512-C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==",
+          "dev": true,
+          "requires": {
+            "es6-promise": "^4.2.5"
+          }
         }
       }
     },
@@ -8799,31 +8830,11 @@
       }
     },
     "@woocommerce/number": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-2.0.0.tgz",
-      "integrity": "sha512-/YFkF0wwYmF0M58wPVrTtFopVwqdsmMAcrgQGnUFIj3JwXQumKR1co99DhDkjJm9vDMYXFTniwKqwvhBxdviSw==",
-      "dev": true,
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-2.4.0.tgz",
+      "integrity": "sha512-SmEgad2zZ9fGZtpujrdk0/toSXjNuDOUxDKQutJ++ASID17bGKZtLxXcu/E7mvF1tTgszpiToPvqZlyC+vjOlg==",
       "requires": {
-        "@babel/runtime-corejs2": "7.7.4",
-        "locutus": "2.0.11"
-      },
-      "dependencies": {
-        "@babel/runtime-corejs2": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.4.tgz",
-          "integrity": "sha512-hKNcmHQbBSJFnZ82ewYtWDZ3fXkP/l1XcfRtm7c8gHPM/DMecJtFFBEp7KMLZTuHwwb7RfemHdsEnd7L916Z6A==",
-          "dev": true,
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-          "dev": true
-        }
+        "locutus": "^2.0.16"
       }
     },
     "@wordpress/a11y": {
@@ -23351,13 +23362,9 @@
       }
     },
     "locutus": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz",
-      "integrity": "sha512-C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==",
-      "dev": true,
-      "requires": {
-        "es6-promise": "^4.2.5"
-      }
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.16.tgz",
+      "integrity": "sha512-pGfl6Hb/1mXLzrX5kl5lH7gz25ey0vwQssZp8Qo2CEF59di6KrAgdFm+0pW8ghLnvNzzJGj5tlWhhv2QbK3jeQ=="
     },
     "lodash": {
       "version": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@stripe/react-stripe-js": "1.4.1",
     "@stripe/stripe-js": "1.15.1",
     "@woocommerce/explat": "^1.0.1",
+    "@woocommerce/number": "^2.4.0",
     "debug": "^4.1.1",
     "interpolate-components": "^1.1.1",
     "intl-tel-input": "^17.0.15",


### PR DESCRIPTION
Fixes #3728

### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

When there are more than 999 transactions, the transactions count does not display the thousand separator. This PR installs the Number package and adds the appropriate thousand separator based on the site language.

### Before

This is how the transactions count looked like before adding the thousand separator (on an English language site):

![before-thousand-operator](https://user-images.githubusercontent.com/6534920/182590080-a96b7a5d-6ca4-41e1-b4c2-32db3b5d5fac.jpeg)

### After

This is how the transactions count looks like after adding the thousand separator: 

On an **English** language site:

![after-thousand-operator](https://user-images.githubusercontent.com/6534920/182590124-68b57bf3-3630-4b44-80fe-a4ff2311b16c.jpeg)

On a **German** language site:

![Image 2022-08-10 at 11 48 10 AM](https://user-images.githubusercontent.com/6534920/183825232-52efe1d3-8aad-4912-8a5c-976285d2f905.jpg)

And on a **French** language site:

![Image 2022-08-10 at 11 49 19 AM](https://user-images.githubusercontent.com/6534920/183825258-ec7ae7f6-64f1-4208-bd0b-ecb17a2b5e59.jpg)

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

### Testing instructions

1. Clone the `fix/page-result-count-formatting` branch in your local machine
2. Navigate to `woocommerce-payments/client/transactions/list/index.tsx`
3. Run `npm run watch` in the terminal
4. Find this line in the index.tsx file: ``value:  `${ applyThousandSeparator(transactionsSummary.count as number) }` ``
5. Change `transactionsSummary.count` to any number greater than 999 and save changes
6. Refresh wp-admin > Payments > Transactions and you should see the thousand separator in the transaction count.
7. Go to wp-admin > Settings > General and change site language to `Deutsch`.
8. Refresh wp-admin > Payments > Transactions and you should see `dot` as the thousand separator.
9. Go to wp-admin > Settings > General and change site language to `Français`.
10. Refresh wp-admin > Payments > Transactions and you should see `space` as the thousand separator.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
