### PR TITLE
Display analytics orders in customer currency

### DIFF
--- a/changelog/add-4446-display-analytics-in-customer-currency
+++ b/changelog/add-4446-display-analytics-in-customer-currency
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+New Multi-Currency filter to display Analytics > Orders in customer currency.

--- a/client/multi-currency-analytics/index.js
+++ b/client/multi-currency-analytics/index.js
@@ -122,3 +122,41 @@ addFilter(
 		return tableData;
 	}
 );
+
+addFilter(
+	'woocommerce_admin_orders_report_filters',
+	'woocommerce-payments',
+	( filters ) => [
+		{
+			label: __( 'Currency', 'woocommerce-payments' ),
+			param: 'currency',
+			staticParams: [],
+			showFilters: () => true,
+			defaultValue: wcSettings.currency.code,
+			filters: getCustomerCurrencies(),
+		},
+		...filters,
+	]
+);
+
+const currencySymbols = Object.values( wcpaySettings.currencyData ).reduce(
+	( symbols, currency ) => {
+		symbols[ currency.code ] = currency.symbol;
+		return symbols;
+	},
+	{}
+);
+
+addFilter(
+	'woocommerce_admin_report_currency',
+	'woocommerce-payments',
+	( config, { currency } ) => {
+		if ( currency && currencySymbols[ currency ] ) {
+			return {
+				...config,
+				symbol: currencySymbols[ currency ],
+			};
+		}
+		return config;
+	}
+);

--- a/client/multi-currency-analytics/index.js
+++ b/client/multi-currency-analytics/index.js
@@ -139,21 +139,20 @@ addFilter(
 	]
 );
 
