### PR TITLE
Update subscriptions core version to 5.0.0

### DIFF
--- a/changelog/subscriptions-core-5.0.0
+++ b/changelog/subscriptions-core-5.0.0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+New wcs_get_orders_with_meta_query() helper function to query for orders and subscriptions.

--- a/changelog/subscriptions-core-5.0.0-1
+++ b/changelog/subscriptions-core-5.0.0-1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Replace instances of `get_posts()` across codebase with new wcs_get_orders_with_meta_query() function.

--- a/changelog/subscriptions-core-5.0.0-2
+++ b/changelog/subscriptions-core-5.0.0-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Refactor the saving of subscription dates in the subscription datastore to separate fetching changes and saving. Enables backfilling subscription dates when HPOS syncing is enabled.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
       "automattic/jetpack-sync": "1.30.5",
       "automattic/jetpack-tracking": "1.14.5",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "2.5.1"
+      "woocommerce/subscriptions-core": "5.0.0"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7ffeabffefb091ca89ba126afcb7ae7",
+    "content-hash": "059cd8b34483537b86961a0c4c9b720a",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1060,16 +1060,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "2.5.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "0e2633b0f254ff08a860dcf64b66b10c5cc8b7e4"
+                "reference": "12518bb30c5c163fa3042e86b3ef2b6899c3d094"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/0e2633b0f254ff08a860dcf64b66b10c5cc8b7e4",
-                "reference": "0e2633b0f254ff08a860dcf64b66b10c5cc8b7e4",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/12518bb30c5c163fa3042e86b3ef2b6899c3d094",
+                "reference": "12518bb30c5c163fa3042e86b3ef2b6899c3d094",
                 "shasum": ""
             },
             "require": {
@@ -1110,10 +1110,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.5.1",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/5.0.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-11-04T07:37:07+00:00"
+            "time": "2022-11-14T00:46:32+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Changes proposed in this Pull Request
This PR bumps the version of Subscriptions Core from 2.5.1 to 5.0.0. Find relevant PRs:

https://github.com/Automattic/woocommerce-subscriptions-core/pull/259

This version introduces changes to subscription saving in preparation for supporting WooCommerce's High-Performance Order Storage in Subscriptions. 

The changes in this PR should not change any behavior for existing stores.

#### Testing instructions

Test critical WC Pay Subscription flows

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
