### PR TITLE
Fix platform checkout store logo preview

### DIFF
--- a/changelog/fix-13-platform-checkout-brand-logo
+++ b/changelog/fix-13-platform-checkout-brand-logo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix platform checkout store logo preview.

--- a/client/components/file-upload/preview.tsx
+++ b/client/components/file-upload/preview.tsx
@@ -22,7 +22,7 @@ const FileUploadPreview = ( {
 }: FileUploadProps ): JSX.Element => {
 	let url =
 		wcpaySettings.restUrl + NAMESPACE.substring( 1 ) + '/file/' + fileName;
-	url = addQueryArgs( url, { as_account: 0 } );
+	url = addQueryArgs( url, { as_account: 1 } );
 
 	return (
 		<>

--- a/client/components/file-upload/preview.tsx
+++ b/client/components/file-upload/preview.tsx
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import * as React from 'react';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies.
@@ -20,9 +19,8 @@ const FileUploadPreview = ( {
 	fileName,
 	showPreview,
 }: FileUploadProps ): JSX.Element => {
-	let url =
+	const url =
 		wcpaySettings.restUrl + NAMESPACE.substring( 1 ) + '/file/' + fileName;
-	url = addQueryArgs( url, { as_account: 1 } );
 
 	return (
 		<>

--- a/client/settings/express-checkout-settings/file-upload.tsx
+++ b/client/settings/express-checkout-settings/file-upload.tsx
@@ -83,8 +83,6 @@ const PlatformCheckoutFileUpload: React.FunctionComponent< PlatformCheckoutFileU
 		const body = new FormData();
 		body.append( 'file', file );
 		body.append( 'purpose', purpose );
-		// Interpreting as_account as Boolean false in the backend
-		body.append( 'as_account', '0' );
 
 		try {
 			const uploadedFile: unknown = await apiFetch( {

--- a/client/settings/express-checkout-settings/platform-checkout-preview.js
+++ b/client/settings/express-checkout-settings/platform-checkout-preview.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import React from 'react';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies.
@@ -11,9 +10,8 @@ import { addQueryArgs } from '@wordpress/url';
 import { NAMESPACE } from 'wcpay/data/constants';
 
 export default ( { storeName, storeLogo, ...props } ) => {
-	let storeLogoUrl =
+	const storeLogoUrl =
 		wcpaySettings.restUrl + NAMESPACE.substring( 1 ) + '/file/' + storeLogo;
-	storeLogoUrl = addQueryArgs( storeLogoUrl, { as_account: 1 } );
 
 	return (
 		<>

--- a/client/settings/express-checkout-settings/platform-checkout-preview.js
+++ b/client/settings/express-checkout-settings/platform-checkout-preview.js
@@ -13,7 +13,7 @@ import { NAMESPACE } from 'wcpay/data/constants';
 export default ( { storeName, storeLogo, ...props } ) => {
 	let storeLogoUrl =
 		wcpaySettings.restUrl + NAMESPACE.substring( 1 ) + '/file/' + storeLogo;
-	storeLogoUrl = addQueryArgs( storeLogoUrl, { as_account: 0 } );
+	storeLogoUrl = addQueryArgs( storeLogoUrl, { as_account: 1 } );
 
 	return (
 		<>

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1060,7 +1060,7 @@ class WC_Payments {
 			'session_cookie_value' => wp_unslash( $_COOKIE[ $session_cookie_name ] ?? '' ), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 			'store_data'           => [
 				'store_name'                     => get_bloginfo( 'name' ),
-				'store_logo'                     => ! empty( $store_logo ) ? add_query_arg( 'as_account', '1', get_rest_url( null, 'wc/v3/payments/file/' . $store_logo ) ) : '',
+				'store_logo'                     => ! empty( $store_logo ) ? get_rest_url( null, 'wc/v3/payments/file/' . $store_logo ) : '',
 				'custom_message'                 => self::get_gateway()->get_option( 'platform_checkout_custom_message' ),
 				'blog_id'                        => Jetpack_Options::get_option( 'id' ),
 				'blog_url'                       => get_site_url(),

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1060,7 +1060,7 @@ class WC_Payments {
 			'session_cookie_value' => wp_unslash( $_COOKIE[ $session_cookie_name ] ?? '' ), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 			'store_data'           => [
 				'store_name'                     => get_bloginfo( 'name' ),
-				'store_logo'                     => ! empty( $store_logo ) ? add_query_arg( 'as_account', '0', get_rest_url( null, 'wc/v3/payments/file/' . $store_logo ) ) : '',
+				'store_logo'                     => ! empty( $store_logo ) ? add_query_arg( 'as_account', '1', get_rest_url( null, 'wc/v3/payments/file/' . $store_logo ) ) : '',
 				'custom_message'                 => self::get_gateway()->get_option( 'platform_checkout_custom_message' ),
 				'blog_id'                        => Jetpack_Options::get_option( 'id' ),
 				'blog_url'                       => get_site_url(),


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Removed the usage of  `as_account` for platform checkout store logo.

#### Testing instructions
- Go to _WooCommerce -> Settings -> Payments -> WooCommerce Payments_ and enable `WooPay`. Go to `Customize` and upload a logo. The preview of the logo should be present.
- Go to merchant store, add some product to cart, the go to the checkout page. Complete OTP verification for `WooPay` and get redirected to the platform checkout page. The store logo should be present there.