### PR TITLE
Clean up some workflows for the release automation

### DIFF
--- a/.github/workflows/build-zip-file.yml
+++ b/.github/workflows/build-zip-file.yml
@@ -1,19 +1,12 @@
 name: "Build zip file"
 
-# This action will run when a pull request targeting `trunk` is closed/merged or when it is triggered manually.
+# This action will run when it is triggered manually.
 on:
-  pull_request_target:
-    branches:
-      - 'trunk'
-    types:
-      - closed
   workflow_dispatch:
     
 jobs:
-  # The job runs only if the workflow was triggered manually or if it was triggered by a PR targeting trunk which was merged
   build-zip:
     name: "Build the zip file"
-    if: ${{ github.event_name != 'pull_request_target' || startsWith(github.head_ref, 'release/') && github.event.pull_request.merged == true }}
     runs-on: ubuntu-20.04
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/build-zip-file.yml
+++ b/.github/workflows/build-zip-file.yml
@@ -2,6 +2,9 @@ name: "Build zip file"
 
 # This action will run when it is triggered manually.
 on:
+  pull_request:
+    push:
+      branches: [ trunk ]
   workflow_dispatch:
     
 jobs:

--- a/.github/workflows/post-release-updates.yml
+++ b/.github/workflows/post-release-updates.yml
@@ -3,12 +3,6 @@ name: "Handle post-release steps"
 # This action will run when it is triggered manually
 on:
   workflow_dispatch:
-    inputs:
-      allowMerge:
-        description: 'Whether we allow merging trunk back into develop'
-        required: false
-        type: string
-        default: "false"
 
 defaults:
   run:
@@ -81,7 +75,6 @@ jobs:
   merge-trunk-into-develop:
     name: "Merge trunk back into develop"
     needs: get-last-released-version
-    if: ${{ inputs.allowMerge == 'true' }}
     runs-on: ubuntu-20.04
     env:
       RELEASE_VERSION: ${{ needs.get-last-released-version.outputs.releaseVersion }}

--- a/changelog/update-remove-pull-request-trigger-from-zip-workflow
+++ b/changelog/update-remove-pull-request-trigger-from-zip-workflow
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Just some clean-up of GitHub workflow
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Remove the automatic trigger to build a zip file as soon as a PR targeting trunk is merged
  - The zip file workflow will be triggered manually after the release branch is created, and we won't need to build one again when the release branch gets merged into trunk
- Remove `allowMerge` input from the post-release workflow
  - After thinking on this, I don't find necessary this "safety check" because I don't see how one would trigger that workflow by accident. It just adds one more unnecessary step before the release lead can run the workflow.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
