### PR TITLE
Remove unnecessary babel plugins

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,0 @@
-{
-	"env": {},
-	"ignore": [],
-	"presets": [ "@wordpress/babel-preset-default" ]
-}

--- a/babel.config.js
+++ b/babel.config.js
@@ -3,11 +3,7 @@
 module.exports = {
 	ignore: [],
 	presets: [ '@wordpress/babel-preset-default' ],
-	plugins: [
-		[ '@babel/transform-runtime', { corejs: 3 } ],
-		'@babel/plugin-proposal-optional-chaining',
-		'@babel/plugin-proposal-nullish-coalescing-operator',
-	],
+	plugins: [],
 	env: {
 		production: {
 			plugins: [

--- a/changelog/dev-remove-unnecessary-babel-plugins
+++ b/changelog/dev-remove-unnecessary-babel-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove unnecessary babel plugins after IE11 support drop.

--- a/changelog/update-drop-ie11-support
+++ b/changelog/update-drop-ie11-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove IE11 support.

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@wordpress/base-styles": "3.5.4",
         "@wordpress/block-editor": "7.0.2",
         "@wordpress/blocks": "11.0.1",
-        "@wordpress/browserslist-config": "3.0.1",
+        "@wordpress/browserslist-config": "5.3.0",
         "@wordpress/components": "11.1.5",
         "@wordpress/data": "4.23.1",
         "@wordpress/data-controls": "1.6.0",
@@ -11772,12 +11772,12 @@
       }
     },
     "node_modules/@wordpress/browserslist-config": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-3.0.1.tgz",
-      "integrity": "sha512-l0c/X8w2v+NBShzEoykLuaLQNo1qiAONnPKXfIeiI145zAdjA5e8zMR0sUTDVsCxVfqfd2tH+D4wuhf68T3+Aw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.3.0.tgz",
+      "integrity": "sha512-FIhYWu36TrZ49W+knaRwhw3Q+cxaTDEzSaiE83qMDeAPJytT/UaedoJULt5MfxUtfaKLmUa8bPjSFORxoxwbvQ==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@wordpress/components": {
@@ -52088,9 +52088,9 @@
       }
     },
     "@wordpress/browserslist-config": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-3.0.1.tgz",
-      "integrity": "sha512-l0c/X8w2v+NBShzEoykLuaLQNo1qiAONnPKXfIeiI145zAdjA5e8zMR0sUTDVsCxVfqfd2tH+D4wuhf68T3+Aw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.3.0.tgz",
+      "integrity": "sha512-FIhYWu36TrZ49W+knaRwhw3Q+cxaTDEzSaiE83qMDeAPJytT/UaedoJULt5MfxUtfaKLmUa8bPjSFORxoxwbvQ==",
       "dev": true
     },
     "@wordpress/components": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
       },
       "devDependencies": {
         "@automattic/color-studio": "2.3.1",
-        "@babel/plugin-proposal-object-rest-spread": "7.12.13",
         "@pmmmwh/react-refresh-webpack-plugin": "0.5.7",
         "@testing-library/jest-dom": "5.14.1",
         "@testing-library/react": "11.2.5",
@@ -44,7 +43,7 @@
         "@woocommerce/experimental": "2.1.0",
         "@wordpress/api-fetch": "5.1.1",
         "@wordpress/babel-plugin-makepot": "4.2.0",
-        "@wordpress/babel-preset-default": "4.3.0",
+        "@wordpress/babel-preset-default": "7.4.0",
         "@wordpress/base-styles": "3.5.4",
         "@wordpress/block-editor": "7.0.2",
         "@wordpress/blocks": "11.0.1",
@@ -1430,15 +1429,13 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.0.tgz",
-      "integrity": "sha512-JT8tHuFjKBo8NnaUbblz7mIu1nnvUDiHVjXXkulZULyidvo/7P6TY7+YqpV37IfF+KUFxmlK04elKtGKXaiVgw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.3.tgz",
+      "integrity": "sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.13.0",
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/traverse": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "debug": "^4.1.1",
         "lodash.debounce": "^4.0.8",
         "resolve": "^1.14.2",
@@ -1912,20 +1909,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.13.tgz",
-      "integrity": "sha512-WvA1okB/0OS/N3Ldb3sziSrXg6sRphsBgqiccfcQq7woEn5wQLNX82Oc4PlaFcdwcWHuQXAtb8ftbS8Fbsg/sg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-        "@babel/plugin-transform-parameters": "^7.12.13"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-proposal-optional-catch-binding": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.18.6.tgz",
@@ -2124,12 +2107,15 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.13.tgz",
-      "integrity": "sha512-d4HM23Q1K7oq/SLNmG6mRt85l2csmQ0cHRaxRXjKW0YFdEXqlZ5kzFQKH5Uc3rDJECgu+yCRgPkG04Mm98R/1g==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
+      "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13"
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -2229,6 +2215,21 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.18.6.tgz",
+      "integrity": "sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2639,16 +2640,19 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.13.12.tgz",
-      "integrity": "sha512-jcEI2UqIcpCqB5U5DRxIl0tQEProI2gcu+g8VTIqxLO5Iidojb4d77q+fwGseCvd8af/lJ9masp4QWzBXFE2xA==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.19.0.tgz",
+      "integrity": "sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.12.13",
-        "@babel/helper-module-imports": "^7.13.12",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-jsx": "^7.12.13",
-        "@babel/types": "^7.13.12"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.19.0",
+        "@babel/plugin-syntax-jsx": "^7.18.6",
+        "@babel/types": "^7.19.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -2661,40 +2665,6 @@
       "dev": true,
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-development/node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.17.12.tgz",
-      "integrity": "sha512-spyY3E3AURfxh/RHtjx5j6hs8am5NbUBGfcZ2vB3uShSpZdQyXSf5rR5Mk76vbtlAZOelyVQ71Fg0x9SG4fsog==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-development/node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.12.tgz",
-      "integrity": "sha512-Lcaw8bxd1DKht3thfD4A12dqo1X16he1Lm8rIv8sTwjAYNInRS1qHa9aJoqvzpscItXvftKDCfaEQzwoVyXpEQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/plugin-syntax-jsx": "^7.17.12",
-        "@babel/types": "^7.17.12"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2751,17 +2721,20 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.13.15",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.13.15.tgz",
-      "integrity": "sha512-d+ezl76gx6Jal08XngJUkXM4lFXK/5Ikl9Mh4HKDxSfGJXmZ9xG64XT2oivBzfxb/eQ62VfvoMkaCZUKJMVrBA==",
+      "version": "7.19.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.19.6.tgz",
+      "integrity": "sha512-PRH37lz4JU156lYFW1p8OxE5i7d6Sl/zV58ooyr+q1J1lnQPyg5tIiXlIwNVhJaY4W3TmOtdc8jqdXQcB1v5Yw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.13.12",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "babel-plugin-polyfill-corejs2": "^0.2.0",
-        "babel-plugin-polyfill-corejs3": "^0.2.0",
-        "babel-plugin-polyfill-regenerator": "^0.2.0",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.19.0",
+        "babel-plugin-polyfill-corejs2": "^0.3.3",
+        "babel-plugin-polyfill-corejs3": "^0.6.0",
+        "babel-plugin-polyfill-regenerator": "^0.4.1",
         "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -2844,6 +2817,23 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.19.3.tgz",
+      "integrity": "sha512-z6fnuK9ve9u/0X0rRvI9MY0xg+DOUaABDYOe+/SQTxtlptaBB/V9JIUxJn6xp3lMBeb9qe8xSFmHU35oZDXD+w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.19.0",
+        "@babel/helper-plugin-utils": "^7.19.0",
+        "@babel/plugin-syntax-typescript": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3092,32 +3082,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/preset-react/node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.17.12.tgz",
-      "integrity": "sha512-spyY3E3AURfxh/RHtjx5j6hs8am5NbUBGfcZ2vB3uShSpZdQyXSf5rR5Mk76vbtlAZOelyVQ71Fg0x9SG4fsog==",
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.18.6.tgz",
+      "integrity": "sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/preset-react/node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.12.tgz",
-      "integrity": "sha512-Lcaw8bxd1DKht3thfD4A12dqo1X16he1Lm8rIv8sTwjAYNInRS1qHa9aJoqvzpscItXvftKDCfaEQzwoVyXpEQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/plugin-syntax-jsx": "^7.17.12",
-        "@babel/types": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/plugin-transform-typescript": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -10648,35 +10621,164 @@
       "dev": true
     },
     "node_modules/@wordpress/babel-preset-default": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.3.0.tgz",
