### PR TITLE
Add the missing include for authorization API docs in sidebar

### DIFF
--- a/changelog/fix-api-docs--include-authorization-docs
+++ b/changelog/fix-api-docs--include-authorization-docs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Add missing include
+
+

--- a/docs/rest-api/source/index.html.md
+++ b/docs/rest-api/source/index.html.md
@@ -13,6 +13,7 @@ includes:
     - wp-api-v3/introduction
     - wp-api-v3/authentication
     - wp-api-v3/order
+    - wp-api-v3/authorization
 
 search: false
 ---


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The docs added in #5088 are not displayed in the sidebar due to a missing include. As a result, there's no way to access them from the [generated site](https://automattic.github.io/woocommerce-payments). This PR fixes that.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (does not apply)
- [ ] Tested on mobile (does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
