### PR TITLE
Add dependabot.yml to enable automatic creation of PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+    # Enable version updates for npm
+    - package-ecosystem: 'npm'
+      # Look for `package.json` and `lock` files in the `root` directory
+      directory: '/'
+      # Check the npm registry for updates every day (weekdays)
+      schedule:
+          interval: 'daily'
+      # Reviewers for issues created
+      reviewers:
+          - 'jessepearson'
+
+    # Enable version updates for composer
+    - package-ecosystem: 'composer'
+      # Look for `package.json` and `lock` files in the `root` directory
+      directory: '/'
+      # Check the npm registry for updates every day (weekdays)
+      schedule:
+          interval: 'daily'
+      # Reviewers for issues created
+      reviewers:
+          - 'jessepearson'
+
+    # Enable version updates for Docker
+    - package-ecosystem: 'docker'
+      # Look for a `Dockerfile` in the `root` directory
+      directory: '/'
+      # Check for updates once a week
+      schedule:
+          interval: 'weekly'
+      # Reviewers for issues created
+      reviewers:
+          - 'jessepearson'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We were using Renovatebot to have PRs opened for us to update dependencies, however, the bot has been suspended indefinitely. This PR adds the necessary dependabot.yml file to allow Dependabot to automatically create PRs for us to review and merge. A changelog was not added because this is internal and doesn't change the client itself.

* It started with being a copy of the example file found here:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#example-dependabotyml-file
* There are 3 [`package-ecosystem`s](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem) added: `npm`, `composer`, and `docker`. 
* I have currently set the [schedule interval](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval) for `npm` and `composer` to `daily` to allow for the creation of items as quickly as possible, as we are behind on items.
  * The [default max number of PRs to be created per ecosystem is 5](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit).
* I have [set the `reviewers` to myself](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers) for now, but others, or a team can be added.

#### Testing instructions

* Adding this is the test to see if this will allow us to have a better workflow to update dependencies.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