-      "integrity": "sha512-yj/JEQh8SJzI3d6h531iVnKvFSYssdFb2PwpMCL5BuIXk98U+FOKSmIHj134WJ1lm4viwMIQeH3UZ93bJ0MqTQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.4.0.tgz",
+      "integrity": "sha512-7drcVBIajDE8s3At7yUr9UdHROYkfPYgR4OaG+EugDn9MzuDIEsGalnazDYwvjerLAwsf8S/S8o34bi6IrthYQ==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.4.4",
-        "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
-        "@babel/plugin-transform-react-jsx": "^7.3.0",
-        "@babel/plugin-transform-runtime": "^7.4.4",
-        "@babel/preset-env": "^7.4.4",
-        "@babel/runtime": "^7.4.4",
-        "@wordpress/babel-plugin-import-jsx-pragma": "^2.2.0",
-        "@wordpress/browserslist-config": "^2.5.0"
+        "@babel/core": "^7.16.0",
+        "@babel/plugin-transform-react-jsx": "^7.16.0",
+        "@babel/plugin-transform-runtime": "^7.16.0",
+        "@babel/preset-env": "^7.16.0",
+        "@babel/preset-typescript": "^7.16.0",
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/babel-plugin-import-jsx-pragma": "^4.3.0",
+        "@wordpress/browserslist-config": "^5.3.0",
+        "@wordpress/element": "^4.18.0",
+        "@wordpress/warning": "^2.20.0",
+        "browserslist": "^4.17.6",
+        "core-js": "^3.19.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14"
+      }
+    },
+    "node_modules/@wordpress/babel-preset-default/node_modules/@types/react": {
+      "version": "17.0.50",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.50.tgz",
+      "integrity": "sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@wordpress/babel-preset-default/node_modules/@types/react-dom": {
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.17.tgz",
+      "integrity": "sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "^17"
+      }
+    },
+    "node_modules/@wordpress/babel-preset-default/node_modules/@wordpress/babel-plugin-import-jsx-pragma": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.3.0.tgz",
+      "integrity": "sha512-7AnWnpItOqH5YEcFA3RgxeOlb96R8KDWDPAZjZ6TpsdOVjFynT8H3Buc4v127BHmxuxKGyd2vxPIQIzC9dLzOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^7.12.9"
       }
     },
     "node_modules/@wordpress/babel-preset-default/node_modules/@wordpress/browserslist-config": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.7.0.tgz",
