### PR TITLE
Only offer WooPay when cart needs payment

### DIFF
--- a/changelog/update-woopay-cart-needs-no-payment
+++ b/changelog/update-woopay-cart-needs-no-payment
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Only offer WooPay when cart needs payment. Fix for an issue introduced by an earlier PR in this release cycle.
+
+

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -806,7 +806,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			is_checkout() &&
 			! has_block( 'woocommerce/checkout' ) &&
 			! is_wc_endpoint_url( 'order-pay' ) &&
-			! WC()->cart->is_empty()
+			! WC()->cart->is_empty() &&
+			WC()->cart->needs_payment()
 		) {
 			return true;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #4540, we [removed a check](https://github.com/Automattic/woocommerce-payments/pull/4540/files#diff-bcfd303d507c33a27671935e724ee64d0df30ff2a18bb6ef4c94f28d48190124L759-L762) for `$cart_total > 0` that was used to determine whether to offer WooPay on the checkout page. Previously, that check ensured that if the cart total was $0, WooPay was not offered. We removed that check to allow subscriptions with free trials, which have an initial $0 payment but do require payment later.

However, a consequence of that approach is that carts that truly require no payment (e.g. free products, or free subscriptions) now offer checkout via WooPay when no payment method is needed. This PR checks to make sure that the cart needs payment before offering WooPay checkout — this allows free trial subscriptions (which do need payment) but doesn't allow free products (which don't).

#### Testing instructions

1. Add a paid product to your cart — verify that WooPay **is** offered on the checkout page when you enter your email address.
2. Add a paid subscription with a free trial to your cart –  verify that WooPay **is** offered on the checkout page when you enter your email address.
3. Add a free product to your cart –  verify that WooPay **is not** offered on the checkout page when you enter your email address.
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
