### PR TITLE
Decode HTML in format currency for rendering currency symbols

### DIFF
--- a/changelog/update-4664-currency-formatting
+++ b/changelog/update-4664-currency-formatting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update formatCurrency to decode HTML entities for rendering currency symbols.

--- a/client/components/account-status/account-fees/test/__snapshots__/index.js.snap
+++ b/client/components/account-status/account-fees/test/__snapshots__/index.js.snap
@@ -415,9 +415,9 @@ exports[`AccountFees renders non-USD base fee 1`] = `
   Euro 
   (EUR) 
   <s>
-    2.9% + 0,25&nbsp;€ per transaction
+    2.9% + 0,25 € per transaction
   </s>
-   2.9% + 0,30&nbsp;€ per transaction
+   2.9% + 0,30 € per transaction
   <p>
     <a
       href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"

--- a/client/components/account-status/test/__snapshots__/index.js.snap
+++ b/client/components/account-status/test/__snapshots__/index.js.snap
@@ -131,9 +131,9 @@ exports[`AccountStatus renders normal status 1`] = `
       Euro 
       (EUR) 
       <s>
-        2.9% + 0,00&nbsp;€ per transaction
+        2.9% + 0,00 € per transaction
       </s>
-       2.9% + 0,30&nbsp;€ per transaction
+       2.9% + 0,30 € per transaction
       <p>
         <a
           href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"

--- a/client/components/deposits-information/test/__snapshots__/index.js.snap
+++ b/client/components/deposits-information/test/__snapshots__/index.js.snap
@@ -245,7 +245,7 @@ exports[`Deposits information renders correctly with multiple currencies 1`] = `
         <div
           class="wcpay-deposits-information-block__value"
         >
-          33,43&nbsp;€
+          33,43 €
         </div>
         <div
           class="wcpay-deposits-information-block__extra"
@@ -270,7 +270,7 @@ exports[`Deposits information renders correctly with multiple currencies 1`] = `
         <div
           class="wcpay-deposits-information-block__value"
         >
-          33,43&nbsp;€
+          33,43 €
         </div>
         <div
           class="wcpay-deposits-information-block__extra"
@@ -299,7 +299,7 @@ exports[`Deposits information renders correctly with multiple currencies 1`] = `
         <div
           class="wcpay-deposits-information-block__value"
         >
-          31,60&nbsp;€
+          31,60 €
         </div>
         <div
           class="wcpay-deposits-information-block__extra"
@@ -324,7 +324,7 @@ exports[`Deposits information renders correctly with multiple currencies 1`] = `
         <div
           class="wcpay-deposits-information-block__value"
         >
-          20,30&nbsp;€
+          20,30 €
         </div>
         <div
           class="wcpay-deposits-information-block__extra"