-      "integrity": "sha512-pB45JlfmHuEigNFZ1X+CTgIsOT3/TTb9iZxw1DHXge/7ytY8FNhtcNwTfF9IgnS6/xaFRZBqzw4DyH4sP1Lyxg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.3.0.tgz",
+      "integrity": "sha512-FIhYWu36TrZ49W+knaRwhw3Q+cxaTDEzSaiE83qMDeAPJytT/UaedoJULt5MfxUtfaKLmUa8bPjSFORxoxwbvQ==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=14"
+      }
+    },
+    "node_modules/@wordpress/babel-preset-default/node_modules/@wordpress/element": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.18.0.tgz",
+      "integrity": "sha512-+3gA4RTD/EDj1h2y/qikh+h0uCUxhShfM7QoDngKOBNSTZHqc0W2p6IMEe+AMdrmu8tyZboTJW/eONjUHE4n7g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/react": "^17.0.37",
+        "@types/react-dom": "^17.0.11",
+        "@wordpress/escape-html": "^2.20.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/babel-preset-default/node_modules/@wordpress/escape-html": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.20.0.tgz",
+      "integrity": "sha512-bhHkFQrEkuJjhSB6OlQq/Kq+43k8E6JwUw/pCDAjJX2uU/DDG3tW3eftYn2ae7W23bPrNEs1/qULWzbaziPQnw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/babel-preset-default/node_modules/@wordpress/warning": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.20.0.tgz",
+      "integrity": "sha512-swTE3rUbk00rddyrQo2sA6yojbzNYUXTntAHbfoF68AC53i7cFunB3Bcod+paDPGR0gq1mr3rfatrWHze8qz3Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/babel-preset-default/node_modules/core-js": {
+      "version": "3.25.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.5.tgz",
+      "integrity": "sha512-nbm6eZSjm+ZuBQxCUPQKQCoUEfFOXjUZ8dTTyikyKaWrTYmAVbykQfwsKE5dBK88u3QCkCrzsx/PPlKfhsvgpw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/@wordpress/babel-preset-default/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@wordpress/babel-preset-default/node_modules/react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@wordpress/babel-preset-default/node_modules/react-dom": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
+      },
+      "peerDependencies": {
+        "react": "17.0.2"
+      }
+    },
+    "node_modules/@wordpress/babel-preset-default/node_modules/scheduler": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "node_modules/@wordpress/base-styles": {
@@ -17900,13 +18002,13 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.0.tgz",
-      "integrity": "sha512-9bNwiR0dS881c5SHnzCmmGlMkJLl0OUZvxrxHo9w/iNoRuqaPjqlvBf4HrovXtQs/au5yKkpcdgfT1cC5PAZwg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
+      "integrity": "sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.13.11",
-        "@babel/helper-define-polyfill-provider": "^0.2.0",
+        "@babel/compat-data": "^7.17.7",
+        "@babel/helper-define-polyfill-provider": "^0.3.3",
         "semver": "^6.1.1"
       },
       "peerDependencies": {
@@ -17923,25 +18025,25 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.0.tgz",
-      "integrity": "sha512-zZyi7p3BCUyzNxLx8KV61zTINkkV65zVkDAFNZmrTCRVhjo1jAS+YLvDJ9Jgd/w2tsAviCwFHReYfxO3Iql8Yg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz",
+      "integrity": "sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.2.0",
-        "core-js-compat": "^3.9.1"
+        "@babel/helper-define-polyfill-provider": "^0.3.3",
+        "core-js-compat": "^3.25.1"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.0.tgz",
-      "integrity": "sha512-J7vKbCuD2Xi/eEHxquHN14bXAW9CXtecwuLrOIDJtcZzTaPzV1VdEfoUf9AzcRBMolKUQKM9/GVojeh0hFiqMg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.1.tgz",
+      "integrity": "sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.2.0"
+        "@babel/helper-define-polyfill-provider": "^0.3.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -18514,9 +18616,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
       "funding": [
         {
@@ -18529,10 +18631,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "update-browserslist-db": "^1.0.9"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -18850,9 +18952,9 @@
       "dev": true
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001390",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001390.tgz",
-      "integrity": "sha512-sS4CaUM+/+vqQUlCvCJ2WtDlV81aWtHhqeEVkLokVJJa3ViN4zDxAGfq9R8i1m90uGHxo99cy10Od+lvn3hf0g==",
+      "version": "1.0.30001422",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz",
+      "integrity": "sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==",
       "dev": true,
       "funding": [
         {
@@ -19994,26 +20096,16 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.0.tgz",
-      "integrity": "sha512-extKQM0g8/3GjFx9US12FAgx8KJawB7RCQ5y8ipYLbmfzEzmFRWdDjIlxDx82g7ygcNG85qMVUSRyABouELdow==",
+      "version": "3.25.5",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.5.tgz",
+      "integrity": "sha512-ovcyhs2DEBUIE0MGEKHP4olCUW/XYte3Vroyxuh38rD1wAO4dHohsovUC4eAOuzFxE6b+RXvBU3UZ9o0YhUTkA==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.21.3",
-        "semver": "7.0.0"
+        "browserslist": "^4.21.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/core-js-compat/node_modules/semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/core-js-pure": {
@@ -21302,9 +21394,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.242",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.242.tgz",
-      "integrity": "sha512-nPdgMWtjjWGCtreW/2adkrB2jyHjClo9PtVhR6rW+oxa4E4Wom642Tn+5LslHP3XPL5MCpkn5/UEY60EXylNeQ==",
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -40296,9 +40388,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.7.tgz",
-      "integrity": "sha512-iN/XYesmZ2RmmWAiI4Z5rq0YqSiv0brj9Ce9CfhNE4xIW2h+MFxcgkxIzZ+ShkFPUkjU3gQ+3oypadD3RAMtrg==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
       "dev": true,
       "funding": [
         {
@@ -43737,15 +43829,13 @@
       }
     },
     "@babel/helper-define-polyfill-provider": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.0.tgz",
-      "integrity": "sha512-JT8tHuFjKBo8NnaUbblz7mIu1nnvUDiHVjXXkulZULyidvo/7P6TY7+YqpV37IfF+KUFxmlK04elKtGKXaiVgw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.3.tgz",
+      "integrity": "sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==",
       "dev": true,
       "requires": {
-        "@babel/helper-compilation-targets": "^7.13.0",
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/traverse": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "debug": "^4.1.1",
         "lodash.debounce": "^4.0.8",
         "resolve": "^1.14.2",
@@ -44079,17 +44169,6 @@
         "@babel/plugin-syntax-numeric-separator": "^7.10.4"
       }
     },
-    "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.13.tgz",
-      "integrity": "sha512-WvA1okB/0OS/N3Ldb3sziSrXg6sRphsBgqiccfcQq7woEn5wQLNX82Oc4PlaFcdwcWHuQXAtb8ftbS8Fbsg/sg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-        "@babel/plugin-transform-parameters": "^7.12.13"
-      }
-    },
     "@babel/plugin-proposal-optional-catch-binding": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.18.6.tgz",
@@ -44225,12 +44304,12 @@
       }
     },
     "@babel/plugin-syntax-jsx": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.13.tgz",
-      "integrity": "sha512-d4HM23Q1K7oq/SLNmG6mRt85l2csmQ0cHRaxRXjKW0YFdEXqlZ5kzFQKH5Uc3rDJECgu+yCRgPkG04Mm98R/1g==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
+      "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
@@ -44303,6 +44382,15 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.18.6.tgz",
+      "integrity": "sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
@@ -44557,16 +44645,16 @@
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.13.12.tgz",
-      "integrity": "sha512-jcEI2UqIcpCqB5U5DRxIl0tQEProI2gcu+g8VTIqxLO5Iidojb4d77q+fwGseCvd8af/lJ9masp4QWzBXFE2xA==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.19.0.tgz",
+      "integrity": "sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.12.13",
-        "@babel/helper-module-imports": "^7.13.12",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-jsx": "^7.12.13",
-        "@babel/types": "^7.13.12"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.19.0",
+        "@babel/plugin-syntax-jsx": "^7.18.6",
+        "@babel/types": "^7.19.0"
       }
     },
     "@babel/plugin-transform-react-jsx-development": {
@@ -44576,30 +44664,6 @@
       "dev": true,
       "requires": {
         "@babel/plugin-transform-react-jsx": "^7.16.7"
-      },
-      "dependencies": {
-        "@babel/plugin-syntax-jsx": {
-          "version": "7.17.12",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.17.12.tgz",
-          "integrity": "sha512-spyY3E3AURfxh/RHtjx5j6hs8am5NbUBGfcZ2vB3uShSpZdQyXSf5rR5Mk76vbtlAZOelyVQ71Fg0x9SG4fsog==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.17.12"
-          }
-        },
-        "@babel/plugin-transform-react-jsx": {
-          "version": "7.17.12",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.12.tgz",
-          "integrity": "sha512-Lcaw8bxd1DKht3thfD4A12dqo1X16he1Lm8rIv8sTwjAYNInRS1qHa9aJoqvzpscItXvftKDCfaEQzwoVyXpEQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-annotate-as-pure": "^7.16.7",
-            "@babel/helper-module-imports": "^7.16.7",
-            "@babel/helper-plugin-utils": "^7.17.12",
-            "@babel/plugin-syntax-jsx": "^7.17.12",
-            "@babel/types": "^7.17.12"
-          }
-        }
       }
     },
     "@babel/plugin-transform-react-pure-annotations": {
@@ -44632,16 +44696,16 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.13.15",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.13.15.tgz",
-      "integrity": "sha512-d+ezl76gx6Jal08XngJUkXM4lFXK/5Ikl9Mh4HKDxSfGJXmZ9xG64XT2oivBzfxb/eQ62VfvoMkaCZUKJMVrBA==",
+      "version": "7.19.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.19.6.tgz",
+      "integrity": "sha512-PRH37lz4JU156lYFW1p8OxE5i7d6Sl/zV58ooyr+q1J1lnQPyg5tIiXlIwNVhJaY4W3TmOtdc8jqdXQcB1v5Yw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.13.12",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "babel-plugin-polyfill-corejs2": "^0.2.0",
-        "babel-plugin-polyfill-corejs3": "^0.2.0",
-        "babel-plugin-polyfill-regenerator": "^0.2.0",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.19.0",
+        "babel-plugin-polyfill-corejs2": "^0.3.3",
+        "babel-plugin-polyfill-corejs3": "^0.6.0",
+        "babel-plugin-polyfill-regenerator": "^0.4.1",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -44697,6 +44761,17 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.9"
+      }
+    },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.19.3.tgz",
+      "integrity": "sha512-z6fnuK9ve9u/0X0rRvI9MY0xg+DOUaABDYOe+/SQTxtlptaBB/V9JIUxJn6xp3lMBeb9qe8xSFmHU35oZDXD+w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.19.0",
+        "@babel/helper-plugin-utils": "^7.19.0",
+        "@babel/plugin-syntax-typescript": "^7.18.6"
       }
     },
     "@babel/plugin-transform-unicode-escapes": {
@@ -44891,30 +44966,17 @@
         "@babel/plugin-transform-react-jsx": "^7.17.12",
         "@babel/plugin-transform-react-jsx-development": "^7.16.7",
         "@babel/plugin-transform-react-pure-annotations": "^7.16.7"
-      },
-      "dependencies": {
-        "@babel/plugin-syntax-jsx": {
-          "version": "7.17.12",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.17.12.tgz",
-          "integrity": "sha512-spyY3E3AURfxh/RHtjx5j6hs8am5NbUBGfcZ2vB3uShSpZdQyXSf5rR5Mk76vbtlAZOelyVQ71Fg0x9SG4fsog==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.17.12"
-          }
-        },
-        "@babel/plugin-transform-react-jsx": {
-          "version": "7.17.12",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.12.tgz",
-          "integrity": "sha512-Lcaw8bxd1DKht3thfD4A12dqo1X16he1Lm8rIv8sTwjAYNInRS1qHa9aJoqvzpscItXvftKDCfaEQzwoVyXpEQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-annotate-as-pure": "^7.16.7",
-            "@babel/helper-module-imports": "^7.16.7",
-            "@babel/helper-plugin-utils": "^7.17.12",
-            "@babel/plugin-syntax-jsx": "^7.17.12",
-            "@babel/types": "^7.17.12"
-          }
-        }
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.18.6.tgz",
+      "integrity": "sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/plugin-transform-typescript": "^7.18.6"
       }
     },
     "@babel/runtime": {
@@ -51174,27 +51236,130 @@
       }
     },
     "@wordpress/babel-preset-default": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.3.0.tgz",
