### PR TITLE
Fix Apple Pay verify domain waring notice showing up constantly

### DIFF
--- a/changelog/fix-4712-apple-pay-incorrect-admin-notice
+++ b/changelog/fix-4712-apple-pay-incorrect-admin-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Apple Pay domain verify file missing error notice constantly displayed

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -391,8 +391,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// Update the email field position.
 		add_filter( 'woocommerce_billing_fields', [ $this, 'checkout_update_email_field_priority' ], 50 );
-
-		add_action( 'woocommerce_woocommerce_payments_admin_applepay_notice', [ $this, 'display_not_supported_apple_pay' ] );
 	}
 
 	/**
@@ -604,56 +602,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					<?php esc_html_e( "All transactions are simulated. Customers can't make real purchases through WooCommerce Payments.", 'woocommerce-payments' ); ?>
 				</p>
 			</div>
-			<?php
-		}
-	}
-
-	/**
-	 * Add notices explaining how to enable Apple Pay.
-	 *
-	 * @return void
-	 */
-	public function display_not_supported_apple_pay() {
-		if ( 'yes' !== $this->get_option( 'payment_request' ) ) {
-			return;
-		}
-
-		if ( WC_Payments_Utils::can_merchant_register_domain_with_applepay( $this->account->get_account_country() ) ) {
-			return;
-		}
-		if ( ! WC_Payments_Utils::is_account_in_supported_applepay_countries( $this->account->get_account_country() ) &&
-			'1' !== get_user_meta( get_current_user_id(), 'dismissed_applepay_not_in_supported_countries_notice', true ) ) {
-			?>
-			<div id="wcpay-applepay-error" class="notice notice-error woocommerce-message">
-				<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'applepay_not_in_supported_countries' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce-payments' ); ?></a>
-				<p>
-					<b><?php esc_html_e( 'Apple Pay: ', 'woocommerce-payments' ); ?></b>
-					<?php
-					echo sprintf(
-						/* translators: 1: supported country list */
-						__( 'Apple Pay isn’t currently supported in your country. <a href="%1$s">Countries and regions that support Apple Pay (Apple Support)</a>', 'woocommerce-payments' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						'https://support.apple.com/en-us/HT207957'
-					);
-					?>
-				</p>
-			</div>
-			<?php
-		}
-
-		if ( ! WC_Payments_Utils::has_domain_association_file_permissions() ) {
-			?>
-		<div id="wcpay-applepay-error" class="notice notice-error">
-			<p>
-				<b><?php esc_html_e( 'Apple Pay: ', 'woocommerce-payments' ); ?></b>
-				<?php
-				echo sprintf(
-					/* translators: 1: apple pay support */
-					__( 'We were not able to verify your domain. <a href="%1$s">This help documentation</a> will walk you through the process to verify with Apple that you control your domain.', 'woocommerce-payments' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					'https://woocommerce.com/document/payments/apple-pay/#apple-pay-button-does-not-appear'
-				);
-				?>
-			</p>
-		</div>
 			<?php
 		}
 	}

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -386,7 +386,7 @@ class WC_Payments_Apple_Pay_Registration {
 		$well_known_dir = untrailingslashit( ABSPATH ) . '/' . self::DOMAIN_ASSOCIATION_FILE_DIR;
 		$full_path      = $well_known_dir . '/' . self::DOMAIN_ASSOCIATION_FILE_NAME;
 
-		return is_dir( $well_known_dir ) && is_writable( $well_known_dir ) && file_exists( $full_path ) && is_readable( $full_path );
+		return is_dir( $well_known_dir ) && is_writable( $well_known_dir ) && file_exists( $full_path ) && is_writable( $full_path );
 	}
 
 	/**

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -545,7 +545,7 @@ class WC_Payments_Apple_Pay_Registration {
 						<?php
 							echo sprintf(
 								/* translators: 1: apple pay support */
-								__( 'We were not able to access your domain verification file. WooCommerce Payments will keep on working, but we recommend using <a href="%1$s" target="_blank">this documentation</a> to walk you through the process to verify with Apple that you control your domain.', 'woocommerce-payments' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+								__( 'We are not able to access your Apple Pay domain verification file. WooCommerce Payments will continue to work, but we suggest using <a href="%1$s" target="_blank">this document</a> to help you verify with Apple that you control this domain.', 'woocommerce-payments' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 								'https://woocommerce.com/document/payments/apple-pay/#apple-pay-button-does-not-appear'
 							);
 						?>

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -386,7 +386,7 @@ class WC_Payments_Apple_Pay_Registration {
 		$well_known_dir = untrailingslashit( ABSPATH ) . '/' . self::DOMAIN_ASSOCIATION_FILE_DIR;
 		$full_path      = $well_known_dir . '/' . self::DOMAIN_ASSOCIATION_FILE_NAME;
 
-		return is_dir( $well_known_dir ) && is_writable( $well_known_dir ) && file_exists( $full_path ) && is_writable( $full_path );
+		return ( file_exists( $full_path ) && is_writable( $full_path ) ) || ( is_dir( $well_known_dir ) && is_writable( $well_known_dir ) );
 	}
 
 	/**

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -89,6 +89,7 @@ class WC_Payments_Apple_Pay_Registration {
 
 		add_action( 'woocommerce_woocommerce_payments_admin_notices', [ $this, 'display_error_notice' ] );
 		add_action( 'woocommerce_woocommerce_payments_admin_notices', [ $this, 'display_live_account_notice' ] );
+		add_action( 'woocommerce_woocommerce_payments_admin_applepay_notice', [ $this, 'display_not_supported_apple_pay' ] );
 		add_action( 'add_option_woocommerce_woocommerce_payments_settings', [ $this, 'verify_domain_on_new_settings' ], 10, 2 );
 		add_action( 'update_option_woocommerce_woocommerce_payments_settings', [ $this, 'verify_domain_on_updated_settings' ], 10, 2 );
 	}
@@ -261,7 +262,7 @@ class WC_Payments_Apple_Pay_Registration {
 	 */
 	public function register_domain_with_apple() {
 		$error = null;
-		if ( ! WC_Payments_Utils::can_merchant_register_domain_with_applepay( $this->account->get_account_country() ) ) {
+		if ( ! $this->can_merchant_register_domain_with_applepay( $this->account->get_account_country() ) ) {
 			Logger::log( 'Error registering domain with Apple: merchant isn\'t in the supported countries or domain association file does not have the correct permissions' );
 			return;
 		}
@@ -352,6 +353,54 @@ class WC_Payments_Apple_Pay_Registration {
 	}
 
 	/**
+	 * Apple Pay supported country codes.
+	 *
+	 * @return string[]
+	 */
+	public static function supported_applepay_country_codes(): array {
+		return [
+			'ZA', 'AU', 'CN', 'HK', 'JP', 'MO', 'NZ', 'SG', 'TW', 'AM', 'AT', 'AZ', 'BY', 'BE', 'BG', 'HR', 'CY', 'CZ', // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
+			'DK', 'EE', 'FO', 'FI', 'FR', 'GE', 'DE', 'GR', 'GL', 'GG', 'HU', 'IS', 'IE', 'IM', 'IT', 'KZ', 'JE', 'LV', // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
+			'LI', 'LT', 'LU', 'MT', 'MD', 'MC', 'ME', 'NL', 'NO', 'PL', 'PT', 'RO', 'SM', 'RS', 'SK', 'SI', 'ES', 'SE', // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
+			'CH', 'UA', 'GB', 'VA', 'AR', 'CO', 'CR', 'BR', 'MX', 'PE', 'BH', 'IL', 'PS', 'QA', 'SA', 'AE', 'CA', 'US', // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
+		];
+	}
+
+	/**
+	 * Check if merchant can register domain with Apple Pay.
+	 *
+	 * @param string $account_country - Account country.
+	 *
+	 * @return bool
+	 */
+	public function can_merchant_register_domain_with_applepay( string $account_country ): bool {
+		return $this->is_account_in_supported_applepay_countries( $account_country ) && $this->has_domain_association_file_permissions();
+	}
+
+	/**
+	 * Check if domain association file has the proper permissions.
+	 *
+	 * @return bool
+	 */
+	public function has_domain_association_file_permissions(): bool {
+		$well_known_dir = untrailingslashit( ABSPATH ) . '/' . self::DOMAIN_ASSOCIATION_FILE_DIR;
+		$full_path      = $well_known_dir . '/' . self::DOMAIN_ASSOCIATION_FILE_NAME;
+
+		return is_dir( $well_known_dir ) && is_writable( $well_known_dir ) && file_exists( $full_path ) && is_readable( $full_path );
+	}
+
+	/**
+	 * Check if merchant is in Apple Pay supported countries list.
+	 *
+	 * @param string $account_country Account country.
+	 *
+	 * @return bool
+	 */
+	public function is_account_in_supported_applepay_countries( string $account_country ): bool {
+		return in_array( $account_country, self::supported_applepay_country_codes(), true );
+	}
+
+	/**
 	 * Display warning notice explaining that the domain can't be registered without a live account.
 	 */
 	public function display_live_account_notice() {
@@ -433,5 +482,77 @@ class WC_Payments_Apple_Pay_Registration {
 			<p><?php echo $check_log_text; /* @codingStandardsIgnoreLine */ ?></p>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Add notices explaining how to enable Apple Pay.
+	 *
+	 * @return void
+	 */
+	public function display_not_supported_apple_pay() {
+		if ( 'yes' !== $this->gateway->get_option( 'payment_request' ) ) {
+			return;
+		}
+
+		if ( $this->can_merchant_register_domain_with_applepay( $this->account->get_account_country() ) ) {
+			return;
+		}
+
+		if ( ! $this->is_account_in_supported_applepay_countries( $this->account->get_account_country() ) &&
+			'1' !== get_user_meta( get_current_user_id(), 'dismissed_applepay_not_in_supported_countries_notice', true ) ) {
+			?>
+			<div id="wcpay-applepay-error" class="notice notice-error woocommerce-message">
+				<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'applepay_not_in_supported_countries' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce-payments' ); ?></a>
+				<p>
+					<b><?php esc_html_e( 'Apple Pay: ', 'woocommerce-payments' ); ?></b>
+					<?php
+					echo sprintf(
+						/* translators: 1: supported country list */
+						__( 'Apple Pay is not currently supported in your country. <a href="%1$s">Countries and regions that support Apple Pay (Apple Support)</a>', 'woocommerce-payments' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						'https://support.apple.com/en-us/HT207957'
+					);
+					?>
+				</p>
+			</div>
+			<?php
+		}
+
+		if ( ! $this->has_domain_association_file_permissions() ) {
+			/**
+			 * In case domain association file is missing or the DOMAIN_ASSOCIATION_FILE_DIR folder is inaccessible,
+			 * permalink structure should be checked to evaluate if error or warning message should be displayed.
+			 */
+			if ( '' === get_option( 'permalink_structure', '' ) ) {
+				?>
+				<div id="wcpay-applepay-error" class="notice notice-error">
+					<p>
+						<b><?php esc_html_e( 'Apple Pay: ', 'woocommerce-payments' ); ?></b>
+						<?php
+							echo sprintf(
+								/* translators: 1: apple pay support */
+								__( 'We were not able to verify your domain. <a href="%1$s" target="_blank">This help documentation</a> will walk you through the process to verify with Apple that you control your domain.', 'woocommerce-payments' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+								'https://woocommerce.com/document/payments/apple-pay/#apple-pay-button-does-not-appear'
+							);
+						?>
+					</p>
+				</div>
+				<?php
+			} else {
+				?>
+				<div id="wcpay-applepay-warning" class="notice notice-warning">
+					<p>
+						<b><?php esc_html_e( 'Apple Pay: ', 'woocommerce-payments' ); ?></b>
+						<?php
+							echo sprintf(
+								/* translators: 1: apple pay support */
+								__( 'We were not able to access your domain verification file. WooCommerce Payments will keep on working, but we recommend using <a href="%1$s" target="_blank">this documentation</a> to walk you through the process to verify with Apple that you control your domain.', 'woocommerce-payments' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+								'https://woocommerce.com/document/payments/apple-pay/#apple-pay-button-does-not-appear'
+							);
+						?>
+					</p>
+				</div>
+				<?php
+			}
+		}
 	}
 }

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -241,53 +241,6 @@ class WC_Payments_Utils {
 	}
 
 	/**
-	 * Apple Pay supported country codes.
-	 *
-	 * @return string[]
-	 */
-	public static function supported_applepay_country_codes(): array {
-		return [
-			'ZA', 'AU', 'CN', 'HK', 'JP', 'MO', 'NZ', 'SG', 'TW', 'AM', 'AT', 'AZ', 'BY', 'BE', 'BG', 'HR', 'CY', 'CZ', // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-			'DK', 'EE', 'FO', 'FI', 'FR', 'GE', 'DE', 'GR', 'GL', 'GG', 'HU', 'IS', 'IE', 'IM', 'IT', 'KZ', 'JE', 'LV', // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-			'LI', 'LT', 'LU', 'MT', 'MD', 'MC', 'ME', 'NL', 'NO', 'PL', 'PT', 'RO', 'SM', 'RS', 'SK', 'SI', 'ES', 'SE', // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-			'CH', 'UA', 'GB', 'VA', 'AR', 'CO', 'CR', 'BR', 'MX', 'PE', 'BH', 'IL', 'PS', 'QA', 'SA', 'AE', 'CA', 'US',  // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-		];
-	}
-
-	/**
-	 * Check if merchant can register domain with Apple Pay.
-	 *
-	 * @param string $account_country - Account country.
-	 * @return bool
-	 */
-	public static function can_merchant_register_domain_with_applepay( string $account_country ): bool {
-		return self::is_account_in_supported_applepay_countries( $account_country ) && self::has_domain_association_file_permissions();
-	}
-
-	/**
-	 * Check if domain association file has the proper permissions.
-	 *
-	 * @return bool
-	 */
-	public static function has_domain_association_file_permissions(): bool {
-		$well_known_dir = untrailingslashit( ABSPATH ) . '/' . WC_Payments_Apple_Pay_Registration::DOMAIN_ASSOCIATION_FILE_DIR;
-		$full_path      = $well_known_dir . '/' . WC_Payments_Apple_Pay_Registration::DOMAIN_ASSOCIATION_FILE_NAME;
-
-		return is_dir( $well_known_dir ) && is_writable( $well_known_dir ) && file_exists( $full_path ) && is_readable( $full_path );
-	}
-
-	/**
-	 * Check if merchant is in supported countries by ApplePay.
-	 *
-	 * @param string $account_country - Account country.
-	 *
-	 * @return bool
-	 */
-	public static function is_account_in_supported_applepay_countries( string $account_country ): bool {
-		return in_array( $account_country, self::supported_applepay_country_codes(), true );
-	}
-
-	/**
 	 * Verifies whether a certain ZIP code is valid for the US, incl. 4-digit extensions.
 	 *
 	 * @param string $zip The ZIP code to verify.


### PR DESCRIPTION
Fixes #4712

#### Changes proposed in this Pull Request
The Apple Pay admin domain verify notice introduced on #4551 displays the false positive **error** notice without checking the site permalinks structure asking for not required steps that could confuse merchants.

This PR proposes adding a  **warning** notice that informs merchants we are not able to access their domain verification file when the pretty permalinks structure is enabled with the following message:

`We were not able to access your domain verification file. WooCommerce Payments will keep on working, but we recommend using this documentation to walk you through the process to verify with Apple that you control your domain.`

#### Testing instructions
- Navigate to `Payments` -> `Settings`
- Under Express Checkouts, enable "Apple Pay / Google Pay", if not enabled already. Save and reload the page.

**Scenario 1**
- Navigate to `Settings` -> `Permalinks` and set the permalinks to `Post name`
- Rename `docker/wordpress/.well-known/apple-developer-merchantid-domain-association`
- Navigate to `Payments` -> `Settings`
- Verify a warning message is displayed like the one below:
<img width="1527" alt="Screenshot 2022-09-09 at 14 17 59" src="https://user-images.githubusercontent.com/8667118/189338494-84c9c210-94ee-49e6-acd9-6e53633d6ef1.png">

**Scenario 2**
- Navigate to `Settings` -> `Permalinks` and set the permalinks to `Plain`
- Rename `docker/wordpress/.well-known/apple-developer-merchantid-domain-association`
- Navigate to `Payments` -> `Settings`
- Verify a warning message is displayed like the one below:
<img width="1522" alt="Screenshot 2022-09-09 at 14 19 22" src="https://user-images.githubusercontent.com/8667118/189338694-32a89811-3ceb-42b4-a6e6-43451c20fe41.png">

**Scenario 3**
- Rename `docker/wordpress/.well-known/apple-developer-merchantid-domain-association` to original file.
- Navigate to `Payments` -> `Settings`
- Verify no error or warning message is displayed.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)