### PR TITLE
Update margin to fix cropping of search field for Multi-Currency currency search

### DIFF
--- a/changelog/fix-5074-multi-currency-search-input-cropping
+++ b/changelog/fix-5074-multi-currency-search-input-cropping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update margin to fix cropping of search field for Multi-Currency currency search

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/style.scss
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/style.scss
@@ -182,7 +182,7 @@
 
 	&__search {
 		border-bottom: 1px solid $studio-gray-5;
-		margin: -24px -24px 0;
+		margin: -16px -24px 0;
 		padding: 16px;
 	}
 }


### PR DESCRIPTION
Fixes #5074

#### Changes proposed in this Pull Request

* Update margin for search field in Multi-Currency currency search to prevent the top part of the field from being hidden.

#### Testing instructions

* Go to WooCommerce > Settings > Multi-Currency
* Click _Add currencies_
* Verify the top border of the search field is not hidden.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
