### PR TITLE
fixed problem that would not close the redirect iframe after clicking the back button on safari

### DIFF
--- a/changelog/fix-5113-safari-iframe-not-closing
+++ b/changelog/fix-5113-safari-iframe-not-closing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Redirect modal not closing when customer clicks back button on safari

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -604,6 +604,13 @@ export const handlePlatformCheckoutEmailInput = async (
 		}
 	} );
 
+	window.addEventListener( 'pageshow', function ( event ) {
+		if ( event.persisted ) {
+			// Safari needs to close iframe with this.
+			closeIframe( false );
+		}
+	} );
+
 	if ( ! customerClickedBackButton ) {
 		// Check if user already has a WooPay login session.
 		if ( ! hasCheckedLoginSession ) {


### PR DESCRIPTION
Fixes #5113

#### Changes proposed in this Pull Request
This PR adds a listener to make sure the redirect modal gets closed when a customer clicks the safari back button.

#### Testing instructions
- Test on Safari
- Add a product to your cart and checkout using WooPay
- When you get to the WooPay checkout click the WooPay back button
- Make sure you do **not** get redirected back to WooPay
- Make sure the redirect modal does not show up
*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
