### PR TITLE
Revert "Support Platform Checkout from Checkout Blocks (#4611)"

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,22 @@
+name: Build WooCommerce Payments
+description: Build WooCommerce Payments
+inputs: 
+  release-filename:
+    description: "The name of the release filename"
+    default: 'woocommerce-payments.zip'
+
+runs:
+  using: composite
+  steps:
+    - name: Build the plugin
+      shell: bash
+      env:
+        RELEASE_FILENAME: ${{ inputs.release-filename }}
+      run: |
+        npm ci
+        npm run build
+        
+        if [[ ! -f $RELEASE_FILENAME ]]; then
+          echo "::error::Failed to create release archive $RELEASE_FILENAME."
+          exit 1
+        fi

--- a/.github/actions/create-branch-tag/action.yml
+++ b/.github/actions/create-branch-tag/action.yml
@@ -35,7 +35,7 @@ runs:
         TRIMMED_TAG_NAME=$(echo "$TAG_NAME" | xargs) 
         
         if ${{ env.IS_PRERELEASE == 'true' }}; then
-          TAG_FORMAT="^[0-9]\.[0-9]\.[0-9](-test-[1-9])*$"
+          TAG_FORMAT="^[0-9]\.[0-9]\.[0-9]-test-[1-9]$"
         else
           TAG_FORMAT="^[0-9]\.[0-9]\.[0-9]$"
         fi

--- a/.github/actions/create-branch-tag/action.yml
+++ b/.github/actions/create-branch-tag/action.yml
@@ -1,0 +1,74 @@
+name: Create a branch and a tag
+description: Create a branch and a tag from the version provided
+
+inputs:
+  tag-name:
+    description: "The tag name that the action should use to determine which branch and tag it should create (e.g. 4.5.0 or 4.5.0-test-2)"
+    required: true
+  is-pre-release:
+    description: "Whether the action runs in the context of a pre-release (default: true)"
+    required: true
+    default: "true"
+    
+outputs: 
+  branch-name:
+    description: "The name of the branch created"
+    value: ${{ steps.create_branch_tag.outputs.BRANCH_NAME }}
+  tag-name:
+    description: "The trimmed tag name"
+    value: ${{ steps.tag_format_check.outputs.TAG_NAME }}
+  tag-message:
+    description: "The tagging message"
+    value: ${{ steps.create_branch_tag.outputs.TAG_MESSAGE }}
+
+runs:
+  using: composite
+  steps:
+    - name: "Check the format of the tag"
+      id: tag_format_check
+      shell: bash
+      env:
+        IS_PRERELEASE: ${{ inputs.is-pre-release }}
+        TAG_NAME: ${{ inputs.tag-name }}
+      run: |
+        # Trim leading and ending whitespaces
+        TRIMMED_TAG_NAME=$(echo "$TAG_NAME" | xargs) 
+        
+        if ${{ env.IS_PRERELEASE == 'true' }}; then
+          TAG_FORMAT="^[0-9]\.[0-9]\.[0-9](-test-[1-9])*$"
+        else
+          TAG_FORMAT="^[0-9]\.[0-9]\.[0-9]$"
+        fi
+        
+        if [[ $TRIMMED_TAG_NAME =~ $TAG_FORMAT ]]; then
+          echo "TAG_NAME=$TRIMMED_TAG_NAME" >> $GITHUB_OUTPUT
+        else
+          echo "::error::The tag name provided doesn't respect the format expected (tag: $TRIMMED_TAG_NAME; format: $TAG_FORMAT)."
+          exit 1
+        fi
+    - name: "Create a branch and tag"
+      id: create_branch_tag
+      shell: bash
+      env:
+        IS_PRERELEASE: ${{ contains( steps.tag_format_check.outputs.TAG_NAME, 'test') }}
+        TAG_NAME: ${{ steps.tag_format_check.outputs.TAG_NAME }}
+      run: |
+        if ${{ env.IS_PRERELEASE == 'true' }}; then
+          BRANCH_NAME="testing/$TAG_NAME"
+          TAG_MESSAGE="Version for testing $TAG_NAME. Not for Production"
+          echo "Created branch $BRANCH_NAME and tag $TAG_NAME." >> $GITHUB_STEP_SUMMARY
+        else
+          BRANCH_NAME="release/$TAG_NAME"
+          TAG_MESSAGE="Version $TAG_NAME"
+          echo ":rocket: Created branch $BRANCH_NAME and tag $TAG_NAME. :rocket:" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        git checkout -b $BRANCH_NAME
+        git push origin $BRANCH_NAME
+        echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
+        
+        git config user.name "${{ github.actor }}"
+        git config user.email "${{ github.actor }}@users.noreply.github.com"
+        git tag -a -m "$TAG_MESSAGE" $TAG_NAME
+        git push origin $TAG_NAME
+        echo "TAG_MESSAGE=$TAG_MESSAGE" >> $GITHUB_OUTPUT

