### PR TITLE
Handle rate limit errors during the checkout process

### DIFF
--- a/changelog/fix-4801-429-lock-timeout-error
+++ b/changelog/fix-4801-429-lock-timeout-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed issue with Stripe rate limit during the checkout

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -447,15 +447,15 @@ export default class WCPayAPI {
 	/**
 	 * Confirm Stripe payment with fallback for rate limit error.
 	 *
-	 * @param {Object} confirmParams Confirm payment request parameters.
 	 * @param {Object|StripeElements} elements Stripe elements.
+	 * @param {Object} confirmParams Confirm payment request parameters.
 	 * @param {string|null} paymentIntentSecret Payment intent secret used to validate payment on rate limit error
 	 *
-	 * @return {Promise} The final promise for the request to the server.
+	 * @return {Promise} The payment confirmation promise.
 	 */
 	async handlePaymentConfirmation(
-		confirmParams,
 		elements,
+		confirmParams,
 		paymentIntentSecret
 	) {
 		const stripe = this.getStripe();

--- a/client/checkout/blocks/confirm-upe-payment.js
+++ b/client/checkout/blocks/confirm-upe-payment.js
@@ -4,6 +4,7 @@
  * @param {WCPayAPI} api            The API used for connection both with the server and Stripe.
  * @param {string}   redirectUrl    The URL to redirect to after confirming the intent on Stripe.
  * @param {boolean}  paymentNeeded  A boolean whether a payment or a setup confirmation is needed.
+ * @param {string|null}   paymentIntentSecret Payment Intent Secret used to validate payment on rate limit error.
  * @param {Object}   elements       Reference to the UPE elements mounted on the page.
  * @param {Object}   billingData    An object containing the customer's billing data.
  * @param {Object}   emitResponse   Various helpers for usage with observer response objects.
@@ -13,6 +14,7 @@ export default async function confirmUPEPayment(
 	api,
 	redirectUrl,
 	paymentNeeded,
+	paymentIntentSecret,
 	elements,
 	billingData,
 	emitResponse
@@ -44,10 +46,11 @@ export default async function confirmUPEPayment(
 		};
 
 		if ( paymentNeeded ) {
-			const { error } = await api.getStripe().confirmPayment( {
-				elements,
+			const { error } = await api.handlePaymentConfirmation(
 				confirmParams,
-			} );
+				elements,
+				paymentIntentSecret
+			);
 			if ( error ) {
 				throw error;
 			}

--- a/client/checkout/blocks/confirm-upe-payment.js
+++ b/client/checkout/blocks/confirm-upe-payment.js
@@ -47,8 +47,8 @@ export default async function confirmUPEPayment(
 
 		if ( paymentNeeded ) {
 			const { error } = await api.handlePaymentConfirmation(
-				confirmParams,
 				elements,
+				confirmParams,
 				paymentIntentSecret
 			);
 			if ( error ) {

--- a/client/checkout/blocks/upe-fields.js
+++ b/client/checkout/blocks/upe-fields.js
@@ -64,6 +64,7 @@ const WCPayUPEFields = ( {
 	},
 	emitResponse,
 	paymentIntentId,
+	paymentIntentSecret,
 	errorMessage,
 	shouldSavePayment,
 } ) => {
@@ -268,6 +269,7 @@ const WCPayUPEFields = ( {
 							api,
 							paymentDetails.redirect_url,
 							paymentDetails.payment_needed,
+							paymentIntentSecret,
 							elements,
 							billingData,
 							emitResponse
@@ -423,6 +425,7 @@ const ConsumableWCPayFields = ( { api, ...props } ) => {
 			<WCPayUPEFields
 				api={ api }
 				paymentIntentId={ paymentIntentId }
+				paymentIntentSecret={ clientSecret }
 				errorMessage={ errorMessage }
 				{ ...props }
 			/>

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -52,6 +52,7 @@ jQuery( function ( $ ) {
 	let elements = null;
 	let upeElement = null;
 	let paymentIntentId = null;
+	let paymentIntentClientSecret = null;
 	let isUPEComplete = false;
 	const hiddenBillingFields = {
 		name:
@@ -226,6 +227,7 @@ jQuery( function ( $ ) {
 		}
 
 		paymentIntentId = intentId;
+		paymentIntentClientSecret = clientSecret;
 
 		let appearance = getConfig( 'upeAppearance' );
 
@@ -379,12 +381,13 @@ jQuery( function ( $ ) {
 		}
 		if ( ! isUPEComplete ) {
 			// If UPE fields are not filled, confirm payment to trigger validation errors
-			const { error } = await api.getStripe().confirmPayment( {
-				elements,
-				confirmParams: {
+			const { error } = await api.handlePaymentConfirmation(
+				{
 					return_url: returnUrl,
 				},
-			} );
+				elements,
+				null
+			);
 			$form.removeClass( 'processing' ).unblock();
 			showErrorCheckout( error.message );
 			return false;
@@ -429,12 +432,13 @@ jQuery( function ( $ ) {
 				$( '#wcpay_payment_country' ).val()
 			);
 
-			const { error } = await api.getStripe().confirmPayment( {
-				elements,
-				confirmParams: {
+			const { error } = await api.handlePaymentConfirmation(
+				{
 					return_url: returnUrl,
 				},
-			} );
+				elements,
+				getPaymentIntentSecret()
+			);
 			if ( error ) {
 				throw error;
 			}
@@ -513,9 +517,11 @@ jQuery( function ( $ ) {
 			};
 			let error;
 			if ( response.payment_needed ) {
-				( { error } = await api
-					.getStripe()
-					.confirmPayment( upeConfig ) );
+				( { error } = await api.handlePaymentConfirmation(
+					upeConfig.confirmParams,
+					elements,
+					getPaymentIntentSecret()
+				) );
 			} else {
 				( { error } = await api.getStripe().confirmSetup( upeConfig ) );
 			}
@@ -523,25 +529,6 @@ jQuery( function ( $ ) {
 				// Log payment errors on charge and then throw the error.
 				const logError = await api.logPaymentError( error.charge );
 				if ( logError ) {
-					if ( 'lock_timeout' === error.code ) {
-						const paymentIntent = getPaymentIntentFromSession();
-
-						if ( paymentIntent.hasOwnProperty( 'clientSecret' ) ) {
-							const paymentIntentResponse = await api
-								.getStripe()
-								.retrievePaymentIntent(
-									paymentIntent.clientSecret
-								);
-							if (
-								! paymentIntentResponse.error &&
-								'succeeded' ===
-									paymentIntentResponse.paymentIntent.status
-							) {
-								window.location.href = redirectUrl;
-								return;
-							}
-						}
-					}
 					throw error;
 				}
 			}
@@ -652,6 +639,19 @@ jQuery( function ( $ ) {
 		}
 
 		return {};
+	}
+
+	/**
+	 * Returns stripe intent secret that will be used to confirm payment
+	 *
+	 * @return {string | null} The intent secret required to confirm payment during the rate limit error.
+	 */
+	function getPaymentIntentSecret() {
+		if ( paymentIntentClientSecret ) {
+			return paymentIntentClientSecret;
+		}
+		const { clientSecret } = getPaymentIntentFromSession();
+		return clientSecret ? clientSecret : null;
 	}
 
 	// Handle the checkout form when WooCommerce Payments is chosen.

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -382,10 +382,10 @@ jQuery( function ( $ ) {
 		if ( ! isUPEComplete ) {
 			// If UPE fields are not filled, confirm payment to trigger validation errors
 			const { error } = await api.handlePaymentConfirmation(
+				elements,
 				{
 					return_url: returnUrl,
 				},
-				elements,
 				null
 			);
 			$form.removeClass( 'processing' ).unblock();
@@ -433,10 +433,10 @@ jQuery( function ( $ ) {
 			);
 
 			const { error } = await api.handlePaymentConfirmation(
+				elements,
 				{
 					return_url: returnUrl,
 				},
-				elements,
 				getPaymentIntentSecret()
 			);
 			if ( error ) {
@@ -518,8 +518,8 @@ jQuery( function ( $ ) {
 			let error;
 			if ( response.payment_needed ) {
 				( { error } = await api.handlePaymentConfirmation(
-					upeConfig.confirmParams,
 					elements,
+					upeConfig.confirmParams,
 					getPaymentIntentSecret()
 				) );
 			} else {

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -523,6 +523,25 @@ jQuery( function ( $ ) {
 				// Log payment errors on charge and then throw the error.
 				const logError = await api.logPaymentError( error.charge );
 				if ( logError ) {
+					if ( 'lock_timeout' === error.code ) {
+						const paymentIntent = getPaymentIntentFromSession();
+
+						if ( paymentIntent.hasOwnProperty( 'clientSecret' ) ) {
+							const paymentIntentResponse = await api
+								.getStripe()
+								.retrievePaymentIntent(
+									paymentIntent.clientSecret
+								);
+							if (
+								! paymentIntentResponse.error &&
+								'succeeded' ===
+									paymentIntentResponse.paymentIntent.status
+							) {
+								window.location.href = redirectUrl;
+								return;
+							}
+						}
+					}
 					throw error;
 				}
 			}


### PR DESCRIPTION
Fixes #4801 

#### Changes proposed in this Pull Request

During the checkout process, sometimes Stripe API return an error with code that says that request is rate limited. In most cases, the payment is already processed and the only step that needs to be done is to redirect the customer to the order received page.

To address this issue, additional checks have been added that will monitor error code and if the error code is the one that tells us that rate limit is in place, an additional request will be made that will get payment intent. If payment intent is succeeded, the user will be redirected. If that's not a case, the original error message will be shown

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

This flow will be difficult to test because it will be difficult to replicate stripe response with specific error code. One way to test it is to manually edit the code with a specific error code that is mentioned in the original issue. Make sure that payment intent succeeded and make sure that part of code that calls additional payment intent API request is called by manually setting error variable.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
