### PR TITLE
Update some workflow files to use an env variable for L-2 versions

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -3,29 +3,36 @@ name: Compatibility - WC, WP and PHP
 on:
   pull_request
 
+env:
+  WC_L2_VERSION: '6.8.2'
+  WP_L2_VERSION: '5.8'
+
 jobs:
+  generate-matrix:
+    name: "Generate the matrix for woocommerce compatibility dynamically"
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.generate_matrix.outputs.matrix }}
+    steps:
+      - name: "Generate matrix"
+        id: generate_matrix
+        run: |
+          WC_VERSIONS=$( echo "[\"$WC_L2_VERSION\", \"latest\", \"beta\"]" )
+          MATRIX_INCLUDE=$( echo "[{\"woocommerce\":\"$WC_L2_VERSION\",\"wordpress\":\"$WP_L2_VERSION\",\"gutenberg\":\"13.6.0\",\"php\":\"7.2\"}]" )
+          echo "matrix={\"woocommerce\":$WC_VERSIONS,\"wordpress\":[\"latest\"],\"gutenberg\":[\"latest\"],\"php\":[\"7.4\"], \"include\":$MATRIX_INCLUDE}" >> $GITHUB_OUTPUT
+  
   woocommerce-compatibility:
-    name:    WC compatibility
+    name: "WC compatibility"
+    needs: generate-matrix
     runs-on: ubuntu-18.04
+    env:
+      WP_VERSION: ${{ matrix.wordpress }}
+      WC_VERSION: ${{ matrix.woocommerce }}
+      GUTENBERG_VERSION: ${{ matrix.gutenberg }}
     strategy:
       fail-fast:    false
       max-parallel: 10
-      matrix:
-        # Minimum support version, ..., Latest version, `beta`.
-        woocommerce: [ '6.8.2', 'latest', 'beta' ]
-        wordpress:   [ 'latest' ]
-        gutenberg:   [ 'latest' ]
-        php:         [ '7.4' ]
-        include:
-          # Edge case: oldest dependencies compatibility
-          - woocommerce: '6.8.2'
-            wordpress:   '5.8'
-            gutenberg:   '13.6.0' # The latest version supporting WP 5.8.
-            php:         '7.2' # Minimum supported PHP version
-    env:
-      WP_VERSION:        ${{ matrix.wordpress }}
-      WC_VERSION:        ${{ matrix.woocommerce }}
-      GUTENBERG_VERSION: ${{ matrix.gutenberg }}
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     steps:
       # clone the repository
       - uses: actions/checkout@v2

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -23,21 +23,30 @@ env:
   E2E_SLACK_TOKEN:       ${{ secrets.E2E_SLACK_TOKEN }}
   E2E_USE_LOCAL_SERVER:  false
   E2E_RESULT_FILEPATH:   'tests/e2e/results.json'
+  WC_L2_VERSION: '6.8.2'
 
 
 jobs:
+  generate-matrix:
+    name: "Generate the matrix for subscriptions-tests dynamically"
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.generate_matrix.outputs.matrix }}
+    steps:
+      - name: "Generate matrix"
+        id: generate_matrix
+        run: |
+          WC_VERSIONS=$( echo "[\"$WC_L2_VERSION\", \"latest\", \"beta\"]" )
+          echo "matrix={\"woocommerce\":$WC_VERSIONS,\"test_groups\":[\"wcpay\", \"subscriptions\"],\"test_branches\":[\"merchant\", \"shopper\"]}" >> $GITHUB_OUTPUT
+
   # Run WCPay & subscriptions tests against specific WC versions
   wcpay-subscriptions-tests:
     runs-on: ubuntu-20.04
-
+    needs: generate-matrix
     strategy:
       fail-fast:     false
-      matrix:
-        # Min WooCommerce | L-2 | L(atest) | beta
-        woocommerce:   [ '6.8.2', 'latest', 'beta' ]
-        test_groups:   [ 'wcpay', 'subscriptions' ]
-        test_branches: [ 'merchant', 'shopper' ]
-
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    
     name: WC - ${{ matrix.woocommerce }} | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 
     env:

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   WP_VERSION:        latest
-  WC_VERSION: 6.8.2  # the min supported version as per L-2 policy
+  WC_L2_VERSION: '6.8.2'  # the min supported version as per L-2 policy
   GUTENBERG_VERSION: latest
 
 jobs:
@@ -53,3 +53,5 @@ jobs:
           coverage:    xdebug2
       # run CI checks
       - run: bash bin/run-ci-tests.bash
+        env:
+          WC_VERSION: ${{ env.WC_L2_VERSION }}

--- a/changelog/dev-refactor-ci-workflow-for-l-2-versions
+++ b/changelog/dev-refactor-ci-workflow-for-l-2-versions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update a few workflows to use an env variable for the L-2 version of WC/WP


### PR DESCRIPTION
Fixes #4685

#### Changes proposed in this Pull Request

Instead of copying/pasting the L-2 value for both WP and WC in several locations for some workflow files, I defined a single variable in the global env of each workflow file to be reused in the job steps.
To do that, I had to implement a step to generate the matrix dynamically, otherwise it was not possible to use an env variable directly.

The goal was to simplify the work of updating the L-2 versions, both locally (current way) or through a script (new way: see the related PR in woorelease: https://github.com/woocommerce/woorelease-extensions/pull/8).

#### Testing instructions

- Trigger the `compatibility.yml` workflow and make sure that all the combinations from the matrix are generated as expected (last run on this branch: https://github.com/Automattic/woocommerce-payments/actions/runs/3311694781; compare with an old run from last week)
- Trigger the `e2e-test.yml` workflow and make sure that all the combinations from the matrix are generated as expected (compare with an old run from last week).
- Trigger the `php-lint-test.yml` workflow and make sure that the WC version installed for the `PHP testing (7.x)` steps is `6.8.2` (i.e. the current L-2 version; you can check for the line `Installing WooCommerce (6.8.2)` in the logs from `Run bash bin/run-ci-tests.bash` step). Last run on this branch: https://github.com/Automattic/woocommerce-payments/actions/runs/3311694813

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
