### PR TITLE
Use botwoo machine user to merge trunk changes in develop

### DIFF
--- a/.github/workflows/post-release-updates.yml
+++ b/.github/workflows/post-release-updates.yml
@@ -85,11 +85,12 @@ jobs:
         with:
           ref: 'trunk'
           fetch-depth: 0
+          token: ${{ SECRETS.BOTWOO_TOKEN }}
 
       - name: "Merge trunk back into develop"
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "botwoo"
+          git config user.email "botwoo@users.noreply.github.com"
           git checkout develop && git pull
           git merge trunk --no-ff -m "Merge trunk v$RELEASE_VERSION into develop"
           git push

--- a/changelog/update-use-botwoo-post-release-steps-workflow
+++ b/changelog/update-use-botwoo-post-release-steps-workflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use botwoo user for a job in the post-release-updates workflow


### PR DESCRIPTION
Fixes #5132 

#### Changes proposed in this Pull Request

- Use `botwoo` machine user for the "merge trunk into develop" job from the `post-release-updates.yml` workflow

The `develop` branch is protected, and we cannot merge changes into it without a Pull Request and the required status checks.
This was already a problem with the previous release process (manually merging trunk into develop) but the new `post-release-updates` workflow also tries to commit and push on behalf of the user triggering it, so he will be denied the rights to push to `develop` in the same way.

A workaround is to use a bot (or [machine user](https://docs.github.com/en/developers/overview/managing-deploy-keys#machine-users)).

How does this work?

- There already exists a bot user for Woo: [botwoo](https://mc.a8c.com/secret-store/?secret_id=9366)
- From the `botwoo` account, add a Personal Access Token (PAT) with `public_repo` scope (the minimum scope required)
- From the woocommerce-payments repo, invite `botwoo` as an outside collaborator and give him Admin rights
- Allow `botwoo` to bypass the required PR in the branch protection settings for `develop`
- Add the `botwoo` PAT as a Secret for Actions in woocommerce-payments
- Use the secret to checkout the branch in the workflow, and use the `botwoo` username to merge the changes

#### Caveats

- This only works if `botwoo` has Admin rights. I initially only gave him Read/Write rights, but it was not working because it seems that the bypass setting is applied to administrators. After researching the matter, this seems like the only way to do this currently (although several issues/questions were already raised for some time in GitHub community forums about this). Ideally, we'd have a way to allow the generic GitHub Actions bot (which uses the GITHUB_TOKEN) to do that specifically, but that's not the case. I don't see this as a big security issue since any account (from Gammas, Pulsar, and Sigma to name a few Admins) could also be compromised; that's not different from today.

- The context for reusing `botwoo`: https://wooengineering.wordpress.com/2022/04/01/%f0%9f%a4%96-beep-bop-im-a-bot-and-all-your-repos-are-belong-to-us/#comment-687
Creating and adding bots to an organization costs money, so according to Beau's comment, we need to have a few bots that we can reuse instead every team everyone creating its own (that's what I understood, at least).

#### Testing instructions

- I created 2 dummy branches: `fake-develop` and `fake-trunk`.
- I added a commit to `fake-trunk`.
- I tweaked the workflow to only run the ` merge-trunk-into-develop` job to avoid further side-effects when testing. I also replaced occurrences of `trunk` by `fake-trunk` and `develop` by `fake-develop` in the workflow file.
- I replicated the branch protection settings from `develop`, for the new `fake-develop` branch, and applied the mentioned changes in the description above.

Successful run: https://github.com/Automattic/woocommerce-payments/actions/runs/3541644701

For reference, the failed run when the branch protection settings were identical to the ones from `develop`, or when `botwoo` had only read/write rights: https://github.com/Automattic/woocommerce-payments/actions/runs/3541639586
You can see the error: 
```
remote: error: GH006: Protected branch update failed for refs/heads/fake-develop.        
remote: error: 6 of 6 required status checks are expected.        
To https://github.com/Automattic/woocommerce-payments
 ! [remote rejected]   fake-develop -> fake-develop (protected branch hook declined)
```

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
