### PR TITLE
Fix fatal error when hidden Blocks input added from CRON (#5223)

### DIFF
--- a/changelog/patch-fix-fatal-error-blocks-hidden-input-added-by-cron
+++ b/changelog/patch-fix-fatal-error-blocks-hidden-input-added-by-cron
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Minor patch fix to cron functionality that does not appear to have front-end ramifications for customers.
+
+

--- a/includes/class-wc-payments-blocks-payment-method.php
+++ b/includes/class-wc-payments-blocks-payment-method.php
@@ -114,9 +114,13 @@ class WC_Payments_Blocks_Payment_Method extends AbstractPaymentMethodType {
 	 * @return  string
 	 */
 	public function maybe_add_card_testing_token( $content ) {
+		if ( ! wp_script_is( 'WCPAY_BLOCKS_CHECKOUT' ) ) {
+			return $content;
+		}
+
 		$fraud_prevention_service = Fraud_Prevention_Service::get_instance();
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		if ( $fraud_prevention_service->is_enabled() && wp_script_is( 'WCPAY_BLOCKS_CHECKOUT' ) ) {
+		if ( $fraud_prevention_service->is_enabled() ) {
 			$content .= '<input type="hidden" name="wcpay-fraud-prevention-token" id="wcpay-fraud-prevention-token" value="' . esc_attr( Fraud_Prevention_Service::get_instance()->get_token() ) . '">';
 		}
 		return $content;


### PR DESCRIPTION
Patch to fix fatal error that occurs when a scheduled action calls `the_content` filter, creating a fatal error, because this inserted Blocks hidden input relies on absent WC session data.

It was merged into develop (see https://github.com/Automattic/woocommerce-payments/pull/5223) but we need this fix into trunk to start the release PR creation