### PR TITLE
Drop IE11 support

### DIFF
--- a/changelog/update-drop-ie11-support
+++ b/changelog/update-drop-ie11-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove IE11 support.

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@wordpress/base-styles": "3.5.4",
         "@wordpress/block-editor": "7.0.2",
         "@wordpress/blocks": "11.0.1",
-        "@wordpress/browserslist-config": "3.0.1",
+        "@wordpress/browserslist-config": "5.3.0",
         "@wordpress/components": "11.1.5",
         "@wordpress/data": "4.23.1",
         "@wordpress/data-controls": "1.6.0",
@@ -11772,12 +11772,12 @@
       }
     },
     "node_modules/@wordpress/browserslist-config": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-3.0.1.tgz",
-      "integrity": "sha512-l0c/X8w2v+NBShzEoykLuaLQNo1qiAONnPKXfIeiI145zAdjA5e8zMR0sUTDVsCxVfqfd2tH+D4wuhf68T3+Aw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.3.0.tgz",
+      "integrity": "sha512-FIhYWu36TrZ49W+knaRwhw3Q+cxaTDEzSaiE83qMDeAPJytT/UaedoJULt5MfxUtfaKLmUa8bPjSFORxoxwbvQ==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@wordpress/components": {
@@ -52088,9 +52088,9 @@
       }
     },
     "@wordpress/browserslist-config": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-3.0.1.tgz",
-      "integrity": "sha512-l0c/X8w2v+NBShzEoykLuaLQNo1qiAONnPKXfIeiI145zAdjA5e8zMR0sUTDVsCxVfqfd2tH+D4wuhf68T3+Aw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.3.0.tgz",
+      "integrity": "sha512-FIhYWu36TrZ49W+knaRwhw3Q+cxaTDEzSaiE83qMDeAPJytT/UaedoJULt5MfxUtfaKLmUa8bPjSFORxoxwbvQ==",
       "dev": true
     },
     "@wordpress/components": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@wordpress/base-styles": "3.5.4",
     "@wordpress/block-editor": "7.0.2",
     "@wordpress/blocks": "11.0.1",
-    "@wordpress/browserslist-config": "3.0.1",
+    "@wordpress/browserslist-config": "5.3.0",
     "@wordpress/components": "11.1.5",
     "@wordpress/data": "4.23.1",
     "@wordpress/data-controls": "1.6.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Now that we require at least WP 5.8, and it dropped IE11 a while ago, we can proceed to do the same and reduce our bundle size. As we rely on `@wordpress/browserslist-config` for browsers version support, updating it drops IE11 from the list.

#### Testing instructions
Building the project should work without errors and E2E tests should pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
