### PR TITLE
Fix fatal error when hidden Blocks input added from CRON

### DIFF
--- a/changelog/patch-fix-fatal-error-blocks-hidden-input-added-by-cron
+++ b/changelog/patch-fix-fatal-error-blocks-hidden-input-added-by-cron
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Minor patch fix to cron functionality that does not appear to have front-end ramifications for customers.
+
+

--- a/includes/class-wc-payments-blocks-payment-method.php
+++ b/includes/class-wc-payments-blocks-payment-method.php
@@ -114,9 +114,13 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 	 * @return  string
 	 */
 	public function maybe_add_card_testing_token( $content ) {
+		if ( ! wp_script_is( 'WCPAY_BLOCKS_CHECKOUT' ) ) {
+			return $content;
+		}
+
 		$fraud_prevention_service = Fraud_Prevention_Service::get_instance();
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		if ( $fraud_prevention_service->is_enabled() && wp_script_is( 'WCPAY_BLOCKS_CHECKOUT' ) ) {
+		if ( $fraud_prevention_service->is_enabled() ) {
 			$content .= '<input type="hidden" name="wcpay-fraud-prevention-token" id="wcpay-fraud-prevention-token" value="' . esc_attr( Fraud_Prevention_Service::get_instance()->get_token() ) . '">';
 		}
 		return $content;


### PR DESCRIPTION
Please see p1669899593524019-slack-CGGCLBN58 for more details. 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
# Fix fatal error when hidden Blocks input added from CRON

Ensure that hidden Blocks input is only added when `the_content` filter is fired from front-end and WC Session is available. 

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
See @jessepearson's [instructions below](https://github.com/Automattic/woocommerce-payments/pull/5223#issuecomment-1334480617) to simulate the issue and test this patch. 
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.