-      "integrity": "sha512-yj/JEQh8SJzI3d6h531iVnKvFSYssdFb2PwpMCL5BuIXk98U+FOKSmIHj134WJ1lm4viwMIQeH3UZ93bJ0MqTQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.4.0.tgz",
+      "integrity": "sha512-7drcVBIajDE8s3At7yUr9UdHROYkfPYgR4OaG+EugDn9MzuDIEsGalnazDYwvjerLAwsf8S/S8o34bi6IrthYQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.4.4",
-        "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
-        "@babel/plugin-transform-react-jsx": "^7.3.0",
-        "@babel/plugin-transform-runtime": "^7.4.4",
-        "@babel/preset-env": "^7.4.4",
-        "@babel/runtime": "^7.4.4",
-        "@wordpress/babel-plugin-import-jsx-pragma": "^2.2.0",
-        "@wordpress/browserslist-config": "^2.5.0"
+        "@babel/core": "^7.16.0",
+        "@babel/plugin-transform-react-jsx": "^7.16.0",
+        "@babel/plugin-transform-runtime": "^7.16.0",
+        "@babel/preset-env": "^7.16.0",
+        "@babel/preset-typescript": "^7.16.0",
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/babel-plugin-import-jsx-pragma": "^4.3.0",
+        "@wordpress/browserslist-config": "^5.3.0",
+        "@wordpress/element": "^4.18.0",
+        "@wordpress/warning": "^2.20.0",
+        "browserslist": "^4.17.6",
+        "core-js": "^3.19.1"
       },
       "dependencies": {
-        "@wordpress/browserslist-config": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.7.0.tgz",
-          "integrity": "sha512-pB45JlfmHuEigNFZ1X+CTgIsOT3/TTb9iZxw1DHXge/7ytY8FNhtcNwTfF9IgnS6/xaFRZBqzw4DyH4sP1Lyxg==",
+        "@types/react": {
+          "version": "17.0.50",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.50.tgz",
+          "integrity": "sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==",
+          "dev": true,
+          "requires": {
+            "@types/prop-types": "*",
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
+          }
+        },
+        "@types/react-dom": {
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.17.tgz",
+          "integrity": "sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==",
+          "dev": true,
+          "requires": {
+            "@types/react": "^17"
+          }
+        },
+        "@wordpress/babel-plugin-import-jsx-pragma": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.3.0.tgz",
+          "integrity": "sha512-7AnWnpItOqH5YEcFA3RgxeOlb96R8KDWDPAZjZ6TpsdOVjFynT8H3Buc4v127BHmxuxKGyd2vxPIQIzC9dLzOw==",
           "dev": true
+        },
+        "@wordpress/browserslist-config": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.3.0.tgz",
+          "integrity": "sha512-FIhYWu36TrZ49W+knaRwhw3Q+cxaTDEzSaiE83qMDeAPJytT/UaedoJULt5MfxUtfaKLmUa8bPjSFORxoxwbvQ==",
+          "dev": true
+        },
+        "@wordpress/element": {
+          "version": "4.18.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.18.0.tgz",
+          "integrity": "sha512-+3gA4RTD/EDj1h2y/qikh+h0uCUxhShfM7QoDngKOBNSTZHqc0W2p6IMEe+AMdrmu8tyZboTJW/eONjUHE4n7g==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@types/react": "^17.0.37",
+            "@types/react-dom": "^17.0.11",
+            "@wordpress/escape-html": "^2.20.0",
+            "change-case": "^4.1.2",
+            "is-plain-object": "^5.0.0",
+            "react": "^17.0.2",
+            "react-dom": "^17.0.2"
+          }
+        },
+        "@wordpress/escape-html": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.20.0.tgz",
+          "integrity": "sha512-bhHkFQrEkuJjhSB6OlQq/Kq+43k8E6JwUw/pCDAjJX2uU/DDG3tW3eftYn2ae7W23bPrNEs1/qULWzbaziPQnw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0"
+          }
+        },
+        "@wordpress/warning": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.20.0.tgz",
+          "integrity": "sha512-swTE3rUbk00rddyrQo2sA6yojbzNYUXTntAHbfoF68AC53i7cFunB3Bcod+paDPGR0gq1mr3rfatrWHze8qz3Q==",
+          "dev": true
+        },
+        "core-js": {
+          "version": "3.25.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.5.tgz",
+          "integrity": "sha512-nbm6eZSjm+ZuBQxCUPQKQCoUEfFOXjUZ8dTTyikyKaWrTYmAVbykQfwsKE5dBK88u3QCkCrzsx/PPlKfhsvgpw==",
+          "dev": true
+        },
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+          "dev": true
+        },
+        "react": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-dom": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+          "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "scheduler": "^0.20.2"
+          }
+        },
+        "scheduler": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+          "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
         }
       }
     },
