### PR TITLE
E2E GitHub Workflow: Re-run Failed Test Files.

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -64,7 +64,7 @@ jobs:
       E2E_WC_VERSION: ${{ matrix.woocommerce }}
       E2E_GROUP:  ${{ matrix.test_groups }}
       E2E_BRANCH: ${{ matrix.test_branches }}
-      E2E_RESULT_FILEPATH: './tests/e2e/results.json'
+      E2E_FIRST_RUN_RESULT_FILEPATH: 'tests/e2e/results.json'
 
     steps:
       # Conditionally skip WC Blocks tests. Remove/update based on min supported WC version by the blocks checkout plugin.
@@ -150,9 +150,9 @@ jobs:
         # Use +e to trap errors when running E2E tests.
         shell: /bin/bash +e {0}
         run: | 
-          npm run test:e2e -- --json --outputFile="$E2E_RESULT_FILEPATH"
+          npm run test:e2e -- --json --outputFile="$E2E_FIRST_RUN_RESULT_FILEPATH"
           
-          E2E_NUM_FAILED_TEST_SUITES=$(cat "$E2E_RESULT_FILEPATH" | jq '.numFailedTestSuites')
+          E2E_NUM_FAILED_TEST_SUITES=$(cat "$E2E_FIRST_RUN_RESULT_FILEPATH" | jq '.numFailedTestSuites')
 
           echo "::set-output name=FIRST_RUN_FAILED_TEST_SUITES::$(echo $E2E_NUM_FAILED_TEST_SUITES)"
 
@@ -165,7 +165,7 @@ jobs:
         if: ${{ steps.first_run_e2e_tests.outputs.FIRST_RUN_FAILED_TEST_SUITES > 0  }}
         # Filter failed E2E files from the result JSON file, and re-run them.
         run: |
-          cat "$E2E_RESULT_FILEPATH" | jq '.testResults[] | select(.status == "failed") | .name' | xargs npm run test:e2e
+          cat "$E2E_FIRST_RUN_RESULT_FILEPATH" | jq '.testResults[] | select(.status == "failed") | .name' | xargs npm run test:e2e
 
       # Archive screenshots if any
       - name: Archive e2e test screenshots & logs
@@ -176,5 +176,6 @@ jobs:
             path: |
               tests/e2e/screenshots
               tests/e2e/docker/wordpress/wp-content/debug.log
+              ${{ env.E2E_FIRST_RUN_RESULT_FILEPATH }}
             if-no-files-found: ignore
             retention-days: 5

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -147,17 +147,20 @@ jobs:
 
       # Run Tests
       - name: Run E2E Tests
+        id: first_run_e2e_tests
+        # Use +e to trap errors when running E2E tests.
         shell: /bin/bash +e {0}
         run: | 
           npm run test:e2e -- --json --outputFile="$E2E_RESULT_FILEPATH"
           E2E_NUM_FAILED_TEST_SUITES=$(cat "$E2E_RESULT_FILEPATH" | jq '.numFailedTestSuites')
+          echo "::set-output name=E2E_NUM_FAILED_TEST_SUITES::$(echo E2E_NUM_FAILED_TEST_SUITES)"
           if [[ ${E2E_NUM_FAILED_TEST_SUITES} -gt 0 ]]; then
-            echo 'Some tests failed but we will try them again in the next job.'
+            echo '::notice Some tests failed but we will try them again in the next job.'
             exit 0
           fi
       
       - name: Re-try failed test files
-        if: ${{ env.E2E_NUM_FAILED_TEST_SUITES > 0  }}
+        if: ${{ steps.first_run_e2e_tests.outputs.E2E_NUM_FAILED_TEST_SUITES > 0  }}
         run: |
           cat "$E2E_RESULT_FILEPATH" | jq '.testResults[] | select(.status == "failed") | .name' | xargs npm run test:e2e
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -64,6 +64,7 @@ jobs:
       E2E_WC_VERSION: ${{ matrix.woocommerce }}
       E2E_GROUP:  ${{ matrix.test_groups }}
       E2E_BRANCH: ${{ matrix.test_branches }}