@@ -533,7 +533,7 @@ exports[`Deposits information renders instant deposit button only where applicab
         <div
           class="wcpay-deposits-information-block__value"
         >
-          33,43&nbsp;€
+          33,43 €
         </div>
         <div
           class="wcpay-deposits-information-block__extra"
@@ -558,7 +558,7 @@ exports[`Deposits information renders instant deposit button only where applicab
         <div
           class="wcpay-deposits-information-block__value"
         >
-          33,43&nbsp;€
+          33,43 €
         </div>
         <div
           class="wcpay-deposits-information-block__extra"
@@ -587,7 +587,7 @@ exports[`Deposits information renders instant deposit button only where applicab
         <div
           class="wcpay-deposits-information-block__value"
         >
-          31,60&nbsp;€
+          31,60 €
         </div>
         <div
           class="wcpay-deposits-information-block__extra"
@@ -612,7 +612,7 @@ exports[`Deposits information renders instant deposit button only where applicab
         <div
           class="wcpay-deposits-information-block__value"
         >
-          20,30&nbsp;€
+          20,30 €
         </div>
         <div
           class="wcpay-deposits-information-block__extra"

--- a/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
+++ b/client/payment-details/timeline/test/__snapshots__/map-events.js.snap
@@ -207,7 +207,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-04T13:51:06.000Z,
-    "headline": "21,64&nbsp;$ USD will be deducted from a future deposit.",
+    "headline": "21,64 $ USD will be deducted from a future deposit.",
     "icon": <t
       className=""
       icon="minus"
@@ -216,11 +216,11 @@ Array [
   },
   Object {
     "body": Array [
-      "1,00 EUR → 1,20222 USD: 21,64&nbsp;$ USD",
+      "1,00 EUR → 1,20222 USD: 21,64 $ USD",
       "",
     ],
     "date": 2020-04-04T13:51:06.000Z,
-    "headline": "A payment of 18,00&nbsp;€ EUR was successfully refunded.",
+    "headline": "A payment of 18,00 € EUR was successfully refunded.",
     "icon": <t
       className="is-success"
       icon="checkmark"
@@ -245,7 +245,7 @@ Array [
   Object {
     "body": Array [],
     "date": 2020-04-03T18:58:01.000Z,
-    "headline": "6,00&nbsp;$ USD will be deducted from a future deposit.",
+    "headline": "6,00 $ USD will be deducted from a future deposit.",
     "icon": <t
       className=""
       icon="minus"
@@ -254,11 +254,11 @@ Array [
   },
   Object {
     "body": Array [
-      "1,00 EUR → 1,2 USD: 6,00&nbsp;$ USD",
+      "1,00 EUR → 1,2 USD: 6,00 $ USD",
       "Acquirer Reference Number (ARN) 4785767637658864",
     ],
     "date": 2020-04-03T18:58:01.000Z,
-    "headline": "A payment of 5,00&nbsp;€ EUR was successfully refunded.",
+    "headline": "A payment of 5,00 € EUR was successfully refunded.",
     "icon": <t
       className="is-success"
       icon="checkmark"

--- a/client/utils/currency/index.js
+++ b/client/utils/currency/index.js
@@ -111,10 +111,12 @@ export const formatCurrency = (
 
 	try {
 		return 'function' === typeof currency.formatAmount
-			? currency.formatAmount( amount )
-			: currency.formatCurrency( amount );
+			? htmlDecode( currency.formatAmount( amount ) )
+			: htmlDecode( currency.formatCurrency( amount ) );
 	} catch ( err ) {
-		return composeFallbackCurrency( amount, currencyCode, isZeroDecimal );
+		return htmlDecode(
+			composeFallbackCurrency( amount, currencyCode, isZeroDecimal )
+		);
 	}
 };
 
@@ -261,4 +263,9 @@ function trimEndingZeroes( formattedCurrencyAmount = '' ) {
 			endsWith( chunk, '0' ) ? trimEnd( chunk, '0' ) : chunk
 		)
 		.join( ' ' );
+}
+
+function htmlDecode( input ) {
+	const doc = new DOMParser().parseFromString( input, 'text/html' );
+	return doc.documentElement.textContent;
 }

--- a/client/utils/currency/test/index.js
+++ b/client/utils/currency/test/index.js
@@ -100,7 +100,7 @@ describe( 'Currency utilities', () => {
 
 	test( 'getCurrency with baseCurrencyCode should not use store country currency', () => {
 		expect( utils.formatCurrency( 100000, 'USD', 'EUR' ) ).toEqual(
-			'1 000,00&nbsp;$'
+			'1 000,00 $'
 		);
 	} );
 


### PR DESCRIPTION
Fixes #4664 

#### Changes proposed in this Pull Request
- Currently, something like `&#67;&#72;&#70;` gets formatted to `&amp;#67;&amp;#72;&amp;#70;` which breaks rendering of the currency symbol, this introduces decoding HTML in `formatCurrency` to render the currency symbols properly.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
- Set up an account with CHF currency.
  - Select`CH` in the Stripe connect screen when selecting mobile code in first screen and then update currency to `CHF` in the bank selecting screen.
- Ensure the payments overview screen renders `CHF` currency properly.
- Since `formatCurrency` is used in other places like Transaction list and transaction details, this should fix the same issue in those places as well.

<img width="671" alt="Screenshot 2022-10-03 at 3 02 05 PM" src="https://user-images.githubusercontent.com/68396823/193545436-d7c65f45-c0c0-4434-a6a9-564a13a8ae88.png">


<img width="1340" alt="Screenshot 2022-10-03 at 3 02 24 PM" src="https://user-images.githubusercontent.com/68396823/193545506-2210cd28-8c46-4601-a532-da8a84bf6ae5.png">
<!--


Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
