### PR TITLE
Fixed fatal error when calling the payment_gateways api endpoint

### DIFF
--- a/changelog/fix-rest-api-fatal-error
+++ b/changelog/fix-rest-api-fatal-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed rest api error for payment_gateways endpoint

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2944,6 +2944,15 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		return $field;
 	}
 
+	/**
+	 * Returns the URL of the configuration screen for this gateway, for use in internal links.
+	 *
+	 * @return string URL of the configuration screen for this gateway
+	 */
+	public static function get_settings_url() {
+		return WC_Payments_Admin_Settings::get_settings_url();
+	}
+
 	// Start: Deprecated functions.
 
 	/**
@@ -2956,18 +2965,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public static function is_current_page_settings() {
 		wc_deprecated_function( __FUNCTION__, '5.0.0', 'WC_Payments_Admin_Settings::is_current_page_settings' );
 		return WC_Payments_Admin_Settings::is_current_page_settings();
-	}
-
-	/**
-	 * Returns the URL of the configuration screen for this gateway, for use in internal links.
-	 *
-	 * @deprecated 5.0.0
-	 *
-	 * @return string URL of the configuration screen for this gateway
-	 */
-	public static function get_settings_url() {
-		wc_deprecated_function( __FUNCTION__, '5.0.0', 'WC_Payments_Admin_Settings::get_settings_url' );
-		return WC_Payments_Admin_Settings::get_settings_url();
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -387,11 +387,11 @@ class WC_Payments {
 		WC_Payments_Explicit_Price_Formatter::init();
 
 		include_once WCPAY_ABSPATH . '/includes/class-wc-payments-captured-event-note.php';
+		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin-settings.php';
 
 		// Add admin screens.
 		if ( is_admin() ) {
 			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin.php';
-			include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-admin-settings.php';
 		}
 
 		if ( is_admin() && current_user_can( 'manage_woocommerce' ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR fixes a fatal error when the /wp-json/wc/v3/payment_gateways endpoint was called.

#### Testing instructions
- Create a WooCommerce api key on WooCommerce > Settings > Advanced > Rest Api
- On Postman set the `https://<test_site>/wp-json/wc/v3/payment_gateways` endpoint as the url(notice the https)
- Set the authorization to Basic Auth
- Add the Consumer key as the user and the secret key as the password
- Execute the request
- Make sure no error shows up
- Test the basic UPE and non-UPE checkout flow
- Make sure you can open the settings page and save changes
*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. …api endpoint