--- a/.github/actions/generate-changelog/action.yml
+++ b/.github/actions/generate-changelog/action.yml
@@ -1,0 +1,40 @@
+name: Generate the changelog for WooCommerce Payments
+description: Generate the changelog from the version provided
+
+inputs:
+  release-version:
+    description: "The release version for which the action should generate the changelog (e.g. 4.5.0)"
+    required: true
+  release-date:
+    description: "The release date (format: YYYY-MM-DD) for which the action should generate the changelog (default: unreleased)"
+    required: false
+    default: "unreleased"
+    
+outputs: 
+  changelog:
+    description: "The escaped changelog content generated from the release version provided"
+    value: ${{ steps.get_changelog.outputs.CHANGELOG }}
+
+runs:
+  using: composite
+  steps:
+    - name: Generate changelog
+      id: get_changelog
+      shell: bash
+      env:
+        VERSION: ${{ inputs.release-version }}
+        RELEASE_DATE: ${{ inputs.release-date }}
+      run: |
+        # Install this dev package globally to gather changelog entries while not including it into the release package
+        composer global require automattic/jetpack-changelogger:^3.0.7
+        
+        # Gather changelog entries
+        ~/.composer/vendor/bin/changelogger write --use-version="$VERSION" --release-date="$RELEASE_DATE"
+        
+        echo "Picking up changelog for version '$VERSION'..."
+        CHANGELOG=$(awk '/^= / { if (p) { exit }; p=1; next } p && NF' changelog.txt)
+        echo "$CHANGELOG"
+        
+        # New line characters need to be escaped because set-output doesn't support multi-line strings out of the box
+        CHANGELOG="${CHANGELOG//$'\n'/\\n}"  
+        echo "CHANGELOG=$CHANGELOG" >> $GITHUB_OUTPUT

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -1,0 +1,29 @@
+name: Setup WooCommerce Payments repository
+description: Handles the installation, building, and caching of the projects within the repository.
+
+inputs:
+  php-version:
+    description: The version of PHP that the action should set up.
+    default: "7.4"
+
+runs:
+  using: composite
+  steps:
+    - name: Enable composer dependencies caching
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/composer/
+        key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'npm'
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php-version }}
+        tools: composer
+        coverage: none

--- a/.github/workflows/build-zip-file.yml
+++ b/.github/workflows/build-zip-file.yml
@@ -1,0 +1,28 @@
+name: "Build zip file"
+
+# This action will run when it is triggered manually
+on:
+  workflow_dispatch:
+    
+jobs:
+  build-zip:
+    name: Build the zip file
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node and PHP with cache
+        uses: ./.github/actions/setup-repo
+
+      - name: Build the plugin
+        uses: ./.github/actions/build
+      
+      - name: Upload the zip file as an artifact
+        uses: actions/upload-artifact@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: woocommerce-payments
+          path: 'woocommerce-payments.zip'
+          retention-days: 7

