### PR TITLE
Check if user can `manage_woocommerce` in maybe_redirect_to_onboarding()

### DIFF
--- a/changelog/fix-5096-fatal-error-admin
+++ b/changelog/fix-5096-fatal-error-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error when non-admin access admin pages.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -565,7 +565,7 @@ class WC_Payments_Account {
 	 * @return bool True if the redirection happened.
 	 */
 	public function maybe_redirect_to_onboarding() {
-		if ( wp_doing_ajax() ) {
+		if ( wp_doing_ajax() || ! current_user_can( 'manage_woocommerce' ) ) {
 			return false;
 		}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -389,14 +389,11 @@ class WC_Payments {
 		include_once WCPAY_ABSPATH . '/includes/class-wc-payments-captured-event-note.php';
 
 		// Add admin screens.
-		if ( is_admin() ) {
-			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin-settings.php';
-		}
-
 		if ( is_admin() && current_user_can( 'manage_woocommerce' ) ) {
 			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin.php';
 			new WC_Payments_Admin( self::$api_client, self::get_gateway(), self::$account, self::$database_cache );
 
+			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin-settings.php';
 			new WC_Payments_Admin_Settings( self::get_gateway() );
 
 			add_filter( 'plugin_action_links_' . plugin_basename( WCPAY_PLUGIN_FILE ), [ __CLASS__, 'add_plugin_links' ] );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -389,11 +389,14 @@ class WC_Payments {
 		include_once WCPAY_ABSPATH . '/includes/class-wc-payments-captured-event-note.php';
 
 		// Add admin screens.
+		if ( is_admin() ) {
+			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin-settings.php';
+		}
+
 		if ( is_admin() && current_user_can( 'manage_woocommerce' ) ) {
 			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin.php';
 			new WC_Payments_Admin( self::$api_client, self::get_gateway(), self::$account, self::$database_cache );
 
-			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin-settings.php';
 			new WC_Payments_Admin_Settings( self::get_gateway() );
 
 			add_filter( 'plugin_action_links_' . plugin_basename( WCPAY_PLUGIN_FILE ), [ __CLASS__, 'add_plugin_links' ] );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -389,11 +389,14 @@ class WC_Payments {
 		include_once WCPAY_ABSPATH . '/includes/class-wc-payments-captured-event-note.php';
 
 		// Add admin screens.
-		if ( is_admin() && current_user_can( 'manage_woocommerce' ) ) {
+		if ( is_admin() ) {
 			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin.php';
+			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin-settings.php';
+		}
+
+		if ( is_admin() && current_user_can( 'manage_woocommerce' ) ) {
 			new WC_Payments_Admin( self::$api_client, self::get_gateway(), self::$account, self::$database_cache );
 
-			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin-settings.php';
 			new WC_Payments_Admin_Settings( self::get_gateway() );
 
 			add_filter( 'plugin_action_links_' . plugin_basename( WCPAY_PLUGIN_FILE ), [ __CLASS__, 'add_plugin_links' ] );


### PR DESCRIPTION
Fixe #5096

As explained in https://github.com/Automattic/woocommerce-payments/issues/5096, the fatal error is because `WC_Payments_Account::maybe_redirect_to_onboarding()` calls `WC_Payments_Admin_Settings` but `WC_Payments_Admin_Settings` is only defined if page is admin and user has `manage_woocommerce` capability. The fatal error should be experienced only by users who accesses admin pages but they don't have `manage_woocommerce` capability.

#### Changes proposed in this Pull Request

1. Always load `WC_Payments_Admin` (`includes/admin/class-wc-payments-admin-settings.php`) and `WC_Payments_Admin_Settings` (`includes/admin/class-wc-payments-admin-settings.php`) if page is admin. There is no risk of doing that because there is only class definition and no side-effect from including those files. I don't see any logic in the code base that checks for those class existence too, so I don't expect any side-effect just by having those classes defined.

2. Check if user can `manage_woocommerce` in [maybe_redirect_to_onboarding()](https://github.com/Automattic/woocommerce-payments/blob/ab029f5facb1c48495df4ac00a538bd2a35b4b83/includes/class-wc-payments-account.php#L567-L572). I also don't see the risk of adding this check because only admins with `manage_woocommerce` capability that should be able to onboard. 


3. Updating unit tests that calls `maybe_redirect_to_onboarding()` because in those unit tests, the test user does not have `manage_woocommerce` capability. My change sets it so test user has `manage_woocommerce` capability to make those unit tests pass.

4. Add a new unit test to make sure `maybe_redirect_to_onboarding()` does not do anything if user does not have `manage_woocommerce` capabiltiy.

#### Testing instructions

1. Create a new user without the `manage_woocommerce` capability. This includes all default non-admin roles, for example: `Editor` role.
5. Log in with that user's credentials.
6. Navigate to any admin page, including just /wp-admin.
7. Admin pages should load just fine without fatal error. With this base branch, you will see a fatal error.
```
Fatal error: Uncaught Error: Class 'WC_Payments_Admin_Settings' not found in /var/www/html/wp-content/plugins/woocommerce-payments/includes/class-wc-payments-account.php on line 572
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
