### PR TITLE
Fix otp modal when auto redirecting to platform checkout

### DIFF
--- a/changelog/fix-4855-prevent-otp-modal-when-redirecting
+++ b/changelog/fix-4855-prevent-otp-modal-when-redirecting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent OTP modal from showing up when auto redirection is in progress.

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -381,8 +381,6 @@ export const handlePlatformCheckoutEmailInput = async ( field, api ) => {
 	};
 
 	const closeLoginSessionIframe = () => {
-		hasCheckedLoginSession = true;
-
 		loginSessionIframeWrapper.remove();
 		loginSessionIframe.classList.remove( 'open' );
 		platformCheckoutEmailInput.focus();
@@ -473,6 +471,7 @@ export const handlePlatformCheckoutEmailInput = async ( field, api ) => {
 
 		switch ( e.data.action ) {
 			case 'auto_redirect_to_platform_checkout':
+				hasCheckedLoginSession = true;
 				api.initPlatformCheckout(
 					'',
 					e.data.platformCheckoutUserSession
@@ -492,6 +491,7 @@ export const handlePlatformCheckoutEmailInput = async ( field, api ) => {
 				} );
 				break;
 			case 'close_auto_redirection_modal':
+				hasCheckedLoginSession = true;
 				closeLoginSessionIframe();
 				break;
 			case 'redirect_to_platform_checkout':


### PR DESCRIPTION
Fixes #4855 

#### Changes proposed in this Pull Request
The `hasCheckedLoginSession` was getting set too late. Now setting the value as soon as a message from iframe is received (message/event related to auto redirection)

#### Steps to Reproduce

- Add a product to the cart and go to the checkout page
- Use an email that exists in WooPay and complete the purchase paying via WooPay
- Again, add a product to the cart and go to the checkout page
- Wait for the `email/exists` check to run. Don't do anything
- Notice that the OTP modal shows up and a redirection starts
- Don't enter any code in the modal, and notice you get redirected to WooPay

#### Testing instructions

- Add a product to the cart and go to the checkout page
- Use an email that exists in WooPay and complete the purchase paying via WooPay
- Again, add a product to the cart and go to the checkout page
- Wait for a few seconds. Auto redirection should start
- Confirm in the network tab that no `email/exists` request was made. 