### PR TITLE
Fix jest tests due to daylight saving

### DIFF
--- a/changelog/fix-jest-timezone-nov-2022
+++ b/changelog/fix-jest-timezone-nov-2022
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+

--- a/client/data/transactions/test/resolvers.js
+++ b/client/data/transactions/test/resolvers.js
@@ -43,7 +43,7 @@ describe( 'getTransactions resolver', () => {
 		'page=1&pagesize=25&sort=date&direction=desc' +
 		'&match=all&date_before=2020-04-29%2003%3A59%3A59&date_after=2020-04-29%2004%3A00%3A00' +
 		'&date_between%5B0%5D=2020-04-28%2004%3A00%3A00&date_between%5B1%5D=2020-04-30%2003%3A59%3A59&type_is=charge' +
-		'&type_is_not=dispute&loan_id_is=mock_flxln_id&deposit_id=mock_po_id&search=Test%20user&user_timezone=-04%3A00';
+		'&type_is_not=dispute&loan_id_is=mock_flxln_id&deposit_id=mock_po_id&search=Test%20user&user_timezone=-05%3A00';
 	let generator = null;
 
 	beforeEach( () => {
@@ -89,7 +89,7 @@ describe( 'getTransactionsSummary resolver', () => {
 	const expectedQueryString =
 		'match=all&date_before=2020-04-29%2003%3A59%3A59&date_after=2020-04-29%2004%3A00%3A00' +
 		'&date_between%5B0%5D=2020-04-28%2004%3A00%3A00&date_between%5B1%5D=2020-04-30%2003%3A59%3A59&type_is=charge' +
-		'&type_is_not=dispute&loan_id_is=mock_flxln_id&deposit_id=mock_po_id&search=Test%20user&user_timezone=-04%3A00';
+		'&type_is_not=dispute&loan_id_is=mock_flxln_id&deposit_id=mock_po_id&search=Test%20user&user_timezone=-05%3A00';
 	let generator = null;
 
 	beforeEach( () => {

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -520,7 +520,7 @@ describe( 'Transactions list', () => {
 				expect( mockApiFetch ).toHaveBeenCalledWith( {
 					method: 'POST',
 					path:
-						'/wc/v3/payments/transactions/download?user_email=mock%40example.com&user_timezone=-04%3A00',
+						'/wc/v3/payments/transactions/download?user_email=mock%40example.com&user_timezone=-05%3A00',
 				} );
 			} );
 		} );
@@ -575,7 +575,7 @@ describe( 'Transactions list', () => {
 				expect( mockApiFetch ).toHaveBeenCalledWith( {
 					method: 'POST',
 					path:
-						'/wc/v3/payments/transactions/download?user_email=mock%40example.com&deposit_id=po_mock&user_timezone=-04%3A00',
+						'/wc/v3/payments/transactions/download?user_email=mock%40example.com&deposit_id=po_mock&user_timezone=-05%3A00',
 				} );
 			} );
 		} );


### PR DESCRIPTION
Due to daylight saving, some jest tests failed, for example: https://github.com/Automattic/woocommerce-payments/actions/runs/3411736308/jobs/5676322360.

#### Changes proposed in this Pull Request

Quick fix the failing tests to unblock release process. This fix will break again when there is next daylight saving change. I created this issue https://github.com/Automattic/woocommerce-payments/issues/5063 to fix the problem long term.

#### Testing instructions

Make sure all GitHub checks are green.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
