### PR TITLE
Show apple pay and supported currency notice once only

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -618,7 +618,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return;
 		}
 
-		if ( WC_Payments_Utils::can_merchant_register_domain_with_applepay( $this->account->get_account_country() ) ) {
+		if ( WC_Payments_Utils::can_merchant_register_domain_with_applepay( $this->account->get_account_country() ) || get_class( $this ) !== 'WCPay\Payment_Methods\CC_Payment_Gateway' ) {
 			return;
 		}
 		if ( ! WC_Payments_Utils::is_account_in_supported_applepay_countries( $this->account->get_account_country() ) &&
@@ -666,7 +666,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return;
 		}
 
-		if ( ! $this->is_available_for_current_currency() ) {
+		if ( ! $this->is_available_for_current_currency() && get_class( $this ) === 'WCPay\Payment_Methods\CC_Payment_Gateway' ) {
 			?>
 			<div id="wcpay-unsupported-currency-notice" class="notice notice-warning">
 				<p>


### PR DESCRIPTION
Fixes #4682 

#### Changes proposed in this Pull Request
Notices are duplicated when UPE is broken into multiple UPE instances. Changes in this PR checks if it is the main WCPay gateway class and ensure that `display_not_supported_apple_pay()` and `display_not_supported_currency_notice()` only display the notice for the main WCPay gateway class. Changes are made following https://github.com/Automattic/woocommerce-payments/pull/4545 which fixes notice pollution for test mode notice.

#### Testing instructions
- Navigate to WooCommerce > Settings > Payments
- Enable a few UPE payment methods.
- Enable Apple Pay (to make the Apple Pay notice appear)
- Return `false` from [is_available_for_current_currency](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payment-gateway-wcpay.php#L582) (to make the unsupported currency appear, this is a hack as I could not find any possible unsupported currency to make the notice appear)
- Refresh the page.
- In the [poc/upe-instances-multiplied](https://github.com/Automattic/woocommerce-payments/pull/3968) branch multiple notices should appear on page refresh.
- In this branch only one notice should be displayed for each of these- Test mode, Apple Pay, Supported currency.

![wcpay notices](https://user-images.githubusercontent.com/33387139/189093084-1cc9faaf-d446-40b5-9a46-a523ee849b0b.png)