+      E2E_RESULT_FILEPATH: './tests/e2e/results.json'
 
     steps:
       # Conditionally skip WC Blocks tests. Remove/update based on min supported WC version by the blocks checkout plugin.
@@ -146,7 +147,21 @@ jobs:
 
       # Run Tests
       - name: Run E2E Tests
-        run: npm run test:e2e
+        run: | 
+          npm run test:e2e --json --outputFile="$E2E_RESULT_FILEPATH"
+          if [[ $? -ne 0 ]]; then
+            echo 'Some tests failed but we will try again in the next job.'
+            exit 0
+          fi 
+      
+      - name: Re-try failed test files
+        run: |
+          if [[ $(cat "$E2E_RESULT_FILEPATH" | jq '.numFailedTestSuites') -gt 0 ]]; then
+            echo "Re-running failed test files..."
+            cat "$E2E_RESULT_FILEPATH" | jq '.testResults[] | select(.status == "failed") | .name' | xargs npm run test:e2e
+          else
+            echo 'Good news! No failed test file to run.'
+          fi
 
       # Archive screenshots if any
       - name: Archive e2e test screenshots & logs

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -153,9 +153,9 @@ jobs:
         run: | 
           npm run test:e2e -- --json --outputFile="$E2E_RESULT_FILEPATH"
           E2E_NUM_FAILED_TEST_SUITES=$(cat "$E2E_RESULT_FILEPATH" | jq '.numFailedTestSuites')
-          echo "::set-output name=E2E_NUM_FAILED_TEST_SUITES::$(echo E2E_NUM_FAILED_TEST_SUITES)"
+          echo "::set-output name=E2E_NUM_FAILED_TEST_SUITES::$(echo "$E2E_NUM_FAILED_TEST_SUITES")"
           if [[ ${E2E_NUM_FAILED_TEST_SUITES} -gt 0 ]]; then
-            echo '::notice Some tests failed but we will try them again in the next job.'
+            echo '::notice::Some tests failed but we will try them again in the next job.'
             exit 0
           fi
       

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -157,7 +157,7 @@ jobs:
           echo "::set-output name=FIRST_RUN_FAILED_TEST_SUITES::$(echo $E2E_NUM_FAILED_TEST_SUITES)"
 
           if [[ ${E2E_NUM_FAILED_TEST_SUITES} -gt 0 ]]; then
-            echo '::notice::Some E2E tests failed in the first run but we will try them again in the second run.'
+            echo "::notice::${E2E_NUM_FAILED_TEST_SUITES} E2E test(s) failed in the first run but we will try (it) them again in the second run."
             exit 0
           fi
       

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -153,7 +153,7 @@ jobs:
         run: | 
           npm run test:e2e -- --json --outputFile="$E2E_RESULT_FILEPATH"
           E2E_NUM_FAILED_TEST_SUITES=$(cat "$E2E_RESULT_FILEPATH" | jq '.numFailedTestSuites')
-          echo "::set-output name=E2E_NUM_FAILED_TEST_SUITES::$(echo "$E2E_NUM_FAILED_TEST_SUITES")"
+          echo "::set-output name=E2E_NUM_FAILED_TEST_SUITES::$(echo $E2E_NUM_FAILED_TEST_SUITES)"
           if [[ ${E2E_NUM_FAILED_TEST_SUITES} -gt 0 ]]; then
             echo '::notice::Some tests failed but we will try them again in the next job.'
             exit 0

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -148,7 +148,7 @@ jobs:
       # Run Tests
       - name: Run E2E Tests
         run: | 
-          npm run test:e2e --json --outputFile="$E2E_RESULT_FILEPATH"
+          npm run test:e2e -- --json --outputFile="$E2E_RESULT_FILEPATH"
           if [[ $? -ne 0 ]]; then
             echo 'Some tests failed but we will try again in the next job.'
             exit 0

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -153,14 +153,14 @@ jobs:
         run: | 
           npm run test:e2e -- --json --outputFile="$E2E_RESULT_FILEPATH"
           E2E_NUM_FAILED_TEST_SUITES=$(cat "$E2E_RESULT_FILEPATH" | jq '.numFailedTestSuites')
