### PR TITLE
fixed bug that would not allow customers using firefox to be redirect to WooPay

### DIFF
--- a/changelog/fix-5110-firefox-auto-redirect
+++ b/changelog/fix-5110-firefox-auto-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed bug that would not allow customers using firefox to log in to WooPay sometimes

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -494,7 +494,11 @@ export const handlePlatformCheckoutEmailInput = async (
 	};
 
 	platformCheckoutEmailInput.addEventListener( 'input', ( e ) => {
-		if ( ! hasCheckedLoginSession ) {
+		if ( ! hasCheckedLoginSession && ! customerClickedBackButton ) {
+			if ( customerClickedBackButton ) {
+				openLoginSessionIframe( platformCheckoutEmailInput.value );
+			}
+
 			return;
 		}
 


### PR DESCRIPTION
Fixes #5110

#### Changes proposed in this Pull Request
This PR fixes an error that would not allow customer to be auto redirected to WooPay on firefox. 
It also allow the customer to be redirected/log in to WooPay again by changing the email after clicking the back button.

While working on this one I found this bug #5113 

#### Testing instructions
- Test on Firefox and Chrome 
- Add a product to your cart and checkout using WooPay
- When you get to the WooPay checkout click the WooPay back button
- Make sure you do **not** get redirected back to WooPay
- Reload the page make sure you do get redirecte
- Click the browser back button
- Make sure you do **not** get redirected back to WooPay
- Remove and type again the last character of your email
- Make sure you do get redirected to WooPay
- Go back again and this time type another WooPay account email
- Make sure the OTP modal shows up

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.