### PR TITLE
Pin WordPress to 6.0.3 for pull request checks.

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -19,8 +19,8 @@ jobs:
         run: |
           WC_VERSIONS=$( echo "[\"$WC_L2_VERSION\", \"latest\", \"beta\"]" )
           MATRIX_INCLUDE=$( echo "[{\"woocommerce\":\"$WC_L2_VERSION\",\"wordpress\":\"$WP_L2_VERSION\",\"gutenberg\":\"13.6.0\",\"php\":\"7.2\"}]" )
-          echo "matrix={\"woocommerce\":$WC_VERSIONS,\"wordpress\":[\"latest\"],\"gutenberg\":[\"latest\"],\"php\":[\"7.4\"], \"include\":$MATRIX_INCLUDE}" >> $GITHUB_OUTPUT
-  
+          echo "matrix={\"woocommerce\":$WC_VERSIONS,\"wordpress\":[\"6.0.3\"],\"gutenberg\":[\"latest\"],\"php\":[\"7.4\"], \"include\":$MATRIX_INCLUDE}" >> $GITHUB_OUTPUT
+
   woocommerce-compatibility:
     name: "WC compatibility"
     needs: generate-matrix
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         woocommerce: [ 'beta' ]
-        wordpress:   [ 'latest' ]
+        wordpress:   [ '6.0.3' ]
         gutenberg:   [ 'latest' ]
         php:         [ '7.2', '8.0', '8.1' ]
     env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ jobs:
       max-parallel: 10
       matrix:
         woocommerce: [ 'latest' ]
-        wordpress:   [ 'latest' ]
+        wordpress:   [ '6.0.3' ]
         php:         [ '7.4' ]
     env:
       WP_VERSION: ${{ matrix.wordpress }}

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -4,7 +4,7 @@ on:
   pull_request
 
 env:
-  WP_VERSION:        latest
+  WP_VERSION:        '6.0.3'
   WC_L2_VERSION: '6.8.2'  # the min supported version as per L-2 policy
   GUTENBERG_VERSION: latest
 

--- a/changelog/fix-5042-pin-earlier-wp-version-in-tests
+++ b/changelog/fix-5042-pin-earlier-wp-version-in-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This change relates to a devops change.
+
+


### PR DESCRIPTION
Fixes #5042

#### Changes proposed in this Pull Request

⚠️ **This PR is intended as a temporary change to help unblock development and releases.**

This PR pins WordPress to 6.0.3 for the compatibility, code coverage and PHP linting and tests pull request checks.

#### Testing instructions

* The compatibility, code coverage and PHP linting and tests **pass** on this pull request. (these pull request checks currently fail on `develop`.)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
