### PR TITLE
WooPay express checkout button on blocks checkout

### DIFF
--- a/changelog/task-1409-express-checkout-button-on-blocks-checkout
+++ b/changelog/task-1409-express-checkout-button-on-blocks-checkout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added support for a WooPay express checkout button on checkout blocks. This feature is currently behind a feature flag and is not yet publicly available.

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -53,12 +53,13 @@ registerPaymentMethod( {
 
 registerExpressPaymentMethod( paymentRequestPaymentMethod( api ) );
 
-// If platform checkout is enabled and this is the checkout page.
-if (
-	getConfig( 'isPlatformCheckoutEnabled' ) &&
-	document.querySelector( '[data-block-name="woocommerce/checkout"]' )
-) {
-	handlePlatformCheckoutEmailInput( '#email', api, true );
+if ( getConfig( 'isPlatformCheckoutEnabled' ) ) {
+	// Call handlePlatformCheckoutEmailInput if platform checkout is enabled and this is the checkout page.
+	if (
+		document.querySelector( '[data-block-name="woocommerce/checkout"]' )
+	) {
+		handlePlatformCheckoutEmailInput( '#email', api, true );
+	}
 	if ( getConfig( 'isWoopayExpressCheckoutEnabled' ) ) {
 		registerExpressPaymentMethod( wooPayExpressCheckoutPaymentMethod() );
 	}

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -22,6 +22,7 @@ import request from '../utils/request';
 import enqueueFraudScripts from 'fraud-scripts';
 import paymentRequestPaymentMethod from '../../payment-request/blocks';
 import { handlePlatformCheckoutEmailInput } from '../platform-checkout/email-input-iframe';
+import wooPayExpressCheckoutPaymentMethod from '../platform-checkout/express-button/woopay-express-checkout-payment-method';
 
 // Create an API object, which will be used throughout the checkout.
 const api = new WCPayAPI(
@@ -54,6 +55,9 @@ registerExpressPaymentMethod( paymentRequestPaymentMethod( api ) );
 
 if ( getConfig( 'isPlatformCheckoutEnabled' ) ) {
 	handlePlatformCheckoutEmailInput( '#email', api, true );
+	if ( getConfig( 'isWoopayExpressCheckoutEnabled' ) ) {
+		registerExpressPaymentMethod( wooPayExpressCheckoutPaymentMethod() );
+	}
 }
 
 window.addEventListener( 'load', () => {

--- a/client/checkout/constants.js
+++ b/client/checkout/constants.js
@@ -6,4 +6,6 @@ export const PAYMENT_METHOD_NAME_SOFORT = 'woocommerce_payments_sofort';
 export const PAYMENT_METHOD_NAME_UPE = 'woocommerce_payments_upe';
 export const PAYMENT_METHOD_NAME_PAYMENT_REQUEST =
 	'woocommerce_payments_payment_request';
+export const PAYMENT_METHOD_NAME_WOOPAY_EXPRESS_CHECKOUT =
+	'woocommerce_payments_woopay_express_checkout';
 export const WC_STORE_CART = 'wc/store/cart';

--- a/client/checkout/platform-checkout/express-button/woopay-express-checkout-payment-method.js
+++ b/client/checkout/platform-checkout/express-button/woopay-express-checkout-payment-method.js
@@ -16,6 +16,7 @@ const wooPayExpressCheckoutPaymentMethod = () => ( {
 	edit: (
 		<WoopayExpressCheckoutButton
 			buttonSettings={ wcpayWooPayExpressParams?.button }
+			isPreview={ true }
 		/>
 	),
 	canMakePayment: () => true,

--- a/client/checkout/platform-checkout/express-button/woopay-express-checkout-payment-method.js
+++ b/client/checkout/platform-checkout/express-button/woopay-express-checkout-payment-method.js
@@ -1,0 +1,28 @@
+/* global wcpayWooPayExpressParams */
+/**
+ * Internal dependencies
+ */
+import { PAYMENT_METHOD_NAME_WOOPAY_EXPRESS_CHECKOUT } from '../../constants';
+import { WoopayExpressCheckoutButton } from './woopay-express-checkout-button';
+import { getConfig } from '../../../utils/checkout';
+
+const wooPayExpressCheckoutPaymentMethod = () => ( {
+	name: PAYMENT_METHOD_NAME_WOOPAY_EXPRESS_CHECKOUT,
+	content: (
+		<WoopayExpressCheckoutButton
+			buttonSettings={ wcpayWooPayExpressParams?.button }
+		/>
+	),
+	edit: (
+		<WoopayExpressCheckoutButton
+			buttonSettings={ wcpayWooPayExpressParams?.button }
+		/>
+	),
+	canMakePayment: () => true,
+	paymentMethodId: PAYMENT_METHOD_NAME_WOOPAY_EXPRESS_CHECKOUT,
+	supports: {
+		features: getConfig( 'features' ),
+	},
+} );
+
+export default wooPayExpressCheckoutPaymentMethod;

--- a/client/checkout/platform-checkout/style.scss
+++ b/client/checkout/platform-checkout/style.scss
@@ -138,6 +138,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	white-space: nowrap;
 
 	svg {
 		fill: $studio-woocommerce-purple-60;

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -115,6 +115,7 @@ class WC_Payments_Checkout {
 			'isUPEEnabled'                   => WC_Payments_Features::is_upe_enabled(),
 			'isSavedCardsEnabled'            => $this->gateway->is_saved_cards_enabled(),
 			'isPlatformCheckoutEnabled'      => $this->platform_checkout_util->should_enable_platform_checkout( $this->gateway ),
+			'isWoopayExpressCheckoutEnabled' => $this->platform_checkout_util->is_woopay_express_checkout_enabled(),
 			'isClientEncryptionEnabled'      => WC_Payments_Features::is_client_secret_encryption_enabled(),
 			'platformCheckoutHost'           => defined( 'PLATFORM_CHECKOUT_FRONTEND_HOST' ) ? PLATFORM_CHECKOUT_FRONTEND_HOST : 'https://pay.woo.com',
 			'platformTrackerNonce'           => wp_create_nonce( 'platform_tracks_nonce' ),

--- a/includes/platform-checkout/class-platform-checkout-utilities.php
+++ b/includes/platform-checkout/class-platform-checkout-utilities.php
@@ -31,6 +31,15 @@ class Platform_Checkout_Utilities {
 	}
 
 	/**
+	 * Check conditions to determine if woopay express checkout is enabled.
+	 *
+	 * @return boolean
+	 */
+	public function is_woopay_express_checkout_enabled() {
+		return WC_Payments_Features::is_woopay_express_checkout_enabled(); // Feature flag.
+	}
+
+	/**
 	 * Generates a hash based on the store's blog token, merchant ID, and the time step window.
 	 *
 	 * @return string


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Used `registerExpressPaymentMethod` to render the WooPay express checkout button on the blocks checkout and cart page. This PR only takes care of displaying the button. No functionality has been added yet.

#### Testing instructions
- Run `npm start`
- Install the latest [dev-tools](https://github.com/Automattic/woocommerce-payments-dev-tools). Go to the dev tools page and click the `Enable the WooPay Express Checkout button` checkbox and save the settings.
- Go to the WooCommerce Payments settings screen and click the `Customize` button of WooPay.
- Select `Cart` and `Checkout` as the button location and save the settings.
- Add `Checkout Block` on the checkout page and `Cart Block` on the cart page.
- Ensure that the WooPay button shows up on the blocks checkout screen as per the saved settings.
- Ensure that the WooPay button shows up on the blocks cart screen as per the saved settings.
