### PR TITLE
Fix errors when PRBs are enabled and products have empty prices

### DIFF
--- a/changelog/fix-errors-products-with-no-price-prb
+++ b/changelog/fix-errors-products-with-no-price-prb
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent errors on PHP 8 when a product price is empty and PRB is enabled

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -220,7 +220,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 		}
 
 		// Add subscription sign-up fees to product price.
-		if ( 'subscription' === $product->get_type() && class_exists( 'WC_Subscriptions_Product' ) ) {
+		if ( 'subscription' === $product->get_type() && class_exists( 'WC_Subscriptions_Product' ) && is_numeric( $product_price ) ) {
 			$product_price = $product_price + WC_Subscriptions_Product::get_sign_up_fee( $product );
 		}
 
@@ -794,8 +794,8 @@ class WC_Payments_Payment_Request_Button_Handler {
 			$is_supported = false;
 		}
 
-		// Products with an empty price.
-		if ( '' === $product->get_price() ) {
+		// Products with an empty price are not supported.
+		if ( ! is_numeric( $this->get_product_price( $product ) ) ) {
 			$is_supported = false;
 		}
 

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -794,6 +794,11 @@ class WC_Payments_Payment_Request_Button_Handler {
 			$is_supported = false;
 		}
 
+		// Products with an empty price.
+		if ( '' === $product->get_price() ) {
+			$is_supported = false;
+		}
+
 		// Pre Orders charge upon release not supported.
 		if ( class_exists( 'WC_Pre_Orders_Product' ) && WC_Pre_Orders_Product::product_is_charged_upon_release( $product ) ) {
 			$is_supported = false;


### PR DESCRIPTION
Fixes #4579

#### Changes proposed in this Pull Request

Make products with an empty price unsupported for PRB.

Adding a check under `is_product_supported` to exclude PRB from products with no price.

#### Testing instructions

- Make sure you're using a site with PHP 8. Jurassic Ninja and ephemeral sites do the trick

**Variable products**
- As a merchant, create a variable product with a couple of variations
- Leave the prices of all variations empty
- As a shopper, go to the product page you just created
- Confirm the page loads fine and there are no errors

**Subscriptions**
- As a merchant, create a simple subscription with an empty subscription price
- As a shopper, go to the product page you just created
- Confirm the page loads fine and there are no errors

**Regression** 
- Confirm paying with PRBs continue to work fine

Please test other scenarios you see that could be impacted by this change, or that still be problematic.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
