### PR TITLE
Fix trial subscription checkout without WooPay signing up

### DIFF
--- a/changelog/fix-4777-fix-trial-subscription-without-woopay-signing-up
+++ b/changelog/fix-4777-fix-trial-subscription-without-woopay-signing-up
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix trial subscription checkout without WooPay signing up.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1251,17 +1251,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			$payment_methods = WC_Payments::get_gateway()->get_payment_method_ids_enabled_at_checkout( null, true );
 
-			// Make sure the payment method being charged was created in the platform.
-			if (
-				! $payment_information->is_using_saved_payment_method() &&
-				$this->should_use_stripe_platform_on_checkout_page() &&
-				// This flag is useful to differentiate between PRB, blocks and shortcode checkout, since this endpoint is being used for all of them.
-				! empty( $_POST['wcpay-is-platform-payment-method'] ) && // phpcs:ignore WordPress.Security.NonceVerification
-				filter_var( $_POST['wcpay-is-platform-payment-method'], FILTER_VALIDATE_BOOLEAN ) // phpcs:ignore WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-			) {
-				// This payment method was created under the platform account.
-				$additional_api_parameters['is_platform_payment_method'] = 'true';
-			}
+			$additional_api_parameters['is_platform_payment_method'] = $this->is_platform_payment_method( $payment_information );
 
 			// This meta is only set by WooPay.
 			// We want to handle the intention creation differently when there are subscriptions.
@@ -1370,6 +1360,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					$payment_information->get_payment_method(),
 					$customer_id,
 					false,
+					$this->is_platform_payment_method( $payment_information ),
 					$save_user_in_platform_checkout,
 					$metadata
 				);
@@ -2939,7 +2930,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		return $this->payments_api_client->create_and_confirm_setup_intent(
 			$payment_information->get_payment_method(),
 			$customer_id,
-			$should_save_in_platform_account
+			$should_save_in_platform_account,
+			$this->is_platform_payment_method( $payment_information )
 		);
 	}
 
@@ -3234,5 +3226,28 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$field = str_replace( '</span>', '<button class="wcpay-stripelink-modal-trigger"></button></span>', $field );
 		}
 		return $field;
+	}
+
+	/**
+	 * Determine if current payment method is a platform payment method.
+	 *
+	 * @param Payment_Information $payment_information The payment information.
+	 *
+	 * @return boolean True if it is a platform payment method.
+	 */
+	private function is_platform_payment_method( Payment_Information $payment_information ) {
+		// Make sure the payment method being charged was created in the platform.
+		if (
+			! $payment_information->is_using_saved_payment_method() &&
+			$this->should_use_stripe_platform_on_checkout_page() &&
+			// This flag is useful to differentiate between PRB, blocks and shortcode checkout, since this endpoint is being used for all of them.
+			! empty( $_POST['wcpay-is-platform-payment-method'] ) && // phpcs:ignore WordPress.Security.NonceVerification
+			filter_var( $_POST['wcpay-is-platform-payment-method'], FILTER_VALIDATE_BOOLEAN ) // phpcs:ignore WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		) {
+			// This payment method was created under the platform account.
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1251,7 +1251,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			$payment_methods = WC_Payments::get_gateway()->get_payment_method_ids_enabled_at_checkout( null, true );
 
-			$additional_api_parameters['is_platform_payment_method'] = $this->is_platform_payment_method( $payment_information );
+			$additional_api_parameters['is_platform_payment_method'] = $this->is_platform_payment_method( $payment_information->is_using_saved_payment_method() );
 
 			// This meta is only set by WooPay.
 			// We want to handle the intention creation differently when there are subscriptions.
@@ -1360,7 +1360,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					$payment_information->get_payment_method(),
 					$customer_id,
 					false,
-					$this->is_platform_payment_method( $payment_information ),
+					$this->is_platform_payment_method( $payment_information->is_using_saved_payment_method() ),
 					$save_user_in_platform_checkout,
 					$metadata
 				);
@@ -2931,7 +2931,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$payment_information->get_payment_method(),
 			$customer_id,
 			$should_save_in_platform_account,
-			$this->is_platform_payment_method( $payment_information )
+			$this->is_platform_payment_method( $payment_information->is_using_saved_payment_method() )
 		);
 	}
 