+const currencySymbols = Object.values( wcpaySettings.currencyData ).reduce(
+	( symbols, { code, symbol } ) => {
+		symbols[ code ] = symbol;
+		return symbols;
+	},
+	{}
+);
+
 // Filter report currency formatter to display the selected currency symbol.
 addFilter(
 	'woocommerce_admin_report_currency',
 	'woocommerce-payments',
 	( config, { currency } ) => {
-		if ( ! currency ) return config;
-
-		const currencySymbols = Object.values(
-			wcpaySettings.currencyData
-		).reduce( ( symbols, { code, symbol } ) => {
-			symbols[ code ] = symbol;
-			return symbols;
-		}, {} );
-
-		if ( ! currencySymbols[ currency ] ) return config;
+		if ( ! currency && ! currencySymbols[ currency ] ) return config;
 
 		return {
 			...config,

--- a/client/multi-currency-analytics/index.js
+++ b/client/multi-currency-analytics/index.js
@@ -128,7 +128,7 @@ addFilter(
 	'woocommerce-payments',
 	( filters ) => [
 		{
-			label: __( 'Currency', 'woocommerce-payments' ),
+			label: __( 'Customer currency', 'woocommerce-payments' ),
 			param: 'currency',
 			staticParams: [],
 			showFilters: () => true,

--- a/client/multi-currency-analytics/index.js
+++ b/client/multi-currency-analytics/index.js
@@ -132,8 +132,13 @@ addFilter(
 			param: 'currency',
 			staticParams: [],
 			showFilters: () => true,
-			defaultValue: wcSettings.currency.code,
-			filters: getCustomerCurrencies(),
+			filters: [
+				{
+					label: __( 'All currencies', 'woocommerce-payments' ),
+					value: 'all',
+				},
+				...getCustomerCurrencies(),
+			],
 		},
 		...filters,
 	]

--- a/client/multi-currency-analytics/index.js
+++ b/client/multi-currency-analytics/index.js
@@ -144,24 +144,22 @@ addFilter(
 	]
 );
 
-const currencySymbols = Object.values( wcpaySettings.currencyData ).reduce(
-	( symbols, { code, symbol } ) => {
-		symbols[ code ] = symbol;
-		return symbols;
-	},
-	{}
-);
-
 // Filter report currency formatter to display the selected currency symbol.
 addFilter(
 	'woocommerce_admin_report_currency',
 	'woocommerce-payments',
 	( config, { currency } ) => {
-		if ( ! currency && ! currencySymbols[ currency ] ) return config;
+		if ( ! currency ) return config;
+
+		const currencyData = Object.values( wcpaySettings.currencyData ).find(
+			( c ) => c.code === currency
+		);
+
+		if ( ! currencyData ) return config;
 
 		return {
 			...config,
-			symbol: currencySymbols[ currency ],
+			symbol: currencyData.symbol,
 		};
 	}
 );

--- a/client/multi-currency-analytics/index.js
+++ b/client/multi-currency-analytics/index.js
@@ -139,24 +139,25 @@ addFilter(
 	]
 );
 
-const currencySymbols = Object.values( wcpaySettings.currencyData ).reduce(
-	( symbols, currency ) => {
-		symbols[ currency.code ] = currency.symbol;
-		return symbols;
-	},
-	{}
-);
-
+// Filter report currency formatter to display the selected currency symbol.
 addFilter(
 	'woocommerce_admin_report_currency',
 	'woocommerce-payments',
 	( config, { currency } ) => {
-		if ( currency && currencySymbols[ currency ] ) {
-			return {
-				...config,
-				symbol: currencySymbols[ currency ],
-			};
-		}
-		return config;
+		if ( ! currency ) return config;
+
+		const currencySymbols = Object.values(
+			wcpaySettings.currencyData
+		).reduce( ( symbols, { code, symbol } ) => {
+			symbols[ code ] = symbol;
+			return symbols;
+		}, {} );
+
+		if ( ! currencySymbols[ currency ] ) return config;
+
+		return {
+			...config,
+			symbol: currencySymbols[ currency ],
+		};
 	}
 );

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -94,7 +94,7 @@ class Analytics {
 		add_filter( 'woocommerce_analytics_clauses_where_orders_stats_interval', [ $this, 'filter_where_clauses' ] );
 
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( ! empty( $_GET['currency'] ) ) {
+		if ( ! empty( $_GET['currency'] ) && $_GET['currency'] !== $this->multi_currency->get_default_currency()->get_code() ) {
 			add_filter( 'woocommerce_analytics_clauses_select_orders_subquery', [ $this, 'filter_select_orders_clauses' ] );
 			add_filter( 'woocommerce_analytics_clauses_select_orders_stats_total', [ $this, 'filter_select_orders_clauses' ] );
 		}
@@ -379,9 +379,7 @@ class Analytics {
 	 * @return array
 	 */
 	public function filter_select_orders_clauses( array $clauses ): array {
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotValidated
-		if ( apply_filters( MultiCurrency::FILTER_PREFIX . 'disable_filter_select_orders_clauses', false ) || $this->multi_currency->get_default_currency()->get_code() === $_GET['currency'] ) {
+		if ( apply_filters( MultiCurrency::FILTER_PREFIX . 'disable_filter_select_orders_clauses', false ) ) {
 			return $clauses;
 		}
 

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -95,8 +95,8 @@ class Analytics {
 
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( ! empty( $_GET['currency'] ) ) {
-			add_filter( 'woocommerce_analytics_clauses_select_orders_subquery', [ $this, 'filter_select_orders' ] );
-			add_filter( 'woocommerce_analytics_clauses_select_orders_stats_total', [ $this, 'filter_select_orders' ] );
+			add_filter( 'woocommerce_analytics_clauses_select_orders_subquery', [ $this, 'filter_select_orders_clauses' ] );
+			add_filter( 'woocommerce_analytics_clauses_select_orders_stats_total', [ $this, 'filter_select_orders_clauses' ] );
 		}
 	}
 
@@ -371,7 +371,13 @@ class Analytics {
 		return apply_filters( MultiCurrency::FILTER_PREFIX . 'filter_where_clauses', $clauses );
 	}
 
-	public function filter_select_orders( array $clauses ) {
+	/**
+	 * Convert amounts back to order currency (if a currency has been selected).
+	 *
+	 * @param string[] $clauses - An array containing the SELECT orders clauses to be applied.
+	 * @return array
+	 */
+	public function filter_select_orders_clauses( array $clauses ): array {
 		global $wpdb;
 		$exchange_rate        = 'wcpay_multicurrency_exchange_rate_meta.meta_value';
 		$stripe_exchange_rate = 'wcpay_multicurrency_stripe_exchange_rate_meta.meta_value';
@@ -396,7 +402,7 @@ class Analytics {
 			}
 		}
 
-		return $clauses;
+		return apply_filters( MultiCurrency::FILTER_PREFIX . 'filter_select_orders_clauses', $clauses );
 	}
 
 	/**

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -92,6 +92,12 @@ class Analytics {
 		add_filter( 'woocommerce_analytics_clauses_where_orders_subquery', [ $this, 'filter_where_clauses' ] );
 		add_filter( 'woocommerce_analytics_clauses_where_orders_stats_total', [ $this, 'filter_where_clauses' ] );
 		add_filter( 'woocommerce_analytics_clauses_where_orders_stats_interval', [ $this, 'filter_where_clauses' ] );
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( ! empty( $_GET['currency'] ) ) {
+			add_filter( 'woocommerce_analytics_clauses_select_orders_subquery', [ $this, 'filter_select_orders' ] );
+			add_filter( 'woocommerce_analytics_clauses_select_orders_stats_total', [ $this, 'filter_select_orders' ] );
+		}
 	}
 
 	/**
@@ -358,7 +364,38 @@ class Analytics {
 			$clauses[]       = "AND {$currency_field} NOT IN ({$currency_is_not})";
 		}
 
+		if ( ! empty( $currency_args['currency'] ) ) {
+			$clauses[] = "AND {$currency_field} = '{$currency_args['currency']}'";
+		}
+
 		return apply_filters( MultiCurrency::FILTER_PREFIX . 'filter_where_clauses', $clauses );
+	}
+
+	public function filter_select_orders( array $clauses ) {
+		global $wpdb;
+		$exchange_rate        = 'wcpay_multicurrency_exchange_rate_meta.meta_value';
+		$stripe_exchange_rate = 'wcpay_multicurrency_stripe_exchange_rate_meta.meta_value';
+		$net_total            = "{$wpdb->prefix}wc_order_stats.net_total";
+
+		foreach ( $clauses as $k => $clause ) {
+			if ( strpos( $clause, $net_total ) !== false ) {
+				$is_orders_subquery = strpos( $clause, $net_total . ',' ) !== false;
+				$variable           = $is_orders_subquery ? "$net_total," : $net_total;
+				$alias              = $is_orders_subquery ? ' as net_total,' : '';
+
+				$clauses[ $k ] = str_replace(
+					$variable,
+					$this->generate_case_when(
+						$stripe_exchange_rate,
+						"$net_total / $stripe_exchange_rate",
+						"$net_total * $exchange_rate"
+					) . $alias,
+					$clause
+				);
+			}
+		}
+
+		return $clauses;
 	}
 
 	/**
@@ -495,6 +532,7 @@ class Analytics {
 		$args = [
 			'currency_is'     => [],
 			'currency_is_not' => [],
+			'currency'        => null,
 		];
 
 		/* phpcs:disable WordPress.Security.NonceVerification */
@@ -504,6 +542,10 @@ class Analytics {
 
 		if ( isset( $_GET['currency_is_not'] ) ) {
 			$args['currency_is_not'] = array_map( 'sanitize_text_field', wp_unslash( $_GET['currency_is_not'] ) );
+		}
+
+		if ( isset( $_GET['currency'] ) ) {
+			$args['currency'] = sanitize_text_field( wp_unslash( $_GET['currency'] ) );
 		}
 		/* phpcs:enable WordPress.Security.NonceVerification */
 

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -382,13 +382,14 @@ class Analytics {
 				$is_orders_subquery = strpos( $clause, $net_total . ',' ) !== false;
 				$variable           = $is_orders_subquery ? "$net_total," : $net_total;
 				$alias              = $is_orders_subquery ? ' as net_total,' : '';
+				$dp                 = wc_get_price_decimals();
 
 				$clauses[ $k ] = str_replace(
 					$variable,
 					$this->generate_case_when(
 						$stripe_exchange_rate,
-						"$net_total / $stripe_exchange_rate",
-						"$net_total * $exchange_rate"
+						"ROUND($net_total / $stripe_exchange_rate, $dp)",
+						"ROUND($net_total * $exchange_rate, $dp)"
 					) . $alias,
 					$clause
 				);

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -373,11 +373,18 @@ class Analytics {
 
 	/**
 	 * Convert amounts back to order currency (if a currency has been selected).
+	 * Skipping it for default currency.
 	 *
 	 * @param string[] $clauses - An array containing the SELECT orders clauses to be applied.
 	 * @return array
 	 */
 	public function filter_select_orders_clauses( array $clauses ): array {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+		if ( apply_filters( MultiCurrency::FILTER_PREFIX . 'disable_filter_select_orders_clauses', false ) || $this->multi_currency->get_default_currency()->get_code() === $_GET['currency'] ) {
+			return $clauses;
+		}
+
 		global $wpdb;
 		$exchange_rate        = 'wcpay_multicurrency_exchange_rate_meta.meta_value';
 		$stripe_exchange_rate = 'wcpay_multicurrency_stripe_exchange_rate_meta.meta_value';

--- a/tests/unit/multi-currency/test-class-analytics.php
+++ b/tests/unit/multi-currency/test-class-analytics.php
@@ -382,6 +382,24 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 		);
 	}
 
+	public function test_filter_where_clauses_with_currency() {
+		global $wpdb;
+
+		$clauses  = [ "WHERE {$wpdb->prefix}wc_order_stats.order_id = 123" ];
+		$expected = [
+			"WHERE {$wpdb->prefix}wc_order_stats.order_id = 123",
+			"AND wcpay_multicurrency_currency_meta.meta_value = 'USD'",
+		];
+
+		// Simulate a currency being passed in via GET request.
+		$_GET['currency'] = 'USD';
+
+		$this->assertEquals(
+			$expected,
+			$this->analytics->filter_where_clauses( $clauses )
+		);
+	}
+
 	public function test_filter_where_clauses_with_multiple_currency_args() {
 		global $wpdb;
 
@@ -466,6 +484,84 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 			}
 		);
 		$this->assertEquals( $expected, $this->analytics->filter_join_clauses( $clauses, 'orders_stats' ) );
+	}
+
+	/**
+	 * @dataProvider select_orders_clause_provider
+	 */
+	public function test_filter_select_orders_clauses( $currency, $clauses, $expected ) {
+		// Simulate a currency being passed in via GET request.
+		$_GET['currency'] = $currency;
+
+		$this->mock_multi_currency->expects( $this->once() )
+			->method( 'get_default_currency' )
+			->willReturn( new Currency( 'USD', 1.0 ) );
+
+		$this->assertEquals( $expected, $this->analytics->filter_select_orders_clauses( $clauses ) );
+	}
+
+	public function select_orders_clause_provider() {
+		global $wpdb;
+
+		return [
+			'should filter subquery'             => [
+				'EUR',
+				[
+					"DISTINCT {$wpdb->prefix}wc_order_stats.order_id, {$wpdb->prefix}wc_order_stats.parent_id, {$wpdb->prefix}wc_order_stats.date_created, {$wpdb->prefix}wc_order_stats.date_created_gmt, REPLACE({$wpdb->prefix}wc_order_stats.status, 'wc-', '') as status, {$wpdb->prefix}wc_order_stats.customer_id, {$wpdb->prefix}wc_order_stats.net_total, {$wpdb->prefix}wc_order_stats.total_sales, {$wpdb->prefix}wc_order_stats.num_items_sold, (CASE WHEN {$wpdb->prefix}wc_order_stats.returning_customer = 0 THEN 'new' ELSE 'returning' END) as customer_type",
+					', wcpay_multicurrency_currency_meta.meta_value AS order_currency',
+				],
+				[
+					"DISTINCT {$wpdb->prefix}wc_order_stats.order_id, {$wpdb->prefix}wc_order_stats.parent_id, {$wpdb->prefix}wc_order_stats.date_created, {$wpdb->prefix}wc_order_stats.date_created_gmt, REPLACE({$wpdb->prefix}wc_order_stats.status, 'wc-', '') as status, {$wpdb->prefix}wc_order_stats.customer_id, CASE WHEN wcpay_multicurrency_stripe_exchange_rate_meta.meta_value IS NOT NULL THEN ROUND({$wpdb->prefix}wc_order_stats.net_total / wcpay_multicurrency_stripe_exchange_rate_meta.meta_value, 2) ELSE ROUND({$wpdb->prefix}wc_order_stats.net_total * wcpay_multicurrency_exchange_rate_meta.meta_value, 2) END as net_total, {$wpdb->prefix}wc_order_stats.total_sales, {$wpdb->prefix}wc_order_stats.num_items_sold, (CASE WHEN {$wpdb->prefix}wc_order_stats.returning_customer = 0 THEN 'new' ELSE 'returning' END) as customer_type",
+					', wcpay_multicurrency_currency_meta.meta_value AS order_currency',
+				],
+			],
+			'should filter stats total'          => [
+				'EUR',
+				[
+					"SUM( CASE WHEN {$wpdb->prefix}wc_order_stats.parent_id = 0 THEN 1 ELSE 0 END ) as orders_count, SUM({$wpdb->prefix}wc_order_stats.net_total) AS net_revenue, SUM( {$wpdb->prefix}wc_order_stats.net_total ) / SUM( CASE WHEN {$wpdb->prefix}wc_order_stats.parent_id = 0 THEN 1 ELSE 0 END ) AS avg_order_value, SUM( {$wpdb->prefix}wc_order_stats.num_items_sold ) / SUM( CASE WHEN {$wpdb->prefix}wc_order_stats.parent_id = 0 THEN 1 ELSE 0 END ) AS avg_items_per_order",
+					', wcpay_multicurrency_currency_meta.meta_value AS order_currency',
+				],
+				[
+					"SUM( CASE WHEN {$wpdb->prefix}wc_order_stats.parent_id = 0 THEN 1 ELSE 0 END ) as orders_count, SUM(CASE WHEN wcpay_multicurrency_stripe_exchange_rate_meta.meta_value IS NOT NULL THEN ROUND({$wpdb->prefix}wc_order_stats.net_total / wcpay_multicurrency_stripe_exchange_rate_meta.meta_value, 2) ELSE ROUND({$wpdb->prefix}wc_order_stats.net_total * wcpay_multicurrency_exchange_rate_meta.meta_value, 2) END) AS net_revenue, SUM( CASE WHEN wcpay_multicurrency_stripe_exchange_rate_meta.meta_value IS NOT NULL THEN ROUND({$wpdb->prefix}wc_order_stats.net_total / wcpay_multicurrency_stripe_exchange_rate_meta.meta_value, 2) ELSE ROUND({$wpdb->prefix}wc_order_stats.net_total * wcpay_multicurrency_exchange_rate_meta.meta_value, 2) END ) / SUM( CASE WHEN {$wpdb->prefix}wc_order_stats.parent_id = 0 THEN 1 ELSE 0 END ) AS avg_order_value, SUM( {$wpdb->prefix}wc_order_stats.num_items_sold ) / SUM( CASE WHEN {$wpdb->prefix}wc_order_stats.parent_id = 0 THEN 1 ELSE 0 END ) AS avg_items_per_order",
+					', wcpay_multicurrency_currency_meta.meta_value AS order_currency',
+				],
+			],
+			'should not filter default currency' => [
+				'USD',
+				[
+					"SUM({$wpdb->prefix}wc_order_stats.net_total) AS net_revenue",
+					', wcpay_multicurrency_currency_meta.meta_value AS order_currency',
+				],
+				[
+					"SUM({$wpdb->prefix}wc_order_stats.net_total) AS net_revenue",
+					', wcpay_multicurrency_currency_meta.meta_value AS order_currency',
+				],
+			],
+		];
+	}
+
+	public function test_filter_select_orders_clauses_disable_filter() {
+		// Simulate a currency being passed in via GET request.
+		$_GET['currency'] = 'USD';
+
+		$expected = [ 'Santa Claus', 'Mrs. Claus' ];
+		add_filter( 'wcpay_multi_currency_disable_filter_select_orders_clauses', '__return_true' );
+		$this->assertEquals( $expected, $this->analytics->filter_select_orders_clauses( $expected ) );
+	}
+
+	public function test_filter_select_orders_clauses_return_filter() {
+		// Simulate a currency being passed in via GET request.
+		$_GET['currency'] = 'USD';
+
+		$clauses  = [ 'Santa Claus', 'Mrs. Claus' ];
+		$expected = array_reverse( $clauses );
+		add_filter(
+			'wcpay_multi_currency_filter_select_orders_clauses',
+			function( $new_clauses ) use ( $clauses ) {
+				return array_reverse( $clauses );
+			}
+		);
+		$this->assertEquals( $expected, $this->analytics->filter_select_orders_clauses( $clauses ) );
 	}
 
 	private function order_args_provider( $order_id, $parent_id, $num_items_sold, $total_sales, $tax_total, $shipping_total, $net_total ) {

--- a/tests/unit/multi-currency/test-class-analytics.php
+++ b/tests/unit/multi-currency/test-class-analytics.php
@@ -489,14 +489,7 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 	/**
 	 * @dataProvider select_orders_clause_provider
 	 */
-	public function test_filter_select_orders_clauses( $currency, $clauses, $expected ) {
-		// Simulate a currency being passed in via GET request.
-		$_GET['currency'] = $currency;
-
-		$this->mock_multi_currency->expects( $this->once() )
-			->method( 'get_default_currency' )
-			->willReturn( new Currency( 'USD', 1.0 ) );
-
+	public function test_filter_select_orders_clauses( $clauses, $expected ) {
 		$this->assertEquals( $expected, $this->analytics->filter_select_orders_clauses( $clauses ) );
 	}
 
@@ -504,8 +497,7 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 		global $wpdb;
 
 		return [
-			'should filter subquery'             => [
-				'EUR',
+			'subquery'    => [
 				[
 					"DISTINCT {$wpdb->prefix}wc_order_stats.order_id, {$wpdb->prefix}wc_order_stats.parent_id, {$wpdb->prefix}wc_order_stats.date_created, {$wpdb->prefix}wc_order_stats.date_created_gmt, REPLACE({$wpdb->prefix}wc_order_stats.status, 'wc-', '') as status, {$wpdb->prefix}wc_order_stats.customer_id, {$wpdb->prefix}wc_order_stats.net_total, {$wpdb->prefix}wc_order_stats.total_sales, {$wpdb->prefix}wc_order_stats.num_items_sold, (CASE WHEN {$wpdb->prefix}wc_order_stats.returning_customer = 0 THEN 'new' ELSE 'returning' END) as customer_type",
 					', wcpay_multicurrency_currency_meta.meta_value AS order_currency',
@@ -515,8 +507,7 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 					', wcpay_multicurrency_currency_meta.meta_value AS order_currency',
 				],
 			],
-			'should filter stats total'          => [
-				'EUR',
+			'stats total' => [
 				[
 					"SUM( CASE WHEN {$wpdb->prefix}wc_order_stats.parent_id = 0 THEN 1 ELSE 0 END ) as orders_count, SUM({$wpdb->prefix}wc_order_stats.net_total) AS net_revenue, SUM( {$wpdb->prefix}wc_order_stats.net_total ) / SUM( CASE WHEN {$wpdb->prefix}wc_order_stats.parent_id = 0 THEN 1 ELSE 0 END ) AS avg_order_value, SUM( {$wpdb->prefix}wc_order_stats.num_items_sold ) / SUM( CASE WHEN {$wpdb->prefix}wc_order_stats.parent_id = 0 THEN 1 ELSE 0 END ) AS avg_items_per_order",
 					', wcpay_multicurrency_currency_meta.meta_value AS order_currency',
@@ -526,33 +517,16 @@ class WCPay_Multi_Currency_Analytics_Tests extends WCPAY_UnitTestCase {
 					', wcpay_multicurrency_currency_meta.meta_value AS order_currency',
 				],
 			],
-			'should not filter default currency' => [
-				'USD',
-				[
-					"SUM({$wpdb->prefix}wc_order_stats.net_total) AS net_revenue",
-					', wcpay_multicurrency_currency_meta.meta_value AS order_currency',
-				],
-				[
-					"SUM({$wpdb->prefix}wc_order_stats.net_total) AS net_revenue",
-					', wcpay_multicurrency_currency_meta.meta_value AS order_currency',
-				],
-			],
 		];
 	}
 
 	public function test_filter_select_orders_clauses_disable_filter() {
-		// Simulate a currency being passed in via GET request.
-		$_GET['currency'] = 'USD';
-
 		$expected = [ 'Santa Claus', 'Mrs. Claus' ];
 		add_filter( 'wcpay_multi_currency_disable_filter_select_orders_clauses', '__return_true' );
 		$this->assertEquals( $expected, $this->analytics->filter_select_orders_clauses( $expected ) );
 	}
 
 	public function test_filter_select_orders_clauses_return_filter() {
-		// Simulate a currency being passed in via GET request.
-		$_GET['currency'] = 'USD';
-
 		$clauses  = [ 'Santa Claus', 'Mrs. Claus' ];
 		$expected = array_reverse( $clauses );
 		add_filter(


### PR DESCRIPTION
Fixes #4446 

#### Changes proposed in this Pull Request
- Add a **Customer Currency** filter in **Analytics → Orders** with all the enabled ones plus `All currencies` as default value. Hooking into `woocommerce_admin_orders_report_filters`.
- Use `woocommerce_admin_report_currency` to hook into report currency format and display amounts using the selected currency symbol.
- Use `currency` as argument for this new filter. As it doesn't collide with existing `currency_is` and `currency_is_not`. Adding it as another `WHERE` clause to only display orders in the selected currency.
- Filter `woocommerce_analytics_clauses_select_orders_subquery` and `woocommerce_analytics_clauses_select_orders_stats_total` when there is a currency selected, and it isn't the default one.
- Replace all occurrences of `wc_order_stats.net_total` on those queries with:
  - `CASE` to check if we have `wcpay_multicurrency_stripe_exchange_rate_meta` or need to fall back to `wcpay_multicurrency_exchange_rate_meta`.
  - `ROUND` of the arithmetic operation using `wc_get_price_decimals()`.
  - The actual multiply or divide operation based on the available rate.

#### Testing instructions
You'll need a store with more than one currency added and orders in at least 2 different currencies.

- Go to **Analytics → Orders**.
- The new **Customer Currency** filter should be there with value `All currencies`.
- Select a **Date range** where you have orders in more than one currency.
- Select your store currency in the **Customer Currency** filter.
  - Only orders in your store currency should be visible.
- Select a different currency in the filter.
  - Only orders in this currency should be visible.
  - All amounts should be converted and use the correct currency symbol and store format.
  - Ensure all the conversions are good including **Net sales** and **Average order value**, and there is no rounding issues between the order amounts and totals.
- Disable

#### Screenshots
| Currency options | All currencies | EUR | ISK |
|-|-|-|-|
|<img width="325" alt="4446-currency-options" src="https://user-images.githubusercontent.com/7670276/194829950-2e44537b-4f32-4048-b42a-468d550533f7.png">|<img width="1225" alt="4446-all-currencies" src="https://user-images.githubusercontent.com/7670276/194829960-15e7af5a-22bb-414f-916c-d05ec11f0015.png">|<img width="1224" alt="4446-eur" src="https://user-images.githubusercontent.com/7670276/194829975-1991ca64-daf7-407b-b2dc-06beea01365a.png">|<img width="1221" alt="4446-isk" src="https://user-images.githubusercontent.com/7670276/194829984-7ee02f4c-e5a7-46a5-9d63-30e3d1077d75.png">|

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : [Testing instructions](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-4.9.0#display-analytics-orders-in-customer-currency)
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
