### PR TITLE
Expose fraud prevention token, send it to blocks checkout

### DIFF
--- a/changelog/fix-card-testing-nonce-blocks-checkout
+++ b/changelog/fix-card-testing-nonce-blocks-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix blocks checkout when card testing prevention is active

--- a/client/checkout/blocks/generate-payment-method.js
+++ b/client/checkout/blocks/generate-payment-method.js
@@ -32,10 +32,9 @@ const generatePaymentMethod = async ( api, elements, billingData ) => {
 			paymentMethod: { id },
 		} = await request.send();
 
-		const fraudPreventionToken =
-			document
-				.querySelector( '#wcpay-fraud-prevention-token' )
-				?.getAttribute( 'value' ) ?? null;
+		const fraudPreventionToken = document
+			.querySelector( '#wcpay-fraud-prevention-token' )
+			?.getAttribute( 'value' );
 
 		return {
 			type: 'success',
@@ -43,7 +42,7 @@ const generatePaymentMethod = async ( api, elements, billingData ) => {
 				paymentMethodData: {
 					paymentMethod: PAYMENT_METHOD_NAME_CARD,
 					'wcpay-payment-method': id,
-					'wcpay-fraud-prevention-token': fraudPreventionToken,
+					'wcpay-fraud-prevention-token': fraudPreventionToken ?? '',
 				},
 			},
 		};

--- a/client/checkout/blocks/generate-payment-method.js
+++ b/client/checkout/blocks/generate-payment-method.js
@@ -32,12 +32,18 @@ const generatePaymentMethod = async ( api, elements, billingData ) => {
 			paymentMethod: { id },
 		} = await request.send();
 
+		const fraudPreventionToken =
+			document
+				.querySelector( '#wcpay-fraud-prevention-token' )
+				?.getAttribute( 'value' ) ?? null;
+
 		return {
 			type: 'success',
 			meta: {
 				paymentMethodData: {
 					paymentMethod: PAYMENT_METHOD_NAME_CARD,
 					'wcpay-payment-method': id,
+					'wcpay-fraud-prevention-token': fraudPreventionToken,
 				},
 			},
 		};

--- a/client/checkout/blocks/upe-fields.js
+++ b/client/checkout/blocks/upe-fields.js
@@ -230,6 +230,11 @@ const WCPayUPEFields = ( {
 					};
 				}
 
+				const fraudPreventionToken =
+					document
+						.querySelector( '#wcpay-fraud-prevention-token' )
+						?.getAttribute( 'value' ) ?? null;
+
 				return {
 					type: 'success',
 					meta: {
@@ -237,6 +242,7 @@ const WCPayUPEFields = ( {
 							paymentMethod: PAYMENT_METHOD_NAME_CARD,
 							wc_payment_intent_id: paymentIntentId,
 							wcpay_selected_upe_payment_type: selectedUPEPaymentType,
+							'wcpay-fraud-prevention-token': fraudPreventionToken,
 						},
 					},
 				};

--- a/client/checkout/blocks/upe-fields.js
+++ b/client/checkout/blocks/upe-fields.js
@@ -230,10 +230,9 @@ const WCPayUPEFields = ( {
 					};
 				}
 
-				const fraudPreventionToken =
-					document
-						.querySelector( '#wcpay-fraud-prevention-token' )
-						?.getAttribute( 'value' ) ?? null;
+				const fraudPreventionToken = document
+					.querySelector( '#wcpay-fraud-prevention-token' )
+					?.getAttribute( 'value' );
 
 				return {
 					type: 'success',
@@ -242,7 +241,8 @@ const WCPayUPEFields = ( {
 							paymentMethod: PAYMENT_METHOD_NAME_CARD,
 							wc_payment_intent_id: paymentIntentId,
 							wcpay_selected_upe_payment_type: selectedUPEPaymentType,
-							'wcpay-fraud-prevention-token': fraudPreventionToken,
+							'wcpay-fraud-prevention-token':
+								fraudPreventionToken ?? '',
 						},
 					},
 				};

--- a/includes/class-wc-payments-blocks-payment-method.php
+++ b/includes/class-wc-payments-blocks-payment-method.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
 use WCPay\WC_Payments_Checkout;
 
 /**
@@ -33,6 +34,8 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 		$this->name                 = WC_Payment_Gateway_WCPay::GATEWAY_ID;
 		$this->gateway              = WC_Payments::get_gateway();
 		$this->wc_payments_checkout = WC_Payments::get_wc_payments_checkout();
+
+		add_filter( 'the_content', [ $this, 'maybe_add_card_testing_token' ] );
 	}
 
 	/**
@@ -101,5 +104,21 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 			$platform_checkout_config,
 			$this->wc_payments_checkout->get_payment_fields_js_config()
 		);
+	}
+
+	/**
+	 * Adds the hidden input containing the card testing prevention token to the blocks checkout page.
+	 *
+	 * @param   string $content  The content that's going to be flushed to the browser.
+	 *
+	 * @return  string
+	 */
+	public function maybe_add_card_testing_token( $content ) {
+		$fraud_prevention_service = Fraud_Prevention_Service::get_instance();
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( $fraud_prevention_service->is_enabled() ) {
+			$content .= '<input type="hidden" name="wcpay-fraud-prevention-token" id="wcpay-fraud-prevention-token" value="' . esc_attr( Fraud_Prevention_Service::get_instance()->get_token() ) . '">';
+		}
+		return $content;
 	}
 }

--- a/includes/class-wc-payments-blocks-payment-method.php
+++ b/includes/class-wc-payments-blocks-payment-method.php
@@ -116,7 +116,7 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 	public function maybe_add_card_testing_token( $content ) {
 		$fraud_prevention_service = Fraud_Prevention_Service::get_instance();
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		if ( $fraud_prevention_service->is_enabled() ) {
+		if ( $fraud_prevention_service->is_enabled() && wp_script_is( 'WCPAY_BLOCKS_CHECKOUT' ) ) {
 			$content .= '<input type="hidden" name="wcpay-fraud-prevention-token" id="wcpay-fraud-prevention-token" value="' . esc_attr( Fraud_Prevention_Service::get_instance()->get_token() ) . '">';
 		}
 		return $content;


### PR DESCRIPTION
Fixes #5093

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

This PR adds the `wcpay-fraud-prevention-token` token to the blocks checkout page using the `the_content` filter on the `WC_Payments_Blocks_Payment_Method` class, which is responsible for enqueueing the blocks checkout scripts and styles. and append that token to UPE and non-UPE blocks checkout on the `onPaymentProcessing` event to send it to the gateway's `process_payment` method.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to the server database, set `card_testing_prevention_enabled` in `wcpay_account_meta` table for the account currently in use.
- Go to WCPay Dev Tools and refresh the account cache and see `'card_testing_protection_eligible' => true,` in the bottom of the account cache textarea.
- Enable UPE on WCPay dev tools if it's not enabled.
- Create a checkout page containing the checkout block if it doesn't exist.
- Now, make a payment using the UPE card form. It should be successful.
- Repeat the test with disabling UPE. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
