### PR TITLE
Fix charge id validation for UPE transactions

### DIFF
--- a/changelog/fix-upe-charge-id
+++ b/changelog/fix-upe-charge-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix an issue that was added in 4.5.0 as the Transaction Detail Page was invalidating py_ charge ids.

--- a/changelog/fix-upe-charge-id
+++ b/changelog/fix-upe-charge-id
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix an issue that was added in 4.5.0 as the Transaction Detail Page was invalidating py_ charge ids.
+Fix an issue while loading the Transaction Detail Page with py_ charge ids.

--- a/client/data/payment-intents/hooks.ts
+++ b/client/data/payment-intents/hooks.ts
@@ -10,7 +10,7 @@ import { ChargeResponse } from '../charges/types';
 import { STORE_NAME } from '../constants';
 
 export const getIsChargeId = ( id: string ): boolean =>
-	-1 !== id.indexOf( 'ch_' );
+	-1 !== id.indexOf( 'ch_' ) || -1 !== id.indexOf( 'py_' );
 
 export const usePaymentIntentWithChargeFallback = (
 	id: string


### PR DESCRIPTION
Fixes #3122

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

An issue was added in 4.5.0 as the Transaction Details Page was invalidating `py_` charge ids.

This commit adds the `py_` charge id variant as a valid id.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Git checkout the server to use the [latest commit](https://github.com/Automattic/woocommerce-payments-server/commit/6f3beb6eaecdd5594724086be19b6268d056527c)
- Enable a UPE payment method like Bancontact, P24, and iDeal
- Enable Multi-Currency and the currency switcher in the WC Pay settings
- Use the currency switcher to pay in EUR on the client site and add an item to the cart
- Go through checkout using one of the payment methods above
- An error should pop up when processing the payment redirect
- Open the transactions page and click on the new transaction
- Make sure the transaction details page is loaded successfully

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
