### PR TITLE
Remove GH token to change comment author

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -19,6 +19,5 @@ jobs:
             - name: Checking for file changes
               uses: preactjs/compressed-size-action@b03ec15e1a93cb5c062d66a1c263f9ddbd2f81ef
               with:
-                  repo-token: '${{ secrets.BUNDLE_SIZE_CHECK }}'
                   pattern: '{release/**/*.js,release/**/*.css}'
                   exclude: '{release/vendor/**}'

--- a/changelog/Remove GH token to change comment author for bundle size check
+++ b/changelog/Remove GH token to change comment author for bundle size check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This removes the GH token so that the bundle size check comment author changes to GH actions bot.
+
+


### PR DESCRIPTION
Fixes #4804

#### Changes proposed in this Pull Request

The bundle size check from [this PR](https://github.com/Automattic/woocommerce-payments/pull/4637) posts comments by @fashuvo. This PR will change the comment author to the `github-actions` bot instead.

#### Testing instructions

1. Clone the `test/size-change-test-11` branch in your local machine.
2. Delete/add some code from some file(s).
3. Push that new branch.
4. Create a draft PR.
5. Observe that the comment author is:

- `github-actions` on this branch. Here's a screenshot showing the new message:

![Image 2022-09-27 at 2 14 18 PM](https://user-images.githubusercontent.com/6534920/192471835-21e9aec7-114a-43a8-bc5a-ded4801573ee.jpg)

- `fashuvo` on the develop branch. Here's a screenshot showing the previous message:

![Image 2022-09-27 at 2 13 59 PM](https://user-images.githubusercontent.com/6534920/192471764-d337505d-6445-41cb-8854-aa1e5c7f4ec6.jpg)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