@@ -57073,13 +57238,13 @@
       }
     },
     "babel-plugin-polyfill-corejs2": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.0.tgz",
-      "integrity": "sha512-9bNwiR0dS881c5SHnzCmmGlMkJLl0OUZvxrxHo9w/iNoRuqaPjqlvBf4HrovXtQs/au5yKkpcdgfT1cC5PAZwg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
+      "integrity": "sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.13.11",
-        "@babel/helper-define-polyfill-provider": "^0.2.0",
+        "@babel/compat-data": "^7.17.7",
+        "@babel/helper-define-polyfill-provider": "^0.3.3",
         "semver": "^6.1.1"
       },
       "dependencies": {
@@ -57092,22 +57257,22 @@
       }
     },
     "babel-plugin-polyfill-corejs3": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.0.tgz",
-      "integrity": "sha512-zZyi7p3BCUyzNxLx8KV61zTINkkV65zVkDAFNZmrTCRVhjo1jAS+YLvDJ9Jgd/w2tsAviCwFHReYfxO3Iql8Yg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz",
+      "integrity": "sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==",
       "dev": true,
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.2.0",
-        "core-js-compat": "^3.9.1"
+        "@babel/helper-define-polyfill-provider": "^0.3.3",
+        "core-js-compat": "^3.25.1"
       }
     },
     "babel-plugin-polyfill-regenerator": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.0.tgz",
