### PR TITLE
Fix error that would happen when visiting the plugins page

### DIFF
--- a/changelog/fix-error-on-plugins-page
+++ b/changelog/fix-error-on-plugins-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed error when visiting the plugins page

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -228,7 +228,6 @@ class WC_Payments {
 		add_action( 'admin_init', [ __CLASS__, 'add_woo_admin_notes' ] );
 		add_action( 'init', [ __CLASS__, 'install_actions' ] );
 
-		add_filter( 'plugin_action_links_' . plugin_basename( WCPAY_PLUGIN_FILE ), [ __CLASS__, 'add_plugin_links' ] );
 		add_action( 'woocommerce_blocks_payment_method_type_registration', [ __CLASS__, 'register_checkout_gateway' ] );
 
 		include_once __DIR__ . '/class-wc-payments-db.php';
@@ -396,6 +395,8 @@ class WC_Payments {
 
 			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin-settings.php';
 			new WC_Payments_Admin_Settings( self::get_gateway() );
+
+			add_filter( 'plugin_action_links_' . plugin_basename( WCPAY_PLUGIN_FILE ), [ __CLASS__, 'add_plugin_links' ] );
 
 			// Use tracks loader only in admin screens because it relies on WC_Tracks loaded by WC_Admin.
 			include_once WCPAY_ABSPATH . 'includes/admin/tracks/tracks-loader.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR tries to fix an error that @brettshumaker encountered when updating WC Payments in his ephemeral site.

#### Testing instructions
Checkout this branch and visit the plugins page. Make sure the Settings link shows up in the WC Payments plugin and no error is registered in your logs or shows up

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 