### PR TITLE
Revert Apple Pay domain verification error notices

### DIFF
--- a/changelog/fix-4712-revert-applepay-admin-notices
+++ b/changelog/fix-4712-revert-applepay-admin-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Apple Pay domain verify file missing error notice constantly displayed

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -635,7 +635,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public function admin_options() {
 		// Add notices to the WooCommerce Payments settings page.
 		do_action( 'woocommerce_woocommerce_payments_admin_notices' );
-		do_action( 'woocommerce_woocommerce_payments_admin_applepay_notice' );
 
 		$this->output_payments_settings_screen();
 	}


### PR DESCRIPTION
Fixes #4712

#### Changes proposed in this Pull Request
Reverts the code from #4551 and  #4726 

More context: p1663019690201839/1662580488.851089-slack-CGGCLBN58.

#### Testing instructions
- Go to Payments -> Settings
- Under Express Checkouts, enable "Apple Pay / Google Pay", if not enabled already. Save and reload the page
- Verify Apple Pay domain verification notice is not displayed at the top of the page

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)