### PR TITLE
Add description for capture authorization endpoint docs

### DIFF
--- a/changelog/fix-api-docs-capture-authorization
+++ b/changelog/fix-api-docs-capture-authorization
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add description for capture authorization endpoint

--- a/docs/rest-api/source/includes/wp-api-v3/order.md
+++ b/docs/rest-api/source/includes/wp-api-v3/order.md
@@ -24,9 +24,10 @@ Create a new in-person payment intent for the given order ID without confirming 
 </div>
 
 ### Optional parameters
-- `payment_methods` - array with payment methods. Accepted values: `card_present` and `interac_present`
-- `metadata` - metadata that will be attached to the PaymentIntent
-- `customer_id` - customer that will be attached to the PaymentIntent
+
+-   `payment_methods` - array with payment methods. Accepted values: `card_present` and `interac_present`
+-   `metadata` - metadata that will be attached to the PaymentIntent
+-   `customer_id` - customer that will be attached to the PaymentIntent
 
 ```shell
 curl -X POST https://example.com/wp-json/wc/v3/payments/orders/42/create_terminal_intent \
@@ -109,6 +110,8 @@ curl -X POST https://example.com/wp-json/wc/v3/payments/orders/42/capture_termin
 
 _@since v5.1.0_
 
+Capture the funds of an existing uncaptured payment intent that was marked to be captured manually later.
+
 ### POST params
 
 -   payment_intent_id: string
@@ -117,7 +120,7 @@ _@since v5.1.0_
 ### Error codes
 
 -   `wcpay_missing_order` - Order not found
--   `wcpay_refunded_order_uncapturable` -  Payment cannot be captured for partially or fully refunded orders
+-   `wcpay_refunded_order_uncapturable` - Payment cannot be captured for partially or fully refunded orders
 -   `wcpay_payment_uncapturable` - The payment cannot be captured if intent status is not one of 'processing', 'requires_capture', or 'succeeded'
 -   `wcpay_intent_order_mismatch` - Payment cannot be captured because the order id does not match
 -   `wcpay_capture_error` - Unknown error
@@ -144,21 +147,20 @@ curl -X POST https://example.com/wp-json/wc/v3/payments/orders/42/capture_author
 
 ```json
 {
-  "status": "succeeded",
-  "id": "pi_ZZZZZZZZZZZZZZZZAAAAAAAA"
+	"status": "succeeded",
+	"id": "pi_ZZZZZZZZZZZZZZZZAAAAAAAA"
 }
 ```
 
 ```json
 {
-  "code": "wcpay_payment_uncapturable",
-  "message": "The payment cannot be captured",
-  "data": {
-    "status": 409
-  }
+	"code": "wcpay_payment_uncapturable",
+	"message": "The payment cannot be captured",
+	"data": {
+		"status": 409
+	}
 }
 ```
-
 
 ## Create customer
 

--- a/docs/rest-api/source/includes/wp-api-v3/order.md
+++ b/docs/rest-api/source/includes/wp-api-v3/order.md
@@ -56,7 +56,7 @@ curl -X POST https://example.com/wp-json/wc/v3/payments/orders/42/create_termina
 
 _@since v2.4.0_
 
-Given an intent ID and an order ID, add the intent ID to the order and capture it.
+Capture the funds of an in-person payment intent. Given an intent ID and an order ID, add the intent ID to the order and capture it.
 
 ### POST params
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the missing description for capture authorization endpoint.
* Update the description for capture terminal payment endpoint - a similar API - to differentiate it from the above.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (does not apply)
- [ ] Tested on mobile (does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
