### PR TITLE
Fix Order ID being displayed N/A

### DIFF
--- a/changelog/fix-4752-order-id-displayed-na-transactions
+++ b/changelog/fix-4752-order-id-displayed-na-transactions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes Order ID appearing as N/A in Payments > Transactions

--- a/includes/class-wc-payments-db.php
+++ b/includes/class-wc-payments-db.php
@@ -42,6 +42,7 @@ class WC_Payments_DB {
 		// The order ID is saved to DB in `WC_Payment_Gateway_WCPay::process_payment()`.
 		$orders = wc_get_orders(
 			[
+				'limit'        => -1,
 				'meta_key'     => self::META_KEY_CHARGE_ID, //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_value'   => $charge_ids, //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 				'meta_compare' => 'IN',

--- a/includes/class-wc-payments-db.php
+++ b/includes/class-wc-payments-db.php
@@ -38,11 +38,11 @@ class WC_Payments_DB {
 	 * @return array[]
 	 */
 	public function orders_with_charge_id_from_charge_ids( array $charge_ids ): array {
-
+		
 		// The order ID is saved to DB in `WC_Payment_Gateway_WCPay::process_payment()`.
 		$orders = wc_get_orders(
 			[
-				'limit'        => -1,
+				'limit'        => count( $charge_ids ),
 				'meta_key'     => self::META_KEY_CHARGE_ID, //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_value'   => $charge_ids, //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 				'meta_compare' => 'IN',

--- a/includes/class-wc-payments-db.php
+++ b/includes/class-wc-payments-db.php
@@ -38,7 +38,7 @@ class WC_Payments_DB {
 	 * @return array[]
 	 */
 	public function orders_with_charge_id_from_charge_ids( array $charge_ids ): array {
-		
+
 		// The order ID is saved to DB in `WC_Payment_Gateway_WCPay::process_payment()`.
 		$orders = wc_get_orders(
 			[

--- a/tests/unit/test-class-wc-payments-db.php
+++ b/tests/unit/test-class-wc-payments-db.php
@@ -29,10 +29,19 @@ class WC_Payments_DB_Test extends WCPAY_UnitTestCase {
 		$existing_charge_ids = [
 			'ch_1',
 			'ch_2',
+			'ch_3',
+			'ch_4',
+			'ch_5',
+			'ch_6',
+			'ch_7',
+			'ch_8',
+			'ch_9',
+			'ch_10',
+			'ch_11',
 		];
 
 		$non_existing_charge_ids = [
-			'ch_3',
+			'ch_12',
 		];
 
 		foreach ( $existing_charge_ids as $charge_id ) {
@@ -43,7 +52,7 @@ class WC_Payments_DB_Test extends WCPAY_UnitTestCase {
 
 		$orders_with_charge_ids = $this->wcpay_db->orders_with_charge_id_from_charge_ids( array_merge( $existing_charge_ids, $non_existing_charge_ids ) );
 
-		$this->assertCount( 2, $orders_with_charge_ids );
+		$this->assertCount( 11, $orders_with_charge_ids );
 		$this->assertIsArray( $orders_with_charge_ids[0] );
 		$this->assertTrue( in_array( $orders_with_charge_ids[0]['charge_id'], $existing_charge_ids, true ) );
 		$this->assertIsArray( $orders_with_charge_ids[1] );


### PR DESCRIPTION
Copied from PR #4757, based off `trunk` for potential patch release.

The Order # column in Payments > Transactions returns N/A even when an order ID is present. This issue was most likely introduced in PR #4598.

When replacing the direct DB query with `wc_get_orders` in the `orders_with_charge_id_from_charge_ids` method, no `limit` arg was passed. When no `limit` argument is passed, the `wc_get_order` function will use the default `posts_per_page` value from the user options as the limit which is `10` by default. This default `limit` causes the `orders_with_charge_id_from_charge_ids` method to return an incorrect number of orders with charge ids.

Fixes #4752 

#### Changes proposed in this Pull Request

Passing `limit` argument to the `wc_get_orders` in `orders_with_charge_id_from_charge_ids` method.

The `orders_with_charge_id_from_charge_ids` is used by the `list_transactions` method of the `WC_Payments_API_Client` object to add order info to the transaction. Since there is no limit being passed to `wc_get_orders`, the number of orders with charge ids will be `10` by default or equal to the number set in the **Blog pages show at most** setting in **Settings > Reading**.  Ref: https://github.com/Automattic/woocommerce-payments/blob/develop/includes/wc-payment-api/class-wc-payments-api-client.php#L683

The `orders_with_charge_id_from_charge_ids` returns incorrect number of orders causing the `transactions` array to not have `order` info for many `transactions`. This causes the `order` property to not exist in the API response causing the `Transactions` table to display `N/A` even when an order is present.

I've modified the test cases to add 11 orders with charge IDs and then `assertCount`.  This test case will fail without this PR.


#### Testing instructions

Run `npm run test:php -- "--filter WC_Payments_DB_Test"` to run the unit tests.

1. On current version, add more than 10 orders and check Payments > Transactions screen. Some of the transactions display N/A as the order id.
2. Check that issue is fixed with this branch.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
