### PR TITLE
Use customer from session during Store API checkout

### DIFF
--- a/changelog/fix-4607-guest-woopay-subscription-checkout
+++ b/changelog/fix-4607-guest-woopay-subscription-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add customer ID to WP user during Store API checkout

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -447,7 +447,10 @@ class WC_Payments_Customer_Service {
 	 */
 	public function add_customer_id_to_user( $user_id ) {
 		// Not processing a checkout, bail.
-		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) || ! WOOCOMMERCE_CHECKOUT ) {
+		if (
+			! ( defined( 'WOOCOMMERCE_CHECKOUT' ) && WOOCOMMERCE_CHECKOUT ) &&
+			! ( function_exists( 'wcs_is_checkout_blocks_api_request' ) && wcs_is_checkout_blocks_api_request( 'v1/checkout' ) )
+		) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #4607

#### Changes proposed in this Pull Request

Currently, a duplicate customer is created during WooPay guest subscription checkout. This is because a Stripe Customer is created during platform checkout initialization, but when the new WP user is created for the subscription, that user doesn't have the Stripe Customer attached to it. During normal WC checkout, this is handled by `add_customer_id_to_user`, but that doesn't currently apply to the Store API checkout that WooPay uses.

This PR updates `add_customer_id_to_user` to add the customer to the WP user during Store API checkout as well.

#### Testing instructions

1. Start by clearing cookies as the customer to make sure there’s no WC session.
2. Buy a non-subscription item with a new email address (not previously used for WooPay or for the merchant store), and register for WooPay during checkout.
3. Now, using the same browsing session, buy a subscription item by checking out with WooPay.

Afterwards, verify that:

1. The newly created customer has a payment token.
2. The subscription in WP admin has a billing method.
3. In the Stripe dashboard, a single customer is created that has processed the payment and has a payment method attached.
4. Trigger a renewal and verify that the renewal goes through successfully.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