-          echo "::set-output name=E2E_NUM_FAILED_TEST_SUITES::$(echo $E2E_NUM_FAILED_TEST_SUITES)"
+          echo "::set-output name=FIRST_RUN_FAILED_TEST_SUITES::$(echo $E2E_NUM_FAILED_TEST_SUITES)"
           if [[ ${E2E_NUM_FAILED_TEST_SUITES} -gt 0 ]]; then
             echo '::notice::Some tests failed but we will try them again in the next job.'
             exit 0
           fi
       
       - name: Re-try failed test files
-        if: ${{ steps.first_run_e2e_tests.outputs.E2E_NUM_FAILED_TEST_SUITES > 0  }}
+        if: ${{ steps.first_run_e2e_tests.outputs.FIRST_RUN_FAILED_TEST_SUITES > 0  }}
         run: |
           cat "$E2E_RESULT_FILEPATH" | jq '.testResults[] | select(.status == "failed") | .name' | xargs npm run test:e2e
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -145,22 +145,25 @@ jobs:
       - name: Prepare test environment
         run: npm run test:e2e-setup
 
-      # Run Tests
-      - name: Run E2E Tests
+      - name: First Run E2E Tests
         id: first_run_e2e_tests
         # Use +e to trap errors when running E2E tests.
         shell: /bin/bash +e {0}
         run: | 
           npm run test:e2e -- --json --outputFile="$E2E_RESULT_FILEPATH"
+          
           E2E_NUM_FAILED_TEST_SUITES=$(cat "$E2E_RESULT_FILEPATH" | jq '.numFailedTestSuites')
+
           echo "::set-output name=FIRST_RUN_FAILED_TEST_SUITES::$(echo $E2E_NUM_FAILED_TEST_SUITES)"
+
           if [[ ${E2E_NUM_FAILED_TEST_SUITES} -gt 0 ]]; then
-            echo '::notice::Some tests failed but we will try them again in the next job.'
+            echo '::notice::Some E2E tests failed in the first run but we will try them again in the second run.'
             exit 0
           fi
       
-      - name: Re-try failed test files
+      - name: Re-try Failed E2E Files
         if: ${{ steps.first_run_e2e_tests.outputs.FIRST_RUN_FAILED_TEST_SUITES > 0  }}
+        # Filter failed E2E files from the result JSON file, and re-run them.
         run: |
           cat "$E2E_RESULT_FILEPATH" | jq '.testResults[] | select(.status == "failed") | .name' | xargs npm run test:e2e
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -149,19 +149,16 @@ jobs:
       - name: Run E2E Tests
         run: | 
           npm run test:e2e -- --json --outputFile="$E2E_RESULT_FILEPATH"
-          if [[ $? -ne 0 ]]; then
-            echo 'Some tests failed but we will try again in the next job.'
+          E2E_NUM_FAILED_TEST_SUITES=$(cat "$E2E_RESULT_FILEPATH" | jq '.numFailedTestSuites')
+          if [[ ${E2E_NUM_FAILED_TEST_SUITES} -gt 0 ]]; then
+            echo 'Some tests failed but we will try them again in the next job.'
             exit 0
-          fi 
+          fi
       
       - name: Re-try failed test files
+        if: ${{ env.E2E_NUM_FAILED_TEST_SUITES > 0  }}
         run: |
-          if [[ $(cat "$E2E_RESULT_FILEPATH" | jq '.numFailedTestSuites') -gt 0 ]]; then
-            echo "Re-running failed test files..."
-            cat "$E2E_RESULT_FILEPATH" | jq '.testResults[] | select(.status == "failed") | .name' | xargs npm run test:e2e
-          else
-            echo 'Good news! No failed test file to run.'
-          fi
+          cat "$E2E_RESULT_FILEPATH" | jq '.testResults[] | select(.status == "failed") | .name' | xargs npm run test:e2e
 
       # Archive screenshots if any
       - name: Archive e2e test screenshots & logs

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -147,6 +147,7 @@ jobs:
 
       # Run Tests
       - name: Run E2E Tests
