### PR TITLE
Update copy of Subscriptions warning modal

### DIFF
--- a/changelog/update-5047-warning-modal-while-deactivating-subs-extension
+++ b/changelog/update-5047-warning-modal-while-deactivating-subs-extension
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update copy of warning modal appearing while deactivating Subscriptions extension.

--- a/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
+++ b/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
@@ -21,7 +21,7 @@
 						<?php
 							printf(
 								// Translators: placeholders are opening and closing strong HTML tags.
-								esc_html__( 'By deactivating the %1$sWooCommerce Subscriptions%2$s plugin, your store will switch to %1$sSubscriptions powered by WooCommerce Payments%2$s.', 'woocommerce-payments' ),
+								esc_html__( 'By deactivating the %1$sWooCommerce Subscriptions%2$s plugin, your store will switch to using the subscriptions functionality %1$sbuilt into WooCommerce Payments%2$s.', 'woocommerce-payments' ),
 								'<strong>',
 								'</strong>'
 							);
@@ -30,12 +30,12 @@
 						<?php
 							printf(
 								// Translators: $1 and $2 placeholders are opening and closing strong HTML tags. $3 and $4 are opening and closing link HTML tags. $5 is an opening link HTML tag.
-								esc_html__( 'Existing subscriptions will %1$s%3$srenew manually%4$s%2$s - subscribers will need to log in to pay for renewal. Access to premium features will also be removed. %5$sLearn more.%4$s', 'woocommerce-payments' ),
+								esc_html__( 'Existing subscriptions will %1$s%3$srenew manually%4$s%2$s, meaning that subscribers will need to log in to pay for renewal. Access to the advanced features of the Subscriptions extension will be removed. %5$sLearn more.%4$s', 'woocommerce-payments' ),
 								'<strong>',
 								'</strong>',
 								'<a href="https://woocommerce.com/document/subscriptions/renewal-process/#section-4">',
 								'</a>',
-								'<a href="http://woocommerce.com/document/subscriptions/deactivation/">'
+								'<a href="https://woocommerce.com/document/subscriptions/deactivation/">'
 							);
 							?>
 					</p>


### PR DESCRIPTION
Fixes #5047 

#### Changes proposed in this Pull Request

Update copy on the warning modal that appears when we deactivate the WooCommerce Subscriptions extension, when WC Pay is active. 


<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. Start with a WC Pay test site. The built-in subscriptions functionality is enabled by default. Check to make sure it is.
2. Install and activate the standalone WooCommerce Subscriptions extension.
3. Deactivate Subscriptions.
4. This should trigger the modal. Make sure the copy reads as follows: 


>By deactivating the WooCommerce Subscriptions plugin, your store will switch to using the subscriptions functionality built into WooCommerce Payments. Existing subscriptions will [renew manually](https://woocommerce.com/document/subscriptions/renewal-process/#section-4), meaning that subscribers will need to log in to pay for renewal. Access to the advanced features of the Subscriptions extension will be removed. [Learn more.](http://woocommerce.com/document/subscriptions/deactivation/)

5. Check the links, if they lead to the correct destination pages. 
6. Check if clicking `Yes, deactivate WooCommerce Subscriptions` , deactivates the plugin successfully 
7. Check if clicking `Cancel`, successfully cancels the change and removes the modal

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) - Simple copy change
- [x] Tested on mobile (or does not apply) - Not needed

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
