### PR TITLE
Prevent duplicate orders: Add intent key

### DIFF
--- a/includes/class-wc-payments-db.php
+++ b/includes/class-wc-payments-db.php
@@ -11,8 +11,9 @@ defined( 'ABSPATH' ) || exit;
  * Wrapper class for accessing the database.
  */
 class WC_Payments_DB {
-	const META_KEY_INTENT_ID = '_intent_id';
-	const META_KEY_CHARGE_ID = '_charge_id';
+	const META_KEY_INTENT_ID  = '_intent_id';
+	const META_KEY_CHARGE_ID  = '_charge_id';
+	const META_KEY_INTENT_KEY = '_intent_key';
 
 	/**
 	 * Retrieve an order from the DB using a corresponding Stripe charge ID.
@@ -23,6 +24,21 @@ class WC_Payments_DB {
 	 */
 	public function order_from_charge_id( $charge_id ) {
 		$order_id = $this->order_id_from_meta_key_value( self::META_KEY_CHARGE_ID, $charge_id );
+
+		if ( $order_id ) {
+			return $this->order_from_order_id( $order_id );
+		}
+		return false;
+	}
+
+	/**
+	 * Retrieves an order based on its intent key.
+	 *
+	 * @param string $intent_key The key of the intent.
+	 * @return boolean|WC_Order
+	 */
+	public function order_from_intent_key( $intent_key ) {
+		$order_id = $this->order_id_from_meta_key_value( self::META_KEY_INTENT_KEY, $intent_key );
 
 		if ( $order_id ) {
 			return $this->order_from_order_id( $order_id );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -56,7 +56,7 @@ class WC_Payments {
 	 *
 	 * @var WC_Payments_DB
 	 */
-	private static $db_helper;
+	public static $db_helper;
 
 	/**
 	 * Instance of WC_Payments_Account, created in init function.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2492,7 +2492,7 @@ class WC_Payments_API_Client {
 	 *
 	 * @return string
 	 */
-	private function uuid() {
+	public function uuid() {
 		$arr    = array_values( unpack( 'N1a/n4b/N1c', random_bytes( 16 ) ) );
 		$arr[2] = ( $arr[2] & 0x0fff ) | 0x4000;
 		$arr[3] = ( $arr[3] & 0x3fff ) | 0x8000;


### PR DESCRIPTION
This PR introduces the concept of an "intent key", which is a uniquely generated ID, meant to be:

- associated with orders.
- associated with payment/setup intents.
- stored within the customer's session.

Some code paths in the plugin (incl. payment success, and UPE) have a tight connection between orders and intents, as the intent contains the order ID, and the order contains the intent ID, both as meta data. This connection is only fully established once the intent ID reaches the client, but errors and exceptions might sometimes prevent that from happening.

The purpose of the intent key is to have it generated before the API is ever contacted with a request. This will allow us to retrieve both intents and orders based on their intent key:

- Querying orders by key will allow us to check if there is an identical order with the same key during checkout, marked as paid by a webhook, based on a key stored in the customer's session. **This is the case this PR addresses**.
- Querying intents by key on the server will allow us to retrieve the object, which will be useful while on checkout on a site, which did not manage to receive a webhook for payment confirmation. Once/if implemented on the server (this would require an additional column), another PR here might build on top of this one.

#### How it works

- [  ] Switch from cookie to (WC?) session.
- [  ] This PR checks the cart, make it work for the pay for order page as well.
- [  ] Check for compatibility with UPE.


---

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
