### PR TITLE
Update Stripe Link inbox notification wording

### DIFF
--- a/changelog/fix-link-inbox-notification-wording
+++ b/changelog/fix-link-inbox-notification-wording
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update Stripe Link inbox notification wording.

--- a/includes/notes/class-wc-payments-notes-set-up-stripelink.php
+++ b/includes/notes/class-wc-payments-notes-set-up-stripelink.php
@@ -75,7 +75,7 @@ class WC_Payments_Notes_Set_Up_StripeLink {
 		$note       = new $note_class();
 
 		$note->set_title( __( 'Increase conversion at checkout', 'woocommerce-payments' ) );
-		$note->set_content( __( 'Reduce cart abandonment and create a frictionless checkout experience with Link by Stripe. Link autofills your customer’s payment and shipping details so they can check out in just six seconds with the Link optimized experience. That’s 9x faster than shoppers who don’t use Link. Link increases conversion rates by over 7% for logged-in Link customers.', 'woocommerce-payments' ) );
+		$note->set_content( __( 'Reduce cart abandonment and create a frictionless checkout experience with Link by Stripe. Link autofills your customer’s payment and shipping details so they can check out in just six seconds with the Link optimized experience.', 'woocommerce-payments' ) );
 		$note->set_content_data( (object) [] );
 		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );

--- a/includes/notes/class-wc-payments-notes-set-up-stripelink.php
+++ b/includes/notes/class-wc-payments-notes-set-up-stripelink.php
@@ -75,7 +75,7 @@ class WC_Payments_Notes_Set_Up_StripeLink {
 		$note       = new $note_class();
 
 		$note->set_title( __( 'Increase conversion at checkout', 'woocommerce-payments' ) );
-		$note->set_content( __( 'Reduce cart abandonment and create a frictionless checkout experience with Link by Stripe. Link autofills your customer’s payment and shipping details so they can check out in just six seconds with the Link optimized experience.', 'woocommerce-payments' ) );
+		$note->set_content( __( 'Reduce cart abandonment and create a frictionless checkout experience with Link by Stripe. Link autofills your customer’s payment and shipping details, so they can check out in just six seconds with the Link optimized experience.', 'woocommerce-payments' ) );
 		$note->set_content_data( (object) [] );
 		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );

--- a/tests/unit/notes/test-class-wc-payments-notes-set-up-stripelink.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-set-up-stripelink.php
@@ -44,7 +44,7 @@ class WC_Payments_Notes_Set_Up_StripeLink_Test extends WCPAY_UnitTestCase {
 		$note = \WC_Payments_Notes_Set_Up_StripeLink::get_note();
 
 		$this->assertSame( 'Increase conversion at checkout', $note->get_title() );
-		$this->assertSame( 'Reduce cart abandonment and create a frictionless checkout experience with Link by Stripe. Link autofills your customer’s payment and shipping details so they can check out in just six seconds with the Link optimized experience. That’s 9x faster than shoppers who don’t use Link. Link increases conversion rates by over 7% for logged-in Link customers.', $note->get_content() );
+		$this->assertSame( 'Reduce cart abandonment and create a frictionless checkout experience with Link by Stripe. Link autofills your customer’s payment and shipping details so they can check out in just six seconds with the Link optimized experience.', $note->get_content() );
 		$this->assertSame( 'info', $note->get_type() );
 		$this->assertSame( 'wc-payments-notes-set-up-stripe-link', $note->get_name() );
 		$this->assertSame( 'woocommerce-payments', $note->get_source() );

--- a/tests/unit/notes/test-class-wc-payments-notes-set-up-stripelink.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-set-up-stripelink.php
@@ -44,7 +44,7 @@ class WC_Payments_Notes_Set_Up_StripeLink_Test extends WCPAY_UnitTestCase {
 		$note = \WC_Payments_Notes_Set_Up_StripeLink::get_note();
 
 		$this->assertSame( 'Increase conversion at checkout', $note->get_title() );
-		$this->assertSame( 'Reduce cart abandonment and create a frictionless checkout experience with Link by Stripe. Link autofills your customer’s payment and shipping details so they can check out in just six seconds with the Link optimized experience.', $note->get_content() );
+		$this->assertSame( 'Reduce cart abandonment and create a frictionless checkout experience with Link by Stripe. Link autofills your customer’s payment and shipping details, so they can check out in just six seconds with the Link optimized experience.', $note->get_content() );
 		$this->assertSame( 'info', $note->get_type() );
 		$this->assertSame( 'wc-payments-notes-set-up-stripe-link', $note->get_name() );
 		$this->assertSame( 'woocommerce-payments', $note->get_source() );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Update Stripe Link inbox notification wording to not exceed the maximum allowed characters.

<img width="651" alt="Screenshot 2022-11-01 at 9 36 29" src="https://user-images.githubusercontent.com/8667118/199182652-79141f48-dc8e-47c9-94c3-fd726027dc2f.png">

#### Testing instructions
- Navigate to 'Plugins' -> Deactivate and then activate the WooCommerce Payments plugin
- Navigate to `WooCommerce` -> `Home`.
- Verify the Stripe Link inbox notification text is not cut out.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
