### PR TITLE
Bump ubuntu version in workflow

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   woocommerce-compatibility:
     name:    WC compatibility
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast:    false
       max-parallel: 10
@@ -48,7 +48,7 @@ jobs:
   # a dedicated job, as allowed to fail
   compatibility-woocommerce-beta:
     name:    Environment - WC beta
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -29,6 +29,7 @@ jobs:
     steps:
       # clone the repository
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version-file: '.nvmrc'
       # enable dependencies caching
@@ -65,6 +66,7 @@ jobs:
     steps:
       # clone the repository
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version-file: '.nvmrc'
       # enable dependencies caching

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       # clone the repository
       - uses: actions/checkout@v2
+        with:
+          node-version-file: '.nvmrc'
       # enable dependencies caching
       - uses: actions/cache@v2
         with:
@@ -63,6 +65,8 @@ jobs:
     steps:
       # clone the repository
       - uses: actions/checkout@v2
+        with:
+          node-version-file: '.nvmrc'
       # enable dependencies caching
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   woocommerce-coverage:
     name:    Code coverage
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast:    false
       max-parallel: 10

--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   lint:
     name:    JS linting
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
 
   test:
     name:    JS testing
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       # clone the repository
       - uses: actions/checkout@v2

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          node-version-file: '.nvmrc'
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -7,7 +7,7 @@ jobs:
   # Check for version-specific PHP compatibility
   php-compatibility:
     name: PHP Compatibility
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version-file: '.nvmrc'
       - uses: shivammathur/setup-php@v2

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       # clone the repository
       - uses: actions/checkout@v2
+        with:
+          node-version-file: '.nvmrc'
       # enable dependencies caching
       - uses: actions/cache@v2
         with:
@@ -45,6 +47,7 @@ jobs:
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          node-version-file: '.nvmrc'
       # setup PHP, but without debug extensions for reasonable performance
       - uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   lint:
     name:    PHP linting
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
 
   test:
     name:    PHP testing
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast:    false
       max-parallel: 10

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       # clone the repository
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version-file: '.nvmrc'
       # enable dependencies caching
@@ -42,12 +43,14 @@ jobs:
     steps:
       # clone the repository
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
       # enable dependencies caching
       - uses: actions/cache@v2
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-          node-version-file: '.nvmrc'
       # setup PHP, but without debug extensions for reasonable performance
       - uses: shivammathur/setup-php@v2
         with:

--- a/changelog/task-update-ubuntu-and-node-in-workflow
+++ b/changelog/task-update-ubuntu-and-node-in-workflow
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: This updates the ubuntu version and points to node file in github workflows.


### PR DESCRIPTION
#### Description
The GitHub actions are failing with the following message-

- This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on December 1st, 2022. For more details, see https://github.com/actions/runner-images/issues/6002
- Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/cache, actions/cache, actions/checkout

Example run: 
- https://github.com/Automattic/woocommerce-payments/actions/runs/3250687967
- https://github.com/Automattic/woocommerce-payments/actions/runs/3250914145

#### Changes proposed in this Pull Request
Updated Ubuntu version to the latest and point to the node version file.

#### Note
It turned out to be a scheduled brownout with continues for 6 hrs only.