### PR TITLE
Fix UPE dropdown popover positioning when Gutenberg is active

### DIFF
--- a/changelog/fix-4842-gutenberg-popover-positioning
+++ b/changelog/fix-4842-gutenberg-popover-positioning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix dropdown menu appearance in UPE payment methods when Gutenberg is active.

--- a/client/payment-methods/style.scss
+++ b/client/payment-methods/style.scss
@@ -77,4 +77,11 @@
 			}
 		}
 	}
+
+	// Gutenberg compatibility adjustments. The component changed its classes and
+	// styling in @wordpress/components 19.11.0. We're currently using 11.1.5.
+	// To be removed when we upgrade this package.
+	.components-popover {
+		position: fixed;
+	}
 }


### PR DESCRIPTION
Fixes #4842 

#### Changes proposed in this Pull Request

- Add a "position" CSS rule that was removed in @wordpress/components 19.11.0

We're currently using @wordpress/components 11.1.5. The popover class was used for [positioning in 19.10.0](https://github.com/WordPress/gutenberg/blob/v13.2.2/packages/components/src/popover/style.scss#L4), but it was [changed in 19.11.0](https://github.com/WordPress/gutenberg/blob/v13.3.0/packages/components/src/popover/style.scss#L4) so this rule was applied to the `is-expanded` class of this element, a class that's not added to the component in the version we're using.


#### Testing instructions

* Enable UPE in WCPay
* Install and activate the latest version of the Gutenberg plugin
* On the WCPay settings page, under "Payments accepted on checkout", click on the three dots next to the card heading
  * Confirm that the dropdown shows up without altering the appearance of the card element

Regression tests:
* Install and activate the 13.2.2 version of the Gutenberg plugin
*  Confirm that the dropdown we tested before shows up without altering the appearance of the card element

* Deactivate Gutenberg
* Confirm that the dropdown we tested before shows up without altering the appearance of the card element

**Before**

![gih](https://user-images.githubusercontent.com/273592/193882562-24cd9829-6204-49fc-b743-90025d73a4c0.gif)

**After**

![iqvjO0.gif](https://user-images.githubusercontent.com/41606954/194157068-559898df-f796-48bf-b120-3a2b75c4a03c.gif)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.