### PR TITLE
Prevent the double-zip issue when downloading from zip file workflow

### DIFF
--- a/.github/workflows/build-zip-file.yml
+++ b/.github/workflows/build-zip-file.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: "Unzip the file (prevents double zip issue)"
         run: |
-          echo ":information_source: Unzipping the zip file to a folder. This is to prevent a double-zip issue ([known limitation](https://github.com/actions/upload-artifact#zipped-artifact-downloads)). The increase of the artefact's size is expected since we're uploading the folder instead of a zip." >> $GITHUB_STEP_SUMMARY
+          echo ":information_source: Unzipping to a folder to prevent double-zip issue ([known limitation](https://github.com/actions/upload-artifact#zipped-artifact-downloads)). Increase in artifact size is expected since we're uploading the folder." >> $GITHUB_STEP_SUMMARY
           unzip ${{ steps.build_plugin.outputs.release-filename }} -d zipfile
       
       - name: "Upload the zip file as an artifact"

--- a/.github/workflows/build-zip-file.yml
+++ b/.github/workflows/build-zip-file.yml
@@ -21,9 +21,8 @@ jobs:
 
       - name: "Unzip the file (prevents double zip issue)"
         run: |
-          echo ":information_source: Unzipping the zip file to a folder. This is to prevent a double-zip issue (known limitation: https://github.com/actions/upload-artifact#zipped-artifact-downloads)" >> $GITHUB_STEP_SUMMARY
+          echo ":information_source: Unzipping the zip file to a folder. This is to prevent a double-zip issue ([known limitation](https://github.com/actions/upload-artifact#zipped-artifact-downloads)). The increase of the artefact's size is expected since we're uploading the folder instead of a zip." >> $GITHUB_STEP_SUMMARY
           unzip ${{ steps.build_plugin.outputs.release-filename }} -d zipfile
-          echo ":warning: Uploading the folder instead of the built zip. Don't worry about the artefact's size. Check the downloaded zip's size instead." >> $GITHUB_STEP_SUMMARY
       
       - name: "Upload the zip file as an artifact"
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-zip-file.yml
+++ b/.github/workflows/build-zip-file.yml
@@ -18,6 +18,12 @@ jobs:
       - name: "Build the plugin"
         id: build_plugin
         uses: ./.github/actions/build
+
+      - name: "Unzip the file (prevents double zip issue)"
+        run: |
+          echo ":information_source: Unzipping the zip file to a folder. This is to prevent a double-zip issue (known limitation: https://github.com/actions/upload-artifact#zipped-artifact-downloads)" >> $GITHUB_STEP_SUMMARY
+          unzip ${{ steps.build_plugin.outputs.release-filename }} -d zipfile
+          echo ":warning: Uploading the folder instead of the built zip. Don't worry about the artefact's size. Check the downloaded zip's size instead." >> $GITHUB_STEP_SUMMARY
       
       - name: "Upload the zip file as an artifact"
         uses: actions/upload-artifact@v3
@@ -25,5 +31,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           name: "woocommerce-payments"
-          path: ${{ steps.build_plugin.outputs.release-filename }}
+          path: zipfile
           retention-days: 7

--- a/changelog/fix-prevent-double-zip-issue-for-workflow
+++ b/changelog/fix-prevent-double-zip-issue-for-workflow
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Just a minor fix in a github workflow
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Downloading the artifact from the [build-zip-file workflow](https://github.com/Automattic/woocommerce-payments/blob/develop/.github/workflows/build-zip-file.yml) results in a double-zip, which prevents us from easily using that downloaded zip in a test site (error: `The package could not be installed. No valid plugins were found. Plugin installation failed`).

Why?
- We upload the built zip using the `actions/upload-artifact@v3` action
- When clicking on the GitHub UI to download the artifact, a zip file is automatically generated with the content that was uploaded

This is explained here: https://github.com/actions/upload-artifact#zipped-artifact-downloads

Unzipping the built zip to a temporary folder called `zipfile` and uploading that folder instead solves this issue.
The only downside with that approach is that we will see a large size for the artifact (like 12MB), which can scare someone that is used to seeing something around 5MB for the zip file. This is also why I added a comment in the summary to explain this.

See the latest run to confirm you can upload directly what you are downloading from the artifacts: https://github.com/Automattic/woocommerce-payments/actions/runs/3470087644

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
