### PR TITLE
added meta on payment tokens being used by subscriptions

### DIFF
--- a/changelog/add-add-payment-method-attached-to-subscription-meta
+++ b/changelog/add-add-payment-method-attached-to-subscription-meta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added meta to payment tokens used in subscriptions

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1424,6 +1424,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			if ( $payment_information->is_using_saved_payment_method() ) {
 				$token = $payment_information->get_payment_token();
 				$this->add_token_to_order( $order, $token );
+
+				if ( $order->get_meta( '_woopay_has_subscription' ) ) {
+					$token->update_meta_data( 'is_attached_to_subscription', true );
+					$token->save_meta_data();
+				}
 			}
 
 			if ( 'requires_action' === $status ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1426,7 +1426,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$this->add_token_to_order( $order, $token );
 
 				if ( $order->get_meta( '_woopay_has_subscription' ) ) {
-					$token->update_meta_data( 'is_attached_to_subscription', true );
+					$token->update_meta_data( 'is_attached_to_subscription', '1' );
 					$token->save_meta_data();
 				}
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a meta to payment tokens that are used by subscriptions so we can show the correct message when deleting it via WooPay. Should be tested alongside with 1218-gh-Automattic/woopay

#### Testing instructions

- Follow the instructions on 1218-gh-Automattic/woopay

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 