### PR TITLE
Update subscriptions-core to 2.3.0

### DIFF
--- a/changelog/subscriptions-core-2.3.0
+++ b/changelog/subscriptions-core-2.3.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update subscriptions-core to 2.3.0.

--- a/changelog/subscriptions-core-2.3.0-fix
+++ b/changelog/subscriptions-core-2.3.0-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Move One Time Shipping metabox fields to use the woocommerce_product_options_shipping_product_data hook introduced in WC 6.0.

--- a/changelog/subscriptions-core-2.3.0-update
+++ b/changelog/subscriptions-core-2.3.0-update
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Improve handling of bulk action execution.
+Improve handling of subscription bulk action execution.

--- a/changelog/subscriptions-core-2.3.0-update
+++ b/changelog/subscriptions-core-2.3.0-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Improve handling of bulk action execution.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
       "automattic/jetpack-sync": "1.30.5",
       "automattic/jetpack-tracking": "1.14.5",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "2.2.1"
+      "woocommerce/subscriptions-core": "2.3.0"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0736b15e02fc8de5449d6f28bfae3df7",
+    "content-hash": "90f58d3cd4e9aee92e9c3b2035ba7658",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1060,22 +1060,17 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "2.2.1",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "c4debb6c3150b0732eb29b2b897bcbaef8cc6f97"
+                "reference": "8017438f8e0cfc16494344f783fb134f77284d58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/c4debb6c3150b0732eb29b2b897bcbaef8cc6f97",
-                "reference": "c4debb6c3150b0732eb29b2b897bcbaef8cc6f97",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/8017438f8e0cfc16494344f783fb134f77284d58",
+                "reference": "8017438f8e0cfc16494344f783fb134f77284d58",
                 "shasum": ""
-            },
-            "archive": {
-                "exclude": [
-                    "!/build"
-                ]
             },
             "require": {
                 "composer/installers": "~1.2",
@@ -1090,6 +1085,13 @@
             "type": "wordpress-plugin",
             "extra": {
                 "phpcodesniffer-search-depth": 2
+            },
+            "archive": {
+                "exclude": [
+                    "!/build",
+                    "*.zip",
+                    "node_modules"
+                ]
             },
             "scripts": {
                 "phpcs": [
@@ -1108,10 +1110,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.2.1",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.3.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-08-25T22:15:47+00:00"
+            "time": "2022-10-07T03:45:34+00:00"
         }
     ],
     "packages-dev": [
@@ -5834,5 +5836,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Load newer woocommerce-subscriptions-core's version 2.3.0.
- Added changelog entries from woocommerce-subscriptions-core to the changelog.
- Updated composer.lock as a result of running `composer update woocommerce/subscriptions-core`.

#### Testing instructions

* Checkout this branch.
* [Husky hook should run `composer install`](https://github.com/Automattic/woocommerce-payments/blob/develop/.husky/post-checkout#L8) and your `vendor/woocommerce/subscriptions-core` should be updated to `2.3.0`. Confirm that latest changes from `2.3.0` is present, for example, [vendor/woocommerce/subscriptions-core/changelog.txt is up-to-date](https://github.com/Automattic/woocommerce-subscriptions-core/blob/2.3.0/changelog.txt).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
