### PR TITLE
WCPay as a Platform: Add base request classes

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -946,15 +946,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			$payment_methods = WC_Payments::get_gateway()->get_payment_method_ids_enabled_at_checkout( null, true );
 
-			$additional_api_parameters['is_platform_payment_method'] = $this->is_platform_payment_method( $payment_information->is_using_saved_payment_method() );
-
-			// This meta is only set by WooPay.
-			// We want to handle the intention creation differently when there are subscriptions.
-			// We're using simple products on WooPay so the current logic for WCPay subscriptions won't work there.
-			if ( '1' === $order->get_meta( '_woopay_has_subscription' ) ) {
-				$additional_api_parameters['woopay_has_subscription'] = 'true';
-			}
-
 			// The sanitize_user call here is deliberate: it seems the most appropriate sanitization function
 			// for a string that will only contain latin alphanumeric characters and underscores.
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing
@@ -995,7 +986,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					$request->setup_future_usage();
 				}
 
-				$request = $request->apply_filters( 'wcpay_create_and_confirm_intention_request' );
+				// This method requires `is_platform_payment_method`, which should be moved out of this class as well.
+				$is_platform_payment_method = $this->is_platform_payment_method( $payment_information->is_using_saved_payment_method() );
+
+				$request = $request->apply_filters( 'wcpay_create_and_confirm_intention_request', $order, $is_platform_payment_method );
 				$intent  = $this->payments_api_client->send_request_with_level3_data( $request );
 			}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -989,8 +989,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				// This method requires `is_platform_payment_method`, which should be moved out of this class as well.
 				$is_platform_payment_method = $this->is_platform_payment_method( $payment_information->is_using_saved_payment_method() );
 
