### PR TITLE
 Hide checkout modal button when StripeLink is disabled. 

### DIFF
--- a/changelog/fix-4755-stripelink-button-showing-when-disabled
+++ b/changelog/fix-4755-stripelink-button-showing-when-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide button below email field at checkout, when StripeLink is disabled.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -3265,9 +3265,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			// Add extra `wcpay-checkout-email-field` class.
 			$fields['billing_email']['class'][] = 'wcpay-checkout-email-field';
+
+			add_filter( 'woocommerce_form_field_email', [ $this, 'append_stripelink_button' ], 10, 4 );
 		}
 
-		add_filter( 'woocommerce_form_field_email', [ $this, 'append_stripelink_button' ], 10, 4 );
 		return $fields;
 	}
 


### PR DESCRIPTION
Fixes #4755

#### Changes proposed in this Pull Request
Prevent a random grey button showing below email address field at checkout page, when StripeLink is disabled.

#### Testing instructions

1. Make sure you have StripeLink disabled within `Payments > Settings`
2. On the front-end add any product to cart get to the checkout page.
3. You should **not** see any button below or near the `Email address` field
4. Now enable StripeLink from `Payments > Settings`
5. Try placing an order again, You should see a StripeLink button within a few seconds, and inside the `Email address` text field box. 

#### Screenshots 

##### With StripeLink Disabled
![without-stripelink](https://user-images.githubusercontent.com/4162931/189891474-00db47ce-df77-474e-8d2d-b7558a0f6e24.jpg)

##### With StripeLink Enabled
![with-stripelink](https://user-images.githubusercontent.com/4162931/189891552-a1cc4ef4-9e90-4fd9-ac9b-58b56d9ee4f0.jpg)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply) - not applicable.

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