-      "integrity": "sha512-J7vKbCuD2Xi/eEHxquHN14bXAW9CXtecwuLrOIDJtcZzTaPzV1VdEfoUf9AzcRBMolKUQKM9/GVojeh0hFiqMg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.1.tgz",
+      "integrity": "sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==",
       "dev": true,
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.2.0"
+        "@babel/helper-define-polyfill-provider": "^0.3.3"
       }
     },
     "babel-plugin-syntax-jsx": {
@@ -57600,15 +57765,15 @@
       }
     },
     "browserslist": {
-      "version": "4.21.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "update-browserslist-db": "^1.0.9"
       }
     },
     "bs-logger": {
@@ -57842,9 +58007,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001390",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001390.tgz",
-      "integrity": "sha512-sS4CaUM+/+vqQUlCvCJ2WtDlV81aWtHhqeEVkLokVJJa3ViN4zDxAGfq9R8i1m90uGHxo99cy10Od+lvn3hf0g==",
+      "version": "1.0.30001422",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz",
+      "integrity": "sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==",
       "dev": true
     },
     "capital-case": {
@@ -58762,21 +58927,12 @@
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.0.tgz",
-      "integrity": "sha512-extKQM0g8/3GjFx9US12FAgx8KJawB7RCQ5y8ipYLbmfzEzmFRWdDjIlxDx82g7ygcNG85qMVUSRyABouELdow==",
+      "version": "3.25.5",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.5.tgz",
+      "integrity": "sha512-ovcyhs2DEBUIE0MGEKHP4olCUW/XYte3Vroyxuh38rD1wAO4dHohsovUC4eAOuzFxE6b+RXvBU3UZ9o0YhUTkA==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.21.3",
-        "semver": "7.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-          "dev": true
-        }
+        "browserslist": "^4.21.4"
       }
     },
     "core-js-pure": {
@@ -59840,9 +59996,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.242",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.242.tgz",
-      "integrity": "sha512-nPdgMWtjjWGCtreW/2adkrB2jyHjClo9PtVhR6rW+oxa4E4Wom642Tn+5LslHP3XPL5MCpkn5/UEY60EXylNeQ==",
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
       "dev": true
     },
     "elliptic": {
@@ -74735,9 +74891,9 @@
       "optional": true
     },
     "update-browserslist-db": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.7.tgz",
