### PR TITLE
Disable WooPay when cart does not need payment

### DIFF
--- a/changelog/fix-4635-disable-woopay-when-cart-do-not-need-payment
+++ b/changelog/fix-4635-disable-woopay-when-cart-do-not-need-payment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Disable WooPay when cart does not need payment

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -283,8 +283,10 @@ class WC_Payments {
 			include_once __DIR__ . '/multi-currency/wc-payments-multi-currency.php';
 		}
 
-		// // Load platform checkout save user section if feature is enabled.
-		add_action( 'woocommerce_cart_loaded_from_session', [ __CLASS__, 'init_platform_checkout' ] );
+		// Load platform checkout save user section if feature is enabled.
+		// It needs to be after calculate totals due to subscriptions with trial
+		// that can change the WC()->cart->needs_payment() value.
+		add_action( 'woocommerce_after_calculate_totals', [ __CLASS__, 'init_platform_checkout' ] );
 
 		// Init the email template for In Person payment receipt email. We need to do it before passing the mailer to the service.
 		add_filter( 'woocommerce_email_classes', [ __CLASS__, 'add_ipp_emails' ], 10 );

--- a/includes/platform-checkout/class-platform-checkout-utilities.php
+++ b/includes/platform-checkout/class-platform-checkout-utilities.php
@@ -23,10 +23,11 @@ class Platform_Checkout_Utilities {
 	 * @return boolean
 	 */
 	public function should_enable_platform_checkout( $gateway ) {
+		$needs_payment                 = WC()->cart->needs_payment();
 		$is_platform_checkout_eligible = WC_Payments_Features::is_platform_checkout_eligible(); // Feature flag.
 		$is_platform_checkout_enabled  = 'yes' === $gateway->get_option( 'platform_checkout', 'no' );
 
-		return $is_platform_checkout_eligible && $is_platform_checkout_enabled;
+		return $needs_payment && $is_platform_checkout_eligible && $is_platform_checkout_enabled;
 	}
 
 	/**

--- a/tests/unit/helpers/class-wc-helper-product.php
+++ b/tests/unit/helpers/class-wc-helper-product.php
@@ -57,9 +57,8 @@ class WC_Helper_Product {
 	}
 
 	/**
-	 * Create simple product.
+	 * Create free product.
 	 *
-	 * @since 2.3
 	 * @param bool $save Save or return object.
 	 * @return WC_Product_Simple
 	 */

--- a/tests/unit/helpers/class-wc-helper-product.php
+++ b/tests/unit/helpers/class-wc-helper-product.php
@@ -57,6 +57,37 @@ class WC_Helper_Product {
 	}
 
 	/**
+	 * Create simple product.
+	 *
+	 * @since 2.3
+	 * @param bool $save Save or return object.
+	 * @return WC_Product_Simple
+	 */
+	public static function create_free_product( $save = true ) {
+		$product = new WC_Product_Simple();
+		$product->set_props(
+			[
+				'name'          => 'Dummy Free Product',
+				'regular_price' => 0,
+				'price'         => 0,
+				'sku'           => 'DUMMY Free SKU',
+				'manage_stock'  => false,
+				'downloadable'  => false,
+				'virtual'       => false,
+				'stock_status'  => 'instock',
+				'weight'        => '1.1',
+			]
+		);
+
+		if ( $save ) {
+			$product->save();
+			return wc_get_product( $product->get_id() );
+		} else {
+			return $product;
+		}
+	}
+
+	/**
 	 * Create external product.
 	 *
 	 * @since 3.0.0

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -82,6 +82,12 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	private $order_service;
 
 	/**
+	 * Test product to add to the cart
+	 * @var WC_Product_Simple
+	 */
+	private $simple_product;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
@@ -140,6 +146,8 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			$this->mock_rate_limiter,
 			$this->order_service
 		);
+
+		$this->simple_product = WC_Helper_Product::create_simple_product();
 	}
 
 	/**
@@ -1965,6 +1973,8 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_platform_checkout_enabled_returns_true() {
+		WC()->cart->add_to_cart( $this->simple_product->get_id(), 1 );
+
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
 		$this->wcpay_gateway->update_option( 'platform_checkout', 'yes' );
 		$this->assertTrue( $this->wcpay_gateway->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );


### PR DESCRIPTION
Fixes #4635

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

* Disable WooPay when the cart does not need payment, as currently WCPay is not loaded but it loads WooPay scripts.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* As a merchant, create a product with a $0 price
* As a merchant, confirm WooPay is enabled
* As a shopper, add this free product to your cart and proceed to check out
* On the checkout page, open the browser console
* No error message should be shown
* Add a trial subscription or another product that needs payment
* WCPay and WooPay should be loaded as expected

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
