### PR TITLE
Adjust request parameter name for new card method generation

### DIFF
--- a/client/checkout/blocks/generate-payment-method.js
+++ b/client/checkout/blocks/generate-payment-method.js
@@ -40,7 +40,7 @@ const generatePaymentMethod = async ( api, elements, billingData ) => {
 			type: 'success',
 			meta: {
 				paymentMethodData: {
-					paymentMethod: PAYMENT_METHOD_NAME_CARD,
+					payment_method: PAYMENT_METHOD_NAME_CARD,
 					'wcpay-payment-method': id,
 					'wcpay-fraud-prevention-token': fraudPreventionToken ?? '',
 				},


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5111

#### Changes proposed in this Pull Request
This PR fixes the payment processing with the legacy card on the Blocks checkout page by adjusting the key of the request parameter, which is then taken in the payment processing WCPay gateway implementation. 

Investigation results can be found [here](https://github.com/Automattic/woocommerce-payments/issues/5111#issuecomment-1325083072).

#### Testing instructions
Using the Blocks checkout page confirm that the following use cases are working as expected with UPE turned on: 
1. Pay with a new legacy card (both with and without saving it)
2. Pay with a saved legacy card 
4. Pay with any of the UPE methods
5. Turn off UPE and try steps 1-2 again

#### Why there are no tests added?
The [following e2e tests](https://github.com/Automattic/woocommerce-payments/tree/develop/tests/e2e/specs/blocks/shopper) cover Blocks checkout with a credit card. They [failed before](https://github.com/Automattic/woocommerce-payments/actions/runs/3532004182/jobs/5925827668) and will pass now. 

There are also tests for payment processing in `WC_Payment_Gateway_WCPay_Test`, and requests are mocked to return the right parameter, which is why these tests were not failing. 

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
