### PR TITLE
E2E - Fix failing WP nightly tests

### DIFF
--- a/.github/actions/e2e/run-log-tests/action.yml
+++ b/.github/actions/e2e/run-log-tests/action.yml
@@ -30,7 +30,7 @@ runs:
       if: ${{ failure() }}
       uses: actions/upload-artifact@v2
       with:
-          name: wp(${{ matrix.wordpress }})-wc(${{ matrix.woocommerce }})-${{ matrix.test_groups }}-${{ matrix.test_branches }}
+          name: wp(${{ env.E2E_WP_VERSION }})-wc(${{ env.E2E_WC_VERSION }})-${{ env.E2E_GROUP }}-${{ env.E2E_BRANCH }}
           path: |
             tests/e2e/screenshots
             tests/e2e/docker/wordpress/wp-content/debug.log

--- a/changelog/e2e-fix-failing-nightly-tests
+++ b/changelog/e2e-fix-failing-nightly-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Removes gutenberg plugin installation from E2E environment setup

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -169,8 +169,8 @@ fi
 echo "Updating permalink structure"
 cli wp rewrite structure '/%postname%/'
 
-echo "Installing and activating Gutenberg & WordPress Importer..."
-cli wp plugin install gutenberg wordpress-importer --activate
+echo "Installing and activating WordPress Importer..."
+cli wp plugin install wordpress-importer --activate
 
 # Install WooCommerce
 if [[ -n "$E2E_WC_VERSION" && $E2E_WC_VERSION != 'latest' ]]; then


### PR DESCRIPTION
Fixes #4742 

#### Changes proposed in this Pull Request

This PR mainly address the failing WP nightly E2E tests. The tests were failing due to a change on WP core as mentioned in #4742. Since E2E tests on WCPay doesn't make use of features provided by the Gutenberg plugin, we can safely remove it from being installed, solving the problem at hand.

This PR also, fixes a bug with populating artifact names on GitHub actions. The bug was introduced with this [PR](https://github.com/Automattic/woocommerce-payments/pull/4658), where we removed matrix configurations from some tests and the while uploading the artifacts, the name was populated based on matrix values. The change proposed, replaces matrix with environment variables available.


#### Testing instructions

* Trigger the `E2E Test - All` workflow against this branch and confirm that the environment setup doesn't fail and the tests are successful. Reference job - https://github.com/Automattic/woocommerce-payments/actions/runs/3037234294

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
