### PR TITLE
Fix Node version in Platform Checkout workflow

### DIFF
--- a/.github/workflows/platform-checkout-test-site-sync.yml
+++ b/.github/workflows/platform-checkout-test-site-sync.yml
@@ -23,10 +23,10 @@ jobs:
         with:
           ref: 'develop'
 
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
+      - name: Setup Node
+        uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       # Runs a set of commands using the runners shell
@@ -38,7 +38,7 @@ jobs:
           unzip woocommerce-payments.zip
           mkdir -p htdocs/wp-content/plugins
           cp -R woocommerce-payments htdocs/wp-content/plugins
-      
+
       - name: FTP-Deploy-Action
         uses: Automattic/FTP-Deploy-Action@3.0.1
         with:

--- a/changelog/fix-platform-checkout-workflow
+++ b/changelog/fix-platform-checkout-workflow
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix Node version of the Platform Checkout workflow.
+
+


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

It updates the Platform Checkout workflow to use the Node version of the `nvmrc` file. If this PR is merged, the Node version in this workflow will always be up-to-date as long as we use the file as a single source of truth for the Node version of the project.

This workflow [started to fail](https://github.com/Automattic/woocommerce-payments/actions/workflows/platform-checkout-test-site-sync.yml) after we upgraded Node – see paJDYF-5CY-p2.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The workflow only works on push events in the `develop` branch, so we'll see when/if this is merged.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.