### PR TITLE
Fix undefined element error on Cart block for WooPay enabled site.

### DIFF
--- a/changelog/fix-woopay-cart-block-console-error
+++ b/changelog/fix-woopay-cart-block-console-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix undefined element error on Cart block for WooPay enabled site.

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -52,7 +52,11 @@ registerPaymentMethod( {
 
 registerExpressPaymentMethod( paymentRequestPaymentMethod( api ) );
 
-if ( getConfig( 'isPlatformCheckoutEnabled' ) ) {
+// If platform checkout is enabled and this is the checkout page.
+if (
+	getConfig( 'isPlatformCheckoutEnabled' ) &&
+	document.querySelector( '[data-block-name="woocommerce/checkout"]' )
+) {
 	handlePlatformCheckoutEmailInput( '#email', api, true );
 }
 

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -18,6 +18,11 @@ const waitForElement = ( selector ) => {
 		const checkoutBlock = document.querySelector(
 			'[data-block-name="woocommerce/checkout"]'
 		);
+
+		if ( ! checkoutBlock ) {
+			return resolve( null );
+		}
+
 		const observer = new MutationObserver( ( mutationList, obs ) => {
 			if ( document.querySelector( selector ) ) {
 				resolve( document.querySelector( selector ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Added a check before attaching `MutationObserver` on the Checkout Block element.

#### How to recreate the bug
- Install `woocommerce-gutenberg-product-blocks`.
- Create `Cart` page with `Cart Block`.
- Add some product, go to the `Cart` page and open the browser console.
- Notice that there is an error saying `Uncaught (in promise) TypeError: MutationObserver.observe: Argument 1 is not an object.`

#### Testing instructions
- Install `woocommerce-gutenberg-product-blocks`.
- Create `Cart` page with `Cart Block`.
- Add some product, go to the `Cart` page and open the browser console.
- Ensure that there is no error message in the console.
- Go to `Checkout` page and ensure that nothing has changed there. Providing an email should trigger the platform checkout as before.