### PR TITLE
Bump  WC  and WP versions for 5.0.0 release

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   WC_L2_VERSION: '6.9.0'
-  WP_L2_VERSION: '5.9'
+  WP_L2_VERSION: '6.0'
 
 jobs:
   generate-matrix:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -4,8 +4,8 @@ on:
   pull_request
 
 env:
-  WC_L2_VERSION: '7.0.0'
-  WP_L2_VERSION: '6.2'
+  WC_L2_VERSION: '7.1.0'
+  WP_L2_VERSION: '6.3'
 
 jobs:
   generate-matrix:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   WC_L2_VERSION: '6.9.0'
-  WP_L2_VERSION: '6.0'
+  WP_L2_VERSION: '6.1'
 
 jobs:
   generate-matrix:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -4,8 +4,8 @@ on:
   pull_request
 
 env:
-  WC_L2_VERSION: '6.8.2'
-  WP_L2_VERSION: '5.8'
+  WC_L2_VERSION: '6.9.0'
+  WP_L2_VERSION: '5.9'
 
 jobs:
   generate-matrix:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -4,8 +4,8 @@ on:
   pull_request
 
 env:
-  WC_L2_VERSION: '6.9.0'
-  WP_L2_VERSION: '6.1'
+  WC_L2_VERSION: '7.0.0'
+  WP_L2_VERSION: '6.2'
 
 jobs:
   generate-matrix:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -23,7 +23,7 @@ env:
   E2E_SLACK_TOKEN:       ${{ secrets.E2E_SLACK_TOKEN }}
   E2E_USE_LOCAL_SERVER:  false
   E2E_RESULT_FILEPATH:   'tests/e2e/results.json'
-  WC_L2_VERSION: '6.9.0'
+  WC_L2_VERSION: '7.0.0'
 
 
 jobs:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -23,7 +23,7 @@ env:
   E2E_SLACK_TOKEN:       ${{ secrets.E2E_SLACK_TOKEN }}
   E2E_USE_LOCAL_SERVER:  false
   E2E_RESULT_FILEPATH:   'tests/e2e/results.json'
-  WC_L2_VERSION: '7.0.0'
+  WC_L2_VERSION: '7.1.0'
 
 
 jobs:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -23,7 +23,7 @@ env:
   E2E_SLACK_TOKEN:       ${{ secrets.E2E_SLACK_TOKEN }}
   E2E_USE_LOCAL_SERVER:  false
   E2E_RESULT_FILEPATH:   'tests/e2e/results.json'
