### PR TITLE
Exit before processing a scheduled subscription payment for WCPay Subscriptions

### DIFF
--- a/changelog/issue-4788
+++ b/changelog/issue-4788
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Prevent circumstance where WCPay Subscriptions customers could be double charged when the WC Subscriptions extension is active

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -265,6 +265,13 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 			return;
 		}
 
+		// Exit early if the order belongs to a WCPay Subscription. The payment will be processed by the subscription via webhooks.
+		foreach ( wcs_get_subscriptions_for_renewal_order( $renewal_order ) as $subscription ) {
+			if ( WC_Payments_Subscription_Service::is_wcpay_subscription( $subscription ) ) {
+				return;
+			}
+		}
+
 		try {
 			$payment_information = new Payment_Information( '', $renewal_order, Payment_Type::RECURRING(), $token, Payment_Initiated_By::MERCHANT() );
 			$this->process_payment_for_order( null, $payment_information );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
@@ -239,6 +239,14 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WCPAY_UnitTestCase {
 		);
 		$order->add_payment_token( $this->token );
 
+		$mock_subscription = new WC_Subscription();
+
+		WC_Subscriptions::set_wcs_get_subscriptions_for_renewal_order(
+			function ( $id ) use ( $mock_subscription ) {
+				return [ '1' => $mock_subscription ];
+			}
+		);
+
 		$intent = WC_Helper_Intention::create_intention();
 		$this->mock_api_client
 			->expects( $this->once() )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-payment-types.php
@@ -264,4 +264,38 @@ class WC_Payment_Gateway_WCPay_Payment_Types extends WCPAY_UnitTestCase {
 
 		$this->mock_wcpay_gateway->scheduled_subscription_payment( 100, $order );
 	}
+
+	/**
+	 * Test the scheduled_subscription_payment method is halted before payment when the renewal order is linked to a WCPay Subscription.
+	 */
+	public function test_scheduled_subscription_payment_skipped() {
+		$order = WC_Helper_Order::create_order();
+		$this->mock_wcs_order_contains_subscription( true );
+		WC_Subscriptions::set_wcs_get_subscriptions_for_order(
+			function( $parent_order ) use ( $order ) {
+				return $order;
+			}
+		);
+		$order->add_payment_token( $this->token );
+
+		// Mock a subscription that is a WCPay Subscription.
+		$mock_subscription                 = new WC_Subscription();
+		$mock_subscription->payment_method = 'woocommerce_payments';
+
+		$mock_subscription->update_meta_data( '_wcpay_subscription_id', 'test_is_wcpay_subscription' );
+
+		WC_Subscriptions::set_wcs_get_subscriptions_for_renewal_order(
+			function ( $id ) use ( $mock_subscription ) {
+				return [ '1' => $mock_subscription ];
+			}
+		);
+
+		// Make sure the payment is skipped for WCPay Subscriptions.
+		$this->mock_api_client
+			->expects( $this->never() )
+			->method( 'create_and_confirm_intention' );
+
+		$this->mock_wcpay_gateway->scheduled_subscription_payment( 100, $order );
+
+	}
 }

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -212,6 +212,14 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 		$token = WC_Helper_Token::create_token( self::PAYMENT_METHOD_ID, self::USER_ID );
 		$renewal_order->add_payment_token( $token );
 
+		$mock_subscription = new WC_Subscription();
+
+		WC_Subscriptions::set_wcs_get_subscriptions_for_renewal_order(
+			function ( $id ) use ( $mock_subscription ) {
+				return [ '1' => $mock_subscription ];
+			}
+		);
+
 		$this->mock_customer_service
 			->expects( $this->once() )
 			->method( 'get_customer_id_by_user_id' )
@@ -263,6 +271,14 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 		$token = WC_Helper_Token::create_token( 'new_payment_method', self::USER_ID );
 		$renewal_order->add_payment_token( $token );
 
+		$mock_subscription = new WC_Subscription();
+
+		WC_Subscriptions::set_wcs_get_subscriptions_for_renewal_order(
+			function ( $id ) use ( $mock_subscription ) {
+				return [ '1' => $mock_subscription ];
+			}
+		);
+
 		$this->mock_customer_service
 			->expects( $this->once() )
 			->method( 'get_customer_id_by_user_id' )
@@ -279,6 +295,14 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 		$token = WC_Helper_Token::create_token( 'new_payment_method', self::USER_ID );
 		$renewal_order->add_payment_token( $token );
 		$renewal_order->set_currency( 'EUR' );
+
+		$mock_subscription = new WC_Subscription();
+
+		WC_Subscriptions::set_wcs_get_subscriptions_for_renewal_order(
+			function ( $id ) use ( $mock_subscription ) {
+				return [ '1' => $mock_subscription ];
+			}
+		);
 
 		$this->mock_customer_service
 			->expects( $this->once() )


### PR DESCRIPTION
Fixes #4788 

#### Changes proposed in this Pull Request

This PR adds logic to the `scheduled_subscription_payment` function to ensure the process is halted for WCPay subscriptions. 

This approach is inline with similar code in WC Subscriptions which only processes scheduled payments for PayPal subscriptions if they have a "billing agreement" (reference transaction token) vs a profile ID (PayPal standard). [Code reference. ](https://github.com/automattic/woocommerce-subscriptions-core/blob/trunk/includes/gateways/paypal/class-wcs-paypal.php#L353)

#### Testing instructions

> **Note**
> Make sure your site is listening to webhooks. 

1. On `trunk`
1. With WC Subscription inactive purchase a Subscription product. 
     - You will now have a WCPay Subscription
2. Use the billing clock to process a successful renewal order. 
3. Wait for the renewal order to be created.
     - Go to the customer's page in the Stripe dashboard: eg https://dashboard.stripe.com/acct_123/test/customers/cus_123
     - Make a note of the charges. There should be a single successful charge and a cancelled one. See screenshot below.
5. Enable the WC Subscriptions extension.
6. Go to the **Tools → Scheduled Actions** screen and search for the subscription's post ID. 
7. Run the `woocommerce_scheduled_subscription_payment` scheduled action.
    - Go to the customer's page in the Stripe dashboard again: eg https://dashboard.stripe.com/acct_123/test/customers/cus_123
    - There will now be a 2 successful charges both relate to the same order but one originated from the WCPay subscription side and one from the scheduled action. 
8. Checkout this branch
9. Run the scheduled again. 
10. There shouldn't be any additional payment in Stripe. 
11. To be sure, checkout `trunk` and run the scheduled action again. It will result in an extra charge again. 

**Before the double charge**

<img width="1254" alt="Screen Shot 2022-09-23 at 1 09 24 pm" src="https://user-images.githubusercontent.com/8490476/191885371-8d3d5799-a9de-49d2-8018-961295babd49.png">

**After running the scheduled action**

<img width="1263" alt="Screen Shot 2022-09-23 at 1 14 28 pm" src="https://user-images.githubusercontent.com/8490476/191885773-f91bf92e-3b29-4c65-8e26-dfb312c3091b.png">

**To test the WC Payments and WC Subscription scenario hasn't been impacted by this:**

1. With the WC Subscriptions extension active purchase a subscription product 
   - You will now have a tokenized WCPay Subscription
4. Find the subscription's scheduled action and run it. 
5. Make sure the payment is processed via WC Payments correctly. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
