### PR TITLE
Ensure get_deposit_schedule_monthly_anchor() returns an int or null.

### DIFF
--- a/changelog/fix-4656-rest-invalid-param
+++ b/changelog/fix-4656-rest-invalid-param
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: No changelog necessary as this fixes an unreleased feature.
+
+

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -329,7 +329,7 @@ class WC_Payments_Account {
 	 */
 	public function get_deposit_schedule_monthly_anchor() {
 		$account = $this->get_cached_account_data();
-		return $account['deposits']['monthly_anchor'] ?? null;
+		return ! empty( $account['deposits']['monthly_anchor'] ) ? $account['deposits']['monthly_anchor'] : null;
 	}
 
 	/**


### PR DESCRIPTION
This PR is a follow-up to PR https://github.com/Automattic/woocommerce-payments/pull/4656 which introduced a bug. This bug prevented merchants from saving the WooCommerce Payments settings via the **Payments → Settings** page in certain circumstances.

The merchant would see an "Error saving settings" notice and their changes would not be persisted.

<img width="1127" alt="Screen Shot 2022-09-05 at 11 14 50 am" src="https://user-images.githubusercontent.com/1527164/188342229-5a646a7f-586e-4d7c-95dd-771a90e0236a.png">

#### Changes proposed in this Pull Request

I have changed the logic in the `get_deposit_schedule_monthly_anchor()` to ensure it returns an integer or null as there were instances where it returned a string which resulted in the error flow described above.

**Steps to reproduce**

See the steps to reproduce below:

1. Switch to the `develop` branch.
2. On `woocommerce-payments-server` be on the `trunk` branch.
3. In the Stripe dashboard, change the payout schedule for your account to "Manual" and save.
4. Navigate to WCPay Dev Utils and clear your account cache.
5. Observe that the `monthly_anchor` cache contains an empty string i.e. `''`.
6. Navigate to **Payments → Settings**.
7. Open the Network tab in your browser dev tools.
8. Scroll to the bottom of the page.
9. Click the "Save Changes" button.
10. Observe the following error for the `/settings` request.

```
{
	"code": "rest_invalid_param",
	"message": "Invalid parameter(s): deposit_schedule_monthly_anchor",
	"data": {
		"status": 400,
		"params": {
			"deposit_schedule_monthly_anchor": "deposit_schedule_monthly_anchor is not of type integer,null."
		},
		"details": {
			"deposit_schedule_monthly_anchor": {
				"code": "rest_invalid_type",
				"message": "deposit_schedule_monthly_anchor is not of type integer,null.",
				"data": {
					"param": "deposit_schedule_monthly_anchor"
				}
			}
		}
	}
}
```

**Note:** This error **will not occur** if using the corresponding server branch, i.e. `add/2253-allow-deposit-schedule-updates-via-api`. This is because WCPay Server will correctly return the `monthly_anchor` payload as `null` if empty.

#### Testing instructions

* Switch to this branch.
* Follow steps 2-9 from above.
* Observe the settings are saved successfully.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.