-  WC_L2_VERSION: '6.8.2'
+  WC_L2_VERSION: '6.9.0'
 
 
 jobs:

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   WP_VERSION:        latest
-  WC_L2_VERSION: '6.8.2'  # the min supported version as per L-2 policy
+  WC_L2_VERSION: '6.9.0'  # the min supported version as per L-2 policy
   GUTENBERG_VERSION: latest
 
 jobs:

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   WP_VERSION:        latest
-  WC_L2_VERSION: '6.9.0'  # the min supported version as per L-2 policy
+  WC_L2_VERSION: '7.0.0'  # the min supported version as per L-2 policy
   GUTENBERG_VERSION: latest
 
 jobs:

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   WP_VERSION:        latest
-  WC_L2_VERSION: '7.0.0'  # the min supported version as per L-2 policy
+  WC_L2_VERSION: '7.1.0'  # the min supported version as per L-2 policy
   GUTENBERG_VERSION: latest
 
 jobs:

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,7 +15,7 @@
 	<exclude-pattern>./vendor-dist/*</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="5.9" />
+	<config name="minimum_supported_wp_version" value="6.0" />
 	<config name="testVersion" value="7.0-" />
 
 	<!-- Rules -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,7 +15,7 @@
 	<exclude-pattern>./vendor-dist/*</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="5.8" />
+	<config name="minimum_supported_wp_version" value="5.9" />
 	<config name="testVersion" value="7.0-" />
 
 	<!-- Rules -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,7 +15,7 @@
 	<exclude-pattern>./vendor-dist/*</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="6.2" />
+	<config name="minimum_supported_wp_version" value="6.3" />
 	<config name="testVersion" value="7.0-" />
 
 	<!-- Rules -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,7 +15,7 @@
 	<exclude-pattern>./vendor-dist/*</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="6.0" />
+	<config name="minimum_supported_wp_version" value="6.1" />
 	<config name="testVersion" value="7.0-" />
 
 	<!-- Rules -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,7 +15,7 @@
 	<exclude-pattern>./vendor-dist/*</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="6.1" />
+	<config name="minimum_supported_wp_version" value="6.2" />
 	<config name="testVersion" value="7.0-" />
 
 	<!-- Rules -->

--- a/readme.txt
+++ b/readme.txt
@@ -38,7 +38,7 @@ Our global support team is available to answer questions you may have about WooC
 
 = Requirements =
 
-* WordPress 5.9 or newer.
+* WordPress 6.0 or newer.
 * WooCommerce 6.9 or newer.
 * PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
 

--- a/readme.txt
+++ b/readme.txt
@@ -38,8 +38,8 @@ Our global support team is available to answer questions you may have about WooC
 
 = Requirements =
 
-* WordPress 5.8 or newer.
-* WooCommerce 6.6 or newer.
+* WordPress 5.9 or newer.
+* WooCommerce 6.9 or newer.
 * PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
 
 = Try it now =

--- a/readme.txt
+++ b/readme.txt
@@ -38,8 +38,8 @@ Our global support team is available to answer questions you may have about WooC
 
 = Requirements =
 
-* WordPress 6.2 or newer.
-* WooCommerce 7.0 or newer.
+* WordPress 6.3 or newer.
+* WooCommerce 7.1 or newer.
 * PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
 
 = Try it now =

--- a/readme.txt
+++ b/readme.txt
@@ -38,8 +38,8 @@ Our global support team is available to answer questions you may have about WooC
 
 = Requirements =
 
-* WordPress 6.1 or newer.
-* WooCommerce 6.9 or newer.
+* WordPress 6.2 or newer.
+* WooCommerce 7.0 or newer.
 * PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
 
 = Try it now =

--- a/readme.txt
+++ b/readme.txt
@@ -38,7 +38,7 @@ Our global support team is available to answer questions you may have about WooC
 
 = Requirements =
 
-* WordPress 6.0 or newer.
+* WordPress 6.1 or newer.
 * WooCommerce 6.9 or newer.
 * PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
 

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  * WC requires at least: 6.9
  * WC tested up to: 7.1.0
- * Requires at least: 6.0
+ * Requires at least: 6.1
  * Requires PHP: 7.0
  * Version: 4.9.0
  *

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,9 +8,9 @@
  * Woo: 5278104:bf3cf30871604e15eec560c962593c1f
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
- * WC requires at least: 6.8
- * WC tested up to: 7.0.0
- * Requires at least: 5.8
+ * WC requires at least: 6.9
+ * WC tested up to: 7.1.0
+ * Requires at least: 5.9
  * Requires PHP: 7.0
  * Version: 4.9.0
  *

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  * WC requires at least: 6.9
  * WC tested up to: 7.1.0
- * Requires at least: 5.9
+ * Requires at least: 6.0
  * Requires PHP: 7.0
  * Version: 4.9.0
  *

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,9 +8,9 @@
  * Woo: 5278104:bf3cf30871604e15eec560c962593c1f
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
- * WC requires at least: 6.9
- * WC tested up to: 7.1.0
- * Requires at least: 6.1
+ * WC requires at least: 7.0
+ * WC tested up to: 7.2.0
+ * Requires at least: 6.2
  * Requires PHP: 7.0
  * Version: 4.9.0
  *

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,9 +8,9 @@
  * Woo: 5278104:bf3cf30871604e15eec560c962593c1f
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
- * WC requires at least: 7.0
- * WC tested up to: 7.2.0
- * Requires at least: 6.2
+ * WC requires at least: 7.1
+ * WC tested up to: 7.3.0
+ * Requires at least: 6.3
  * Requires PHP: 7.0
  * Version: 4.9.0
  *


### PR DESCRIPTION
Changes proposed in this Pull Request\n\n- Bump minimum WC version.\n-Bump GH workflows WC versions\n- Bump minimum WP version.\n-Bump GH workflows WP versions\n\n Testing instructions\n\n- Verify the WC L-2 version in every file where it's being used (see https://protonpower.wordpress.com/ > "Next Release" in the sidebar widget)\n- Verify the WP L-2 version in every file where it's being used (see https://wordpress.org/news/category/releases/)