### PR TITLE
Capture charge when order status is processing

### DIFF
--- a/changelog/fix-4789-capture-on-processing-status
+++ b/changelog/fix-4789-capture-on-processing-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Capture charge when order status is processing/complete

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -161,10 +161,12 @@ class WC_Payments_Order_Service {
 	 * @return void
 	 */
 	public function mark_payment_capture_completed( $order, $intent_id, $intent_status, $charge_id ) {
-		if ( ! $this->order_prepared_for_processing( $order, $intent_id ) ) {
+		if ( ! is_a( $order, 'WC_Order' ) || $this->is_order_locked( $order, $intent_id ) ) {
+			Logger::log( 'Error when updating status after capture completed for order ' . $order->get_id() );
 			return;
 		}
 
+		$this->lock_order_payment( $order, $intent_id );
 		$this->update_order_status( $order, 'payment_complete', $intent_id );
 		$this->add_capture_success_note( $order, $intent_id, $charge_id );
 		$this->complete_order_processing( $order, $intent_status );


### PR DESCRIPTION
Fixes #4789 

#### Changes proposed in this Pull Request

If an order has processing/completed status can be captured, but the order is not marked as charged. This PR changes this, updating the order even if the order has status processing/complete.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable authorization
* Create order in the frontend (don’t capture the charge)
* Change the order status to Processing
* Capture charge now
* confirmation about the captured amount should be shown in order notes
* the order can be refunded
-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
