### PR TITLE
Add support for pre-cloning payment methods

### DIFF
--- a/changelog/add-pre-clone-payment-method
+++ b/changelog/add-pre-clone-payment-method
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support to pre-clone payment methods.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1620,6 +1620,30 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Pre-clones a payment method.
+	 *
+	 * @param string $customer_id Stripe customer ID.
+	 * @param string $order_key an order's key.
+	 * @param string $payment_method Payment method ID.
+	 * @return array Payment method details.
+	 *
+	 * @throws API_Exception If detachment fails.
+	 */
+	public function pre_clone_payment_method( $customer_id, $order_key, $payment_method ) {
+		$request = [
+			'customer'       => $customer_id,
+			'order_key'      => $order_key,
+			'payment_method' => $payment_method,
+		];
+
+		return $this->request(
+			$request,
+			self::PAYMENT_METHODS_API . '/pre-clone',
+			self::POST
+		);
+	}
+
+	/**
 	 * Records a new Terms of Service agreement.
 	 *
 	 * @param string $source     A string, which describes where the merchant agreed to the terms.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

A payment method can be cloned, given an order key and a payment method ID.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