--- a/.github/workflows/create-pre-release.yml
+++ b/.github/workflows/create-pre-release.yml
@@ -1,0 +1,92 @@
+---
+name: "Create a pre-release"
+
+# This action will run when it is triggered manually
+on:
+  workflow_dispatch:
+    inputs:
+      tagName:
+        description: 'The tag name (e.g. 4.5.0-test-2 for prerelease during week 2)'
+        required: true
+        type: string
+env:
+  RELEASE_FILENAME: 'woocommerce-payments.zip'
+  
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  create-release:
+    name: Create the pre-release
+    runs-on: ubuntu-20.04
+    env:
+      TAG_NAME: ${{ inputs.tagName }}
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: 'develop'
+        
+      - name: Create a testing branch and tag
+        id: create_branch_tag
+        uses: ./.github/actions/create-branch-tag
+        with:
+          tag-name: ${{ env.TAG_NAME }}
+
+      - name: Setup Node and PHP with cache
+        uses: ./.github/actions/setup-repo
+        
+      - name: Define variables
+        id: define_var
+        env: 
+          TAG_NAME: ${{ steps.create_branch_tag.outputs.tag-name }}
+        run: |
+          echo "RELEASE_VERSION=$( sed -E 's/^([^-]+)-.*/\1/' <<< $TAG_NAME )" >> $GITHUB_OUTPUT
+
+      - name: Generate the changelog
+        id: generate_changelog
+        uses: ./.github/actions/generate-changelog
+        with:
+          release-version: ${{ steps.define_var.outputs.RELEASE_VERSION }}
+          
+      - name: Bump version header
+        env:
+          TAG_NAME: ${{ steps.create_branch_tag.outputs.tag-name }}
+        run: |
+          sed -i "s/^ \* Version: .*$/ * Version: $TAG_NAME/" woocommerce-payments.php
+      
+      - name: Build the plugin
+        uses: ./.github/actions/build
+          
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANGELOG: ${{ steps.generate_changelog.outputs.changelog }}
+          TAG_MESSAGE: ${{ steps.create_branch_tag.outputs.tag-message }}
+          TAG_NAME: ${{ steps.create_branch_tag.outputs.tag-name }}
+        run: |
+          RELEASE_NOTES=$(echo -e "${CHANGELOG}")
+          gh release create $TAG_NAME --notes "$RELEASE_NOTES" --title "$TAG_MESSAGE" --target "develop" "--prerelease" $RELEASE_FILENAME
+          
+      - name: Trigger translations update on GlotPress
+        env:
+          GLOTPRESS_IMPORT_URL: ${{ secrets.GLOTPRESS_IMPORT_URL }}
+          TAG_NAME: ${{ steps.create_branch_tag.outputs.tag-name }}
+        run: |
+          echo "Triggering translations update on GlotPress..."
+
+          CURL_RESPONSE=$(curl --request POST \
+              --url "$GLOTPRESS_IMPORT_URL/$TAG_NAME" \
+              --silent \
+              --write-out "\n%{http_code}\n" )
+          HTTP_CODE=$(echo "$CURL_RESPONSE" | tail -n 1)
+          CURL_RESPONSE=$(echo "$CURL_RESPONSE" | head -n -1)
+
+          if [[ ${HTTP_CODE} -lt 200 || ${HTTP_CODE} -gt 299 ]]; then
+            echo "$CURL_RESPONSE"
+            echo "::error::Couldn't trigger translations."
+            exit 1
+          fi
+          echo "Translations update triggered."

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,46 @@
+---
+name: "Create a draft stable release"
+
+# This action will only run when a pull request targeting `trunk` is closed/merged.
+on:
+  pull_request_target:
+    branches:
+      - 'trunk'
+    types:
+      - closed
+env:
+  RELEASE_FILENAME: 'woocommerce-payments.zip'
+  
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  create-release:
+    # We require that the PR originated from a release branch and that it was merged
+    if: startsWith(github.head_ref, 'release/') && github.event.pull_request.merged == true
+    name: Create the release
+    runs-on: ubuntu-20.04
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Get release version from merge commit
+        id: get_version
+        run: echo "RELEASE_VERSION=$(jq '.version' package.json -r)" >> $GITHUB_OUTPUT
+        
+      - name: Build the plugin
+        uses: ./.github/actions/build
+      
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.get_version.outputs.RELEASE_VERSION }}
+          TAG_MESSAGE: ${{ github.event.pull_request.title }}
+          TARGET_COMMIT: ${{ github.event.pull_request.merge_commit_sha }}
+          RELEASE_NOTES: ${{ github.event.pull_request.body }}
+        run: |
+          gh release create $RELEASE_VERSION --draft --notes "$RELEASE_NOTES" --title "$TAG_MESSAGE" --target $TARGET_COMMIT $RELEASE_FILENAME

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -1,0 +1,145 @@
+name: "Release - Code freeze"
+
+# This action will run according to the cron schedule or when triggered manually
+on:
+  schedule:
+    - cron: '0 12 * * 0' # Run at 1200 UTC on Sundays.
+  workflow_dispatch:
+    inputs:
+      skipSlackPing:
+        description: "If true, the Slack ping will be skipped"
+        type: boolean
+        required: false
+        default: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check-code-freeze:
+    name: "Check that today is the day of the code freeze"
+    runs-on: ubuntu-20.04
+    outputs:
+      freeze: ${{ steps.check-freeze.outputs.FREEZE }}
+      releaseVersion: ${{ steps.next-version.outputs.RELEASE_VERSION }}
+      releaseDate: ${{ steps.next-version.outputs.RELEASE_PLANNED_DATE }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: 'develop'
+    
+      - name: Get current version
+        id: current-version
+        run: |
+          VERSION=$(jq '.version' package.json -r)
+          echo "Current version found: $VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer
+          coverage: none
+
+      - name: Get the next version
+        id: next-version
+        shell: php {0}
+        env:
+          CURRENT_VERSION: ${{ steps.current-version.outputs.VERSION }}
+        run: |
+          <?php
+          
+          $latest_version_with_release = getenv( 'CURRENT_VERSION' );
+          if ( empty( $latest_version_with_release ) ) {
+            echo "::error::Unable to get the latest released version";
+            exit( 1 );
+          }
+          
+          // Because we go from 5.9 to 6.0, we can get the next major_minor by adding 0.1 and formatting appropriately.
+          $latest_version_as_float = (float) $latest_version_with_release;
+          $branch_major_minor      = number_format( $latest_version_as_float + 0.1, 1 );
+          $next_version            = $branch_major_minor.0;
+          echo "::set-output name=RELEASE_VERSION::$next_version" . PHP_EOL;
+
+          $next_wednesday = date('Y-n-d', strtotime('next Wednesday'));
+          echo "::set-output name=RELEASE_PLANNED_DATE::$next_wednesday" . PHP_EOL;
+          
+          echo "Next version: $next_version" >> $GITHUB_STEP_SUMMARY      
+      
+      - name: Check if the next version needs a code freeze
+        id: check-freeze
+        env:
+          NEXT_VERSION: ${{ steps.next-version.outputs.RELEASE_VERSION }} 
+        run: |
+          git fetch --tags origin
+          NEXT_VERSION_TAG_STABLE=$(git tag -l "${{ env.NEXT_VERSION }}" | tail -1)
+          NEXT_VERSION_TAG_FROM_WEEK_2=$(git tag -l "${{ env.NEXT_VERSION }}-test-2" | tail -1)
+          if [[ -z "$NEXT_VERSION_TAG_FROM_WEEK_2" ]]; then
+            echo "Code freeze is not needed :x:" >> $GITHUB_STEP_SUMMARY
+            echo "FREEZE=0" >> $GITHUB_OUTPUT
+          elif [[ -z "$NEXT_VERSION_TAG_STABLE" ]]; then
+            echo "Code freeze is needed :white_check_mark:" >> $GITHUB_STEP_SUMMARY
+            echo "FREEZE=1" >> $GITHUB_OUTPUT
+          fi
+
+  create-release-pr:
+    name: "Raise a PR to trunk"
+    needs: check-code-freeze
+    if: needs.check-code-freeze.outputs.freeze == 1
+    uses: ./.github/workflows/release-pr.yml
+    with:
+      tagName: ${{ needs.check-code-freeze.outputs.releaseVersion }}
+
+  slack-notification:
+    name: "Send notification to Slack"
+    needs: [check-code-freeze, create-release-pr]
+    if: ${{ inputs.skipSlackPing != true }}
+    runs-on: ubuntu-20.04
+    env:
+      RELEASE_VERSION: ${{ needs.check-code-freeze.outputs.releaseVersion }}
+      RELEASE_DATE: ${{ needs.check-code-freeze.outputs.releaseDate }}
+      GITHUB_TAG_URL: ${{ format( '{0}/{1}/releases/tag/{2}', github.server_url, github.repository, needs.check-code-freeze.outputs.releaseVersion ) }}
+    steps:
+      - name: Slack ping
+        uses: slackapi/slack-github-action@v1.23.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CODE_FREEZE_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        with:
+          # For posting a rich message using Block Kit (https://api.slack.com/messaging/interactivity)
+          payload: |       
+            {
+                "blocks": [
+                    {
+                        "type": "header",
+                        "text": {
+                            "type": "plain_text",
+                            "text": "Code freeze notification",
+                            "emoji": true
+                        }
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": "The automated workflow just created a release branch and raised a Pull Request to merge changes on trunk. Any PRs that were not already merged will be a part of the release after that by default.\n If you have something that needs to be released in ${{ env.RELEASE_VERSION }}, please consult the release lead."
+                        }
+                    },
+                    {
+                        "type": "section",
+                        "fields": [
+                            {
+                                "type": "mrkdwn",
+                                "text": "*Version:*\n<${{ env.GITHUB_TAG_URL }}|${{ env.RELEASE_VERSION }}>"
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": "*Planned date:*\n<https://wcpay.wordpress.com/dev-resources/wc-payments-release-calendar/|${{ env.RELEASE_DATE }}>"
+                            }
+                        ]
+                    }
+                ]
+            }

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,106 @@
+name: "Release - Create PR to trunk"
+
+# This action will run inside the release code freeze workflow or when it is triggered manually
+on:
+  workflow_call:
+    inputs:
+      tagName:
+        description: 'The tag name (e.g. 4.5.0)'
+        required: true
+        type: string
+      releaseDateString:
+        description: "The release date in human-readable format, which will be formatted for changelog.txt and readme.txt (default: 'next wednesday')."
+        required: false
+        default: "next wednesday"
+        type: string
+  workflow_dispatch:
+    inputs:
+      tagName:
+        description: 'The tag name (e.g. 4.5.0)'
+        required: true
+        type: string
+      releaseDateString:
+        description: "The release date in human-readable format, which will be formatted for changelog.txt and readme.txt (default: 'next wednesday')."
+        required: false
+        default: "next wednesday"
+        type: string
+  
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  prepare-release:
+    name: Prepare a stable release
+    runs-on: ubuntu-20.04
+    outputs: 
+      branch: ${{ steps.create_branch_tag.outputs.branch-name }}
+    env:
+      TAG_NAME: ${{ inputs.tagName }}
+      RELEASE_DATE_STRING: ${{ inputs.releaseDateString }}    
+    
+    steps:
+      - name: Checkout WCPay repository
+        uses: actions/checkout@v3
+
+      - name: Create a release branch and tag
+        id: create_branch_tag
+        uses: ./.github/actions/create-branch-tag
+        with:
+          tag-name: ${{ env.TAG_NAME }}
+          is-pre-release: "false"
+
+      - name: Setup Node and PHP with cache
+        uses: ./.github/actions/setup-repo
+
+      - name: Define variables
+        id: define_var
+        run: |
+          RELEASE_DATE=$( date "+%Y-%m-%d" -d "$RELEASE_DATE_STRING" ) # Release date formatted as YYYY-MM-DD
+          echo "RELEASE_DATE=$RELEASE_DATE" >> $GITHUB_OUTPUT
+
+      - name: Generate the changelog
+        id: generate_changelog
+        uses: ./.github/actions/generate-changelog
+        with:
+          release-version: ${{ steps.create_branch_tag.outputs.tag-name }}
+          release-date: ${{ steps.define_var.outputs.RELEASE_DATE }}
+          
+      - name: Bump version
+        env:
+          TAG_NAME: ${{ steps.create_branch_tag.outputs.tag-name }}
+          RELEASE_DATE: ${{ steps.define_var.outputs.RELEASE_DATE }}
+          CHANGELOG: ${{ steps.generate_changelog.outputs.changelog }}
+        run: |
+          CURRENT_VERSION=$(jq '.version' package.json -r)
+
+          # 'Version' header in woocommerce-payments.php
+          sed -i "s/^ \* Version: .*$/ * Version: $TAG_NAME/" woocommerce-payments.php
+
+          # 'version' field in package.json
+          sed -ri 's/("version": )".*"/\1"'${TAG_NAME}'"/' package.json
+
+          # 'Stable tag' header in readme.txt;
+          sed -i "s/^Stable tag: .*$/Stable tag: $TAG_NAME/" readme.txt
+
+          # Duplicate the generated changelog into the Changelog section from the readme.txt 
+          sed -ri "s|(== Changelog ==)|\1\n\n= $TAG_NAME - $RELEASE_DATE =\n$CHANGELOG|" readme.txt
+      
+      - name: Commit changes
+        env:
+          TAG_NAME: ${{ steps.create_branch_tag.outputs.tag-name }}
+          BRANCH_NAME: ${{ steps.create_branch_tag.outputs.branch-name }}
+        run: |
+          npm install # To update package-lock.json with the new version of the plugin
+          git commit -am "Update version and add changelog entries for release $TAG_NAME"
+          git push --set-upstream origin $BRANCH_NAME
+
+      - name: Create a PR to trunk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ steps.create_branch_tag.outputs.branch-name }}
+          CHANGELOG: ${{ steps.generate_changelog.outputs.changelog }}
+          TAG_NAME: ${{ steps.create_branch_tag.outputs.tag-name }}
+        run: |
+          PR_BODY=$(echo -e ":warning: Please do not merge the PR from the GitHub interface. :warning:\n\n Instead, you can use the following command: \` git merge --no-ff $BRANCH_NAME -m 'Merge $BRANCH_NAME into trunk' \`\n\`\`\`\n${CHANGELOG}\n\`\`\`")
+          gh pr create --title "Release branch for $TAG_NAME" --body="$PR_BODY" --base="trunk"

