### PR TITLE
Fix the trigger-translations job in the post-release workflow

### DIFF
--- a/.github/workflows/post-release-updates.yml
+++ b/.github/workflows/post-release-updates.yml
@@ -100,6 +100,11 @@ jobs:
     needs: get-last-released-version
     runs-on: ubuntu-20.04
     steps:
+      - name: "Checkout repository (trunk)"
+        uses: actions/checkout@v3
+        with:
+          ref: 'trunk'
+          
       - name: "Trigger translations update on GlotPress"
         uses: ./.github/actions/trigger-translations
         with:

--- a/changelog/fix-5216-translations-job-for-post-release
+++ b/changelog/fix-5216-translations-job-for-post-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix translations job from the post-release workflow


### PR DESCRIPTION
Fixes #5216 

#### Changes proposed in this Pull Request

- Checkout the trunk branch before running the composite action for translations

#### Testing instructions

I don't advise trying the workflow live

See the test run: https://github.com/Automattic/woocommerce-payments/actions/runs/3590946656/jobs/6044904462

For this run, I temporarily removed all jobs except the translations one, with an empty GLOTPRESS_URL variable. We can see in the logs that the translations action no longer displays an error for not finding the action.yml file, so the issue is solved. It still fails, but that's expected since I didn't provide the URL parameter for the API call on purpose.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
