### PR TITLE
Create an inbox note for Stripe Link set-up

### DIFF
--- a/changelog/add-stripe-link-note
+++ b/changelog/add-stripe-link-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add Stripe Link set up inbox notification

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -929,6 +929,10 @@ class WC_Payments {
 			WC_Payments_Notes_Additional_Payment_Methods::set_account( self::get_account_service() );
 			WC_Payments_Notes_Additional_Payment_Methods::possibly_add_note();
 			WC_Payments_Notes_Additional_Payment_Methods::maybe_enable_upe_feature_flag();
+
+			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-stripelink.php';
+			WC_Payments_Notes_Set_Up_StripeLink::set_gateway( self::get_gateway() );
+			WC_Payments_Notes_Set_Up_StripeLink::possibly_add_note();
 		}
 	}
 
@@ -951,6 +955,9 @@ class WC_Payments {
 
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-additional-payment-methods.php';
 			WC_Payments_Notes_Additional_Payment_Methods::possibly_delete_note();
+
+			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-stripelink.php';
+			WC_Payments_Notes_Set_Up_StripeLink::possibly_delete_note();
 		}
 	}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -931,6 +931,7 @@ class WC_Payments {
 			WC_Payments_Notes_Additional_Payment_Methods::maybe_enable_upe_feature_flag();
 
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-stripelink.php';
+			WC_Payments_Notes_Set_Up_StripeLink::set_gateway( self::get_gateway() );
 			WC_Payments_Notes_Set_Up_StripeLink::possibly_add_note();
 		}
 	}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -931,7 +931,6 @@ class WC_Payments {
 			WC_Payments_Notes_Additional_Payment_Methods::maybe_enable_upe_feature_flag();
 
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-stripelink.php';
-			WC_Payments_Notes_Set_Up_StripeLink::set_gateway( self::get_gateway() );
 			WC_Payments_Notes_Set_Up_StripeLink::possibly_add_note();
 		}
 	}

