### PR TITLE
Support Platform Checkout from Checkout Blocks

### DIFF
--- a/changelog/task-4521-platform-checkout-from-checkout-blocks
+++ b/changelog/task-4521-platform-checkout-from-checkout-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Support Platform Checkout from Checkout Blocks.

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -21,6 +21,7 @@ import { SavedTokenHandler } from './saved-token-handler';
 import request from '../utils/request';
 import enqueueFraudScripts from 'fraud-scripts';
 import paymentRequestPaymentMethod from '../../payment-request/blocks';
+import { handlePlatformCheckoutEmailInput } from '../platform-checkout/email-input-iframe';
 
 // Create an API object, which will be used throughout the checkout.
 const api = new WCPayAPI(
@@ -50,6 +51,10 @@ registerPaymentMethod( {
 } );
 
 registerExpressPaymentMethod( paymentRequestPaymentMethod( api ) );
+
+if ( getConfig( 'isPlatformCheckoutEnabled' ) ) {
+	handlePlatformCheckoutEmailInput( '#email', api );
+}
 
 window.addEventListener( 'load', () => {
 	enqueueFraudScripts( getConfig( 'fraudServices' ) );

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -210,6 +210,7 @@ export const handlePlatformCheckoutEmailInput = async ( field, api ) => {
 
 	// Error message to display when there's an error contacting WooPay.
 	const errorMessage = document.createElement( 'div' );
+	errorMessage.style[ 'white-space' ] = 'normal';
 	errorMessage.textContent = __(
 		'WooPay is unavailable at this time. Please complete your checkout below. Sorry for the inconvenience.',
 		'woocommerce-payments'

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -14,6 +14,9 @@ const waitForEmailField = ( selector ) => {
 			return resolve( document.querySelector( selector ) );
 		}
 
+		const checkoutBlock = document.querySelector(
+			'[data-block-name="woocommerce/checkout"]'
+		);
 		const observer = new MutationObserver( () => {
 			if ( document.querySelector( selector ) ) {
 				resolve( document.querySelector( selector ) );
@@ -21,7 +24,7 @@ const waitForEmailField = ( selector ) => {
 			}
 		} );
 
-		observer.observe( document.body, {
+		observer.observe( checkoutBlock, {
 			childList: true,
 			subtree: true,
 		} );

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -7,10 +7,31 @@ import wcpayTracks from 'tracks';
 import request from '../utils/request';
 import showErrorCheckout from '../utils/show-error-checkout';
 
-export const handlePlatformCheckoutEmailInput = ( field, api ) => {
+// Waits for the email field to exist as in the Blocks checkout, sometimes the email field is not immediately available.
+const waitForEmailField = ( selector ) => {
+	return new Promise( ( resolve ) => {
+		if ( document.querySelector( selector ) ) {
+			return resolve( document.querySelector( selector ) );
+		}
+
+		const observer = new MutationObserver( () => {
+			if ( document.querySelector( selector ) ) {
+				resolve( document.querySelector( selector ) );
+				observer.disconnect();
+			}
+		} );
+
+		observer.observe( document.body, {
+			childList: true,
+			subtree: true,
+		} );
+	} );
+};
+
+export const handlePlatformCheckoutEmailInput = async ( field, api ) => {
 	let timer;
 	const waitTime = 500;
-	const platformCheckoutEmailInput = document.querySelector( field );
+	const platformCheckoutEmailInput = await waitForEmailField( field );
 	let hasCheckedLoginSession = false;
 
 	// If we can't find the input, return.


### PR DESCRIPTION
Fixes #4613 

### Description
This PR adds support to checkout via Platform Checkout when a merchant is using Checkout Blocks on their checkout page.

#### Changes proposed in this Pull Request
Reused the `client/checkout/platform-checkout/email-input-iframe.js` to support Platform Checkout when it is enabled in settings and the merchant uses the `Checkout` blocks.

#### Testing instructions
- Firstly ensure that everything works fine on the shortcode checkout page.
- Edit your `Checkout` page and instead of `shortcode-checkout` select the `Checkout` block.
- Go to the merchant store, add some products to the cart and go to the checkout page (having Checkout Blocks)
- Enter an existing Platform Checkout user email, it should prompt the OTP modal. Filling in the correct OTP should redirect to the Platform Checkout page.
- Entering a non-existing Platform Checkout user email should do nothing.
