### PR TITLE
Update default platform checkout host to pay.woo.com

### DIFF
--- a/changelog/fix-woopay-1146
+++ b/changelog/fix-woopay-1146
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update default platform checkout host to pay.woo.com

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -360,7 +360,7 @@ class WC_Payments {
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new Allowed_Payment_Request_Button_Types_Update( self::get_gateway() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Update_Service_Data_From_Server( self::get_account_service() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ '\WCPay\Migrations\Track_Upe_Status', 'maybe_track' ] );
-		add_action( 'woocommerce_woocommerce_payments_updated', [ '\WCPay\Migrations\Delete_Active_Webhook', 'maybe_delete' ] );
+		add_action( 'woocommerce_woocommerce_payments_updated', [ '\WCPay\Migrations\Delete_Active_Platform_Checkout_Webhook', 'maybe_delete' ] );
 
 		include_once WCPAY_ABSPATH . '/includes/class-wc-payments-explicit-price-formatter.php';
 		WC_Payments_Explicit_Price_Formatter::init();

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -356,9 +356,11 @@ class WC_Payments {
 		require_once __DIR__ . '/migrations/class-allowed-payment-request-button-types-update.php';
 		require_once __DIR__ . '/migrations/class-update-service-data-from-server.php';
 		require_once __DIR__ . '/migrations/class-track-upe-status.php';
+		require_once __DIR__ . '/migrations/class-delete-active-webhook.php';
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new Allowed_Payment_Request_Button_Types_Update( self::get_gateway() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Update_Service_Data_From_Server( self::get_account_service() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ '\WCPay\Migrations\Track_Upe_Status', 'maybe_track' ] );
+		add_action( 'woocommerce_woocommerce_payments_updated', [ '\WCPay\Migrations\Delete_Active_Webhook', 'maybe_delete' ] );
 
 		include_once WCPAY_ABSPATH . '/includes/class-wc-payments-explicit-price-formatter.php';
 		WC_Payments_Explicit_Price_Formatter::init();

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -356,7 +356,7 @@ class WC_Payments {
 		require_once __DIR__ . '/migrations/class-allowed-payment-request-button-types-update.php';
 		require_once __DIR__ . '/migrations/class-update-service-data-from-server.php';
 		require_once __DIR__ . '/migrations/class-track-upe-status.php';
-		require_once __DIR__ . '/migrations/class-delete-active-webhook.php';
+		require_once __DIR__ . '/migrations/class-delete-active-platform-checkout-webhook.php';
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new Allowed_Payment_Request_Button_Types_Update( self::get_gateway() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Update_Service_Data_From_Server( self::get_account_service() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ '\WCPay\Migrations\Track_Upe_Status', 'maybe_track' ] );

--- a/includes/migrations/class-delete-active-platform-checkout-webhook.php
+++ b/includes/migrations/class-delete-active-platform-checkout-webhook.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class Delete_Active_Webhook
+ * Class Delete_Active_Platform_Checkout_Webhook
  *
  * @package WooCommerce\Payments
  */
@@ -10,18 +10,18 @@ namespace WCPay\Migrations;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class Delete_Active_Webhook
+ * Class Delete_Active_Platform_Checkout_Webhook
  *
- * Fires an event on plugin upgrade to delete the avtive webhook.
+ * Fires an event on plugin upgrade to delete the active webhook.
  * Runs only once. We want to know whether existing install had it
  * enabled before the current version.
  */
-class Delete_Active_Webhook {
+class Delete_Active_Platform_Checkout_Webhook {
 	/**
 	 * Checks whether we should trigger the event.
 	 */
 	public static function maybe_delete() {
-		if ( version_compare( get_option( 'woocommerce_woocommerce_payments_version' ), '4.8.0', '>' ) ) {
+		if ( version_compare( get_option( 'woocommerce_woocommerce_payments_version' ), '4.9.0', '>=' ) ) {
 			return;
 		}
 

--- a/includes/migrations/class-delete-active-webhook.php
+++ b/includes/migrations/class-delete-active-webhook.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Class Delete_Active_Webhook
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Migrations;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Delete_Active_Webhook
+ *
+ * Fires an event on plugin upgrade to delete the avtive webhook.
+ * Runs only once. We want to know whether existing install had it
+ * enabled before the current version.
+ */
+class Delete_Active_Webhook {
+	/**
+	 * Checks whether we should trigger the event.
+	 */
+	public static function maybe_delete() {
+		if ( version_compare( get_option( 'woocommerce_woocommerce_payments_version' ), '4.8.0', '>' ) ) {
+			return;
+		}
+
+		self::delete();
+	}
+
+	/**
+	 * Deletes the active webhook.
+	 */
+	private static function delete() {
+		\WCPay\Platform_Checkout\Platform_Checkout_Order_Status_Sync::remove_webhook();
+	}
+}

--- a/includes/platform-checkout/class-platform-checkout-order-status-sync.php
+++ b/includes/platform-checkout/class-platform-checkout-order-status-sync.php
@@ -60,7 +60,7 @@ class Platform_Checkout_Order_Status_Sync {
 	 * @return string
 	 */
 	private static function get_webhook_delivery_url() {
-		$platform_checkout_host = defined( 'PLATFORM_CHECKOUT_HOST' ) ? PLATFORM_CHECKOUT_HOST : 'http://host.docker.internal:8090';
+		$platform_checkout_host = defined( 'PLATFORM_CHECKOUT_HOST' ) ? PLATFORM_CHECKOUT_HOST : 'https://pay.woo.com';
 		return $platform_checkout_host . '/wp-json/platform-checkout/v1/merchant-notification';
 	}
 


### PR DESCRIPTION
Fixes [1146-gh-Automattic/woopay](https://github.com/Automattic/woopay/issues/1146)

#### Changes proposed in this Pull Request
Update default platform checkout host from testing site `host.docker.internal:8090` to `pay.woo.com`


#### Screenshots
// Before
<img width="289" alt="before-merchant" src="https://user-images.githubusercontent.com/56378160/192868027-746b195a-5287-4399-8829-6e5941a4fbc8.png">
<img width="231" alt="before-woopay" src="https://user-images.githubusercontent.com/56378160/192868047-545082de-be45-4e8c-bc59-f483ea6f513c.png">

// After
<img width="294" alt="Screen Shot 2022-09-28 at 12 09 52 PM" src="https://user-images.githubusercontent.com/56378160/192868359-6b2527d3-4a6a-4373-b271-1969be24d443.png">
<img width="204" alt="Screen Shot 2022-09-28 at 12 10 00 PM" src="https://user-images.githubusercontent.com/56378160/192868370-5556105d-2978-4a78-a820-40bc4dd7237f.png">

#### Testing instructions
1. Make a purchase via WooPay on your ephemeral site
1. Go to your merchant site -> Orders -> Item section -> Refund button -> Select Qty -> See refunded as image
1. Go to https://pay.woo.com/account/orders 
1. See order status shown Refunded

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.