### PR TITLE
Fix section divider in Authentication API docs

### DIFF
--- a/changelog/fix-api-docs-authentication-section-divider
+++ b/changelog/fix-api-docs-authentication-section-divider
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Fix section divider in Authentication API docs

--- a/docs/rest-api/source/includes/wp-api-v3/authentication.md
+++ b/docs/rest-api/source/includes/wp-api-v3/authentication.md
@@ -4,7 +4,7 @@ WooCommerce includes two ways to authenticate with the WP REST API. It is also p
 
 Refer to the [WooCommerce REST API docs](http://woocommerce.github.io/woocommerce-rest-api-docs/#authentication) for more options and possibilities.
 
----
+## Generate API keys
 
 Pre-generated keys can be used to authenticate use of the REST API endpoints. New keys can be generated either through the WordPress admin interface or they can be auto-generated through an endpoint.
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Replace the ugly line divider on [Authentication docs page](https://automattic.github.io/woocommerce-payments/#authentication) with a section heading.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (does not apply)
- [ ] Tested on mobile (does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