-				$request = $request->apply_filters( 'wcpay_create_and_confirm_intention_request', $order, $is_platform_payment_method );
-				$intent  = $this->payments_api_client->send_request( $request );
+				$intent = $request->send( 'wcpay_create_and_confirm_intention_request', $order, $is_platform_payment_method );
 			}
 
 			$intent_id     = $intent->get_id();

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -970,7 +970,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			if ( empty( $intent ) ) {
 				// This is temporary, those method calls can now be in the right place instead of being stored as variables.
-				$request = \WCPay\Core\Server\Request\Create_And_Confirm_Intention::create()
+				$request = WC_Payments::create_request( \WCPay\Core\Server\Request\Create_And_Confirm_Intention::class )
 					->set_amount( $converted_amount )
 					->set_currency_code( $currency )
 					->set_payment_method( $payment_information->get_payment_method() )

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -990,7 +990,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$is_platform_payment_method = $this->is_platform_payment_method( $payment_information->is_using_saved_payment_method() );
 
 				$request = $request->apply_filters( 'wcpay_create_and_confirm_intention_request', $order, $is_platform_payment_method );
-				$intent  = $this->payments_api_client->send_request_with_level3_data( $request );
+				$intent  = $this->payments_api_client->send_request( $request );
 			}
 
 			$intent_id     = $intent->get_id();

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1335,8 +1335,10 @@ if ( true ) {
 		// $request = new WCPay\Core\Server\Request\Generic( WC_Payments_API_Client::PAYMENT_METHODS_API, 'GET' );
 		// $request->use_user_token();
 
-		$request = new WCPay\Core\Server\Request\WooPay_Create_Intent();
-		$request->set_amount( 100 );
+		$base_request = new WCPay\Core\Server\Request\Create_Intent();
+		$base_request->set_amount( 100 );
+
+		$request = $base_request->extend( WCPay\Core\Server\Request\WooPay_Create_Intent::class );
 		$request->set_save_payment_method_to_platform( true );
 
 		var_dump(

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -221,6 +221,9 @@ class WC_Payments {
 
 		include_once __DIR__ . '/class-wc-payments-utils.php';
 		include_once __DIR__ . '/core/class-mode.php';
+		include_once __DIR__ . '/core/server/class-request.php';
+		include_once __DIR__ . '/core/server/class-response.php';
+		include_once __DIR__ . '/core/server/request/class-generic.php';
 
 		include_once __DIR__ . '/class-database-cache.php';
 		self::$database_cache = new Database_Cache();
@@ -1304,17 +1307,33 @@ class WC_Payments {
 }
 
 /**
- * API examples.
- */
-require_once __DIR__ . '/core/server/class-request.php';
-require_once __DIR__ . '/core/server/class-response.php';
-
-/**
  * Examples here.
  */
+// phpcs:disable
 function requests_example() {
-	echo 'Doing stuff';
+	class Rados_HTTP_Client extends WC_Payments_Http {
+		public function remote_request( $args, $body = null, $is_site_specific = true, $use_user_token = false ) {
+			return [
+				'id' => 'obj_XYZ',
+			];
+		}
+	}
+
+	$http_class = add_filter( 'wc_payments_http', function() {
+		return new Rados_HTTP_Client( new Automattic\Jetpack\Connection\Manager( 'woocommerce-payments' ) );
+	} );
+
+	$request = new WCPay\Core\Server\Request(
+		[
+			'amount' => 1000,
+		]
+	);
+
+	var_dump($request);
+
+	/////
 	exit;
 }
+// phpcs:enable
 
 add_action( 'template_redirect', 'requests_example' );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1338,7 +1338,7 @@ if ( true ) {
 		$request = new Request\Create_Intent();
 		$request->set_amount( 100 );
 		$suggested_amount = 200; // Something that might come from context, and extensions might use.
-		$request = $request->announce( 'wcpay_create_intent_request', $suggested_amount );
+		$request = $request->apply_filters( 'wcpay_create_intent_request', $suggested_amount );
 
 		var_dump(
 			[

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -223,9 +223,12 @@ class WC_Payments {
 		include_once __DIR__ . '/core/class-mode.php';
 		include_once __DIR__ . '/core/server/class-request.php';
 		include_once __DIR__ . '/core/server/class-response.php';
+		include_once __DIR__ . '/core/server/request/trait-intention.php';
 		include_once __DIR__ . '/core/server/request/class-generic.php';
 		include_once __DIR__ . '/core/server/request/class-create-intent.php';
 		include_once __DIR__ . '/core/server/request/class-woopay-create-intent.php';
+		include_once __DIR__ . '/core/server/request/class-create-and-confirm-intention.php';
+		include_once __DIR__ . '/core/server/request/class-woopay-create-and-confirm-intention.php';
 
 		include_once __DIR__ . '/class-database-cache.php';
 		self::$database_cache = new Database_Cache();
@@ -683,7 +686,7 @@ class WC_Payments {
 	 *
 	 * @return WC_Payments_Http_Interface
 	 */
-	private static function get_wc_payments_http() {
+	public static function get_wc_payments_http() {
 		require_once __DIR__ . '/wc-payment-api/class-wc-payments-http-interface.php';
 		require_once __DIR__ . '/wc-payment-api/class-wc-payments-http.php';
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1338,7 +1338,7 @@ if ( true ) {
 		$base_request = new WCPay\Core\Server\Request\Create_Intent();
 		$base_request->set_amount( 100 );
 
-		$request = $base_request->extend( WCPay\Core\Server\Request\WooPay_Create_Intent::class );
+		$request = WCPay\Core\Server\Request\WooPay_Create_Intent::extend( $base_request );
 		$request->set_save_payment_method_to_platform( true );
 
 		var_dump(

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1302,3 +1302,19 @@ class WC_Payments {
 		}
 	}
 }
+
+/**
+ * API examples.
+ */
+require_once __DIR__ . '/core/server/class-request.php';
+require_once __DIR__ . '/core/server/class-response.php';
+
+/**
+ * Examples here.
+ */
+function requests_example() {
+	echo 'Doing stuff';
+	exit;
+}
+
+add_action( 'template_redirect', 'requests_example' );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1310,26 +1310,37 @@ class WC_Payments {
  * Examples here.
  */
 // phpcs:disable
-function requests_example() {
+add_filter( 'wc_payments_http', function() {
 	class Rados_HTTP_Client extends WC_Payments_Http {
 		public function remote_request( $args, $body = null, $is_site_specific = true, $use_user_token = false ) {
 			return [
-				'id' => 'obj_XYZ',
+				'code' => 200,
+				'body' => json_encode( [
+					'id' => 'obj_XYZ',
+				] )
 			];
 		}
 	}
 
-	$http_class = add_filter( 'wc_payments_http', function() {
-		return new Rados_HTTP_Client( new Automattic\Jetpack\Connection\Manager( 'woocommerce-payments' ) );
-	} );
+	return new Rados_HTTP_Client( new Automattic\Jetpack\Connection\Manager( 'woocommerce-payments' ) );
+} );
 
-	$request = new WCPay\Core\Server\Request(
+function requests_example() {
+
+	$request = new WCPay\Core\Server\Request\Generic( WC_Payments_API_Client::PAYMENT_METHODS_API, 'GET' );
+	$request->use_user_token();
+
+	var_dump(
 		[
-			'amount' => 1000,
+			$request,
+			'api'                 => $request->get_api(),
+			'method'              => $request->get_method(),
+			'site_specific'       => $request->is_site_specific(),
+			'use_user_token'      => $request->should_use_user_token(),
+			'return_raw_response' => $request->should_return_raw_response(),
+			WC_Payments::get_payments_api_client()->send_request( $request ),
 		]
 	);
-
-	var_dump($request);
 
 	/////
 	exit;

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 use Automattic\WooCommerce\StoreApi\StoreApi;
 use Automattic\WooCommerce\StoreApi\RoutesController;
 use WCPay\Core\Mode;
+use WCPay\Core\Server\Request;
 use WCPay\Logger;
 use WCPay\Migrations\Allowed_Payment_Request_Button_Types_Update;
 use WCPay\Payment_Methods\CC_Payment_Gateway;
@@ -687,7 +688,7 @@ class WC_Payments {
 	 *
 	 * @return WC_Payments_Http_Interface
 	 */
-	public static function get_wc_payments_http() {
+	private static function get_wc_payments_http() {
 		require_once __DIR__ . '/wc-payment-api/class-wc-payments-http-interface.php';
 		require_once __DIR__ . '/wc-payment-api/class-wc-payments-http.php';
 
@@ -1311,5 +1312,29 @@ class WC_Payments {
 		if ( ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) && file_exists( WCPAY_ABSPATH . 'dist/runtime.js' ) ) {
 			wp_enqueue_script( 'WCPAY_RUNTIME', plugins_url( 'dist/runtime.js', WCPAY_PLUGIN_FILE ), [], self::get_file_version( 'dist/runtime.js' ), true );
 		}
+	}
+
+	/**
+	 * Creates a new request object for a server call.
+	 *
+	 * @param  string $class_name The name of the request class. Must extend WCPay\Core\Server\Request.
+	 * @return Request
+	 * @throws Exception          If the request class is not really a request.
+	 */
+	public static function create_request( $class_name ) {
+		if ( ! is_subclass_of( $class_name, Request::class ) ) {
+			throw new Exception(
+				sprintf(
+					'WC_Payments::create_request() requires a class, which extends %s, %s provided instead',
+					Request::class,
+					$class_name
+				)
+			);
+		}
+
+		$request = new $class_name( self::get_payments_api_client(), self::get_wc_payments_http() );
+
+		return $request;
+
 	}
 }

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1357,12 +1357,20 @@ if ( true ) {
 		exit;
 	}
 
-	add_filter( 'wcpay_create_intent_request', 'requests_filter_example', 10, 2 );
-	function requests_filter_example( Request\Create_Intent $base_request, int $replacement_amount ): Request\WooPay_Create_Intent {
+	// Example how the request can be extended and values updated.
+	// add_filter( 'wcpay_create_intent_request', 'requests_extention_example', 10, 2 );
+	function requests_extention_example( Request\Create_Intent $base_request, int $replacement_amount ): Request\WooPay_Create_Intent {
 		$request = Request\WooPay_Create_Intent::extend( $base_request );
 		$request->set_amount( $replacement_amount );
 		$request->set_save_payment_method_to_platform( true );
 		return $request;
+	}
+
+	// Example how some properties can be updated.
+	add_filter( 'wcpay_create_intent_request', 'requests_value_update', 10, 2 );
+	function requests_value_update( Request\Create_Intent $base_request, int $replacement_amount ): Request\Create_Intent {
+		$base_request->set_amount( $replacement_amount );
+		return $base_request;
 	}
 
 	// phpcs:enable

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -432,8 +432,6 @@ class WC_Payments {
 		add_action( 'woocommerce_woocommerce_payments_updated', [ __CLASS__, 'set_plugin_activation_timestamp' ] );
 
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_dev_runtime_scripts' ] );
-
-		include_once __DIR__ . '/core/server/class-temp-request-examples.php';
 	}
 
 	/**
@@ -688,6 +686,8 @@ class WC_Payments {
 	private static function get_wc_payments_http() {
 		require_once __DIR__ . '/wc-payment-api/class-wc-payments-http-interface.php';
 		require_once __DIR__ . '/wc-payment-api/class-wc-payments-http.php';
+
+		include_once __DIR__ . '/core/server/class-temp-request-examples.php';
 
 		$http_class = apply_filters( 'wc_payments_http', null );
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -221,16 +221,6 @@ class WC_Payments {
 		define( 'WCPAY_VERSION_NUMBER', self::get_plugin_headers()['Version'] );
 
 		include_once __DIR__ . '/class-wc-payments-utils.php';
-		include_once __DIR__ . '/core/class-mode.php';
-		include_once __DIR__ . '/core/server/class-request.php';
-		include_once __DIR__ . '/core/server/class-response.php';
-		include_once __DIR__ . '/core/server/request/trait-intention.php';
-		include_once __DIR__ . '/core/server/request/trait-level3.php';
-		include_once __DIR__ . '/core/server/request/class-generic.php';
-		include_once __DIR__ . '/core/server/request/class-create-intent.php';
-		include_once __DIR__ . '/core/server/request/class-woopay-create-intent.php';
-		include_once __DIR__ . '/core/server/request/class-create-and-confirm-intention.php';
-		include_once __DIR__ . '/core/server/request/class-woopay-create-and-confirm-intention.php';
 
 		include_once __DIR__ . '/class-database-cache.php';
 		self::$database_cache = new Database_Cache();
@@ -254,6 +244,17 @@ class WC_Payments {
 		include_once __DIR__ . '/exceptions/class-base-exception.php';
 		include_once __DIR__ . '/exceptions/class-api-exception.php';
 		include_once __DIR__ . '/exceptions/class-connection-exception.php';
+		include_once __DIR__ . '/core/class-mode.php';
+		include_once __DIR__ . '/core/exceptions/class-invalid-request-param.php';
+		include_once __DIR__ . '/core/server/class-request.php';
+		include_once __DIR__ . '/core/server/class-response.php';
+		include_once __DIR__ . '/core/server/request/trait-intention.php';
+		include_once __DIR__ . '/core/server/request/trait-level3.php';
+		include_once __DIR__ . '/core/server/request/class-generic.php';
+		include_once __DIR__ . '/core/server/request/class-create-intent.php';
+		include_once __DIR__ . '/core/server/request/class-woopay-create-intent.php';
+		include_once __DIR__ . '/core/server/request/class-create-and-confirm-intention.php';
+		include_once __DIR__ . '/core/server/request/class-woopay-create-and-confirm-intention.php';
 
 		self::$api_client = self::create_api_client();
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -224,6 +224,7 @@ class WC_Payments {
 		include_once __DIR__ . '/core/server/class-request.php';
 		include_once __DIR__ . '/core/server/class-response.php';
 		include_once __DIR__ . '/core/server/request/trait-intention.php';
+		include_once __DIR__ . '/core/server/request/trait-level3.php';
 		include_once __DIR__ . '/core/server/request/class-generic.php';
 		include_once __DIR__ . '/core/server/request/class-create-intent.php';
 		include_once __DIR__ . '/core/server/request/class-woopay-create-intent.php';

--- a/includes/core/exceptions/class-invalid-request-param.php
+++ b/includes/core/exceptions/class-invalid-request-param.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Class Invalid_Request_Param
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Core\Exceptions;
+
+use WCPay\Exceptions\Base_Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Exception for throwing an error when payment method can not be identified or used.
+ */
+class Invalid_Request_Param extends Base_Exception {
+}

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -10,6 +10,60 @@ namespace WCPay\Core\Server;
 /**
  * Base for requests to the WCPay server.
  */
-class Request {
+abstract class Request {
+	/**
+	 * Holds the parameters of the request.
+	 *
+	 * @var mixed[]
+	 */
+	protected $params = [];
 
+	/**
+	 * Prevents the class from being constructed directly.
+	 */
+	protected function __construct() {
+		// Nothing to do here yet.
+	}
+
+	/**
+	 * Returns the needed API.
+	 *
+	 * @return string Check WCPay\Core\Server\APIs.
+	 */
+	abstract public function get_api(): string;
+
+	/**
+	 * Returns the method of the request.
+	 *
+	 * @return string See the constants in WordPress's `Requests` class.
+	 */
+	abstract public function get_method(): string;
+
+	/**
+	 * This is a legacy method, and is the same throughout the codebase.
+	 * Might be worth removing while refactoring to use the Core\Server API.
+	 *
+	 * @return bool
+	 */
+	public function is_site_specific(): bool {
+		return false;
+	}
+
+	/**
+	 * If true, the request will be signed with the user token rather than blog token. Defaults to false.
+	 *
+	 * @return bool
+	 */
+	public function use_user_token(): bool {
+		return false;
+	}
+
+	/**
+	 * Indicates if the raw response should be returned.
+	 *
+	 * @return bool
+	 */
+	public function should_return_raw_response(): bool {
+		return false;
+	}
 }

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -42,6 +42,15 @@ abstract class Request {
 	private $protected_mode = false;
 
 	/**
+	 * Creates a new instance of the class.
+	 *
+	 * @return static
+	 */
+	public static function create() {
+		return new static();
+	}
+
+	/**
 	 * Prevents the class from being constructed directly.
 	 */
 	protected function __construct() {

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -105,7 +105,7 @@ abstract class Request {
 	 * @return array
 	 * @throws \Exception If the request has not been initialized yet.
 	 */
-	public function get_params() {
+	final public function get_params() {
 		$missing_params = [];
 		foreach ( $this->get_required_params() as $name ) {
 			if ( ! isset( $this->params[ $name ] ) ) {
@@ -145,7 +145,7 @@ abstract class Request {
 	 * @param string $key   The name of the parameter.
 	 * @param mixed  $value And the value to set.
 	 */
-	protected function set_param( string $key, $value ) {
+	final protected function set_param( string $key, $value ) {
 		if ( $this->protected_mode && in_array( $key, $this->get_immutable_params(), true ) ) {
 			$this->throw_immutable_exception( $key );
 		}

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -23,6 +23,20 @@ abstract class Request {
 	const IMMUTABLE_PARAMS = [];
 
 	/**
+	 * Indicates which parameters are required (keys only).
+	 *
+	 * @var string[]
+	 */
+	const REQUIRED_PARAMS = [];
+
+	/**
+	 * Contains default values for parameters, which are not set automatically.
+	 *
+	 * @var string[]
+	 */
+	const DEFAULT_PARAMS = [];
+
+	/**
 	 * Holds the parameters of the request.
 	 *
 	 * @var mixed[]

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -145,7 +145,7 @@ abstract class Request {
 	 * @throws \Exception     In case a class does not exists, or immutable properties are modified.
 	 * @todo                  Add proper exceptions here.
 	 */
-	final public function announce( $hook, ...$args ) {
+	final public function apply_filters( $hook, ...$args ) {
 		$cloned = clone $this; // Work with a clone to avoid mutations of parameters.
 
 		/**

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -320,7 +320,7 @@ abstract class Request {
 	 * @return string[] The names of those params.
 	 */
 	private function get_immutable_params() {
-		return $this->traverse_class_constants( 'IMMUTABLE_PARAMS' );
+		return $this->traverse_class_constants( 'IMMUTABLE_PARAMS', true );
 	}
 
 	/**
@@ -329,7 +329,7 @@ abstract class Request {
 	 * @return string[] The names of those params.
 	 */
 	private function get_required_params() {
-		return $this->traverse_class_constants( 'REQUIRED_PARAMS' );
+		return $this->traverse_class_constants( 'REQUIRED_PARAMS', true );
 	}
 
 	/**
@@ -343,9 +343,10 @@ abstract class Request {
 	 * Combines array constants from a class's tree.
 	 *
 	 * @param  string $constant_name The name of the constant to load.
+	 * @param  bool   $unique        Whether to return unique items. Useful with numeric keys.
 	 * @return string[] The unique combined values from the arrays.
 	 */
-	private function traverse_class_constants( string $constant_name ) {
+	private function traverse_class_constants( string $constant_name, bool $unique = false ) {
 		$keys       = [];
 		$class_name = get_class( $this );
 
@@ -358,6 +359,10 @@ abstract class Request {
 
 			$class_name = get_parent_class( $class_name );
 		} while ( $class_name );
+
+		if ( $unique ) {
+			$keys = array_unique( $keys );
+		}
 
 		return $keys;
 	}

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -88,4 +88,37 @@ abstract class Request {
 	protected function set_param( string $key, $value ) {
 		$this->params[ $key ] = $value;
 	}
+
+	/**
+	 * Replaces all internal parameters of the class.
+	 * Only accessible from this class, this method is used for `extend`.
+	 *
+	 * @param array $params The new parameters to use.
+	 */
+	private function set_params( $params ) {
+		$this->params = $params;
+	}
+
+	/**
+	 * Creates a new instance of a sub-class, ad sets the same internal props.
+	 *
+	 * @param  string $extended_class The class name of the new object.
+	 * @return static                 An instance of the extended class.
+	 */
+	public function extend( string $extended_class ) {
+		if ( ! is_subclass_of( $extended_class, get_class( $this ) ) ) {
+			throw new \Exception(
+				sprintf(
+					'Failed to extend request. %s is not a subclass of %s',
+					$extended_class,
+					get_class( $this )
+				)
+			);
+		}
+
+		$obj = new $extended_class();
+		$obj->set_params( $this->params );
+
+		return $obj;
+	}
 }

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -209,7 +209,10 @@ abstract class Request {
 	}
 
 	/**
-	 * Creates a new instance the class with the same props as the parent.
+	 * Creates a new instance of the called class with the same props
+	 * as an existing request, which must be of a parent class.
+	 *
+	 * This method is only available within `apply_filters()`.
 	 *
 	 * @param  Request $base_request The request to extend.
 	 * @return static                An instance of the class.
@@ -237,15 +240,18 @@ abstract class Request {
 	}
 
 	/**
-	 * Allows the request to be changed via a hook.
+	 * Allows the request to be altered/replaced through a filter.
 	 *
-	 * Supposedly this method will verify the protected params of parents.
+	 * Call this method when the request has been completely prepared,
+	 * and is ready to be sent to the server. At this point functions,
+	 * which hook into the filter cannot alter the IMMUTABLE_PARAMS
+	 * of the request anymore. Instead they can either modify the other
+	 * mutable params, or extend the request.
 	 *
 	 * @param string $hook    The filter to use.
 	 * @param mixed  ...$args Other parameters for the hook.
 	 * @return static         Either the same instance, or an object from a sub-class.
 	 * @throws \Exception     In case a class does not exists, or immutable properties are modified.
-	 * @todo                  Add proper exceptions here.
 	 */
 	final public function apply_filters( $hook, ...$args ) {
 		// Lock the class in order to prevent `set_param` for protected props.

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -140,6 +140,13 @@ abstract class Request {
 			);
 		}
 
+		foreach ( $params as $key => $value ) {
+			if ( is_bool( $value ) ) {
+				// The WCPay server requires the string 'true'.
+				$params[ $key ] = $value ? 'true' : false;
+			}
+		}
+
 		return $params;
 	}
 
@@ -159,8 +166,9 @@ abstract class Request {
 	 * Use this method within child classes in order to allow
 	 * those properties to be protected by overwriting.
 	 *
-	 * @param string $key   The name of the parameter.
-	 * @param mixed  $value And the value to set.
+	 * @param  string $key   The name of the parameter.
+	 * @param  mixed  $value And the value to set.
+	 * @return static        The instance of the class, ready for method chaining.
 	 */
 	final protected function set_param( string $key, $value ) {
 		if ( $this->protected_mode && in_array( $key, $this->get_immutable_params(), true ) ) {
@@ -168,6 +176,8 @@ abstract class Request {
 		}
 
 		$this->params[ $key ] = $value;
+
+		return $this;
 	}
 
 	/**

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -127,6 +127,16 @@ abstract class Request {
 	}
 
 	/**
+	 * Formats the response from the server.
+	 *
+	 * @param  mixed $response The response from `WC_Payments_API_Client::request`.
+	 * @return mixed           Either the same response, or the correct object.
+	 */
+	public function format_response( $response ) {
+		return new Response( $response );
+	}
+
+	/**
 	 * Stores a parameter within the internal props.
 	 *
 	 * Use this method within child classes in order to allow

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -181,6 +181,24 @@ abstract class Request {
 	}
 
 	/**
+	 * Unsets an existing parameter if it was set before.
+	 *
+	 * @param  string $key The key of the parameter.
+	 * @return static      The instance of the class for method chaining.
+	 */
+	final protected function unset_param( string $key ) {
+		if ( $this->protected_mode && in_array( $key, $this->get_immutable_params(), true ) ) {
+			$this->throw_immutable_exception( $key );
+		}
+
+		if ( isset( $this->params[ $key ] ) ) {
+			unset( $this->params[ $key ] );
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Replaces all internal parameters of the class.
 	 * Only accessible from methods of this class, used for the `extend` method.
 	 *

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -46,7 +46,7 @@ abstract class Request {
 	 * @return bool
 	 */
 	public function is_site_specific(): bool {
-		return false;
+		return true;
 	}
 
 	/**
@@ -54,7 +54,7 @@ abstract class Request {
 	 *
 	 * @return bool
 	 */
-	public function use_user_token(): bool {
+	public function should_use_user_token(): bool {
 		return false;
 	}
 
@@ -65,5 +65,14 @@ abstract class Request {
 	 */
 	public function should_return_raw_response(): bool {
 		return false;
+	}
+
+	/**
+	 * Returns all of the parameters for the request.
+	 *
+	 * @return array
+	 */
+	public function get_params() {
+		return $this->params;
 	}
 }

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Request.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server;
+
+/**
+ * Base for requests to the WCPay server.
+ */
+class Request {
+
+}

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -100,24 +100,25 @@ abstract class Request {
 	}
 
 	/**
-	 * Creates a new instance of a sub-class, ad sets the same internal props.
+	 * Creates a new instance the class with the same props as the parent.
 	 *
-	 * @param  string $extended_class The class name of the new object.
-	 * @return static                 An instance of the extended class.
+	 * @param  Request $base_request The request to extend.
+	 * @return static                An instance of the class.
+	 * @throws \Exception            In case this is not a subclass of the base request.
 	 */
-	public function extend( string $extended_class ) {
-		if ( ! is_subclass_of( $extended_class, get_class( $this ) ) ) {
+	final public static function extend( Request $base_request ) {
+		if ( ! is_subclass_of( static::class, get_class( $base_request ) ) ) {
 			throw new \Exception(
 				sprintf(
 					'Failed to extend request. %s is not a subclass of %s',
-					$extended_class,
-					get_class( $this )
+					static::class,
+					get_class( $base_request )
 				)
 			);
 		}
 
-		$obj = new $extended_class();
-		$obj->set_params( $this->params );
+		$obj = new static();
+		$obj->set_params( $base_request->params );
 
 		return $obj;
 	}

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -16,7 +16,7 @@ abstract class Request {
 	 *
 	 * @var mixed[]
 	 */
-	protected $params = [];
+	private $params = [];
 
 	/**
 	 * Prevents the class from being constructed directly.
@@ -74,5 +74,18 @@ abstract class Request {
 	 */
 	public function get_params() {
 		return $this->params;
+	}
+
+	/**
+	 * Stores a parameter within the internal props.
+	 *
+	 * Use this method within child classes in order to allow
+	 * those properties to be protected by overwriting.
+	 *
+	 * @param string $key   The name of the parameter.
+	 * @param mixed  $value And the value to set.
+	 */
+	protected function set_param( string $key, $value ) {
+		$this->params[ $key ] = $value;
 	}
 }

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -106,9 +106,12 @@ abstract class Request {
 	 * @throws \Exception If the request has not been initialized yet.
 	 */
 	final public function get_params() {
+		$defaults = $this->get_default_params();
+		$params   = array_merge( $defaults, $this->params );
+
 		$missing_params = [];
 		foreach ( $this->get_required_params() as $name ) {
-			if ( ! isset( $this->params[ $name ] ) ) {
+			if ( ! isset( $params[ $name ] ) ) {
 				$missing_params[] = $name;
 			}
 		}
@@ -123,7 +126,7 @@ abstract class Request {
 			);
 		}
 
-		return $this->params;
+		return $params;
 	}
 
 	/**
@@ -279,6 +282,13 @@ abstract class Request {
 	 */
 	private function get_required_params() {
 		return $this->traverse_class_constants( 'REQUIRED_PARAMS' );
+	}
+
+	/**
+	 * Returns an array with the combined default params from all classes.
+	 */
+	private function get_default_params() {
+		return $this->traverse_class_constants( 'DEFAULT_PARAMS' );
 	}
 
 	/**

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -8,6 +8,8 @@
 namespace WCPay\Core\Server;
 
 use Exception;
+use WC_Payments_Http_Interface;
+use WC_Payments_API_Client;
 
 /**
  * Base for requests to the WCPay server.
@@ -56,19 +58,28 @@ abstract class Request {
 	private $protected_mode = false;
 
 	/**
-	 * Creates a new instance of the class.
+	 * Holds the API client of WCPay.
 	 *
-	 * @return static
+	 * @var WC_Payments_API_Client
 	 */
-	public static function create() {
-		return new static();
-	}
+	protected $api_client;
+
+	/**
+	 * Holds the HTTP interface of WCPay.
+	 *
+	 * @var WC_Payments_Http_Interface
+	 */
+	protected $http_interface;
 
 	/**
 	 * Prevents the class from being constructed directly.
+	 *
+	 * @param WC_Payments_API_Client     $api_client     The API client to use to send requests.
+	 * @param WC_Payments_Http_Interface $http_interface The HTTP interface for the server.
 	 */
-	protected function __construct() {
-		// Nothing to do here yet.
+	public function __construct( WC_Payments_API_Client $api_client, WC_Payments_Http_Interface $http_interface ) {
+		$this->api_client     = $api_client;
+		$this->http_interface = $http_interface;
 	}
 
 	/**
@@ -233,7 +244,7 @@ abstract class Request {
 			throw new \Exception( get_class( $base_request ) . ' can only be extended within its ->apply_filters() method.' );
 		}
 
-		$obj = new static();
+		$obj = new static( $base_request->api_client, $base_request->http_interface );
 		$obj->set_params( $base_request->params );
 
 		return $obj;

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -162,6 +162,21 @@ abstract class Request {
 	}
 
 	/**
+	 * Allows the request to be modified, and then sends it.
+	 *
+	 * @param string $hook    The filter to use.
+	 * @param mixed  ...$args Other parameters for the hook.
+	 * @return mixed          Either the response array, or the correct object.
+	 */
+	final public function send( $hook, ...$args ) {
+		$request = $this->apply_filters( $hook, ...$args );
+
+		return $this->format_response(
+			$this->api_client->send_request( $request )
+		);
+	}
+
+	/**
 	 * Formats the response from the server.
 	 *
 	 * @param  mixed $response The response from `WC_Payments_API_Client::request`.

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -144,6 +144,10 @@ abstract class Request {
 			);
 		}
 
+		if ( ! $base_request->protected_mode ) {
+			throw new \Exception( get_class( $base_request ) . ' can only be extended within its ->apply_filters() method.' );
+		}
+
 		$obj = new static();
 		$obj->set_params( $base_request->params );
 

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -249,7 +249,7 @@ abstract class Request {
 		}
 
 		// NB: `array_diff` will only pick up updated props, not new ones.
-		$difference = array_diff( $this->get_params(), $replacement->get_params() );
+		$difference = $this->array_diff( $this->get_params(), $replacement->get_params() );
 		if ( empty( $difference ) ) {
 			// Nothing got overwritten, it's the same request, or one with only new props.
 			return $replacement;
@@ -312,19 +312,37 @@ abstract class Request {
 	 * @return string[] The unique combined values from the arrays.
 	 */
 	private function traverse_class_constants( string $constant_name ) {
-		$immutable  = [];
+		$keys       = [];
 		$class_name = get_class( $this );
 
 		do {
 			$constant = "$class_name::$constant_name";
 
 			if ( defined( $constant ) ) {
-				$immutable = array_merge( $immutable, constant( $constant ) );
+				$keys = array_merge( $keys, constant( $constant ) );
 			}
 
 			$class_name = get_parent_class( $class_name );
 		} while ( $class_name );
 
-		return array_unique( $immutable );
+		return $keys;
+	}
+
+	/**
+	 * Generates the difference between two arrays.
+	 *
+	 * @param array $array1 The first array.
+	 * @param array $array2 The second array.
+	 * @return array        The difference between the two arrays.
+	 */
+	private function array_diff( $array1, $array2 ) {
+		$arr_to_json = function( $item ) {
+			return is_array( $item ) ? wp_json_encode( $item ) : $item;
+		};
+
+		return array_diff_assoc(
+			array_map( $arr_to_json, $array1 ),
+			array_map( $arr_to_json, $array2 )
+		);
 	}
 }

--- a/includes/core/server/class-response.php
+++ b/includes/core/server/class-response.php
@@ -7,9 +7,66 @@
 
 namespace WCPay\Core\Server;
 
+use ArrayAccess;
+
 /**
  * Represents responses from the WCPay server.
  */
-class Response {
+class Response implements ArrayAccess {
+	/**
+	 * Holds the data of the response.
+	 *
+	 * @var array
+	 */
+	protected $data;
 
+	/**
+	 * Constructs the class.
+	 *
+	 * @param array $data The data for the response.
+	 */
+	public function __construct( array $data ) {
+		$this->data = $data;
+	}
+
+	/**
+	 * Checks if a key exists.
+	 *
+	 * @param mixed $offset The key to check.
+	 * @return bool
+	 */
+	public function offsetExists( $offset ) : bool {
+		return isset( $this->data[ $offset ] );
+	}
+
+	/**
+	 * Retrieves the value with a certain key.
+	 *
+	 * @param mixed $offset The key to retrieve.
+	 * @return mixed
+	 */
+	public function offsetGet( $offset ) {
+		return $this->data[ $offset ];
+	}
+
+	/**
+	 * Attempts to set a value in the response.
+	 *
+	 * @param mixed $offset The key of the value.
+	 * @param mixed $value  The value.
+	 * @throws \Exception   It is not possible.
+	 */
+	public function offsetSet( $offset, $value ) {
+		throw new \Exception( 'Server responses cannot be mutated.' );
+	}
+
+	/**
+	 * Removes a value from the response.
+	 *
+	 * @param mixed $offset The offset to remove.
+	 * @throws \Exception   It is not possible.
+	 */
+	public function offsetUnset( $offset ) {
+		throw new \Exception( 'Server responses cannot be mutated.' );
+	}
 }

--- a/includes/core/server/class-response.php
+++ b/includes/core/server/class-response.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Response.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server;
+
+/**
+ * Represents responses from the WCPay server.
+ */
+class Response {
+
+}

--- a/includes/core/server/class-temp-request-examples.php
+++ b/includes/core/server/class-temp-request-examples.php
@@ -19,7 +19,7 @@ class Temp_Request_Examples {
 	}
 
 	public function example() {
-		if ( true ) {
+		if ( false ) {
 			echo "===== CREATE INTENT REQUEST =====\n";
 			$request = Request\Create_Intent::create()
 				->set_amount( 100 )
@@ -27,7 +27,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			// Make sure extending the request does not work outside of `apply_filters`.
 			echo "===== EXTEND WITHOUT FILTERS =====\n";
 			$request = Request\Create_Intent::create()
@@ -39,7 +39,7 @@ class Temp_Request_Examples {
 			}
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== EXTEND TEMPLATE =====\n";
 
 			$callback = function ( Request\Create_Intent $base_request ): Request\WooPay_Create_Intent {
@@ -60,7 +60,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== UPDATING VALUES =====\n";
 			$request = Request\Create_Intent::create()
 				->set_amount( 100 )
@@ -81,7 +81,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== PROTECTING IMMUTABLE VALUES =====\n";
 			$request = Request\Create_Intent::create()
 				->set_amount( 100 )
@@ -101,7 +101,7 @@ class Temp_Request_Examples {
 			remove_filter( 'wcpay_create_intent_request', $callback );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== ENSURING INITIALIZED REQUESTS =====\n";
 			$request = Request\Create_Intent::create()
 				->set_amount( 100 );
@@ -112,7 +112,7 @@ class Temp_Request_Examples {
 			}
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== GENERIC GET REQUEST =====\n";
 			// ToDo: Make sure IDs are properly set somehow.
 			$request = new Request\Generic( WC_Payments_API_Client::PAYMENT_METHODS_API . '/pm_abc123', REQUESTS::GET );
@@ -120,7 +120,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== GENERIC POST REQUEST =====\n";
 			$request = new Request\Generic(
 				WC_Payments_API_Client::CUSTOMERS_API,
@@ -134,7 +134,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== GENERIC POST REQUEST MODIFICATIONS =====\n";
 			$request = new Request\Generic(
 				WC_Payments_API_Client::CUSTOMERS_API,
@@ -155,6 +155,15 @@ class Temp_Request_Examples {
 			remove_filter( 'wcpay_create_customer_request', $callback );
 
 			$this->dump_request( $request );
+		}
+
+		if ( true ) {
+			echo "===== CREATE AND CONFIRM INTENTION REQUEST =====\n";
+			$request = Request\Create_And_Confirm_Intention::create()
+				->set_amount( 300 )
+				->set_metadata( [ 'order_number' => 420 ] );
+
+			var_dump( $request );
 		}
 
 		exit;

--- a/includes/core/server/class-temp-request-examples.php
+++ b/includes/core/server/class-temp-request-examples.php
@@ -162,10 +162,12 @@ class Temp_Request_Examples {
 
 
 	function dump_request( $request ) {
+		$response = WC_Payments::get_payments_api_client()->send_request( $request );
+
 		var_dump(
 			[
 				'object'   => $request,
-				'response' => WC_Payments::get_payments_api_client()->send_request( $request ),
+				'response' => $response['id'],
 				'getters'  => [
 					'params'              => $request->get_params(),
 					'api'                 => $request->get_api(),

--- a/includes/core/server/class-temp-request-examples.php
+++ b/includes/core/server/class-temp-request-examples.php
@@ -44,7 +44,7 @@ class Temp_Request_Examples {
 	public function example() {
 		if ( true ) {
 			echo "===== CREATE INTENT REQUEST =====\n";
-			$request = Request\Create_Intent::create()
+			$request = WC_Payments::create_request( Request\Create_Intent::class )
 				->set_amount( 100 )
 				->set_currency( 'eur' );
 			$this->dump_request( $request );
@@ -53,7 +53,7 @@ class Temp_Request_Examples {
 		if ( true ) {
 			// Make sure extending the request does not work outside of `apply_filters`.
 			echo "===== EXTEND WITHOUT FILTERS =====\n";
-			$request = Request\Create_Intent::create()
+			$request = WC_Payments::create_request( Request\Create_Intent::class )
 				->set_amount( 100 );
 			try {
 				Request\WooPay_Create_Intent::extend( $request );
@@ -73,7 +73,7 @@ class Temp_Request_Examples {
 
 			add_filter( 'wcpay_create_intent_request', $callback );
 
-			$request = Request\Create_Intent::create()
+			$request = WC_Payments::create_request( Request\Create_Intent::class )
 				->set_amount( 100 )
 				->set_currency( 'eur' );
 			$request = $request->apply_filters( 'wcpay_create_intent_request' );
@@ -85,7 +85,7 @@ class Temp_Request_Examples {
 
 		if ( true ) {
 			echo "===== UPDATING VALUES =====\n";
-			$request = Request\Create_Intent::create()
+			$request = WC_Payments::create_request( Request\Create_Intent::class )
 				->set_amount( 100 )
 				->set_currency( 'eur' );
 
@@ -106,7 +106,7 @@ class Temp_Request_Examples {
 
 		if ( true ) {
 			echo "===== PROTECTING IMMUTABLE VALUES =====\n";
-			$request = Request\Create_Intent::create()
+			$request = WC_Payments::create_request( Request\Create_Intent::class )
 				->set_amount( 100 )
 				->set_currency( 'eur' );
 
@@ -126,7 +126,7 @@ class Temp_Request_Examples {
 
 		if ( true ) {
 			echo "===== ENSURING INITIALIZED REQUESTS =====\n";
-			$request = Request\Create_Intent::create()
+			$request = WC_Payments::create_request( Request\Create_Intent::class )
 				->set_amount( 100 );
 			try {
 				$request->get_params();
@@ -182,7 +182,7 @@ class Temp_Request_Examples {
 
 		if ( true ) {
 			echo "===== CREATE AND CONFIRM INTENTION REQUEST =====\n";
-			$request = Request\Create_And_Confirm_Intention::create()
+			$request = WC_Payments::create_request( Request\Create_And_Confirm_Intention::class )
 				->set_amount( 300 )
 				->set_currency_code( 'eur' )
 				->set_metadata( [ 'order_number' => 420 ] )

--- a/includes/core/server/class-temp-request-examples.php
+++ b/includes/core/server/class-temp-request-examples.php
@@ -10,8 +10,11 @@ use WCPay\Core\Server\Request;
 
 class Temp_Request_Examples {
 	public function __construct() {
-		// add_action( 'template_redirect', [ $this, 'example' ] );
-		// add_filter( 'wc_payments_http', [ $this, 'mock_http_class' ] );
+		if ( isset( $_GET['show_basic_examples'] ) ) {
+			add_action( 'template_redirect', [ $this, 'example' ] );
+			add_filter( 'wc_payments_http', [ $this, 'mock_http_class' ] );
+		}
+
 		add_filter( 'wcpay_create_and_confirm_intention_request', [ $this, 'woopay_intention_request'], 10, 3 );
 	}
 
@@ -42,7 +45,9 @@ class Temp_Request_Examples {
 	}
 
 	public function example() {
-		if ( true ) {
+		echo "<pre>\n";
+
+		if ( false ) {
 			echo "===== CREATE INTENT REQUEST =====\n";
 			$request = WC_Payments::create_request( Request\Create_Intent::class )
 				->set_amount( 100 )
@@ -50,7 +55,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			// Make sure extending the request does not work outside of `apply_filters`.
 			echo "===== EXTEND WITHOUT FILTERS =====\n";
 			$request = WC_Payments::create_request( Request\Create_Intent::class )
@@ -62,7 +67,7 @@ class Temp_Request_Examples {
 			}
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== EXTEND TEMPLATE =====\n";
 
 			$callback = function ( Request\Create_Intent $base_request ): Request\WooPay_Create_Intent {
@@ -83,7 +88,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== UPDATING VALUES =====\n";
 			$request = WC_Payments::create_request( Request\Create_Intent::class )
 				->set_amount( 100 )
@@ -104,7 +109,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== PROTECTING IMMUTABLE VALUES =====\n";
 			$request = WC_Payments::create_request( Request\Create_Intent::class )
 				->set_amount( 100 )
@@ -124,7 +129,7 @@ class Temp_Request_Examples {
 			remove_filter( 'wcpay_create_intent_request', $callback );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== ENSURING INITIALIZED REQUESTS =====\n";
 			$request = WC_Payments::create_request( Request\Create_Intent::class )
 				->set_amount( 100 );
@@ -135,7 +140,7 @@ class Temp_Request_Examples {
 			}
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== GENERIC GET REQUEST =====\n";
 			// ToDo: Make sure IDs are properly set somehow.
 			$request = new Request\Generic( WC_Payments_API_Client::PAYMENT_METHODS_API . '/pm_abc123', REQUESTS::GET );
@@ -143,7 +148,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== GENERIC POST REQUEST =====\n";
 			$request = new Request\Generic(
 				WC_Payments_API_Client::CUSTOMERS_API,
@@ -157,7 +162,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== GENERIC POST REQUEST MODIFICATIONS =====\n";
 			$request = new Request\Generic(
 				WC_Payments_API_Client::CUSTOMERS_API,

--- a/includes/core/server/class-temp-request-examples.php
+++ b/includes/core/server/class-temp-request-examples.php
@@ -161,9 +161,10 @@ class Temp_Request_Examples {
 			echo "===== CREATE AND CONFIRM INTENTION REQUEST =====\n";
 			$request = Request\Create_And_Confirm_Intention::create()
 				->set_amount( 300 )
+				->set_currency_code( 'eur' )
 				->set_metadata( [ 'order_number' => 420 ] );
 
-			var_dump( $request );
+			var_dump( $request->get_params() );
 		}
 
 		exit;

--- a/includes/core/server/class-temp-request-examples.php
+++ b/includes/core/server/class-temp-request-examples.php
@@ -30,6 +30,7 @@ class Temp_Request_Examples {
 			echo "===== CREATE INTENT REQUEST =====\n";
 			$request = new Request\Create_Intent();
 			$request->set_amount( 100 );
+			$request->set_currency( 'eur' );
 			$this->dump_request( $request );
 		}
 
@@ -58,6 +59,7 @@ class Temp_Request_Examples {
 
 			$request = new Request\Create_Intent();
 			$request->set_amount( 100 );
+			$request->set_currency( 'eur' );
 			$request = $request->apply_filters( 'wcpay_create_intent_request' );
 
 			remove_filter( 'wcpay_create_intent_request', $callback );
@@ -90,6 +92,7 @@ class Temp_Request_Examples {
 			echo "===== PROTECTING IMMUTABLE VALUES =====\n";
 			$request = new Request\Create_Intent();
 			$request->set_amount( 100 );
+			$request->set_currency( 'eur' );
 
 			$callback = function ( Request\Create_Intent $request ) {
 				try {
@@ -103,6 +106,17 @@ class Temp_Request_Examples {
 			add_filter( 'wcpay_create_intent_request', $callback, 10 );
 			$request->apply_filters( 'wcpay_create_intent_request' );
 			remove_filter( 'wcpay_create_intent_request', $callback );
+		}
+
+		if ( true ) {
+			echo "===== ENSURING INITIALIZED REQUESTS =====\n";
+			$request = new Request\Create_Intent();
+			$request->set_amount( 100 );
+			try {
+				$request->get_params();
+			} catch ( Exception $e ) {
+				echo 'Exception message: ' . $e->getMessage() . "\n\n";
+			}
 		}
 
 		exit;

--- a/includes/core/server/class-temp-request-examples.php
+++ b/includes/core/server/class-temp-request-examples.php
@@ -19,14 +19,7 @@ class Temp_Request_Examples {
 	}
 
 	public function example() {
-		if ( true ) {
-			echo "===== GENERIC REQUEST =====\n";
-			$request = new WCPay\Core\Server\Request\Generic( WC_Payments_API_Client::PAYMENT_METHODS_API, 'POST' );
-			$request->use_user_token();
-			$this->dump_request( $request );
-		}
-
-		if ( true ) {
+		if ( false ) {
 			echo "===== CREATE INTENT REQUEST =====\n";
 			$request = new Request\Create_Intent();
 			$request->set_amount( 100 );
@@ -34,7 +27,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			// Make sure extending the request does not work outside of `apply_filters`.
 			echo "===== EXTEND WITHOUT FILTERS =====\n";
 			$request = new Request\Create_Intent();
@@ -46,7 +39,7 @@ class Temp_Request_Examples {
 			}
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== EXTEND TEMPLATE =====\n";
 
 			$callback = function ( Request\Create_Intent $base_request ): Request\WooPay_Create_Intent {
@@ -67,7 +60,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== UPDATING VALUES =====\n";
 			$request = new Request\Create_Intent();
 			$request->set_amount( 100 );
@@ -88,7 +81,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== PROTECTING IMMUTABLE VALUES =====\n";
 			$request = new Request\Create_Intent();
 			$request->set_amount( 100 );
@@ -108,7 +101,7 @@ class Temp_Request_Examples {
 			remove_filter( 'wcpay_create_intent_request', $callback );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== ENSURING INITIALIZED REQUESTS =====\n";
 			$request = new Request\Create_Intent();
 			$request->set_amount( 100 );
@@ -117,6 +110,28 @@ class Temp_Request_Examples {
 			} catch ( Exception $e ) {
 				echo 'Exception message: ' . $e->getMessage() . "\n\n";
 			}
+		}
+
+		if ( true ) {
+			echo "===== GENERIC GET REQUEST =====\n";
+			// ToDo: Make sure IDs are properly set somehow.
+			$request = new WCPay\Core\Server\Request\Generic( WC_Payments_API_Client::PAYMENT_METHODS_API . '/pm_abc123', 'GET' );
+			$request->use_user_token();
+			$this->dump_request( $request );
+		}
+
+		if ( true ) {
+			echo "===== GENERIC POST REQUEST =====\n";
+			$request = new WCPay\Core\Server\Request\Generic(
+				WC_Payments_API_Client::CUSTOMERS_API,
+				'POST',
+				[
+					'first_name' => 'John',
+					'last_name'  => 'Doe',
+				]
+			);
+			$request->use_user_token();
+			$this->dump_request( $request );
 		}
 
 		exit;

--- a/includes/core/server/class-temp-request-examples.php
+++ b/includes/core/server/class-temp-request-examples.php
@@ -10,8 +10,8 @@ use WCPay\Core\Server\Request;
 
 class Temp_Request_Examples {
 	public function __construct() {
-		add_action( 'template_redirect', [ $this, 'example' ] );
-		add_filter( 'wc_payments_http', [ $this, 'mock_http_class' ] );
+		// add_action( 'template_redirect', [ $this, 'example' ] );
+		// add_filter( 'wc_payments_http', [ $this, 'mock_http_class' ] );
 	}
 
 	public function mock_http_class() {
@@ -157,12 +157,22 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( true ) {
+		if ( false ) {
 			echo "===== CREATE AND CONFIRM INTENTION REQUEST =====\n";
 			$request = Request\Create_And_Confirm_Intention::create()
 				->set_amount( 300 )
 				->set_currency_code( 'eur' )
-				->set_metadata( [ 'order_number' => 420 ] );
+				->set_metadata( [ 'order_number' => 420 ] )
+				->set_payment_method( 'pm_XYZ' )
+				->set_customer( 'cus_ZYX' )
+				->set_capture_method( true )
+				->setup_future_usage()
+				->set_level3( [ 'level3' => 'level3' ] )
+				->set_off_session()
+				->set_payment_methods( [ 'card' ] )
+				->set_cvc_confirmation( 'something_uknown' )
+
+				;
 
 			var_dump( $request->get_params() );
 		}

--- a/includes/core/server/class-temp-request-examples.php
+++ b/includes/core/server/class-temp-request-examples.php
@@ -19,61 +19,94 @@ class Temp_Request_Examples {
 	}
 
 	public function example() {
-		add_filter( 'wcpay_create_intent_request', [ $this, 'extention_example' ], 10, 2 );
-		add_filter( 'wcpay_create_intent_request', [ $this, 'value_update' ], 10, 2 );
+		if ( true ) {
+			echo "===== GENERIC REQUEST =====\n";
+			$request = new WCPay\Core\Server\Request\Generic( WC_Payments_API_Client::PAYMENT_METHODS_API, 'POST' );
+			$request->use_user_token();
+			$this->dump_request( $request );
+		}
 
+		if ( true ) {
+			echo "===== CREATE INTENT REQUEST =====\n";
+			$request = new Request\Create_Intent();
+			$request->set_amount( 100 );
+			$this->dump_request( $request );
+		}
 
-		// $request = new WCPay\Core\Server\Request\Generic( WC_Payments_API_Client::PAYMENT_METHODS_API, 'GET' );
-		// $request->use_user_token();
+		if ( true ) {
+			// Make sure extending the request does not work outside of `apply_filters`.
+			echo "===== EXTEND WITHOUT FILTERS =====\n";
+			$request = new Request\Create_Intent();
+			$request->set_amount( 100 );
+			try {
+				Request\WooPay_Create_Intent::extend( $request );
+			} catch ( Exception $e ) {
+				echo 'Exception message: ' . $e->getMessage() . "\n\n";
+			}
+		}
 
-		$request = new Request\Create_Intent();
-		$request->set_amount( 100 );
-		$suggested_amount = 200; // Something that might come from context, and extensions might use.
-		$request = $request->apply_filters( 'wcpay_create_intent_request', $suggested_amount );
+		if ( true ) {
+			echo "===== EXTEND TEMPLATE =====\n";
 
-		var_dump(
-			[
-				$request,
-				'params'              => $request->get_params(),
-				'api'                 => $request->get_api(),
-				'method'              => $request->get_method(),
-				'site_specific'       => $request->is_site_specific(),
-				'use_user_token'      => $request->should_use_user_token(),
-				'return_raw_response' => $request->should_return_raw_response(),
-				WC_Payments::get_payments_api_client()->send_request( $request ),
-			]
-		);
+			$callback = function ( Request\Create_Intent $base_request ): Request\WooPay_Create_Intent {
+				$request = Request\WooPay_Create_Intent::extend( $base_request );
+				$request->set_save_payment_method_to_platform( true );
+				return $request;
+			};
 
-		/////
+			add_filter( 'wcpay_create_intent_request', $callback );
+
+			$request = new Request\Create_Intent();
+			$request->set_amount( 100 );
+			$request = $request->apply_filters( 'wcpay_create_intent_request' );
+
+			remove_filter( 'wcpay_create_intent_request', $callback );
+
+			$this->dump_request( $request );
+		}
+
+		if ( true ) {
+			echo "===== UPDATING VALUES =====\n";
+			// TBD
+			// add_filter( 'wcpay_create_intent_request', [ $this, 'value_update' ], 10, 2 );
+			// function value_update( Request\Create_Intent $base_request, int $replacement_amount ): Request\Create_Intent {
+			// 	$base_request->set_amount( $replacement_amount );
+			// 	return $base_request;
+			// }
+		}
+
 		exit;
 	}
 
-	/**
-	 * Example how the request can be extended and values updated.
-	 */
-	function extention_example( Request\Create_Intent $base_request, int $replacement_amount ): Request\WooPay_Create_Intent {
-		$request = Request\WooPay_Create_Intent::extend( $base_request );
-		$request->set_amount( $replacement_amount );
-		$request->set_save_payment_method_to_platform( true );
-		return $request;
-	}
 
-	/**
-	 * Example how some properties can be updated.
-	 */
-	function value_update( Request\Create_Intent $base_request, int $replacement_amount ): Request\Create_Intent {
-		$base_request->set_amount( $replacement_amount );
-		return $base_request;
+	function dump_request( $request ) {
+		var_dump(
+			[
+				'object'   => $request,
+				'response' => WC_Payments::get_payments_api_client()->send_request( $request ),
+				'getters'  => [
+					'params'              => $request->get_params(),
+					'api'                 => $request->get_api(),
+					'method'              => $request->get_method(),
+					'site_specific'       => $request->is_site_specific(),
+					'use_user_token'      => $request->should_use_user_token(),
+					'return_raw_response' => $request->should_return_raw_response(),
+				],
+			]
+		);
+		echo "\n\n";
 	}
 }
 
 class Rados_HTTP_Client extends WC_Payments_Http {
 	public function remote_request( $args, $body = null, $is_site_specific = true, $use_user_token = false ) {
+		$body = [
+			'id' => 'obj_XYZ',
+		];
+
 		return [
 			'code' => 200,
-			'body' => json_encode( [
-				'id' => 'obj_XYZ',
-			] )
+			'body' => json_encode( $body )
 		];
 	}
 }

--- a/includes/core/server/class-temp-request-examples.php
+++ b/includes/core/server/class-temp-request-examples.php
@@ -12,6 +12,29 @@ class Temp_Request_Examples {
 	public function __construct() {
 		// add_action( 'template_redirect', [ $this, 'example' ] );
 		// add_filter( 'wc_payments_http', [ $this, 'mock_http_class' ] );
+		add_filter( 'wcpay_create_and_confirm_intention_request', [ $this, 'woopay_intention_request'], 10, 3 );
+	}
+
+	/**
+	 * Example what consumers like WooPay should do to extend the request.
+	 *
+	 * @param Request\Create_And_Confirm_Intention $base_request   The request that's being modified.
+	 * @param WC_Order                             $order          The order which needs payment.
+	 * @param bool                                 $is_platform_pm A pre-calculated flag.
+	 * @return Request\WooPay_Create_And_Confirm_Intention
+	 */
+	public function woopay_intention_request( Request\Create_And_Confirm_Intention $base_request, $order, $is_platform_pm ) {
+		$request = Request\WooPay_Create_And_Confirm_Intention::extend( $base_request );
+
+		// This meta is only set by WooPay.
+		// We want to handle the intention creation differently when there are subscriptions.
+		// We're using simple products on WooPay so the current logic for WCPay subscriptions won't work there.
+		$woopay_has_subscription = '1' === $order->get_meta( '_woopay_has_subscription' );
+
+		$request->set_is_platform_payment_method( $is_platform_pm );
+		$request->set_has_woopay_subscription( $woopay_has_subscription );
+
+		return $request;
 	}
 
 	public function mock_http_class() {
@@ -19,7 +42,7 @@ class Temp_Request_Examples {
 	}
 
 	public function example() {
-		if ( false ) {
+		if ( true ) {
 			echo "===== CREATE INTENT REQUEST =====\n";
 			$request = Request\Create_Intent::create()
 				->set_amount( 100 )
@@ -27,7 +50,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( false ) {
+		if ( true ) {
 			// Make sure extending the request does not work outside of `apply_filters`.
 			echo "===== EXTEND WITHOUT FILTERS =====\n";
 			$request = Request\Create_Intent::create()
@@ -39,7 +62,7 @@ class Temp_Request_Examples {
 			}
 		}
 
-		if ( false ) {
+		if ( true ) {
 			echo "===== EXTEND TEMPLATE =====\n";
 
 			$callback = function ( Request\Create_Intent $base_request ): Request\WooPay_Create_Intent {
@@ -60,7 +83,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( false ) {
+		if ( true ) {
 			echo "===== UPDATING VALUES =====\n";
 			$request = Request\Create_Intent::create()
 				->set_amount( 100 )
@@ -81,7 +104,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( false ) {
+		if ( true ) {
 			echo "===== PROTECTING IMMUTABLE VALUES =====\n";
 			$request = Request\Create_Intent::create()
 				->set_amount( 100 )
@@ -101,7 +124,7 @@ class Temp_Request_Examples {
 			remove_filter( 'wcpay_create_intent_request', $callback );
 		}
 
-		if ( false ) {
+		if ( true ) {
 			echo "===== ENSURING INITIALIZED REQUESTS =====\n";
 			$request = Request\Create_Intent::create()
 				->set_amount( 100 );
@@ -112,7 +135,7 @@ class Temp_Request_Examples {
 			}
 		}
 
-		if ( false ) {
+		if ( true ) {
 			echo "===== GENERIC GET REQUEST =====\n";
 			// ToDo: Make sure IDs are properly set somehow.
 			$request = new Request\Generic( WC_Payments_API_Client::PAYMENT_METHODS_API . '/pm_abc123', REQUESTS::GET );
@@ -120,7 +143,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( false ) {
+		if ( true ) {
 			echo "===== GENERIC POST REQUEST =====\n";
 			$request = new Request\Generic(
 				WC_Payments_API_Client::CUSTOMERS_API,
@@ -134,7 +157,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( false ) {
+		if ( true ) {
 			echo "===== GENERIC POST REQUEST MODIFICATIONS =====\n";
 			$request = new Request\Generic(
 				WC_Payments_API_Client::CUSTOMERS_API,
@@ -157,7 +180,7 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( false ) {
+		if ( true ) {
 			echo "===== CREATE AND CONFIRM INTENTION REQUEST =====\n";
 			$request = Request\Create_And_Confirm_Intention::create()
 				->set_amount( 300 )

--- a/includes/core/server/class-temp-request-examples.php
+++ b/includes/core/server/class-temp-request-examples.php
@@ -115,14 +115,14 @@ class Temp_Request_Examples {
 		if ( true ) {
 			echo "===== GENERIC GET REQUEST =====\n";
 			// ToDo: Make sure IDs are properly set somehow.
-			$request = new WCPay\Core\Server\Request\Generic( WC_Payments_API_Client::PAYMENT_METHODS_API . '/pm_abc123', 'GET' );
+			$request = new Request\Generic( WC_Payments_API_Client::PAYMENT_METHODS_API . '/pm_abc123', 'GET' );
 			$request->use_user_token();
 			$this->dump_request( $request );
 		}
 
 		if ( true ) {
 			echo "===== GENERIC POST REQUEST =====\n";
-			$request = new WCPay\Core\Server\Request\Generic(
+			$request = new Request\Generic(
 				WC_Payments_API_Client::CUSTOMERS_API,
 				'POST',
 				[
@@ -131,6 +131,29 @@ class Temp_Request_Examples {
 				]
 			);
 			$request->use_user_token();
+			$this->dump_request( $request );
+		}
+
+		if ( true ) {
+			echo "===== GENERIC POST REQUEST MODIFICATIONS =====\n";
+			$request = new Request\Generic(
+				WC_Payments_API_Client::CUSTOMERS_API,
+				'POST',
+				[
+					'first_name' => 'John',
+					'last_name'  => 'Doe',
+				]
+			);
+
+			$callback = function( Request\Generic $request ) {
+				$request->set( 'age', 42 );
+				return $request;
+			};
+
+			add_filter( 'wcpay_create_customer_request', $callback );
+			$request->apply_filters( 'wcpay_create_customer_request' );
+			remove_filter( 'wcpay_create_customer_request', $callback );
+
 			$this->dump_request( $request );
 		}
 

--- a/includes/core/server/class-temp-request-examples.php
+++ b/includes/core/server/class-temp-request-examples.php
@@ -19,19 +19,19 @@ class Temp_Request_Examples {
 	}
 
 	public function example() {
-		if ( false ) {
+		if ( true ) {
 			echo "===== CREATE INTENT REQUEST =====\n";
-			$request = new Request\Create_Intent();
-			$request->set_amount( 100 );
-			$request->set_currency( 'eur' );
+			$request = Request\Create_Intent::create()
+				->set_amount( 100 )
+				->set_currency( 'eur' );
 			$this->dump_request( $request );
 		}
 
-		if ( false ) {
+		if ( true ) {
 			// Make sure extending the request does not work outside of `apply_filters`.
 			echo "===== EXTEND WITHOUT FILTERS =====\n";
-			$request = new Request\Create_Intent();
-			$request->set_amount( 100 );
+			$request = Request\Create_Intent::create()
+				->set_amount( 100 );
 			try {
 				Request\WooPay_Create_Intent::extend( $request );
 			} catch ( Exception $e ) {
@@ -39,20 +39,20 @@ class Temp_Request_Examples {
 			}
 		}
 
-		if ( false ) {
+		if ( true ) {
 			echo "===== EXTEND TEMPLATE =====\n";
 
 			$callback = function ( Request\Create_Intent $base_request ): Request\WooPay_Create_Intent {
-				$request = Request\WooPay_Create_Intent::extend( $base_request );
-				$request->set_save_payment_method_to_platform( true );
+				$request = Request\WooPay_Create_Intent::extend( $base_request )
+					->set_save_payment_method_to_platform( true );
 				return $request;
 			};
 
 			add_filter( 'wcpay_create_intent_request', $callback );
 
-			$request = new Request\Create_Intent();
-			$request->set_amount( 100 );
-			$request->set_currency( 'eur' );
+			$request = Request\Create_Intent::create()
+				->set_amount( 100 )
+				->set_currency( 'eur' );
 			$request = $request->apply_filters( 'wcpay_create_intent_request' );
 
 			remove_filter( 'wcpay_create_intent_request', $callback );
@@ -60,11 +60,11 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( false ) {
+		if ( true ) {
 			echo "===== UPDATING VALUES =====\n";
-			$request = new Request\Create_Intent();
-			$request->set_amount( 100 );
-			$request->set_currency( 'eur' );
+			$request = Request\Create_Intent::create()
+				->set_amount( 100 )
+				->set_currency( 'eur' );
 
 			$callback = function ( Request\Create_Intent $request, string $new_currency ) {
 				$request->set_currency( $new_currency );
@@ -81,11 +81,11 @@ class Temp_Request_Examples {
 			$this->dump_request( $request );
 		}
 
-		if ( false ) {
+		if ( true ) {
 			echo "===== PROTECTING IMMUTABLE VALUES =====\n";
-			$request = new Request\Create_Intent();
-			$request->set_amount( 100 );
-			$request->set_currency( 'eur' );
+			$request = Request\Create_Intent::create()
+				->set_amount( 100 )
+				->set_currency( 'eur' );
 
 			$callback = function ( Request\Create_Intent $request ) {
 				try {
@@ -101,10 +101,10 @@ class Temp_Request_Examples {
 			remove_filter( 'wcpay_create_intent_request', $callback );
 		}
 
-		if ( false ) {
+		if ( true ) {
 			echo "===== ENSURING INITIALIZED REQUESTS =====\n";
-			$request = new Request\Create_Intent();
-			$request->set_amount( 100 );
+			$request = Request\Create_Intent::create()
+				->set_amount( 100 );
 			try {
 				$request->get_params();
 			} catch ( Exception $e ) {
@@ -115,7 +115,7 @@ class Temp_Request_Examples {
 		if ( true ) {
 			echo "===== GENERIC GET REQUEST =====\n";
 			// ToDo: Make sure IDs are properly set somehow.
-			$request = new Request\Generic( WC_Payments_API_Client::PAYMENT_METHODS_API . '/pm_abc123', 'GET' );
+			$request = new Request\Generic( WC_Payments_API_Client::PAYMENT_METHODS_API . '/pm_abc123', REQUESTS::GET );
 			$request->use_user_token();
 			$this->dump_request( $request );
 		}
@@ -124,7 +124,7 @@ class Temp_Request_Examples {
 			echo "===== GENERIC POST REQUEST =====\n";
 			$request = new Request\Generic(
 				WC_Payments_API_Client::CUSTOMERS_API,
-				'POST',
+				Requests::POST,
 				[
 					'first_name' => 'John',
 					'last_name'  => 'Doe',
@@ -138,7 +138,7 @@ class Temp_Request_Examples {
 			echo "===== GENERIC POST REQUEST MODIFICATIONS =====\n";
 			$request = new Request\Generic(
 				WC_Payments_API_Client::CUSTOMERS_API,
-				'POST',
+				Requests::POST,
 				[
 					'first_name' => 'John',
 					'last_name'  => 'Doe',

--- a/includes/core/server/class-temp-request-examples.php
+++ b/includes/core/server/class-temp-request-examples.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Request.
+ *
+ * @package WooCommerce Payments
+ */
+
+// phpcs:disable
+use WCPay\Core\Server\Request;
+
+class Temp_Request_Examples {
+	public function __construct() {
+		add_action( 'template_redirect', [ $this, 'example' ] );
+		add_filter( 'wc_payments_http', [ $this, 'mock_http_class' ] );
+	}
+
+	public function mock_http_class() {
+		return new Rados_HTTP_Client( new Automattic\Jetpack\Connection\Manager( 'woocommerce-payments' ) );
+	}
+
+	public function example() {
+		add_filter( 'wcpay_create_intent_request', [ $this, 'extention_example' ], 10, 2 );
+		add_filter( 'wcpay_create_intent_request', [ $this, 'value_update' ], 10, 2 );
+
+
+		// $request = new WCPay\Core\Server\Request\Generic( WC_Payments_API_Client::PAYMENT_METHODS_API, 'GET' );
+		// $request->use_user_token();
+
+		$request = new Request\Create_Intent();
+		$request->set_amount( 100 );
+		$suggested_amount = 200; // Something that might come from context, and extensions might use.
+		$request = $request->apply_filters( 'wcpay_create_intent_request', $suggested_amount );
+
+		var_dump(
+			[
+				$request,
+				'params'              => $request->get_params(),
+				'api'                 => $request->get_api(),
+				'method'              => $request->get_method(),
+				'site_specific'       => $request->is_site_specific(),
+				'use_user_token'      => $request->should_use_user_token(),
+				'return_raw_response' => $request->should_return_raw_response(),
+				WC_Payments::get_payments_api_client()->send_request( $request ),
+			]
+		);
+
+		/////
+		exit;
+	}
+
+	/**
+	 * Example how the request can be extended and values updated.
+	 */
+	function extention_example( Request\Create_Intent $base_request, int $replacement_amount ): Request\WooPay_Create_Intent {
+		$request = Request\WooPay_Create_Intent::extend( $base_request );
+		$request->set_amount( $replacement_amount );
+		$request->set_save_payment_method_to_platform( true );
+		return $request;
+	}
+
+	/**
+	 * Example how some properties can be updated.
+	 */
+	function value_update( Request\Create_Intent $base_request, int $replacement_amount ): Request\Create_Intent {
+		$base_request->set_amount( $replacement_amount );
+		return $base_request;
+	}
+}
+
+class Rados_HTTP_Client extends WC_Payments_Http {
+	public function remote_request( $args, $body = null, $is_site_specific = true, $use_user_token = false ) {
+		return [
+			'code' => 200,
+			'body' => json_encode( [
+				'id' => 'obj_XYZ',
+			] )
+		];
+	}
+}
+
+new Temp_Request_Examples();
+
+// phpcs:enable

--- a/includes/core/server/class-temp-request-examples.php
+++ b/includes/core/server/class-temp-request-examples.php
@@ -67,12 +67,42 @@ class Temp_Request_Examples {
 
 		if ( true ) {
 			echo "===== UPDATING VALUES =====\n";
-			// TBD
-			// add_filter( 'wcpay_create_intent_request', [ $this, 'value_update' ], 10, 2 );
-			// function value_update( Request\Create_Intent $base_request, int $replacement_amount ): Request\Create_Intent {
-			// 	$base_request->set_amount( $replacement_amount );
-			// 	return $base_request;
-			// }
+			$request = new Request\Create_Intent();
+			$request->set_amount( 100 );
+			$request->set_currency( 'eur' );
+
+			$callback = function ( Request\Create_Intent $request, string $new_currency ) {
+				$request->set_currency( $new_currency );
+				return $request;
+			};
+			add_filter( 'wcpay_create_intent_request', $callback, 10, 2 );
+
+			// This is an example of a variable, which comes from somewhere else, and how it can be passed to filters.
+			$other_currency = 'usd';
+			$request->apply_filters( 'wcpay_create_intent_request', $other_currency );
+
+			remove_filter( 'wcpay_create_intent_request', $callback );
+
+			$this->dump_request( $request );
+		}
+
+		if ( true ) {
+			echo "===== PROTECTING IMMUTABLE VALUES =====\n";
+			$request = new Request\Create_Intent();
+			$request->set_amount( 100 );
+
+			$callback = function ( Request\Create_Intent $request ) {
+				try {
+					$request->set_amount( 200 );
+				} catch ( Exception $e ) {
+					echo 'Exception message: ' . $e->getMessage() . "\n\n";
+				}
+				return $request;
+			};
+
+			add_filter( 'wcpay_create_intent_request', $callback, 10 );
+			$request->apply_filters( 'wcpay_create_intent_request' );
+			remove_filter( 'wcpay_create_intent_request', $callback );
 		}
 
 		exit;

--- a/includes/core/server/request/README.md
+++ b/includes/core/server/request/README.md
@@ -1,0 +1,17 @@
+# WooCommerce Payments Request Classes
+
+This document explains how you can use, extend, and modify server request classes within WooCommerce Payments.
+
+## Using requests
+
+TBD
+
+## Modifying existing requests
+
+TBD
+
+## Creating request classses
+
+TBD
+
+## Extending request classes

--- a/includes/core/server/request/class-create-and-confirm-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-intention.php
@@ -34,7 +34,7 @@ class Create_And_Confirm_Intention extends Request {
 	];
 
 	const DEFAULT_PARAMS = [
-		'confirm'        => 'true', // By the definition of the request.
+		'confirm'        => true, // By the definition of the request.
 		'capture_method' => 'automatic',
 		'level3'         => [],
 	];
@@ -62,8 +62,7 @@ class Create_And_Confirm_Intention extends Request {
 	 * @return static      Instance of the class for method chaining.
 	 */
 	public function set_amount( $amount ) {
-		$this->set_param( 'amount', $amount );
-		return $this;
+		return $this->set_param( 'amount', $amount );
 	}
 
 	/**
@@ -73,8 +72,7 @@ class Create_And_Confirm_Intention extends Request {
 	 * @return static                Instance of the class for method chaining.
 	 */
 	public function set_currency_code( $currency_code ) {
-		$this->set_param( 'currency', $currency_code );
-		return $this;
+		return $this->set_param( 'currency', $currency_code );
 	}
 
 	/**
@@ -84,8 +82,7 @@ class Create_And_Confirm_Intention extends Request {
 	 * @return static                    Instance of the class for method chaining.
 	 */
 	public function set_payment_method( $payment_method_id ) {
-		$this->set_param( 'payment_method', $payment_method_id );
-		return $this;
+		return $this->set_param( 'payment_method', $payment_method_id );
 	}
 
 	/**
@@ -95,8 +92,7 @@ class Create_And_Confirm_Intention extends Request {
 	 * @return static              Instance of the class for method chaining.
 	 */
 	public function set_customer( $customer_id ) {
-		$this->set_param( 'customer', $customer_id );
-		return $this;
+		return $this->set_param( 'customer', $customer_id );
 	}
 
 	/**
@@ -106,8 +102,7 @@ class Create_And_Confirm_Intention extends Request {
 	 * @return static               Instance of the class for method chaining.
 	 */
 	public function set_capture_method( $manual_capture = false ) {
-		$this->set_param( 'capture_method', $manual_capture ? 'manual' : 'automatic' );
-		return $this;
+		return $this->set_param( 'capture_method', $manual_capture ? 'manual' : 'automatic' );
 	}
 
 	/**
@@ -116,20 +111,7 @@ class Create_And_Confirm_Intention extends Request {
 	 * @return static Instance of the class for method chaining.
 	 */
 	public function setup_future_usage() {
-		$this->set_param( 'setup_future_usage', 'off_session' );
-		return $this;
-	}
-
-	/**
-	 * Save payment method to platform setter.
-	 *
-	 * @param  bool $save_payment_method_to_platform Whether to save payment method to platform.
-	 * @return static                                Instance of the class for method chaining.
-	 */
-	public function save_payment_method_to_platform( $save_payment_method_to_platform ) {
-		$flag = $save_payment_method_to_platform ? 'true' : '';
-		$this->set_param( 'save_payment_method_to_platform', $flag );
-		return $this;
+		return $this->set_param( 'setup_future_usage', 'off_session' );
 	}
 
 	/**
@@ -162,22 +144,17 @@ class Create_And_Confirm_Intention extends Request {
 	 * @return static        Instance of the class for method chaining.
 	 */
 	public function set_level3( $level3 ) {
-		$this->set_param( 'level3', $level3 );
-		return $this;
+		return $this->set_param( 'level3', $level3 );
 	}
 
 	/**
-	 * AAAA setter.
+	 * Off-sesstion setter.
 	 *
 	 * @param  bool $off_session Whether the payment is off-session (merchant-initiated), or on-session (customer-initiated).
 	 * @return static            Instance of the class for method chaining.
 	 */
 	public function set_off_session( $off_session = true ) {
-		if ( $off_session ) {
-			// @todo: Convert boolean values to `true` automatically?
-			$this->set_param( 'off_session', 'true' );
-		}
-		return $this;
+		return $this->set_param( 'off_session', $off_session );
 	}
 
 	/**
@@ -187,8 +164,7 @@ class Create_And_Confirm_Intention extends Request {
 	 * @return static                 Instance of the class for method chaining.
 	 */
 	public function set_payment_methods( $payment_methods ) {
-		$this->set_param( 'payment_methods_types', $payment_methods );
-		return $this;
+		return $this->set_param( 'payment_methods_types', $payment_methods );
 	}
 
 	/**
@@ -198,8 +174,7 @@ class Create_And_Confirm_Intention extends Request {
 	 * @return static                   Instance of the class for method chaining.
 	 */
 	public function set_cvc_confirmation( $cvc_confirmation ) {
-		$this->set_param( 'cvc_confirmation', $cvc_confirmation );
-		return $this;
+		return $this->set_param( 'cvc_confirmation', $cvc_confirmation );
 	}
 
 	/**

--- a/includes/core/server/request/class-create-and-confirm-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-intention.php
@@ -10,6 +10,7 @@ namespace WCPay\Core\Server\Request;
 use Exception;
 use WC_Payments;
 use WCPay\Core\Server\Request;
+use WCPay\Core\Exceptions\Invalid_Request_Param;
 use WC_Payments_API_Client;
 
 /**
@@ -61,7 +62,7 @@ class Create_And_Confirm_Intention extends Request {
 	 * @param  int $amount Amount to charge.
 	 * @return static      Instance of the class for method chaining.
 	 */
-	public function set_amount( $amount ) {
+	public function set_amount( int $amount ) {
 		return $this->set_param( 'amount', $amount );
 	}
 
@@ -70,8 +71,22 @@ class Create_And_Confirm_Intention extends Request {
 	 *
 	 * @param  string $currency_code Currency to charge in.
 	 * @return static                Instance of the class for method chaining.
+	 * @throws Invalid_Request_Param When the currency code is invalid.
 	 */
-	public function set_currency_code( $currency_code ) {
+	public function set_currency_code( string $currency_code ) {
+		// No checks needed, account data should not be empty when creating intents.
+		$account_data = WC_Payments::get_account_service()->get_cached_account_data();
+		if ( ! in_array( $currency_code, $account_data['customer_currencies']['supported'], true ) ) {
+			throw new Invalid_Request_Param(
+				sprintf(
+					// Translators: %s is a currency code.
+					__( '%s is not a supported currency for payments.', 'woocommerce-payments' ),
+					$currency_code
+				),
+				'currency_not_available'
+			);
+		}
+
 		return $this->set_param( 'currency', $currency_code );
 	}
 
@@ -82,6 +97,7 @@ class Create_And_Confirm_Intention extends Request {
 	 * @return static                    Instance of the class for method chaining.
 	 */
 	public function set_payment_method( $payment_method_id ) {
+		$this->validate_stripe_id( $payment_method_id, [ 'pm', 'src' ] );
 		return $this->set_param( 'payment_method', $payment_method_id );
 	}
 
@@ -91,7 +107,8 @@ class Create_And_Confirm_Intention extends Request {
 	 * @param  string $customer_id ID of the customer making the payment.
 	 * @return static              Instance of the class for method chaining.
 	 */
-	public function set_customer( $customer_id ) {
+	public function set_customer( string $customer_id ) {
+		$this->validate_stripe_id( $customer_id, 'cus' );
 		return $this->set_param( 'customer', $customer_id );
 	}
 
@@ -101,7 +118,7 @@ class Create_And_Confirm_Intention extends Request {
 	 * @param  bool $manual_capture Whether to capture funds via manual action.
 	 * @return static               Instance of the class for method chaining.
 	 */
-	public function set_capture_method( $manual_capture = false ) {
+	public function set_capture_method( bool $manual_capture = false ) {
 		return $this->set_param( 'capture_method', $manual_capture ? 'manual' : 'automatic' );
 	}
 
@@ -117,13 +134,16 @@ class Create_And_Confirm_Intention extends Request {
 	/**
 	 * Metadata setter.
 	 *
-	 * @param  array $metadata Meta data values to be sent along with payment intent creation.
-	 * @return static          Instance of the class for method chaining.
-	 * @throws \Exception      In case there is no order number provided.
+	 * @param  array $metadata       Meta data values to be sent along with payment intent creation.
+	 * @return static                Instance of the class for method chaining.
+	 * @throws Invalid_Request_Param In case there is no order number provided.
 	 */
 	public function set_metadata( $metadata ) {
 		if ( ! isset( $metadata['order_number'] ) ) {
-			throw new \Exception( 'An order number is required!' );
+			throw new Invalid_Request_Param(
+				__( 'An order number is required!', 'woocommerce-payments' ),
+				'missing_metadata_order_number'
+			);
 		}
 
 		// The description is based on the order number here.
@@ -144,7 +164,7 @@ class Create_And_Confirm_Intention extends Request {
 	 * @return static        Instance of the class for method chaining.
 	 */
 	public function set_level3( $level3 ) {
-		if ( empty( $params['level3'] ) || ! is_array( $params['level3'] ) ) {
+		if ( empty( $level3 ) || ! is_array( $level3 ) ) {
 			return $this;
 		}
 
@@ -157,7 +177,7 @@ class Create_And_Confirm_Intention extends Request {
 	 * @param  bool $off_session Whether the payment is off-session (merchant-initiated), or on-session (customer-initiated).
 	 * @return static            Instance of the class for method chaining.
 	 */
-	public function set_off_session( $off_session = true ) {
+	public function set_off_session( bool $off_session = true ) {
 		// This one is tricky. We can have `true`, but otherwise we need to get rid of the parameter.
 		if ( $off_session ) {
 			return $this->set_param( 'off_session', true );
@@ -171,18 +191,27 @@ class Create_And_Confirm_Intention extends Request {
 	 *
 	 * @param  array $payment_methods An array of payment methods that might be used for the payment.
 	 * @return static                 Instance of the class for method chaining.
+	 * @throws Invalid_Request_Param  When there are no payment methods provided.
 	 */
-	public function set_payment_methods( $payment_methods ) {
+	public function set_payment_methods( array $payment_methods ) {
+		// Hard to validate without hardcoding a list here.
+		if ( empty( $payment_methods ) ) {
+			throw new Invalid_Request_Param(
+				__( 'Intentions require at least one payment method', 'woocommerce-payments' ),
+				'missing_payment_method_types'
+			);
+		}
+
 		return $this->set_param( 'payment_methods_types', $payment_methods );
 	}
 
 	/**
 	 * CVC confirmation setter.
 	 *
-	 * @param  string $cvc_confirmation The CVC confirmation for this payment method.
+	 * @param  string $cvc_confirmation The CVC confirmation for this payment method (Optional).
 	 * @return static                   Instance of the class for method chaining.
 	 */
-	public function set_cvc_confirmation( $cvc_confirmation ) {
+	public function set_cvc_confirmation( $cvc_confirmation = null ) {
 		return $this->set_param( 'cvc_confirmation', $cvc_confirmation );
 	}
 

--- a/includes/core/server/request/class-create-and-confirm-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-intention.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Request\Create_Intent.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server\Request;
+
+use Exception;
+use WCPay\Core\Server\Request;
+use WC_Payments_API_Client;
+
+/**
+ * Request class for creating intents.
+ */
+class Create_And_Confirm_Intention extends Request {
+	use Intention;
+
+	const IMMUTABLE_PARAMS = [ 'amount' ];
+	const REQUIRED_PARAMS  = [ 'amount', 'currency' ];
+
+	const DEFAULTS = [
+		'confirm' => 'true',
+	];
+
+	/**
+	 * Returns the request's API.
+	 *
+	 * @return string
+	 */
+	public function get_api(): string {
+		return WC_Payments_API_Client::INTENTIONS_API;
+	}
+
+	/**
+	 * Returns the request's HTTP method.
+	 */
+	public function get_method(): string {
+		return 'POST';
+	}
+
+	/**
+	 * Amount setter.
+	 *
+	 * @param  int $amount Amount to charge.
+	 * @return static      Instance of the class for method chaining.
+	 */
+	public function set_amount( $amount ) {
+		$this->set_param( 'amount', $amount );
+		return $this;
+	}
+
+	/**
+	 * Currency code setter.
+	 *
+	 * @param  string $currency_code Currency to charge in.
+	 * @return static                Instance of the class for method chaining.
+	 */
+	public function set_currency_code( $currency_code ) {
+		$this->set_param( 'currency', $currency_code );
+		return $this;
+	}
+
+	/**
+	 * Payment method setter.
+	 *
+	 * @param  string $payment_method_id ID of payment method to process charge with.
+	 * @return static                    Instance of the class for method chaining.
+	 */
+	public function set_payment_method( $payment_method_id ) {
+		$this->set_param( 'payment_method', $payment_method_id );
+		return $this;
+	}
+
+	/**
+	 * Customer setter.
+	 *
+	 * @param  string $customer_id ID of the customer making the payment.
+	 * @return static              Instance of the class for method chaining.
+	 */
+	public function set_customer( $customer_id ) {
+		$this->set_param( 'customer', $customer_id );
+		return $this;
+	}
+
+	/**
+	 * Capture method setter.
+	 *
+	 * @param  bool $manual_capture Whether to capture funds via manual action.
+	 * @return static               Instance of the class for method chaining.
+	 */
+	public function set_capture_method( $manual_capture = false ) {
+		$this->set_param( 'capture_method', $manual_capture ? 'manual' : 'automatic' );
+		return $this;
+	}
+
+	/**
+	 * If the payment method should be saved to the store, this enables future usage.
+	 *
+	 * @return static Instance of the class for method chaining.
+	 */
+	public function setup_future_usage() {
+		$this->set_param( 'setup_future_usage', 'off_session' );
+		return $this;
+	}
+
+	/**
+	 * Save payment method to platform setter.
+	 *
+	 * @param  bool $save_payment_method_to_platform Whether to save payment method to platform.
+	 * @return static                                Instance of the class for method chaining.
+	 */
+	public function save_payment_method_to_platform( $save_payment_method_to_platform ) {
+		$flag = $save_payment_method_to_platform ? 'true' : '';
+		$this->set_param( 'save_payment_method_to_platform', $flag );
+		return $this;
+	}
+
+	/**
+	 * Metadata setter.
+	 *
+	 * @param  array $metadata Meta data values to be sent along with payment intent creation.
+	 * @return static          Instance of the class for method chaining.
+	 * @throws \Exception      In case there is no order number provided.
+	 */
+	public function set_metadata( $metadata ) {
+		if ( ! isset( $metadata['order_number'] ) ) {
+			throw new \Exception( 'An order number is required!' );
+		}
+
+		// The description is based on the order number here.
+		$description = $this->get_intent_description( $metadata['order_number'] ?? 0 );
+		$this->set_param( 'description', $description );
+
+		// Combine the metadata with the fingerprint.
+		$metadata = array_merge( $metadata, $this->get_fingerprint_metadata() );
+		$this->set_param( 'metadata', $metadata );
+
+		return $this;
+	}
+
+	/**
+	 * Level 3 data setter.
+	 *
+	 * @param  array $level3 Level 3 data.
+	 * @return static        Instance of the class for method chaining.
+	 */
+	public function set_level3( $level3 ) {
+		$this->set_param( 'level3', $level3 );
+		return $this;
+	}
+
+	/**
+	 * AAAA setter.
+	 *
+	 * @param  bool $off_session Whether the payment is off-session (merchant-initiated), or on-session (customer-initiated).
+	 * @return static            Instance of the class for method chaining.
+	 */
+	public function set_off_session( $off_session = true ) {
+		// @todo: Convert boolean values to `true` automatically?
+		$this->set_param( 'off_session', $off_session ? 'true' : '' );
+		return $this;
+	}
+
+	/**
+	 * Payment methods setter.
+	 *
+	 * @param  array $payment_methods An array of payment methods that might be used for the payment.
+	 * @return static                 Instance of the class for method chaining.
+	 */
+	public function set_payment_methods( $payment_methods ) {
+		$this->set_param( 'payment_methods_types', $payment_methods );
+		return $this;
+	}
+
+	/**
+	 * CVC confirmation setter.
+	 *
+	 * @param  string $cvc_confirmation The CVC confirmation for this payment method.
+	 * @return static                   Instance of the class for method chaining.
+	 */
+	public function set_cvc_confirmation( $cvc_confirmation ) {
+		$this->set_param( 'cvc_confirmation', $cvc_confirmation );
+		return $this;
+	}
+}

--- a/includes/core/server/request/class-create-and-confirm-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-intention.php
@@ -148,13 +148,18 @@ class Create_And_Confirm_Intention extends Request {
 	}
 
 	/**
-	 * Off-sesstion setter.
+	 * Off-session setter.
 	 *
 	 * @param  bool $off_session Whether the payment is off-session (merchant-initiated), or on-session (customer-initiated).
 	 * @return static            Instance of the class for method chaining.
 	 */
 	public function set_off_session( $off_session = true ) {
-		return $this->set_param( 'off_session', $off_session );
+		// This one is tricky. We can have `true`, but otherwise we need to get rid of the parameter.
+		if ( $off_session ) {
+			return $this->set_param( 'off_session', true );
+		} else {
+			return $this->unset_param( 'off_session' );
+		}
 	}
 
 	/**

--- a/includes/core/server/request/class-create-and-confirm-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-intention.php
@@ -17,6 +17,7 @@ use WC_Payments_API_Client;
  */
 class Create_And_Confirm_Intention extends Request {
 	use Intention;
+	use Level3;
 
 	const IMMUTABLE_PARAMS = [
 		// Those are up to us, we have to decide.
@@ -36,7 +37,6 @@ class Create_And_Confirm_Intention extends Request {
 	const DEFAULT_PARAMS = [
 		'confirm'        => true, // By the definition of the request.
 		'capture_method' => 'automatic',
-		'level3'         => [],
 	];
 
 	/**
@@ -144,7 +144,11 @@ class Create_And_Confirm_Intention extends Request {
 	 * @return static        Instance of the class for method chaining.
 	 */
 	public function set_level3( $level3 ) {
-		return $this->set_param( 'level3', $level3 );
+		if ( empty( $params['level3'] ) || ! is_array( $params['level3'] ) ) {
+			return $this;
+		}
+
+		return $this->set_param( 'level3', $this->fix_level3_data( $level3 ) );
 	}
 
 	/**

--- a/includes/core/server/request/class-create-and-confirm-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-intention.php
@@ -19,8 +19,7 @@ class Create_And_Confirm_Intention extends Request {
 
 	const IMMUTABLE_PARAMS = [ 'amount' ];
 	const REQUIRED_PARAMS  = [ 'amount', 'currency' ];
-
-	const DEFAULTS = [
+	const DEFAULT_PARAMS   = [
 		'confirm' => 'true',
 	];
 

--- a/includes/core/server/request/class-create-intent.php
+++ b/includes/core/server/request/class-create-intent.php
@@ -13,6 +13,8 @@ use WCPay\Core\Server\Request;
  * Request class for creating intents.
  */
 class Create_Intent extends Request {
+	const IMMUTABLE_PARAMS = [ 'amount' ];
+
 	/**
 	 * Allows the class to be constructed.
 	 *

--- a/includes/core/server/request/class-create-intent.php
+++ b/includes/core/server/request/class-create-intent.php
@@ -17,15 +17,6 @@ class Create_Intent extends Request {
 	const REQUIRED_PARAMS  = [ 'amount', 'currency' ];
 
 	/**
-	 * Allows the class to be constructed.
-	 *
-	 * @todo This could be replaced by static methods.
-	 */
-	public function __construct() {
-		// Nothing to do here yet.
-	}
-
-	/**
 	 * Returns the request's API.
 	 *
 	 * @return string

--- a/includes/core/server/request/class-create-intent.php
+++ b/includes/core/server/request/class-create-intent.php
@@ -51,4 +51,17 @@ class Create_Intent extends Request {
 		$this->set_param( 'amount', $amount );
 		return $this;
 	}
+
+	/**
+	 * Updates the currency of the intent.
+	 *
+	 * This is an example of a non-protected property.
+	 *
+	 * @param string $currency The currency to use.
+	 * @return Create_Intent The instance of the class for method chaining.
+	 */
+	public function set_currency( string $currency ) {
+		$this->set_param( 'currency', $currency );
+		return $this;
+	}
 }

--- a/includes/core/server/request/class-create-intent.php
+++ b/includes/core/server/request/class-create-intent.php
@@ -14,6 +14,7 @@ use WCPay\Core\Server\Request;
  */
 class Create_Intent extends Request {
 	const IMMUTABLE_PARAMS = [ 'amount' ];
+	const REQUIRED_PARAMS  = [ 'amount', 'currency' ];
 
 	/**
 	 * Allows the class to be constructed.

--- a/includes/core/server/request/class-create-intent.php
+++ b/includes/core/server/request/class-create-intent.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Request\Create_Intent.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server\Request;
+
+use WCPay\Core\Server\Request;
+
+/**
+ * Request class for creating intents.
+ */
+class Create_Intent extends Request {
+	/**
+	 * Allows the class to be constructed.
+	 *
+	 * @todo This could be replaced by static methods.
+	 */
+	public function __construct() {
+		// Nothing to do here yet.
+	}
+
+	/**
+	 * Returns the request's API.
+	 *
+	 * @return string
+	 */
+	public function get_api(): string {
+		return 'intents';
+	}
+
+	/**
+	 * Returns the request's HTTP method.
+	 */
+	public function get_method(): string {
+		return 'POST';
+	}
+
+	/**
+	 * Stores the amount for the intent.
+	 *
+	 * @param  int $amount   The amount in ToDo units.
+	 * @return Create_Intent The instance of the class for method chaining.
+	 */
+	final public function set_amount( int $amount ) {
+		// Validation here...
+		$this->set_param( 'amount', $amount );
+		return $this;
+	}
+}

--- a/includes/core/server/request/class-create-intent.php
+++ b/includes/core/server/request/class-create-intent.php
@@ -8,6 +8,7 @@
 namespace WCPay\Core\Server\Request;
 
 use WCPay\Core\Server\Request;
+use WC_Payments_API_Client;
 
 /**
  * Request class for creating intents.
@@ -22,7 +23,7 @@ class Create_Intent extends Request {
 	 * @return string
 	 */
 	public function get_api(): string {
-		return 'intents';
+		return WC_Payments_API_Client::INTENTIONS_API;
 	}
 
 	/**

--- a/includes/core/server/request/class-generic.php
+++ b/includes/core/server/request/class-generic.php
@@ -44,14 +44,31 @@ final class Generic extends Request {
 	 * @param string $method     The request method. See the `Requests` class.
 	 * @param array  $parameters The parameters for the request.
 	 */
-	public function __construct( $api, $method, $parameters = null ) {
+	public function __construct( $api, $method, array $parameters = null ) {
 		$this->api    = $api; // ToDo: Verify.
 		$this->method = $method; // ToDo: Verify.
 
-		if ( $parameters ) {
-			// We'll get to that later.
+		if ( empty( $parameters ) ) {
 			return;
 		}
+
+		foreach ( $parameters as $key => $value ) {
+			$this->set( $key, $value );
+		}
+	}
+
+	/**
+	 * Generic setter for parameters.
+	 *
+	 * @param  string $key   Key of the parameter.
+	 * @param  mixed  $value Value of the parameter.
+	 * @return Generic       Instance of the class for method chaining.
+	 */
+	public function set( $key, $value ) {
+		// Use the `Request` setter here.
+		$this->set_param( $key, $value );
+
+		return $this;
 	}
 
 	/**

--- a/includes/core/server/request/class-generic.php
+++ b/includes/core/server/request/class-generic.php
@@ -16,5 +16,76 @@ use WCPay\Core\Server\Request;
  * it will not be generic anymore, create your own.
  */
 final class Generic extends Request {
+	/**
+	 * The request's API.
+	 *
+	 * @var string Check WCPay\Core\Server\APIs.
+	 */
+	private $api;
 
+	/**
+	 * The method of the request.
+	 *
+	 * @var string See the constants in WordPress's `Requests` class.
+	 */
+	private $method;
+
+	/**
+	 * If true, the request will be signed with the user token rather than blog token. Defaults to false.
+	 *
+	 * @var bool
+	 */
+	private $should_use_user_token = false;
+
+	/**
+	 * Instantiates the request object.
+	 *
+	 * @param string $api        The API to use. See WCPay\Core\Server\APIs.
+	 * @param string $method     The request method. See the `Requests` class.
+	 * @param array  $parameters The parameters for the request.
+	 */
+	public function __construct( $api, $method, $parameters = null ) {
+		$this->api    = $api; // ToDo: Verify.
+		$this->method = $method; // ToDo: Verify.
+
+		if ( $parameters ) {
+			// We'll get to that later.
+		}
+	}
+
+	/**
+	 * Returns the needed API.
+	 *
+	 * @return string
+	 */
+	public function get_api(): string {
+		return $this->api;
+	}
+
+	/**
+	 * Returns the method of the request.
+	 *
+	 * @return string
+	 */
+	public function get_method(): string {
+		return $this->method;
+	}
+
+	/**
+	 * If true, the request will be signed with the user token rather than blog token. Defaults to false.
+	 *
+	 * @return bool
+	 */
+	public function should_use_user_token(): bool {
+		return $this->should_use_user_token;
+	}
+
+	/**
+	 * Sets the request to use the user token.
+	 *
+	 * @return void
+	 */
+	public function use_user_token() {
+		$this->should_use_user_token = true;
+	}
 }

--- a/includes/core/server/request/class-generic.php
+++ b/includes/core/server/request/class-generic.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Request\Generic.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server\Request;
+
+use WCPay\Core\Server\Request;
+
+/**
+ * Generic WCPay Server Request.
+ *
+ * This class is not extendable, if you need something specific,
+ * it will not be generic anymore, create your own.
+ */
+final class Generic extends Request {
+
+}

--- a/includes/core/server/request/class-generic.php
+++ b/includes/core/server/request/class-generic.php
@@ -50,6 +50,7 @@ final class Generic extends Request {
 
 		if ( $parameters ) {
 			// We'll get to that later.
+			return;
 		}
 	}
 

--- a/includes/core/server/request/class-generic.php
+++ b/includes/core/server/request/class-generic.php
@@ -7,7 +7,9 @@
 
 namespace WCPay\Core\Server\Request;
 
+use Exception;
 use WCPay\Core\Server\Request;
+use Requests;
 
 /**
  * Generic WCPay Server Request.
@@ -38,23 +40,37 @@ final class Generic extends Request {
 	private $should_use_user_token = false;
 
 	/**
+	 * Creates a new instance of the class.
+	 *
+	 * @throws \Exception
+	 */
+	public static function create() {
+		throw new \Exception( 'Generic requests should be constructed normally using the `new` keyword.' );
+	}
+
+	/**
 	 * Instantiates the request object.
 	 *
-	 * @param string $api        The API to use. See WCPay\Core\Server\APIs.
-	 * @param string $method     The request method. See the `Requests` class.
-	 * @param array  $parameters The parameters for the request.
+	 * @param  string $api        The API to use. See WCPay\Core\Server\APIs.
+	 * @param  string $method     The request method. See the `Requests` class.
+	 * @param  array  $parameters The parameters for the request.
+	 * @throws \Exception         An exception if there are invalid properties.
 	 */
-	public function __construct( $api, $method, array $parameters = null ) {
-		$this->api    = $api; // ToDo: Verify.
-		$this->method = $method; // ToDo: Verify.
-
-		if ( empty( $parameters ) ) {
-			return;
+	public function __construct( string $api, string $method, array $parameters = null ) {
+		if ( ! defined( 'Requests::' . $method ) ) {
+			throw new \Exception( 'Invalid generic request method' );
 		}
 
-		foreach ( $parameters as $key => $value ) {
-			$this->set( $key, $value );
+		$this->api    = $api;
+		$this->method = $method;
+
+		if ( ! empty( $parameters ) ) {
+			foreach ( $parameters as $key => $value ) {
+				$this->set( $key, $value );
+			}
 		}
+
+		return $this;
 	}
 
 	/**

--- a/includes/core/server/request/class-woopay-create-and-confirm-intention.php
+++ b/includes/core/server/request/class-woopay-create-and-confirm-intention.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Request\Create_And_Confirm_Intention.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server\Request;
+
+/**
+ * Request class for creating intents.
+ */
+class WooPay_Create_And_Confirm_Intention extends Create_And_Confirm_Intention {
+	const DEFAULTS = [
+		'is_platform_payment_method' => false,
+		'woopay_has_subscription'    => false,
+	];
+
+	/**
+	 * Toggles the flag, which indicates that this is a platform payment method.
+	 *
+	 * @param bool $is Whether it is indeed a platform payment method (Optional).
+	 * @return static  An instance of the class, ready for method chaining.
+	 */
+	public function set_is_platform_payment_method( $is = true ) {
+		$this->set_param( 'is_platform_payment_method', $is );
+		return $this;
+	}
+
+	/**
+	 * Toggles the flag, which indicates that there is a WooPay subscription.
+	 *
+	 * @param bool $has Whether there is a subscription (Optional).
+	 * @return static   An instance of the class, ready for method chaining.
+	 */
+	public function set_has_woopay_subscription( $has = true ) {
+		$this->set_param( 'woopay_has_subscription', $has );
+		return $this;
+	}
+}

--- a/includes/core/server/request/class-woopay-create-intent.php
+++ b/includes/core/server/request/class-woopay-create-intent.php
@@ -11,6 +11,8 @@ namespace WCPay\Core\Server\Request;
  * Extended create intent request for WooPay.
  */
 class WooPay_Create_Intent extends Create_Intent {
+	const IMMUTABLE_PARAMS = [ 'save_payment_method_to_platform' ];
+
 	/**
 	 * Indicates whether the payment method needs to be stored with the platform.
 	 *

--- a/includes/core/server/request/class-woopay-create-intent.php
+++ b/includes/core/server/request/class-woopay-create-intent.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Request\WooPay_Create_Intent.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server\Request;
+
+/**
+ * Extended create intent request for WooPay.
+ */
+class WooPay_Create_Intent extends Create_Intent {
+	/**
+	 * Indicates whether the payment method needs to be stored with the platform.
+	 *
+	 * @param  bool $toggle         Whether to toggle the flag.
+	 * @return WooPay_Create_Intent The instance of the class for method chaining.
+	 */
+	public function set_save_payment_method_to_platform( bool $toggle ) {
+		$this->set_param( 'save_payment_method_to_platform', $toggle );
+		return $this;
+	}
+}

--- a/includes/core/server/request/trait-intention.php
+++ b/includes/core/server/request/trait-intention.php
@@ -53,7 +53,7 @@ trait Intention {
 	 * @return integer|NULL Current WPCOM blog ID, or NULL if not connected yet.
 	 */
 	private function get_blog_id() {
-		return $this->is_server_connected() ? WC_Payments::get_wc_payments_http()->get_blog_id() : null;
+		return $this->is_server_connected() ? $this->http_interface->get_blog_id() : null;
 	}
 
 	/**
@@ -62,6 +62,6 @@ trait Intention {
 	 * @return bool
 	 */
 	private function is_server_connected() {
-		return WC_Payments::get_wc_payments_http()->is_connected();
+		return $this->http_interface->is_connected();
 	}
 }

--- a/includes/core/server/request/trait-intention.php
+++ b/includes/core/server/request/trait-intention.php
@@ -11,7 +11,7 @@ use WCPay\Fraud_Prevention\Buyer_Fingerprinting_Service;
 use WC_Payments;
 
 /**
- * Request class for creating intents.
+ * Trait for intention helpers.
  */
 trait Intention {
 	/**

--- a/includes/core/server/request/trait-intention.php
+++ b/includes/core/server/request/trait-intention.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Trait file for WCPay\Core\Server\Request\Intention.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server\Request;
+
+use WCPay\Fraud_Prevention\Buyer_Fingerprinting_Service;
+use WC_Payments;
+
+/**
+ * Request class for creating intents.
+ */
+trait Intention {
+	/**
+	 * Returns a list of fingerprinting metadata to attach to order.
+	 *
+	 * @return array List of fingerprinting metadata.
+	 *
+	 * @throws API_Exception If an error occurs.
+	 */
+	private function get_fingerprint_metadata(): array {
+		$customer_fingerprint_metadata                                    = Buyer_Fingerprinting_Service::get_instance()->get_hashed_data_for_customer();
+		$customer_fingerprint_metadata['fraud_prevention_data_available'] = true;
+
+		return $customer_fingerprint_metadata;
+	}
+
+	/**
+	 * Returns a formatted intention description.
+	 *
+	 * @param  string $order_number The order number (might be different from the ID).
+	 * @return string               A formatted intention description.
+	 */
+	private function get_intent_description( $order_number ): string {
+		$domain_name = str_replace( [ 'https://', 'http://' ], '', get_site_url() );
+		$blog_id     = $this->get_blog_id();
+
+		// Forgo i18n as this is only visible in the Stripe dashboard.
+		return sprintf(
+			'Online Payment%s for %s%s',
+			0 !== $order_number ? " for Order #$order_number" : '',
+			$domain_name,
+			null !== $blog_id ? " blog_id $blog_id" : ''
+		);
+	}
+
+	/**
+	 * Gets the current WP.com blog ID, if the Jetpack connection has been set up.
+	 *
+	 * @return integer|NULL Current WPCOM blog ID, or NULL if not connected yet.
+	 */
+	private function get_blog_id() {
+		return $this->is_server_connected() ? WC_Payments::get_wc_payments_http()->get_blog_id() : null;
+	}
+
+	/**
+	 * Whether the site can communicate with the WCPay server (i.e. Jetpack connection has been established).
+	 *
+	 * @return bool
+	 */
+	private function is_server_connected() {
+		return WC_Payments::get_wc_payments_http()->is_connected();
+	}
+}

--- a/includes/core/server/request/trait-intention.php
+++ b/includes/core/server/request/trait-intention.php
@@ -8,7 +8,6 @@
 namespace WCPay\Core\Server\Request;
 
 use WCPay\Fraud_Prevention\Buyer_Fingerprinting_Service;
-use WC_Payments;
 
 /**
  * Trait for intention helpers.

--- a/includes/core/server/request/trait-level3.php
+++ b/includes/core/server/request/trait-level3.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Trait file for WCPay\Core\Server\Request\Intention.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server\Request;
+
+/**
+ * Tait for fixing intentions' level 3 data.
+ */
+trait Level3 {
+	/**
+	 * Fixes level 3 data data inconsistencies.
+	 *
+	 * @param  array $data The available level 3 data.
+	 * @return array       The fixed level 3 data.
+	 */
+	private function fix_level3_data( array $data ) {
+		// If level3 data doesn't contain any items, add a zero priced fee to meet Stripe's requirement.
+		if (
+			! isset( $data['line_items'] )
+			|| ! is_array( $data['line_items'] )
+			|| 0 === count( $data['line_items'] )
+		) {
+			$data['line_items'] = [
+				[
+					'discount_amount'     => 0,
+					'product_code'        => 'empty-order',
+					'product_description' => 'The order is empty',
+					'quantity'            => 1,
+					'tax_amount'          => 0,
+					'unit_cost'           => 0,
+				],
+			];
+		}
+
+		return $data;
+	}
+}
+
+

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -16,6 +16,8 @@ use Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore;
 use WCPay\Payment_Methods\Link_Payment_Method;
 use WCPay\Payment_Methods\CC_Payment_Method;
 use WCPay\Database_Cache;
+use WCPay\Core\Server\Request;
+use WCPay\Core\Server\Response;
 
 /**
  * Communicates with WooCommerce Payments API.
@@ -1971,10 +1973,10 @@ class WC_Payments_API_Client {
 	/**
 	 * Sends a request object.
 	 *
-	 * @param \WCPay\Core\Server\Request $request The request to send.
-	 * @return \WCPay\Core\Server\Response A response object.
+	 * @param  Request $request The request to send.
+	 * @return Response         A response object.
 	 */
-	public function send_request( \WCPay\Core\Server\Request $request ) {
+	public function send_request( Request $request ) {
 		return $request->format_response(
 			$this->request(
 				$request->get_params(),
@@ -1991,13 +1993,14 @@ class WC_Payments_API_Client {
 	 * Temporary method for level3 data requests.
 	 *
 	 * @todo Replace this method with something more meangingful.
-	 * @param \WCPay\Core\Server\Request $request The request to send.
-	 * @return \WCPay\Core\Server\Response A response object.
+	 * @param  Request $request The request to send.
+	 * @return Response         A response object.
 	 */
-	public function send_request_with_level3_data( \WCPay\Core\Server\Request $request ) {
+	public function send_request_with_level3_data( Request $request ) {
+		$params = $request->get_params();
 		return $request->format_response(
 			$this->request_with_level3_data(
-				$request->get_params(),
+				$params,
 				$request->get_api(),
 				$request->get_method(),
 				$request->is_site_specific(),

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1975,13 +1975,15 @@ class WC_Payments_API_Client {
 	 * @return mixed
 	 */
 	public function send_request( \WCPay\Core\Server\Request $request ) {
-		return $this->request(
-			$request->get_params(),
-			$request->get_api(),
-			$request->get_method(),
-			$request->is_site_specific(),
-			$request->should_use_user_token(),
-			$request->should_return_raw_response()
+		return $request->format_response(
+			$this->request(
+				$request->get_params(),
+				$request->get_api(),
+				$request->get_method(),
+				$request->is_site_specific(),
+				$request->should_use_user_token(),
+				$request->should_return_raw_response()
+			)
 		);
 	}
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1969,6 +1969,23 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Sends a request object.
+	 *
+	 * @param \WCPay\Core\Server\Request $request The request to send.
+	 * @return mixed
+	 */
+	public function send_request( \WCPay\Core\Server\Request $request ) {
+		return $this->request(
+			$request->get_params(),
+			$request->get_api(),
+			$request->get_method(),
+			$request->is_site_specific(),
+			$request->should_use_user_token(),
+			$request->should_return_raw_response()
+		);
+	}
+
+	/**
 	 * Send the request to the WooCommerce Payment API
 	 *
 	 * @param array  $params           - Request parameters to send as either JSON or GET string. Defaults to test_mode=1 if either in dev or test mode, 0 otherwise.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1989,26 +1989,6 @@ class WC_Payments_API_Client {
 		);
 	}
 
-	/**
-	 * Temporary method for level3 data requests.
-	 *
-	 * @todo Replace this method with something more meangingful.
-	 * @param  Request $request The request to send.
-	 * @return Response         A response object.
-	 */
-	public function send_request_with_level3_data( Request $request ) {
-		$params = $request->get_params();
-		return $request->format_response(
-			$this->request_with_level3_data(
-				$params,
-				$request->get_api(),
-				$request->get_method(),
-				$request->is_site_specific(),
-				$request->should_use_user_token(),
-				$request->should_return_raw_response()
-			)
-		);
-	}
 
 	/**
 	 * Send the request to the WooCommerce Payment API

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1977,18 +1977,15 @@ class WC_Payments_API_Client {
 	 * @return Response         A response object.
 	 */
 	public function send_request( Request $request ) {
-		return $request->format_response(
-			$this->request(
-				$request->get_params(),
-				$request->get_api(),
-				$request->get_method(),
-				$request->is_site_specific(),
-				$request->should_use_user_token(),
-				$request->should_return_raw_response()
-			)
+		return $this->request(
+			$request->get_params(),
+			$request->get_api(),
+			$request->get_method(),
+			$request->is_site_specific(),
+			$request->should_use_user_token(),
+			$request->should_return_raw_response()
 		);
 	}
-
 
 	/**
 	 * Send the request to the WooCommerce Payment API

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1988,6 +1988,26 @@ class WC_Payments_API_Client {
 	}
 
 	/**
+	 * Temporary method for level3 data requests.
+	 *
+	 * @todo Replace this method with something more meangingful.
+	 * @param \WCPay\Core\Server\Request $request The request to send.
+	 * @return \WCPay\Core\Server\Response A response object.
+	 */
+	public function send_request_with_level3_data( \WCPay\Core\Server\Request $request ) {
+		return $request->format_response(
+			$this->request_with_level3_data(
+				$request->get_params(),
+				$request->get_api(),
+				$request->get_method(),
+				$request->is_site_specific(),
+				$request->should_use_user_token(),
+				$request->should_return_raw_response()
+			)
+		);
+	}
+
+	/**
 	 * Send the request to the WooCommerce Payment API
 	 *
 	 * @param array  $params           - Request parameters to send as either JSON or GET string. Defaults to test_mode=1 if either in dev or test mode, 0 otherwise.
@@ -2437,7 +2457,7 @@ class WC_Payments_API_Client {
 	 * @return WC_Payments_API_Intention
 	 * @throws API_Exception - Unable to deserialize intention array.
 	 */
-	private function deserialize_intention_object_from_array( array $intention_array ) {
+	public function deserialize_intention_object_from_array( array $intention_array ) {
 		// TODO: Throw an exception if the response array doesn't contain mandatory properties.
 		$created = new DateTime();
 		$created->setTimestamp( $intention_array['created'] );

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1972,7 +1972,7 @@ class WC_Payments_API_Client {
 	 * Sends a request object.
 	 *
 	 * @param \WCPay\Core\Server\Request $request The request to send.
-	 * @return mixed
+	 * @return \WCPay\Core\Server\Response A response object.
 	 */
 	public function send_request( \WCPay\Core\Server\Request $request ) {
 		return $request->format_response(


### PR DESCRIPTION
Alternative approach/Fixes #4954 and #5056.

## Changes proposed in this Pull Request

Adding a base set of request (and a very basic response as a placeholder) classes.

> **This PR includes examples!**
> Check out [includes/core/server/class-temp-request-examples.php](https://github.com/Automattic/woocommerce-payments/pull/5124/files#diff-c94d03fbf684a3218266ae652189248b0b7b032f9cde0643e0b0a5d1de3b918f) to see them.
> The front-end will show the output. Use http://localhost:8082/?show_basic_examples to see it.

There is a new `WCPay\Core\Server\Request` class:
- It is abstract, but can be:
    - Used through `WCPay\Core\Server\Request\Generic`, allowing for existing requests to be wrapped and moved to the `send_request` method of the API client. This class does not have any validation, or additional structure right now.
    - Extended by specific requests, ex. `WCPay\Core\Server\Request\Create_Intent`.
- Uses an internal `$props` array, to privately store all needed values.
- Has abstract/default methods for APIs, HTTP methods, and generic request flags (is site specific, etc.)
- Contains the necessary logic in `get_params()` to ensure that all required parameters are set. Those can be defined as a `IMMUTABLE_PARAMS` constant in child classes, and the constant is retrieved from each individual class to ensure that child classes are not overwriting protected values.
- A `format_response` method, which in the future can be overwritten to return specific responses in child classes.
- A protected `set_param` method, which can be used by inheritants to modify the internal `$params` array.
- Introduces protected mode, which makes it impossible to alter existing protected parameters. This is useful when the class is process through hooks.
- A static `extend` method, which can be used through extended classes to create a new instance, which already contains the same values as the parent object. It is only available when using the `apply_filters` method (see below).

Examples of how the class can be extended can be found in the `Create_Intent` and `WooPay_Create_intent` classes.

**Here is the important part:**

Some details about the `apply_filters` and `extend` methods. `extend` can only be called through `apply_filters`, here is how it cal be called:

```php
<?php
// Imagine you are somewhere in the gateway's `process_payment` method:
$request = WC_Payments::create_request( WCPay\Core\Server\Request\Create_Intent::class )
    ->set_amount( 100 )
    ->set_currency( 'eur' );

// Once everything is prepared, allow modifications. This will also check if all required fields are present. Note that just like the normal `apply_filters`, the method supports an arbitrary number of parameters:
$some_additional_field = 'xyz';
$response = $request->send( 'wcpay_create_intent_request', $some_additional_field ); 
```
 
Once the request is created, this allows it to be safely modified and extended. Here is an example:

```php
add_filter( 'wcpay_create_intent_request', 'woopay_modify_create_intent', 10, 2 );
function woopay_modify_create_intent( WCPay\Core\Server\Request\Create_Intent $base_request, $some_additional_field ): WCPay\Core\Server\Request\WooPay_Create_Intent {
    echo $some_additional_field; // Don't do that, the point is it's available.

    $request = WCPay\Core\Server\Request\WooPay_Create_Intent::extend( $base_request );
    $request->set_save_payment_method_to_platform( true );
    $request->set_amount( 300 ); // This will throw an exception, as the amount is protected.
    return $request;
}
```

Required implementation for request-specific classes includes (except the class skeleton):
1. An `IMMUTABLE_PARAMS` constant, if required.
2. A `REQUIRED_PARAMS` constant for defining required fields.
3. One setter for each prop.

A nice side-effect of the way requests can be overwritten by consumers (example above) is that we do not need a specific method for each request within the API client class, as there would be no possibility to overwrite the type of request before it reaches the `send_request` method.

### Closed Tasks:

- [x] [Make sure all parameters are set](https://github.com/Automattic/woocommerce-payments/pull/5124/commits/c9e14b9d588bd28f540766c38a48ac2e2ab8e16c).
- [x] ~Should any parameters be overwritable?~ Mutable properties can just be overwritten.
- [x] Make sure the generic class can be easily used a replacement of what's currently there: Tried it within a couple of basic requests, it works, but is not commited.
- [x] ~Check if the generic class can be extended similarly to specific classes.~ It does not need to be extended, all params can be changed already.
- [x] [Decide how to instantiate requests.](https://github.com/Automattic/woocommerce-payments/pull/5124/commits/49170a83303cf7a2e5d26d8e70104972f9e51dce)
- [x] [Handle boolean variables properly](https://github.com/Automattic/woocommerce-payments/pull/5124/commits/615dfec60c3afddae3eb177c8abfed10e78dd603).
- [x] [Handle level3 data in the right place](https://github.com/Automattic/woocommerce-payments/pull/5124/commits/a977affe7a9733a45f3f3a476611a70de78f22dd).
- [x] [Update the docs of `apply_filters`.](https://github.com/Automattic/woocommerce-payments/pull/5124/commits/91d10f3939d6e6f1a867f84572ab3fccf27b1997)
- [x] [Restore the unique keys.](https://github.com/Automattic/woocommerce-payments/pull/5124/commits/49170a83303cf7a2e5d26d8e70104972f9e51dce)
- [x] [Add proper dependencies](https://github.com/Automattic/woocommerce-payments/pull/5124/commits/49170a83303cf7a2e5d26d8e70104972f9e51dce)
- [x] Revisit the `Intention` trait: The code is pretty clear, and does not seem to require changes.
- [x] [Rethink the create_and_confirm intention calls while adding validation and helpers](https://github.com/Automattic/woocommerce-payments/pull/5124/commits/ef10ff85f66961312a7c1ba7bdfd93dc46dd7668?diff=split&w=0).
- [x] [Require a key within the `send_request` method for the filter to avoid doing it manually](https://github.com/Automattic/woocommerce-payments/pull/5124/commits/e2933240c2c1b0b62deb39c124e3b8260c04b41d).
- [x] [Remove dependencies on the HTTP client, and make `WC_payments::get_wc_payments_http()` private again.](https://github.com/Automattic/woocommerce-payments/pull/5124/commits/49170a83303cf7a2e5d26d8e70104972f9e51dce)

### Remaining tasks

Here is a list of open tasks for the PR:

#### Responses

Currently theis is a basic [`WCPay\Core\Server\Response` class](https://github.com/Automattic/woocommerce-payments/blob/spike/rado-request-classes/includes/core/server/class-response.php), which simply wraps a successfull response.

**This PR should not focus on responses (it's way too huge already)**, but while creating a base to rewrite request methods, we should make sure that we also have a solid base to build upon for responses later.

Main point: Currently we're still using a lot of functionality from the API client class, but that seems to have attracted a lot of quick & kind-of-dirty solutions like response formatting (examine charges and intentions). This functionality includes error handling (converting errors to exceptions), which should remain in the API client class until we remove all request methods from the class, but we need to make sure that it would be easy for us to move it into the `Response` class later.

This is not something we want to do yet, but currently intents and charges are being "deserialized" (turned into DTOs) within the API client class. Consider what dependencies/actions/filters will be required in order to extract this functionality into custom `format_response` request methods.

In the end, we should have the right infrastructure in place in the PR, then create another PR/issue to implement everything described here.

#### Extract WooPay code to the right place

There is already a working [`WCPay\Core\Server\Request\WooPay_Create_And_Confirm_Intention` request class](https://github.com/Automattic/woocommerce-payments/pull/5124/commits/6e1bf4b23ca55cd7bc342b39467b1bc6577ba85d) in this PR, but the WooPay code, which prepares the parameters for the request [still lives within the gateway class](https://github.com/Automattic/woocommerce-payments/blob/spike/rado-request-classes/includes/class-wc-payment-gateway-wcpay.php#L989-L990).

We need to figure out where to place that code, and how to link it. This could be a follow-up PR, based on this branch as well.

#### Use the right exceptions

Right now the PR is using a generic `\Exception` everywhere, this should be replaced with appropriate exception classes, and translatable messages.

#### Use ENUMs wherever possible

 I'm not sure where else/how we could use enums here:

 - It's hard to validate APIs, as we're receiving the raw API, which we cannot correlate back to a constant.
 - Request methods are validated already, and using ENUM.

Let's take a final look to make sure there are no missed opportunities.

#### Add unit tests and docs

Biggest task so far, yet pretty self-explanatory.

## Testing instructions

Two options right now:

- Check examples
- Perform a standard payment to see the `Create_And_Confirm_Intention` and `WooPay_Create_And_Confirm_Intention` requests in action.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)