@@ -3231,14 +3231,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	/**
 	 * Determine if current payment method is a platform payment method.
 	 *
-	 * @param Payment_Information $payment_information The payment information.
+	 * @param boolean $is_using_saved_payment_method If it is using saved payment method.
 	 *
 	 * @return boolean True if it is a platform payment method.
 	 */
-	private function is_platform_payment_method( Payment_Information $payment_information ) {
+	private function is_platform_payment_method( bool $is_using_saved_payment_method ) {
 		// Make sure the payment method being charged was created in the platform.
 		if (
-			! $payment_information->is_using_saved_payment_method() &&
+			! $is_using_saved_payment_method &&
 			$this->should_use_stripe_platform_on_checkout_page() &&
 			// This flag is useful to differentiate between PRB, blocks and shortcode checkout, since this endpoint is being used for all of them.
 			! empty( $_POST['wcpay-is-platform-payment-method'] ) && // phpcs:ignore WordPress.Security.NonceVerification

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -500,25 +500,23 @@ class WC_Payments_API_Client {
 	 * @param string $payment_method_id              - ID of payment method to be saved.
 	 * @param string $customer_id                    - ID of the customer.
 	 * @param bool   $save_in_platform_account       - Indicate whether payment method should be stored in platform store.
+	 * @param bool   $is_platform_payment_method     - Indicate whether is using platform payment method.
 	 * @param bool   $save_user_in_platform_checkout - Indicate whether is creating a platform checkout user.
 	 * @param array  $metadata                 - Meta data values to be sent along with setup intent creation.
 	 *
 	 * @return array
 	 * @throws API_Exception - Exception thrown on setup intent creation failure.
 	 */
-	public function create_and_confirm_setup_intent( $payment_method_id, $customer_id, $save_in_platform_account = false, $save_user_in_platform_checkout = false, $metadata = [] ) {
+	public function create_and_confirm_setup_intent( $payment_method_id, $customer_id, $save_in_platform_account = false, $is_platform_payment_method = false, $save_user_in_platform_checkout = false, $metadata = [] ) {
 		$request = [
-			'payment_method'           => $payment_method_id,
-			'customer'                 => $customer_id,
-			'save_in_platform_account' => $save_in_platform_account,
-			'metadata'                 => $metadata,
-			'confirm'                  => 'true',
+			'payment_method'                  => $payment_method_id,
+			'customer'                        => $customer_id,
+			'save_in_platform_account'        => $save_in_platform_account,
+			'is_platform_payment_method'      => $is_platform_payment_method,
+			'save_payment_method_to_platform' => $save_user_in_platform_checkout,
+			'metadata'                        => $metadata,
+			'confirm'                         => 'true',
 		];
-
-		if ( $save_user_in_platform_checkout ) {
-			$request['is_platform_payment_method']      = 'true';
-			$request['save_payment_method_to_platform'] = 'true';
-		}
 
 		return $this->request( $request, self::SETUP_INTENTS_API, self::POST );
 	}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -1127,7 +1127,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 				$this->anything(),
 				$this->callback(
 					function( $additional_api_parameters ) {
-						return 'true' === $additional_api_parameters['is_platform_payment_method'];
+						return true === $additional_api_parameters['is_platform_payment_method'];
 					}
 				)
 			)


### PR DESCRIPTION
Fixes #4777 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

* Fix an error that occur when checking out a trial subscription with WooPay without signing up.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On merchant site with WooPay and subscriptions enabled, add a trial subscription to the cart.
* Checkout the order on merchant site without signing up to WooPay (or dismiss the WooPay iframe).
* The order success page should appear as expect.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