--- a/changelog/add-4684-package-creation-workflow
+++ b/changelog/add-4684-package-creation-workflow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add new GitHub workflows for release management (pre-release and release packages)

--- a/changelog/add-pass-tax-display-cart-option-to-woopay
+++ b/changelog/add-pass-tax-display-cart-option-to-woopay
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Pass the value of 'woocommerce_tax_display_cart' option from the merchant's store to WooPay

--- a/changelog/add-stripe-link-note
+++ b/changelog/add-stripe-link-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add Stripe Link set up inbox notification

--- a/changelog/dev-revert-of-4611
+++ b/changelog/dev-revert-of-4611
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Revert of previous commit that wasn't released yet
+
+

--- a/changelog/fix-update-regex-branch-tag-workflow
+++ b/changelog/fix-update-regex-branch-tag-workflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adjust regex to check the format of a tag for a pre-release in our GitHub workflow

--- a/changelog/task-4521-platform-checkout-from-checkout-blocks
+++ b/changelog/task-4521-platform-checkout-from-checkout-blocks
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Support Platform Checkout from Checkout Blocks.

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -21,7 +21,6 @@ import { SavedTokenHandler } from './saved-token-handler';
 import request from '../utils/request';
 import enqueueFraudScripts from 'fraud-scripts';
 import paymentRequestPaymentMethod from '../../payment-request/blocks';
