### PR TITLE
Fix regex to check format of tag for a pre-release

### DIFF
--- a/.github/actions/create-branch-tag/action.yml
+++ b/.github/actions/create-branch-tag/action.yml
@@ -35,7 +35,7 @@ runs:
         TRIMMED_TAG_NAME=$(echo "$TAG_NAME" | xargs) 
         
         if ${{ env.IS_PRERELEASE == 'true' }}; then
-          TAG_FORMAT="^[0-9]\.[0-9]\.[0-9](-test-[1-9])*$"
+          TAG_FORMAT="^[0-9]\.[0-9]\.[0-9]-test-[1-9]$"
         else
           TAG_FORMAT="^[0-9]\.[0-9]\.[0-9]$"
         fi

--- a/changelog/fix-update-regex-branch-tag-workflow
+++ b/changelog/fix-update-regex-branch-tag-workflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adjust regex to check the format of a tag for a pre-release in our GitHub workflow


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There's a small mistake in the regex to check the format of a tag for a pre-release in our GitHub workflow `create-pre-release.yml`.
It currently allows 0 or more instances of "-test-[1-9]" while it should just be a mandatory occurrence in the string.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
