### PR TITLE
Fix error sorting the Uncaptured table using Capture by column

### DIFF
--- a/changelog/fix-5184-sort-by-capture-by-column-of-uncaptured-transactions-table-causes-an-error
+++ b/changelog/fix-5184-sort-by-capture-by-column-of-uncaptured-transactions-table-causes-an-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix an error in the Uncaptured transactions table when it is sorted using the Capture by column.

--- a/client/data/authorizations/resolvers.ts
+++ b/client/data/authorizations/resolvers.ts
@@ -27,12 +27,17 @@ import { NAMESPACE } from '../constants';
 import { ApiError } from 'wcpay/types/errors';
 
 export function* getAuthorizations( query: Query ): Generator< unknown > {
-	const {
+	let {
 		paged = 1,
 		per_page: perPage = 25,
 		orderby = 'created',
 		order = 'desc',
 	} = query;
+
+	if ( orderby === 'capture_by' ) {
+		// The API does not expect 'capture_by' to be a valid sorting field, since it is a derived field, calculated from the 'created' field.
+		orderby = 'created';
+	}
 
 	const path = addQueryArgs( `${ NAMESPACE }/authorizations`, {
 		page: paged,

--- a/client/transactions/uncaptured/index.tsx
+++ b/client/transactions/uncaptured/index.tsx
@@ -55,10 +55,8 @@ const getColumns = (): Column[] =>
 			screenReaderLabel: __( 'Capture by', 'woocommerce-payments' ),
 			required: true,
 			isLeftAligned: true,
-			defaultOrder: 'desc',
 			cellClassName: 'date-time',
 			isSortable: true,
-			defaultSort: true,
 		},
 		{
 			key: 'order',


### PR DESCRIPTION
Fixes #5184

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This change fixes an error in the Uncaptured transactions table, when the table is sorted clicking on the Capture by column.
The error is caused by a 500 response from the endpoint, because 'capture_by' is not a valid sorting field in the API, since it is a value calculated in the front end, derived from the 'created' field.

To solve the issue, I am rewriting the orderby field in the resolver to 'created', in case the 'capture_by' field is specified. This has the same effect, and does not cause an error in the API endpoint.


<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* As a merchant, enable 'Issue an authorization at checkout...' in `Payments > Settings`
* As a shopper, purchase at least 2 orders.
* As a merchant, to go Payments > Transactions and click on Uncaptured tab.
* Check that the table is sorted when clicking on Capture by column and no errors are thrown.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
