### PR TITLE
fixed bug that would not allow a customer to add new payment methods in WooPay

### DIFF
--- a/changelog/fix-5155-cant-add-payment-method
+++ b/changelog/fix-5155-cant-add-payment-method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fixed bug that would not allow customers to add new payment methods to WooPay

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2635,7 +2635,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	public function create_and_confirm_setup_intent() {
 		$payment_information             = Payment_Information::from_payment_request( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification
-		$should_save_in_platform_account = $this->platform_checkout_util->should_save_platform_customer();
+		$should_save_in_platform_account = false;
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( ! empty( $_POST['save_payment_method_in_platform_account'] ) && filter_var( wp_unslash( $_POST['save_payment_method_in_platform_account'] ), FILTER_VALIDATE_BOOLEAN ) ) {
+			$should_save_in_platform_account = true;
+		}
 
 		// Determine the customer adding the payment method, create one if we don't have one already.
 		$user        = wp_get_current_user();


### PR DESCRIPTION
Fixes #5155

#### Changes proposed in this Pull Request
This PR fixes a bug introduced in #4638 which made it not possible for a customer to add a new payment method in WooPay because the `save_user_in_platform_checkout` POST key is not set making WC Payments try to add a payment method to a user in the merchant account which does not exist. 

The key `save_payment_method_in_platform_account` is available. I believe we ended up misreading the key name and refactored to use the incorrect function.


#### Testing instructions
- As a shopper checkout using WooPay or go to /account page of WooPay
- Try to add a new payment method
- No error should show up
- As a shopper add a new payment method in the merchant store
- No error should show up

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 

**Post merge**
- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
