### PR TITLE
Apply timezone formatting only in case client provides user timezone

### DIFF
--- a/changelog/update-timezone-check-client
+++ b/changelog/update-timezone-check-client
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add timezone formatting only in case client provides user timezone.

--- a/includes/admin/class-wc-rest-payments-transactions-controller.php
+++ b/includes/admin/class-wc-rest-payments-transactions-controller.php
@@ -171,12 +171,12 @@ class WC_REST_Payments_Transactions_Controller extends WC_Payments_REST_Controll
 	 * Formats the incoming transaction date as per the blog's timezone.
 	 *
 	 * @param string|null $transaction_date Transaction date to format.
-	 * @param string      $user_timezone         User's timezone passed from client.
+	 * @param string|null $user_timezone         User's timezone passed from client.
 	 *
 	 * @return string|null The formatted transaction date as per timezone.
 	 */
 	private function format_transaction_date_with_timestamp( $transaction_date, $user_timezone ) {
-		if ( is_null( $transaction_date ) ) {
+		if ( is_null( $transaction_date ) || is_null( $user_timezone ) ) {
 			return $transaction_date;
 		}
 


### PR DESCRIPTION
Fixes 

#### Changes proposed in this Pull Request
- Add timezone formatting only in case the client provides user's timezone.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add filters to the transaction list from client.
* Manually remove the user timezone from transaction filters in `formatQueryFilters` in `client/data/transactions/resolvers.js`. 
* Ensure the REST API works with the supplied default timezone.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
