### PR TITLE
Update subscriptions-core version 2.4.0

### DIFF
--- a/changelog/subscriptions-core-2.4.0
+++ b/changelog/subscriptions-core-2.4.0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+The subscription creation function `wcs_create_subscription` has been updated to use WooCommerce CRUD methods in preparation for supporting High Performance Order Storage (HPOS).

--- a/changelog/subscriptions-core-2.4.0-2
+++ b/changelog/subscriptions-core-2.4.0-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+ImImprove wcs_copy_order_address() to use modern APIs for setting address fields.

--- a/changelog/subscriptions-core-2.4.0-2
+++ b/changelog/subscriptions-core-2.4.0-2
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-ImImprove wcs_copy_order_address() to use modern APIs for setting address fields.
+Improve wcs_copy_order_address() to use modern APIs for setting address fields.

--- a/changelog/subscriptions-core-2.4.0-3
+++ b/changelog/subscriptions-core-2.4.0-3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+woocommerce_new_subscription_data hook will only work with CPT datastore and so has been deprecated.

--- a/changelog/subscriptions-core-2.4.0-4
+++ b/changelog/subscriptions-core-2.4.0-4
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+i18n usage of strftime has been deprecated for subscription titles. Date is now formatted using woocommerce standard date formatting.

--- a/changelog/subscriptions-core-2.4.0-5
+++ b/changelog/subscriptions-core-2.4.0-5
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update subscriptions-core to 2.4.0.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
       "automattic/jetpack-sync": "1.30.5",
       "automattic/jetpack-tracking": "1.14.5",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "2.3.0"
+      "woocommerce/subscriptions-core": "2.4.0"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "90f58d3cd4e9aee92e9c3b2035ba7658",
+    "content-hash": "f545845c79fc028c20fcfb386cb7a889",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1060,16 +1060,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "2.3.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "8017438f8e0cfc16494344f783fb134f77284d58"
+                "reference": "c4a90a83dcd876633589f6a159dae654fc4d123a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/8017438f8e0cfc16494344f783fb134f77284d58",
-                "reference": "8017438f8e0cfc16494344f783fb134f77284d58",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/c4a90a83dcd876633589f6a159dae654fc4d123a",
+                "reference": "c4a90a83dcd876633589f6a159dae654fc4d123a",
                 "shasum": ""
             },
             "require": {
@@ -1110,10 +1110,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.3.0",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.4.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-10-07T03:45:34+00:00"
+            "time": "2022-10-28T05:47:16+00:00"
         }
     ],
     "packages-dev": [
@@ -5836,5 +5836,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR bumps the `subscriptions-core` version in WooCommerce Payments to 2.4.0 and adds any relevant changelog entries.

This new version of Subscriptions Core includes changes to our `wcs_create_subscription()` in preparation for supporting High-Performance Order Storage (HPOS).

More details can be found in the merged PRs over on the `subscriptions-core` repository:
- https://github.com/Automattic/woocommerce-subscriptions-core/pull/226
- https://github.com/Automattic/woocommerce-subscriptions-core/pull/228


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : Additional QA Testing Not Applicable
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
