### PR TITLE
Fetch authorization data only if the payment is marked for manual capture

### DIFF
--- a/changelog/fix-fetch-auth
+++ b/changelog/fix-fetch-auth
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fetch authorization data in payment details page only when the payment needs manual capture

--- a/client/data/authorizations/hooks.ts
+++ b/client/data/authorizations/hooks.ts
@@ -71,16 +71,19 @@ export const useAuthorizationsSummary = (
 
 export const useAuthorization = (
 	paymentIntentId: string,
-	orderId: number
+	orderId: number,
+	requiresCapture = true
 ): {
 	isLoading: boolean;
 	doCaptureAuthorization: () => void;
-	authorization: Authorization;
+	authorization?: Authorization;
 } => {
 	const { authorization, isLoading } = useSelect( ( select ) => {
 		const { getAuthorization, isResolving } = select( STORE_NAME );
 		return {
-			authorization: getAuthorization( paymentIntentId ),
+			authorization: requiresCapture
+				? getAuthorization( paymentIntentId )
+				: null,
 			isLoading: isResolving( 'getAuthorization', [ paymentIntentId ] ),
 		};
 	} );

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -107,9 +107,17 @@ const PaymentDetailsSummary = ( {
 		: placeholderValues;
 	const renderStorePrice =
 		charge.currency && balance.currency !== charge.currency;
+
+	// We should only fetch the authorization data if the payment is marked for manual capture
+	const shouldFetchAuthorization =
+		charge.amount !== charge.amount_captured &&
+		charge.amount_refunded === 0 &&
+		displayCaptureAuthorizationSection;
+
 	const { authorization } = useAuthorization(
 		charge.payment_intent as string,
-		charge.order?.number as number
+		charge.order?.number as number,
+		shouldFetchAuthorization
 	);
 
 	return (


### PR DESCRIPTION
Fixes #5061 

This change implements the logic to avoid fetching authorization data from the server if the payment is not marked as manual capture. In this case it makes no sense to retrieve the data from the server, since there will be no authorization linked to the payment

#### Changes proposed in this Pull Request
* Modifies useAuthorization hook to accept a new parameter: `requiresCapture`
* Inside the hook, use the flag to call the selector/resolver only if `requiresCapture` is true. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
_Payment with automatic capture_
* Navigate to the details page of a payment set to be captured automatically (this is the default behavior, so any payment from transactions details should work)
* Check that there is no GET request to `/payments/authorizations/<payment_intent_id>`

_Payment with manual capture_

- Enable `Issue an authorization on checkout and capture later` option in WP Admin > Payments > Settings
- Set `displayAuthorizations` and `displayCaptureAuthorizationSection` to true
- Make sure WCPay client is connected to local server, and that the server is listening for webhooks events from Stripe
- Purchase an order
- Navigate to WP Admin > Payments > Transactions > Uncaptured tab
- Click on the row for the order you just created
- A GET request to `/payments/authorizations/<payment_intent_id>` should be fired
- The Capture section should be displayed. It should contain the deadline date and the Capture CTA button

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
