### PR TITLE
Fixes purchasing a synced subscription with WCPay Subscriptions results in an unsynced subscription

### DIFF
--- a/changelog/subscriptions-core-2.5.2
+++ b/changelog/subscriptions-core-2.5.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Purchasing a synced subscription with WCPay Subscriptions correctly sets the next payment date to the sync date in Stripe.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
       "automattic/jetpack-sync": "1.30.5",
       "automattic/jetpack-tracking": "1.14.5",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "2.5.1"
+      "woocommerce/subscriptions-core": "2.5.2"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7ffeabffefb091ca89ba126afcb7ae7",
+    "content-hash": "fbeb3ac66b23050530cfda3e06393b3f",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1060,16 +1060,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "2.5.1",
+            "version": "2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "0e2633b0f254ff08a860dcf64b66b10c5cc8b7e4"
+                "reference": "3a347e2549fadfb691673e15c4050df84c7fe9a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/0e2633b0f254ff08a860dcf64b66b10c5cc8b7e4",
-                "reference": "0e2633b0f254ff08a860dcf64b66b10c5cc8b7e4",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/3a347e2549fadfb691673e15c4050df84c7fe9a7",
+                "reference": "3a347e2549fadfb691673e15c4050df84c7fe9a7",
                 "shasum": ""
             },
             "require": {
@@ -1110,10 +1110,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.5.1",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.5.2",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-11-04T07:37:07+00:00"
+            "time": "2022-11-15T09:19:48+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Fixes #5131 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In WooCommerce Payments 5.0 we released a bug where the Stripe Billing subscription weren't properly setting the next payment date to the sync date.

After investigation, this was caused by the `WC_Payments_Subscription_Service::has_delayed_payment()` function being passed an older subscription object which didn't have the synced meta saved on it (happens during the checkout create subscription process) and therefore calling `$subscription->get_meta( '_contains_synced_subscription' )` was returning incorrect information.

To fix this and potentially other issues, we have updated our `subscriptions-core` library to make sure our `WC_Subscriptions_Checkout::create_subscription()` function is fetching the latest copy of the subscription from the database after calling `$subscription->save()`.

#### Testing instructions

1. Make sure WC Subscriptions plugin is disabled and WCPay Subscriptions is enabled.
2. While on trunk of Subscriptions Core, purchase a synced subscription with WC Payments. In my tests, I purchased a subscription that is synced to the 1st of the month.
3. Check the subscription in Stripe Billing and confirm there's no trial period and the next payment date is not set correctly.
![image](https://user-images.githubusercontent.com/2275145/201841167-82ee290d-fe60-442b-bf51-5df00cd723bb.png)
4. Checkout this branch
5. Purchase a synced subscription with WC Payments again
6. Check the subscription in Stripe Billing and confirm there's a trial end period and the next payment date aligns with the sync date.

![image](https://user-images.githubusercontent.com/2275145/201848407-d3e44c3f-7c8f-49e0-8739-b4161b45c595.png)

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
