### PR TITLE
Fix fetch authorization data and wrong capture deadline in the payment details screen.

### DIFF
--- a/changelog/fix-5231-wrong-call-to-fetch-authorization-data-from-the-transaction-details-for-failed-payments
+++ b/changelog/fix-5231-wrong-call-to-fetch-authorization-data-from-the-transaction-details-for-failed-payments
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix wrong capture deadline date in the payment details page.
+Fix wrong time displayed in the "You need to capture this charge before..." text on the payment details page.

--- a/changelog/fix-5231-wrong-call-to-fetch-authorization-data-from-the-transaction-details-for-failed-payments
+++ b/changelog/fix-5231-wrong-call-to-fetch-authorization-data-from-the-transaction-details-for-failed-payments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wrong capture deadline date in the payment details page.

--- a/client/data/authorizations/resolvers.ts
+++ b/client/data/authorizations/resolvers.ts
@@ -77,11 +77,13 @@ export function* getAuthorization(
 			const {
 				is_captured: isCaptured,
 				payment_intent_id: paymentIntentId,
+				created,
 			} = result as GetAuthorizationApiResponse;
 
 			yield updateAuthorization( {
 				payment_intent_id: paymentIntentId,
 				captured: isCaptured,
+				created,
 			} as Authorization );
 		}
 	} catch ( e ) {

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -114,9 +114,12 @@ const PaymentDetailsSummary = ( {
 	} = useContext( WCPaySettingsContext );
 
 	// We should only fetch the authorization data if the payment is marked for manual capture and it is not already captured.
+	// We also need to exclude failed payments and payments that have been refunded, because capture === false in those cases, even
+	// if the capture is automatic.
 	const shouldFetchAuthorization =
-		'captured' in charge && // captured key is only present for manual capture payments. See https://stripe.com/docs/api/charges/object#charge_object-captured
 		! charge.captured &&
+		charge.status !== 'failed' &&
+		charge.amount_refunded === 0 &&
 		isAuthAndCaptureEnabled;
 
 	const { authorization } = useAuthorization(

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -265,7 +265,6 @@ const PaymentDetailsSummary = ( {
 											moment
 												.utc( authorization.created )
 												.add( 7, 'days' )
-												.toISOString()
 										) }
 									</b>
 								</div>

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -113,10 +113,10 @@ const PaymentDetailsSummary = ( {
 		featureFlags: { isAuthAndCaptureEnabled },
 	} = useContext( WCPaySettingsContext );
 
-	// We should only fetch the authorization data if the payment is marked for manual capture
+	// We should only fetch the authorization data if the payment is marked for manual capture and it is not already captured.
 	const shouldFetchAuthorization =
-		charge.amount !== charge.amount_captured &&
-		charge.amount_refunded === 0 &&
+		'captured' in charge && // captured key is only present for manual capture payments. See https://stripe.com/docs/api/charges/object#charge_object-captured
+		! charge.captured &&
 		isAuthAndCaptureEnabled;
 
 	const { authorization } = useAuthorization(

--- a/client/payment-details/summary/test/__snapshots__/index.tsx.snap
+++ b/client/payment-details/summary/test/__snapshots__/index.tsx.snap
@@ -477,6 +477,257 @@ exports[`PaymentDetailsSummary renders a charge with subscriptions 1`] = `
 </div>
 `;
 
+exports[`PaymentDetailsSummary renders capture section correctly 1`] = `
+<div>
+  <div
+    class="components-card is-size-medium css-1xs3c37-CardUI e1q7k77g0"
+  >
+    <div
+      class="components-card__body is-size-medium css-xmjzce-BodyUI e1q7k77g3"
+    >
+      <div
+        class="payment-details-summary"
+      >
+        <div
+          class="payment-details-summary__section"
+        >
+          <p
+            class="payment-details-summary__amount"
+          >
+            $20.00
+            <span
+              class="payment-details-summary__amount-currency"
+            >
+              usd
+            </span>
+            <span
+              class="chip chip-primary"
+            >
+              Payment authorized
+            </span>
+          </p>
+          <div
+            class="payment-details-summary__breakdown"
+          >
+            
+            <p>
+              Fee: 
+              $-0.70
+            </p>
+            
+            <p>
+              Net: 
+              $19.30
+            </p>
+          </div>
+        </div>
+        <div
+          class="payment-details-summary__section"
+        >
+          <div
+            class="payment-details-summary__id"
+          >
+            Payment ID: 
+            ch_38jdHA39KKA
+          </div>
+        </div>
+      </div>
+    </div>
+    <hr
+      class="components-card__divider css-lh2anh-DividerUI e1q7k77g5"
+      role="separator"
+    />
+    <div
+      class="components-card__body is-size-medium css-xmjzce-BodyUI e1q7k77g3"
+    >
+      <ul
+        class="woocommerce-list woocommerce-list--horizontal"
+        role="menu"
+      >
+        <li
+          class="woocommerce-list__item"
+        >
+          <div
+            class="woocommerce-list__item-inner"
+          >
+            <div
+              class="woocommerce-list__item-text"
+            >
+              <span
+                class="woocommerce-list__item-title"
+              >
+                Date
+              </span>
+              <span
+                class="woocommerce-list__item-content"
+              >
+                Sep 19, 2019, 5:24pm
+              </span>
+            </div>
+          </div>
+        </li>
+        <li
+          class="woocommerce-list__item"
+        >
+          <div
+            class="woocommerce-list__item-inner"
+          >
+            <div
+              class="woocommerce-list__item-text"
+            >
+              <span
+                class="woocommerce-list__item-title"
+              >
+                Channel
+              </span>
+              <span
+                class="woocommerce-list__item-content"
+              >
+                <span>
+                  Online
+                </span>
+              </span>
+            </div>
+          </div>
+        </li>
+        <li
+          class="woocommerce-list__item"
+        >
+          <div
+            class="woocommerce-list__item-inner"
+          >
+            <div
+              class="woocommerce-list__item-text"
+            >
+              <span
+                class="woocommerce-list__item-title"
+              >
+                Customer
+              </span>
+              <span
+                class="woocommerce-list__item-content"
+              >
+                <a
+                  data-link-type="wc-admin"
+                  href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&search%5B0%5D=Customer%20name"
+                >
+                  Customer name
+                </a>
+              </span>
+            </div>
+          </div>
+        </li>
+        <li
+          class="woocommerce-list__item"
+        >
+          <div
+            class="woocommerce-list__item-inner"
+          >
+            <div
+              class="woocommerce-list__item-text"
+            >
+              <span
+                class="woocommerce-list__item-title"
+              >
+                Order
+              </span>
+              <span
+                class="woocommerce-list__item-content"
+              >
+                <a
+                  data-link-type="external"
+                  href="https://somerandomorderurl.com/?edit_order=45981"
+                >
+                  45981
+                </a>
+              </span>
+            </div>
+          </div>
+        </li>
+        <li
+          class="woocommerce-list__item"
+        >
+          <div
+            class="woocommerce-list__item-inner"
+          >
+            <div
+              class="woocommerce-list__item-text"
+            >
+              <span
+                class="woocommerce-list__item-title"
+              >
+                Payment method
+              </span>
+              <span
+                class="woocommerce-list__item-content"
+              >
+                <span
+                  class="payment-method-details"
+                >
+                  <span
+                    class="payment-method__brand payment-method__brand--visa"
+                  />
+                   •••• 
+                  4242
+                </span>
+              </span>
+            </div>
+          </div>
+        </li>
+        <li
+          class="woocommerce-list__item"
+        >
+          <div
+            class="woocommerce-list__item-inner"
+          >
+            <div
+              class="woocommerce-list__item-text"
+            >
+              <span
+                class="woocommerce-list__item-title"
+              >
+                Risk evaluation
+              </span>
+              <span
+                class="woocommerce-list__item-content"
+              >
+                Normal
+              </span>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="components-flex components-card__footer is-size-medium payment-details-capture-notice e1q7k77g4 css-oliaol-Flex-FooterUI eboqfv50"
+    >
+      <div
+        class="payment-details-capture-notice__section"
+      >
+        <div
+          class="payment-details-capture-notice__text"
+        >
+          You need to capture this charge before 
+          <b>
+            Sep 26, 2019 / 5:24PM
+          </b>
+        </div>
+        <div
+          class="payment-details-capture-notice__button"
+        >
+          <button
+            class="components-button is-primary"
+            type="button"
+          >
+            Capture
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`PaymentDetailsSummary renders fully refunded information for a charge 1`] = `
 <div>
   <div

--- a/client/payment-details/summary/test/index.tsx
+++ b/client/payment-details/summary/test/index.tsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 /**
@@ -10,6 +10,7 @@ import React from 'react';
  */
 import PaymentDetailsSummary from '../';
 import { Charge } from 'wcpay/types/charges';
+import { useAuthorization } from 'wcpay/data';
 
 declare const global: {
 	wcpaySettings: {
@@ -24,6 +25,16 @@ declare const global: {
 		};
 	};
 };
+
+jest.mock( 'wcpay/data', () => ( {
+	useAuthorization: jest.fn( () => ( {
+		authorization: null,
+	} ) ),
+} ) );
+
+const mockUseAuthorization = useAuthorization as jest.MockedFunction<
+	typeof useAuthorization
+>;
 
 const getBaseCharge = (): Charge =>
 	( {
@@ -76,6 +87,8 @@ function renderCharge( charge: Charge, isLoading = false ) {
 
 describe( 'PaymentDetailsSummary', () => {
 	beforeEach( () => {
+		jest.clearAllMocks();
+
 		global.wcpaySettings = {
 			isSubscriptionsActive: false,
 			zeroDecimalCurrencies: [],
@@ -83,7 +96,7 @@ describe( 'PaymentDetailsSummary', () => {
 				country: 'US',
 			},
 			featureFlags: {
-				isAuthAndCaptureEnabled: false,
+				isAuthAndCaptureEnabled: true,
 			},
 			currencyData: {
 				US: {
@@ -165,5 +178,41 @@ describe( 'PaymentDetailsSummary', () => {
 
 	test( 'renders loading state', () => {
 		expect( renderCharge( {} as any, true ) ).toMatchSnapshot();
+	} );
+
+	test( 'renders capture section correctly', () => {
+		mockUseAuthorization.mockReturnValueOnce( {
+			authorization: {
+				captured: false,
+				charge_id: 'ch_mock',
+				amount: 1000,
+				currency: 'usd',
+				created: '2019-09-19 17:24:00',
+				order_id: 123,
+				risk_level: 1,
+				customer_country: 'US',
+				customer_email: 'test@example.com',
+				customer_name: 'Test Customer',
+				payment_intent_id: 'pi_mock',
+			},
+			isLoading: false,
+			doCaptureAuthorization: jest.fn(),
+		} );
+		const charge = getBaseCharge();
+		charge.captured = false;
+
+		const container = renderCharge( charge );
+
+		expect(
+			screen.getByRole( 'button', { name: /Capture/i } )
+		).toBeInTheDocument();
+
+		expect(
+			screen.getByText( /You need to capture this charge/i )
+		).toHaveTextContent(
+			'You need to capture this charge before Sep 26, 2019 / 5:24PM'
+		);
+
+		expect( container ).toMatchSnapshot();
 	} );
 } );

--- a/client/types/authorizations.d.ts
+++ b/client/types/authorizations.d.ts
@@ -52,6 +52,7 @@ export interface CaptureAuthorizationApiResponse {
 export interface GetAuthorizationApiResponse {
 	payment_intent_id: string;
 	is_captured: boolean;
+	created: string;
 }
 
 export interface UpdateAuthorizationAction {

--- a/includes/wc-payment-api/models/class-wc-payments-api-charge.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-charge.php
@@ -473,10 +473,10 @@ class WC_Payments_API_Charge implements \JsonSerializable {
 			'paid'                   => $this->get_paid(),
 			'paydown'                => $this->get_paydown(),
 			'payment_intent'         => $this->get_payment_intent(),
+			'captured'               => $this->is_captured(),
 			'refunded'               => $this->get_refunded(),
 			'refunds'                => $this->get_refunds(),
 			'status'                 => $this->get_status(),
-			'captured'               => $this->is_captured(),
 		];
 	}
 }

--- a/includes/wc-payment-api/models/class-wc-payments-api-charge.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-charge.php
@@ -476,6 +476,7 @@ class WC_Payments_API_Charge implements \JsonSerializable {
 			'refunded'               => $this->get_refunded(),
 			'refunds'                => $this->get_refunds(),
 			'status'                 => $this->get_status(),
+			'captured'               => $this->is_captured(),
 		];
 	}
 }


### PR DESCRIPTION
The previous logic was failing when the payment was in Failed state.

Fixes #5231 #5221

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
This change fixes two bugs in the payment details screen related to the manual capture workflow:

* Only fetch authorization data when the payment is set to manual capture. The previous implementation had a bug that was causing to fetch authorization data for failed payments.
![Screenshot 2022-12-02 at 18 44 21](https://user-images.githubusercontent.com/1553182/205353666-afa09db6-3eac-44e8-a025-6aac569157cb.png)
    
* Fix wrong hour in the capture deadline caused by missing 'created' information in the front end store.
![Screenshot 2022-12-05 at 21 37 49](https://user-images.githubusercontent.com/1553182/205738604-99536c83-d1ac-44ff-af63-6af6edc5556d.png)


<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
_Automatic capture_
1. As a shopper, checkout an order using a card that will cause a failed payment. You can use Stripe test card 4000000000009995 (more [info](https://stripe.com/docs/testing#declined-payments)). Please note that you'll see an error in the checkout form but the order will be created in failed state.
2. As a merchant, go to WooCommerce > Orders and find the order you just created. Note the status will be Failed.
3. In the order details page, click on the payment id to go to the transactions details page.
4. Open the Network tab on the browser developer tools
5. Ensure there is no call to the payments/authorizations/<payment_intent_id endpoint, since the payment is not marked to be manually captured.
6. Check that the Payment status is `Paid`.

_Manual capture_
1. Using Merchant account enable Manual capture on Payments > Settings page and save settings. 
2. Follow normal card checkout flow as a Shopper to make a purchase. Take a note of order number created.
3. Using Merchant account go to Payments > Transactions. Check there is an Uncaptured tab next to Transactions tab.
4. Click on Uncaptured tab.
5. In the Uncaptured transactions table, click on the row with the order you created in previous step. It will take you to the payment details page.
6. In the payment details page, check that there is a section that contains information about the capture deadline and a Capture button
7. Check that the date in the capture deadline is correct (add 7 days to date creation)
![Screenshot 2022-12-05 at 22 02 33](https://user-images.githubusercontent.com/1553182/205742391-f4e53e10-278d-4e15-8102-34d5fe17cfcc.png)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) :  'QA Testing Not Applicable'
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
