### PR TITLE
Bump WC versions for 4.9.0 release

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -12,13 +12,13 @@ jobs:
       max-parallel: 10
       matrix:
         # Minimum support version, ..., Latest version, `beta`.
-        woocommerce: [ '6.6.1', '6.7.0', '6.8.2', 'latest', 'beta' ]
+        woocommerce: [ '6.8.2', 'latest', 'beta' ]
         wordpress:   [ 'latest' ]
         gutenberg:   [ 'latest' ]
         php:         [ '7.4' ]
         include:
           # Edge case: oldest dependencies compatibility
-          - woocommerce: '6.6.1'
+          - woocommerce: '6.8.2'
             wordpress:   '5.8'
             gutenberg:   '13.6.0' # The latest version supporting WP 5.8.
             php:         '7.2' # Minimum supported PHP version

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast:     false
       matrix:
         # Min WooCommerce | L-2 | L(atest) | beta
-        woocommerce:   [ '6.6.1', '6.7.0', '6.8.2', 'latest', 'beta' ]
+        woocommerce:   [ '6.8.2', 'latest', 'beta' ]
         test_groups:   [ 'wcpay', 'subscriptions' ]
         test_branches: [ 'merchant', 'shopper' ]
 

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   WP_VERSION:        latest
-  WC_VERSION: 6.6.1  # the min supported version as per L-2 policy
+  WC_VERSION: 6.8.2  # the min supported version as per L-2 policy
   GUTENBERG_VERSION: latest
 
 jobs:

--- a/changelog/dev-bump-versions-4-9-0
+++ b/changelog/dev-bump-versions-4-9-0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Bump minimum required version of WooCommerce to 6.8 to support L2 policy

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -11,7 +11,7 @@
  * WC requires at least: 6.8
  * WC tested up to: 7.0.0
  * Requires at least: 5.8
- * Requires PHP: 7.2
+ * Requires PHP: 7.0
  * Version: 4.8.0
  *
  * @package WooCommerce\Payments

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,10 +8,10 @@
  * Woo: 5278104:bf3cf30871604e15eec560c962593c1f
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
- * WC requires at least: 6.6
- * WC tested up to: 6.9.0
+ * WC requires at least: 6.8
+ * WC tested up to: 7.0.0
  * Requires at least: 5.8
- * Requires PHP: 7.0
+ * Requires PHP: 7.2
  * Version: 4.8.0
  *
  * @package WooCommerce\Payments


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Minimum required WooCommerce version bumped to 6.8.2 (L2 policy will be integrated with this release and WooCommerce 7 will be released in 8 days).
- WC tested up to bumped to 7.0.0
- Verify that E2E tests are passing. More info [here](https://github.com/Automattic/woocommerce-payments/actions/runs/3173926608/jobs/5170090762).


#### Testing instructions
- Verify that version numbers line up with the [WooCommerce release version numbers](https://developer.woocommerce.com/releases/).