--- a/includes/notes/class-wc-payments-notes-set-up-stripelink.php
+++ b/includes/notes/class-wc-payments-notes-set-up-stripelink.php
@@ -34,6 +34,11 @@ class WC_Payments_Notes_Set_Up_StripeLink {
 	 * @return bool
 	 */
 	public static function should_display_note() {
+		// If UPE is not enabled, skip.
+		if ( ! \WC_Payments_Features::is_upe_enabled() ) {
+			return false;
+		}
+
 		// WCPay gateway instance.
 		$gateway = \WC_Payments::get_gateway();
 

--- a/includes/notes/class-wc-payments-notes-set-up-stripelink.php
+++ b/includes/notes/class-wc-payments-notes-set-up-stripelink.php
@@ -40,7 +40,7 @@ class WC_Payments_Notes_Set_Up_StripeLink {
 	 *
 	 * @return bool
 	 */
-	public static function should_display_note() {
+	public static function should_display_note():bool {
 		// If UPE is not enabled, skip.
 		if ( ! \WC_Payments_Features::is_upe_enabled() ) {
 			return false;
@@ -48,21 +48,15 @@ class WC_Payments_Notes_Set_Up_StripeLink {
 
 		// Check if Link payment is available.
 		$available_upe_payment_methods = self::$gateway->get_upe_available_payment_methods();
-
 		if ( ! in_array( Link_Payment_Method::PAYMENT_METHOD_STRIPE_ID, $available_upe_payment_methods, true ) ) {
 			return false;
 		}
 
 		// Retrieve enabled payment methods at checkout.
 		$enabled_payment_methods = self::$gateway->get_payment_method_ids_enabled_at_checkout( null, true );
-
-		// If card payment method is not enabled, skip.
-		if ( ! in_array( CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID, $enabled_payment_methods, true ) ) {
-			return false;
-		}
-
-		// If Link payment method is enabled, skip.
-		if ( in_array( Link_Payment_Method::PAYMENT_METHOD_STRIPE_ID, $enabled_payment_methods, true ) ) {
+		// If card payment method is not enabled or Link payment method is enabled, skip.
+		if ( ! in_array( CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID, $enabled_payment_methods, true )
+				|| in_array( Link_Payment_Method::PAYMENT_METHOD_STRIPE_ID, $enabled_payment_methods, true ) ) {
 			return false;
 		}
 

--- a/includes/notes/class-wc-payments-notes-set-up-stripelink.php
+++ b/includes/notes/class-wc-payments-notes-set-up-stripelink.php
@@ -29,6 +29,13 @@ class WC_Payments_Notes_Set_Up_StripeLink {
 	const NOTE_DOCUMENTATION_URL = 'https://woocommerce.com/document/payments/woocommerce-payments-stripe-link/';
 
 	/**
+	 * The account service instance.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private static $gateway;
+
+	/**
 	 * Checks if a note can and should be added.
 	 *
 	 * @return bool
@@ -39,18 +46,15 @@ class WC_Payments_Notes_Set_Up_StripeLink {
 			return false;
 		}
 
-		// WCPay gateway instance.
-		$gateway = \WC_Payments::get_gateway();
-
 		// Check if Link payment is available.
-		$available_upe_payment_methods = $gateway->get_upe_available_payment_methods();
+		$available_upe_payment_methods = self::$gateway->get_upe_available_payment_methods();
 
 		if ( ! in_array( Link_Payment_Method::PAYMENT_METHOD_STRIPE_ID, $available_upe_payment_methods, true ) ) {
 			return false;
 		}
 
 		// Retrieve enabled payment methods at checkout.
-		$enabled_payment_methods = $gateway->get_payment_method_ids_enabled_at_checkout( null, true );
+		$enabled_payment_methods = self::$gateway->get_payment_method_ids_enabled_at_checkout( null, true );
 
 		// If card payment method is not enabled, skip.
 		if ( ! in_array( CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID, $enabled_payment_methods, true ) ) {
@@ -91,5 +95,14 @@ class WC_Payments_Notes_Set_Up_StripeLink {
 		);
 
 		return $note;
+	}
+
+	/**
+	 * Sets the WCPay gateway instance reference on the class.
+	 *
+	 * @param WC_Payment_Gateway_WCPay $gateway WCPay gateway instance.
+	 */
+	public static function set_gateway( WC_Payment_Gateway_WCPay $gateway ) {
+		self::$gateway = $gateway;
 	}
 }

--- a/includes/notes/class-wc-payments-notes-set-up-stripelink.php
+++ b/includes/notes/class-wc-payments-notes-set-up-stripelink.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Set up Stripe Link note for WooCommerce inbox.
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WC_Payments_Notes_Setup_StripeLink
+ */
+class WC_Payments_Notes_Set_Up_StripeLink {
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-payments-notes-set-up-stripe-link';
+
+	/**
+	 * CTA button link
+	 */
+	const NOTE_DOCUMENTATION_URL = 'https://woocommerce.com/document/payments/woocommerce-payments-stripe-link/';
+
+	/**
+	 * The payment gateway service instance.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private static $gateway;
+
+	/**
+	 * Checks if a note can and should be added.
+	 *
+	 * @return bool
+	 */
+	public static function should_display_note() {
+		$payment_method_statuses = self::$gateway->get_upe_enabled_payment_method_statuses();
+		$status                  = $payment_method_statuses['link_payments']['status'] ?? null;
+
+		if ( 'unrequested' === $status ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		if ( ! self::should_display_note() ) {
+			return;
+		}
+
+		$note_class = WC_Payment_Woo_Compat_Utils::get_note_class();
+		$note       = new $note_class();
+
+		$note->set_title( __( 'Increase conversion at checkout', 'woocommerce-payments' ) );
+		$note->set_content( __( 'Reduce cart abandonment and create a frictionless checkout experience with Link by Stripe. Link autofills your customer’s payment and shipping details so they can check out in just six seconds with the Link optimized experience. That’s 9x faster than shoppers who don’t use Link. Link increases conversion rates by over 7% for logged-in Link customers.', 'woocommerce-payments' ) );
+		$note->set_content_data( (object) [] );
+		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-payments' );
+		$note->add_action(
+			self::NOTE_NAME,
+			__( 'Set up now', 'woocommerce-payments' ),
+			self::NOTE_DOCUMENTATION_URL,
+			'unactioned',
+			true
+		);
+
+		return $note;
+	}
+
+	/**
+	 * Sets the payment gateway instance reference on the class.
+	 *
+	 * @param WC_Payment_Gateway_WCPay $gateway Payment gateway.
+	 */
+	public static function set_gateway( WC_Payment_Gateway_WCPay $gateway ) {
+		self::$gateway = $gateway;
+	}
+}

--- a/tests/unit/notes/test-class-wc-payments-notes-set-up-stripelink.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-set-up-stripelink.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Class WC_Payments_Notes_Set_Up_StripeLink_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\Session_Rate_Limiter;
+
+/**
+ * Class WC_Payments_Notes_Set_Up_StripeLink tests.
+ */
+class WC_Payments_Notes_Set_Up_StripeLink_Test extends WCPAY_UnitTestCase {
+	/**
+	 * System under test.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private $mock_wcpay_gateway;
+
+	/**
+	 * Mock WC_Payments_Customer_Service.
+	 *
+	 * @var WC_Payments_Customer_Service|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_customer_service;
+
+	/**
+	 * Mock WC_Payments_Token_Service.
+	 *
+	 * @var WC_Payments_Token_Service|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_token_service;
+
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_API_Client|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_api_client;
+
+	/**
+	 * Mock WC_Payments_Action_Scheduler_Service.
+	 *
+	 * @var WC_Payments_Action_Scheduler_Service|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_action_scheduler_service;
+
+	/**
+	 * Mock Session_Rate_Limiter.
+	 *
+	 * @var Session_Rate_Limiter|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_rate_limiter;
+
+	/**
+	 * WC_Payments_Order_Service.
+	 *
+	 * @var WC_Payments_Order_Service
+	 */
+	private $order_service;
+
+	/**
+	 * Mock WC_Payments_Account.
+	 *
+	 * @var WC_Payments_Account|PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mock_wcpay_account;
+
+	public function set_up() {
+		parent::set_up();
+
+		require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-stripelink.php';
+
+		$this->mock_api_client = $this->getMockBuilder( 'WC_Payments_API_Client' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mock_wcpay_account = $this->createMock( WC_Payments_Account::class );
+
+		$this->mock_customer_service = $this->getMockBuilder( 'WC_Payments_Customer_Service' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mock_token_service = $this->getMockBuilder( 'WC_Payments_Token_Service' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mock_action_scheduler_service = $this->getMockBuilder( 'WC_Payments_Action_Scheduler_Service' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->mock_rate_limiter = $this->createMock( Session_Rate_Limiter::class );
+
+		$this->order_service = new WC_Payments_Order_Service( $this->mock_api_client );
+
+		$this->mock_wcpay_gateway = $this->getMockBuilder( '\WC_Payment_Gateway_WCPay' )
+			->setConstructorArgs(
+				[
+					$this->mock_api_client,
+					$this->mock_wcpay_account,
+					$this->mock_customer_service,
+					$this->mock_token_service,
+					$this->mock_action_scheduler_service,
+					$this->mock_rate_limiter,
+					$this->order_service,
+				]
+			)
+			->setMethods(
+				[
+					'get_upe_available_payment_methods',
+					'get_payment_method_ids_enabled_at_checkout',
+				]
+			)
+			->getMock();
+	}
+
+	public function tear_down() {
+		delete_option( '_wcpay_feature_upe' );
+
+		parent::tear_down();
+	}
+
+	public function test_stripelink_setup_get_note() {
+		$this->mock_gateway_data( '1', [ 'card', 'link' ], [ 'card' ] );
+
+		$note = \WC_Payments_Notes_Set_Up_StripeLink::get_note();
+
+		$this->assertSame( 'Increase conversion at checkout', $note->get_title() );
+		$this->assertSame( 'Reduce cart abandonment and create a frictionless checkout experience with Link by Stripe. Link autofills your customer’s payment and shipping details so they can check out in just six seconds with the Link optimized experience. That’s 9x faster than shoppers who don’t use Link. Link increases conversion rates by over 7% for logged-in Link customers.', $note->get_content() );
+		$this->assertSame( 'info', $note->get_type() );
+		$this->assertSame( 'wc-payments-notes-set-up-stripe-link', $note->get_name() );
+		$this->assertSame( 'woocommerce-payments', $note->get_source() );
+
+		list( $set_up_action ) = $note->get_actions();
+		$this->assertSame( 'wc-payments-notes-set-up-stripe-link', $set_up_action->name );
+		$this->assertSame( 'Set up now', $set_up_action->label );
+		$this->assertStringStartsWith( 'https://woocommerce.com/document/payments/woocommerce-payments-stripe-link/', $set_up_action->query );
+	}
+
+	public function test_stripelink_setup_note_null_when_upe_disabled() {
+		$this->mock_gateway_data( '0', [ 'card', 'link' ], [ 'card' ] );
+
+		$note = \WC_Payments_Notes_Set_Up_StripeLink::get_note();
+
+		$this->assertNull( $note );
+	}
+
+	public function test_stripelink_setup_note_null_when_link_not_available() {
+		$this->mock_gateway_data( '1', [ 'card' ], [ 'card' ] );
+
+		$note = \WC_Payments_Notes_Set_Up_StripeLink::get_note();
+
+		$this->assertNull( $note );
+	}
+
+	public function test_stripelink_setup_note_null_when_link_enabled() {
+		$this->mock_gateway_data( '1', [ 'card', 'link' ], [ 'card', 'link' ] );
+
+		$note = \WC_Payments_Notes_Set_Up_StripeLink::get_note();
+
+		$this->assertNull( $note );
+	}
+
+	public function mock_gateway_data( $upe_enabled = '0', $available_methods, $enabled_methods ) {
+		update_option( '_wcpay_feature_upe', $upe_enabled );
+
+		$this->mock_wcpay_gateway
+			->expects( $this->any() )
+			->method( 'get_upe_available_payment_methods' )
+			->willReturn( $available_methods );
+
+		$this->mock_wcpay_gateway
+			->expects( $this->any() )
+			->method( 'get_payment_method_ids_enabled_at_checkout' )
+			->willReturn( $enabled_methods );
+
+		\WC_Payments_Notes_Set_Up_StripeLink::set_gateway( $this->mock_wcpay_gateway );
+
+		WC_Payments_Notes_Set_Up_StripeLink::possibly_add_note();
+	}
+}

--- a/tests/unit/notes/test-class-wc-payments-notes-set-up-stripelink.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-set-up-stripelink.php
@@ -5,8 +5,6 @@
  * @package WooCommerce\Payments\Tests
  */
 
-use WCPay\Session_Rate_Limiter;
-
 /**
  * Class WC_Payments_Notes_Set_Up_StripeLink tests.
  */
@@ -18,94 +16,13 @@ class WC_Payments_Notes_Set_Up_StripeLink_Test extends WCPAY_UnitTestCase {
 	 */
 	private $mock_wcpay_gateway;
 
-	/**
-	 * Mock WC_Payments_Customer_Service.
-	 *
-	 * @var WC_Payments_Customer_Service|PHPUnit_Framework_MockObject_MockObject
-	 */
-	private $mock_customer_service;
-
-	/**
-	 * Mock WC_Payments_Token_Service.
-	 *
-	 * @var WC_Payments_Token_Service|PHPUnit_Framework_MockObject_MockObject
-	 */
-	private $mock_token_service;
-
-	/**
-	 * Mock WC_Payments_API_Client.
-	 *
-	 * @var WC_Payments_API_Client|PHPUnit_Framework_MockObject_MockObject
-	 */
-	private $mock_api_client;
-
-	/**
-	 * Mock WC_Payments_Action_Scheduler_Service.
-	 *
-	 * @var WC_Payments_Action_Scheduler_Service|PHPUnit_Framework_MockObject_MockObject
-	 */
-	private $mock_action_scheduler_service;
-
-	/**
-	 * Mock Session_Rate_Limiter.
-	 *
-	 * @var Session_Rate_Limiter|PHPUnit_Framework_MockObject_MockObject
-	 */
-	private $mock_rate_limiter;
-
-	/**
-	 * WC_Payments_Order_Service.
-	 *
-	 * @var WC_Payments_Order_Service
-	 */
-	private $order_service;
-
-	/**
-	 * Mock WC_Payments_Account.
-	 *
-	 * @var WC_Payments_Account|PHPUnit_Framework_MockObject_MockObject
-	 */
-	private $mock_wcpay_account;
-
 	public function set_up() {
 		parent::set_up();
 
 		require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-stripelink.php';
 
-		$this->mock_api_client = $this->getMockBuilder( 'WC_Payments_API_Client' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->mock_wcpay_account = $this->createMock( WC_Payments_Account::class );
-
-		$this->mock_customer_service = $this->getMockBuilder( 'WC_Payments_Customer_Service' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->mock_token_service = $this->getMockBuilder( 'WC_Payments_Token_Service' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->mock_action_scheduler_service = $this->getMockBuilder( 'WC_Payments_Action_Scheduler_Service' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->mock_rate_limiter = $this->createMock( Session_Rate_Limiter::class );
-
-		$this->order_service = new WC_Payments_Order_Service( $this->mock_api_client );
-
 		$this->mock_wcpay_gateway = $this->getMockBuilder( '\WC_Payment_Gateway_WCPay' )
-			->setConstructorArgs(
-				[
-					$this->mock_api_client,
-					$this->mock_wcpay_account,
-					$this->mock_customer_service,
-					$this->mock_token_service,
-					$this->mock_action_scheduler_service,
-					$this->mock_rate_limiter,
-					$this->order_service,
-				]
-			)
+			->disableOriginalConstructor()
 			->setMethods(
 				[
 					'get_upe_available_payment_methods',
@@ -177,6 +94,6 @@ class WC_Payments_Notes_Set_Up_StripeLink_Test extends WCPAY_UnitTestCase {
 
 		\WC_Payments_Notes_Set_Up_StripeLink::set_gateway( $this->mock_wcpay_gateway );
 
-		WC_Payments_Notes_Set_Up_StripeLink::possibly_add_note();
+		\WC_Payments_Notes_Set_Up_StripeLink::possibly_add_note();
 	}
 }


### PR DESCRIPTION
Fixes #4844

#### Changes proposed in this Pull Request
This PR adds an inbox note when:
- Stripe Link is not enabled;
- Stripe is an available payment method ( Country US );
- UPE is enabled;

<img width="691" alt="Screenshot 2022-10-17 at 12 36 53" src="https://user-images.githubusercontent.com/8667118/196144331-44aed2a3-8a42-4f68-a023-f5f31e6d7326.png">

<img width="683" alt="Screenshot 2022-10-17 at 12 37 24" src="https://user-images.githubusercontent.com/8667118/196144352-660dd943-25e6-48d6-9c9f-83a5f698d838.png">

#### Testing instructions

*Case 1*
- Verify Stripe Link payment method is available
- Disable Stripe Link payment method if already enabled
- Verify the note is added to the Inbox section on `WooCommerce` -> `Home`

*Case 2*
- Disable UPE by updating `_wcpay_feature_upe` option to `0`
- Deactivate and Activate WCPay
- Verify the note is not added to the Inbox section on `WooCommerce` -> `Home`

*Case 3*
- Enable UPE by updating `_wcpay_feature_upe` to `1`
- Enable Stripe Link from 
- Deactivate and Activate WCPay
- Verify the note is not added to the Inbox section on `WooCommerce` -> `Home`

*Case 4*
- Connect to non-US merchant account
- Deactivate and Activate WCPay
- Verify the note is not added to the Inbox section on `WooCommerce` -> `Home`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
