### PR TITLE
Apple Pay: revert enhancements in domain association file permissions checks

### DIFF
--- a/changelog/fix-4712-apple-pay-incorrect-admin-notice
+++ b/changelog/fix-4712-apple-pay-incorrect-admin-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Apple Pay: corrections in domain association file permissions check

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -386,7 +386,7 @@ class WC_Payments_Apple_Pay_Registration {
 		$well_known_dir = untrailingslashit( ABSPATH ) . '/' . self::DOMAIN_ASSOCIATION_FILE_DIR;
 		$full_path      = $well_known_dir . '/' . self::DOMAIN_ASSOCIATION_FILE_NAME;
 
-		return ( file_exists( $full_path ) && is_writable( $full_path ) ) || ( is_dir( $well_known_dir ) && is_writable( $well_known_dir ) );
+		return is_dir( $well_known_dir ) && is_writable( $well_known_dir ) && file_exists( $full_path ) && is_readable( $full_path );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #4712 

#### Changes proposed in this Pull Request

Reverts the enhancements introduced in https://github.com/Automattic/woocommerce-payments/pull/4726 to resolve p1663019690201839/1662580488.851089-slack-CGGCLBN58.

#### Testing instructions

* Ensure under the described conditions, the notice is not displayed

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.