### PR TITLE
Pass down the feature flag parameter for the task list in Payments > Overview

### DIFF
--- a/changelog/fix-4471-some-tasks-missing-in-payments-overview-task-list
+++ b/changelog/fix-4471-some-tasks-missing-in-payments-overview-task-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+The feature flag for the task list in Payments > Overview page was not passed correctly. We now see the business details, force secure checkout and reconnect wpcom user task when appropriate.

--- a/changelog/fix-4471-some-tasks-missing-in-payments-overview-task-list
+++ b/changelog/fix-4471-some-tasks-missing-in-payments-overview-task-list
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-The feature flag for the task list in Payments > Overview page was not passed correctly. We now see the business details, force secure checkout and reconnect wpcom user task when appropriate.
+The feature flag for the task list in Payments > Overview page was not passed correctly. We now see the business details and reconnect wpcom user task when appropriate.

--- a/client/index.js
+++ b/client/index.js
@@ -270,12 +270,14 @@ addFilter(
 		const {
 			accountStatus,
 			showUpdateDetailsTask,
+			wpcomReconnectUrl,
 			featureFlags: { accountOverviewTaskList },
 		} = wcpaySettings;
 
 		const wcPayTasks = getTasks( {
 			accountStatus,
 			showUpdateDetailsTask,
+			wpcomReconnectUrl,
 			isAccountOverviewTasksEnabled: Boolean( accountOverviewTaskList ),
 		} );
 

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -32,7 +32,6 @@ const OverviewPage = () => {
 		showUpdateDetailsTask,
 		wpcomReconnectUrl,
 		featureFlags: { accountOverviewTaskList },
-		needsHttpsSetup,
 	} = wcpaySettings;
 	const numDisputesNeedingResponse =
 		parseInt( wcpaySettings.numDisputesNeedingResponse, 10 ) || 0;
@@ -43,7 +42,6 @@ const OverviewPage = () => {
 		showUpdateDetailsTask,
 		wpcomReconnectUrl,
 		isAccountOverviewTasksEnabled: Boolean( accountOverviewTaskList ),
-		needsHttpsSetup,
 		numDisputesNeedingResponse,
 	} );
 	const tasks =

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -42,6 +42,7 @@ const OverviewPage = () => {
 		accountStatus,
 		showUpdateDetailsTask,
 		wpcomReconnectUrl,
+		isAccountOverviewTasksEnabled: Boolean( accountOverviewTaskList ),
 		needsHttpsSetup,
 		numDisputesNeedingResponse,
 	} );

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -18,7 +18,6 @@ export const getTasks = ( {
 	showUpdateDetailsTask,
 	wpcomReconnectUrl,
 	isAccountOverviewTasksEnabled,
-	needsHttpsSetup,
 	numDisputesNeedingResponse = 0,
 } ) => {
 	const { status, currentDeadline, pastDue, accountLink } = accountStatus;
@@ -94,26 +93,6 @@ export const getTasks = ( {
 				expandable: true,
 				expanded: true,
 				showActionButton: true,
-			},
-		isAccountOverviewTasksEnabled &&
-			needsHttpsSetup && {
-				key: 'force-secure-checkout',
-				title: __( 'Force secure checkout', 'woocommerce-payments' ),
-				content: __(
-					'Protect your customers data and increase trustworthiness of your store by forcing HTTPS on checkout pages.',
-					'woocommerce-payments'
-				),
-				completed: false,
-				onClick: () => {
-					window.open(
-						'https://woocommerce.com/document/ssl-and-https/#section-7',
-						'_blank'
-					);
-				},
-				expanded: true,
-				isDeletable: true,
-				isDismissable: true,
-				allowSnooze: true,
 			},
 		isDisputeTaskVisible && {
 			key: 'dispute-resolution-task',

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -80,7 +80,7 @@ export const getTasks = ( {
 					'Reconnect WooCommerce Payments',
 					'woocommerce-payments'
 				),
-				content: __(
+				additionalInfo: __(
 					'WooCommerce Payments is missing a connected WordPress.com account. ' +
 						'Some functionality will be limited without a connected account.',
 					'woocommerce-payments'

--- a/client/overview/task-list/test/tasks.js
+++ b/client/overview/task-list/test/tasks.js
@@ -114,14 +114,12 @@ describe( 'getTasks()', () => {
 			showUpdateDetailsTask: 'yes',
 			wpcomReconnectUrl: 'http://example.com',
 			accountStatus: {},
-			needsHttpsSetup: true,
 		} );
 
 		expect( tasks ).toEqual(
 			expect.arrayContaining( [
 				expect.objectContaining( { key: 'update-business-details' } ),
 				expect.objectContaining( { key: 'reconnect-wpcom-user' } ),
-				expect.objectContaining( { key: 'force-secure-checkout' } ),
 			] )
 		);
 	} );
@@ -131,14 +129,12 @@ describe( 'getTasks()', () => {
 			showUpdateDetailsTask: 'yes',
 			wpcomReconnectUrl: 'http://example.com',
 			accountStatus: {},
-			needsHttpsSetup: true,
 		} );
 
 		expect( tasks ).toEqual(
 			expect.not.arrayContaining( [
 				expect.objectContaining( { key: 'update-business-details' } ),
 				expect.objectContaining( { key: 'reconnect-wpcom-user' } ),
-				expect.objectContaining( { key: 'force-secure-checkout' } ),
 			] )
 		);
 	} );

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -479,7 +479,6 @@ class WC_Payments_Admin {
 			'multiCurrencySetup'         => [
 				'isSetupCompleted' => get_option( 'wcpay_multi_currency_setup_completed' ),
 			],
-			'needsHttpsSetup'            => $this->wcpay_gateway->needs_https_setup(),
 			'isMultiCurrencyEnabled'     => WC_Payments_Features::is_customer_multi_currency_enabled(),
 			'shouldUseExplicitPrice'     => WC_Payments_Explicit_Price_Formatter::should_output_explicit_price(),
 			'overviewTasksVisibility'    => [

--- a/includes/notes/class-wc-payments-notes-set-https-for-checkout.php
+++ b/includes/notes/class-wc-payments-notes-set-https-for-checkout.php
@@ -48,8 +48,8 @@ class WC_Payments_Notes_Set_Https_For_Checkout {
 		$note_class = WC_Payment_Woo_Compat_Utils::get_note_class();
 		$note       = new $note_class();
 
-		$note->set_title( __( 'Force secure checkout', 'woocommerce-payments' ) );
-		$note->set_content( __( 'Protect your customers data and increase trustworthiness of your store by forcing HTTPS on checkout pages.', 'woocommerce-payments' ) );
+		$note->set_title( __( 'Enable secure checkout', 'woocommerce-payments' ) );
+		$note->set_content( __( 'Enable HTTPS on your checkout pages to display all available payment methods and protect your customers data.', 'woocommerce-payments' ) );
 		$note->set_content_data( (object) [] );
 		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );


### PR DESCRIPTION
Fixes #4471 

#### Changes proposed in this Pull Request

The task list feature flag was mistakenly omitted from the Tasks component for the Payments > Overview page. Consequently, we couldn't see 3 tasks even though that feature flag is now active (planned to be removed in #4489).
Everything works out of the box once the feature flag parameter is passed down to the Tasks component.

**One thing to note**: since the `Force secure checkout` task also exists as an inbox note in WooCommerce Home, it was decided to remove that task from the Payments > Overview page and reword the related note so that we use "Enable" (see the reasoning here: https://github.com/Automattic/woocommerce-payments/pull/4707#issuecomment-1241118531)

#### Testing instructions

To enable the 2 tasks, follow the below instructions:

- Update WooCommerce Payments business details 

Hardcode the value `'yes'` at the following line: https://github.com/Automattic/woocommerce-payments/blob/f2a1437c69dcfa7760a98e653b34d6ddfdab6739/includes/admin/class-wc-payments-admin.php#L474

- WooCommerce Payments is missing a connected WordPress.com account. Some functionality will be limited without a connected account.
 
Hardcode the value `'WC_Payments_Account::get_wpcom_reconnect_url()'` at the following line: https://github.com/Automattic/woocommerce-payments/blob/f2a1437c69dcfa7760a98e653b34d6ddfdab6739/includes/admin/class-wc-payments-admin.php#L475

To see the new wording for the "Secure checkout" inbox note, you should just need to deactivate and activate again the WCPay plugin.

Once that is done, you should:
- see those 2 tasks in the "Things to do" when visiting the Payments > Overview page and also notice that we're using the word "Enable" instead of "Force" in the WooCommerce inbox note, if you're using that branch
- not see any of those tasks, and still see "Force secure checkout" for the inbox note if you're using the `develop` branch

Payments > Overview "Things to do" list
![image](https://user-images.githubusercontent.com/28830738/189608983-33c6c16d-cbf7-4b71-b6bb-9375ed047cb9.png)

WooCommerce Home > Inbox note
![image](https://user-images.githubusercontent.com/28830738/189609145-fb358a50-b964-422e-b7a5-7949d8687d8c.png)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
