### PR TITLE
Fix off by one error

### DIFF
--- a/changelog/fix-4759-off-by-one-woopay-error
+++ b/changelog/fix-4759-off-by-one-woopay-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix off by one error

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -968,8 +968,6 @@ class WC_Payments {
 
 		if ( $is_platform_checkout_eligible && $is_platform_checkout_enabled ) {
 			add_action( 'wc_ajax_wcpay_init_platform_checkout', [ __CLASS__, 'ajax_init_platform_checkout' ] );
-			add_filter( 'determine_current_user', [ __CLASS__, 'determine_current_user_for_platform_checkout' ] );
-			add_filter( 'woocommerce_cookie', [ __CLASS__, 'determine_session_cookie_for_platform_checkout' ] );
 
 			// This injects the payments API and draft orders into core, so the WooCommerce Blocks plugin is not necessary.
 			// We should remove this once both features are available by default in the WC minimum supported version.
@@ -1121,37 +1119,6 @@ class WC_Payments {
 		}
 
 		return get_rest_url( null, $store_api_url ?? 'wc/store' );
-	}
-
-	/**
-	 * Tells WC to use platform checkout session cookie if the header is present.
-	 *
-	 * @param string $cookie_hash Default cookie hash.
-	 *
-	 * @return string
-	 */
-	public static function determine_session_cookie_for_platform_checkout( $cookie_hash ) {
-		if ( isset( $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) && 0 === (int) $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) {
-			return 'platform_checkout_session';
-		}
-		return $cookie_hash;
-	}
-
-	/**
-	 * Determine the current user
-	 *
-	 * @param WP_User|int $user The user to determine.
-	 */
-	public static function determine_current_user_for_platform_checkout( $user ) {
-		if ( $user ) {
-			return $user;
-		}
-
-		if ( ! isset( $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) || ! is_numeric( $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) ) {
-			return $user;
-		}
-
-		return (int) $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'];
 	}
 
 	/**

--- a/includes/platform-checkout/class-platform-checkout-session.php
+++ b/includes/platform-checkout/class-platform-checkout-session.php
@@ -29,9 +29,9 @@ class Platform_Checkout_Session {
 	/**
 	 * Sets the current user as the user sent via the api from WooPay if present.
 	 *
-	 * @param WP_User|null|int $user user to be used during the request.
+	 * @param \WP_User|null|int $user user to be used during the request.
 	 *
-	 * @return int|WP_User|null
+	 * @return \WP_User|null|int
 	 */
 	public static function determine_current_user_for_platform_checkout( $user ) {
 		if ( $user ) {

--- a/includes/platform-checkout/class-platform-checkout-session.php
+++ b/includes/platform-checkout/class-platform-checkout-session.php
@@ -14,6 +14,8 @@ namespace WCPay\Platform_Checkout;
  */
 class Platform_Checkout_Session {
 
+	const PLATFORM_CHECKOUT_SESSION_COOKIE_NAME = 'platform_checkout_session';
+
 	/**
 	 * Init the hooks.
 	 *
@@ -52,7 +54,7 @@ class Platform_Checkout_Session {
 	 */
 	public static function determine_session_cookie_for_platform_checkout( $cookie_hash ) {
 		if ( isset( $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) && 0 === (int) $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) {
-			return 'platform_checkout_session';
+			return self::PLATFORM_CHECKOUT_SESSION_COOKIE_NAME;
 		}
 
 		return $cookie_hash;

--- a/includes/platform-checkout/class-platform-checkout-session.php
+++ b/includes/platform-checkout/class-platform-checkout-session.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Class WC_Payments_Session.
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Platform_Checkout;
+
+/**
+ * Class responsible for handling platform checkout sessions.
+ * This class should be loaded as soon as possible so the correct session is loaded.
+ * So don't load it in the WC_Payments::init() function.
+ */
+class Platform_Checkout_Session {
+
+	/**
+	 * Init the hooks.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_filter( 'determine_current_user', [ __CLASS__, 'determine_current_user_for_platform_checkout' ] );
+		add_filter( 'woocommerce_cookie', [ __CLASS__, 'determine_session_cookie_for_platform_checkout' ] );
+	}
+
+	/**
+	 * Sets the current user as the user sent via the api from WooPay if present.
+	 *
+	 * @param WP_User|null|int $user user to be used during the request.
+	 *
+	 * @return int|WP_User|null
+	 */
+	public static function determine_current_user_for_platform_checkout( $user ) {
+		if ( $user ) {
+			return $user;
+		}
+
+		if ( ! isset( $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) || ! is_numeric( $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) ) {
+			return null;
+		}
+
+		return (int) $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'];
+	}
+
+	/**
+	 * Tells WC to use platform checkout session cookie if the header is present.
+	 *
+	 * @param string $cookie_hash Default cookie hash.
+	 *
+	 * @return string
+	 */
+	public static function determine_session_cookie_for_platform_checkout( $cookie_hash ) {
+		if ( isset( $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) && 0 === (int) $_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] ) {
+			return 'platform_checkout_session';
+		}
+
+		return $cookie_hash;
+	}
+}

--- a/tests/unit/platform-checkout/test-class-platform-checkout-session.php
+++ b/tests/unit/platform-checkout/test-class-platform-checkout-session.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Class Platform_Checkout_Session_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use \WCPay\Platform_Checkout\Platform_Checkout_Session;
+
+/**
+ * Platform_Checkout_Session unit tests.
+ */
+class Platform_Checkout_Session_Test extends WP_UnitTestCase {
+
+	public function test_determine_current_user_for_platform_checkout_passing_null() {
+		$result = Platform_Checkout_Session::determine_current_user_for_platform_checkout( null );
+		$this->assertEquals( null, $result );
+	}
+
+	public function test_determine_current_user_for_platform_checkout_passing_user() {
+		$user = new WP_User();
+
+		$result = Platform_Checkout_Session::determine_current_user_for_platform_checkout( $user );
+		$this->assertEquals( $user, $result );
+	}
+
+	public function test_determine_current_user_for_platform_checkout_via_header() {
+		$_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] = 'asdf';
+
+		$result = Platform_Checkout_Session::determine_current_user_for_platform_checkout( null );
+		$this->assertEquals( null, $result );
+	}
+
+	public function test_determine_current_user_for_platform_checkout_via_invalid_header() {
+		$_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] = 1;
+
+		$result = Platform_Checkout_Session::determine_current_user_for_platform_checkout( null );
+		$this->assertEquals( 1, $result );
+	}
+
+	public function test_determine_session_cookie_for_platform_checkout() {
+		$cookie_hash = 'cookie_hash';
+
+		$result = Platform_Checkout_Session::determine_session_cookie_for_platform_checkout( $cookie_hash );
+		$this->assertEquals( $cookie_hash, $result );
+	}
+
+	public function test_determine_session_cookie_for_platform_checkout_via_header() {
+		$cookie_hash = 'cookie_hash';
+
+		$_SERVER['HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER'] = 0;
+
+		$result = Platform_Checkout_Session::determine_session_cookie_for_platform_checkout( $cookie_hash );
+		$this->assertEquals( Platform_Checkout_Session::PLATFORM_CHECKOUT_SESSION_COOKIE_NAME, $result );
+	}
+}

--- a/tests/unit/test-class-wc-payments.php
+++ b/tests/unit/test-class-wc-payments.php
@@ -12,10 +12,6 @@ class WC_Payments_Test extends WCPAY_UnitTestCase {
 
 	const EXPECTED_PLATFORM_CHECKOUT_HOOKS = [
 		'wc_ajax_wcpay_init_platform_checkout' => [ WC_Payments::class, 'ajax_init_platform_checkout' ],
-		'determine_current_user'               => [
-			WC_Payments::class,
-			'determine_current_user_for_platform_checkout',
-		],
 	];
 
 	public function set_up() {

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -26,6 +26,15 @@ define( 'WCPAY_SUBSCRIPTIONS_ABSPATH', __DIR__ . '/vendor/woocommerce/subscripti
 
 require_once __DIR__ . '/vendor/autoload_packages.php';
 require_once __DIR__ . '/includes/class-wc-payments-features.php';
+require_once __DIR__ . '/includes/platform-checkout/class-platform-checkout-session.php';
+
+use \WCPay\Platform_Checkout\Platform_Checkout_Session;
+
+/**
+ * Needs to be loaded as soon as possible
+ * Check https://github.com/Automattic/woocommerce-payments/issues/4759
+ */
+Platform_Checkout_Session::init();
 
 /**
  * Plugin activation hook.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes an error that would only happen on some production sites where the wrong user was loaded during checkout.
It makes WC Payments hook to `determine_current_user` and `woocommerce_cookie` earlier so we can load the correct user.

fix #4759

#### Testing instructions
This is hard to test because it depends on an unknown setup to happen. So making sure we don't have any regressions will be enough here. Later this will be tested again in the https://woopaymerchantsitedemo.com which is the site that the error shows up

**Setup**
- Enable WooCommerce > Settings > Accounts & Privacy > Allow customer to place orders without an account
- Enable WooCommerce > Settings > Accounts & Privacy > Allow customers to create an account during checkout
- This is just to make it easier to create or skip the account creation

**Customer with site account**
- As a non logged shopper add a product to the cart
- Go to checkout
- Create a new WooPay user by checking the option `Save my data for faster checkouts`
- Check the option to create the user in the merchant site
- Try to buy a product using WooPay
- No errors should be generated and you should be redirected to the success page
- No new draft order should be created

**Guest customer**
- As a non logged shopper add a product to the cart
- Go to checkout
- Create a new WooPay user by checking the option `Save my data for faster checkouts`
- **Don't check** the option to create the user in the merchant site
- Try to buy a product using WooPay
- No errors should be generated and you should be redirected to the success page
- No new draft order should be created
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
