### PR TITLE
Add support for getting an invoice

### DIFF
--- a/changelog/add-get-invoice-endpoint
+++ b/changelog/add-get-invoice-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for getting a Stripe invoice

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1418,6 +1418,23 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Fetch an invoice.
+	 *
+	 * @param string $invoice_id ID of the invoice to get.
+	 *
+	 * @return array The invoice.
+	 *
+	 * @throws API_Exception If fetching the invoice fails.
+	 */
+	public function get_invoice( string $invoice_id ) {
+		return $this->request(
+			[],
+			self::INVOICES_API . '/' . $invoice_id,
+			self::GET
+		);
+	}
+
+	/**
 	 * Charges an invoice.
 	 *
 	 * Calling this function charges the customer. Pass the param 'paid_out_of_band' => true to mark the invoice as paid without charging the customer.

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -1634,6 +1634,26 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Test a successful fetch of a single invoice.
+	 *
+	 * @throws Exception In case of test failure.
+	 */
+	public function test_get_invoice_success() {
+		$invoice_id = 'in_test_invoice';
+
+		$this->set_http_mock_response(
+			200,
+			[
+				'id'     => $invoice_id,
+				'object' => 'invoice',
+			]
+		);
+
+		$invoice = $this->payments_api_client->get_invoice( $invoice_id );
+		$this->assertEquals( $invoice_id, $invoice['id'] );
+	}
+
+	/**
 	 * Test a successful call to cancel subscription.
 	 *
 	 * @throws Exception - In the event of test failure.


### PR DESCRIPTION
Part of the fix for 35-gh-Automattic/woocommerce-payments-dev-tools

#### Changes proposed in this Pull Request

Currently, attempting to enable billing clocks for free trial subscriptions fails because the invoice is already paid. This PR adds a `get_invoice` function to the API client to get the invoice so we can check if it needs payment before attempting to pay it.

#### Testing instructions

See testing instructions in 72-gh-Automattic/woocommerce-payments-dev-tools

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