-      "integrity": "sha512-iN/XYesmZ2RmmWAiI4Z5rq0YqSiv0brj9Ce9CfhNE4xIW2h+MFxcgkxIzZ+ShkFPUkjU3gQ+3oypadD3RAMtrg==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
       "dev": true,
       "requires": {
         "escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
   },
   "devDependencies": {
     "@automattic/color-studio": "2.3.1",
-    "@babel/plugin-proposal-object-rest-spread": "7.12.13",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.7",
     "@testing-library/jest-dom": "5.14.1",
     "@testing-library/react": "11.2.5",
@@ -98,7 +97,7 @@
     "@woocommerce/experimental": "2.1.0",
     "@wordpress/api-fetch": "5.1.1",
     "@wordpress/babel-plugin-makepot": "4.2.0",
-    "@wordpress/babel-preset-default": "4.3.0",
+    "@wordpress/babel-preset-default": "7.4.0",
     "@wordpress/base-styles": "3.5.4",
     "@wordpress/block-editor": "7.0.2",
     "@wordpress/blocks": "11.0.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@wordpress/base-styles": "3.5.4",
     "@wordpress/block-editor": "7.0.2",
     "@wordpress/blocks": "11.0.1",
-    "@wordpress/browserslist-config": "3.0.1",
+    "@wordpress/browserslist-config": "5.3.0",
     "@wordpress/components": "11.1.5",
     "@wordpress/data": "4.23.1",
     "@wordpress/data-controls": "1.6.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Follow-up from #4948 

After dropping IE11 support we don't need those babel plugins anymore. Our current supported browsers don't need any polyfills or runtime transforms for those features.

- Remove all unnecessary babel plugins:
  - `@babel/transform-runtime` – Used to support async/await.
  - `@babel/plugin-proposal-optional-chaining` – Used to support `?.` syntax.
  - `@babel/plugin-proposal-nullish-coalescing-operator` – Used to support `??` operator.
- Remove unused dependency `@babel/plugin-proposal-object-rest-spread`.
- Remove `.babelrc` as we already use `babel.config.js` for the same purpose.

#### Testing instructions
The build process and E2E tests should pass without errors. We can also quickly test it having UPE enabled and following those instructions:
- Build the project running `npm run build`.
- Add a product to the cart and go to **Checkout**
- Should work as expected without errors on the browser's console.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
