### PR TITLE
Add count of pending authorizations to Uncaptured tab

### DIFF
--- a/changelog/fix-5089-count-of-pending-authorizations-with-parenthesis
+++ b/changelog/fix-5089-count-of-pending-authorizations-with-parenthesis
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add a counter of pending authorizations to Uncaptured tab in Transactions page.

--- a/client/transactions/index.tsx
+++ b/client/transactions/index.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { Experiment } from '@woocommerce/explat';
 import { TabPanel } from '@wordpress/components';
+import { getQuery } from '@woocommerce/navigation';
 import { __ } from '@wordpress/i18n';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
 
@@ -18,6 +19,7 @@ import {
 	EmptyStateTableHeaders,
 } from '../empty-state-table/list';
 import EmptyStateTable from 'empty-state-table';
+import { useAuthorizationsSummary } from 'wcpay/data';
 import ListBanner from '../empty-state-table/transactions-banner.svg';
 import Authorizations from './uncaptured';
 import './style.scss';
@@ -58,6 +60,8 @@ export const TransactionsPage = (): JSX.Element => {
 		/>
 	);
 
+	const { authorizationsSummary } = useAuthorizationsSummary( getQuery() );
+
 	if ( displayAuthorizations ) {
 		return (
 			<Page>
@@ -74,7 +78,10 @@ export const TransactionsPage = (): JSX.Element => {
 						},
 						{
 							name: 'uncaptured-page',
-							title: __( 'Uncaptured', 'woocommerce-payments' ),
+							// TODO: Find way to show a proper badge (as in menu) and convert back to translated string.
+							title: `Uncaptured (${
+								authorizationsSummary.count ?? '...'
+							})`,
 							className: 'authorizations-list',
 						},
 					] }

--- a/client/transactions/index.tsx
+++ b/client/transactions/index.tsx
@@ -4,9 +4,8 @@
 import React from 'react';
 import { Experiment } from '@woocommerce/explat';
 import { TabPanel } from '@wordpress/components';
-import { getQuery } from '@woocommerce/navigation';
-import { __ } from '@wordpress/i18n';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -78,10 +77,14 @@ export const TransactionsPage = (): JSX.Element => {
 						},
 						{
 							name: 'uncaptured-page',
-							// TODO: Find way to show a proper badge (as in menu) and convert back to translated string.
-							title: `Uncaptured (${
+							title: sprintf(
+								/* translators: %1: number of uncaptured authorizations */
+								__(
+									'Uncaptured (%1$s)',
+									'woocommerce-payments'
+								),
 								authorizationsSummary.count ?? '...'
-							})`,
+							),
 							className: 'authorizations-list',
 						},
 					] }

--- a/client/transactions/test/index.tsx
+++ b/client/transactions/test/index.tsx
@@ -139,7 +139,7 @@ describe( 'TransactionsPage', () => {
 		} );
 
 		await renderTransactionsPage();
-		expect( screen.queryByText( 'Uncaptured' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /uncaptured/i ) ).toBeInTheDocument();
 	} );
 
 	test( 'renders uncaptured tab if auth&capture is ENABLED and authorizations are present', async () => {
@@ -152,7 +152,7 @@ describe( 'TransactionsPage', () => {
 		} );
 
 		await renderTransactionsPage();
-		expect( screen.queryByText( 'Uncaptured' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /uncaptured/i ) ).toBeInTheDocument();
 	} );
 
 	test( 'renders uncaptured tab if auth&capture is ENABLED and no authorizations are present', async () => {
@@ -165,7 +165,7 @@ describe( 'TransactionsPage', () => {
 		} );
 
 		await renderTransactionsPage();
-		expect( screen.queryByText( 'Uncaptured' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /uncaptured/i ) ).toBeInTheDocument();
 	} );
 
 	test( 'do not render uncaptured tab if auth&capture is DISABLED and no authorizations are present', async () => {
@@ -178,6 +178,6 @@ describe( 'TransactionsPage', () => {
 		} );
 
 		await renderTransactionsPage();
-		expect( screen.queryByText( 'Uncaptured' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /uncaptured/i ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/transactions/uncaptured/index.tsx
+++ b/client/transactions/uncaptured/index.tsx
@@ -167,7 +167,7 @@ export const AuthorizationsList = (): JSX.Element => {
 			order: {
 				value: auth.order_id,
 				display: clickable(
-					`#${ auth.order_id } from ${ auth.customer_name }`
+					`#${ auth.order_id } ${ auth.customer_name }`
 				),
 			},
 			risk_level: {

--- a/client/transactions/uncaptured/test/__snapshots__/index.test.tsx.snap
+++ b/client/transactions/uncaptured/test/__snapshots__/index.test.tsx.snap
@@ -295,7 +295,7 @@ exports[`Authorizations list renders correctly 1`] = `
                     href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_4242"
                     tabindex="-1"
                   >
-                    #24 from Good boy
+                    #24 Good boy
                   </a>
                 </td>
                 <td
@@ -372,7 +372,7 @@ exports[`Authorizations list renders correctly 1`] = `
                     href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions%2Fdetails&id=pi_4243"
                     tabindex="-1"
                   >
-                    #25 from Good boy
+                    #25 Good boy
                   </a>
                 </td>
                 <td


### PR DESCRIPTION
Fixes #5089 

#### Changes proposed in this Pull Request
* Add a counter of pending authorizations to the Uncaptured tab of Transactions page.
* Design tweak
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
<img width="380" alt="Screen Shot 2022-11-10 at 12 55 17" src="https://user-images.githubusercontent.com/1553182/201087461-459aa1ad-30a8-4a77-a63e-1d864fe83774.png">

#### Testing instructions
##### Pre-requisites:

* Set `displayAuthorizations = true` [here](https://github.com/Automattic/woocommerce-payments/blob/d85445d1d2666d3658fa1fea3f85d653d1497088/client/transactions/index.tsx#L26)
* Enable the setting `Issue an authorization on checkout, and capture later` [here](http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments).
* Set your local WCPay server instance to listen to webhooks: ./local/bin/listen-to-webhooks.sh.

##### Counter shows number of pending authorizations:
* Purchase an order from WC frontend.
* Navigate to WP Admin → Payments → Transactions.
* Check that the number of pending authorizations appears in the Uncaptured tab (see screenshot 👆 for reference)
* Check that the number of pending authorizations in the tab matches the number displayed in the summary (i.e. `1 authorization(s)`)
* Click the Capture button
* Check again that the number of pending authorizations in the tab matches the number displayed in the summary


##### Cancel an authorization:

* Purchase another order from WC frontend.
* Navigate to WP Admin → Payments → Transactions.
* Check that the number of pending authorizations appears in the Uncaptured tab (see screenshot 👆 for reference)
* Check that the number of pending authorizations in the tab matches the number displayed in the summary (i.e. `1 authorization(s)`)
* Go to the order's detail page from WP Admin → WooCommerce → Orders. Cancel the authorization from the "Order actions" menu.
* Check again that the number of pending authorizations in the tab matches the number displayed in the summary

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
