### PR TITLE
Fix fatal error on expired fraud prevention token

### DIFF
--- a/changelog/fix-5166-fatal-on-fraud-token-check
+++ b/changelog/fix-5166-fatal-on-fraud-token-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This change is adding an extra check for an existing method, which prevents fatal error caused by passing null to a string parameter type
+
+

--- a/includes/fraud-prevention/class-fraud-prevention-service.php
+++ b/includes/fraud-prevention/class-fraud-prevention-service.php
@@ -117,6 +117,13 @@ class Fraud_Prevention_Service {
 	 * @return bool
 	 */
 	public function verify_token( string $token = null ): bool {
-		return null !== $token && hash_equals( $this->session->get( self::TOKEN_NAME ), $token );
+		$session_token = $this->session->get( self::TOKEN_NAME );
+
+		// Check if the tokens are both strings.
+		if ( ! is_string( $session_token ) || ! is_string( $token ) ) {
+			return false;
+		}
+		// Compare the hashes to check request validity.
+		return hash_equals( $session_token, $token );
 	}
 }


### PR DESCRIPTION
Fixes #5166

#### Changes proposed in this Pull Request

Related Slack convo: p1669140141614499-slack-CLEPPN1EX Details are there.


<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tests shall pass. 
* Enable `card_testing_prevention_enabled` meta flag for your store on the local server DB, if it doesn't exist, add it to `wcpay_account_meta` table with "1" as the value. 
* Refresh the client account info by clicking the "Clear" button on WCPay dev tools. Verify that you see `'card_testing_protection_eligible' => true,` in the new account cache.
* Apply this patch to simulate session token returning `null`:
```patch
diff --git a/includes/fraud-prevention/class-fraud-prevention-service.php b/includes/fraud-prevention/class-fraud-prevention-service.php
index fdb2f1a9..632e3969 100644
--- a/includes/fraud-prevention/class-fraud-prevention-service.php
+++ b/includes/fraud-prevention/class-fraud-prevention-service.php
@@ -118,6 +118,7 @@ class Fraud_Prevention_Service {
 	 */
 	public function verify_token( string $token = null ): bool {
 		$session_token = $this->session->get( self::TOKEN_NAME );
+		$session_token = null;
 
 		// Check if the tokens are both strings.
 		if ( ! is_string( $session_token ) || ! is_string( $token ) ) {
```
* Try to sell something, you should see an error saying `We're not able to process this payment. Please refresh the page and try again.`.
* No fatal errors should be added.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.