### PR TITLE
Update webhook processing to override existing meta data

### DIFF
--- a/changelog/update-order-meta-data-override
+++ b/changelog/update-order-meta-data-override
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update webhook processing to override existing meta data.

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -385,17 +385,14 @@ class WC_Payments_Webhook_Processing_Service {
 			WC_Payments_Utils::ORDER_INTENT_CURRENCY_META_KEY => $currency,
 		];
 
-		$order_changed = false;
 		foreach ( $meta_data_to_update as $key => $value ) {
 			// Override existing meta data with incoming values, if present.
 			if ( $value ) {
-				$order_changed = true;
 				$order->update_meta_data( $key, $value );
 			}
 		}
-		if ( true === $order_changed ) {
-			$order->save();
-		}
+		// Save the order after updating the meta data values.
+		$order->save();
 
 		$this->order_service->mark_payment_completed( $order, $intent_id, $intent_status, $charge_id );
 

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -387,7 +387,8 @@ class WC_Payments_Webhook_Processing_Service {
 
 		$order_changed = false;
 		foreach ( $meta_data_to_update as $key => $value ) {
-			if ( $value && ! $order->get_meta( $key ) ) {
+			// Override existing meta data with incoming values, if present.
+			if ( $value ) {
 				$order_changed = true;
 				$order->update_meta_data( $key, $value );
 			}


### PR DESCRIPTION
Fixes #4771 

#### Changes proposed in this Pull Request
- Currently, we had a check for `! $order->get_meta( $key )` during webhook processing for updating metadata, which meant we only update it in case the key isn't present already for that order. This led to an issue where we might have stale data stored for order and an incoming webhook for that order wouldn't update it since the key already exists.
- This PR removes that check and thus overrides the metadata whenever there is an incoming webhook.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create an order like you normally would.
* Update the metadata associated with the order, for example charge_id.
* Rerun the webhook for the `payment_intent.succeeded` event using the Stripe CLI
```
stripe events resend<EVENT_ID> --account=<ACCOUNT_ID>   
```
* Ensure the charge_id value is updated to the original value.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
