### PR TITLE
Fix fatal error in Multi-Currency Compatibility

### DIFF
--- a/changelog/fix-4818-multi-currency-compatibility-fatal
+++ b/changelog/fix-4818-multi-currency-compatibility-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error with call to MultiCurrency/Compatibility::convert_order_prices method.

--- a/includes/multi-currency/Compatibility.php
+++ b/includes/multi-currency/Compatibility.php
@@ -157,16 +157,16 @@ class Compatibility extends BaseCompatibility {
 	 *
 	 * @param WC_Order[]|WC_Order_Refund[] $results The results returned by the orders query.
 	 *
-	 * @return array
+	 * @return array|object of WC_Order objects
 	 */
-	public function convert_order_prices( $results ): array {
+	public function convert_order_prices( $results ) {
 		$backtrace_calls = [
 			'Automattic\WooCommerce\Admin\Notes\NewSalesRecord::sum_sales_for_date',
 			'Automattic\WooCommerce\Admin\Notes\NewSalesRecord::possibly_add_note',
 		];
 
-		// If the call we're expecting isn't in the backtrace, then just do nothing and return the results.
-		if ( ! $this->utils->is_call_in_backtrace( $backtrace_calls ) ) {
+		// If the results are not an array, or if the call we're expecting isn't in the backtrace, then just do nothing and return the results.
+		if ( ! is_array( $results ) || ! $this->utils->is_call_in_backtrace( $backtrace_calls ) ) {
 			return $results;
 		}
 

--- a/tests/unit/multi-currency/test-class-compatibility.php
+++ b/tests/unit/multi-currency/test-class-compatibility.php
@@ -190,4 +190,15 @@ class WCPay_Multi_Currency_Compatibility_Tests extends WCPAY_UnitTestCase {
 		$order = wc_get_order( $result->get_id() );
 		$this->assertEquals( 1000, $order->get_total() );
 	}
+
+	public function test_filter_woocommerce_order_query_with_object_not_array() {
+		$order = wc_create_order();
+		$order->set_total( 1000 );
+		$order->set_currency( 'GBP' );
+
+		// Turn the order array into an object to confirm the object is returned as is.
+		$expected = (object) [ $order ];
+
+		$this->assertEquals( $expected, $this->compatibility->convert_order_prices( $expected, [] ) );
+	}
 }


### PR DESCRIPTION
Fixes #4818

#### Changes proposed in this Pull Request

* Removes the return type declaration on the `convert_order_prices` method.
* Update docblock to declare return can be an array or object.
* Add early check to see if the item being processed is an array, and return if it is not. (We only expect arrays with the data we're processing.)

This is all done due to the `WC_Order_Query::get_orders` method can return an object or an array, depending on the args passed. Since we are _always_ filtering the results with the `woocommerce_order_query` filter, we need to be able to return both an object and an array.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

As mentioned in the issue, I am unsure how to reproduce in the wild, however, I have been able to replicate in an unconventional way. I was not able to find a way to get the `paginate` arg to `true` by normal means. The only time I saw this available in the code is when custom order tables are being used.

* **Do not apply branch yet.**
* Apply below action snippet to your site.
  * This can be done through the [Code Snippets plugin](https://wordpress.org/plugins/code-snippets/), or
  * This can be done by adding the snippet to your `functions.php` file in your theme.
* Run the `wc_admin_daily` cron event.
  * This can be done via CLI: `wp cron event run wc_admin_daily` or
  * This can be done via the [WP Crontrol plugin](https://wordpress.org/plugins/wp-crontrol/) under Tools > Cron Events.
* Error should be received:
  * > PHP Fatal error:  Uncaught TypeError: Return value of WCPay\MultiCurrency\Compatibility::convert_order_prices() must be of the type array, object returned in .../wp-content/plugins/woocommerce-payments/includes/multi-currency/Compatibility.php:170
* Apply the branch to your site.
* Run the `wc_admin_daily` cron event.
* No error should be received, and you should get a success message.
  * > Success: Executed a total of 1 cron event.
* Be sure to remove action snippet.

Action snippet:
```
add_action( 'woocommerce_admin_sales_record_milestone_enabled', function() {
	$orders = wc_get_orders( [ 'paginate' => true ] );
}, 99 );
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
