### PR TITLE
Removing unnecessary check against server response

### DIFF
--- a/changelog/fix-4699-remove-unneeded-key-check
+++ b/changelog/fix-4699-remove-unneeded-key-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Removing unneeded check against server response.
+
+

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -192,7 +192,7 @@ class WC_Payments_Account {
 			'country'             => $account['country'] ?? 'US',
 			'status'              => $account['status'],
 			'paymentsEnabled'     => $account['payments_enabled'],
-			'deposits'            => $account['deposits'],
+			'deposits'            => $account['deposits'] ?? [],
 			'currentDeadline'     => isset( $account['current_deadline'] ) ? $account['current_deadline'] : false,
 			'pastDue'             => isset( $account['has_overdue_requirements'] ) ? $account['has_overdue_requirements'] : false,
 			'accountLink'         => $this->get_login_url(),

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -180,9 +180,7 @@ class WC_Payments_Account {
 			];
 		}
 
-		if ( ! isset( $account['status'] )
-			|| ! isset( $account['payments_enabled'] )
-			|| ! isset( $account['deposits']['status'] ) ) {
+		if ( ! isset( $account['status'], $account['payments_enabled'] ) ) {
 			// return an error if any of the account data is missing.
 			return [
 				'error' => true,


### PR DESCRIPTION
Fixes #4699

#### Changes proposed in this Pull Request

Removed unnecessary check for `deposit.status` / `deposit_status` on response from server. As this key always exists when the other conditions are met.

Whenever the `payments_enabled` key is returned from the server, the deposit status is also returned.

#### Testing instructions

* Check that when `payments_enabled` is returned from the server that `deposits.status` or `deposits_status` is returned.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
