### PR TITLE
Avoid execution context errors for E2E tests

### DIFF
--- a/changelog/dev-fix-e2e-tests-execution-context-errors
+++ b/changelog/dev-fix-e2e-tests-execution-context-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Avoid execution context errors during E2E tests

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -154,9 +154,9 @@ export async function confirmCardAuthentication(
 		);
 		challengeFrame = await acsFrameHandle.contentFrame();
 	}
-	const button = await challengeFrame.waitForSelector( target );
 	// Need to wait for the CSS animations to complete.
 	await page.waitFor( 500 );
+	const button = await challengeFrame.waitForSelector( target );
 	await button.click();
 }
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

In the E2E tests reports, we can come across the following kind of errors: `Execution context was destroyed, most likely because of a navigation.`.
As the error message suggests, it probably means we're trying to use an element that doesn't exist anymore because the browser started to navigate elsewhere.

An interesting topic on Stackoverflow regarding this: https://stackoverflow.com/questions/55877263/puppeteer-execution-context-was-destroyed-most-likely-because-of-a-navigation

Essentially, we must avoid defining elements too early compared to when we use them. We should grab them the moment we want to use them in order to make sure they are not obsolete.

#### Testing instructions

- Trigger a new E2E tests workflow
- Make sure you don't see any failing scenarios that relates to the execution context error

Latest run (0 errors related to that): https://github.com/Automattic/woocommerce-payments/actions/runs/2795204044

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
