### PR TITLE
Fix adding payment tokens for platform-created setup intents

### DIFF
--- a/changelog/fix-woopay-trial-subscription-payment-tokens
+++ b/changelog/fix-woopay-trial-subscription-payment-tokens
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fixes adding payment tokens for platform-created setup intents
+Fix adding payment tokens for platform-created setup intents

--- a/changelog/fix-woopay-trial-subscription-payment-tokens
+++ b/changelog/fix-woopay-trial-subscription-payment-tokens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes adding payment tokens for platform-created setup intents

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1323,9 +1323,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					$token = null;
 
 					// Setup intents are currently not deserialized as payment intents are, so check if it's an array first.
-					// For payment intents, we may provide a platform payment method from `$payment_information`, but we need
+					// For WooPay checkouts, we may provide a platform payment method from `$payment_information`, but we need
 					// to return a connected payment method. So we should always retrieve the payment method from the intent.
-					$payment_method_id = is_array( $intent ) ? $payment_information->get_payment_method() : $intent->get_payment_method_id();
+					$payment_method_id = is_array( $intent ) ? $intent['payment_method'] : $intent->get_payment_method_id();
 
 					// Handle orders that are paid via WooPay and contain subscriptions.
 					if ( $order->get_meta( 'is_woopay' ) && function_exists( 'wcs_order_contains_subscription' ) && wcs_order_contains_subscription( $order ) ) {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -81,10 +81,11 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 	 * @var array
 	 */
 	private $setup_intent = [
-		'id'            => self::SETUP_INTENT_ID,
-		'status'        => 'succeeded',
-		'client_secret' => 'test_client_secret',
-		'next_action'   => [],
+		'id'             => self::SETUP_INTENT_ID,
+		'status'         => 'succeeded',
+		'client_secret'  => 'test_client_secret',
+		'next_action'    => [],
+		'payment_method' => self::PAYMENT_METHOD_ID,
 	];
 
 	/**


### PR DESCRIPTION
Addition to #4500 to fix a bug related to 1158-gh-Automattic/woopay

#### Changes proposed in this Pull Request

When subscriptions with free trials are purchased via WooPay, currently no payment token is added to the customer's account, so renewals don't process correctly. This is because we attempt to add the payment method with the wrong ID — we're adding the platform payment method (present in the payment information) instead of the connected payment method (present on the intent). This PR fixes the logic for setup intents to behave the same way as payment intents, so that the correct payment method is added.

cc @ricardo — since this is core payment processing code, out of caution I'm asking for another pair of eyes and I see that you were the one who originally wrote the lines in question for payment intents. Essentially what this PR aims to do is to do the same for setup intents so that we're always using the connected payment method instead of the platform payment method.

#### Testing instructions

**Setup**

- Check out 1167-gh-Automattic/woopay and 2225-gh-Automattic/woocommerce-payments-server
- Check "Enable WooPay for subscriptions (Work in progress)" in WCPay Dev Tools
- Install and activate the WooCommerce Subscriptions extension
- Create a simple subscription product with a non-zero free trial.

**Test**
- As the customer, add the subscription product (which has a free trial) to the cart and check out via WooPay.
- On the WooPay checkout screen, verify that the initial total is $0 but the recurring total is the correct recurring amount.
- Complete checkout.
- As the merchant, go to WooCommerce > Subscriptions and click on the subscription. Verify that it is active and was created successfully.
- Click the pencil next to "Billing" to see subscription details, you should see the correct payment method selected automatically under "Saved payment method"
- Under "Subscription actions" in the upper right, "Process renewal". Verify that the renewal processes and the customer is charged.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
