### PR TITLE
Subscriptions core/5.1.0

### DIFF
--- a/changelog/subscriptions-core-5.1.0
+++ b/changelog/subscriptions-core-5.1.0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Manual renewal orders created with HPOS and data syncing enabled are properly linked to the subscription by its `_subscription_renewal` meta and backfilled to posts table.

--- a/changelog/subscriptions-core-5.1.0-1
+++ b/changelog/subscriptions-core-5.1.0-1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Introduce a WC_Subscription::set_status() function to handle subscriptions set with a draft or auto-draft status. Replaces the need for the overriding WC_Subscription::get_status() which has been deleted.

--- a/changelog/subscriptions-core-5.1.0-10
+++ b/changelog/subscriptions-core-5.1.0-10
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Return a fresh instance of the renewal order after creating it. Fixes caching issues on HPOS sites where the returned order has no line items.

--- a/changelog/subscriptions-core-5.1.0-11
+++ b/changelog/subscriptions-core-5.1.0-11
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Refactor `WCS_Meta_Box_Schedule::save` to support HPOS stores, fixing a PHP warning notice when updating an order via the Edit Order screen.

--- a/changelog/subscriptions-core-5.1.0-12
+++ b/changelog/subscriptions-core-5.1.0-12
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+On HPOS stores, ensure payment tokens are copied from the subscription to the renewal order.

--- a/changelog/subscriptions-core-5.1.0-13
+++ b/changelog/subscriptions-core-5.1.0-13
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+When viewing My Account > Subscriptions, fix an issue where no subscriptions were listed when HPOS is enabled.

--- a/changelog/subscriptions-core-5.1.0-14
+++ b/changelog/subscriptions-core-5.1.0-14
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+On HPOS stores, when a subscription is loaded from the database, make sure all core subscription properties are read directly from meta.

--- a/changelog/subscriptions-core-5.1.0-15
+++ b/changelog/subscriptions-core-5.1.0-15
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+On HPOS stores, when saving a subscription make sure subscription properties (ie `_requires_manual_renewal`) are saved to the database.

--- a/changelog/subscriptions-core-5.1.0-16
+++ b/changelog/subscriptions-core-5.1.0-16
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+On HPOS stores, when querying for subscriptions with wcs_get_orders_with_meta_query() with status 'any', ensure that wc_get_orders() queries for subscription statuses.

--- a/changelog/subscriptions-core-5.1.0-17
+++ b/changelog/subscriptions-core-5.1.0-17
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Set payment tokens when copying data between orders and subscriptions in a CRUD compatible way. Fixes PHP notices during renewal order process.

--- a/changelog/subscriptions-core-5.1.0-2
+++ b/changelog/subscriptions-core-5.1.0-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Removed the deprecated "wcs_subscriptions_for_{$relation_type}_order" dynamic hook used to filter the list of related subscriptions for the given relation type. The following hooks have been removed with no alternative: wcs_subscriptions_for_renewal_order, wcs_subscriptions_for_switch_order, wcs_subscriptions_for_resubscribe_order

--- a/changelog/subscriptions-core-5.1.0-3
+++ b/changelog/subscriptions-core-5.1.0-3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+On HPOS stores, make sure the links in the related-orders table redirect to the new Edit Order URL.

--- a/changelog/subscriptions-core-5.1.0-4
+++ b/changelog/subscriptions-core-5.1.0-4
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Display related orders table when viewing the new "Edit Order" page (HPOS enabled stores).

--- a/changelog/subscriptions-core-5.1.0-5
+++ b/changelog/subscriptions-core-5.1.0-5
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Refactor our Related Orders data store classes (WCS_Related_Order_Store_Cached_CPT and WCS_Related_Order_Store_CPT) to use CRUD methods to support subscriptions and orders stored in HPOS.

--- a/changelog/subscriptions-core-5.1.0-6
+++ b/changelog/subscriptions-core-5.1.0-6
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Refactor the `wcs_is_subscription` helper function to support HPOS.

--- a/changelog/subscriptions-core-5.1.0-7
+++ b/changelog/subscriptions-core-5.1.0-7
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+With HPOS and data syncing enabled, updating the status of a pending manual renewal order to a paid status correctly activates the related subscription.

--- a/changelog/subscriptions-core-5.1.0-8
+++ b/changelog/subscriptions-core-5.1.0-8
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Use supported CRUD apis to determine if subscriptions are present on store (`wcs_do_subscriptions_exist`)

--- a/changelog/subscriptions-core-5.1.0-9
+++ b/changelog/subscriptions-core-5.1.0-9
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Processing a manual renewal order with HPOS and data syncing enabled correctly saves the related order cache metadata on the subscription and prevents the post and order meta data getting out of sync.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
       "automattic/jetpack-sync": "1.30.5",
       "automattic/jetpack-tracking": "1.14.5",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "2.5.2"
+      "woocommerce/subscriptions-core": "5.1.0"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbeb3ac66b23050530cfda3e06393b3f",
+    "content-hash": "41836a9d944c0ebfae18044da0409615",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1060,16 +1060,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "2.5.2",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "3a347e2549fadfb691673e15c4050df84c7fe9a7"
+                "reference": "121ef4b833aa9ae47e91e22389fca8d30057deba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/3a347e2549fadfb691673e15c4050df84c7fe9a7",
-                "reference": "3a347e2549fadfb691673e15c4050df84c7fe9a7",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/121ef4b833aa9ae47e91e22389fca8d30057deba",
+                "reference": "121ef4b833aa9ae47e91e22389fca8d30057deba",
                 "shasum": ""
             },
             "require": {
@@ -1110,10 +1110,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/2.5.2",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/5.1.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2022-11-15T09:19:48+00:00"
+            "time": "2022-11-24T01:28:40+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update `woocommerce/subscriptions-core` to `5.1.0`.
The changes mainly to add HPOS support for subscription.

`composer.lock`'s change is a result of running `composer update woocommerce/subscriptions-core`.

I pluck changelog entries from [subscriptions-core's 5.1 changelog entries](https://github.com/Automattic/woocommerce-subscriptions-core/blob/trunk/changelog.txt#L3-L25) but I left out entries that are not 'changes' from WCPay's prespective, like:
```
Fix - Infinite loop that can occur with `WCS_Orders_Table_Subscription_Data_Store::read_multiple()` on HPOS-enabled stores.
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
