### PR TITLE
Drops auth. and capture feature flag

### DIFF
--- a/changelog/add-4933-authorizations-drop-auth-capture-project-feature-flags
+++ b/changelog/add-4933-authorizations-drop-auth-capture-project-feature-flags
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Enable the improvements to the authorization and capture workflow, that were hidden behind a feature flag.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -161,7 +161,7 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_auth_and_capture_enabled() {
-		return '1' === get_option( self::AUTH_AND_CAPTURE_FLAG_NAME, '0' );
+		return '1' === get_option( self::AUTH_AND_CAPTURE_FLAG_NAME, '1' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #4933 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

This PR disables the feature flag we created for the Auth. and Capture improvements. After this PR is merged, given the capture later option is enabled, merchants will see:
- Uncaptured tab in Transactions page.
- List of uncaptured payments under the same tab.
- Capture support in the payment details page.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
_Prerequisites_
If testing locally, you need to:

- Connect your local WCPay client store to the local server instance
- Your local WCPay server instance should listen for Stripe webhooks (i.e. run` ./local/bin/listen-to-webhooks.sh`)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
_Test plan_
* Go to WP Admin > Payments > Settings and enable `Issue an authorization on checkout, and capture later` option
* Save changes.
* As a shopper, purchase an order.
* Go to WP Admin > Payments > Transactions
* Notice there is a new `Uncaptured` tab, next to `Transactions`
* Click on the `Uncaptured` tab, and you should see a list of uncaptured orders.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : [_link_](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-5.1.0#improvements-to-the-authorization-and-capture-workflow-for-merchants)
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
