### PR TITLE
Added numeric validation check to product price

### DIFF
--- a/changelog/fix-4579-handling-products-without-price
+++ b/changelog/fix-4579-handling-products-without-price
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed issue with incorrect product price

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -239,11 +239,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 
 		/** @var WC_Product_Variable $product */ // phpcs:ignore
 		$product  = $this->get_product();
-
-		$product_price = $this->get_product_price( $product );
-		if ( ! is_numeric( $product_price ) ) {
-			return false;
-		}
 		$currency = get_woocommerce_currency();
 
 		if ( 'variable' === $product->get_type() || 'variable-subscription' === $product->get_type() ) {
@@ -269,6 +264,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 
 		$data          = [];
 		$items         = [];
+		$product_price = $this->get_product_price( $product );
 
 		$items[] = [
 			'label'  => $product->get_name(),
@@ -342,7 +338,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 
 		if ( $order->get_shipping_total() ) {
 			$shipping_label = sprintf(
-			// Translators: %s is the name of the shipping method.
+				// Translators: %s is the name of the shipping method.
 				__( 'Shipping (%s)', 'woocommerce-payments' ),
 				$order->get_shipping_method()
 			);
@@ -517,6 +513,11 @@ class WC_Payments_Payment_Request_Button_Handler {
 		// Cart has unsupported product type.
 		if ( ( $this->is_checkout() || $this->is_cart() ) && ! $this->has_allowed_items_in_cart() ) {
 			Logger::log( 'Items in the cart have unsupported product type ( Payment Request button disabled )' );
+			return false;
+		}
+		$product_price = $this->get_product_price( $this->get_product() );
+
+		if ( ! is_numeric( $product_price ) ) {
 			return false;
 		}
 
@@ -1345,7 +1346,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 		if ( ! $is_supported ) {
 			wc_add_notice(
 				sprintf(
-				/* translators: %s: country. */
+					/* translators: %s: country. */
 					__( 'The payment request button is not supported in %s because some required fields couldn\'t be verified. Please proceed to the checkout page and try again.', 'woocommerce-payments' ),
 					$countries[ $posted_data['billing_country'] ] ?? $posted_data['billing_country']
 				),

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -239,6 +239,11 @@ class WC_Payments_Payment_Request_Button_Handler {
 
 		/** @var WC_Product_Variable $product */ // phpcs:ignore
 		$product  = $this->get_product();
+
+		$product_price = $this->get_product_price( $product );
+		if ( ! is_numeric( $product_price ) ) {
+			return false;
+		}
 		$currency = get_woocommerce_currency();
 
 		if ( 'variable' === $product->get_type() || 'variable-subscription' === $product->get_type() ) {
@@ -264,7 +269,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 
 		$data          = [];
 		$items         = [];
-		$product_price = $this->get_product_price( $product );
 
 		$items[] = [
 			'label'  => $product->get_name(),
@@ -338,7 +342,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 
 		if ( $order->get_shipping_total() ) {
 			$shipping_label = sprintf(
-				// Translators: %s is the name of the shipping method.
+			// Translators: %s is the name of the shipping method.
 				__( 'Shipping (%s)', 'woocommerce-payments' ),
 				$order->get_shipping_method()
 			);
@@ -1341,7 +1345,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 		if ( ! $is_supported ) {
 			wc_add_notice(
 				sprintf(
-					/* translators: %s: country. */
+				/* translators: %s: country. */
 					__( 'The payment request button is not supported in %s because some required fields couldn\'t be verified. Please proceed to the checkout page and try again.', 'woocommerce-payments' ),
 					$countries[ $posted_data['billing_country'] ] ?? $posted_data['billing_country']
 				),


### PR DESCRIPTION
Fixes #[4579](https://github.com/Automattic/woocommerce-payments/issues/4579)

#### Changes proposed in this Pull Request

When the product doesn't have price, the exception will be thrown because the function that is used for formatting the price with currency expects the number as a parameter inside request payment button handler.

This PR will prevent that by validating a price before the function that is used for formatting is called. If the product doesn't have a valid price, the function will exit without product data.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. Create a variable product or subscription and leave all prices empty
2. Publish product
3. Visit product and make sure that no errors are shown

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
