### PR TITLE
Add public WooPay link in registration copy

### DIFF
--- a/changelog/add-917-add-public-woopay-link-to-registrtion-copy
+++ b/changelog/add-917-add-public-woopay-link-to-registrtion-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update public WooPay link in registration copy

--- a/client/components/platform-checkout/save-user/additional-information.js
+++ b/client/components/platform-checkout/save-user/additional-information.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import interpolateComponents from 'interpolate-components';
 
 /**
  * Internal dependencies
@@ -17,11 +18,24 @@ const AdditionalInformation = () => {
 					<PhoneIcon />
 				</div>
 				<span>
-					{ __(
-						'Enter your mobile phone number to save your checkout information for faster checkouts here, ' +
-							'and at other stores powered by WooPay.',
-						'woocommerce-payments'
-					) }
+					{ interpolateComponents( {
+						mixedString: __(
+							'Enter your mobile phone number to save your checkout information for faster checkouts here, ' +
+								'and at other stores powered by {{wooPayLink/}} .',
+							'woocommerce-payments'
+						),
+						components: {
+							wooPayLink: (
+								<a
+									target="_blank"
+									href="https://woocommerce.com/woopay/"
+									rel="noopener noreferrer"
+								>
+									{ __( 'WooPay', 'woocommerce-payments' ) }
+								</a>
+							),
+						},
+					} ) }
 				</span>
 			</div>
 			<div className="additional-information">

--- a/client/components/platform-checkout/save-user/additional-information.js
+++ b/client/components/platform-checkout/save-user/additional-information.js
@@ -21,7 +21,7 @@ const AdditionalInformation = () => {
 					{ interpolateComponents( {
 						mixedString: __(
 							'Enter your mobile phone number to save your checkout information for faster checkouts here, ' +
-								'and at other stores powered by {{wooPayLink/}} .',
+								'and at other stores powered by {{wooPayLink/}}.',
 							'woocommerce-payments'
 						),
 						components: {


### PR DESCRIPTION
Fixes 917-gh-Automattic/woopay

#### Changes proposed in this Pull Request
Add public WooPay link in the registration copy

#### Screenshots
*Before*

<img width="292" alt="Screen Shot 2022-08-03 at 4 19 02 PM" src="https://user-images.githubusercontent.com/56378160/182730951-1abeec56-1f7c-4a9f-b765-9a9e7d6f6c9e.png">

*After*

<img width="281" alt="Screen Shot 2022-08-03 at 4 19 53 PM" src="https://user-images.githubusercontent.com/56378160/182730974-1942912a-2075-4bfb-8e1b-3d971f07343a.png">

#### Testing instructions
1. Go to the shop and put a product in the cart
2. Go to checkout
3. Find 'Remember your details?' and tick 'Save my information for faster checkouts'
4. Find '......at other stores powered by WooPay.'
5. See WooPay with the link style and click on the link
6. It should open another page and link to https://woocommerce.com/woopay/

*

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [X] Covered with tests (or have a good reason not to test in description ☝️)
- [X] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
