### PR TITLE
Fix tests for WP 6.1

### DIFF
--- a/changelog/fix-wp-6.1-tests
+++ b/changelog/fix-wp-6.1-tests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Fix tests with WordPress 6.1

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -77,6 +77,13 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 	private $mock_db_cache;
 
 	/**
+	 * Mock WC_Payments_Token_Service.
+	 *
+	 * @var WC_Payments_Token_Service
+	 */
+	private $mock_token_service;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
@@ -101,6 +108,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$action_scheduler_service = new WC_Payments_Action_Scheduler_Service( $this->mock_api_client );
 		$mock_rate_limiter        = $this->createMock( Session_Rate_Limiter::class );
 		$order_service            = new WC_Payments_Order_Service( $this->mock_api_client );
+		$this->mock_token_service = $this->createMock( 'WC_Payments_Token_Service' );
 
 		$this->gateway    = new WC_Payment_Gateway_WCPay(
 			$this->mock_api_client,
@@ -126,6 +134,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 			Ideal_Payment_Method::class,
 			Link_Payment_Method::class,
 		];
+
 		foreach ( $payment_method_classes as $payment_method_class ) {
 			$mock_payment_method = $this->getMockBuilder( $payment_method_class )
 				->setConstructorArgs( [ $this->mock_token_service ] )

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -77,13 +77,6 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 	private $mock_db_cache;
 
 	/**
-	 * Mock WC_Payments_Token_Service.
-	 *
-	 * @var WC_Payments_Token_Service
-	 */
-	private $mock_token_service;
-
-	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
@@ -108,7 +101,6 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$action_scheduler_service = new WC_Payments_Action_Scheduler_Service( $this->mock_api_client );
 		$mock_rate_limiter        = $this->createMock( Session_Rate_Limiter::class );
 		$order_service            = new WC_Payments_Order_Service( $this->mock_api_client );
-		$this->mock_token_service = $this->createMock( 'WC_Payments_Token_Service' );
 
 		$this->gateway    = new WC_Payment_Gateway_WCPay(
 			$this->mock_api_client,
@@ -137,7 +129,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 
 		foreach ( $payment_method_classes as $payment_method_class ) {
 			$mock_payment_method = $this->getMockBuilder( $payment_method_class )
-				->setConstructorArgs( [ $this->mock_token_service ] )
+				->setConstructorArgs( [ $token_service ] )
 				->setMethods( [ 'is_subscription_item_in_cart' ] )
 				->getMock();
 			$mock_payment_method->expects( $this->any() )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -96,6 +96,16 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	private $payments_checkout;
 
 	/**
+	 * @var string
+	 */
+	private $mock_charge_id = 'ch_mock';
+
+	/**
+	 * @var integer
+	 */
+	private $mock_charge_created = 1653076178;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -542,7 +542,11 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$mock_order = $this->createMock( WC_Order::class );
-		$mock_order->expects( $this->any() )->method( 'get_id' )->willReturn( 1234 );
+
+		$mock_order
+			->expects( $this->any() )
+			->method( 'get_id' )
+			->willReturn( 1234 );
 
 		$mock_order
 			->expects( $this->exactly( 5 ) )
@@ -614,7 +618,11 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$mock_order = $this->createMock( WC_Order::class );
-		$mock_order->expects( $this->any() )->method( 'get_id' )->willReturn( 1234 );
+
+		$mock_order
+			->expects( $this->any() )
+			->method( 'get_id' )
+			->willReturn( 1234 );
 
 		$mock_order
 			->expects( $this->exactly( 5 ) )
@@ -692,7 +700,11 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$mock_order = $this->createMock( WC_Order::class );
-		$mock_order->expects( $this->any() )->method( 'get_id' )->willReturn( 1234 );
+
+		$mock_order
+			->expects( $this->any() )
+			->method( 'get_id' )
+			->willReturn( 1234 );
 
 		$mock_order
 			->expects( $this->exactly( 4 ) )
@@ -775,7 +787,11 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$mock_order = $this->createMock( WC_Order::class );
-		$mock_order->expects( $this->any() )->method( 'get_id' )->willReturn( 1234 );
+
+		$mock_order
+			->expects( $this->any() )
+			->method( 'get_id' )
+			->willReturn( 1234 );
 
 		$mock_order
 			->expects( $this->exactly( 2 ) )
@@ -851,7 +867,11 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$mock_order = $this->createMock( WC_Order::class );
-		$mock_order->expects( $this->any() )->method( 'get_id' )->willReturn( 1234 );
+
+		$mock_order
+			->expects( $this->any() )
+			->method( 'get_id' )
+			->willReturn( 1234 );
 
 		$mock_order
 			->expects( $this->exactly( 2 ) )
@@ -916,7 +936,12 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$mock_order = $this->createMock( WC_Order::class );
-		$mock_order->expects( $this->any() )->method( 'get_id' )->willReturn( 1234 );
+
+		$mock_order
+			->expects( $this->any() )
+			->method( 'get_id' )
+			->willReturn( 1234 );
+
 		$mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )
@@ -954,7 +979,12 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$mock_order = $this->createMock( WC_Order::class );
-		$mock_order->expects( $this->any() )->method( 'get_id' )->willReturn( 1234 );
+
+		$mock_order
+			->expects( $this->any() )
+			->method( 'get_id' )
+			->willReturn( 1234 );
+
 		$mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )
@@ -991,7 +1021,12 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$mock_order = $this->createMock( WC_Order::class );
-		$mock_order->expects( $this->any() )->method( 'get_id' )->willReturn( 1234 );
+
+		$mock_order
+			->expects( $this->any() )
+			->method( 'get_id' )
+			->willReturn( 1234 );
+
 		$mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -75,6 +75,11 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	private $event_body;
 
 	/**
+	 * @var WC_Order
+	 */
+	private $mock_order;
+
+	/**
 	 * Pre-test setup
 	 */
 	public function set_up() {
@@ -116,6 +121,12 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 
 		$this->event_body         = [];
 		$this->event_body['data'] = $event_data;
+
+		$this->mock_order = $this->createMock( WC_Order::class );
+		$this->mock_order
+			->expects( $this->any() )
+			->method( 'get_id' )
+			->willReturn( 1234 );
 	}
 
 	/**
@@ -189,11 +200,9 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			'currency' => 'gbp',
 		];
 
-		$mock_order = $this->createMock( WC_Order::class );
+		$this->mock_order->method( 'get_currency' )->willReturn( 'GBP' );
 
-		$mock_order->method( 'get_currency' )->willReturn( 'GBP' );
-
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with(
@@ -202,7 +211,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 
 		// The expects condition here is the real test; we expect that the 'update_meta_data' function
 		// is called with the appropriate values.
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'update_meta_data' )
 			->with( '_wcpay_refund_status', 'failed' );
@@ -211,7 +220,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'order_from_charge_id' )
 			->with( 'test_charge_id' )
-			->willReturn( $mock_order );
+			->willReturn( $this->mock_order );
 
 		// Run the test.
 		$this->webhook_processing_service->process( $this->event_body );
@@ -237,8 +246,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		$mock_refund_2 = $this->createMock( WC_Order_Refund::class );
 		$mock_refund_2->method( 'get_meta' )->willReturn( 'test_refund_id' );
 
-		$mock_order = $this->createMock( WC_Order::class );
-		$mock_order->method( 'get_refunds' )->willReturn(
+		$this->mock_order->method( 'get_refunds' )->willReturn(
 			[
 				$mock_refund_1,
 				$mock_refund_2,
@@ -249,7 +257,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'order_from_charge_id' )
 			->with( 'test_charge_id' )
-			->willReturn( $mock_order );
+			->willReturn( $this->mock_order );
 
 		$mock_refund_1
 			->expects( $this->never() )
@@ -273,15 +281,13 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			'status' => 'success',
 		];
 
-		$mock_order = $this->createMock( WC_Order::class );
-
 		$this->mock_db_wrapper
 			->expects( $this->never() )
 			->method( 'order_from_charge_id' );
 
 		// The expects condition here is the real test; we expect that the 'update_meta_data' function
 		// is never called to update the meta data.
-		$mock_order
+		$this->mock_order
 			->expects( $this->never() )
 			->method( 'update_meta_data' );
 
@@ -303,11 +309,9 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			'currency' => 'gbp',
 		];
 
-		$mock_order = $this->createMock( WC_Order::class );
+		$this->mock_order->method( 'get_currency' )->willReturn( 'GBP' );
 
-		$mock_order->method( 'get_currency' )->willReturn( 'GBP' );
-
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with(
@@ -318,7 +322,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'order_from_charge_id' )
 			->with( 'test_charge_id' )
-			->willReturn( $mock_order );
+			->willReturn( $this->mock_order );
 
 		// Run the test.
 		$this->webhook_processing_service->process( $this->event_body );
@@ -338,11 +342,9 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			'currency' => 'eur',
 		];
 
-		$mock_order = $this->createMock( WC_Order::class );
+		$this->mock_order->method( 'get_currency' )->willReturn( 'GBP' );
 
-		$mock_order->method( 'get_currency' )->willReturn( 'GBP' );
-
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with( 'A refund of <span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&euro;</span>9.99</bdi></span> was <strong>unsuccessful</strong> using WooCommerce Payments (<code>test_refund_id</code>).' );
@@ -351,7 +353,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'order_from_charge_id' )
 			->with( 'test_charge_id' )
-			->willReturn( $mock_order );
+			->willReturn( $this->mock_order );
 
 		// Run the test.
 		$this->webhook_processing_service->process( $this->event_body );
@@ -371,11 +373,9 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			'currency' => 'jpy',
 		];
 
-		$mock_order = $this->createMock( WC_Order::class );
+		$this->mock_order->method( 'get_currency' )->willReturn( 'GBP' );
 
-		$mock_order->method( 'get_currency' )->willReturn( 'GBP' );
-
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with( 'A refund of <span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&yen;</span>999.00</bdi></span> was <strong>unsuccessful</strong> using WooCommerce Payments (<code>test_refund_id</code>).' );
@@ -384,7 +384,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'order_from_charge_id' )
 			->with( 'test_charge_id' )
-			->willReturn( $mock_order );
+			->willReturn( $this->mock_order );
 
 		// Run the test.
 		$this->webhook_processing_service->process( $this->event_body );
@@ -541,14 +541,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			'status'   => $intent_status = 'succeeded',
 		];
 
-		$mock_order = $this->createMock( WC_Order::class );
-
-		$mock_order
-			->expects( $this->any() )
-			->method( 'get_id' )
-			->willReturn( 1234 );
-
-		$mock_order
+		$this->mock_order
 			->expects( $this->exactly( 5 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
@@ -559,17 +552,17 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 				[ '_intention_status', $intent_status ]
 			);
 
-		$mock_order
+		$this->mock_order
 			->expects( $this->exactly( 2 ) )
 			->method( 'save' );
 
-		$mock_order
+		$this->mock_order
 			->expects( $this->exactly( 2 ) )
 			->method( 'has_status' )
 			->with( [ 'processing', 'completed' ] )
 			->willReturn( false );
 
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'payment_complete' );
 
@@ -577,9 +570,9 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'order_from_intent_id' )
 			->with( 'pi_123123123123123' )
-			->willReturn( $mock_order );
+			->willReturn( $this->mock_order );
 
-		$mock_order
+		$this->mock_order
 			->method( 'get_data_store' )
 			->willReturn( new \WC_Mock_WC_Data_Store() );
 
@@ -617,14 +610,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			'metadata' => [ 'order_id' => 'id_1323' ], // Using order_id inside of the intent metadata to find the order.
 		];
 
-		$mock_order = $this->createMock( WC_Order::class );
-
-		$mock_order
-			->expects( $this->any() )
-			->method( 'get_id' )
-			->willReturn( 1234 );
-
-		$mock_order
+		$this->mock_order
 			->expects( $this->exactly( 5 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
@@ -635,17 +621,17 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 				[ '_intention_status', $intent_status ]
 			);
 
-		$mock_order
+		$this->mock_order
 			->expects( $this->exactly( 2 ) )
 			->method( 'save' );
 
-		$mock_order
+		$this->mock_order
 			->expects( $this->exactly( 2 ) )
 			->method( 'has_status' )
 			->with( [ 'processing', 'completed' ] )
 			->willReturn( false );
 
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'payment_complete' );
 
@@ -659,9 +645,9 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'order_from_order_id' )
 			->with( 'id_1323' )
-			->willReturn( $mock_order );
+			->willReturn( $this->mock_order );
 
-		$mock_order
+		$this->mock_order
 			->method( 'get_data_store' )
 			->willReturn( new \WC_Mock_WC_Data_Store() );
 
@@ -699,14 +685,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			'status'   => $intent_status = 'succeeded',
 		];
 
-		$mock_order = $this->createMock( WC_Order::class );
-
-		$mock_order
-			->expects( $this->any() )
-			->method( 'get_id' )
-			->willReturn( 1234 );
-
-		$mock_order
+		$this->mock_order
 			->expects( $this->exactly( 4 ) )
 			->method( 'update_meta_data' )
 			->withConsecutive(
@@ -716,17 +695,17 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 				[ WC_Payments_Utils::ORDER_INTENT_CURRENCY_META_KEY, $currency ]
 			);
 
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'save' );
 
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'has_status' )
 			->with( [ 'processing', 'completed' ] )
 			->willReturn( true );
 
-		$mock_order
+		$this->mock_order
 			->expects( $this->never() )
 			->method( 'payment_complete' );
 
@@ -734,9 +713,9 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'order_from_intent_id' )
 			->with( 'pi_123123123123123' )
-			->willReturn( $mock_order );
+			->willReturn( $this->mock_order );
 
-		$mock_order
+		$this->mock_order
 			->method( 'get_data_store' )
 			->willReturn( new \WC_Mock_WC_Data_Store() );
 
@@ -786,20 +765,13 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			],
 		];
 
-		$mock_order = $this->createMock( WC_Order::class );
-
-		$mock_order
-			->expects( $this->any() )
-			->method( 'get_id' )
-			->willReturn( 1234 );
-
-		$mock_order
+		$this->mock_order
 			->expects( $this->exactly( 2 ) )
 			->method( 'has_status' )
 			->with( [ 'processing', 'completed' ] )
 			->willReturn( false );
 
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'payment_complete' );
 
@@ -807,9 +779,9 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'order_from_intent_id' )
 			->with( 'pi_123123123123123' )
-			->willReturn( $mock_order );
+			->willReturn( $this->mock_order );
 
-		$mock_order
+		$this->mock_order
 			->method( 'get_data_store' )
 			->willReturn( new \WC_Mock_WC_Data_Store() );
 
@@ -817,7 +789,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'send_customer_ipp_receipt_email' )
 			->with(
-				$mock_order,
+				$this->mock_order,
 				$mock_merchant_settings,
 				$this->event_body['data']['object']['charges']['data'][0]
 			);
@@ -866,14 +838,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			'status'   => 'requires_payment_method',
 		];
 
-		$mock_order = $this->createMock( WC_Order::class );
-
-		$mock_order
-			->expects( $this->any() )
-			->method( 'get_id' )
-			->willReturn( 1234 );
-
-		$mock_order
+		$this->mock_order
 			->expects( $this->exactly( 2 ) )
 			->method( 'get_meta' )
 			->withConsecutive(
@@ -885,7 +850,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 				false
 			);
 
-		$mock_order
+		$this->mock_order
 			->expects( $this->exactly( 3 ) )
 			->method( 'has_status' )
 			->withConsecutive(
@@ -895,7 +860,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			)
 			->willReturn( false );
 
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with(
@@ -904,12 +869,12 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 				)
 			);
 
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'update_status' )
 			->with( 'failed' );
 
-		$mock_order
+		$this->mock_order
 			->method( 'get_data_store' )
 			->willReturn( new \WC_Mock_WC_Data_Store() );
 
@@ -917,7 +882,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'order_from_intent_id' )
 			->with( 'pi_123123123123123' )
-			->willReturn( $mock_order );
+			->willReturn( $this->mock_order );
 
 		// Run the test.
 		$this->webhook_processing_service->process( $this->event_body );
@@ -935,14 +900,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			'reason' => 'test_reason',
 		];
 
-		$mock_order = $this->createMock( WC_Order::class );
-
-		$mock_order
-			->expects( $this->any() )
-			->method( 'get_id' )
-			->willReturn( 1234 );
-
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with(
@@ -951,7 +909,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 				)
 			);
 
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'update_status' )
 			->with( 'on-hold' );
@@ -960,7 +918,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'order_from_charge_id' )
 			->with( 'test_charge_id' )
-			->willReturn( $mock_order );
+			->willReturn( $this->mock_order );
 
 		// Run the test.
 		$this->webhook_processing_service->process( $this->event_body );
@@ -978,14 +936,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			'status' => 'test_status',
 		];
 
-		$mock_order = $this->createMock( WC_Order::class );
-
-		$mock_order
-			->expects( $this->any() )
-			->method( 'get_id' )
-			->willReturn( 1234 );
-
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with(
@@ -994,7 +945,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 				)
 			);
 
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'update_status' )
 			->with( 'completed' );
@@ -1003,7 +954,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'order_from_charge_id' )
 			->with( 'test_charge_id' )
-			->willReturn( $mock_order );
+			->willReturn( $this->mock_order );
 
 		// Run the test.
 		$this->webhook_processing_service->process( $this->event_body );
@@ -1020,14 +971,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			'charge' => 'test_charge_id',
 		];
 
-		$mock_order = $this->createMock( WC_Order::class );
-
-		$mock_order
-			->expects( $this->any() )
-			->method( 'get_id' )
-			->willReturn( 1234 );
-
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with(
@@ -1040,7 +984,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'order_from_charge_id' )
 			->with( 'test_charge_id' )
-			->willReturn( $mock_order );
+			->willReturn( $this->mock_order );
 
 		// Run the test.
 		$this->webhook_processing_service->process( $this->event_body );
@@ -1057,8 +1001,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			'charge' => 'test_charge_id',
 		];
 
-		$mock_order = $this->createMock( WC_Order::class );
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with(
@@ -1071,7 +1014,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'order_from_charge_id' )
 			->with( 'test_charge_id' )
-			->willReturn( $mock_order );
+			->willReturn( $this->mock_order );
 
 		// Run the test.
 		$this->webhook_processing_service->process( $this->event_body );
@@ -1088,8 +1031,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			'charge' => 'test_charge_id',
 		];
 
-		$mock_order = $this->createMock( WC_Order::class );
-		$mock_order
+		$this->mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with(
@@ -1102,7 +1044,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'order_from_charge_id' )
 			->with( 'test_charge_id' )
-			->willReturn( $mock_order );
+			->willReturn( $this->mock_order );
 
 		// Run the test.
 		$this->webhook_processing_service->process( $this->event_body );

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -542,6 +542,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$mock_order = $this->createMock( WC_Order::class );
+		$mock_order->expects( $this->any() )->method( 'get_id' )->willReturn( 1234 );
 
 		$mock_order
 			->expects( $this->exactly( 5 ) )
@@ -613,6 +614,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$mock_order = $this->createMock( WC_Order::class );
+		$mock_order->expects( $this->any() )->method( 'get_id' )->willReturn( 1234 );
 
 		$mock_order
 			->expects( $this->exactly( 5 ) )
@@ -690,6 +692,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$mock_order = $this->createMock( WC_Order::class );
+		$mock_order->expects( $this->any() )->method( 'get_id' )->willReturn( 1234 );
 
 		$mock_order
 			->expects( $this->exactly( 4 ) )
@@ -772,6 +775,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$mock_order = $this->createMock( WC_Order::class );
+		$mock_order->expects( $this->any() )->method( 'get_id' )->willReturn( 1234 );
 
 		$mock_order
 			->expects( $this->exactly( 2 ) )
@@ -847,6 +851,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$mock_order = $this->createMock( WC_Order::class );
+		$mock_order->expects( $this->any() )->method( 'get_id' )->willReturn( 1234 );
 
 		$mock_order
 			->expects( $this->exactly( 2 ) )
@@ -911,6 +916,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$mock_order = $this->createMock( WC_Order::class );
+		$mock_order->expects( $this->any() )->method( 'get_id' )->willReturn( 1234 );
 		$mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )
@@ -948,6 +954,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$mock_order = $this->createMock( WC_Order::class );
+		$mock_order->expects( $this->any() )->method( 'get_id' )->willReturn( 1234 );
 		$mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )
@@ -984,6 +991,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		];
 
 		$mock_order = $this->createMock( WC_Order::class );
+		$mock_order->expects( $this->any() )->method( 'get_id' )->willReturn( 1234 );
 		$mock_order
 			->expects( $this->once() )
 			->method( 'add_order_note' )


### PR DESCRIPTION
Fixes #5042

#### Changes proposed in this Pull Request

- Add [missing props](https://github.com/Automattic/woocommerce-payments/pull/5049/commits/b9fef9083dac4b56c549f56a422b5cbdbdc67ee2) to `WC_Payment_Gateway_WCPay_Test` to make the `test_capture_charge_metadata` work within the test (seems to be moved over from another one).
- Make sure that [mock orders return an ID](https://github.com/Automattic/woocommerce-payments/pull/5049/commits/d5b7b6d8cb1d80f110825fcca6f0345f07b00244) for `Webhook_Processing_Service`. This way we're not using null values for `wp_cache_*` methods. This way https://core.trac.wordpress.org/ticket/56198 will not cause errors.
- `WC_REST_Payments_Settings_Controller_Test` was missing the `$mock_token_service` mock, which was required for most of the tests in the file.

#### Testing instructions

All tests should pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 