### PR TITLE
Add event when skipped the platform checkout

### DIFF
--- a/changelog/fix-woopay-1358
+++ b/changelog/fix-woopay-1358
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add event when skipped the platform checkout

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -459,6 +459,10 @@ export const handlePlatformCheckoutEmailInput = async ( field, api ) => {
 				openLoginSessionIframe();
 			}
 		} else {
+			wcpayTracks.recordUserEvent(
+				wcpayTracks.events.PLATFORM_CHECKOUT_SKIPPED
+			);
+
 			searchParams.delete( 'skip_platform_checkout' );
 
 			let { pathname } = window.location;

--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -82,6 +82,7 @@ const events = {
 	PLATFORM_CHECKOUT_OTP_COMPLETE: 'platform_checkout_otp_prompt_complete',
 	PLATFORM_CHECKOUT_OTP_FAILED: 'platform_checkout_otp_prompt_failed',
 	PLATFORM_CHECKOUT_AUTO_REDIRECT: 'platform_checkout_auto_redirect',
+	PLATFORM_CHECKOUT_SKIPPED: 'platform_checkout_skipped',
 };
 
 export default {


### PR DESCRIPTION
Fixes Automattic/woopay/issues/1358

#### Changes proposed in this Pull Request
[As part of the monitoring project for scope phase two](pdpOw2-1mz-p2), we should detect shoppers who complete OTP authentication but checkout with WCPay.  Adding this track would let us know that a shopper landed on a merchant's checkout page after coming back from the WooPay checkout page.


#### Testing instructions
1. Test via sandbox
1. Purchase an item, opt-in, and go to the platform checkout page
1. Click on the `back` button on the top left
1. After about 5 minutes, go to the Tracks live view at https://mc.a8c.com/tracks/live/ and search for `platform_checkout_skipped`

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.