### PR TITLE
Refactoring Direct DB query in orders_with_charge_id_from_charge_ids 

### DIFF
--- a/changelog/fix-4151-orders_with_charge_id_from_charge_ids
+++ b/changelog/fix-4151-orders_with_charge_id_from_charge_ids
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Replaced direct DB query in oorders_with_charge_id_from_charge_ids with wc_get_orders

--- a/includes/class-wc-payments-db.php
+++ b/includes/class-wc-payments-db.php
@@ -51,7 +51,7 @@ class WC_Payments_DB {
 		return array_map(
 			function ( WC_Order $order ) : array {
 				return [
-					'order'     => $this->order_from_order_id( $order->get_order_number() ),
+					'order'     => $this->order_from_order_id( (string) $order->get_id() ),
 					'charge_id' => $order->get_meta( self::META_KEY_CHARGE_ID ),
 				];
 			},

--- a/includes/class-wc-payments-db.php
+++ b/includes/class-wc-payments-db.php
@@ -51,7 +51,7 @@ class WC_Payments_DB {
 		return array_map(
 			function ( WC_Order $order ) : array {
 				return [
-					'order'     => $this->order_from_order_id( (string) $order->get_id() ),
+					'order'     => $order,
 					'charge_id' => $order->get_meta( self::META_KEY_CHARGE_ID ),
 				];
 			},

--- a/tests/unit/test-class-wc-payments-db.php
+++ b/tests/unit/test-class-wc-payments-db.php
@@ -45,9 +45,9 @@ class WC_Payments_DB_Test extends WCPAY_UnitTestCase {
 
 		$this->assertCount( 2, $orders_with_charge_ids );
 		$this->assertIsArray( $orders_with_charge_ids[0] );
-		$this->assertTrue( in_array( $orders_with_charge_ids[0]['charge_id'], $existing_charge_ids ), true );
+		$this->assertTrue( in_array( $orders_with_charge_ids[0]['charge_id'], $existing_charge_ids, true ) );
 		$this->assertIsArray( $orders_with_charge_ids[1] );
-		$this->assertTrue( in_array( $orders_with_charge_ids[1]['charge_id'], $existing_charge_ids ), true );
+		$this->assertTrue( in_array( $orders_with_charge_ids[1]['charge_id'], $existing_charge_ids, true ) );
 	}
 
 }

--- a/tests/unit/test-class-wc-payments-db.php
+++ b/tests/unit/test-class-wc-payments-db.php
@@ -45,9 +45,9 @@ class WC_Payments_DB_Test extends WCPAY_UnitTestCase {
 
 		$this->assertCount( 2, $orders_with_charge_ids );
 		$this->assertIsArray( $orders_with_charge_ids[0] );
-		$this->assertSame( 'ch_1', $orders_with_charge_ids[0]['charge_id'] );
+		$this->assertTrue( in_array( $orders_with_charge_ids[0]['charge_id'], $existing_charge_ids ), true );
 		$this->assertIsArray( $orders_with_charge_ids[1] );
-		$this->assertSame( 'ch_2', $orders_with_charge_ids[1]['charge_id'] );
+		$this->assertTrue( in_array( $orders_with_charge_ids[1]['charge_id'], $existing_charge_ids ), true );
 	}
 
 }


### PR DESCRIPTION
Fixes #4151

#### Changes proposed in this Pull Request

Replaced the direct DB query in `orders_with_charge_id_from_charge_ids()` with `wc_get_orders`


#### Testing instructions
The function `orders_with_charge_id_from_charge_ids` is used in `WC_Payments_API_Client::list_transactions` which is used in the REST API `/transactions`. This API is used on the Transactions listing page.

1) Place an order, and ensure its captured (if Capture Later is enabled)
2) Sync Transactions `wp wcpay sync_transactions_for <account_id>`
3) Go to **Payments** > **Transactions** and check that the transaction is listed.
4) The above steps should be tested under all the following conditions:
    -  No COT
    -  COT, using orders table and no sync
    -  COT, using posts table and no sync
    -  COT, using order table with sync
    -  COT, using posts table with sync

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
