### PR TITLE
Support client-side intent confirmation via filter

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1426,7 +1426,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				}
 			}
 
-			if ( 'requires_action' === $status ) {
+			if ( 'requires_action' === $status || 'requires_confirmation' === $status ) {
 				if ( isset( $next_action['type'] ) && 'redirect_to_url' === $next_action['type'] && ! empty( $next_action['redirect_to_url']['url'] ) ) {
 					$response = [
 						'result'   => 'success',
@@ -1615,6 +1615,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$this->order_service->mark_payment_authorized( $order, $intent_id, $intent_status, $charge_id );
 				break;
 			case 'requires_action':
+			case 'requires_confirmation':
 			case 'requires_payment_method':
 				$this->order_service->mark_payment_started( $order, $intent_id, $intent_status, $charge_id );
 				break;

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -216,7 +216,6 @@ class WC_Payments_API_Client {
 		$request                   = [];
 		$request['amount']         = $amount;
 		$request['currency']       = $currency_code;
-		$request['confirm']        = 'true';
 		$request['payment_method'] = $payment_method_id;
 		$request['customer']       = $customer_id;
 		$request['capture_method'] = $manual_capture ? 'manual' : 'automatic';
@@ -230,6 +229,10 @@ class WC_Payments_API_Client {
 
 		$request             = array_merge( $request, $additional_parameters );
 		$request['metadata'] = array_merge( $request['metadata'], $this->get_fingerprint_metadata() );
+
+		if ( apply_filters( 'wcpay_server_side_intent_confirmation', true ) || $off_session ) {
+			$request['confirm'] = 'true';
+		}
 
 		if ( $off_session ) {
 			$request['off_session'] = 'true';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a filter `wcpay_server_side_intent_confirmation'` allowing the `confirm` param to be omitted on intent creation for on-session payments. This applies to the non-UPE flow only (since UPE already/currently uses client-side confirmation), reuses the same code path that was built for the SCA flow (i.e. hash redirect), and enables Stripe.js to perform additional pre-confirmation actions if necessary.

The filter will be used in the same way as the existing filter `wcpay_force_network_saved_cards`, but I'm definitely open to suggestions on better ways to enable this customization (and on whether the filter should live at a higher level than the API client, for that matter) – cc @zmaglica et al.

I believe we _could_ enable client-side confirmation in all cases, but I wasn't prepared to make that change without further consideration, in part because there is a performance hit related to making the extra confirmation request (in many cases if not all).

(Can use an automated test, based on [this one](https://github.com/Automattic/woocommerce-payments/blob/ca4325592ba30bf2d15bd09c5d4e407e2a747fc2/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php#L68) – or if it's moved to the caller code, perhaps a test based on [this one](https://github.com/Automattic/woocommerce-payments/blob/ca4325592ba30bf2d15bd09c5d4e407e2a747fc2/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php#L698).)

#### Testing instructions

Add this somewhere (like [here](https://github.com/Automattic/woocommerce-payments/blob/ca4325592ba30bf2d15bd09c5d4e407e2a747fc2/includes/class-wc-payments.php#L390), or as a snippet):
```php
add_filter( 'wcpay_server_side_intent_confirmation', '__return_false' );
```
With "new checkout experience" disabled, place order on checkout and verify that the payment goes through. (Also, logs related to the intent should show an extra `/confirm` request.)

Can also test a renewal order and verify that it goes through as well (despite lack of client-side confirmation).

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
