### PR TITLE
Bump WC versions for 4.8.0 release

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -21,7 +21,7 @@ jobs:
           - woocommerce: '6.6.1'
             wordpress:   '5.8'
             gutenberg:   '13.6.0' # The latest version supporting WP 5.8.
-            php:         '7.1' # Minimum supported PHP version
+            php:         '7.2' # Minimum supported PHP version
     env:
       WP_VERSION:        ${{ matrix.wordpress }}
       WC_VERSION:        ${{ matrix.woocommerce }}

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -12,13 +12,13 @@ jobs:
       max-parallel: 10
       matrix:
         # Minimum support version, ..., Latest version, `beta`.
-        woocommerce: [ '6.4.1', '6.5.1', '6.6.1', '6.7.0', 'latest', 'beta' ]
+        woocommerce: [ '6.6.1', '6.7.0', 'latest', 'beta' ]
         wordpress:   [ 'latest' ]
         gutenberg:   [ 'latest' ]
         php:         [ '7.4' ]
         include:
           # Edge case: oldest dependencies compatibility
-          - woocommerce: '6.4.1'
+          - woocommerce: '6.6.1'
             wordpress:   '5.8'
             gutenberg:   '13.6.0' # The latest version supporting WP 5.8.
             php:         '7.1' # Minimum supported PHP version

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -12,7 +12,7 @@ jobs:
       max-parallel: 10
       matrix:
         # Minimum support version, ..., Latest version, `beta`.
-        woocommerce: [ '6.6.1', '6.7.0', 'latest', 'beta' ]
+        woocommerce: [ '6.6.1', '6.7.0', '6.8.2', 'latest', 'beta' ]
         wordpress:   [ 'latest' ]
         gutenberg:   [ 'latest' ]
         php:         [ '7.4' ]

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast:     false
       matrix:
         # Min WooCommerce | L-2 | L(atest) | beta
-        woocommerce:   [ '6.6.1', '6.7.0', 'latest', 'beta' ]
+        woocommerce:   [ '6.6.1', '6.7.0', '6.8.2', 'latest', 'beta' ]
         test_groups:   [ 'wcpay', 'subscriptions' ]
         test_branches: [ 'merchant', 'shopper' ]
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast:     false
       matrix:
         # Min WooCommerce | L-2 | L(atest) | beta
-        woocommerce:   [ '6.4.1', '6.6.1', 'latest', 'beta' ]
+        woocommerce:   [ '6.6.1', '6.7.0', 'latest', 'beta' ]
         test_groups:   [ 'wcpay', 'subscriptions' ]
         test_branches: [ 'merchant', 'shopper' ]
 

--- a/changelog/dev-bump-versions-4-8-0
+++ b/changelog/dev-bump-versions-4-8-0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Bump minimum required version of WooCommerce from 6.4 to 6.6

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Woo: 5278104:bf3cf30871604e15eec560c962593c1f
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
- * WC requires at least: 6.4
+ * WC requires at least: 6.6
  * WC tested up to: 6.9.0
  * Requires at least: 5.8
  * Requires PHP: 7.0


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

- Bump minimum WC version from 6.4 to 6.6.
- Bump GH workflow WC versions from 6.4.1 to 6.6.1.

No changes in WC tested up to because 6.9.0 is released tomorrow. No WP updates to catch up on.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- Verify that wherever we used 6.4 as a minimum before, we now use 6.6.
- Please check the CI checks in the GH workflows.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