-import { handlePlatformCheckoutEmailInput } from '../platform-checkout/email-input-iframe';
 
 // Create an API object, which will be used throughout the checkout.
 const api = new WCPayAPI(
@@ -51,10 +50,6 @@ registerPaymentMethod( {
 } );
 
 registerExpressPaymentMethod( paymentRequestPaymentMethod( api ) );
-
-if ( getConfig( 'isPlatformCheckoutEnabled' ) ) {
-	handlePlatformCheckoutEmailInput( '#email', api );
-}
 
 window.addEventListener( 'load', () => {
 	enqueueFraudScripts( getConfig( 'fraudServices' ) );

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -7,34 +7,10 @@ import wcpayTracks from 'tracks';
 import request from '../utils/request';
 import showErrorCheckout from '../utils/show-error-checkout';
 
-// Waits for the email field to exist as in the Blocks checkout, sometimes the email field is not immediately available.
-const waitForEmailField = ( selector ) => {
-	return new Promise( ( resolve ) => {
-		if ( document.querySelector( selector ) ) {
-			return resolve( document.querySelector( selector ) );
-		}
-
-		const checkoutBlock = document.querySelector(
-			'[data-block-name="woocommerce/checkout"]'
-		);
-		const observer = new MutationObserver( () => {
-			if ( document.querySelector( selector ) ) {
-				resolve( document.querySelector( selector ) );
-				observer.disconnect();
-			}
-		} );
-
-		observer.observe( checkoutBlock, {
-			childList: true,
-			subtree: true,
-		} );
-	} );
-};
-
-export const handlePlatformCheckoutEmailInput = async ( field, api ) => {
+export const handlePlatformCheckoutEmailInput = ( field, api ) => {
 	let timer;
 	const waitTime = 500;
-	const platformCheckoutEmailInput = await waitForEmailField( field );
+	const platformCheckoutEmailInput = document.querySelector( field );
 	let hasCheckedLoginSession = false;
 
 	// If we can't find the input, return.
@@ -213,7 +189,6 @@ export const handlePlatformCheckoutEmailInput = async ( field, api ) => {
 
 	// Error message to display when there's an error contacting WooPay.
 	const errorMessage = document.createElement( 'div' );
-	errorMessage.style[ 'white-space' ] = 'normal';
 	errorMessage.textContent = __(
 		'WooPay is unavailable at this time. Please complete your checkout below. Sorry for the inconvenience.',
 		'woocommerce-payments'

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -929,6 +929,10 @@ class WC_Payments {
 			WC_Payments_Notes_Additional_Payment_Methods::set_account( self::get_account_service() );
 			WC_Payments_Notes_Additional_Payment_Methods::possibly_add_note();
 			WC_Payments_Notes_Additional_Payment_Methods::maybe_enable_upe_feature_flag();
+
+			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-stripelink.php';
+			WC_Payments_Notes_Set_Up_StripeLink::set_gateway( self::get_gateway() );
+			WC_Payments_Notes_Set_Up_StripeLink::possibly_add_note();
 		}
 	}
 
@@ -951,6 +955,9 @@ class WC_Payments {
 
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-additional-payment-methods.php';
 			WC_Payments_Notes_Additional_Payment_Methods::possibly_delete_note();
+
+			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-stripelink.php';
+			WC_Payments_Notes_Set_Up_StripeLink::possibly_delete_note();
 		}
 	}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1071,6 +1071,7 @@ class WC_Payments {
 				'test_mode'                      => self::get_gateway()->is_in_test_mode(),
 				'capture_method'                 => empty( self::get_gateway()->get_option( 'manual_capture' ) ) || 'no' === self::get_gateway()->get_option( 'manual_capture' ) ? 'automatic' : 'manual',
 				'is_subscriptions_plugin_active' => self::get_gateway()->is_subscriptions_plugin_active(),
+				'woocommerce_tax_display_cart'   => get_option( 'woocommerce_tax_display_cart' ),
 			],
 			'user_session'         => isset( $_REQUEST['user_session'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['user_session'] ) ) : null,
 		];

--- a/includes/notes/class-wc-payments-notes-set-up-stripelink.php
+++ b/includes/notes/class-wc-payments-notes-set-up-stripelink.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Set up Stripe Link note for WooCommerce inbox.
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+use WCPay\Payment_Methods\Link_Payment_Method;
+use WCPay\Payment_Methods\CC_Payment_Method;
+
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WC_Payments_Notes_Setup_StripeLink
+ */
+class WC_Payments_Notes_Set_Up_StripeLink {
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-payments-notes-set-up-stripe-link';
+
+	/**
+	 * CTA button link
+	 */
+	const NOTE_DOCUMENTATION_URL = 'https://woocommerce.com/document/payments/woocommerce-payments-stripe-link/';
+
+	/**
+	 * The account service instance.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private static $gateway;
+
+	/**
+	 * Checks if a note can and should be added.
+	 *
+	 * @return bool
+	 */
+	public static function should_display_note():bool {
+		// If UPE is not enabled, skip.
+		if ( ! \WC_Payments_Features::is_upe_enabled() ) {
+			return false;
+		}
+
+		// Check if Link payment is available.
+		$available_upe_payment_methods = self::$gateway->get_upe_available_payment_methods();
+		if ( ! in_array( Link_Payment_Method::PAYMENT_METHOD_STRIPE_ID, $available_upe_payment_methods, true ) ) {
+			return false;
+		}
+
+		// Retrieve enabled payment methods at checkout.
+		$enabled_payment_methods = self::$gateway->get_payment_method_ids_enabled_at_checkout( null, true );
+		// If card payment method is not enabled or Link payment method is enabled, skip.
+		if ( ! in_array( CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID, $enabled_payment_methods, true )
+				|| in_array( Link_Payment_Method::PAYMENT_METHOD_STRIPE_ID, $enabled_payment_methods, true ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		if ( ! self::should_display_note() ) {
+			return;
+		}
+
+		$note_class = WC_Payment_Woo_Compat_Utils::get_note_class();
+		$note       = new $note_class();
+
+		$note->set_title( __( 'Increase conversion at checkout', 'woocommerce-payments' ) );
+		$note->set_content( __( 'Reduce cart abandonment and create a frictionless checkout experience with Link by Stripe. Link autofills your customer’s payment and shipping details so they can check out in just six seconds with the Link optimized experience. That’s 9x faster than shoppers who don’t use Link. Link increases conversion rates by over 7% for logged-in Link customers.', 'woocommerce-payments' ) );
+		$note->set_content_data( (object) [] );
+		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-payments' );
+		$note->add_action(
+			self::NOTE_NAME,
+			__( 'Set up now', 'woocommerce-payments' ),
+			self::NOTE_DOCUMENTATION_URL,
+			'unactioned',
+			true
+		);
+
+		return $note;
+	}
+
+	/**
+	 * Sets the WCPay gateway instance reference on the class.
+	 *
+	 * @param WC_Payment_Gateway_WCPay $gateway WCPay gateway instance.
+	 */
+	public static function set_gateway( WC_Payment_Gateway_WCPay $gateway ) {
+		self::$gateway = $gateway;
+	}
+}

--- a/tests/unit/notes/test-class-wc-payments-notes-set-up-stripelink.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-set-up-stripelink.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Class WC_Payments_Notes_Set_Up_StripeLink_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * Class WC_Payments_Notes_Set_Up_StripeLink tests.
+ */
+class WC_Payments_Notes_Set_Up_StripeLink_Test extends WCPAY_UnitTestCase {
+	/**
+	 * System under test.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private $mock_wcpay_gateway;
+
+	public function set_up() {
+		parent::set_up();
+
+		require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-stripelink.php';
+
+		$this->mock_wcpay_gateway = $this->getMockBuilder( '\WC_Payment_Gateway_WCPay' )
+			->disableOriginalConstructor()
+			->setMethods(
+				[
+					'get_upe_available_payment_methods',
+					'get_payment_method_ids_enabled_at_checkout',
+				]
+			)
+			->getMock();
+	}
+
+	public function tear_down() {
+		delete_option( '_wcpay_feature_upe' );
+
+		parent::tear_down();
+	}
+
+	public function test_stripelink_setup_get_note() {
+		$this->mock_gateway_data( '1', [ 'card', 'link' ], [ 'card' ] );
+
+		$note = \WC_Payments_Notes_Set_Up_StripeLink::get_note();
+
+		$this->assertSame( 'Increase conversion at checkout', $note->get_title() );
+		$this->assertSame( 'Reduce cart abandonment and create a frictionless checkout experience with Link by Stripe. Link autofills your customer’s payment and shipping details so they can check out in just six seconds with the Link optimized experience. That’s 9x faster than shoppers who don’t use Link. Link increases conversion rates by over 7% for logged-in Link customers.', $note->get_content() );
+		$this->assertSame( 'info', $note->get_type() );
+		$this->assertSame( 'wc-payments-notes-set-up-stripe-link', $note->get_name() );
+		$this->assertSame( 'woocommerce-payments', $note->get_source() );
+
+		list( $set_up_action ) = $note->get_actions();
+		$this->assertSame( 'wc-payments-notes-set-up-stripe-link', $set_up_action->name );
+		$this->assertSame( 'Set up now', $set_up_action->label );
+		$this->assertStringStartsWith( 'https://woocommerce.com/document/payments/woocommerce-payments-stripe-link/', $set_up_action->query );
+	}
+
+	public function test_stripelink_setup_note_null_when_upe_disabled() {
+		$this->mock_gateway_data( '0', [ 'card', 'link' ], [ 'card' ] );
+
+		$note = \WC_Payments_Notes_Set_Up_StripeLink::get_note();
+
+		$this->assertNull( $note );
+	}
+
+	public function test_stripelink_setup_note_null_when_link_not_available() {
+		$this->mock_gateway_data( '1', [ 'card' ], [ 'card' ] );
+
+		$note = \WC_Payments_Notes_Set_Up_StripeLink::get_note();
+
+		$this->assertNull( $note );
+	}
+
+	public function test_stripelink_setup_note_null_when_link_enabled() {
+		$this->mock_gateway_data( '1', [ 'card', 'link' ], [ 'card', 'link' ] );
+
+		$note = \WC_Payments_Notes_Set_Up_StripeLink::get_note();
+
+		$this->assertNull( $note );
+	}
+
+	public function mock_gateway_data( $upe_enabled = '0', $available_methods, $enabled_methods ) {
+		update_option( '_wcpay_feature_upe', $upe_enabled );
+
+		$this->mock_wcpay_gateway
+			->expects( $this->any() )
+			->method( 'get_upe_available_payment_methods' )
+			->willReturn( $available_methods );
+
+		$this->mock_wcpay_gateway
+			->expects( $this->any() )
+			->method( 'get_payment_method_ids_enabled_at_checkout' )
+			->willReturn( $enabled_methods );
+
+		\WC_Payments_Notes_Set_Up_StripeLink::set_gateway( $this->mock_wcpay_gateway );
+
+		\WC_Payments_Notes_Set_Up_StripeLink::possibly_add_note();
+	}
+}


### PR DESCRIPTION
This reverts commit 6dba845e3831bed2b9f5b788f9d496e58d29f247.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
