### PR TITLE
Check for undefined params before using

### DIFF
--- a/changelog/fix-woopay-params-undefined
+++ b/changelog/fix-woopay-params-undefined
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix an undefined variable bug in WooPay Express Checkout.

--- a/client/checkout/platform-checkout/express-button/utils.js
+++ b/client/checkout/platform-checkout/express-button/utils.js
@@ -4,7 +4,7 @@
  * Retrieves a configuration value.
  *
  * @param {string} name The name of the config parameter.
- * @return {*}         The value of the parameter of null.
+ * @return {*}         The value of the parameter or undefined.
  */
 export const getWooPayExpressData = ( name ) => {
 	if ( 'undefined' === typeof wcpayWooPayExpressParams ) {

--- a/client/checkout/platform-checkout/express-button/utils.js
+++ b/client/checkout/platform-checkout/express-button/utils.js
@@ -4,7 +4,7 @@
  * Retrieves a configuration value.
  *
  * @param {string} name The name of the config parameter.
- * @return {*}         The value of the parameter or undefined.
+ * @return {*}          The value of the parameter or undefined.
  */
 export const getWooPayExpressData = ( name ) => {
 	if ( 'undefined' === typeof wcpayWooPayExpressParams ) {

--- a/client/checkout/platform-checkout/express-button/utils.js
+++ b/client/checkout/platform-checkout/express-button/utils.js
@@ -7,5 +7,9 @@
  * @return {*}         The value of the parameter of null.
  */
 export const getWooPayExpressData = ( name ) => {
+	if ( 'undefined' === typeof wcpayWooPayExpressParams ) {
+		return undefined;
+	}
+
 	return wcpayWooPayExpressParams?.[ name ];
 };


### PR DESCRIPTION
Fixes #5233

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
A bug was found in a recent PR in which `wcpayWooPayExpressParams` was being referenced while undefined. This PR adds an additional check to be sure the variable is defined before using.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure the Express Checkout feature flag is enabled from the latest Dev Tools.
- Make sure the Express Checkout button is set to display on Cart and Checkout page from Payments > Settings > WooPay Customize > Show express checkouts on.
- Add a product to the cart.
- Visit the cart, confirm display of WooPay button.
- Click on WooPay button and confirm iframe loads with email input.
- Enter email and verify OTP.
- Confirm that session gets initialized and shopper is redirected to WooPay checkout.
- Complete a full checkout and confirm successfully returned to merchant store with successful checkout.
- Return to merchant store and add a product to the cart.
- Visit the checkout page and confirm the display of the WooPay button.
- Click on WooPay button and confirm iframe loads with email input.
- Enter email and verify OTP.
- Confirm that session gets initialized and shopper is redirected to WooPay checkout.
- Complete a full checkout and confirm successfully returned to merchant store with successful checkout.

**Now disable the Express Checkout feature flag in Dev Tools.**

- Add a product to the cart.
- Visit the cart, confirm no WooPay button is displayed.
- Confirm no errors in the console.
- Enter an email address that for a valid WooPay user and confirm iframe pops up.
- Verify OTP.
- Confirm that session gets initialized and shopper is redirected to WooPay checkout.
- Complete a full checkout and confirm successfully returned to merchant store with successful checkout.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
