### PR TITLE
Set github-actions bot as the commit author for the code freeze workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -93,6 +93,8 @@ jobs:
         run: |
           npm install # To update package-lock.json with the new version of the plugin
           git config user.name "github-actions[bot]"
+          # We could consider fetching the bot's ID through an API call to be future-proof. Hardcoded for now. 
+          # See https://github.com/Automattic/woocommerce-payments/pull/5200#discussion_r1034560144
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -am "Update version and add changelog entries for release $RELEASE_VERSION"
           git push --set-upstream origin $BRANCH_NAME

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -92,8 +92,8 @@ jobs:
           BRANCH_NAME: ${{ steps.create_branch.outputs.branch-name }}
         run: |
           npm install # To update package-lock.json with the new version of the plugin
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -am "Update version and add changelog entries for release $RELEASE_VERSION"
           git push --set-upstream origin $BRANCH_NAME
 

--- a/changelog/fix-commit-author-code-freeze-workflow
+++ b/changelog/fix-commit-author-code-freeze-workflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Set commit author as github-actions bot for the code freeze workflow


### PR DESCRIPTION
Fixes #5196 

#### Changes proposed in this Pull Request

- Replace `github.actor` by github-actions bot to commit changes in the `release-pr.yml` workflow (used under the hood by the code freeze workflow)

#### Testing instructions

- Run the [Release- Create PR to trunk](https://github.com/Automattic/woocommerce-payments/actions/workflows/release-pr.yml) workflow from this branch (`fix/commit-author-code-freeze-workflow`) with a dummy release version (like 7.2.6)
- Confirm that the last commit on the newly created release branch is authored by github-actions bot
- Clean up the side effects of the workflow run
  - Close the PR that was created
  - Delete the release branch that was created 

Last test:
- workflow run: https://github.com/Automattic/woocommerce-payments/actions/runs/3564196419

![image](https://user-images.githubusercontent.com/28830738/204265519-917344b8-1f8c-4877-ba4e-f848e13b1408.png)

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
