### PR TITLE
Update Subscriptions Core to 2.5.1

### DIFF
--- a/changelog/subscriptions-core-2.4.1
+++ b/changelog/subscriptions-core-2.4.1
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Update subscriptions-core to 2.4.1.

--- a/changelog/subscriptions-core-2.5.0
+++ b/changelog/subscriptions-core-2.5.0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update subscriptions-core to 2.5.0.

--- a/changelog/subscriptions-core-2.5.0
+++ b/changelog/subscriptions-core-2.5.0
@@ -1,4 +1,4 @@
 Significance: minor
 Type: dev
 
-Update subscriptions-core to 2.5.0.
+Update subscriptions-core to 2.5.1.

--- a/changelog/subscriptions-core-2.5.0-changelog-1
+++ b/changelog/subscriptions-core-2.5.0-changelog-1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+New WCS_Orders_Table_Subscription_Data_Store class to support subscriptions stored in High-Performance Order Storage (HPOS).

--- a/changelog/subscriptions-core-2.5.0-changelog-2
+++ b/changelog/subscriptions-core-2.5.0-changelog-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+New WCS_Orders_Table_Data_Store_Controller class to load the proper subscriptions data store when the store has HPOS enabled.

--- a/changelog/subscriptions-core-2.5.0-changelog-3
+++ b/changelog/subscriptions-core-2.5.0-changelog-3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+New data copier class to copy data to subscriptions and related orders in place of direct database queries in prepraration for HPOS support.

--- a/changelog/subscriptions-core-2.5.0-changelog-4
+++ b/changelog/subscriptions-core-2.5.0-changelog-4
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+When saving sync meta data on a new subscription, use 'woocommerce_new_subscription' instead of 'save_post'. This is to prevent errors when purchasing a subscription on stores that have HPOS enabled.[.

--- a/changelog/subscriptions-core-2.5.0-changelog-5
+++ b/changelog/subscriptions-core-2.5.0-changelog-5
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Improve maybe_add_subscription_meta() and subscription_contains_synced_product() inside our WC_Subscriptions_Synchroniser class to use CRUD methods.

--- a/changelog/subscriptions-core-2.5.0-changelog-6
+++ b/changelog/subscriptions-core-2.5.0-changelog-6
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+wcs_get_objects_property and wcs_set_objects_property have been marked as deprecated. Getters/Setters should be used on the objects instead.

--- a/changelog/subscriptions-core-2.5.0-changelog-7
+++ b/changelog/subscriptions-core-2.5.0-changelog-7
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Deprecated the "wcs_{type}_meta_query" dynamic hook used to alter the database query used to fetch the meta data to copy between subscriptions and renewal orders. There is no direct replacement. Third-parties should use the "wc_subscriptions_{type}_data" or "wc_subscriptions_object_data" hooks instead.

--- a/changelog/subscriptions-core-2.5.0-changelog-8
+++ b/changelog/subscriptions-core-2.5.0-changelog-8
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Deprecated the "wcs_{type}_meta" dynamic hook used to filter data copied to subscriptions and renewal orders. Third-parties should use wc_subscriptions_{type}_data instead.

--- a/changelog/subscriptions-core-2.5.1-changelog-1
+++ b/changelog/subscriptions-core-2.5.1-changelog-1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Replace the use of the deprecated wcs_renewal_order_meta hook with wc_subscription_renewal_order_data in the WCS_Related_Order_Store_Cached_CPT class.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
       "automattic/jetpack-sync": "1.30.5",
       "automattic/jetpack-tracking": "1.14.5",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "2.4.1"
+      "woocommerce/subscriptions-core": "2.5.0"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
       "automattic/jetpack-sync": "1.30.5",
       "automattic/jetpack-tracking": "1.14.5",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "2.5.0"
+      "woocommerce/subscriptions-core": "2.5.1"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f320dcc6030ee5c6e0e85e362a68b19",
+    "content-hash": "d7ffeabffefb091ca89ba126afcb7ae7",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1060,16 +1060,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "0edb769529b89d8241c13602ba8a120d2cc00f1d"
+                "reference": "0e2633b0f254ff08a860dcf64b66b10c5cc8b7e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/0edb769529b89d8241c13602ba8a120d2cc00f1d",
-                "reference": "0edb769529b89d8241c13602ba8a120d2cc00f1d",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/0e2633b0f254ff08a860dcf64b66b10c5cc8b7e4",
+                "reference": "0e2633b0f254ff08a860dcf64b66b10c5cc8b7e4",
                 "shasum": ""
             },
             "require": {
@@ -1110,10 +1110,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.5.0",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.5.1",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-11-04T05:59:53+00:00"
+            "time": "2022-11-04T07:37:07+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "680bfeb604135fc68fdb40284bdac3e8",
+    "content-hash": "3f320dcc6030ee5c6e0e85e362a68b19",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1060,16 +1060,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "2.4.1",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "843b65c7c388f7e6f5cffddc33f5f36e6ed75b93"
+                "reference": "0edb769529b89d8241c13602ba8a120d2cc00f1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/843b65c7c388f7e6f5cffddc33f5f36e6ed75b93",
-                "reference": "843b65c7c388f7e6f5cffddc33f5f36e6ed75b93",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/0edb769529b89d8241c13602ba8a120d2cc00f1d",
+                "reference": "0edb769529b89d8241c13602ba8a120d2cc00f1d",
                 "shasum": ""
             },
             "require": {
@@ -1110,10 +1110,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.4.1",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.5.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-11-02T03:06:10+00:00"
+            "time": "2022-11-04T05:59:53+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR bumps the version of Subscriptions Core from 2.4.0 to 2.5.1. Find relevant PRs:
 - https://github.com/Automattic/woocommerce-subscriptions-core/pull/245
 - https://github.com/Automattic/woocommerce-subscriptions-core/pull/247

In this version we're introducing new classes and refactoring some existing code in preparation for supporting WooCommerce's High-Performance Order Storage in Subscriptions.

The changes in this PR should not change any behavior for existing stores.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test critical WC Pay Subscription flows

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
