### PR TITLE
Fix fatal errors thrown during the renewal process on stores without the wcpay feature enabled

### DIFF
--- a/changelog/issue-4829
+++ b/changelog/issue-4829
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error thrown during the renewal order payment flow when the store doesn't have the WCPay Subscriptions feature enabled

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -266,10 +266,8 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 		}
 
 		// Exit early if the order belongs to a WCPay Subscription. The payment will be processed by the subscription via webhooks.
-		foreach ( wcs_get_subscriptions_for_renewal_order( $renewal_order ) as $subscription ) {
-			if ( WC_Payments_Subscription_Service::is_wcpay_subscription( $subscription ) ) {
-				return;
-			}
+		if ( $this->is_wcpay_subscription_renewal_order( $renewal_order ) ) {
+			return;
 		}
 
 		try {
@@ -769,5 +767,28 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 		if ( isset( $this->order_pay_var ) ) {
 			$wp->query_vars['order-pay'] = $this->order_pay_var;
 		}
+	}
+
+	/**
+	 * Checks if a renewal order is linked to a WCPay subscription.
+	 *
+	 * @param WC_Order $renewal_order The renewal order to check.
+	 * @return bool True if the renewal order is linked to a renewal order. Otherwise false.
+	 */
+	private function is_wcpay_subscription_renewal_order( WC_Order $renewal_order ) {
+
+		// Exit early if WCPay subscriptions functionality isn't enabled.
+		if ( ! WC_Payments_Features::is_wcpay_subscriptions_enabled() ) {
+			return false;
+		}
+
+		// Check if the renewal order is linked to a subscription which is a WCPay Subscription.
+		foreach ( wcs_get_subscriptions_for_renewal_order( $renewal_order ) as $subscription ) {
+			if ( WC_Payments_Subscription_Service::is_wcpay_subscription( $subscription ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
> **Note**
> **This PR is being merged into `trunk` as this will be a patch release.**

Fixes #4829 

#### Changes proposed in this Pull Request

For stores with WC Subscriptions (the plugin) and WCPay Subscriptions (the feature) **disabled**, the following error occurs during the renewal order flow. 

```
Uncaught Error: Class "WC_Payments_Subscription_Service" not found in /srv/htdocs/wp-content/plugins/woocommerce-payments/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php:270
Stack trace:
#0 /wp-includes/class-wp-hook.php(307): WC_Payment_Gateway_WCPay->scheduled_subscription_payment('45.00', Object(Automattic\WooCommerce\Admin\Overrides\Order))
#1 /wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters('', Array)
#2 /wp-includes/plugin.php(476): WP_Hook->do_action(Array)
#3 /srv/htdocs/wp-content/plugins/woocommerce-subscriptions/includes/gateways/class-wc-subscriptions-payment-gateways.php(97): do_action('woocommerce_sch...', '45.00', Object(Automattic\WooCommerce\Admin\Overrides\Order))
#4 /srv/htdocs/wp-content/plugins/woocommerce-subscriptions/includes/gateways/class-wc-subscriptions-payment-gateways.php(81): WC_Subscriptions_Payment_Gateways::trigger_gateway_renewal_payment_hook(Object(Automattic\WooCommerce\Admin\Overrides\Order))
#5 /wp-includes/class-wp-hook.php(307): WC_Subscriptions_Payment_Gateways::gateway_scheduled_subscription_payment(70991)
#6 /wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters(NULL, Array)
#7 /wp-includes/plugin.php(524): WP_Hook->do_action(Array)
#8 /wordpress/plugins/woocommerce/6.9.4/packages/action-scheduler/classes/actions/ActionScheduler_Action.php(22): do_action_ref_array('woocommerce_sch...', Array)
#9 /wordpress/plugins/woocommerce/6.9.4/packages/action-scheduler/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php(65): ActionScheduler_Action->execute()
#10 /wordpress/plugins/woocommerce/6.9.4/packages/action-scheduler/classes/ActionScheduler_QueueRunner.php(162): ActionScheduler_Abstract_QueueRunner->process_action(75569, 'WP Cron')
#11 /wordpress/plugins/woocommerce/6.9.4/packages/action-scheduler/classes/ActionScheduler_QueueRunner.php(132): ActionScheduler_QueueRunner->do_batch(25, 'WP Cron')
#12 /wp-includes/class-wp-hook.php(307): ActionScheduler_QueueRunner->run('WP Cron')
#13 /wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters('', Array)
#14 /wp-includes/plugin.php(524): WP_Hook->do_action(Array)
#15 /wp-cron.php(138): do_action_ref_array('action_schedule...', Array)
#16 {main}
  thrown
```

The cause of this error was introduced in https://github.com/Automattic/woocommerce-payments/commit/e25a7e55cdcae2d407fd2a59753e6526e8ecfe54. 

The error occurs because the `WC_Payments_Subscription_Service` class is only loaded on stores with `WC_Payments_Features::is_wcpay_subscriptions_enabled()` ([code ref](https://github.com/automattic/woocommerce-payments/blob/issue/4829/includes/class-wc-payments.php#L383)). 

This PR fixes it by making sure we only call `WC_Payments_Features::is_wcpay_subscriptions_enabled()` if the WCPay subscription feature is enabled and therefore, the function is available.

### Testing instructions

**Fatal error fixed**

1. Make sure `WC_Payments_Features::is_wcpay_subscriptions_enabled` returns `false`. By either: 
     - hard coding it to return `false`,
     - use the filter `add_filter( 'wcpay_is_wcpay_subscriptions_enabled', '__return_false' )` \
     - change the option via the db. 
     - or go through the process of disabling the feature via the front end: 
          - Disable WC Subscription (the plugin).
          - Go to the WC Payments advanced settings
          - Uncheck the “Enable Subscriptions with WooCommerce Payments” setting
2. Enable the WC Subscriptions extension.
3. Purchase a subscription using WC Payments.
4. Go to the edit subscription screen for the newly purchased subscription.
5. From the **Actions** drop down select **"Process renewal"**
6. Save.

On `trunk` you will get a fatal error. On this branch the renewal should run successfully. 

**Previous double charge issue still fixed** 
_Copied from #4790_

> **Warning**
> 1. Make sure your site is listening to webhooks.
> 2. Remove any changes to `WC_Payments_Features::is_wcpay_subscriptions_enabled` you might have added for the test above.

1. With WC Subscriptions inactive, purchase a Subscription product. 
     - You will now have a WCPay Subscription
2. Use the billing clock to process a successful renewal order. 
3. Wait for the renewal order to be created.
     - Go to the customer's page in the Stripe dashboard: eg https://dashboard.stripe.com/acct_123/test/customers/cus_123
     - Make a note of the charges. There should be a single successful charge and a cancelled one. See screenshot below.
5. Enable the WC Subscriptions extension.
6. Go to the **Tools → Scheduled Actions** screen and search for the subscription's post ID. 
7. Run the `woocommerce_scheduled_subscription_payment` scheduled action.
    - Go to the customer's page in the Stripe dashboard again: eg https://dashboard.stripe.com/acct_123/test/customers/cus_123
    - There should still only be a single charge

You might want to add a breakpoint or error logging to observe that the payment process halts in this scenario because of [this](https://github.com/Automattic/woocommerce-payments/commit/45f84bacf3dc51f471828b323ae4f9c096866cef#diff-66bbfee02f23d61d5be427672d6f26214263718f1dcd3e5162c1e95bfdd7ad53R788) condition. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
