### PR TITLE
Calculate the shipping price correctly when using MultiCurrency and Table Rate Shipping

### DIFF
--- a/changelog/fix-4609-table-rate-shipping-wrong-rate-calculated
+++ b/changelog/fix-4609-table-rate-shipping-wrong-rate-calculated
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the rate calculation when using Table Rate Shipping and per item or per line item calculation type

--- a/includes/multi-currency/FrontendPrices.php
+++ b/includes/multi-currency/FrontendPrices.php
@@ -135,9 +135,10 @@ class FrontendPrices {
 	 * @return array Shipping rate args with converted cost.
 	 */
 	public function convert_shipping_method_rate_cost( $args ) {
+		$cost = is_array( $args['cost'] ) ? array_sum( $args['cost'] ) : $args['cost'];
 		$args = wp_parse_args(
 			[
-				'cost' => $this->multi_currency->get_price( $args['cost'], 'shipping' ),
+				'cost' => $this->multi_currency->get_price( $cost, 'shipping' ),
 			],
 			$args
 		);


### PR DESCRIPTION
Fixes #4609, #4526 

#### Changes proposed in this Pull Request

#4434  caused a regression in calculating the shipping cost using Table Rate Shipping.
We should expect to receive a cost or an array of costs (for instance, if we define a "Handling fee" with the table rate, which would come in addition to the fee per line item).

#### Testing instructions

- Download and activate the [Table Rate Shipping](https://woocommerce.com/products/table-rate-shipping) extension
- Set up a shipping zone in WooCommerce > Settings > Shipping
- Select that shipping zone and add a "Table rate" shipping method
- Configure the table rate as following (by clicking on "Edit" just below the shipping method):

![image](https://user-images.githubusercontent.com/28830738/188470495-9ad9719f-2cc4-4bfa-84cf-ab201fd6a5ac.png)

- Add an item with a price of $20.00 and another item with a price of $16.00 to your cart
- Visit your cart, and you should see the Table Rate cost:
   - $44.50 on this branch
   - $1 on `develop`

As per the Table Rate setting, we expect:
- Handling fee = $2.50 (applied once to the whole order)
- Handling fee per line item = $1, so that makes $2 for both items
- Item cost = $20 so that makes $40 for both items

Which makes a total of $44.50

Calculating per line should now also display the right cost.
If you remove the Handling fees or decide to calculate per order, the total should still make sense with the content of your cart (instead of showing $1).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
