### PR TITLE
Fix email notification error with StripeLink button code 

### DIFF
--- a/changelog/fix-4675-stripelink-notification
+++ b/changelog/fix-4675-stripelink-notification
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Remove button HTML code seen in error notification, when email address is kept blank
+Correct empty email error when StripeLink is active on checkout page.

--- a/changelog/fix-4675-stripelink-notification
+++ b/changelog/fix-4675-stripelink-notification
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove button HTML code seen in error notification, when email address is kept blank

--- a/client/checkout/classic/style.scss
+++ b/client/checkout/classic/style.scss
@@ -43,7 +43,7 @@
 	position: relative;
 }
 
-div.col2-set > div.col-1 > div > button.wcpay-stripelink-modal-trigger {
+.wcpay-checkout-email-field button.wcpay-stripelink-modal-trigger {
 	display: none;
 	position: absolute;
 	right: 5px;

--- a/client/checkout/classic/style.scss
+++ b/client/checkout/classic/style.scss
@@ -43,7 +43,7 @@
 	position: relative;
 }
 
-.wcpay-checkout-email-field button.wcpay-stripelink-modal-trigger {
+div.col2-set > div.col-1 > div > button.wcpay-stripelink-modal-trigger {
 	display: none;
 	position: absolute;
 	right: 5px;

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -3227,11 +3227,16 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			// Add extra `wcpay-checkout-email-field` class.
 			$fields['billing_email']['class'][] = 'wcpay-checkout-email-field';
 
-			// Append StripeLink modal trigger button for logged in users.
-			$fields['billing_email']['label'] = $fields['billing_email']['label']
-				. ' <button class="wcpay-stripelink-modal-trigger"></button>';
+			/**
+			 * Append the Stripe Link modal button.
+			 *
+			 * @return void
+			 */
+			function wcpay_append_stripelink_modal_button() {
+				echo '<button class="wcpay-stripelink-modal-trigger"></button>';
+			}
+			add_action( 'woocommerce_before_checkout_billing_form', 'wcpay_append_stripelink_modal_button' );
 		}
-
 		return $fields;
 	}
 }

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -3226,12 +3226,26 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			// Add extra `wcpay-checkout-email-field` class.
 			$fields['billing_email']['class'][] = 'wcpay-checkout-email-field';
-
-			// Append StripeLink modal trigger button for logged in users.
-			$fields['billing_email']['label'] = $fields['billing_email']['label']
-				. ' <button class="wcpay-stripelink-modal-trigger"></button>';
 		}
 
+		add_filter( 'woocommerce_form_field_email', [ $this, 'append_stripelink_button' ], 10, 4 );
 		return $fields;
+	}
+
+	/**
+	 * Append StripeLink button within email field for logged in users.
+	 *
+	 * @param string $field    - HTML content within email field.
+	 * @param string $key      - Key.
+	 * @param array  $args     - Arguments.
+	 * @param string $value    - Default value.
+	 *
+	 * @return string $field    - Updated email field content with the button appended.
+	 */
+	public function append_stripelink_button( $field, $key, $args, $value ) {
+		if ( 'billing_email' === $key ) {
+			$field = str_replace( '</span>', '<button class="wcpay-stripelink-modal-trigger"></button></span>', $field );
+		}
+		return $field;
 	}
 }

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -3227,16 +3227,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			// Add extra `wcpay-checkout-email-field` class.
 			$fields['billing_email']['class'][] = 'wcpay-checkout-email-field';
 
-			/**
-			 * Append the Stripe Link modal button.
-			 *
-			 * @return void
-			 */
-			function wcpay_append_stripelink_modal_button() {
-				echo '<button class="wcpay-stripelink-modal-trigger"></button>';
-			}
-			add_action( 'woocommerce_before_checkout_billing_form', 'wcpay_append_stripelink_modal_button' );
+			// Append StripeLink modal trigger button for logged in users.
+			$fields['billing_email']['label'] = $fields['billing_email']['label']
+				. ' <button class="wcpay-stripelink-modal-trigger"></button>';
 		}
+
 		return $fields;
 	}
 }


### PR DESCRIPTION
Fixes #4675

#### Changes proposed in this Pull Request

Prevent button HTML code from appearing in the error notification, when the email address is blank. 


 #### Testing instructions

1. Make sure you have StripeLink feature enabled within `Payments > Settings`, under Express checkouts.
<img width="1149" alt="image" src="https://user-images.githubusercontent.com/4162931/189147462-24c7a6db-04e0-431d-af5c-1b08f10e2ab6.png">

2. Create a new order from front-end, and browse to the checkout page
3. Fill in all required details, except email address and click the `Place order` button
4. You should see an error message `Billling Email address is a required field.` , without any unwanted HTML code within it. 

##### Before 
![image](https://user-images.githubusercontent.com/4162931/189148508-3896a9cf-d105-44f7-a92f-7d33369f619e.png)

##### After
![image - after](https://user-images.githubusercontent.com/4162931/189148870-719c014e-d94c-44f4-a1ab-63e9c87a74ab.png)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) - Tested with a resized browser window. Link button appears fine in its intended place. 

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