+        shell: /bin/bash +e {0}
         run: | 
           npm run test:e2e -- --json --outputFile="$E2E_RESULT_FILEPATH"
           E2E_NUM_FAILED_TEST_SUITES=$(cat "$E2E_RESULT_FILEPATH" | jq '.numFailedTestSuites')

--- a/changelog/dev-e2e-retry-failed-test-files
+++ b/changelog/dev-e2e-retry-failed-test-files
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+E2E GitHub Workflow: Re-run Failed Test Files.


### PR DESCRIPTION
Fixes #4421 and maybe other similar issues. 

### Changes proposed in this Pull Request

- Export the first E2E test result to a JSON file - [Jest doc ref](https://jestjs.io/docs/cli#--outputfilefilename).
- Check this result file to decide whether to run the second run with only failed test files. 

### Rationale for this approach: 

- When monitoring https://github.com/Automattic/woocommerce-payments/issues/4421 and other flaky E2E issues, I noticed that many of them failed due to loading the client site with error status 503 (Service Unavailable) or 429 (Too Many Requests). 
- With our test nature, many tests rely on previous tests in the same spec/test file. E.g: tests/e2e/specs/wcpay/shopper/shopper-checkout-save-card-and-purchase.spec.js, OR wcpay/shopper/shopper-myaccount-save-card-and-checkout.spec.js. 
- Also, many flaky results have only one failed test file. 
- With three reasons above, we think that re-running only failed test files will allow the client site having time to recover from failure and reduce the flakiness. 

Also note that, I also tried to use the built-in [jest.retryTimes()](https://jestjs.io/docs/jest-object#jestretrytimesnumretries-options) but it does not serve our specific test nature well because Jest will retry failed tests in sequence right away before it goes to the next test. 

### Rationale for changing in the GitHub workflow: 

- First, I proposed this approach https://eng.wealthfront.com/2022/04/21/retrying-e2e-test-suites-with-jest/, i.e. writing a custom NodeJS script and running them. 
- However, I faced some challenges: 
     - The article uses `runCLI`, which is NOT documented in Jest docs: https://jestjs.io/docs/ though we can look at its definition in [the Jest code package](https://github.com/facebook/jest/blob/240587bde5dae1467ced0fdeee2e668e01caf896/packages/jest-core/src/cli/index.ts#L37).
     - This approach means running Jest Puppeteer directly without a wrapper provided by `wp-scripts` through `npm run test:e2e`. This results in providing many unexpected tweaks in the NodeJS script, which is not ideal.
     - Last bust not least, when running the NodeJS script, this error pops up `Cannot use import statement outside a module`. I tried a few away to fix it but no way is promsing. It seems an issue with the specific Node version and it's not really easy to deal with our current setup. 
- With my approach in this PR, it is more elegant, and we just need to touch GitHub Actions, which is what we want finally. 

Relevant discussion: p1659950516959449-slack-C01BPL3ALGP

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

### Testing instructions

I think these two E2E tests for this PR branch `dev/e2e-retry-failed-test-files` can show how effectively this approach is. 

#### First example: https://github.com/Automattic/woocommerce-payments/actions/runs/2829780984

- In this link, there are two tests failed in the first run: 

![Markup on 2022-08-10 at 10:43:52](https://user-images.githubusercontent.com/10045087/183808333-59a7d1b4-1c44-4623-9867-7d1f0bc7b73d.png)

- However, they were successfully in the second run with only over 1 minute (rather than 6 minutes for the first run). Looking into them in detail, they all failed due to this error `Failed to load resource: the server responded with a status of 429`. 

![Markup on 2022-08-10 at 10:47:19](https://user-images.githubusercontent.com/10045087/183808737-ef33afa4-c06a-475c-947b-2acf2f0c98a4.png)

#### Second example https://github.com/Automattic/woocommerce-payments/actions/runs/2826082997

- There were even more failed tests in the first run.
- But many of them were fixed in the second run.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.