### PR TITLE
Show "Remember your details" when Platform Checkout is enabled with multiple UPE instances

### DIFF
--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -60,7 +60,11 @@ export default class WCPayAPI {
 			isStripeLinkEnabled,
 		} = this.options;
 
-		if ( forceNetworkSavedCards && ! forceAccountRequest ) {
+		if (
+			forceNetworkSavedCards &&
+			! forceAccountRequest &&
+			! isUPEEnabled
+		) {
 			if ( ! this.stripePlatform ) {
 				this.stripePlatform = this.createStripe(
 					publishableKey,

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -818,7 +818,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if (
 			WC_Payments_Features::is_platform_checkout_eligible() &&
 			'yes' === $this->get_option( 'platform_checkout', 'no' ) &&
-			! WC_Payments_Features::is_upe_enabled() &&
 			is_checkout() &&
 			! has_block( 'woocommerce/checkout' ) &&
 			! is_wc_endpoint_url( 'order-pay' ) &&


### PR DESCRIPTION
Fixes #4680 

#### Changes proposed in this Pull Request
- Returning `true` from `should_use_stripe_platform_on_checkout_page` function from [here](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payment-gateway-wcpay.php#L819) to support Platform Checkout when UPE is enabled.
- As the above change makes `forceNetworkSavedCards=true` for UPE now, had to filter out the UPE enabled scenario [here](https://github.com/Automattic/woocommerce-payments/pull/4750/files#diff-bc05e644f9133795b10f0696ea2862c0abeecfeed6f3ff2eaf48a691c701e14bR66). Otherwise this `if` block is executed and that results in error. With UPE enabled [this block](https://github.com/Automattic/woocommerce-payments/blob/develop/client/checkout/api/index.js#L74-L81) should be executed.

#### Testing instructions
- Navigate to WooCommerce > Settings > Payments
- Enable a few UPE payment methods.
- Enable Platform Checkout
- Go to merchant store, add some product to cart, go to the checkout page
- Select credit card payment and input a new email
- `Remember your details` section should appear 
- Select `Save my information for faster checkouts` and Complete the checkout. Ensure that a new platform checkout user is created.
