### PR TITLE
[Authorizations][Capture from table] Add capture_authorization endpoint

### DIFF
--- a/changelog/add-4569-capture-auth-endpoint
+++ b/changelog/add-4569-capture-auth-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add capture_authorization endpoint

--- a/docs/rest-api/source/includes/wp-api-v3/order.md
+++ b/docs/rest-api/source/includes/wp-api-v3/order.md
@@ -107,12 +107,12 @@ curl -X POST https://example.com/wp-json/wc/v3/payments/orders/42/capture_termin
 
 ## Capture an authorization
 
-_@since vX.X.X_
+_@since vX.X.X_ <!-- TODO: add version. -->
 
 ### POST params
 
 -   payment_intent_id: string
--   order_id: string??? or number??
+-   order_id: string
 
 ### Error codes
 
@@ -151,10 +151,10 @@ curl -X POST https://example.com/wp-json/wc/v3/payments/orders/42/capture_author
 
 ```json
 {
-  "code": "wcpay_server_error",
-  "message": "Unexpected server error",
+  "code": "wcpay_payment_uncapturable",
+  "message": "The payment cannot be captured",
   "data": {
-    "status": 500
+    "status": 409
   }
 }
 ```

--- a/docs/rest-api/source/includes/wp-api-v3/order.md
+++ b/docs/rest-api/source/includes/wp-api-v3/order.md
@@ -105,6 +105,61 @@ curl -X POST https://example.com/wp-json/wc/v3/payments/orders/42/capture_termin
 }
 ```
 
+## Capture an authorization
+
+_@since vX.X.X_
+
+### POST params
+
+-   payment_intent_id: string
+-   order_id: string??? or number??
+
+### Error codes
+
+-   `wcpay_missing_order` - Order not found
+-   `wcpay_refunded_order_uncapturable` -  Payment cannot be captured for partially or fully refunded orders
+-   `wcpay_payment_uncapturable` - The payment cannot be captured if intent status is not one of 'processing', 'requires_capture', or 'succeeded'
+-   `wcpay_intent_order_mismatch` - Payment cannot be captured because the order id does not match
+-   `wcpay_capture_error` - Unknown error
+
+### HTTP request
+
+<div class="api-endpoint">
+  <div class="endpoint-data">
+    <i class="label label-get">POST</i>
+    <h6>/wp-json/wc/v3/payments/orders/&lt;order_id&gt;/capture_authorization</h6>
+  </div>
+</div>
+
+```shell
+curl -X POST https://example.com/wp-json/wc/v3/payments/orders/42/capture_authorization \
+  -u consumer_key:consumer_secret \
+  -H "Content-Type: application/json" \
+  -d '{
+    "payment_intent_id": "pi_ZZZZZZZZZZZZZZZZAAAAAAAA"
+}'
+```
+
+> JSON response example:
+
+```json
+{
+  "status": "succeeded",
+  "id": "pi_ZZZZZZZZZZZZZZZZAAAAAAAA"
+}
+```
+
+```json
+{
+  "code": "wcpay_server_error",
+  "message": "Unexpected server error",
+  "data": {
+    "status": 500
+  }
+}
+```
+
+
 ## Create customer
 
 _@since v2.8.0_

--- a/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
@@ -591,7 +591,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 'processing', $result_order->get_status() );
 	}
 
-	public function test_capture_authorization_succeeded_intent() {
+	public function test_capture_authorization_succeeded_intent_throws_error() {
 		$order = $this->create_mock_order();
 		$order->set_payment_method( WC_Payment_Gateway_WCPay::GATEWAY_ID );
 		$order->set_payment_method_title( 'WooCommerce Payments' );
@@ -679,7 +679,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 409, $data['status'] );
 	}
 
-	public function test_capture_authorization_succeeded_payment_intent_missing_order_id() {
+	public function test_capture_authorization_with_succeeded_payment_intent_and_missing_order_id_throws_error() {
 		$order = $this->create_mock_order();
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'succeeded' ] );

--- a/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
@@ -534,6 +534,358 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( 404, $data['status'] );
 	}
 
+	public function test_capture_authorization_success() {
+		$order = $this->create_mock_order();
+		$order->set_payment_method( WC_Payment_Gateway_WCPay::GATEWAY_ID );
+		$order->set_payment_method_title( 'WooCommerce Payments' );
+		$order->save();
+
+		$mock_intent = WC_Helper_Intention::create_intention(
+			[
+				'status'   => 'requires_capture',
+				'metadata' => [
+					'order_id' => $order->get_id(),
+				],
+			]
+		);
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->willReturn( $mock_intent );
+
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'capture_charge' )
+			->with( $this->isInstanceOf( WC_Order::class ) )
+			->willReturn(
+				[
+					'status' => 'succeeded',
+					'id'     => $this->mock_intent_id,
+				]
+			);
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params(
+			[
+				'order_id'          => $order->get_id(),
+				'payment_intent_id' => $this->mock_intent_id,
+			]
+		);
+
+		$response      = $this->controller->capture_authorization( $request );
+		$response_data = $response->get_data();
+
+		$this->assertSame( 200, $response->status );
+		$this->assertSame(
+			[
+				'status' => 'succeeded',
+				'id'     => $this->mock_intent_id,
+			],
+			$response_data
+		);
+
+		$result_order = wc_get_order( $order->get_id() );
+		$this->assertSame( 'woocommerce_payments', $result_order->get_payment_method() );
+		$this->assertSame( 'WooCommerce Payments', $result_order->get_payment_method_title() );
+		$this->assertSame( 'processing', $result_order->get_status() );
+	}
+
+	public function test_capture_authorization_succeeded_intent() {
+		$order = $this->create_mock_order();
+		$order->set_payment_method( WC_Payment_Gateway_WCPay::GATEWAY_ID );
+		$order->set_payment_method_title( 'WooCommerce Payments' );
+		$order->save();
+
+		$mock_intent = WC_Helper_Intention::create_intention(
+			[
+				'metadata' => [
+					'order_id' => $order->get_id(),
+				],
+			]
+		);
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->willReturn( $mock_intent );
+
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'capture_charge' )
+			->with( $this->isInstanceOf( WC_Order::class ) )
+			->willReturn(
+				[
+					'status'    => 'failed',
+					'message'   => 'Test error',
+					'http_code' => 502,
+				]
+			);
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params(
+			[
+				'order_id'          => $order->get_id(),
+				'payment_intent_id' => $this->mock_intent_id,
+			]
+		);
+
+		$response = $this->controller->capture_authorization( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertSame( 502, $data['status'] );
+	}
+
+	public function test_capture_authorization_intent_non_capturable() {
+		$order = $this->create_mock_order();
+		$order->set_payment_method( WC_Payment_Gateway_WCPay::GATEWAY_ID );
+		$order->set_payment_method_title( 'WooCommerce Payments' );
+		$order->save();
+
+		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->willReturn( $mock_intent );
+
+		$this->mock_gateway
+			->expects( $this->never() )
+			->method( 'capture_charge' );
+
+		$this->mock_gateway
+			->expects( $this->never() )
+			->method( 'attach_intent_info_to_order' );
+
+		$this->mock_gateway
+			->expects( $this->never() )
+			->method( 'update_order_status_from_intent' );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params(
+			[
+				'order_id'          => $order->get_id(),
+				'payment_intent_id' => $this->mock_intent_id,
+			]
+		);
+
+		$response = $this->controller->capture_authorization( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertSame( 409, $data['status'] );
+	}
+
+	public function test_capture_authorization_succeeded_payment_intent_missing_order_id() {
+		$order = $this->create_mock_order();
+
+		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'succeeded' ] );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->willReturn( $mock_intent );
+
+		$this->mock_gateway
+			->expects( $this->never() )
+			->method( 'capture_charge' );
+
+		$this->mock_gateway
+			->expects( $this->never() )
+			->method( 'attach_intent_info_to_order' );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params(
+			[
+				'order_id'          => $order->get_id(),
+				'payment_intent_id' => $this->mock_intent_id,
+			]
+		);
+
+		$response = $this->controller->capture_authorization( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertSame( 409, $data['status'] );
+		$this->assertFalse( $order->has_status( 'completed' ) );
+	}
+
+	public function test_capture_authorization_refunded_order() {
+		$order       = $this->create_mock_order();
+		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'succeeded' ] );
+
+		wc_create_refund(
+			[
+				'order_id'   => $order->get_id(),
+				'amount'     => 10.0,
+				'line_items' => [],
+			]
+		);
+
+		$this->mock_api_client
+			->expects( $this->never() )
+			->method( 'get_intent' );
+
+		$this->mock_gateway
+			->expects( $this->never() )
+			->method( 'capture_charge' );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params(
+			[
+				'order_id'          => $order->get_id(),
+				'payment_intent_id' => $this->mock_intent_id,
+			]
+		);
+
+		$response = $this->controller->capture_authorization( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertSame( 400, $data['status'] );
+	}
+
+	public function test_capture_authorization_error_when_capturing() {
+		$order = $this->create_mock_order();
+
+		$mock_intent = WC_Helper_Intention::create_intention(
+			[
+				'status'   => 'requires_capture',
+				'metadata' => [
+					'order_id' => $order->get_id(),
+				],
+			]
+		);
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->willReturn( $mock_intent );
+
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'capture_charge' )
+			->willReturn(
+				[
+					'status'  => 'failed',
+					'message' => 'Test error',
+				]
+			);
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params(
+			[
+				'order_id'          => $order->get_id(),
+				'payment_intent_id' => $this->mock_intent_id,
+			]
+		);
+
+		$response = $this->controller->capture_authorization( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertSame( 502, $data['status'] );
+		$this->assertSame( 'Payment capture failed to complete with the following message: Test error', $response->get_error_message() );
+	}
+
+	public function test_capture_authorization_error_invalid_arguments() {
+		$order = $this->create_mock_order();
+
+		$mock_intent = WC_Helper_Intention::create_intention(
+			[
+				'status'   => 'requires_capture',
+				'metadata' => [
+					'order_id' => $order->get_id(),
+				],
+			]
+		);
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->willReturn( $mock_intent );
+
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'capture_charge' )
+			->willReturn(
+				// See https://stripe.com/docs/error-codes#amount-too-large.
+				[
+					'status'    => 'failed',
+					'message'   => 'Error: The payment could not be captured because the requested capture amount is greater than the authorized amount.',
+					'http_code' => 400,
+				]
+			);
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params(
+			[
+				'order_id'          => $order->get_id(),
+				'payment_intent_id' => $this->mock_intent_id,
+			]
+		);
+
+		$response = $this->controller->capture_authorization( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertSame( 400, $data['status'] );
+		$this->assertSame( 'wcpay_capture_error', $response->get_error_code() );
+		$this->assertSame(
+			'Payment capture failed to complete with the following message: ' .
+			'Error: The payment could not be captured because the requested capture amount is greater than the authorized amount.',
+			$response->get_error_message()
+		);
+	}
+
+	public function test_capture_authorization_handles_exceptions() {
+		$order = $this->create_mock_order();
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_intent' )
+			->willThrowException( new Exception( 'test error' ) );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params(
+			[
+				'order_id'          => $order->get_id(),
+				'payment_intent_id' => $this->mock_intent_id,
+			]
+		);
+
+		$response = $this->controller->capture_authorization( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertSame( 500, $data['status'] );
+	}
+
+	public function test_capture_authorization_not_found() {
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params(
+			[
+				'order_id'          => 'not_an_id',
+				'payment_intent_id' => $this->mock_intent_id,
+			]
+		);
+
+		$response = $this->controller->capture_authorization( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response );
+		$data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertSame( 404, $data['status'] );
+	}
+
 	/**
 	 * @expectedDeprecated create_customer
 	 */


### PR DESCRIPTION
Fixes #4569 

_These changes come from a [bigger PR](https://github.com/Automattic/woocommerce-payments/pull/4676) that we decided to split into smaller chunks. I created an [integration branch](https://github.com/Automattic/woocommerce-payments/pull/4962) where we will merge all split PRs, including this one._

#### Changes proposed in this Pull Request

This PR adds a new `capture_authorization` endpoint. It will be used to allow merchants to capture a payment from the authorizations list.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

No manual testing needed, changes are covered by unit tests. We will test manually the [integration branch](https://github.com/Automattic/woocommerce-payments/pull/4962), once all partial PRs are merged.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

