### PR TITLE
Fix PR checks not triggered for release PR created by workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -99,10 +99,10 @@ jobs:
 
       - name: "Create a PR to trunk"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOTWOO_TOKEN }}
           BRANCH_NAME: ${{ steps.create_branch.outputs.branch-name }}
           CHANGELOG: ${{ steps.generate_changelog.outputs.changelog }}
           RELEASE_VERSION: ${{ steps.create_branch.outputs.trimmed-version }}
         run: |
-          PR_BODY=$(echo -e ":warning: Please do not merge the PR from the GitHub interface. :warning:\n\n Instead, you can use the following command: \` git merge --no-ff $BRANCH_NAME -m 'Merge $BRANCH_NAME into trunk' \`\n\`\`\`\n${CHANGELOG}\n\`\`\`")
+          PR_BODY=$(echo -e ":warning: Please do not merge the PR from the GitHub interface. :warning:\n\n Instead, you can use the following command:\n\`\`\`\n git checkout trunk && git pull \n git merge --no-ff $BRANCH_NAME -m 'Merge $BRANCH_NAME into trunk' \n git push origin trunk \n\`\`\` \n Changelog: \n\`\`\`\n${CHANGELOG}\n\`\`\`")
           gh pr create --title "Release branch for $RELEASE_VERSION" --body="$PR_BODY" --base="trunk"

--- a/changelog/fix-5197-required-checks-not-triggered-for-pr-created-by-workflow
+++ b/changelog/fix-5197-required-checks-not-triggered-for-pr-created-by-workflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+PR created by the code freeze workflow is now done by botwoo to allow PR checks to be triggered


### PR DESCRIPTION
Fixes #5197 

#### Changes proposed in this Pull Request

- Use `botwoo` machine user to create the Pull Request for the release instead of the regular github-actions bot
- As a bonus, enhance the PR description a little with the whole list of manual commands to run to merge manually the PR

Old PR body format: 
![image](https://user-images.githubusercontent.com/28830738/204298765-d51488d8-74d0-4e22-b85f-52220deb1b95.png)

New PR body format: 
![image](https://user-images.githubusercontent.com/28830738/204298807-9a72d126-db22-4b35-9cac-a99909b86c1d.png)

The problem is nicely described in a third-party action's README: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

And the official explanation can be found here: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.

#### Testing instructions

- Run the [Release- Create PR to trunk](https://github.com/Automattic/woocommerce-payments/actions/workflows/release-pr.yml) workflow from this branch (fix/5197-required-checks-not-triggered-for-pr-created-by-workflow) with a dummy release version (like 7.2.6)
- Confirm that the PR is created by `botwoo` and that all the checks expected on the PR are triggered
- Clean up the side effects of the workflow run
  - Close the PR that was created
  - Delete the release branch that was created

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
