### PR TITLE
Update the minimum WC version used in GH workflows

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -12,7 +12,7 @@ jobs:
       max-parallel: 10
       matrix:
         # Minimum support version, ..., Latest version, `beta`.
-        woocommerce: [ '6.2.2', '6.3.1', '6.4.1', '6.5.1', '6.6.1', '6.7.0', 'latest', 'beta' ]
+        woocommerce: [ '6.4.1', '6.5.1', '6.6.1', '6.7.0', 'latest', 'beta' ]
         wordpress:   [ 'latest' ]
         gutenberg:   [ 'latest' ]
         php:         [ '7.4' ]

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast:     false
       matrix:
         # Min WooCommerce | L-2 | L(atest) | beta
-        woocommerce:   [ '6.2.2', '6.6.1', 'latest', 'beta' ]
+        woocommerce:   [ '6.4.1', '6.6.1', 'latest', 'beta' ]
         wordpress:     [ 'latest', 'nightly' ]
         php:           [ '7.4' ]
         test_groups:   [ 'wcpay', 'subscriptions', 'blocks' ]
@@ -44,11 +44,11 @@ jobs:
         exclude:
           - test_groups: 'blocks'
             test_branches: 'merchant'
-          - woocommerce: '6.2.2'
+          - woocommerce: '6.4.1'
             test_groups: 'blocks'
             test_branches: 'shopper'
           - wordpress: 'nightly'
-            woocommerce: '6.2.2'
+            woocommerce: '6.4.1'
           - wordpress: 'nightly'
             woocommerce: 'beta'
 
@@ -65,7 +65,7 @@ jobs:
       # Conditionally skip WC Blocks tests. Remove/update based on min supported WC version by the blocks checkout plugin.
       - name: Conditionally skip WC Blocks tests
         run: |
-          SKIP_WC_VERSIONS=('6.2.2')
+          SKIP_WC_VERSIONS=('6.4.1')
           if [[ " ${SKIP_WC_VERSIONS[@]} " =~ " ${E2E_WC_VERSION} " ]]; then
             echo "SKIP_WC_BLOCKS_TESTS=1" >> $GITHUB_ENV
           fi
@@ -144,9 +144,9 @@ jobs:
         id: first_run_e2e_tests
         # Use +e to trap errors when running E2E tests.
         shell: /bin/bash +e {0}
-        run: | 
+        run: |
           npm run test:e2e -- --json --outputFile="$E2E_FIRST_RUN_RESULT_FILEPATH"
-          
+
           E2E_NUM_FAILED_TEST_SUITES=$(cat "$E2E_FIRST_RUN_RESULT_FILEPATH" | jq '.numFailedTestSuites')
 
           echo "::set-output name=FIRST_RUN_FAILED_TEST_SUITES::$(echo $E2E_NUM_FAILED_TEST_SUITES)"
@@ -155,7 +155,7 @@ jobs:
             echo "::notice::${E2E_NUM_FAILED_TEST_SUITES} E2E test(s) failed in the first run but we will try (it) them again in the second run."
             exit 0
           fi
-      
+
       - name: Re-try Failed E2E Files
         if: ${{ steps.first_run_e2e_tests.outputs.FIRST_RUN_FAILED_TEST_SUITES > 0  }}
         # Filter failed E2E files from the result JSON file, and re-run them.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update the minimum WC version in GH flows from 6.2.2 to 6.4.1.

Updating the version in the oldest compatibility PHP unit setup is pending. One test is failing when the minimum version there is updated. To be addressed separately.

#### Testing instructions

* Confirm that the GH flows for PHP unit tests pass with no errors
* Confirm that no new e2e tests are failing compared with the flows completed for other branches
* Confirm that 6.2.2 is replaced everywhere in the workflows by 6.4.1 (except for [this instance](https://github.com/Automattic/woocommerce-payments/blob/develop/.github/workflows/compatibility.yml#L21) which is going to be addressed separately)

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
