### PR TITLE
Refactor WC_Payment_Gateway_WCPay Part 1

### DIFF
--- a/changelog/fix-823-refactor-gateway-class
+++ b/changelog/fix-823-refactor-gateway-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Refactor WC_Payment_Gateway_WCPay part 1

--- a/includes/admin/class-wc-payments-admin-settings.php
+++ b/includes/admin/class-wc-payments-admin-settings.php
@@ -18,6 +18,17 @@ class WC_Payments_Admin_Settings {
 	private $gateway;
 
 	/**
+	 * Set of parameters to build the URL to the gateway's settings page.
+	 *
+	 * @var string[]
+	 */
+	private static $settings_url_params = [
+		'page'    => 'wc-settings',
+		'tab'     => 'checkout',
+		'section' => WC_Payment_Gateway_WCPay::GATEWAY_ID,
+	];
+
+	/**
 	 * Initialize class actions.
 	 *
 	 * @param WC_Payment_Gateway_WCPay $gateway Payment Gateway.
@@ -42,5 +53,23 @@ class WC_Payments_Admin_Settings {
 			</div>
 			<?php
 		}
+	}
+
+	/**
+	 * Whether the current page is the WooCommerce Payments settings page.
+	 *
+	 * @return bool
+	 */
+	public static function is_current_page_settings() {
+		return count( self::$settings_url_params ) === count( array_intersect_assoc( $_GET, self::$settings_url_params ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
+	 * Returns the URL of the configuration screen for this gateway, for use in internal links.
+	 *
+	 * @return string URL of the configuration screen for this gateway
+	 */
+	public static function get_settings_url() {
+		return admin_url( add_query_arg( self::$settings_url_params, 'admin.php' ) );
 	}
 }

--- a/includes/admin/class-wc-payments-admin-settings.php
+++ b/includes/admin/class-wc-payments-admin-settings.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Class WC_Payments_Admin_Settings
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+/**
+ * WC_Payments_Admin_Settings class.
+ */
+class WC_Payments_Admin_Settings {
+
+	/**
+	 * WC_Payment_Gateway_WCPay.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private $gateway;
+
+	/**
+	 * Initialize class actions.
+	 *
+	 * @param WC_Payment_Gateway_WCPay $gateway Payment Gateway.
+	 */
+	public function __construct( WC_Payment_Gateway_WCPay $gateway ) {
+		$this->gateway = $gateway;
+
+		add_action( 'woocommerce_woocommerce_payments_admin_notices', [ $this, 'display_test_mode_notice' ] );
+	}
+
+	/**
+	 * Add notice explaining test mode when it's enabled.
+	 */
+	public function display_test_mode_notice() {
+		if ( $this->gateway->is_in_test_mode() ) {
+			?>
+			<div id="wcpay-test-mode-notice" class="notice notice-warning">
+				<p>
+					<b><?php esc_html_e( 'Test mode active: ', 'woocommerce-payments' ); ?></b>
+					<?php esc_html_e( "All transactions are simulated. Customers can't make real purchases through WooCommerce Payments.", 'woocommerce-payments' ); ?>
+				</p>
+			</div>
+			<?php
+		}
+	}
+}

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -90,6 +90,8 @@ class WC_Payments_Admin {
 		$this->account             = $account;
 		$this->database_cache      = $database_cache;
 
+		add_action( 'admin_notices', [ $this, 'display_not_supported_currency_notice' ], 9999 );
+
 		// Add menu items.
 		add_action( 'admin_menu', [ $this, 'add_payments_menu' ], 0 );
 		add_action( 'admin_init', [ $this, 'maybe_redirect_to_onboarding' ], 11 ); // Run this after the WC setup wizard and onboarding redirection logic.
@@ -139,6 +141,29 @@ class WC_Payments_Admin {
 				],
 			],
 		];
+	}
+
+	/**
+	 * Add notice explaining that the selected currency is not available.
+	 */
+	public function display_not_supported_currency_notice() {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
+		if ( ! $this->wcpay_gateway->is_available_for_current_currency() ) {
+			?>
+			<div id="wcpay-unsupported-currency-notice" class="notice notice-warning">
+				<p>
+					<b>
+						<?php esc_html_e( 'Unsupported currency:', 'woocommerce-payments' ); ?>
+						<?php esc_html( ' ' . get_woocommerce_currency() ); ?>
+					</b>
+					<?php esc_html_e( 'The selected currency is not available for the country set in your WooCommerce Payments account.', 'woocommerce-payments' ); ?>
+				</p>
+			</div>
+			<?php
+		}
 	}
 
 	/**
@@ -788,7 +813,8 @@ class WC_Payments_Admin {
 	 * This is where the "Are you sure you want to disable WCPay?" confirmation dialog is rendered.
 	 */
 	public function payment_gateways_container() {
-		?><div id="wcpay-payment-gateways-container" />
+		?>
+		<div id="wcpay-payment-gateways-container" />
 		<?php
 	}
 

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -320,7 +320,7 @@ class WC_Payments_Admin {
 			$submenu[ $last_submenu_key ][] = [ // PHPCS:Ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 				$this->get_settings_menu_item_name(),
 				'manage_woocommerce',
-				WC_Payment_Gateway_WCPay::get_settings_url(),
+				WC_Payments_Admin_Settings::get_settings_url(),
 			];
 
 			// Temporary fix to settings menu disappearance is to register the page after settings menu has been manually added.
@@ -640,7 +640,7 @@ class WC_Payments_Admin {
 				'WCPAY_TOS',
 				'wcpay_tos_settings',
 				[
-					'settingsUrl'          => $this->wcpay_gateway->get_settings_url(),
+					'settingsUrl'          => WC_Payments_Admin_Settings::get_settings_url(),
 					'tosAgreementRequired' => $tos_agreement_required,
 					'tosAgreementDeclined' => $tos_agreement_declined,
 					'trackStripeConnected' => $track_stripe_connected,

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -380,57 +380,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Add a new logo column on the right of "method" in the payment methods table.
-	 *
-	 * @param array $columns the columns in the "all payment methods" page.
-	 *
-	 * @deprecated 4.9.0
-	 *
-	 * @return array
-	 */
-	public function add_all_payment_methods_logos_column( $columns ) {
-		wc_deprecated_function( __FUNCTION__, '4.9.0' );
-		$logos  = [ 'logos' => '' ]; // Setting an ID for the column, but not a label.
-		$offset = array_search( 'name', array_keys( $columns ), true ) + 1;
-
-		return array_merge( array_slice( $columns, 0, $offset ), $logos, array_slice( $columns, $offset ) );
-	}
-
-	/**
-	 * Add a list of payment method logos to WooCommerce Payment in the logo column.
-	 *
-	 * @param WC_Payment_Gateway $gateway the current gateway iterated over to be displayed in the "all payment methods" page.
-	 *
-	 * @deprecated 4.9.0
-	 */
-	public function add_all_payment_methods_icon_logos( $gateway ) {
-		wc_deprecated_function( __FUNCTION__, '4.9.0' );
-		if ( 'woocommerce_payments' !== $gateway->id ) {
-			echo '<td class="logo"></td>';
-
-			return;
-		}
-
-		$icons = [
-			'visa',
-			'mastercard',
-			'amex',
-			'apple-pay',
-			'google-pay',
-		];
-
-		echo '<td class="logo">';
-		?>
-		<div>
-			<?php foreach ( $icons as $icon ) : ?>
-				<span class="payment-method__icon payment-method__brand payment-method__brand--<?php echo esc_attr( $icon ); ?>"/></span>
-			<?php endforeach; ?>
-		</div>
-		<?php
-		echo '</td>';
-	}
-
-	/**
 	 * Proceed with current request using new login session (to ensure consistent nonce).
 	 *
 	 * @param string $cookie New cookie value.
@@ -460,30 +409,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		$account_status = $this->account->get_account_status_data();
 		return parent::needs_setup() || ! empty( $account_status['error'] ) || ! $account_status['paymentsEnabled'];
-	}
-
-	/**
-	 * Whether the current page is the WooCommerce Payments settings page.
-	 *
-	 * @deprecated 4.9.0
-	 *
-	 * @return bool
-	 */
-	public static function is_current_page_settings() {
-		wc_deprecated_function( __FUNCTION__, '4.9.0', 'WC_Payments_Admin_Settings::is_current_page_settings' );
-		return WC_Payments_Admin_Settings::is_current_page_settings();
-	}
-
-	/**
-	 * Returns the URL of the configuration screen for this gateway, for use in internal links.
-	 *
-	 * @deprecated 4.9.0
-	 *
-	 * @return string URL of the configuration screen for this gateway
-	 */
-	public static function get_settings_url() {
-		wc_deprecated_function( __FUNCTION__, '4.9.0', 'WC_Payments_Admin_Settings::get_settings_url' );
-		return WC_Payments_Admin_Settings::get_settings_url();
 	}
 
 	/**
@@ -620,21 +545,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Generates the configuration values, needed for payment fields.
-	 *
-	 * Isolated as a separate method in order to be available both
-	 * during the classic checkout, as well as the checkout block.
-	 *
-	 * @deprecated use WC_Payments_Checkout::get_payment_fields_js_config instead.
-	 *
-	 * @return array
-	 */
-	public function get_payment_fields_js_config() {
-		wc_deprecated_function( __FUNCTION__, '4.9.0', 'WC_Payments_Checkout::get_payment_fields_js_config' );
-		return WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config();
-	}
-
-	/**
 	 * Registers all scripts, necessary for the gateway.
 	 */
 	public function register_scripts() {
@@ -710,20 +620,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Prepares customer data to be used on 'Pay for Order' or 'Add Payment Method' pages.
-	 * Customer data is retrieved from order when on Pay for Order.
-	 * Customer data is retrieved from customer when on 'Add Payment Method'.
-	 *
-	 * @deprecated use WC_Payments_Customer_Service::get_prepared_customer_data() instead.
-	 *
-	 * @return array|null An array with customer data or nothing.
-	 */
-	public function get_prepared_customer_data() {
-		wc_deprecated_function( __FUNCTION__, '4.9.0', 'WC_Payments_Customer_Service::get_prepared_customer_data' );
-		return WC_Payments::get_customer_service()->get_prepared_customer_data();
 	}
 
 	/**
@@ -3047,6 +2943,114 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 		return $field;
 	}
+
+	// Start: Deprecated functions.
+
+	/**
+	 * Add a new logo column on the right of "method" in the payment methods table.
+	 *
+	 * @param array $columns the columns in the "all payment methods" page.
+	 *
+	 * @deprecated 4.9.0
+	 *
+	 * @return array
+	 */
+	public function add_all_payment_methods_logos_column( $columns ) {
+		wc_deprecated_function( __FUNCTION__, '4.9.0' );
+		$logos  = [ 'logos' => '' ]; // Setting an ID for the column, but not a label.
+		$offset = array_search( 'name', array_keys( $columns ), true ) + 1;
+
+		return array_merge( array_slice( $columns, 0, $offset ), $logos, array_slice( $columns, $offset ) );
+	}
+
+	/**
+	 * Add a list of payment method logos to WooCommerce Payment in the logo column.
+	 *
+	 * @param WC_Payment_Gateway $gateway the current gateway iterated over to be displayed in the "all payment methods" page.
+	 *
+	 * @deprecated 4.9.0
+	 */
+	public function add_all_payment_methods_icon_logos( $gateway ) {
+		wc_deprecated_function( __FUNCTION__, '4.9.0' );
+		if ( 'woocommerce_payments' !== $gateway->id ) {
+			echo '<td class="logo"></td>';
+
+			return;
+		}
+
+		$icons = [
+			'visa',
+			'mastercard',
+			'amex',
+			'apple-pay',
+			'google-pay',
+		];
+
+		echo '<td class="logo">';
+		?>
+		<div>
+			<?php foreach ( $icons as $icon ) : ?>
+				<span class="payment-method__icon payment-method__brand payment-method__brand--<?php echo esc_attr( $icon ); ?>"/></span>
+			<?php endforeach; ?>
+		</div>
+		<?php
+		echo '</td>';
+	}
+
+	/**
+	 * Whether the current page is the WooCommerce Payments settings page.
+	 *
+	 * @deprecated 4.9.0
+	 *
+	 * @return bool
+	 */
+	public static function is_current_page_settings() {
+		wc_deprecated_function( __FUNCTION__, '4.9.0', 'WC_Payments_Admin_Settings::is_current_page_settings' );
+		return WC_Payments_Admin_Settings::is_current_page_settings();
+	}
+
+	/**
+	 * Returns the URL of the configuration screen for this gateway, for use in internal links.
+	 *
+	 * @deprecated 4.9.0
+	 *
+	 * @return string URL of the configuration screen for this gateway
+	 */
+	public static function get_settings_url() {
+		wc_deprecated_function( __FUNCTION__, '4.9.0', 'WC_Payments_Admin_Settings::get_settings_url' );
+		return WC_Payments_Admin_Settings::get_settings_url();
+	}
+
+	/**
+	 * Generates the configuration values, needed for payment fields.
+	 *
+	 * Isolated as a separate method in order to be available both
+	 * during the classic checkout, as well as the checkout block.
+	 *
+	 * @deprecated use WC_Payments_Checkout::get_payment_fields_js_config instead.
+	 *
+	 * @return array
+	 */
+	public function get_payment_fields_js_config() {
+		wc_deprecated_function( __FUNCTION__, '4.9.0', 'WC_Payments_Checkout::get_payment_fields_js_config' );
+		return WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config();
+	}
+
+	/**
+	 * Prepares customer data to be used on 'Pay for Order' or 'Add Payment Method' pages.
+	 * Customer data is retrieved from order when on Pay for Order.
+	 * Customer data is retrieved from customer when on 'Add Payment Method'.
+	 *
+	 * @deprecated use WC_Payments_Customer_Service::get_prepared_customer_data() instead.
+	 *
+	 * @return array|null An array with customer data or nothing.
+	 */
+	public function get_prepared_customer_data() {
+		wc_deprecated_function( __FUNCTION__, '4.9.0', 'WC_Payments_Customer_Service::get_prepared_customer_data' );
+		return WC_Payments::get_customer_service()->get_prepared_customer_data();
+	}
+
+	// End: Deprecated functions.
 
 	/**
 	 * Determine if current payment method is a platform payment method.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1717,7 +1717,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 *
 	 * @return string Statement descriptor of default value.
 	 */
-	protected function get_account_statement_descriptor( string $empty_value = '' ): string {
+	public function get_account_statement_descriptor( string $empty_value = '' ): string {
 		try {
 			if ( $this->is_connected() ) {
 				return $this->account->get_statement_descriptor();

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -76,17 +76,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	const USER_FORMATTED_TOKENS_LIMIT = 100;
 
 	/**
-	 * Set of parameters to build the URL to the gateway's settings page.
-	 *
-	 * @var string[]
-	 */
-	private static $settings_url_params = [
-		'page'    => 'wc-settings',
-		'tab'     => 'checkout',
-		'section' => self::GATEWAY_ID,
-	];
-
-	/**
 	 * Client for making requests to the WooCommerce Payments API
 	 *
 	 * @var WC_Payments_API_Client
@@ -422,24 +411,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		$account_status = $this->account->get_account_status_data();
 		return parent::needs_setup() || ! empty( $account_status['error'] ) || ! $account_status['paymentsEnabled'];
-	}
-
-	/**
-	 * Whether the current page is the WooCommerce Payments settings page.
-	 *
-	 * @return bool
-	 */
-	public static function is_current_page_settings() {
-		return count( self::$settings_url_params ) === count( array_intersect_assoc( $_GET, self::$settings_url_params ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	}
-
-	/**
-	 * Returns the URL of the configuration screen for this gateway, for use in internal links.
-	 *
-	 * @return string URL of the configuration screen for this gateway
-	 */
-	public static function get_settings_url() {
-		return admin_url( add_query_arg( self::$settings_url_params, 'admin.php' ) );
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -713,7 +713,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			if ( $display_tokenization ) {
 				$this->tokenization_script();
-				echo $this->saved_payment_methods(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				$this->saved_payment_methods();
 			}
 			?>
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -380,6 +380,57 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Add a new logo column on the right of "method" in the payment methods table.
+	 *
+	 * @param array $columns the columns in the "all payment methods" page.
+	 *
+	 * @deprecated 4.9.0
+	 *
+	 * @return array
+	 */
+	public function add_all_payment_methods_logos_column( $columns ) {
+		wc_deprecated_function( __FUNCTION__, '4.9.0' );
+		$logos  = [ 'logos' => '' ]; // Setting an ID for the column, but not a label.
+		$offset = array_search( 'name', array_keys( $columns ), true ) + 1;
+
+		return array_merge( array_slice( $columns, 0, $offset ), $logos, array_slice( $columns, $offset ) );
+	}
+
+	/**
+	 * Add a list of payment method logos to WooCommerce Payment in the logo column.
+	 *
+	 * @param WC_Payment_Gateway $gateway the current gateway iterated over to be displayed in the "all payment methods" page.
+	 *
+	 * @deprecated 4.9.0
+	 */
+	public function add_all_payment_methods_icon_logos( $gateway ) {
+		wc_deprecated_function( __FUNCTION__, '4.9.0' );
+		if ( 'woocommerce_payments' !== $gateway->id ) {
+			echo '<td class="logo"></td>';
+
+			return;
+		}
+
+		$icons = [
+			'visa',
+			'mastercard',
+			'amex',
+			'apple-pay',
+			'google-pay',
+		];
+
+		echo '<td class="logo">';
+		?>
+		<div>
+			<?php foreach ( $icons as $icon ) : ?>
+				<span class="payment-method__icon payment-method__brand payment-method__brand--<?php echo esc_attr( $icon ); ?>"/></span>
+			<?php endforeach; ?>
+		</div>
+		<?php
+		echo '</td>';
+	}
+
+	/**
 	 * Proceed with current request using new login session (to ensure consistent nonce).
 	 *
 	 * @param string $cookie New cookie value.
@@ -409,6 +460,30 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		$account_status = $this->account->get_account_status_data();
 		return parent::needs_setup() || ! empty( $account_status['error'] ) || ! $account_status['paymentsEnabled'];
+	}
+
+	/**
+	 * Whether the current page is the WooCommerce Payments settings page.
+	 *
+	 * @deprecated 4.9.0
+	 *
+	 * @return bool
+	 */
+	public static function is_current_page_settings() {
+		wc_deprecated_function( __FUNCTION__, '4.9.0', 'WC_Payments_Admin_Settings::is_current_page_settings' );
+		return WC_Payments_Admin_Settings::is_current_page_settings();
+	}
+
+	/**
+	 * Returns the URL of the configuration screen for this gateway, for use in internal links.
+	 *
+	 * @deprecated 4.9.0
+	 *
+	 * @return string URL of the configuration screen for this gateway
+	 */
+	public static function get_settings_url() {
+		wc_deprecated_function( __FUNCTION__, '4.9.0', 'WC_Payments_Admin_Settings::get_settings_url' );
+		return WC_Payments_Admin_Settings::get_settings_url();
 	}
 
 	/**
@@ -545,6 +620,21 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Generates the configuration values, needed for payment fields.
+	 *
+	 * Isolated as a separate method in order to be available both
+	 * during the classic checkout, as well as the checkout block.
+	 *
+	 * @deprecated use WC_Payments_Checkout::get_payment_fields_js_config instead.
+	 *
+	 * @return array
+	 */
+	public function get_payment_fields_js_config() {
+		wc_deprecated_function( __FUNCTION__, '4.9.0', 'WC_Payments_Checkout::get_payment_fields_js_config' );
+		return WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config();
+	}
+
+	/**
 	 * Registers all scripts, necessary for the gateway.
 	 */
 	public function register_scripts() {
@@ -620,6 +710,20 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Prepares customer data to be used on 'Pay for Order' or 'Add Payment Method' pages.
+	 * Customer data is retrieved from order when on Pay for Order.
+	 * Customer data is retrieved from customer when on 'Add Payment Method'.
+	 *
+	 * @deprecated use WC_Payments_Customer_Service::get_prepared_customer_data() instead.
+	 *
+	 * @return array|null An array with customer data or nothing.
+	 */
+	public function get_prepared_customer_data() {
+		wc_deprecated_function( __FUNCTION__, '4.9.0', 'WC_Payments_Customer_Service::get_prepared_customer_data' );
+		return WC_Payments::get_customer_service()->get_prepared_customer_data();
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -664,52 +664,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		return false;
 	}
 
-	/**
-	 * Prepares customer data to be used on 'Pay for Order' or 'Add Payment Method' pages.
-	 * Customer data is retrieved from order when on Pay for Order.
-	 * Customer data is retrieved from customer when on 'Add Payment Method'.
-	 *
-	 * @return array|null An array with customer data or nothing.
-	 */
-	public function get_prepared_customer_data() {
-		if ( ! isset( $_GET['pay_for_order'] ) && ! is_add_payment_method_page() ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return null;
-		}
 
-		global $wp;
-		$user_email = '';
-		$firstname  = '';
-		$lastname   = '';
-
-		if ( isset( $_GET['pay_for_order'] ) && 'true' === $_GET['pay_for_order'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$order_id = absint( $wp->query_vars['order-pay'] );
-			$order    = wc_get_order( $order_id );
-
-			if ( is_a( $order, 'WC_Order' ) ) {
-				$firstname  = $order->get_billing_first_name();
-				$lastname   = $order->get_billing_last_name();
-				$name       = $firstname . ' ' . $lastname;
-				$user_email = $order->get_billing_email();
-			}
-		}
-
-		if ( is_add_payment_method_page() ) {
-			$user = wp_get_current_user();
-
-			if ( $user->ID ) {
-				$firstname  = $user->user_firstname;
-				$lastname   = $user->user_lastname;
-				$user_email = get_user_meta( $user->ID, 'billing_email', true );
-				$user_email = $user_email ? $user_email : $user->user_email;
-			}
-		}
-		$prepared_customer_data = [
-			'name'  => $firstname . ' ' . $lastname,
-			'email' => $user_email,
-		];
-
-		return $prepared_customer_data;
-	}
 	/**
 	 * Renders the credit card input fields needed to get the user's payment information on the checkout page.
 	 *
@@ -721,7 +676,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			add_action( 'wp_footer', [ $this, 'enqueue_payment_scripts' ] );
 
-			$prepared_customer_data = $this->get_prepared_customer_data();
+			$prepared_customer_data = $this->customer_service->get_prepared_customer_data();
 			if ( ! empty( $prepared_customer_data ) ) {
 				wp_localize_script( 'WCPAY_CHECKOUT', 'wcpayCustomerData', $prepared_customer_data );
 			}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -368,7 +368,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
 		add_action( 'admin_notices', [ $this, 'display_errors' ], 9999 );
-		add_action( 'woocommerce_woocommerce_payments_admin_notices', [ $this, 'display_test_mode_notice' ] );
 		add_action( 'admin_notices', [ $this, 'display_not_supported_currency_notice' ], 9999 );
 		add_action( 'woocommerce_order_actions', [ $this, 'add_order_actions' ] );
 		add_action( 'woocommerce_order_action_capture_charge', [ $this, 'capture_charge' ] );
@@ -588,22 +587,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		return in_array( $current_currency, $supported_currencies, true );
-	}
-
-	/**
-	 * Add notice explaining test mode when it's enabled.
-	 */
-	public function display_test_mode_notice() {
-		if ( $this->is_in_test_mode() ) {
-			?>
-			<div id="wcpay-test-mode-notice" class="notice notice-warning">
-				<p>
-					<b><?php esc_html_e( 'Test mode active: ', 'woocommerce-payments' ); ?></b>
-					<?php esc_html_e( "All transactions are simulated. Customers can't make real purchases through WooCommerce Payments.", 'woocommerce-payments' ); ?>
-				</p>
-			</div>
-			<?php
-		}
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -406,7 +406,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * external plugins to check if a connection has been established.
 	 */
 	public function is_connected() {
-		return $this->account->is_stripe_connected( false );
+		return $this->account->is_stripe_connected();
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -393,50 +393,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Add a new logo column on the right of "method" in the payment methods table.
-	 *
-	 * @param array $columns the columns in the "all payment methods" page.
-	 * @return array
-	 */
-	public function add_all_payment_methods_logos_column( $columns ) {
-		$logos  = [ 'logos' => '' ]; // Setting an ID for the column, but not a label.
-		$offset = array_search( 'name', array_keys( $columns ), true ) + 1;
-
-		return array_merge( array_slice( $columns, 0, $offset ), $logos, array_slice( $columns, $offset ) );
-	}
-
-	/**
-	 * Add a list of payment method logos to WooCommerce Payment in the logo column.
-	 *
-	 * @param WC_Payment_Gateway $gateway the current gateway iterated over to be displayed in the "all payment methods" page.
-	 */
-	public function add_all_payment_methods_icon_logos( $gateway ) {
-		if ( 'woocommerce_payments' !== $gateway->id ) {
-			echo '<td class="logo"></td>';
-
-			return;
-		}
-
-		$icons = [
-			'visa',
-			'mastercard',
-			'amex',
-			'apple-pay',
-			'google-pay',
-		];
-
-		echo '<td class="logo">';
-		?>
-		<div>
-			<?php foreach ( $icons as $icon ) : ?>
-				<span class="payment-method__icon payment-method__brand payment-method__brand--<?php echo esc_attr( $icon ); ?>"/></span>
-			<?php endforeach; ?>
-		</div>
-		<?php
-		echo '</td>';
-	}
-
-	/**
 	 * Proceed with current request using new login session (to ensure consistent nonce).
 	 *
 	 * @param string $cookie New cookie value.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2947,57 +2947,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	// Start: Deprecated functions.
 
 	/**
-	 * Add a new logo column on the right of "method" in the payment methods table.
-	 *
-	 * @param array $columns the columns in the "all payment methods" page.
-	 *
-	 * @deprecated 4.9.0
-	 *
-	 * @return array
-	 */
-	public function add_all_payment_methods_logos_column( $columns ) {
-		wc_deprecated_function( __FUNCTION__, '4.9.0' );
-		$logos  = [ 'logos' => '' ]; // Setting an ID for the column, but not a label.
-		$offset = array_search( 'name', array_keys( $columns ), true ) + 1;
-
-		return array_merge( array_slice( $columns, 0, $offset ), $logos, array_slice( $columns, $offset ) );
-	}
-
-	/**
-	 * Add a list of payment method logos to WooCommerce Payment in the logo column.
-	 *
-	 * @param WC_Payment_Gateway $gateway the current gateway iterated over to be displayed in the "all payment methods" page.
-	 *
-	 * @deprecated 4.9.0
-	 */
-	public function add_all_payment_methods_icon_logos( $gateway ) {
-		wc_deprecated_function( __FUNCTION__, '4.9.0' );
-		if ( 'woocommerce_payments' !== $gateway->id ) {
-			echo '<td class="logo"></td>';
-
-			return;
-		}
-
-		$icons = [
-			'visa',
-			'mastercard',
-			'amex',
-			'apple-pay',
-			'google-pay',
-		];
-
-		echo '<td class="logo">';
-		?>
-		<div>
-			<?php foreach ( $icons as $icon ) : ?>
-				<span class="payment-method__icon payment-method__brand payment-method__brand--<?php echo esc_attr( $icon ); ?>"/></span>
-			<?php endforeach; ?>
-		</div>
-		<?php
-		echo '</td>';
-	}
-
-	/**
 	 * Whether the current page is the WooCommerce Payments settings page.
 	 *
 	 * @deprecated 4.9.0

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -357,7 +357,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
 		add_action( 'admin_notices', [ $this, 'display_errors' ], 9999 );
-		add_action( 'admin_notices', [ $this, 'display_not_supported_currency_notice' ], 9999 );
 		add_action( 'woocommerce_order_actions', [ $this, 'add_order_actions' ] );
 		add_action( 'woocommerce_order_action_capture_charge', [ $this, 'capture_charge' ] );
 		add_action( 'woocommerce_order_action_cancel_authorization', [ $this, 'cancel_authorization' ] );
@@ -514,29 +513,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		return in_array( $current_currency, $supported_currencies, true );
-	}
-
-	/**
-	 * Add notice explaining that the selected currency is not available.
-	 */
-	public function display_not_supported_currency_notice() {
-		if ( ! current_user_can( 'manage_woocommerce' ) ) {
-			return;
-		}
-
-		if ( ! $this->is_available_for_current_currency() ) {
-			?>
-			<div id="wcpay-unsupported-currency-notice" class="notice notice-warning">
-				<p>
-					<b>
-						<?php esc_html_e( 'Unsupported currency:', 'woocommerce-payments' ); ?>
-						<?php esc_html( ' ' . get_woocommerce_currency() ); ?>
-					</b>
-					<?php esc_html_e( 'The selected currency is not available for the country set in your WooCommerce Payments account.', 'woocommerce-payments' ); ?>
-				</p>
-			</div>
-			<?php
-		}
 	}
 
 	/**

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -569,7 +569,7 @@ class WC_Payments_Account {
 			return false;
 		}
 
-		$is_on_settings_page           = WC_Payment_Gateway_WCPay::is_current_page_settings();
+		$is_on_settings_page           = WC_Payments_Admin_Settings::is_current_page_settings();
 		$should_redirect_to_onboarding = (bool) get_option( 'wcpay_should_redirect_to_onboarding', false );
 
 		if (
@@ -711,7 +711,7 @@ class WC_Payments_Account {
 		}
 
 		if ( isset( $_GET['wcpay-reconnect-wpcom'] ) && check_admin_referer( 'wcpay-reconnect-wpcom' ) ) {
-			$this->payments_api_client->start_server_connection( WC_Payment_Gateway_WCPay::get_settings_url() );
+			$this->payments_api_client->start_server_connection( WC_Payments_Admin_Settings::get_settings_url() );
 			return;
 		}
 

--- a/includes/class-wc-payments-blocks-payment-method.php
+++ b/includes/class-wc-payments-blocks-payment-method.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+use WCPay\WC_Payments_Checkout;
 
 /**
  * The payment method, which allows the gateway to work with WooCommerce Blocks.
@@ -17,6 +18,13 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 	 * @var WC_Payment_Gateway_WCPay
 	 */
 	private $gateway;
+
+	/**
+	 * WC Payments Checkout
+	 *
+	 * @var WC_Payments_Checkout
+	 */
+	private $wc_payments_checkout;
 
 	/**
 	 * Initializes the class.

--- a/includes/class-wc-payments-blocks-payment-method.php
+++ b/includes/class-wc-payments-blocks-payment-method.php
@@ -22,8 +22,9 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 	 * Initializes the class.
 	 */
 	public function initialize() {
-		$this->name    = WC_Payment_Gateway_WCPay::GATEWAY_ID;
-		$this->gateway = WC_Payments::get_gateway();
+		$this->name                 = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+		$this->gateway              = WC_Payments::get_gateway();
+		$this->wc_payments_checkout = WC_Payments::get_wc_payments_checkout();
 	}
 
 	/**
@@ -90,7 +91,7 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 				'is_admin'    => is_admin(), // Used to display payment method preview in wp-admin.
 			],
 			$platform_checkout_config,
-			$this->gateway->get_payment_fields_js_config()
+			$this->wc_payments_checkout->get_payment_fields_js_config()
 		);
 	}
 }

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * Class WC_Payments_Checkout
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay;
+
+use Jetpack_Options;
+use WC_AJAX;
+use WC_Checkout;
+use WC_Payment_Gateway_WCPay;
+use WC_Payments;
+use WC_Payments_Account;
+use WC_Payments_Customer_Service;
+use WC_Payments_Features;
+use WC_Payments_Utils;
+use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
+use WCPay\Platform_Checkout\Platform_Checkout_Utilities;
+
+
+/**
+ * WC_Payments_Checkout
+ */
+class WC_Payments_Checkout {
+
+	/**
+	 * WC Payments Gateway.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private $gateway;
+
+	/**
+	 * Platform Checkout Utilities.
+	 *
+	 * @var Platform_Checkout_Utilities
+	 */
+	private $platform_checkout_util;
+
+	/**
+	 * WC Payments Account.
+	 *
+	 * @var WC_Payments_Account
+	 */
+	private $account;
+
+	/**
+	 * WC Payments Customer Service
+	 *
+	 * @var WC_Payments_Customer_Service
+	 */
+	private $customer_service;
+
+
+	/**
+	 * Construct.
+	 *
+	 * @param WC_Payment_Gateway_WCPay     $gateway                WC Payment Gateway.
+	 * @param Platform_Checkout_Utilities  $platform_checkout_util Platform Checkout Utilities.
+	 * @param WC_Payments_Account          $account                WC Payments Account.
+	 * @param WC_Payments_Customer_Service $customer_service       WC Payments Customer Service.
+	 */
+	public function __construct(
+		WC_Payment_Gateway_WCPay $gateway,
+		Platform_Checkout_Utilities $platform_checkout_util,
+		WC_Payments_Account $account,
+		WC_Payments_Customer_Service $customer_service
+	) {
+		$this->gateway                = $gateway;
+		$this->platform_checkout_util = $platform_checkout_util;
+		$this->account                = $account;
+		$this->customer_service       = $customer_service;
+
+		add_action( 'wc_payments_add_payment_fields', [ $this, 'payment_fields' ] );
+	}
+
+	/**
+	 * Enqueues and localizes WCPay's checkout scripts.
+	 */
+	public function enqueue_payment_scripts() {
+		wp_localize_script( 'WCPAY_CHECKOUT', 'wcpay_config', $this->get_payment_fields_js_config() );
+		wp_enqueue_script( 'WCPAY_CHECKOUT' );
+	}
+
+	/**
+	 * Generates the configuration values, needed for payment fields.
+	 *
+	 * Isolated as a separate method in order to be available both
+	 * during the classic checkout, as well as the checkout block.
+	 *
+	 * @return array
+	 */
+	public function get_payment_fields_js_config() {
+
+		$wc_checkout = WC_Checkout::instance();
+
+		return [
+			'publishableKey'                   => $this->account->get_publishable_key( $this->gateway->is_in_test_mode() ),
+			'testMode'                         => $this->gateway->is_in_test_mode(),
+			'accountId'                        => $this->account->get_stripe_account_id(),
+			'ajaxUrl'                          => admin_url( 'admin-ajax.php' ),
+			'wcAjaxUrl'                        => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+			'createSetupIntentNonce'           => wp_create_nonce( 'wcpay_create_setup_intent_nonce' ),
+			'createPaymentIntentNonce'         => wp_create_nonce( 'wcpay_create_payment_intent_nonce' ),
+			'updatePaymentIntentNonce'         => wp_create_nonce( 'wcpay_update_payment_intent_nonce' ),
+			'initPlatformCheckoutNonce'        => wp_create_nonce( 'wcpay_init_platform_checkout_nonce' ),
+			'genericErrorMessage'              => __( 'There was a problem processing the payment. Please check your email inbox and refresh the page to try again.', 'woocommerce-payments' ),
+			'fraudServices'                    => $this->account->get_fraud_services_config(),
+			'features'                         => $this->gateway->supports,
+			'forceNetworkSavedCards'           => WC_Payments::is_network_saved_cards_enabled() || $this->gateway->should_use_stripe_platform_on_checkout_page(),
+			'locale'                           => WC_Payments_Utils::convert_to_stripe_locale( get_locale() ),
+			'isUPEEnabled'                     => WC_Payments_Features::is_upe_enabled(),
+			'isSavedCardsEnabled'              => $this->gateway->is_saved_cards_enabled(),
+			'isPlatformCheckoutEnabled'        => $this->platform_checkout_util->should_enable_platform_checkout( $this->gateway ),
+			'platformCheckoutHost'             => defined( 'PLATFORM_CHECKOUT_FRONTEND_HOST' ) ? PLATFORM_CHECKOUT_FRONTEND_HOST : 'https://pay.woo.com',
+			'platformTrackerNonce'             => wp_create_nonce( 'platform_tracks_nonce' ),
+			'accountIdForIntentConfirmation'   => apply_filters( 'wc_payments_account_id_for_intent_confirmation', '' ),
+			'wcpayVersionNumber'               => WCPAY_VERSION_NUMBER,
+			'platformCheckoutNeedLogin'        => ! is_user_logged_in() && $wc_checkout->is_registration_required(),
+			'userExistsEndpoint'               => get_rest_url( null, '/wc/v3/users/exists' ),
+			'platformCheckoutRequestSignature' => $this->platform_checkout_util->get_platform_checkout_request_signature(),
+			'platformCheckoutMerchantId'       => Jetpack_Options::get_option( 'id' ),
+		];
+	}
+
+	/**
+	 * Renders the credit card input fields needed to get the user's payment information on the checkout page.
+	 *
+	 * We also add the JavaScript which drives the UI.
+	 */
+	public function payment_fields() {
+		try {
+			$display_tokenization = $this->gateway->supports( 'tokenization' ) && ( is_checkout() || is_add_payment_method_page() );
+
+			add_action( 'wp_footer', [ $this, 'enqueue_payment_scripts' ] );
+
+			$prepared_customer_data = $this->customer_service->get_prepared_customer_data();
+			if ( ! empty( $prepared_customer_data ) ) {
+				wp_localize_script( 'WCPAY_CHECKOUT', 'wcpayCustomerData', $prepared_customer_data );
+			}
+
+			wp_enqueue_style(
+				'WCPAY_CHECKOUT',
+				plugins_url( 'dist/checkout.css', WCPAY_PLUGIN_FILE ),
+				[],
+				WC_Payments::get_file_version( 'dist/checkout.css' )
+			);
+
+			// Output the form HTML.
+			?>
+			<?php if ( ! empty( $this->gateway->get_description() ) ) : ?>
+				<p><?php echo wp_kses_post( $this->gateway->get_description() ); ?></p>
+			<?php endif; ?>
+
+			<?php if ( $this->gateway->is_in_test_mode() ) : ?>
+				<p class="testmode-info">
+					<?php
+					echo WC_Payments_Utils::esc_interpolated_html(
+					/* translators: link to Stripe testing page */
+						__( '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC, or any test card numbers listed <a>here</a>.', 'woocommerce-payments' ),
+						[
+							'strong' => '<strong>',
+							'a'      => '<a href="https://woocommerce.com/document/payments/testing/#test-cards" target="_blank">',
+						]
+					);
+					?>
+				</p>
+			<?php endif; ?>
+
+			<?php
+
+			if ( $display_tokenization ) {
+				$this->gateway->tokenization_script();
+				$this->gateway->saved_payment_methods();
+			}
+			?>
+
+			<fieldset id="wc-<?php echo esc_attr( $this->gateway->id ); ?>-cc-form" class="wc-credit-card-form wc-payment-form">
+				<div id="wcpay-card-element"></div>
+				<div id="wcpay-errors" role="alert"></div>
+				<input id="wcpay-payment-method" type="hidden" name="wcpay-payment-method" />
+				<input type="hidden" name="wcpay-is-platform-payment-method" value="<?php echo esc_attr( $this->gateway->should_use_stripe_platform_on_checkout_page() ); ?>" />
+				<?php
+				if ( $this->gateway->is_saved_cards_enabled() ) {
+					$force_save_payment = ( $display_tokenization && ! apply_filters( 'wc_payments_display_save_payment_method_checkbox', $display_tokenization ) ) || is_add_payment_method_page();
+					$this->gateway->save_payment_method_checkbox( $force_save_payment );
+				}
+				?>
+
+			</fieldset>
+
+			<?php if ( Fraud_Prevention_Service::get_instance()->is_enabled() ) : ?>
+				<input type="hidden" name="wcpay-fraud-prevention-token" value="<?php echo esc_attr( Fraud_Prevention_Service::get_instance()->get_token() ); ?>">
+			<?php endif; ?>
+
+			<?php
+
+			do_action( 'wcpay_payment_fields_wcpay', $this->gateway->id );
+
+		} catch ( Exception $e ) {
+			// Output the error message.
+			?>
+			<div>
+				<?php
+				echo esc_html__( 'An error was encountered when preparing the payment form. Please try again later.', 'woocommerce-payments' );
+				?>
+			</div>
+			<?php
+		}
+	}
+
+}

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -30,28 +30,28 @@ class WC_Payments_Checkout {
 	 *
 	 * @var WC_Payment_Gateway_WCPay
 	 */
-	private $gateway;
+	protected $gateway;
 
 	/**
 	 * Platform Checkout Utilities.
 	 *
 	 * @var Platform_Checkout_Utilities
 	 */
-	private $platform_checkout_util;
+	protected $platform_checkout_util;
 
 	/**
 	 * WC Payments Account.
 	 *
 	 * @var WC_Payments_Account
 	 */
-	private $account;
+	protected $account;
 
 	/**
 	 * WC Payments Customer Service
 	 *
 	 * @var WC_Payments_Customer_Service
 	 */
-	private $customer_service;
+	protected $customer_service;
 
 
 	/**

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -199,7 +199,7 @@ class WC_Payments_Checkout {
 
 			do_action( 'wcpay_payment_fields_wcpay', $this->gateway->id );
 
-		} catch ( Exception $e ) {
+		} catch ( \Exception $e ) {
 			// Output the error message.
 			?>
 			<div>

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -463,4 +463,50 @@ class WC_Payments_Customer_Service {
 
 		$this->update_user_customer_id( $user_id, $customer_id );
 	}
+
+	/**
+	 * Prepares customer data to be used on 'Pay for Order' or 'Add Payment Method' pages.
+	 * Customer data is retrieved from order when on Pay for Order.
+	 * Customer data is retrieved from customer when on 'Add Payment Method'.
+	 *
+	 * @return array|null An array with customer data or nothing.
+	 */
+	public function get_prepared_customer_data() {
+		if ( ! isset( $_GET['pay_for_order'] ) && ! is_add_payment_method_page() ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return null;
+		}
+
+		global $wp;
+		$user_email = '';
+		$firstname  = '';
+		$lastname   = '';
+
+		if ( isset( $_GET['pay_for_order'] ) && 'true' === $_GET['pay_for_order'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$order_id = absint( $wp->query_vars['order-pay'] );
+			$order    = wc_get_order( $order_id );
+
+			if ( is_a( $order, 'WC_Order' ) ) {
+				$firstname  = $order->get_billing_first_name();
+				$lastname   = $order->get_billing_last_name();
+				$user_email = $order->get_billing_email();
+			}
+		}
+
+		if ( is_add_payment_method_page() ) {
+			$user = wp_get_current_user();
+
+			if ( $user->ID ) {
+				$firstname  = $user->user_firstname;
+				$lastname   = $user->user_lastname;
+				$user_email = get_user_meta( $user->ID, 'billing_email', true );
+				$user_email = $user_email ? $user_email : $user->user_email;
+			}
+		}
+		$prepared_customer_data = [
+			'name'  => $firstname . ' ' . $lastname,
+			'email' => $user_email,
+		];
+
+		return $prepared_customer_data;
+	}
 }

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -153,7 +153,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 		$enabled_payment_methods = $this->gateway->get_payment_method_ids_enabled_at_checkout();
 
 		if ( $this->gateway->is_subscriptions_enabled() && $this->gateway->is_changing_payment_method_for_subscription() ) {
-			$enabled_payment_methods = array_filter( $enabled_payment_methods, [ $this, 'is_enabled_for_saved_payments' ] );
+			$enabled_payment_methods = array_filter( $enabled_payment_methods, [ $this->gateway, 'is_enabled_for_saved_payments' ] );
 		}
 
 		$payment_methods = $this->gateway->get_payment_methods();
@@ -259,7 +259,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 
 			do_action( 'wcpay_payment_fields_upe', $this->gateway->id );
 
-		} catch ( Exception $e ) {
+		} catch ( \Exception $e ) {
 			// Output the error message.
 			Logger::log( 'Error: ' . $e->getMessage() );
 			?>

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -8,7 +8,6 @@
 namespace WCPay;
 
 use Exception;
-use WC_Payment_Gateway_WCPay;
 use WC_Payments;
 use WC_Payments_Account;
 use WC_Payments_Customer_Service;
@@ -26,7 +25,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 	/**
 	 * WC Payments Gateway.
 	 *
-	 * @var WC_Payment_Gateway_WCPay
+	 * @var UPE_Payment_Gateway
 	 */
 	protected $gateway;
 

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Class WC_Payments_Checkout
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay;
+
+use Exception;
+use WC_Payment_Gateway_WCPay;
+use WC_Payments;
+use WC_Payments_Account;
+use WC_Payments_Customer_Service;
+use WC_Payments_Utils;
+use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
+use WCPay\Payment_Methods\UPE_Payment_Gateway;
+use WCPay\Platform_Checkout\Platform_Checkout_Utilities;
+
+
+/**
+ * WC_Payments_Checkout
+ */
+class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
+
+	/**
+	 * WC Payments Gateway.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	protected $gateway;
+
+	/**
+	 * Platform Checkout Utilities.
+	 *
+	 * @var Platform_Checkout_Utilities
+	 */
+	protected $platform_checkout_util;
+
+	/**
+	 * WC Payments Account.
+	 *
+	 * @var WC_Payments_Account
+	 */
+	protected $account;
+
+	/**
+	 * WC Payments Customer Service
+	 *
+	 * @var WC_Payments_Customer_Service
+	 */
+	protected $customer_service;
+
+
+	/**
+	 * Construct.
+	 *
+	 * @param UPE_Payment_Gateway          $gateway                WC Payment Gateway.
+	 * @param Platform_Checkout_Utilities  $platform_checkout_util Platform Checkout Utilities.
+	 * @param WC_Payments_Account          $account                WC Payments Account.
+	 * @param WC_Payments_Customer_Service $customer_service       WC Payments Customer Service.
+	 */
+	public function __construct(
+		UPE_Payment_Gateway $gateway,
+		Platform_Checkout_Utilities $platform_checkout_util,
+		WC_Payments_Account $account,
+		WC_Payments_Customer_Service $customer_service
+	) {
+		$this->gateway                = $gateway;
+		$this->platform_checkout_util = $platform_checkout_util;
+		$this->account                = $account;
+		$this->customer_service       = $customer_service;
+
+		add_action( 'wc_payments_add_payment_fields', [ $this, 'payment_fields' ] );
+	}
+
+	/**
+	 * Generates the configuration values, needed for payment fields.
+	 *
+	 * Isolated as a separate method in order to be available both
+	 * during the classic checkout, as well as the checkout block.
+	 *
+	 * @return array
+	 */
+	public function get_payment_fields_js_config() {
+
+		$payment_fields                             = parent::get_payment_fields_js_config();
+		$payment_fields['accountDescriptor']        = $this->gateway->get_account_statement_descriptor();
+		$payment_fields['addPaymentReturnURL']      = wc_get_account_endpoint_url( 'payment-methods' );
+		$payment_fields['gatewayId']                = UPE_Payment_Gateway::GATEWAY_ID;
+		$payment_fields['isCheckout']               = is_checkout();
+		$payment_fields['paymentMethodsConfig']     = $this->get_enabled_payment_method_config();
+		$payment_fields['saveUPEAppearanceNonce']   = wp_create_nonce( 'wcpay_save_upe_appearance_nonce' );
+		$payment_fields['testMode']                 = $this->gateway->is_in_test_mode();
+		$payment_fields['upeAppearance']            = get_transient( UPE_Payment_Gateway::UPE_APPEARANCE_TRANSIENT );
+		$payment_fields['wcBlocksUPEAppearance']    = get_transient( UPE_Payment_Gateway::WC_BLOCKS_UPE_APPEARANCE_TRANSIENT );
+		$payment_fields['checkoutTitle']            = $this->gateway->get_checkout_title();
+		$payment_fields['cartContainsSubscription'] = $this->gateway->is_subscription_item_in_cart();
+		$payment_fields['logPaymentErrorNonce']     = wp_create_nonce( 'wcpay_log_payment_error_nonce' );
+		$payment_fields['upePaymentIntentData']     = WC()->session->get( UPE_Payment_Gateway::KEY_UPE_PAYMENT_INTENT );
+		$payment_fields['upeSetupIntentData']       = WC()->session->get( UPE_Payment_Gateway::KEY_UPE_SETUP_INTENT );
+
+		$enabled_billing_fields = [];
+		foreach ( WC()->checkout()->get_checkout_fields( 'billing' ) as $billing_field => $billing_field_options ) {
+			if ( ! isset( $billing_field_options['enabled'] ) || $billing_field_options['enabled'] ) {
+				$enabled_billing_fields[] = $billing_field;
+			}
+		}
+		$payment_fields['enabledBillingFields'] = $enabled_billing_fields;
+
+		if ( is_wc_endpoint_url( 'order-pay' ) ) {
+			if ( $this->gateway->is_subscriptions_enabled() && $this->gateway->is_changing_payment_method_for_subscription() ) {
+				$payment_fields['isChangingPayment']   = true;
+				$payment_fields['addPaymentReturnURL'] = esc_url_raw( home_url( add_query_arg( [] ) ) );
+
+				if ( $this->gateway->is_setup_intent_success_creation_redirection() && isset( $_GET['_wpnonce'] ) && wp_verify_nonce( wc_clean( wp_unslash( $_GET['_wpnonce'] ) ) ) ) {
+					$setup_intent_id = isset( $_GET['setup_intent'] ) ? wc_clean( wp_unslash( $_GET['setup_intent'] ) ) : '';
+					$token           = $this->gateway->create_token_from_setup_intent( $setup_intent_id, wp_get_current_user() );
+					if ( null !== $token ) {
+						$payment_fields['newTokenFormId'] = '#wc-' . $token->get_gateway_id() . '-payment-token-' . $token->get_id();
+					}
+				}
+				return $payment_fields;
+			}
+
+			$payment_fields['isOrderPay'] = true;
+			$order_id                     = absint( get_query_var( 'order-pay' ) );
+			$payment_fields['orderId']    = $order_id;
+			$order                        = wc_get_order( $order_id );
+
+			if ( is_a( $order, 'WC_Order' ) ) {
+				$payment_fields['orderReturnURL'] = esc_url_raw(
+					add_query_arg(
+						[
+							'order_id'          => $order_id,
+							'wc_payment_method' => UPE_Payment_Gateway::GATEWAY_ID,
+							'_wpnonce'          => wp_create_nonce( 'wcpay_process_redirect_order_nonce' ),
+						],
+						$this->gateway->get_return_url( $order )
+					)
+				);
+			}
+		}
+		return $payment_fields;
+	}
+
+	/**
+	 * Gets payment method settings to pass to client scripts
+	 *
+	 * @return array
+	 */
+	public function get_enabled_payment_method_config() {
+		$settings                = [];
+		$enabled_payment_methods = $this->gateway->get_payment_method_ids_enabled_at_checkout();
+
+		if ( $this->gateway->is_subscriptions_enabled() && $this->gateway->is_changing_payment_method_for_subscription() ) {
+			$enabled_payment_methods = array_filter( $enabled_payment_methods, [ $this, 'is_enabled_for_saved_payments' ] );
+		}
+
+		$payment_methods = $this->gateway->get_payment_methods();
+
+		foreach ( $enabled_payment_methods as $payment_method ) {
+			$settings[ $payment_method ] = [
+				'isReusable' => $payment_methods[ $payment_method ]->is_reusable(),
+				'title'      => $payment_methods[ $payment_method ]->get_title(),
+			];
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * Renders the UPE input fields needed to get the user's payment information on the checkout page.
+	 *
+	 * We also add the JavaScript which drives the UI.
+	 */
+	public function payment_fields() {
+		try {
+			$display_tokenization = $this->gateway->supports( 'tokenization' ) && ( is_checkout() || is_add_payment_method_page() );
+
+			/**
+			 * Localizing scripts within shortcodes does not work in WP 5.9,
+			 * but we need `$this->get_payment_fields_js_config` to be called
+			 * before `$this->saved_payment_methods()`.
+			 */
+			$payment_fields = $this->get_payment_fields_js_config();
+			wp_enqueue_script( 'wcpay-upe-checkout' );
+			add_action(
+				'wp_footer',
+				function() use ( $payment_fields ) {
+					wp_localize_script( 'wcpay-upe-checkout', 'wcpay_config', $payment_fields );
+				}
+			);
+
+			$prepared_customer_data = $this->customer_service->get_prepared_customer_data();
+			if ( ! empty( $prepared_customer_data ) ) {
+				wp_localize_script( 'wcpay-upe-checkout', 'wcpayCustomerData', $prepared_customer_data );
+			}
+
+			wp_enqueue_style(
+				'wcpay-upe-checkout',
+				plugins_url( 'dist/checkout.css', WCPAY_PLUGIN_FILE ),
+				[],
+				WC_Payments::get_file_version( 'dist/checkout.css' )
+			);
+
+			// Output the form HTML.
+			?>
+			<?php if ( ! empty( $this->gateway->get_description() ) ) : ?>
+				<p><?php echo wp_kses_post( $this->gateway->get_description() ); ?></p>
+			<?php endif; ?>
+
+			<?php if ( $this->gateway->is_in_test_mode() ) : ?>
+				<p class="testmode-info">
+					<?php
+					echo WC_Payments_Utils::esc_interpolated_html(
+					/* translators: link to Stripe testing page */
+						__( '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a>here</a>.', 'woocommerce-payments' ),
+						[
+							'strong' => '<strong>',
+							'a'      => '<a href="https://woocommerce.com/document/payments/testing/#test-cards" target="_blank">',
+						]
+					);
+					?>
+				</p>
+			<?php endif; ?>
+
+			<?php
+
+			if ( $display_tokenization ) {
+				$this->gateway->tokenization_script();
+				$this->gateway->saved_payment_methods();
+			}
+			?>
+
+			<fieldset id="wc-<?php echo esc_attr( $this->gateway->id ); ?>-upe-form" class="wc-upe-form wc-payment-form">
+				<div id="wcpay-upe-element"></div>
+				<div id="wcpay-upe-errors" role="alert"></div>
+				<input id="wcpay-payment-method-upe" type="hidden" name="wcpay-payment-method-upe" />
+				<input id="wcpay_selected_upe_payment_type" type="hidden" name="wcpay_selected_upe_payment_type" />
+				<input id="wcpay_payment_country" type="hidden" name="wcpay_payment_country" />
+
+				<?php
+				$methods_enabled_for_saved_payments = array_filter( $this->gateway->get_upe_enabled_payment_method_ids(), [ $this->gateway, 'is_enabled_for_saved_payments' ] );
+				if ( $this->gateway->is_saved_cards_enabled() && ! empty( $methods_enabled_for_saved_payments ) ) {
+					$force_save_payment = ( $display_tokenization && ! apply_filters( 'wc_payments_display_save_payment_method_checkbox', $display_tokenization ) ) || is_add_payment_method_page();
+					if ( is_user_logged_in() || $force_save_payment ) {
+						$this->gateway->save_payment_method_checkbox( $force_save_payment );
+					}
+				}
+				?>
+
+			</fieldset>
+
+			<?php if ( Fraud_Prevention_Service::get_instance()->is_enabled() ) : ?>
+				<input type="hidden" name="wcpay-fraud-prevention-token" value="<?php echo esc_attr( Fraud_Prevention_Service::get_instance()->get_token() ); ?>">
+			<?php endif; ?>
+
+			<?php
+
+			do_action( 'wcpay_payment_fields_upe', $this->gateway->id );
+
+		} catch ( Exception $e ) {
+			// Output the error message.
+			Logger::log( 'Error: ' . $e->getMessage() );
+			?>
+			<div>
+				<?php
+				echo esc_html__( 'An error was encountered when preparing the payment form. Please try again later.', 'woocommerce-payments' );
+				?>
+			</div>
+			<?php
+		}
+	}
+
+}

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -71,7 +71,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 		$this->account                = $account;
 		$this->customer_service       = $customer_service;
 
-		add_action( 'wc_payments_add_payment_fields', [ $this, 'payment_fields' ] );
+		add_action( 'wc_payments_add_upe_payment_fields', [ $this, 'payment_fields' ] );
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -31,6 +31,7 @@ use WCPay\Payment_Methods\Link_Payment_Method;
 use WCPay\Session_Rate_Limiter;
 use WCPay\Database_Cache;
 use WCPay\WC_Payments_Checkout;
+use WCPay\WC_Payments_UPE_Checkout;
 
 /**
  * Main class for the WooCommerce Payments extension. Its responsibility is to initialize the extension.
@@ -247,6 +248,7 @@ class WC_Payments {
 		include_once __DIR__ . '/class-session-rate-limiter.php';
 		include_once __DIR__ . '/class-wc-payment-gateway-wcpay.php';
 		include_once __DIR__ . '/class-wc-payments-checkout.php';
+		include_once __DIR__ . '/class-wc-payments-upe-checkout.php';
 		include_once __DIR__ . '/payment-methods/class-cc-payment-gateway.php';
 		include_once __DIR__ . '/payment-methods/class-upe-payment-gateway.php';
 		include_once __DIR__ . '/payment-methods/class-upe-payment-method.php';
@@ -322,6 +324,7 @@ class WC_Payments {
 		self::$order_service                       = new WC_Payments_Order_Service( self::$api_client );
 		self::$order_success_page                  = new WC_Payments_Order_Success_Page();
 		self::$onboarding_service                  = new WC_Payments_Onboarding_Service( self::$api_client, self::$database_cache );
+		self::$platform_checkout_util              = new Platform_Checkout_Utilities();
 
 		if ( WC_Payments_Features::is_upe_enabled() ) {
 			$payment_methods        = [];
@@ -337,17 +340,19 @@ class WC_Payments {
 				Eps_Payment_Method::class,
 				Link_Payment_Method::class,
 			];
+
 			foreach ( $payment_method_classes as $payment_method_class ) {
 				$payment_method                               = new $payment_method_class( self::$token_service );
 				$payment_methods[ $payment_method->get_id() ] = $payment_method;
 			}
-			self::$card_gateway = new UPE_Payment_Gateway( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service, $payment_methods, self::$failed_transaction_rate_limiter, self::$order_service );
+
+			self::$card_gateway         = new UPE_Payment_Gateway( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service, $payment_methods, self::$failed_transaction_rate_limiter, self::$order_service );
+			self::$wc_payments_checkout = new WC_Payments_UPE_Checkout( self::get_gateway(), self::$platform_checkout_util, self::$account, self::$customer_service );
 		} else {
-			self::$card_gateway = new CC_Payment_Gateway( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service, self::$failed_transaction_rate_limiter, self::$order_service );
+			self::$card_gateway         = new CC_Payment_Gateway( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service, self::$failed_transaction_rate_limiter, self::$order_service );
+			self::$wc_payments_checkout = new WC_Payments_Checkout( self::get_gateway(), self::$platform_checkout_util, self::$account, self::$customer_service );
 		}
 
-		self::$platform_checkout_util      = new Platform_Checkout_Utilities();
-		self::$wc_payments_checkout        = new WC_Payments_Checkout( self::get_gateway(), self::$platform_checkout_util, self::$account, self::$customer_service );
 		self::$webhook_processing_service  = new WC_Payments_Webhook_Processing_Service( self::$api_client, self::$db_helper, self::$account, self::$remote_note_service, self::$order_service, self::$in_person_payments_receipts_service, self::get_gateway(), self::$customer_service, self::$database_cache );
 		self::$webhook_reliability_service = new WC_Payments_Webhook_Reliability_Service( self::$api_client, self::$action_scheduler_service, self::$webhook_processing_service );
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -373,6 +373,9 @@ class WC_Payments {
 			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin.php';
 			new WC_Payments_Admin( self::$api_client, self::get_gateway(), self::$account, self::$database_cache );
 
+			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin-settings.php';
+			new WC_Payments_Admin_Settings( self::get_gateway() );
+
 			// Use tracks loader only in admin screens because it relies on WC_Tracks loaded by WC_Admin.
 			include_once WCPAY_ABSPATH . 'includes/admin/tracks/tracks-loader.php';
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -464,7 +464,7 @@ class WC_Payments {
 	 */
 	public static function add_plugin_links( $links ) {
 		$plugin_links = [
-			'<a href="' . esc_attr( WC_Payment_Gateway_WCPay::get_settings_url() ) . '">' . esc_html__( 'Settings', 'woocommerce-payments' ) . '</a>',
+			'<a href="' . esc_attr( WC_Payments_Admin_Settings::get_settings_url() ) . '">' . esc_html__( 'Settings', 'woocommerce-payments' ) . '</a>',
 		];
 
 		return array_merge( $plugin_links, $links );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -201,7 +201,7 @@ class WC_Payments {
 	/**
 	 * WC Payments Checkout
 	 *
-	 * @var WC_Payments_Checkout
+	 * @var WC_Payments_Checkout|WC_Payments_UPE_Checkout
 	 */
 	private static $wc_payments_checkout;
 
@@ -791,16 +791,16 @@ class WC_Payments {
 	/**
 	 * Returns the WC_Payment_Gateway_WCPay instance
 	 *
-	 * @return WC_Payment_Gateway_WCPay gateway instance
+	 * @return WC_Payment_Gateway_WCPay|UPE_Payment_Gateway gateway instance
 	 */
 	public static function get_gateway() {
 		return self::$card_gateway;
 	}
 
 	/**
-	 * Returns the WC_Payment_Gateway_WCPay instance
+	 * Returns the WC_Payments_Checkout instance
 	 *
-	 * @return WC_Payment_Gateway_WCPay gateway instance
+	 * @return WC_Payments_Checkout|WC_Payments_UPE_Checkout gateway instance
 	 */
 	public static function get_wc_payments_checkout() {
 		return self::$wc_payments_checkout;

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -211,7 +211,7 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 			return false;
 		}
 
-		$js_config                     = $this->get_payment_fields_js_config();
+		$js_config                     = WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config();
 		$js_config['intentSecret']     = $intent->get_client_secret();
 		$js_config['updateOrderNonce'] = wp_create_nonce( 'wcpay_update_order_status_nonce' );
 		wp_localize_script( 'WCPAY_CHECKOUT', 'wcpay_config', $js_config );

--- a/includes/notes/class-wc-payments-remote-note-service.php
+++ b/includes/notes/class-wc-payments-remote-note-service.php
@@ -86,7 +86,7 @@ class WC_Payments_Remote_Note_Service {
 				}
 
 				if ( 'wcpay_settings' === $action['url'] ) {
-					$url = WC_Payment_Gateway_WCPay::get_settings_url();
+					$url = WC_Payments_Admin_Settings::get_settings_url();
 				} elseif ( isset( $action['url_is_admin'] ) && (bool) $action['url_is_admin'] ) {
 					$url = admin_url( $action['url'] );
 				} else {

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -700,6 +700,18 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	}
 
 	/**
+	 * Generates the configuration values, needed for UPE payment fields.
+	 *
+	 * @deprecated 4.9.0
+	 *
+	 * @return array
+	 */
+	public function get_payment_fields_js_config() {
+		wc_deprecated_function( __FUNCTION__, '4.9.0', 'WC_Payments_UPE_Checkout::get_payment_fields_js_config' );
+		return WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config();
+	}
+
+	/**
 	 * True if the request contains the values that indicates a redirection after a successful setup intent creation.
 	 *
 	 * @return bool
@@ -908,6 +920,18 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			}
 		}
 		return $title;
+	}
+
+	/**
+	 * Gets payment method settings to pass to client scripts
+	 *
+	 * @deprecated 4.9.0
+	 *
+	 * @return array
+	 */
+	private function get_enabled_payment_method_config() {
+		wc_deprecated_function( __FUNCTION__, '4.9.0', 'WC_Payments_UPE_Checkout::get_enabled_payment_method_config' );
+		return WC_Payments::get_wc_payments_checkout()->get_enabled_payment_method_config();
 	}
 
 	/**

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -834,7 +834,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 				}
 			);
 
-			$prepared_customer_data = $this->get_prepared_customer_data();
+			$prepared_customer_data = $this->customer_service->get_prepared_customer_data();
 			if ( ! empty( $prepared_customer_data ) ) {
 				wp_localize_script( 'wcpay-upe-checkout', 'wcpayCustomerData', $prepared_customer_data );
 			}

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -702,7 +702,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	/**
 	 * Generates the configuration values, needed for UPE payment fields.
 	 *
-	 * @deprecated 4.9.0
+	 * @deprecated 5.0.0
 	 *
 	 * @return array
 	 */
@@ -925,7 +925,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	/**
 	 * Gets payment method settings to pass to client scripts
 	 *
-	 * @deprecated 4.9.0
+	 * @deprecated 5.0.0
 	 *
 	 * @return array
 	 */

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -691,72 +691,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	}
 
 	/**
-	 * Generates the configuration values, needed for UPE payment fields.
-	 *
-	 * @return array
-	 */
-	public function get_payment_fields_js_config() {
-		$payment_fields                             = parent::get_payment_fields_js_config();
-		$payment_fields['accountDescriptor']        = $this->get_account_statement_descriptor();
-		$payment_fields['addPaymentReturnURL']      = wc_get_account_endpoint_url( 'payment-methods' );
-		$payment_fields['gatewayId']                = self::GATEWAY_ID;
-		$payment_fields['isCheckout']               = is_checkout();
-		$payment_fields['paymentMethodsConfig']     = $this->get_enabled_payment_method_config();
-		$payment_fields['saveUPEAppearanceNonce']   = wp_create_nonce( 'wcpay_save_upe_appearance_nonce' );
-		$payment_fields['testMode']                 = $this->is_in_test_mode();
-		$payment_fields['upeAppearance']            = get_transient( self::UPE_APPEARANCE_TRANSIENT );
-		$payment_fields['wcBlocksUPEAppearance']    = get_transient( self::WC_BLOCKS_UPE_APPEARANCE_TRANSIENT );
-		$payment_fields['checkoutTitle']            = $this->checkout_title;
-		$payment_fields['cartContainsSubscription'] = $this->is_subscription_item_in_cart();
-		$payment_fields['logPaymentErrorNonce']     = wp_create_nonce( 'wcpay_log_payment_error_nonce' );
-		$payment_fields['upePaymentIntentData']     = WC()->session->get( self::KEY_UPE_PAYMENT_INTENT );
-		$payment_fields['upeSetupIntentData']       = WC()->session->get( self::KEY_UPE_SETUP_INTENT );
-
-		$enabled_billing_fields = [];
-		foreach ( WC()->checkout()->get_checkout_fields( 'billing' ) as $billing_field => $billing_field_options ) {
-			if ( ! isset( $billing_field_options['enabled'] ) || $billing_field_options['enabled'] ) {
-				$enabled_billing_fields[] = $billing_field;
-			}
-		}
-		$payment_fields['enabledBillingFields'] = $enabled_billing_fields;
-
-		if ( is_wc_endpoint_url( 'order-pay' ) ) {
-			if ( $this->is_subscriptions_enabled() && $this->is_changing_payment_method_for_subscription() ) {
-				$payment_fields['isChangingPayment']   = true;
-				$payment_fields['addPaymentReturnURL'] = esc_url_raw( home_url( add_query_arg( [] ) ) );
-
-				if ( $this->is_setup_intent_success_creation_redirection() && isset( $_GET['_wpnonce'] ) && wp_verify_nonce( wc_clean( wp_unslash( $_GET['_wpnonce'] ) ) ) ) {
-					$setup_intent_id = isset( $_GET['setup_intent'] ) ? wc_clean( wp_unslash( $_GET['setup_intent'] ) ) : '';
-					$token           = $this->create_token_from_setup_intent( $setup_intent_id, wp_get_current_user() );
-					if ( null !== $token ) {
-						$payment_fields['newTokenFormId'] = '#wc-' . $token->get_gateway_id() . '-payment-token-' . $token->get_id();
-					}
-				}
-				return $payment_fields;
-			}
-
-			$payment_fields['isOrderPay'] = true;
-			$order_id                     = absint( get_query_var( 'order-pay' ) );
-			$payment_fields['orderId']    = $order_id;
-			$order                        = wc_get_order( $order_id );
-
-			if ( is_a( $order, 'WC_Order' ) ) {
-				$payment_fields['orderReturnURL'] = esc_url_raw(
-					add_query_arg(
-						[
-							'order_id'          => $order_id,
-							'wc_payment_method' => self::GATEWAY_ID,
-							'_wpnonce'          => wp_create_nonce( 'wcpay_process_redirect_order_nonce' ),
-						],
-						$this->get_return_url( $order )
-					)
-				);
-			}
-		}
-		return $payment_fields;
-	}
-
-	/**
 	 * True if the request contains the values that indicates a redirection after a successful setup intent creation.
 	 *
 	 * @return bool
@@ -809,110 +743,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		$order->set_payment_method( self::GATEWAY_ID );
 		$order->set_payment_method_title( $payment_method_title );
 		$order->save();
-	}
-
-	/**
-	 * Renders the UPE input fields needed to get the user's payment information on the checkout page.
-	 *
-	 * We also add the JavaScript which drives the UI.
-	 */
-	public function payment_fields() {
-		try {
-			$display_tokenization = $this->supports( 'tokenization' ) && ( is_checkout() || is_add_payment_method_page() );
-
-			/**
-			 * Localizing scripts within shortcodes does not work in WP 5.9,
-			 * but we need `$this->get_payment_fields_js_config` to be called
-			 * before `$this->saved_payment_methods()`.
-			 */
-			$payment_fields = $this->get_payment_fields_js_config();
-			wp_enqueue_script( 'wcpay-upe-checkout' );
-			add_action(
-				'wp_footer',
-				function() use ( $payment_fields ) {
-					wp_localize_script( 'wcpay-upe-checkout', 'wcpay_config', $payment_fields );
-				}
-			);
-
-			$prepared_customer_data = $this->customer_service->get_prepared_customer_data();
-			if ( ! empty( $prepared_customer_data ) ) {
-				wp_localize_script( 'wcpay-upe-checkout', 'wcpayCustomerData', $prepared_customer_data );
-			}
-
-			wp_enqueue_style(
-				'wcpay-upe-checkout',
-				plugins_url( 'dist/checkout.css', WCPAY_PLUGIN_FILE ),
-				[],
-				WC_Payments::get_file_version( 'dist/checkout.css' )
-			);
-
-			// Output the form HTML.
-			?>
-			<?php if ( ! empty( $this->get_description() ) ) : ?>
-				<p><?php echo wp_kses_post( $this->get_description() ); ?></p>
-			<?php endif; ?>
-
-			<?php if ( $this->is_in_test_mode() ) : ?>
-				<p class="testmode-info">
-				<?php
-					echo WC_Payments_Utils::esc_interpolated_html(
-						/* translators: link to Stripe testing page */
-						__( '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a>here</a>.', 'woocommerce-payments' ),
-						[
-							'strong' => '<strong>',
-							'a'      => '<a href="https://woocommerce.com/document/payments/testing/#test-cards" target="_blank">',
-						]
-					);
-				?>
-				</p>
-			<?php endif; ?>
-
-			<?php
-
-			if ( $display_tokenization ) {
-				$this->tokenization_script();
-				$this->saved_payment_methods();
-			}
-			?>
-
-			<fieldset id="wc-<?php echo esc_attr( $this->id ); ?>-upe-form" class="wc-upe-form wc-payment-form">
-				<div id="wcpay-upe-element"></div>
-				<div id="wcpay-upe-errors" role="alert"></div>
-				<input id="wcpay-payment-method-upe" type="hidden" name="wcpay-payment-method-upe" />
-				<input id="wcpay_selected_upe_payment_type" type="hidden" name="wcpay_selected_upe_payment_type" />
-				<input id="wcpay_payment_country" type="hidden" name="wcpay_payment_country" />
-
-			<?php
-			$methods_enabled_for_saved_payments = array_filter( $this->get_upe_enabled_payment_method_ids(), [ $this, 'is_enabled_for_saved_payments' ] );
-			if ( $this->is_saved_cards_enabled() && ! empty( $methods_enabled_for_saved_payments ) ) {
-				$force_save_payment = ( $display_tokenization && ! apply_filters( 'wc_payments_display_save_payment_method_checkbox', $display_tokenization ) ) || is_add_payment_method_page();
-				if ( is_user_logged_in() || $force_save_payment ) {
-					$this->save_payment_method_checkbox( $force_save_payment );
-				}
-			}
-			?>
-
-			</fieldset>
-
-			<?php if ( Fraud_Prevention_Service::get_instance()->is_enabled() ) : ?>
-				<input type="hidden" name="wcpay-fraud-prevention-token" value="<?php echo esc_attr( Fraud_Prevention_Service::get_instance()->get_token() ); ?>">
-			<?php endif; ?>
-
-			<?php
-
-			do_action( 'wcpay_payment_fields_upe', $this->id );
-
-		} catch ( Exception $e ) {
-			// Output the error message.
-			Logger::log( 'Error: ' . $e->getMessage() );
-			?>
-			<div>
-				<?php
-				echo esc_html__( 'An error was encountered when preparing the payment form. Please try again later.', 'woocommerce-payments' );
-				?>
-			</div>
-			<?php
-		}
 	}
 
 	/**
@@ -1072,29 +902,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	}
 
 	/**
-	 * Gets payment method settings to pass to client scripts
-	 *
-	 * @return array
-	 */
-	private function get_enabled_payment_method_config() {
-		$settings                = [];
-		$enabled_payment_methods = $this->get_payment_method_ids_enabled_at_checkout();
-
-		if ( $this->is_subscriptions_enabled() && $this->is_changing_payment_method_for_subscription() ) {
-			$enabled_payment_methods = array_filter( $enabled_payment_methods, [ $this, 'is_enabled_for_saved_payments' ] );
-		}
-
-		foreach ( $enabled_payment_methods as $payment_method ) {
-			$settings[ $payment_method ] = [
-				'isReusable' => $this->payment_methods[ $payment_method ]->is_reusable(),
-				'title'      => $this->payment_methods[ $payment_method ]->get_title(),
-			];
-		}
-
-		return $settings;
-	}
-
-	/**
 	 * Function to be used with array_filter
 	 * to filter UPE payment methods that support saved payments
 	 *
@@ -1102,7 +909,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	 *
 	 * @return bool
 	 */
-	private function is_enabled_for_saved_payments( $payment_method_id ) {
+	public function is_enabled_for_saved_payments( $payment_method_id ) {
 		if ( ! isset( $this->payment_methods[ $payment_method_id ] ) ) {
 			return false;
 		}
@@ -1204,5 +1011,23 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	 */
 	public function remove_upe_setup_intent_from_session() {
 		WC()->session->__unset( self::KEY_UPE_SETUP_INTENT );
+	}
+
+	/**
+	 * Returns the checkout tile.
+	 *
+	 * @return string Checkout title.
+	 */
+	public function get_checkout_title() {
+		return $this->checkout_title;
+	}
+
+	/**
+	 * Returns the payment methods for this gateway.
+	 *
+	 * @return array|UPE_Payment_Method[]
+	 */
+	public function get_payment_methods() {
+		return $this->payment_methods;
 	}
 }

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -402,6 +402,15 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	}
 
 	/**
+	 * Renders the credit card input fields needed to get the user's payment information on the checkout page.
+	 *
+	 * We also add the JavaScript which drives the UI.
+	 */
+	public function payment_fields() {
+		do_action( 'wc_payments_add_upe_payment_fields' );
+	}
+
+	/**
 	 * Update payment intent for completed checkout and return redirect URL for Stripe to confirm payment.
 	 *
 	 * @param int $order_id Order ID to process the payment for.

--- a/tests/unit/admin/test-class-wc-payments-admin.php
+++ b/tests/unit/admin/test-class-wc-payments-admin.php
@@ -87,7 +87,7 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls = wp_list_pluck( $submenu['wc-admin&path=/payments/overview'], 0, 2 );
-		$settings_item_name = $item_names_by_urls[ WC_Payment_Gateway_WCPay::get_settings_url() ];
+		$settings_item_name = $item_names_by_urls[ WC_Payments_Admin_Settings::get_settings_url() ];
 
 		$this->assertEquals( 'Settings' . WC_Payments_Admin::MENU_NOTIFICATION_BADGE, $settings_item_name );
 	}
@@ -111,7 +111,7 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls = wp_list_pluck( $submenu['wc-admin&path=/payments/overview'], 0, 2 );
-		$settings_item_name = $item_names_by_urls[ WC_Payment_Gateway_WCPay::get_settings_url() ];
+		$settings_item_name = $item_names_by_urls[ WC_Payments_Admin_Settings::get_settings_url() ];
 
 		$this->assertEquals( 'Settings', $settings_item_name );
 	}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -69,6 +69,7 @@ function _manually_load_plugin() {
 
 	require_once $_plugin_dir . 'includes/exceptions/class-rest-request-exception.php';
 	require_once $_plugin_dir . 'includes/admin/class-wc-payments-admin.php';
+	require_once $_plugin_dir . 'includes/admin/class-wc-payments-admin-settings.php';
 	require_once $_plugin_dir . 'includes/admin/class-wc-payments-admin-sections-overwrite.php';
 	require_once $_plugin_dir . 'includes/admin/class-wc-payments-rest-controller.php';
 	require_once $_plugin_dir . 'includes/admin/class-wc-rest-payments-accounts-controller.php';

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -269,6 +269,15 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 	public function test_payment_fields_outputs_fields() {
 		$this->set_cart_contains_subscription_items( false );
 		$this->set_get_upe_enabled_payment_method_statuses_return_value();
+
+		// Add the UPE Checkout action.
+		new WC_Payments_UPE_Checkout(
+			$this->mock_upe_gateway,
+			$this->mock_platform_checkout_utilities,
+			$this->mock_wcpay_account,
+			$this->mock_customer_service
+		);
+
 		$this->mock_upe_gateway->payment_fields();
 
 		$this->expectOutputRegex( '/<div id="wcpay-upe-element"><\/div>/' );

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -15,6 +15,7 @@ use WCPay\Exceptions\Connection_Exception;
 use WCPay\Exceptions\Process_Payment_Exception;
 use WCPay\Logger;
 use WCPay\MultiCurrency\Currency;
+use WCPay\Platform_Checkout\Platform_Checkout_Utilities;
 use WCPay\Session_Rate_Limiter;
 
 use WC_Payment_Gateway_WCPay;
@@ -32,6 +33,7 @@ use WC_Helper_Token;
 use WC_Payments_Utils;
 use WC_Subscriptions;
 use WC_Subscriptions_Cart;
+use WCPay\WC_Payments_UPE_Checkout;
 use WCPAY_UnitTestCase;
 use WP_User;
 use Exception;
@@ -119,6 +121,13 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 	private $mock_wcpay_account;
 
 	/**
+	 * Platform_Checkout_Utilities instance.
+	 *
+	 * @var Platform_Checkout_Utilities
+	 */
+	private $mock_platform_checkout_utilities;
+
+	/**
 	 * Mocked value of return_url.
 	 * The value is used in the set up and tests, so it's set as a private
 	 * variable for easy reference.
@@ -166,6 +175,8 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 
 		$this->mock_wcpay_account = $this->createMock( WC_Payments_Account::class );
 		$this->mock_wcpay_account->method( 'get_account_country' )->willReturn( 'US' );
+
+		$this->mock_platform_checkout_utilities = $this->createMock( Platform_Checkout_Utilities::class );
 
 		// Arrange: Mock WC_Payments_Customer_Service so its methods aren't called directly.
 		$this->mock_customer_service = $this->getMockBuilder( 'WC_Payments_Customer_Service' )
@@ -1381,7 +1392,14 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 				$this->returnValue( [ 'link_payments' => [ 'status' => 'active' ] ] )
 			);
 
-		$this->assertSame( $mock_upe_gateway->get_payment_fields_js_config()['paymentMethodsConfig'], [] );
+		$upe_checkout = new WC_Payments_UPE_Checkout(
+			$mock_upe_gateway,
+			$this->mock_platform_checkout_utilities,
+			$this->mock_wcpay_account,
+			$this->mock_customer_service
+		);
+
+		$this->assertSame( $upe_checkout->get_payment_fields_js_config()['paymentMethodsConfig'], [] );
 	}
 
 	public function test_link_payment_method_if_card_enabled() {
@@ -1425,8 +1443,15 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 				)
 			);
 
+		$upe_checkout = new WC_Payments_UPE_Checkout(
+			$mock_upe_gateway,
+			$this->mock_platform_checkout_utilities,
+			$this->mock_wcpay_account,
+			$this->mock_customer_service
+		);
+
 		$this->assertSame(
-			$mock_upe_gateway->get_payment_fields_js_config()['paymentMethodsConfig'],
+			$upe_checkout->get_payment_fields_js_config()['paymentMethodsConfig'],
 			[
 				'card' => [
 					'isReusable' => true,

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -9,13 +9,11 @@ use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Exceptions\Amount_Too_Small_Exception;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Constants\Payment_Type;
-use WCPay\Exceptions\Process_Payment_Exception;
 use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
 use WCPay\Payment_Information;
 use WCPay\Platform_Checkout\Platform_Checkout_Utilities;
 use WCPay\Session_Rate_Limiter;
 use WCPay\WC_Payments_Checkout;
-use WCPay\WC_Payments_UPE_Checkout;
 
 // Need to use WC_Mock_Data_Store.
 require_once dirname( __FILE__ ) . '/helpers/class-wc-mock-wc-data-store.php';
@@ -89,7 +87,13 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	 *
 	 * @var Platform_Checkout_Utilities
 	 */
-	private $mock_platform_checkout_utilities;
+	private $platform_checkout_utilities;
+
+	/**
+	 * WC_Payments_Checkout instance.
+	 * @var WC_Payments_Checkout
+	 */
+	private $payments_checkout;
 
 	/**
 	 * Pre-test setup
@@ -151,11 +155,11 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			$this->order_service
 		);
 
-		$this->mock_platform_checkout_utilities = $this->createMock( Platform_Checkout_Utilities::class );
+		$this->platform_checkout_utilities = new Platform_Checkout_Utilities();
 
-		$this->upe_checkout = new WC_Payments_Checkout(
+		$this->payments_checkout = new WC_Payments_Checkout(
 			$this->wcpay_gateway,
-			$this->mock_platform_checkout_utilities,
+			$this->platform_checkout_utilities,
 			$this->mock_wcpay_account,
 			$this->mock_customer_service
 		);
@@ -290,6 +294,8 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	public function test_save_card_checkbox_not_displayed_when_saved_cards_disabled() {
 		$this->wcpay_gateway->update_option( 'saved_cards', 'no' );
 
+		$this->refresh_payments_checkout();
+
 		// Use a callback to get and test the output (also suppresses the output buffering being printed to the CLI).
 		$this->setOutputCallback(
 			function ( $output ) {
@@ -313,6 +319,8 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'get_token' )
 			->willReturn( $token_value );
+
+		$this->refresh_payments_checkout();
 
 		// Use a callback to get and test the output (also suppresses the output buffering being printed to the CLI).
 		$this->setOutputCallback(
@@ -1626,16 +1634,6 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		// need to delete the existing options to ensure nothing is in the DB from the `setUp` phase, where the method is instantiated.
 		delete_option( 'woocommerce_woocommerce_payments_settings' );
 
-		$this->wcpay_gateway = new WC_Payment_Gateway_WCPay(
-			$this->mock_api_client,
-			$this->mock_wcpay_account,
-			$this->mock_customer_service,
-			$this->mock_token_service,
-			$this->mock_action_scheduler_service,
-			$this->mock_rate_limiter,
-			$this->order_service
-		);
-
 		$this->assertEquals(
 			[
 				'product',
@@ -1986,7 +1984,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	public function test_is_platform_checkout_enabled_returns_true() {
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
 		$this->wcpay_gateway->update_option( 'platform_checkout', 'yes' );
-		$this->assertTrue( $this->upe_checkout->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
+		$this->assertTrue( $this->payments_checkout->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
 	}
 
 	public function test_force_network_saved_cards_is_returned_as_true_if_should_use_stripe_platform() {
@@ -1997,24 +1995,24 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'should_use_stripe_platform_on_checkout_page' )
 			->willReturn( true );
 
-		$upe_checkout = new WC_Payments_Checkout(
+		$payments_checkout = new WC_Payments_Checkout(
 			$mock_wcpay_gateway,
-			$this->mock_platform_checkout_utilities,
+			$this->platform_checkout_utilities,
 			$this->mock_wcpay_account,
 			$this->mock_customer_service
 		);
 
-		$this->assertTrue( $upe_checkout->get_payment_fields_js_config()['forceNetworkSavedCards'] );
+		$this->assertTrue( $payments_checkout->get_payment_fields_js_config()['forceNetworkSavedCards'] );
 	}
 
 	public function test_is_platform_checkout_enabled_returns_false_if_ineligible() {
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => false ] );
-		$this->assertFalse( $this->upe_checkout->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
+		$this->assertFalse( $this->payments_checkout->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
 	}
 
 	public function test_is_platform_checkout_enabled_returns_false_if_ineligible_and_enabled() {
 		$this->wcpay_gateway->update_option( 'platform_checkout', 'yes' );
-		$this->assertFalse( $this->upe_checkout->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
+		$this->assertFalse( $this->payments_checkout->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
 	}
 
 	public function is_platform_checkout_falsy_value_provider() {
@@ -2072,5 +2070,16 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$created->setTimestamp( $this->mock_charge_created );
 
 		return new WC_Payments_API_Charge( $this->mock_charge_id, 1500, $created );
+	}
+
+	private function refresh_payments_checkout() {
+		remove_all_actions( 'wc_payments_add_payment_fields' );
+
+		$this->payments_checkout = new WC_Payments_Checkout(
+			$this->wcpay_gateway,
+			$this->platform_checkout_utilities,
+			$this->mock_wcpay_account,
+			$this->mock_customer_service
+		);
 	}
 }

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -12,7 +12,10 @@ use WCPay\Constants\Payment_Type;
 use WCPay\Exceptions\Process_Payment_Exception;
 use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
 use WCPay\Payment_Information;
+use WCPay\Platform_Checkout\Platform_Checkout_Utilities;
 use WCPay\Session_Rate_Limiter;
+use WCPay\WC_Payments_Checkout;
+use WCPay\WC_Payments_UPE_Checkout;
 
 // Need to use WC_Mock_Data_Store.
 require_once dirname( __FILE__ ) . '/helpers/class-wc-mock-wc-data-store.php';
@@ -82,6 +85,13 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	private $order_service;
 
 	/**
+	 * Platform_Checkout_Utilities instance.
+	 *
+	 * @var Platform_Checkout_Utilities
+	 */
+	private $mock_platform_checkout_utilities;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
@@ -139,6 +149,15 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			$this->mock_action_scheduler_service,
 			$this->mock_rate_limiter,
 			$this->order_service
+		);
+
+		$this->mock_platform_checkout_utilities = $this->createMock( Platform_Checkout_Utilities::class );
+
+		$this->upe_checkout = new WC_Payments_Checkout(
+			$this->wcpay_gateway,
+			$this->mock_platform_checkout_utilities,
+			$this->mock_wcpay_account,
+			$this->mock_customer_service
 		);
 	}
 
@@ -1967,7 +1986,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	public function test_is_platform_checkout_enabled_returns_true() {
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
 		$this->wcpay_gateway->update_option( 'platform_checkout', 'yes' );
-		$this->assertTrue( $this->wcpay_gateway->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
+		$this->assertTrue( $this->upe_checkout->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
 	}
 
 	public function test_force_network_saved_cards_is_returned_as_true_if_should_use_stripe_platform() {
@@ -1978,17 +1997,24 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'should_use_stripe_platform_on_checkout_page' )
 			->willReturn( true );
 
-		$this->assertTrue( $mock_wcpay_gateway->get_payment_fields_js_config()['forceNetworkSavedCards'] );
+		$upe_checkout = new WC_Payments_Checkout(
+			$mock_wcpay_gateway,
+			$this->mock_platform_checkout_utilities,
+			$this->mock_wcpay_account,
+			$this->mock_customer_service
+		);
+
+		$this->assertTrue( $upe_checkout->get_payment_fields_js_config()['forceNetworkSavedCards'] );
 	}
 
 	public function test_is_platform_checkout_enabled_returns_false_if_ineligible() {
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => false ] );
-		$this->assertFalse( $this->wcpay_gateway->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
+		$this->assertFalse( $this->upe_checkout->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
 	}
 
 	public function test_is_platform_checkout_enabled_returns_false_if_ineligible_and_enabled() {
 		$this->wcpay_gateway->update_option( 'platform_checkout', 'yes' );
-		$this->assertFalse( $this->wcpay_gateway->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
+		$this->assertFalse( $this->upe_checkout->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
 	}
 
 	public function is_platform_checkout_falsy_value_provider() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Related to #823 
This PR is the first part of a series of refactors of the WC_Payment_Gateway_WCPay class.

#### Testing instructions
- With test mode active
- Go to WooCommerce > Payments
- Make sure the notice `Test mode active: All transactions are simulated. Customers can't make real purchases through WooCommerce Payments.` shows up

- Go to plugins
- Make sure the Settings link shows up and works

- Make [is_available_for_current_currency](https://github.com/Automattic/woocommerce-payments/blob/3d81b3467672c989c9143a16673adb4c4b0d72b1/includes/class-wc-payment-gateway-wcpay.php#L504) return false
- Make sure the `Unsupported currency: The selected currency is not available for the country set in your WooCommerce Payments account.` notice shows up on wp-admin

- As a shopper add a product to the cart
- Make sure you can see the card inputs
- Test again using UPE

- As a shopper buy any product
- As a shopper buy any product using WooPay


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
