### PR TITLE
Implementation of Intent request classes

### DIFF
--- a/includes/admin/class-wc-rest-payments-charges-controller.php
+++ b/includes/admin/class-wc-rest-payments-charges-controller.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Payments\Admin
  */
 
+use WCPay\Core\Server\Request\Get_Charge;
 use WCPay\Exceptions\API_Exception;
 
 defined( 'ABSPATH' ) || exit;
@@ -45,7 +46,9 @@ class WC_REST_Payments_Charges_Controller extends WC_Payments_REST_Controller {
 		$charge_id = $request->get_param( 'charge_id' );
 
 		try {
-			$charge = $this->api_client->get_charge( $charge_id );
+			$wcpay_request = Get_Charge::create();
+			$wcpay_request->set_charge_id( $charge_id );
+			$charge = $wcpay_request->send( 'wcpay_get_charge_request', $charge_id );
 		} catch ( API_Exception $e ) {
 			return rest_ensure_response( new WP_Error( 'wcpay_get_charge', $e->getMessage() ) );
 		}

--- a/includes/admin/class-wc-rest-payments-charges-controller.php
+++ b/includes/admin/class-wc-rest-payments-charges-controller.php
@@ -46,9 +46,8 @@ class WC_REST_Payments_Charges_Controller extends WC_Payments_REST_Controller {
 		$charge_id = $request->get_param( 'charge_id' );
 
 		try {
-			$wcpay_request = Get_Charge::create();
-			$wcpay_request->set_charge_id( $charge_id );
-			$charge = $wcpay_request->send( 'wcpay_get_charge_request', $charge_id );
+			$wcpay_request = Get_Charge::create( $charge_id );
+			$charge        = $wcpay_request->send( 'wcpay_get_charge_request', $charge_id );
 		} catch ( API_Exception $e ) {
 			return rest_ensure_response( new WP_Error( 'wcpay_get_charge', $e->getMessage() ) );
 		}

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -367,7 +367,7 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 			$wcpay_server_request->set_metadata( $metadata );
 			$wcpay_server_request->set_payment_method_types( $this->get_terminal_intent_payment_method( $request ) );
 			$wcpay_server_request->set_capture_method( 'manual' === $this->get_terminal_intent_capture_method( $request ) );
-			$intent = $wcpay_server_request->send( 'create_wcpay_terminal_intent_request', $order );
+			$intent = $wcpay_server_request->send( 'create_wcpay_intent_request', $order );
 
 			return rest_ensure_response(
 				[

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -10,7 +10,6 @@ defined( 'ABSPATH' ) || exit;
 use WCPay\Constants\Payment_Method;
 use WCPay\Core\Server\Request\Create_Intention;
 use WCPay\Core\Server\Request\Get_Intention;
-use WCPay\Exceptions\API_Exception;
 use WCPay\Logger;
 
 /**

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -141,9 +141,9 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 			}
 
 			// Do not process intents that can't be captured.
-			$request = Get_Intention::create();
-			$request->set_intent_id( $intent_id );
-			$intent                   = $request->send( 'wcpay_get_intent_request', $order );
+			$request = Get_Intention::create( $intent_id );
+			$intent  = $request->send( 'wcpay_get_intent_request', $order );
+
 			$intent_metadata          = is_array( $intent->get_metadata() ) ? $intent->get_metadata() : [];
 			$intent_meta_order_id_raw = $intent_metadata['order_id'] ?? '';
 			$intent_meta_order_id     = is_numeric( $intent_meta_order_id_raw ) ? intval( $intent_meta_order_id_raw ) : 0;
@@ -246,9 +246,8 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 			}
 
 			// Do not process intents that can't be captured.
-			$request = Get_Intention::create();
-			$request->set_intent_id( $intent_id );
-			$intent = $request->send( 'wcpay_get_intent_request', $order );
+			$request = Get_Intention::create( $intent_id );
+			$intent  = $request->send( 'wcpay_get_intent_request', $order );
 
 			$intent_metadata          = is_array( $intent->get_metadata() ) ? $intent->get_metadata() : [];
 			$intent_meta_order_id_raw = $intent_metadata['order_id'] ?? '';

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -9,6 +9,7 @@ defined( 'ABSPATH' ) || exit;
 
 use WCPay\Constants\Payment_Method;
 use WCPay\Core\Server\Request\Create_Intent;
+use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Logger;
 
@@ -140,7 +141,9 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 			}
 
 			// Do not process intents that can't be captured.
-			$intent                   = $this->api_client->get_intent( $intent_id );
+			$request = Get_Intent::create();
+			$request->set_intent_id( $intent_id );
+			$intent                   = $request->send( 'wcpay_get_intent_request', $order );
 			$intent_metadata          = is_array( $intent->get_metadata() ) ? $intent->get_metadata() : [];
 			$intent_meta_order_id_raw = $intent_metadata['order_id'] ?? '';
 			$intent_meta_order_id     = is_numeric( $intent_meta_order_id_raw ) ? intval( $intent_meta_order_id_raw ) : 0;
@@ -243,7 +246,10 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 			}
 
 			// Do not process intents that can't be captured.
-			$intent                   = $this->api_client->get_intent( $intent_id );
+			$request = Get_Intent::create();
+			$request->set_intent_id( $intent_id );
+			$intent = $request->send( 'wcpay_get_intent_request', $order );
+
 			$intent_metadata          = is_array( $intent->get_metadata() ) ? $intent->get_metadata() : [];
 			$intent_meta_order_id_raw = $intent_metadata['order_id'] ?? '';
 			$intent_meta_order_id     = is_numeric( $intent_meta_order_id_raw ) ? intval( $intent_meta_order_id_raw ) : 0;

--- a/includes/admin/class-wc-rest-payments-orders-controller.php
+++ b/includes/admin/class-wc-rest-payments-orders-controller.php
@@ -8,8 +8,8 @@
 defined( 'ABSPATH' ) || exit;
 
 use WCPay\Constants\Payment_Method;
-use WCPay\Core\Server\Request\Create_Intent;
-use WCPay\Core\Server\Request\Get_Intent;
+use WCPay\Core\Server\Request\Create_Intention;
+use WCPay\Core\Server\Request\Get_Intention;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Logger;
 
@@ -141,7 +141,7 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 			}
 
 			// Do not process intents that can't be captured.
-			$request = Get_Intent::create();
+			$request = Get_Intention::create();
 			$request->set_intent_id( $intent_id );
 			$intent                   = $request->send( 'wcpay_get_intent_request', $order );
 			$intent_metadata          = is_array( $intent->get_metadata() ) ? $intent->get_metadata() : [];
@@ -246,7 +246,7 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 			}
 
 			// Do not process intents that can't be captured.
-			$request = Get_Intent::create();
+			$request = Get_Intention::create();
 			$request->set_intent_id( $intent_id );
 			$intent = $request->send( 'wcpay_get_intent_request', $order );
 
@@ -364,7 +364,7 @@ class WC_REST_Payments_Orders_Controller extends WC_Payments_REST_Controller {
 			$metadata                 = $request->get_param( 'metadata' ) ?? [];
 			$metadata['order_number'] = $order->get_order_number();
 
-			$wcpay_server_request = Create_Intent::create();
+			$wcpay_server_request = Create_Intention::create();
 			$wcpay_server_request->set_currency_code( $currency );
 			$wcpay_server_request->set_amount( WC_Payments_Utils::prepare_amount( $order->get_total(), $currency ) );
 			if ( $customer_id ) {

--- a/includes/admin/class-wc-rest-payments-reader-controller.php
+++ b/includes/admin/class-wc-rest-payments-reader-controller.php
@@ -279,9 +279,8 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 
 			$charge         = $payment_intent->get_charge();
 			$charge_id      = $charge ? $charge->get_id() : null;
-			$charge_request = Get_Charge::create();
-			$charge_request->set_charge_id( $charge_id );
-			$charge_array = $charge_request->send( 'wcpay_get_charge_request', $charge_id );
+			$charge_request = Get_Charge::create( $charge_id );
+			$charge_array   = $charge_request->send( 'wcpay_get_charge_request', $charge_id );
 
 			/* Collect receipt data, stored on the store side. */
 			$order = wc_get_order( $charge_array['order']['number'] );

--- a/includes/admin/class-wc-rest-payments-reader-controller.php
+++ b/includes/admin/class-wc-rest-payments-reader-controller.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Payments\Admin
  */
 
+use WCPay\Core\Server\Request\Get_Charge;
 use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Exceptions\API_Exception;
 
@@ -277,9 +278,11 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 				throw new \RuntimeException( __( 'Invalid payment intent', 'woocommerce-payments' ) );
 			}
 
-			$charge       = $payment_intent->get_charge();
-			$charge_id    = $charge ? $charge->get_id() : null;
-			$charge_array = $this->api_client->get_charge( $charge_id );
+			$charge         = $payment_intent->get_charge();
+			$charge_id      = $charge ? $charge->get_id() : null;
+			$charge_request = Get_Charge::create();
+			$charge_request->set_charge_id( $charge_id );
+			$charge_array = $charge_request->send( 'wcpay_get_charge_request', $charge_id );
 
 			/* Collect receipt data, stored on the store side. */
 			$order = wc_get_order( $charge_array['order']['number'] );

--- a/includes/admin/class-wc-rest-payments-reader-controller.php
+++ b/includes/admin/class-wc-rest-payments-reader-controller.php
@@ -6,7 +6,7 @@
  */
 
 use WCPay\Core\Server\Request\Get_Charge;
-use WCPay\Core\Server\Request\Get_Intent;
+use WCPay\Core\Server\Request\Get_Intention;
 use WCPay\Exceptions\API_Exception;
 
 defined( 'ABSPATH' ) || exit;
@@ -271,7 +271,7 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 	public function generate_print_receipt( $request ) {
 		try {
 			/* Collect the data, available on the server side. */
-			$wcpay_request = Get_Intent::create();
+			$wcpay_request = Get_Intention::create();
 			$wcpay_request->set_intent_id( $request->get_param( 'payment_intent_id' ) );
 			$payment_intent = $wcpay_request->send( 'wcpay_get_intent_request' );
 			if ( 'succeeded' !== $payment_intent->get_status() ) {

--- a/includes/admin/class-wc-rest-payments-reader-controller.php
+++ b/includes/admin/class-wc-rest-payments-reader-controller.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Payments\Admin
  */
 
+use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Exceptions\API_Exception;
 
 defined( 'ABSPATH' ) || exit;
@@ -269,7 +270,9 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 	public function generate_print_receipt( $request ) {
 		try {
 			/* Collect the data, available on the server side. */
-			$payment_intent = $this->api_client->get_intent( $request->get_param( 'payment_intent_id' ) );
+			$wcpay_request = Get_Intent::create();
+			$wcpay_request->set_intent_id( $request->get_param( 'payment_intent_id' ) );
+			$payment_intent = $wcpay_request->send( 'wcpay_get_intent_request' );
 			if ( 'succeeded' !== $payment_intent->get_status() ) {
 				throw new \RuntimeException( __( 'Invalid payment intent', 'woocommerce-payments' ) );
 			}

--- a/includes/admin/class-wc-rest-payments-reader-controller.php
+++ b/includes/admin/class-wc-rest-payments-reader-controller.php
@@ -271,8 +271,7 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 	public function generate_print_receipt( $request ) {
 		try {
 			/* Collect the data, available on the server side. */
-			$wcpay_request = Get_Intention::create();
-			$wcpay_request->set_intent_id( $request->get_param( 'payment_intent_id' ) );
+			$wcpay_request  = Get_Intention::create( $request->get_param( 'payment_intent_id' ) );
 			$payment_intent = $wcpay_request->send( 'wcpay_get_intent_request' );
 			if ( 'succeeded' !== $payment_intent->get_status() ) {
 				throw new \RuntimeException( __( 'Invalid payment intent', 'woocommerce-payments' ) );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1256,9 +1256,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if ( $currency_order !== $currency_account ) {
 			// We check that the currency used in the order is different than the one set in the WC Payments account
 			// to avoid requesting the charge if not needed.
-			$request = Get_Charge::create();
-			$request->set_charge_id( $charge_id );
-			$charge = $request->send( 'wcpay_get_charge_request', $charge_id );
+			$request = Get_Charge::create( $charge_id );
+			$charge  = $request->send( 'wcpay_get_charge_request', $charge_id );
 
 			$exchange_rate = $charge['balance_transaction']['exchange_rate'] ?? null;
 			if ( isset( $exchange_rate ) ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -962,9 +962,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$intent = null;
 			if ( ! empty( $platform_checkout_intent_id ) ) {
 				// If the intent is included in the request use that intent.
-				$request = Get_Intention::create();
-				$request->set_intent_id( $platform_checkout_intent_id );
-				$intent = $request->send( 'wcpay_get_intent_request', $order );
+				$request = Get_Intention::create( $platform_checkout_intent_id );
+				$intent  = $request->send( 'wcpay_get_intent_request', $order );
 
 				$intent_meta_order_id_raw = $intent->get_metadata()['order_id'] ?? '';
 				$intent_meta_order_id     = is_numeric( $intent_meta_order_id_raw ) ? intval( $intent_meta_order_id_raw ) : 0;
@@ -1511,9 +1510,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$payment_method_details = $this->payments_api_client->get_payment_method( $payment_method_id );
 		} elseif ( $order->meta_exists( '_intent_id' ) ) {
 			$payment_intent_id = $order->get_meta( '_intent_id', true );
-			$request           = Get_Intention::create();
-			$request->set_intent_id( $payment_intent_id );
-			$payment_intent = $request->send( 'wcpay_get_intent_request', $order );
+			$request           = Get_Intention::create( $payment_intent_id );
+			$payment_intent    = $request->send( 'wcpay_get_intent_request', $order );
 
 			$charge                 = $payment_intent ? $payment_intent->get_charge() : null;
 			$payment_method_details = $charge ? $charge->get_payment_method_details() : [];
@@ -2093,9 +2091,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		try {
 			$intent_id = $order->get_transaction_id();
 
-			$request = Get_Intention::create();
-			$request->set_intent_id( $intent_id );
-			$intent = $request->send( 'wcpay_get_intent_request', $order );
+			$request = Get_Intention::create( $intent_id );
+			$intent  = $request->send( 'wcpay_get_intent_request', $order );
 
 			$payment_type = $this->is_payment_recurring( $order->get_id() ) ? Payment_Type::RECURRING() : Payment_Type::SINGLE();
 
@@ -2105,7 +2102,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			$wcpay_request = Update_Intention::create( $intent_id );
 			$wcpay_request->set_metadata( $merged_metadata );
-			$request->send( 'wcpay_prepare_intention_for_capture', $order );
+			$wcpay_request->send( 'wcpay_prepare_intention_for_capture', $order );
 
 			$intent = $this->payments_api_client->capture_intention(
 				$intent_id,
@@ -2181,9 +2178,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		} catch ( API_Exception $e ) {
 			try {
 				// Fetch the Intent to check if it's already expired and the site missed the "charge.expired" webhook.
-				$request = Get_Intention::create();
-				$request->set_intent_id( $order->get_transaction_id() );
-				$intent = $request->send( 'wcpay_get_intent_request', $order );
+				$request = Get_Intention::create( $order->get_transaction_id() );
+				$intent  = $request->send( 'wcpay_get_intent_request', $order );
 
 				$status = $intent->get_status();
 				if ( 'canceled' !== $status ) {
@@ -2381,9 +2377,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			if ( $amount > 0 ) {
 				// An exception is thrown if an intent can't be found for the given intent ID.
-				$request = Get_Intention::create();
-				$request->set_intent_id( $intent_id );
-				$intent = $request->send( 'wcpay_get_intent_request', $order );
+				$request = Get_Intention::create( $intent_id );
+				$intent  = $request->send( 'wcpay_get_intent_request', $order );
 
 				$status    = $intent->get_status();
 				$charge    = $intent->get_charge();

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 use WCPay\Core\Mode;
 use WCPay\Exceptions\{ Add_Payment_Method_Exception, Amount_Too_Small_Exception, Process_Payment_Exception, Intent_Authentication_Exception, API_Exception };
 use WCPay\Core\Server\Request\Create_And_Confirm_Intention;
+use WCPay\Core\Server\Request\Create_Intent;
 use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
 use WCPay\Logger;
 use WCPay\Payment_Information;
@@ -2546,51 +2547,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				strtotime( '+5 seconds' ),
 				'wcpay_track_update_order',
 				[ 'order_id' => $order_id ]
-			);
-		}
-	}
-
-	/**
-	 * Create a payment intent without confirming the intent.
-	 *
-	 * @param WC_Order    $order           - Order based on which to create intent.
-	 * @param array       $payment_methods - A list of allowed payment methods. Eg. card, card_present.
-	 * @param string      $capture_method  - Controls when the funds will be captured from the customer's account ("automatic" or "manual").
-	 *  It must be "manual" for in-person (terminal) payments.
-	 * @param array       $metadata        - A list of intent metadata.
-	 * @param string|null $customer_id     - Customer id for intent.
-	 *
-	 * @return array|WP_Error On success, an array containing info about the newly created intent. On failure, WP_Error object.
-	 *
-	 * @throws Exception - When an error occurs in intent creation.
-	 */
-	public function create_intent( WC_Order $order, array $payment_methods, string $capture_method = 'automatic', array $metadata = [], string $customer_id = null ) {
-		$currency         = strtolower( $order->get_currency() );
-		$converted_amount = WC_Payments_Utils::prepare_amount( $order->get_total(), $currency );
-
-		try {
-			$intent = $this->payments_api_client->create_intention(
-				$converted_amount,
-				$currency,
-				$payment_methods,
-				$order->get_order_number(),
-				$capture_method,
-				$metadata,
-				$customer_id
-			);
-
-			return [
-				'id' => ! empty( $intent ) ? $intent->get_id() : null,
-			];
-		} catch ( API_Exception $e ) {
-			return new WP_Error(
-				'wcpay_intent_creation_error',
-				sprintf(
-					// translators: %s: the error message.
-					__( 'Intent creation failed with the following message: %s', 'woocommerce-payments' ),
-					$e->getMessage() ?? __( 'Unknown error', 'woocommerce-payments' )
-				),
-				[ 'status' => $e->get_http_code() ]
 			);
 		}
 	}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -13,6 +13,7 @@ use WCPay\Core\Mode;
 use WCPay\Exceptions\{ Add_Payment_Method_Exception, Amount_Too_Small_Exception, Process_Payment_Exception, Intent_Authentication_Exception, API_Exception };
 use WCPay\Core\Server\Request\Create_And_Confirm_Intention;
 use WCPay\Core\Server\Request\Create_Intent;
+use WCPay\Core\Server\Request\Get_Charge;
 use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
 use WCPay\Logger;
@@ -1256,7 +1257,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if ( $currency_order !== $currency_account ) {
 			// We check that the currency used in the order is different than the one set in the WC Payments account
 			// to avoid requesting the charge if not needed.
-			$charge        = $this->payments_api_client->get_charge( $charge_id );
+			$request = Get_Charge::create();
+			$request->set_charge_id( $charge_id );
+			$charge = $request->send( 'wcpay_get_charge_request', $charge_id );
+
 			$exchange_rate = $charge['balance_transaction']['exchange_rate'] ?? null;
 			if ( isset( $exchange_rate ) ) {
 				$exchange_rate = WC_Payments_Utils::interpret_string_exchange_rate( $exchange_rate, $currency_order, $currency_account );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2106,7 +2106,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			$capture_intention_request = Capture_Intention::create( $intent_id );
 			$capture_intention_request->set_amount_to_capture( WC_Payments_Utils::prepare_amount( $amount, $order->get_currency() ) );
-			$capture_intention_request->set_level3( $include_level3 ? $this->get_level3_data_from_order( $order ) : [] );
+			if ( $include_level3 ) {
+				$capture_intention_request->set_level3( $this->get_level3_data_from_order( $order ) );
+			}
 			$intent = $capture_intention_request->send( 'wcpay_capture_intent_request', $order );
 
 			$status    = $intent->get_status();

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -12,9 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 use WCPay\Core\Mode;
 use WCPay\Exceptions\{ Add_Payment_Method_Exception, Amount_Too_Small_Exception, Process_Payment_Exception, Intent_Authentication_Exception, API_Exception };
 use WCPay\Core\Server\Request\Create_And_Confirm_Intention;
-use WCPay\Core\Server\Request\Create_Intention;
 use WCPay\Core\Server\Request\Get_Charge;
 use WCPay\Core\Server\Request\Get_Intention;
+use WCPay\Core\Server\Request\Update_Intention;
 use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
 use WCPay\Logger;
 use WCPay\Payment_Information;
@@ -2103,10 +2103,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$metadata_from_order  = $this->get_metadata_from_order( $order, $payment_type );
 			$merged_metadata      = array_merge( (array) $metadata_from_order, (array) $metadata_from_intent ); // prioritize metadata from mobile app.
 
-			$this->payments_api_client->prepare_intention_for_capture(
-				$intent_id,
-				$merged_metadata
-			);
+			$wcpay_request = Update_Intention::create( $intent_id );
+			$wcpay_request->set_metadata( $merged_metadata );
+			$request->send( 'wcpay_prepare_intention_for_capture', $order );
 
 			$intent = $this->payments_api_client->capture_intention(
 				$intent_id,

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -12,9 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 use WCPay\Core\Mode;
 use WCPay\Exceptions\{ Add_Payment_Method_Exception, Amount_Too_Small_Exception, Process_Payment_Exception, Intent_Authentication_Exception, API_Exception };
 use WCPay\Core\Server\Request\Create_And_Confirm_Intention;
-use WCPay\Core\Server\Request\Create_Intent;
+use WCPay\Core\Server\Request\Create_Intention;
 use WCPay\Core\Server\Request\Get_Charge;
-use WCPay\Core\Server\Request\Get_Intent;
+use WCPay\Core\Server\Request\Get_Intention;
 use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
 use WCPay\Logger;
 use WCPay\Payment_Information;
@@ -962,7 +962,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$intent = null;
 			if ( ! empty( $platform_checkout_intent_id ) ) {
 				// If the intent is included in the request use that intent.
-				$request = Get_Intent::create();
+				$request = Get_Intention::create();
 				$request->set_intent_id( $platform_checkout_intent_id );
 				$intent = $request->send( 'wcpay_get_intent_request', $order );
 
@@ -1511,7 +1511,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$payment_method_details = $this->payments_api_client->get_payment_method( $payment_method_id );
 		} elseif ( $order->meta_exists( '_intent_id' ) ) {
 			$payment_intent_id = $order->get_meta( '_intent_id', true );
-			$request           = Get_Intent::create();
+			$request           = Get_Intention::create();
 			$request->set_intent_id( $payment_intent_id );
 			$payment_intent = $request->send( 'wcpay_get_intent_request', $order );
 
@@ -2093,7 +2093,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		try {
 			$intent_id = $order->get_transaction_id();
 
-			$request = Get_Intent::create();
+			$request = Get_Intention::create();
 			$request->set_intent_id( $intent_id );
 			$intent = $request->send( 'wcpay_get_intent_request', $order );
 
@@ -2182,7 +2182,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		} catch ( API_Exception $e ) {
 			try {
 				// Fetch the Intent to check if it's already expired and the site missed the "charge.expired" webhook.
-				$request = Get_Intent::create();
+				$request = Get_Intention::create();
 				$request->set_intent_id( $order->get_transaction_id() );
 				$intent = $request->send( 'wcpay_get_intent_request', $order );
 
@@ -2382,7 +2382,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			if ( $amount > 0 ) {
 				// An exception is thrown if an intent can't be found for the given intent ID.
-				$request = Get_Intent::create();
+				$request = Get_Intention::create();
 				$request->set_intent_id( $intent_id );
 				$intent = $request->send( 'wcpay_get_intent_request', $order );
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use WCPay\Core\Mode;
 use WCPay\Exceptions\{ Add_Payment_Method_Exception, Amount_Too_Small_Exception, Process_Payment_Exception, Intent_Authentication_Exception, API_Exception };
+use WCPay\Core\Server\Request\Cancel_Intention;
 use WCPay\Core\Server\Request\Capture_Intention;
 use WCPay\Core\Server\Request\Create_And_Confirm_Intention;
 use WCPay\Core\Server\Request\Get_Charge;
@@ -2172,8 +2173,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$error_message = null;
 
 		try {
-			$intent = $this->payments_api_client->cancel_intention( $order->get_transaction_id() );
-			$status = $intent->get_status();
+			$request = Cancel_Intention::create( $order->get_transaction_id() );
+			$intent  = $request->send( 'wcpay_cancel_intent_request', $order );
+			$status  = $intent->get_status();
 		} catch ( API_Exception $e ) {
 			try {
 				// Fetch the Intent to check if it's already expired and the site missed the "charge.expired" webhook.

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -315,9 +315,8 @@ class WC_Payments_Webhook_Processing_Service {
 		// Get the intent_id and then its status.
 		$intent_id = $event_object['payment_intent'] ?? $order->get_meta( '_intent_id' );
 
-		$request = Get_Intention::create();
-		$request->set_intent_id( $intent_id );
-		$intent = $request->send( 'wcpay_get_intent_request', $order );
+		$request = Get_Intention::create( $intent_id );
+		$intent  = $request->send( 'wcpay_get_intent_request', $order );
 
 		$intent_status = $intent->get_status();
 

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -6,6 +6,7 @@
  */
 
 use WCPay\Constants\Payment_Method;
+use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Exceptions\Invalid_Payment_Method_Exception;
 use WCPay\Exceptions\Invalid_Webhook_Data_Exception;
 use WCPay\Exceptions\Rest_Request_Exception;
@@ -312,8 +313,12 @@ class WC_Payments_Webhook_Processing_Service {
 		}
 
 		// Get the intent_id and then its status.
-		$intent_id     = $event_object['payment_intent'] ?? $order->get_meta( '_intent_id' );
-		$intent        = $this->api_client->get_intent( $intent_id );
+		$intent_id = $event_object['payment_intent'] ?? $order->get_meta( '_intent_id' );
+
+		$request = Get_Intent::create();
+		$request->set_intent_id( $intent_id );
+		$intent = $request->send( 'wcpay_get_intent_request', $order );
+
 		$intent_status = $intent->get_status();
 
 		// TODO: Revisit this logic once we support partial captures or multiple charges for order. We'll need to handle the "payment_intent.canceled" event too.

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -6,7 +6,7 @@
  */
 
 use WCPay\Constants\Payment_Method;
-use WCPay\Core\Server\Request\Get_Intent;
+use WCPay\Core\Server\Request\Get_Intention;
 use WCPay\Exceptions\Invalid_Payment_Method_Exception;
 use WCPay\Exceptions\Invalid_Webhook_Data_Exception;
 use WCPay\Exceptions\Rest_Request_Exception;
@@ -315,7 +315,7 @@ class WC_Payments_Webhook_Processing_Service {
 		// Get the intent_id and then its status.
 		$intent_id = $event_object['payment_intent'] ?? $order->get_meta( '_intent_id' );
 
-		$request = Get_Intent::create();
+		$request = Get_Intention::create();
 		$request->set_intent_id( $intent_id );
 		$intent = $request->send( 'wcpay_get_intent_request', $order );
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1339,18 +1339,18 @@ class WC_Payments {
 	 * Creates a new request object for a server call.
 	 *
 	 * @param  string $class_name The name of the request class. Must extend WCPay\Core\Server\Request.
-	 * @param  array  ...$constructor_arguments Used to pass constructor arguments.
+	 * @param  mixed  $id         The item ID, if the request needs it (Optional).
 	 * @return Request
 	 * @throws Exception          If the request class is not really a request.
 	 */
-	public static function create_request( $class_name, ...$constructor_arguments ) {
+	public static function create_request( $class_name, $id = null ) {
 		/**
 		 * Used for unit tests only, as requests have dependencies, which are not publicly available in live mode.
 		 *
 		 * @param Request $request    Null, but if the filter returns a request, it will be used.
 		 * @param string  $class_name The name of the request class.
 		 */
-		$request = apply_filters( 'wcpay_create_request', null, $class_name );
+		$request = apply_filters( 'wcpay_create_request', null, $class_name, $id );
 		if ( $request instanceof Request ) {
 			return $request;
 		}
@@ -1365,7 +1365,7 @@ class WC_Payments {
 			);
 		}
 
-		return new $class_name( self::get_payments_api_client(), self::get_wc_payments_http(), ...$constructor_arguments );
+		return new $class_name( self::get_payments_api_client(), self::get_wc_payments_http(), $id );
 
 	}
 }

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -266,6 +266,7 @@ class WC_Payments {
 		include_once __DIR__ . '/core/server/request/trait-level3.php';
 		include_once __DIR__ . '/core/server/request/class-generic.php';
 		include_once __DIR__ . '/core/server/request/class-create-intent.php';
+		include_once __DIR__ . '/core/server/request/class-update-intention.php';
 		include_once __DIR__ . '/core/server/request/class-woopay-create-intent.php';
 		include_once __DIR__ . '/core/server/request/class-create-and-confirm-intention.php';
 		include_once __DIR__ . '/core/server/request/class-woopay-create-and-confirm-intention.php';

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -269,6 +269,7 @@ class WC_Payments {
 		include_once __DIR__ . '/core/server/request/class-create-intention.php';
 		include_once __DIR__ . '/core/server/request/class-update-intention.php';
 		include_once __DIR__ . '/core/server/request/class-capture-intention.php';
+		include_once __DIR__ . '/core/server/request/class-cancel-intention.php';
 		include_once __DIR__ . '/core/server/request/class-get-charge.php';
 		include_once __DIR__ . '/core/server/request/class-woopay-create-intent.php';
 		include_once __DIR__ . '/core/server/request/class-create-and-confirm-intention.php';

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -271,10 +271,12 @@ class WC_Payments {
 		include_once __DIR__ . '/core/server/request/class-capture-intention.php';
 		include_once __DIR__ . '/core/server/request/class-cancel-intention.php';
 		include_once __DIR__ . '/core/server/request/class-create-setup-intention.php';
+		include_once __DIR__ . '/core/server/request/class-create-and-confirm-setup-intention.php';
 		include_once __DIR__ . '/core/server/request/class-get-charge.php';
 		include_once __DIR__ . '/core/server/request/class-woopay-create-intent.php';
 		include_once __DIR__ . '/core/server/request/class-create-and-confirm-intention.php';
 		include_once __DIR__ . '/core/server/request/class-woopay-create-and-confirm-intention.php';
+		include_once __DIR__ . '/core/server/request/class-woopay-create-and-confirm-setup-intention.php';
 
 		include_once __DIR__ . '/woopay/services/class-checkout-service.php';
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -265,8 +265,8 @@ class WC_Payments {
 		include_once __DIR__ . '/core/server/request/trait-intention.php';
 		include_once __DIR__ . '/core/server/request/trait-level3.php';
 		include_once __DIR__ . '/core/server/request/class-generic.php';
-		include_once __DIR__ . '/core/server/request/class-get-intent.php';
-		include_once __DIR__ . '/core/server/request/class-create-intent.php';
+		include_once __DIR__ . '/core/server/request/class-get-intention.php';
+		include_once __DIR__ . '/core/server/request/class-create-intention.php';
 		include_once __DIR__ . '/core/server/request/class-update-intention.php';
 		include_once __DIR__ . '/core/server/request/class-get-charge.php';
 		include_once __DIR__ . '/core/server/request/class-woopay-create-intent.php';

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -265,6 +265,7 @@ class WC_Payments {
 		include_once __DIR__ . '/core/server/request/trait-intention.php';
 		include_once __DIR__ . '/core/server/request/trait-level3.php';
 		include_once __DIR__ . '/core/server/request/class-generic.php';
+		include_once __DIR__ . '/core/server/request/class-get-intent.php';
 		include_once __DIR__ . '/core/server/request/class-create-intent.php';
 		include_once __DIR__ . '/core/server/request/class-update-intention.php';
 		include_once __DIR__ . '/core/server/request/class-woopay-create-intent.php';

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1339,10 +1339,11 @@ class WC_Payments {
 	 * Creates a new request object for a server call.
 	 *
 	 * @param  string $class_name The name of the request class. Must extend WCPay\Core\Server\Request.
+	 * @param  array  ...$constructor_arguments Used to pass constructor arguments.
 	 * @return Request
 	 * @throws Exception          If the request class is not really a request.
 	 */
-	public static function create_request( $class_name ) {
+	public static function create_request( $class_name, ...$constructor_arguments ) {
 		/**
 		 * Used for unit tests only, as requests have dependencies, which are not publicly available in live mode.
 		 *
@@ -1364,9 +1365,7 @@ class WC_Payments {
 			);
 		}
 
-		$request = new $class_name( self::get_payments_api_client(), self::get_wc_payments_http() );
-
-		return $request;
+		return new $class_name( self::get_payments_api_client(), self::get_wc_payments_http(), ...$constructor_arguments );
 
 	}
 }

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -268,6 +268,7 @@ class WC_Payments {
 		include_once __DIR__ . '/core/server/request/class-get-intent.php';
 		include_once __DIR__ . '/core/server/request/class-create-intent.php';
 		include_once __DIR__ . '/core/server/request/class-update-intention.php';
+		include_once __DIR__ . '/core/server/request/class-get-charge.php';
 		include_once __DIR__ . '/core/server/request/class-woopay-create-intent.php';
 		include_once __DIR__ . '/core/server/request/class-create-and-confirm-intention.php';
 		include_once __DIR__ . '/core/server/request/class-woopay-create-and-confirm-intention.php';

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -268,6 +268,7 @@ class WC_Payments {
 		include_once __DIR__ . '/core/server/request/class-get-intention.php';
 		include_once __DIR__ . '/core/server/request/class-create-intention.php';
 		include_once __DIR__ . '/core/server/request/class-update-intention.php';
+		include_once __DIR__ . '/core/server/request/class-capture-intention.php';
 		include_once __DIR__ . '/core/server/request/class-get-charge.php';
 		include_once __DIR__ . '/core/server/request/class-woopay-create-intent.php';
 		include_once __DIR__ . '/core/server/request/class-create-and-confirm-intention.php';

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -270,6 +270,7 @@ class WC_Payments {
 		include_once __DIR__ . '/core/server/request/class-update-intention.php';
 		include_once __DIR__ . '/core/server/request/class-capture-intention.php';
 		include_once __DIR__ . '/core/server/request/class-cancel-intention.php';
+		include_once __DIR__ . '/core/server/request/class-create-setup-intention.php';
 		include_once __DIR__ . '/core/server/request/class-get-charge.php';
 		include_once __DIR__ . '/core/server/request/class-woopay-create-intent.php';
 		include_once __DIR__ . '/core/server/request/class-create-and-confirm-intention.php';

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-use WCPay\Core\Server\Request\Get_Intent;
+use WCPay\Core\Server\Request\Get_Intention;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Exceptions\Invalid_Payment_Method_Exception;
 use WCPay\Exceptions\Add_Payment_Method_Exception;
@@ -211,7 +211,7 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 	public function prepare_intent_for_order_pay_page(): bool {
 		$order = wc_get_order( absint( get_query_var( 'order-pay' ) ) );
 
-		$request = Get_Intent::create();
+		$request = Get_Intention::create();
 		$request->set_intent_id( $order->get_transaction_id() );
 		$intent = $request->send( 'wcpay_get_intent_request', $order );
 

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Exceptions\Invalid_Payment_Method_Exception;
 use WCPay\Exceptions\Add_Payment_Method_Exception;
@@ -208,8 +209,11 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 	 * @return bool True if the Intent was fetched and prepared successfully, false otherwise.
 	 */
 	public function prepare_intent_for_order_pay_page(): bool {
-		$order  = wc_get_order( absint( get_query_var( 'order-pay' ) ) );
-		$intent = $this->payments_api_client->get_intent( $order->get_transaction_id() );
+		$order = wc_get_order( absint( get_query_var( 'order-pay' ) ) );
+
+		$request = Get_Intent::create();
+		$request->set_intent_id( $order->get_transaction_id() );
+		$intent = $request->send( 'wcpay_get_intent_request', $order );
 
 		if ( ! $intent || 'requires_action' !== $intent->get_status() ) {
 			return false;

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -211,9 +211,8 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 	public function prepare_intent_for_order_pay_page(): bool {
 		$order = wc_get_order( absint( get_query_var( 'order-pay' ) ) );
 
-		$request = Get_Intention::create();
-		$request->set_intent_id( $order->get_transaction_id() );
-		$intent = $request->send( 'wcpay_get_intent_request', $order );
+		$request = Get_Intention::create( $order->get_transaction_id() );
+		$intent  = $request->send( 'wcpay_get_intent_request', $order );
 
 		if ( ! $intent || 'requires_action' !== $intent->get_status() ) {
 			return false;

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -77,10 +77,12 @@ abstract class Request {
 	/**
 	 * Creates a new request, loading dependencies in there.
 	 *
+	 * @param mixed ...$constructor_arguments Constructor arguments.
+	 *
 	 * @return static
 	 */
-	public static function create() {
-		return WC_Payments::create_request( static::class );
+	public static function create( ...$constructor_arguments ) {
+		return WC_Payments::create_request( static::class, ...$constructor_arguments );
 	}
 
 	/**

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -75,25 +75,43 @@ abstract class Request {
 	protected $http_interface;
 
 	/**
+	 * Holds the ID of an item, which is included in the request URL.
+	 *
+	 * @var mixed (int|string)
+	 */
+	protected $id;
+
+	/**
 	 * Creates a new request, loading dependencies in there.
 	 *
-	 * @param mixed ...$constructor_arguments Constructor arguments.
+	 * @param mixed $id The identifier for various update/get/delete requests.
 	 *
 	 * @return static
 	 */
-	public static function create( ...$constructor_arguments ) {
-		return WC_Payments::create_request( static::class, ...$constructor_arguments );
+	public static function create( $id = null ) {
+		return WC_Payments::create_request( static::class, $id );
 	}
 
 	/**
 	 * Prevents the class from being constructed directly.
 	 *
-	 * @param WC_Payments_API_Client     $api_client     The API client to use to send requests.
+	 * @param WC_Payments_API_Client     $api_client The API client to use to send requests.
 	 * @param WC_Payments_Http_Interface $http_interface The HTTP interface for the server.
+	 * @param mixed                      $id An optional ID for the item that will be updated/retrieved/deleted.
+	 *
+	 * @throws Invalid_Request_Parameter_Exception
 	 */
-	public function __construct( WC_Payments_API_Client $api_client, WC_Payments_Http_Interface $http_interface ) {
+	public function __construct( WC_Payments_API_Client $api_client, WC_Payments_Http_Interface $http_interface, $id = null ) {
 		$this->api_client     = $api_client;
 		$this->http_interface = $http_interface;
+
+		if ( method_exists( $this, 'set_id' ) ) {
+			if ( null !== $id ) {
+				$this->set_id( $id );
+			} else {
+				throw new Invalid_Request_Parameter_Exception( 'This request requires an item ID.', 'wcpay_core_invalid_request_parameter_missing_id' );
+			}
+		}
 	}
 
 	/**

--- a/includes/core/server/class-response.php
+++ b/includes/core/server/class-response.php
@@ -70,4 +70,13 @@ class Response implements ArrayAccess {
 	public function offsetUnset( $offset ) {
 		throw new Server_Response_Exception( 'Server responses cannot be mutated.', 'wcpay_core_server_response_malformed' );
 	}
+
+	/**
+	 * Return data as an array.
+	 *
+	 * @return array
+	 */
+	public function to_array() {
+		return $this->data;
+	}
 }

--- a/includes/core/server/request/class-cancel-intention.php
+++ b/includes/core/server/request/class-cancel-intention.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Request\Update_Intent.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server\Request;
+
+use WC_Payments;
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
+use WCPay\Core\Server\Request;
+use WC_Payments_API_Client;
+
+/**
+ * Request class for canceling intents.
+ */
+class Cancel_Intention extends Request {
+	use Intention;
+	use Level3;
+
+	const IMMUTABLE_PARAMS = [];
+	const REQUIRED_PARAMS  = [];
+	const DEFAULT_PARAMS   = [];
+
+
+
+	/**
+	 * Sets the intent ID, which will be used in the request URL.
+	 *
+	 * @param string $id Sets the intent ID, which will be used in the request URL.
+	 *
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	protected function set_id( string $id ) {
+		$this->validate_stripe_id( $id );
+		$this->id = $id;
+	}
+
+	/**
+	 * Returns the request's API.
+	 *
+	 * @return string
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function get_api(): string {
+		return WC_Payments_API_Client::INTENTIONS_API . '/' . $this->id . '/cancel';
+	}
+
+	/**
+	 * Returns the request's HTTP method.
+	 */
+	public function get_method(): string {
+		return 'POST';
+	}
+
+	/**
+	 * Formats the response from the server.
+	 *
+	 * @param  mixed $response The response from `WC_Payments_API_Client::request`.
+	 * @return mixed           Either the same response, or the correct object.
+	 */
+	public function format_response( $response ) {
+		return WC_Payments::get_payments_api_client()->deserialize_intention_object_from_array( $response );
+	}
+}

--- a/includes/core/server/request/class-cancel-intention.php
+++ b/includes/core/server/request/class-cancel-intention.php
@@ -23,8 +23,6 @@ class Cancel_Intention extends Request {
 	const REQUIRED_PARAMS  = [];
 	const DEFAULT_PARAMS   = [];
 
-
-
 	/**
 	 * Sets the intent ID, which will be used in the request URL.
 	 *

--- a/includes/core/server/request/class-capture-intention.php
+++ b/includes/core/server/request/class-capture-intention.php
@@ -25,8 +25,6 @@ class Capture_Intention extends Request {
 		'level3' => [],
 	];
 
-
-
 	/**
 	 * Sets the intent ID, which will be used in the request URL.
 	 *
@@ -38,8 +36,6 @@ class Capture_Intention extends Request {
 		$this->validate_stripe_id( $id );
 		$this->id = $id;
 	}
-
-
 
 	/**
 	 * Returns the request's API.
@@ -66,8 +62,6 @@ class Capture_Intention extends Request {
 	public function set_amount_to_capture( int $amount ) {
 		$this->set_param( 'amount_to_capture', $amount );
 	}
-
-
 
 	/**
 	 * Level 3 data setter.

--- a/includes/core/server/request/class-capture-intention.php
+++ b/includes/core/server/request/class-capture-intention.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Request\Update_Intent.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server\Request;
+
+use WC_Payments;
+use WC_Payments_Http_Interface;
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
+use WCPay\Core\Server\Request;
+use WC_Payments_API_Client;
+use WCPay\Payment_Methods\CC_Payment_Method;
+use WCPay\Payment_Methods\Link_Payment_Method;
+
+/**
+ * Request class for creating intents.
+ */
+class Capture_Intention extends Request {
+	use Intention;
+	use Level3;
+
+	const IMMUTABLE_PARAMS = [ 'amount' ];
+	const REQUIRED_PARAMS  = []; // This use to be amount and currency, but since it is not required on server API, I will leave it blank.
+	const DEFAULT_PARAMS   = [
+		'receipt_email' => '',
+		'metadata'      => [],
+	];
+
+
+
+	/**
+	 * Sets the intent ID, which will be used in the request URL.
+	 *
+	 * @param string $id Sets the intent ID, which will be used in the request URL.
+	 *
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	protected function set_id( string $id ) {
+		$this->validate_stripe_id( $id );
+		$this->id = $id;
+	}
+
+
+
+	/**
+	 * Returns the request's API.
+	 *
+	 * @return string
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function get_api(): string {
+		return WC_Payments_API_Client::INTENTIONS_API . '/' . $this->id . '/capture';
+	}
+
+	/**
+	 * Returns the request's HTTP method.
+	 */
+	public function get_method(): string {
+		return 'POST';
+	}
+
+	/**
+	 * Stores the amount for the intent.
+	 *
+	 * @param int $amount Amount to capture.
+	 */
+	public function set_amount_to_capture( int $amount ) {
+		$this->set_param( 'amount_to_capture', $amount );
+	}
+
+
+
+	/**
+	 * Level 3 data setter.
+	 *
+	 * @param array $level3 Level 3 data.
+	 */
+	public function set_level3( $level3 ) {
+		if ( empty( $level3 ) || ! is_array( $level3 ) ) {
+			return;
+		}
+
+		$this->set_param( 'level3', $this->fix_level3_data( $level3 ) );
+	}
+
+	/**
+	 * Formats the response from the server.
+	 *
+	 * @param  mixed $response The response from `WC_Payments_API_Client::request`.
+	 * @return mixed           Either the same response, or the correct object.
+	 */
+	public function format_response( $response ) {
+		return WC_Payments::get_payments_api_client()->deserialize_intention_object_from_array( $response );
+	}
+}

--- a/includes/core/server/request/class-capture-intention.php
+++ b/includes/core/server/request/class-capture-intention.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class file for WCPay\Core\Server\Request\Update_Intent.
+ * Class file for WCPay\Core\Server\Request\Capture_Intention.
  *
  * @package WooCommerce Payments
  */
@@ -8,25 +8,21 @@
 namespace WCPay\Core\Server\Request;
 
 use WC_Payments;
-use WC_Payments_Http_Interface;
 use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
 use WCPay\Core\Server\Request;
 use WC_Payments_API_Client;
-use WCPay\Payment_Methods\CC_Payment_Method;
-use WCPay\Payment_Methods\Link_Payment_Method;
 
 /**
- * Request class for creating intents.
+ * Request class for capturing intents.
  */
 class Capture_Intention extends Request {
 	use Intention;
 	use Level3;
 
-	const IMMUTABLE_PARAMS = [ 'amount' ];
-	const REQUIRED_PARAMS  = []; // This use to be amount and currency, but since it is not required on server API, I will leave it blank.
+	const IMMUTABLE_PARAMS = [ 'amount_to_capture' ];
+	const REQUIRED_PARAMS  = [ 'amount_to_capture' ];
 	const DEFAULT_PARAMS   = [
-		'receipt_email' => '',
-		'metadata'      => [],
+		'level3' => [],
 	];
 
 

--- a/includes/core/server/request/class-create-and-confirm-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-intention.php
@@ -9,15 +9,13 @@ namespace WCPay\Core\Server\Request;
 
 use WC_Payments;
 use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
-use WCPay\Core\Server\Request;
 use WC_Payments_API_Client;
 
 /**
  * Request class for creating intents.
  */
-class Create_And_Confirm_Intention extends Request {
-	use Intention;
-	use Level3;
+class Create_And_Confirm_Intention extends Create_Intent {
+
 
 
 	const IMMUTABLE_PARAMS = [
@@ -57,97 +55,12 @@ class Create_And_Confirm_Intention extends Request {
 	}
 
 	/**
-	 * Amount setter.
-	 *
-	 * @param int $amount Amount to charge.
-	 */
-	public function set_amount( int $amount ) {
-		$this->validate_is_larger_then( $amount, 0 );
-		$this->set_param( 'amount', $amount );
-	}
-
-	/**
-	 * Currency code setter.
-	 *
-	 * @param  string $currency_code Currency to charge in.
-	 * @throws Invalid_Request_Parameter_Exception When the currency code is invalid.
-	 */
-	public function set_currency_code( string $currency_code ) {
-		$this->validate_currency_code( $currency_code );
-		$this->set_param( 'currency', $currency_code );
-	}
-
-	/**
-	 * Payment method setter.
-	 *
-	 * @param string $payment_method_id ID of payment method to process charge with.
-	 */
-	public function set_payment_method( $payment_method_id ) {
-		$this->validate_stripe_id( $payment_method_id, [ 'pm', 'src' ] );
-		$this->set_param( 'payment_method', $payment_method_id );
-	}
-
-	/**
-	 * Customer setter.
-	 *
-	 * @param string $customer_id ID of the customer making the payment.
-	 */
-	public function set_customer( string $customer_id ) {
-		$this->validate_stripe_id( $customer_id, 'cus' );
-		$this->set_param( 'customer', $customer_id );
-	}
-
-	/**
-	 * Capture method setter.
-	 *
-	 * @param bool $manual_capture Whether to capture funds via manual action.
-	 */
-	public function set_capture_method( bool $manual_capture = false ) {
-		$this->set_param( 'capture_method', $manual_capture ? 'manual' : 'automatic' );
-	}
-
-	/**
 	 * If the payment method should be saved to the store, this enables future usage.
 	 */
 	public function setup_future_usage() {
 		$this->set_param( 'setup_future_usage', 'off_session' );
 	}
 
-	/**
-	 * Metadata setter.
-	 *
-	 * @param  array $metadata                     Meta data values to be sent along with payment intent creation.
-	 * @throws Invalid_Request_Parameter_Exception In case there is no order number provided.
-	 */
-	public function set_metadata( $metadata ) {
-		if ( ! isset( $metadata['order_number'] ) ) {
-			throw new Invalid_Request_Parameter_Exception(
-				__( 'An order number is required!', 'woocommerce-payments' ),
-				'wcpay_core_invalid_request_parameter_metadata_order_number'
-			);
-		}
-
-		// The description is based on the order number here.
-		$description = $this->get_intent_description( $metadata['order_number'] ?? 0 );
-		$this->set_param( 'description', $description );
-
-		// Combine the metadata with the fingerprint.
-		$metadata = array_merge( $metadata, $this->get_fingerprint_metadata() );
-		$this->set_param( 'metadata', $metadata );
-	}
-
-	/**
-	 * Level 3 data setter.
-	 *
-	 * @param array $level3 Level 3 data.
-	 */
-	public function set_level3( $level3 ) {
-		if ( empty( $level3 ) || ! is_array( $level3 ) ) {
-			return;
-		}
-
-		$this->set_param( 'level3', $this->fix_level3_data( $level3 ) );
-	}
 
 	/**
 	 * Off-session setter.

--- a/includes/core/server/request/class-create-and-confirm-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-intention.php
@@ -15,8 +15,6 @@ use WC_Payments_API_Client;
  */
 class Create_And_Confirm_Intention extends Create_Intention {
 
-
-
 	const IMMUTABLE_PARAMS = [
 		// Those are up to us, we have to decide.
 		'amount',
@@ -59,7 +57,6 @@ class Create_And_Confirm_Intention extends Create_Intention {
 	public function setup_future_usage() {
 		$this->set_param( 'setup_future_usage', 'off_session' );
 	}
-
 
 	/**
 	 * Off-session setter.

--- a/includes/core/server/request/class-create-and-confirm-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-intention.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class file for WCPay\Core\Server\Request\Create_Intent.
+ * Class file for WCPay\Core\Server\Request\Create_Intention.
  *
  * @package WooCommerce Payments
  */
@@ -13,7 +13,7 @@ use WC_Payments_API_Client;
 /**
  * Request class for creating intents.
  */
-class Create_And_Confirm_Intention extends Create_Intent {
+class Create_And_Confirm_Intention extends Create_Intention {
 
 
 

--- a/includes/core/server/request/class-create-and-confirm-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-intention.php
@@ -7,7 +7,6 @@
 
 namespace WCPay\Core\Server\Request;
 
-use WC_Payments;
 use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
 use WC_Payments_API_Client;
 
@@ -101,15 +100,5 @@ class Create_And_Confirm_Intention extends Create_Intent {
 	 */
 	public function set_cvc_confirmation( $cvc_confirmation = null ) {
 		$this->set_param( 'cvc_confirmation', $cvc_confirmation );
-	}
-
-	/**
-	 * Formats the response from the server.
-	 *
-	 * @param  mixed $response The response from `WC_Payments_API_Client::request`.
-	 * @return mixed           Either the same response, or the correct object.
-	 */
-	public function format_response( $response ) {
-		return WC_Payments::get_payments_api_client()->deserialize_intention_object_from_array( $response );
 	}
 }

--- a/includes/core/server/request/class-create-and-confirm-setup-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-setup-intention.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Request\Create_Setup_Intention.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server\Request;
+
+use WC_Payments;
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
+use WCPay\Core\Server\Request;
+use WC_Payments_API_Client;
+
+/**
+ * Request class for creating setup intents.
+ */
+class Create_And_Confirm_Setup_Intention extends Request {
+	use Intention;
+	use Level3;
+
+	const IMMUTABLE_PARAMS = [ 'customer', 'confirm' ];
+	const REQUIRED_PARAMS  = [ 'customer' ];
+
+	const DEFAULT_PARAMS = [
+		'confirm'  => 'true',
+		'metadata' => [],
+	];
+
+	/**
+	 * Returns the request's API.
+	 *
+	 * @return string
+	 */
+	public function get_api(): string {
+		return WC_Payments_API_Client::SETUP_INTENTS_API;
+	}
+
+	/**
+	 * Returns the request's HTTP method.
+	 */
+	public function get_method(): string {
+		return 'POST';
+	}
+
+	/**
+	 * Customer setter.
+	 *
+	 * @param string $customer_id ID of the customer making the payment.
+	 * @return void
+	 *
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function set_customer( string $customer_id ) {
+		$this->validate_stripe_id( $customer_id, 'cus' );
+		$this->set_param( 'customer', $customer_id );
+	}
+
+	/**
+	 * Set metadata.
+	 *
+	 * @param array $metadata Metadata to set.
+	 *
+	 * @return void
+	 */
+	public function set_metadata( array $metadata ) {
+		$this->set_param( 'metadata', $metadata );
+	}
+
+	/**
+	 * Payment method setter.
+	 *
+	 * @param string $payment_method_id ID of payment method to process charge with.
+	 *
+	 * @return void
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function set_payment_method( string $payment_method_id ) {
+		$this->validate_stripe_id( $payment_method_id, [ 'pm', 'src' ] );
+		$this->set_param( 'payment_method', $payment_method_id );
+	}
+}

--- a/includes/core/server/request/class-create-and-confirm-setup-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-setup-intention.php
@@ -7,7 +7,6 @@
 
 namespace WCPay\Core\Server\Request;
 
-use WC_Payments;
 use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
 use WCPay\Core\Server\Request;
 use WC_Payments_API_Client;
@@ -64,6 +63,10 @@ class Create_And_Confirm_Setup_Intention extends Request {
 	 * @return void
 	 */
 	public function set_metadata( array $metadata ) {
+		if ( isset( $metadata['order_number'] ) ) {
+			$description = $this->get_intent_description( $metadata['order_number'] );
+			$this->set_param( 'description', $description );
+		}
 		$this->set_param( 'metadata', $metadata );
 	}
 

--- a/includes/core/server/request/class-create-intent.php
+++ b/includes/core/server/request/class-create-intent.php
@@ -15,6 +15,9 @@ use WC_Payments_API_Client;
  * Request class for creating intents.
  */
 class Create_Intent extends Request {
+	use Intention;
+	use Level3;
+
 	const IMMUTABLE_PARAMS = [ 'amount' ];
 	const REQUIRED_PARAMS  = [ 'amount', 'currency' ];
 
@@ -35,24 +38,106 @@ class Create_Intent extends Request {
 	}
 
 	/**
+	 * Payment method setter.
+	 *
+	 * @param string $payment_method_id ID of payment method to process charge with.
+	 *
+	 * @return void
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function set_payment_method( $payment_method_id ) {
+		$this->validate_stripe_id( $payment_method_id, [ 'pm', 'src' ] );
+		$this->set_param( 'payment_method', $payment_method_id );
+	}
+
+	/**
+	 * Payment methods type setter.
+	 *
+	 * @param array $payment_methods List of payment methods.
+	 *
+	 * @return void
+	 */
+	public function set_payment_method_types( array $payment_methods ) {
+		$this->set_param( 'payment_method_types', $payment_methods );
+	}
+
+	/**
+	 * Customer setter.
+	 *
+	 * @param string $customer_id ID of the customer making the payment.
+	 * @return void
+	 *
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function set_customer( string $customer_id ) {
+		$this->validate_stripe_id( $customer_id, 'cus' );
+		$this->set_param( 'customer', $customer_id );
+	}
+
+	/**
 	 * Stores the amount for the intent.
 	 *
 	 * @param int $amount The amount in ToDo units.
 	 * @throws Invalid_Request_Parameter_Exception
 	 */
-	final public function set_amount( int $amount ) {
+	public function set_amount( int $amount ) {
 		$this->validate_is_larger_then( $amount, 0 );
 		$this->set_param( 'amount', $amount );
 	}
 
 	/**
-	 * Updates the currency of the intent.
+	 * Currency code setter.
 	 *
-	 * This is an example of a non-protected property.
-	 *
-	 * @param string $currency The currency to use.
+	 * @param  string $currency_code Currency to charge in.
+	 * @throws Invalid_Request_Parameter_Exception When the currency code is invalid.
 	 */
-	public function set_currency( string $currency ) {
-		$this->set_param( 'currency', $currency );
+	public function set_currency_code( string $currency_code ) {
+		$this->validate_currency_code( $currency_code );
+		$this->set_param( 'currency', $currency_code );
+	}
+
+	/**
+	 * Capture method setter.
+	 *
+	 * @param bool $manual_capture Whether to capture funds via manual action.
+	 */
+	public function set_capture_method( bool $manual_capture = false ) {
+		$this->set_param( 'capture_method', $manual_capture ? 'manual' : 'automatic' );
+	}
+
+	/**
+	 * Metadata setter.
+	 *
+	 * @param  array $metadata                     Meta data values to be sent along with payment intent creation.
+	 * @throws Invalid_Request_Parameter_Exception In case there is no order number provided.
+	 */
+	public function set_metadata( $metadata ) {
+		if ( ! isset( $metadata['order_number'] ) ) {
+			throw new Invalid_Request_Parameter_Exception(
+				__( 'An order number is required!', 'woocommerce-payments' ),
+				'wcpay_core_invalid_request_parameter_metadata_order_number'
+			);
+		}
+
+		// The description is based on the order number here.
+		$description = $this->get_intent_description( $metadata['order_number'] ?? 0 );
+		$this->set_param( 'description', $description );
+
+		// Combine the metadata with the fingerprint.
+		$metadata = array_merge( $metadata, $this->get_fingerprint_metadata() );
+		$this->set_param( 'metadata', $metadata );
+	}
+
+	/**
+	 * Level 3 data setter.
+	 *
+	 * @param array $level3 Level 3 data.
+	 */
+	public function set_level3( $level3 ) {
+		if ( empty( $level3 ) || ! is_array( $level3 ) ) {
+			return;
+		}
+
+		$this->set_param( 'level3', $this->fix_level3_data( $level3 ) );
 	}
 }

--- a/includes/core/server/request/class-create-intent.php
+++ b/includes/core/server/request/class-create-intent.php
@@ -7,6 +7,7 @@
 
 namespace WCPay\Core\Server\Request;
 
+use WC_Payments;
 use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
 use WCPay\Core\Server\Request;
 use WC_Payments_API_Client;
@@ -139,5 +140,15 @@ class Create_Intent extends Request {
 		}
 
 		$this->set_param( 'level3', $this->fix_level3_data( $level3 ) );
+	}
+
+	/**
+	 * Formats the response from the server.
+	 *
+	 * @param  mixed $response The response from `WC_Payments_API_Client::request`.
+	 * @return mixed           Either the same response, or the correct object.
+	 */
+	public function format_response( $response ) {
+		return WC_Payments::get_payments_api_client()->deserialize_intention_object_from_array( $response );
 	}
 }

--- a/includes/core/server/request/class-create-intention.php
+++ b/includes/core/server/request/class-create-intention.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class file for WCPay\Core\Server\Request\Create_Intent.
+ * Class file for WCPay\Core\Server\Request\Create_Intention.
  *
  * @package WooCommerce Payments
  */
@@ -15,7 +15,7 @@ use WC_Payments_API_Client;
 /**
  * Request class for creating intents.
  */
-class Create_Intent extends Request {
+class Create_Intention extends Request {
 	use Intention;
 	use Level3;
 

--- a/includes/core/server/request/class-create-setup-intention.php
+++ b/includes/core/server/request/class-create-setup-intention.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Request\Create_Setup_Intention.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server\Request;
+
+use WC_Payments;
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
+use WCPay\Core\Server\Request;
+use WC_Payments_API_Client;
+
+/**
+ * Request class for creating setup intents.
+ */
+class Create_Setup_Intention extends Request {
+	use Intention;
+	use Level3;
+
+	const IMMUTABLE_PARAMS = [ 'customer', 'confirm' ];
+	const REQUIRED_PARAMS  = [ 'customer', 'payment_method_types' ];
+
+	const DEFAULT_PARAMS = [
+		'confirm' => 'false',
+	];
+
+	/**
+	 * Returns the request's API.
+	 *
+	 * @return string
+	 */
+	public function get_api(): string {
+		return WC_Payments_API_Client::SETUP_INTENTS_API;
+	}
+
+	/**
+	 * Returns the request's HTTP method.
+	 */
+	public function get_method(): string {
+		return 'POST';
+	}
+
+
+	/**
+	 * Payment methods type setter.
+	 *
+	 * @param array $payment_methods List of payment methods.
+	 *
+	 * @return void
+	 */
+	public function set_payment_method_types( array $payment_methods ) {
+		$this->set_param( 'payment_method_types', $payment_methods );
+	}
+
+	/**
+	 * Customer setter.
+	 *
+	 * @param string $customer_id ID of the customer making the payment.
+	 * @return void
+	 *
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function set_customer( string $customer_id ) {
+		$this->validate_stripe_id( $customer_id, 'cus' );
+		$this->set_param( 'customer', $customer_id );
+	}
+}

--- a/includes/core/server/request/class-create-setup-intention.php
+++ b/includes/core/server/request/class-create-setup-intention.php
@@ -7,7 +7,6 @@
 
 namespace WCPay\Core\Server\Request;
 
-use WC_Payments;
 use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
 use WCPay\Core\Server\Request;
 use WC_Payments_API_Client;

--- a/includes/core/server/request/class-create-setup-intention.php
+++ b/includes/core/server/request/class-create-setup-intention.php
@@ -42,7 +42,6 @@ class Create_Setup_Intention extends Request {
 		return 'POST';
 	}
 
-
 	/**
 	 * Payment methods type setter.
 	 *

--- a/includes/core/server/request/class-generic.php
+++ b/includes/core/server/request/class-generic.php
@@ -42,11 +42,11 @@ final class Generic extends Request {
 	/**
 	 * Creates a new instance of the class.
 	 *
-	 * @param array ...$arguments Constructor arguments.
+	 * @param string|null $id Request parameter ID (intent_id, charge_id, ...).
 	 *
 	 * @throws Server_Request_Exception
 	 */
-	public static function create( ...$arguments ) {
+	public static function create( $id = null ) {
 		throw new Server_Request_Exception( 'You cannot create request this way.', 'wcpay_core_server_request_invalid_method_call' );
 	}
 

--- a/includes/core/server/request/class-generic.php
+++ b/includes/core/server/request/class-generic.php
@@ -42,7 +42,7 @@ final class Generic extends Request {
 	/**
 	 * Creates a new instance of the class.
 	 *
-	 * @param string|null $id Request parameter ID (intent_id, charge_id, ...).
+	 * @param mixed $id The identifier for various update/get/delete requests.
 	 *
 	 * @throws Server_Request_Exception
 	 */

--- a/includes/core/server/request/class-generic.php
+++ b/includes/core/server/request/class-generic.php
@@ -42,9 +42,11 @@ final class Generic extends Request {
 	/**
 	 * Creates a new instance of the class.
 	 *
+	 * @param array ...$arguments Constructor arguments.
+	 *
 	 * @throws Server_Request_Exception
 	 */
-	public static function create() {
+	public static function create( ...$arguments ) {
 		throw new Server_Request_Exception( 'You cannot create request this way.', 'wcpay_core_server_request_invalid_method_call' );
 	}
 

--- a/includes/core/server/request/class-get-charge.php
+++ b/includes/core/server/request/class-get-charge.php
@@ -17,9 +17,6 @@ use WC_Payments_API_Client;
  * Request class for getting intents.
  */
 class Get_Charge extends Request {
-
-
-
 	/**
 	 * Sets the intent ID, which will be used in the request URL.
 	 *

--- a/includes/core/server/request/class-get-charge.php
+++ b/includes/core/server/request/class-get-charge.php
@@ -8,7 +8,6 @@
 namespace WCPay\Core\Server\Request;
 
 use WC_Payments;
-use WC_Payments_Http_Interface;
 use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
 use WCPay\Core\Server\Request;
 use WC_Payments_API_Client;

--- a/includes/core/server/request/class-get-charge.php
+++ b/includes/core/server/request/class-get-charge.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Request\Get_Charge.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server\Request;
+
+use WC_Payments;
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
+use WCPay\Core\Server\Request;
+use WC_Payments_API_Client;
+
+/**
+ * Request class for getting intents.
+ */
+class Get_Charge extends Request {
+
+
+	/**
+	 * Charge id.
+	 *
+	 * @var string|null $intent_id
+	 */
+	private $charge_id = null;
+
+	/**
+	 * Set intent id.
+	 *
+	 * @param string $charge_id Charge id.
+	 *
+	 * @return void
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function set_charge_id( string $charge_id ) {
+		$this->validate_stripe_id( $charge_id, [ 'ch' ] );
+
+		// Prevent mutation of charge id. It can be only set once.
+		if ( null === $this->charge_id ) {
+			$this->charge_id = $charge_id;
+		}
+	}
+
+	/**
+	 * Returns the request's API.
+	 *
+	 * @return string
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function get_api(): string {
+		if ( null === $this->charge_id ) {
+			throw new Invalid_Request_Parameter_Exception( __( 'Charge ID is not set.', 'woocommerce-payments' ), 'wcpay_core_request_intent_not_set' );
+		}
+		return WC_Payments_API_Client::CHARGES_API . '/' . $this->charge_id;
+	}
+
+	/**
+	 * Returns the request's HTTP method.
+	 */
+	public function get_method(): string {
+		return 'GET';
+	}
+	/**
+	 * Formats the response from the server.
+	 *
+	 * @param  mixed $response The response from `WC_Payments_API_Client::request`.
+	 * @return mixed           Either the same response, or the correct object.
+	 */
+	public function format_response( $response ) {
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return WC_Payments::get_payments_api_client()->add_additional_info_to_charge( $response );
+	}
+}

--- a/includes/core/server/request/class-get-charge.php
+++ b/includes/core/server/request/class-get-charge.php
@@ -8,6 +8,7 @@
 namespace WCPay\Core\Server\Request;
 
 use WC_Payments;
+use WC_Payments_Http_Interface;
 use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
 use WCPay\Core\Server\Request;
 use WC_Payments_API_Client;
@@ -18,28 +19,17 @@ use WC_Payments_API_Client;
 class Get_Charge extends Request {
 
 
-	/**
-	 * Charge id.
-	 *
-	 * @var string|null $intent_id
-	 */
-	private $charge_id = null;
 
 	/**
-	 * Set intent id.
+	 * Sets the intent ID, which will be used in the request URL.
 	 *
-	 * @param string $charge_id Charge id.
+	 * @param string $id Sets the intent ID, which will be used in the request URL.
 	 *
-	 * @return void
 	 * @throws Invalid_Request_Parameter_Exception
 	 */
-	public function set_charge_id( string $charge_id ) {
-		$this->validate_stripe_id( $charge_id, [ 'ch' ] );
-
-		// Prevent mutation of charge id. It can be only set once.
-		if ( null === $this->charge_id ) {
-			$this->charge_id = $charge_id;
-		}
+	protected function set_id( string $id ) {
+		$this->validate_stripe_id( $id, [ 'ch' ] );
+		$this->id = $id;
 	}
 
 	/**
@@ -49,10 +39,7 @@ class Get_Charge extends Request {
 	 * @throws Invalid_Request_Parameter_Exception
 	 */
 	public function get_api(): string {
-		if ( null === $this->charge_id ) {
-			throw new Invalid_Request_Parameter_Exception( __( 'Charge ID is not set.', 'woocommerce-payments' ), 'wcpay_core_request_intent_not_set' );
-		}
-		return WC_Payments_API_Client::CHARGES_API . '/' . $this->charge_id;
+		return WC_Payments_API_Client::CHARGES_API . '/' . $this->id;
 	}
 
 	/**

--- a/includes/core/server/request/class-get-intent.php
+++ b/includes/core/server/request/class-get-intent.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Request\Create_Intent.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server\Request;
+
+use WC_Payments;
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
+use WCPay\Core\Server\Request;
+use WC_Payments_API_Client;
+
+/**
+ * Request class for getting intents.
+ */
+class Get_Intent extends Request {
+
+
+	/**
+	 * Intent id.
+	 *
+	 * @var string|null $intent_id
+	 */
+	private $intent_id = null;
+
+	/**
+	 * Set intent id.
+	 *
+	 * @param string $intent_id Intent id.
+	 *
+	 * @return void
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function set_intent_id( string $intent_id ) {
+		$this->validate_stripe_id( $intent_id, [ 'pi' ] );
+
+		// Prevent mutation of intent id. It can be only set once.
+		if ( null === $this->intent_id ) {
+			$this->intent_id = $intent_id;
+		}
+	}
+
+	/**
+	 * Returns the request's API.
+	 *
+	 * @return string
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function get_api(): string {
+		if ( null === $this->intent_id ) {
+			throw new Invalid_Request_Parameter_Exception( __( 'Intent ID is not set.', 'woocommerce-payments' ), 'wcpay_core_request_intent_not_set' );
+		}
+		return WC_Payments_API_Client::INTENTIONS_API . '/' . $this->intent_id;
+	}
+
+	/**
+	 * Returns the request's HTTP method.
+	 */
+	public function get_method(): string {
+		return 'GET';
+	}
+	/**
+	 * Formats the response from the server.
+	 *
+	 * @param  mixed $response The response from `WC_Payments_API_Client::request`.
+	 * @return mixed           Either the same response, or the correct object.
+	 */
+	public function format_response( $response ) {
+		return WC_Payments::get_payments_api_client()->deserialize_intention_object_from_array( $response );
+	}
+}

--- a/includes/core/server/request/class-get-intention.php
+++ b/includes/core/server/request/class-get-intention.php
@@ -17,8 +17,6 @@ use WC_Payments_API_Client;
  * Request class for getting intents.
  */
 class Get_Intention extends Request {
-
-
 	/**
 	 * Intent id.
 	 *
@@ -57,6 +55,7 @@ class Get_Intention extends Request {
 	public function get_method(): string {
 		return 'GET';
 	}
+
 	/**
 	 * Formats the response from the server.
 	 *

--- a/includes/core/server/request/class-get-intention.php
+++ b/includes/core/server/request/class-get-intention.php
@@ -15,7 +15,7 @@ use WC_Payments_API_Client;
 /**
  * Request class for getting intents.
  */
-class Get_Intent extends Request {
+class Get_Intention extends Request {
 
 
 	/**

--- a/includes/core/server/request/class-get-intention.php
+++ b/includes/core/server/request/class-get-intention.php
@@ -8,6 +8,7 @@
 namespace WCPay\Core\Server\Request;
 
 use WC_Payments;
+use WC_Payments_Http_Interface;
 use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
 use WCPay\Core\Server\Request;
 use WC_Payments_API_Client;
@@ -21,25 +22,23 @@ class Get_Intention extends Request {
 	/**
 	 * Intent id.
 	 *
-	 * @var string|null $intent_id
+	 * @var string $intent_id
 	 */
-	private $intent_id = null;
+	private $intent_id;
 
 	/**
-	 * Set intent id.
+	 * Class constructor.
 	 *
-	 * @param string $intent_id Intent id.
+	 * @param WC_Payments_API_Client     $api_client Api client.
+	 * @param WC_Payments_Http_Interface $http_interface Http interface.
+	 * @param string                     $intent_id Intent id.
 	 *
-	 * @return void
 	 * @throws Invalid_Request_Parameter_Exception
 	 */
-	public function set_intent_id( string $intent_id ) {
-		$this->validate_stripe_id( $intent_id, [ 'pi' ] );
-
-		// Prevent mutation of intent id. It can be only set once.
-		if ( null === $this->intent_id ) {
-			$this->intent_id = $intent_id;
-		}
+	public function __construct( WC_Payments_API_Client $api_client, WC_Payments_Http_Interface $http_interface, string $intent_id ) {
+		$this->validate_stripe_id( $intent_id );
+		parent::__construct( $api_client, $http_interface );
+		$this->intent_id = $intent_id;
 	}
 
 	/**
@@ -49,9 +48,6 @@ class Get_Intention extends Request {
 	 * @throws Invalid_Request_Parameter_Exception
 	 */
 	public function get_api(): string {
-		if ( null === $this->intent_id ) {
-			throw new Invalid_Request_Parameter_Exception( __( 'Intent ID is not set.', 'woocommerce-payments' ), 'wcpay_core_request_intent_not_set' );
-		}
 		return WC_Payments_API_Client::INTENTIONS_API . '/' . $this->intent_id;
 	}
 

--- a/includes/core/server/request/class-update-intention.php
+++ b/includes/core/server/request/class-update-intention.php
@@ -11,8 +11,6 @@ use WC_Payments;
 use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
 use WCPay\Core\Server\Request;
 use WC_Payments_API_Client;
-use WCPay\Payment_Methods\CC_Payment_Method;
-use WCPay\Payment_Methods\Link_Payment_Method;
 
 /**
  * Request class for creating intents.

--- a/includes/core/server/request/class-update-intention.php
+++ b/includes/core/server/request/class-update-intention.php
@@ -29,35 +29,18 @@ class Update_Intention extends Request {
 		'metadata'      => [],
 	];
 
-	/**
-	 * Intent id.
-	 *
-	 * @var string $intent_id
-	 */
-	private $intent_id;
+
 
 	/**
-	 * Action.
+	 * Sets the intent ID, which will be used in the request URL.
 	 *
-	 * @var string|null $action
-	 */
-	private $action;
-
-	/**
-	 * Class constructor.
-	 *
-	 * @param WC_Payments_API_Client     $api_client Api client.
-	 * @param WC_Payments_Http_Interface $http_interface Http interface.
-	 * @param string                     $intent_id Intent id.
-	 * @param string|null                $action Intent action (capture/delete/confirm,...).
+	 * @param string $id Sets the intent ID, which will be used in the request URL.
 	 *
 	 * @throws Invalid_Request_Parameter_Exception
 	 */
-	public function __construct( WC_Payments_API_Client $api_client, WC_Payments_Http_Interface $http_interface, string $intent_id, string $action = null ) {
-		$this->validate_stripe_id( $intent_id );
-		$this->intent_id = $intent_id;
-		$this->action    = $action;
-		parent::__construct( $api_client, $http_interface );
+	protected function set_id( string $id ) {
+		$this->validate_stripe_id( $id );
+		$this->id = $id;
 	}
 
 
@@ -69,8 +52,7 @@ class Update_Intention extends Request {
 	 * @throws Invalid_Request_Parameter_Exception
 	 */
 	public function get_api(): string {
-		$endpoint = WC_Payments_API_Client::INTENTIONS_API . '/' . $this->intent_id;
-		return $this->action ? $endpoint . '/' . $this->action : $endpoint;
+		return WC_Payments_API_Client::INTENTIONS_API . '/' . $this->id;
 	}
 
 	/**

--- a/includes/core/server/request/class-update-intention.php
+++ b/includes/core/server/request/class-update-intention.php
@@ -99,28 +99,14 @@ class Update_Intention extends Request {
 	}
 
 	/**
-	 * Set selected UPE payment method type.
+	 * Set/update payment methods.
 	 *
-	 * @param string $selected_upe_payment_type Selected UPE payment method.
-	 * @param array  $enabled_payment_methods Enabled payment methods.
+	 * @param array $payment_methods Payment methods.
 	 *
 	 * @return void
 	 */
-	public function set_selected_upe_payment_method_type( string $selected_upe_payment_type, array $enabled_payment_methods ) {
-		if ( '' !== $selected_upe_payment_type ) {
-			// Only update the payment_method_types if we have a reference to the payment type the customer selected.
-			$payment_methods = [ $selected_upe_payment_type ];
-
-			if ( CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID === $selected_upe_payment_type ) {
-				$is_link_enabled = in_array(
-					Link_Payment_Method::PAYMENT_METHOD_STRIPE_ID,
-					$enabled_payment_methods,
-					true
-				);
-				if ( $is_link_enabled ) {
-					$payment_methods[] = Link_Payment_Method::PAYMENT_METHOD_STRIPE_ID;
-				}
-			}
+	public function set_payment_method_types( array $payment_methods ) {
+		if ( ! empty( $payment_methods ) ) {
 			$this->set_param( 'payment_method_types', $payment_methods );
 		}
 	}

--- a/includes/core/server/request/class-update-intention.php
+++ b/includes/core/server/request/class-update-intention.php
@@ -183,4 +183,14 @@ class Update_Intention extends Request {
 
 		$this->set_param( 'level3', $this->fix_level3_data( $level3 ) );
 	}
+
+	/**
+	 * Formats the response from the server.
+	 *
+	 * @param  mixed $response The response from `WC_Payments_API_Client::request`.
+	 * @return mixed           Either the same response, or the correct object.
+	 */
+	public function format_response( $response ) {
+		return WC_Payments::get_payments_api_client()->deserialize_intention_object_from_array( $response );
+	}
 }

--- a/includes/core/server/request/class-update-intention.php
+++ b/includes/core/server/request/class-update-intention.php
@@ -8,7 +8,6 @@
 namespace WCPay\Core\Server\Request;
 
 use WC_Payments;
-use WC_Payments_Http_Interface;
 use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
 use WCPay\Core\Server\Request;
 use WC_Payments_API_Client;
@@ -23,7 +22,6 @@ class Update_Intention extends Request {
 	use Level3;
 
 	const IMMUTABLE_PARAMS = [ 'amount' ];
-	const REQUIRED_PARAMS  = []; // This use to be amount and currency, but since it is not required on server API, I will leave it blank.
 	const DEFAULT_PARAMS   = [
 		'receipt_email' => '',
 		'metadata'      => [],

--- a/includes/core/server/request/class-update-intention.php
+++ b/includes/core/server/request/class-update-intention.php
@@ -29,8 +29,6 @@ class Update_Intention extends Request {
 		'metadata'      => [],
 	];
 
-
-
 	/**
 	 * Sets the intent ID, which will be used in the request URL.
 	 *
@@ -42,8 +40,6 @@ class Update_Intention extends Request {
 		$this->validate_stripe_id( $id );
 		$this->id = $id;
 	}
-
-
 
 	/**
 	 * Returns the request's API.

--- a/includes/core/server/request/class-update-intention.php
+++ b/includes/core/server/request/class-update-intention.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Request\Update_Intent.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server\Request;
+
+use WC_Payments;
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
+use WCPay\Core\Server\Request;
+use WC_Payments_API_Client;
+use WCPay\Payment_Methods\CC_Payment_Method;
+use WCPay\Payment_Methods\Link_Payment_Method;
+
+/**
+ * Request class for creating intents.
+ */
+class Update_Intention extends Request {
+	use Intention;
+	use Level3;
+
+	const IMMUTABLE_PARAMS = [ 'amount' ];
+	const REQUIRED_PARAMS  = [ 'amount', 'currency' ];
+	const DEFAULT_PARAMS   = [
+		'receipt_email' => '',
+		'metadata'      => [],
+	];
+
+	/**
+	 * Intent id.
+	 *
+	 * @var string|null $intent_id
+	 */
+	private $intent_id = null;
+
+	/**
+	 * Set intent id.
+	 *
+	 * @param string $intent_id Intent id.
+	 *
+	 * @return void
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function set_intent_id( string $intent_id ) {
+		$this->validate_stripe_id( $intent_id, [ 'pi' ] );
+
+		// Prevent mutation of intent id. It can be only set once.
+		if ( null === $this->intent_id ) {
+			$this->intent_id = $intent_id;
+		}
+	}
+
+	/**
+	 * Returns the request's API.
+	 *
+	 * @return string
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function get_api(): string {
+		if ( null === $this->intent_id ) {
+			throw new Invalid_Request_Parameter_Exception( __( 'Intent ID is not set.', 'woocommerce-payments' ), 'wcpay_core_request_intent_not_set' );
+		}
+		return WC_Payments_API_Client::INTENTIONS_API . '/' . $this->intent_id;
+	}
+
+	/**
+	 * Returns the request's HTTP method.
+	 */
+	public function get_method(): string {
+		return 'POST';
+	}
+
+	/**
+	 * If the payment method should be saved to the store, this enables future usage.
+	 */
+	public function setup_future_usage() {
+		$this->set_param( 'setup_future_usage', 'off_session' );
+	}
+
+	/**
+	 * Customer setter.
+	 *
+	 * @param string $customer_id ID of the customer making the payment.
+	 * @return void
+	 *
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function set_customer( string $customer_id ) {
+		$this->validate_stripe_id( $customer_id, 'cus' );
+		$this->set_param( 'customer', $customer_id );
+	}
+
+	/**
+	 * Stores the amount for the intent.
+	 *
+	 * @param int $amount The amount in ToDo units.
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function set_amount( int $amount ) {
+		$this->validate_is_larger_then( $amount, 0 );
+		$this->set_param( 'amount', $amount );
+	}
+
+	/**
+	 * Currency code setter.
+	 *
+	 * @param  string $currency_code Currency to charge in.
+	 * @throws Invalid_Request_Parameter_Exception When the currency code is invalid.
+	 */
+	public function set_currency_code( string $currency_code ) {
+		$this->validate_currency_code( $currency_code );
+		$this->set_param( 'currency', $currency_code );
+	}
+
+	/**
+	 * Set selected UPE payment method type.
+	 *
+	 * @param string $selected_upe_payment_type Selected UPE payment method.
+	 * @param array  $enabled_payment_methods Enabled payment methods.
+	 *
+	 * @return void
+	 */
+	public function set_selected_upe_payment_method_type( string $selected_upe_payment_type, array $enabled_payment_methods ) {
+		if ( '' !== $selected_upe_payment_type ) {
+			// Only update the payment_method_types if we have a reference to the payment type the customer selected.
+			$payment_methods = [ $selected_upe_payment_type ];
+
+			if ( CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID === $selected_upe_payment_type ) {
+				$is_link_enabled = in_array(
+					Link_Payment_Method::PAYMENT_METHOD_STRIPE_ID,
+					$enabled_payment_methods,
+					true
+				);
+				if ( $is_link_enabled ) {
+					$payment_methods[] = Link_Payment_Method::PAYMENT_METHOD_STRIPE_ID;
+				}
+			}
+			$this->set_param( 'payment_method_types', $payment_methods );
+		}
+	}
+
+	/**
+	 * Set payment country.
+	 *
+	 * @param string $payment_country Set payment country.
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function set_payment_country( string $payment_country ) {
+		if ( $payment_country && ! WC_Payments::mode()->is_dev() ) {
+			// Do not update on dev mode, Stripe tests cards don't return the appropriate country.
+			$this->set_param( 'payment_country', $payment_country );
+		}
+	}
+
+	/**
+	 * Metadata setter.
+	 *
+	 * @param  array $metadata Meta data values to be sent along with payment intent creation.
+	 */
+	public function set_metadata( $metadata ) {
+		// The description is based on the order number here.
+		$description = $this->get_intent_description( $metadata['order_number'] ?? 0 );
+		$this->set_param( 'description', $description );
+
+		// Combine the metadata with the fingerprint.
+		$metadata = array_merge( $metadata, $this->get_fingerprint_metadata() );
+		$this->set_param( 'metadata', $metadata );
+	}
+
+	/**
+	 * Level 3 data setter.
+	 *
+	 * @param array $level3 Level 3 data.
+	 */
+	public function set_level3( $level3 ) {
+		if ( empty( $level3 ) || ! is_array( $level3 ) ) {
+			return;
+		}
+
+		$this->set_param( 'level3', $this->fix_level3_data( $level3 ) );
+	}
+}

--- a/includes/core/server/request/class-woopay-create-and-confirm-setup-intention.php
+++ b/includes/core/server/request/class-woopay-create-and-confirm-setup-intention.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Request\WooPay_Create_And_Confirm_Setup_Intention.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server\Request;
+
+/**
+ * Request class for creating woopay setup intents.
+ */
+class WooPay_Create_And_Confirm_Setup_Intention extends Create_And_Confirm_Setup_Intention {
+	const DEFAULTS = [
+		'save_in_platform_account'        => false,
+		'is_platform_payment_method'      => false,
+		'save_payment_method_to_platform' => false,
+	];
+
+	/**
+	 * Toggles the flag, which indicates that this is a platform payment method.
+	 *
+	 * @param bool $is Whether it is indeed a platform payment method (Optional).
+	 */
+	public function set_is_platform_payment_method( $is = true ) {
+		$this->set_param( 'is_platform_payment_method', $is );
+	}
+
+	/**
+	 * Save to platform account.
+	 *
+	 * @param bool $save save to platform account or not.
+	 */
+	public function set_save_in_platform_account( $save = true ) {
+		$this->set_param( 'save_in_platform_account', $save );
+	}
+
+	/**
+	 * Save payment method to platform.
+	 *
+	 * @param bool $save save payment method to platform.
+	 */
+	public function set_save_payment_method_to_platform( $save = true ) {
+		$this->set_param( 'save_payment_method_to_platform', $save );
+	}
+
+}

--- a/includes/core/server/request/class-woopay-create-intent.php
+++ b/includes/core/server/request/class-woopay-create-intent.php
@@ -10,7 +10,7 @@ namespace WCPay\Core\Server\Request;
 /**
  * Extended create intent request for WooPay.
  */
-class WooPay_Create_Intent extends Create_Intent {
+class WooPay_Create_Intent extends Create_Intention {
 	const IMMUTABLE_PARAMS = [ 'save_payment_method_to_platform' ];
 
 	/**

--- a/includes/core/server/request/trait-level3.php
+++ b/includes/core/server/request/trait-level3.php
@@ -39,5 +39,3 @@ trait Level3 {
 		return $data;
 	}
 }
-
-

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -12,6 +12,7 @@ use WC_Payment_Token_WCPay_SEPA;
 use WC_Payments_Explicit_Price_Formatter;
 use WCPay\Constants\Payment_Method;
 use WCPay\Core\Server\Request\Create_Intent;
+use WCPay\Core\Server\Request\Get_Charge;
 use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Core\Server\Request\Update_Intention;
 use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
@@ -982,7 +983,9 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			}
 
 			// Get charge data from WCPay Server.
-			$charge_data = $this->payments_api_client->get_charge( $charge_id );
+			$request = Get_Charge::create();
+			$request->set_charge_id( $charge_id );
+			$charge_data = $request->send( 'wcpay_get_charge_request', $charge_id );
 			$order_id    = $charge_data['metadata']['order_id'];
 
 			// Validate Order ID and proceed with logging errors and updating order status.

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -213,8 +213,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		if ( $payment_intent_id ) {
 			list( $user, $customer_id ) = $this->manage_customer_details_for_order( $order );
 			$payment_type               = $this->is_payment_recurring( $order_id ) ? Payment_Type::RECURRING() : Payment_Type::SINGLE();
-			$request                    = Update_Intention::create();
-			$request->set_intent_id( $payment_intent_id );
+			$request                    = Update_Intention::create( $payment_intent_id );
 			$request->set_currency_code( strtolower( $currency ) );
 			$request->set_amount( WC_Payments_Utils::prepare_amount( $amount, $currency ) );
 			$request->set_metadata( $this->get_metadata_from_order( $order, $payment_type ) );
@@ -463,8 +462,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 				try {
 
-					$request = Update_Intention::create();
-					$request->set_intent_id( $payment_intent_id );
+					$request = Update_Intention::create( $payment_intent_id );
 					$request->set_currency_code( strtolower( $currency ) );
 					$request->set_amount( WC_Payments_Utils::prepare_amount( $amount, $currency ) );
 					$request->set_metadata( $this->get_metadata_from_order( $order, $payment_type ) );

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -390,8 +390,8 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		$request->set_payment_method_types( array_values( $enabled_payment_methods ) );
 		$setup_intent = $request->send( 'wcpay_create_setup_intention_request' );
 		return [
-			'id'            => $setup_intent->offsetGet( 'id' ),
-			'client_secret' => $setup_intent->offsetGet( 'client_secret' ),
+			'id'            => $setup_intent['id'],
+			'client_secret' => $setup_intent['client_secret'],
 		];
 	}
 

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -980,8 +980,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			}
 
 			// Get charge data from WCPay Server.
-			$request = Get_Charge::create();
-			$request->set_charge_id( $charge_id );
+			$request     = Get_Charge::create( $charge_id );
 			$charge_data = $request->send( 'wcpay_get_charge_request', $charge_id );
 			$order_id    = $charge_data['metadata']['order_id'];
 

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -12,6 +12,7 @@ use WC_Payment_Token_WCPay_SEPA;
 use WC_Payments_Explicit_Price_Formatter;
 use WCPay\Constants\Payment_Method;
 use WCPay\Core\Server\Request\Create_Intent;
+use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Core\Server\Request\Update_Intention;
 use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
 use WP_User;
@@ -619,7 +620,10 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 			// Get payment intent to confirm status.
 			if ( $payment_needed ) {
-				$intent                 = $this->payments_api_client->get_intent( $intent_id );
+				$request = Get_Intent::create();
+				$request->set_intent_id( $intent_id );
+
+				$intent                 = $request->send( 'wcpay_get_intent_request', $order );
 				$client_secret          = $intent->get_client_secret();
 				$status                 = $intent->get_status();
 				$charge                 = $intent->get_charge();
@@ -987,8 +991,12 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 				throw new Exception( 'Order not found. Unable to log error.' );
 			}
 
-			$intent_id     = $charge_data['payment_intent'] ?? $order->get_meta( '_intent_id' );
-			$intent        = $this->payments_api_client->get_intent( $intent_id );
+			$intent_id = $charge_data['payment_intent'] ?? $order->get_meta( '_intent_id' );
+
+			$request = Get_Intent::create();
+			$request->set_intent_id( $intent_id );
+			$intent = $request->send( 'wcpay_get_intent_request', $order );
+
 			$intent_status = $intent->get_status();
 			$error_message = esc_html( rtrim( $charge_data['failure_message'], '.' ) );
 

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -211,12 +211,13 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		if ( $payment_intent_id ) {
 			list( $user, $customer_id ) = $this->manage_customer_details_for_order( $order );
 			$payment_type               = $this->is_payment_recurring( $order_id ) ? Payment_Type::RECURRING() : Payment_Type::SINGLE();
+			$payment_methods            = $this->get_selected_upe_payment_methods( (string) $selected_upe_payment_type, $this->get_payment_method_ids_enabled_at_checkout( null, true ) );
 			$request                    = Update_Intention::create( $payment_intent_id );
 			$request->set_currency_code( strtolower( $currency ) );
 			$request->set_amount( WC_Payments_Utils::prepare_amount( $amount, $currency ) );
 			$request->set_metadata( $this->get_metadata_from_order( $order, $payment_type ) );
 			$request->set_level3( $this->get_level3_data_from_order( $order ) );
-			$request->set_selected_upe_payment_method_type( (string) $selected_upe_payment_type, $this->get_payment_method_ids_enabled_at_checkout( null, true ) );
+			$request->set_payment_method_types( $payment_methods );
 			if ( $payment_country ) {
 				$request->set_payment_country( $payment_country );
 			}
@@ -459,13 +460,14 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 				}
 
 				try {
+					$payment_methods = $this->get_selected_upe_payment_methods( (string) $selected_upe_payment_type, $this->get_payment_method_ids_enabled_at_checkout( null, true ) );
 
 					$request = Update_Intention::create( $payment_intent_id );
 					$request->set_currency_code( strtolower( $currency ) );
 					$request->set_amount( WC_Payments_Utils::prepare_amount( $amount, $currency ) );
 					$request->set_metadata( $this->get_metadata_from_order( $order, $payment_type ) );
 					$request->set_level3( $this->get_level3_data_from_order( $order ) );
-					$request->set_selected_upe_payment_method_type( (string) $selected_upe_payment_type, $this->get_payment_method_ids_enabled_at_checkout( null, true ) );
+					$request->set_payment_method_types( $payment_methods );
 					if ( $payment_country ) {
 						$request->set_payment_country( $payment_country );
 					}
@@ -541,6 +543,33 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		return ( $page_id && is_page( $page_id ) && ( isset( $wp->query_vars['payment-methods'] ) ) );
 	}
 
+	/**
+	 * Get selected UPE payment methods.
+	 *
+	 * @param string $selected_upe_payment_type Selected payment methods.
+	 * @param array  $enabled_payment_methods Enabled payment methods.
+	 *
+	 * @return array
+	 */
+	private function get_selected_upe_payment_methods( string $selected_upe_payment_type, array $enabled_payment_methods ) {
+		$payment_methods = [];
+		if ( '' !== $selected_upe_payment_type ) {
+			// Only update the payment_method_types if we have a reference to the payment type the customer selected.
+			$payment_methods[] = $selected_upe_payment_type;
+
+			if ( CC_Payment_Method::PAYMENT_METHOD_STRIPE_ID === $selected_upe_payment_type ) {
+				$is_link_enabled = in_array(
+					Link_Payment_Method::PAYMENT_METHOD_STRIPE_ID,
+					$enabled_payment_methods,
+					true
+				);
+				if ( $is_link_enabled ) {
+					$payment_methods[] = Link_Payment_Method::PAYMENT_METHOD_STRIPE_ID;
+				}
+			}
+		}
+		return $payment_methods;
+	}
 	/**
 	 * Check for a redirect payment method on order received page or setup intent on payment methods page.
 	 */

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -12,6 +12,7 @@ use WC_Payment_Token_WCPay_SEPA;
 use WC_Payments_Explicit_Price_Formatter;
 use WCPay\Constants\Payment_Method;
 use WCPay\Core\Server\Request\Create_Intention;
+use WCPay\Core\Server\Request\Create_Setup_Intention;
 use WCPay\Core\Server\Request\Get_Charge;
 use WCPay\Core\Server\Request\Get_Intention;
 use WCPay\Core\Server\Request\Update_Intention;
@@ -384,13 +385,13 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 		$enabled_payment_methods = array_filter( $this->get_upe_enabled_payment_method_ids(), [ $this, 'is_enabled_for_saved_payments' ] );
 
-		$setup_intent = $this->payments_api_client->create_setup_intention(
-			$customer_id,
-			array_values( $enabled_payment_methods )
-		);
+		$request = Create_Setup_Intention::create();
+		$request->set_customer( $customer_id );
+		$request->set_payment_method_types( array_values( $enabled_payment_methods ) );
+		$setup_intent = $request->send( 'wcpay_create_setup_intention_request' );
 		return [
-			'id'            => $setup_intent['id'],
-			'client_secret' => $setup_intent['client_secret'],
+			'id'            => $setup_intent->offsetGet( 'id' ),
+			'client_secret' => $setup_intent->offsetGet( 'client_secret' ),
 		];
 	}
 

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -619,8 +619,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 			// Get payment intent to confirm status.
 			if ( $payment_needed ) {
-				$request = Get_Intention::create();
-				$request->set_intent_id( $intent_id );
+				$request = Get_Intention::create( $intent_id );
 
 				$intent                 = $request->send( 'wcpay_get_intent_request', $order );
 				$client_secret          = $intent->get_client_secret();
@@ -994,9 +993,8 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 			$intent_id = $charge_data['payment_intent'] ?? $order->get_meta( '_intent_id' );
 
-			$request = Get_Intention::create();
-			$request->set_intent_id( $intent_id );
-			$intent = $request->send( 'wcpay_get_intent_request', $order );
+			$request = Get_Intention::create( $intent_id );
+			$intent  = $request->send( 'wcpay_get_intent_request', $order );
 
 			$intent_status = $intent->get_status();
 			$error_message = esc_html( rtrim( $charge_data['failure_message'], '.' ) );

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -9,7 +9,6 @@ namespace WCPay\Payment_Methods;
 
 use WC_Order;
 use WC_Payment_Token_WCPay_SEPA;
-use WC_Payments_Explicit_Price_Formatter;
 use WCPay\Constants\Payment_Method;
 use WCPay\Core\Server\Request\Create_Intention;
 use WCPay\Core\Server\Request\Create_Setup_Intention;
@@ -20,7 +19,6 @@ use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
 use WP_User;
 use WCPay\Exceptions\Add_Payment_Method_Exception;
 use WCPay\Logger;
-use WCPay\Payment_Information;
 use WCPay\Constants\Payment_Type;
 use WCPay\Session_Rate_Limiter;
 use WC_Payment_Gateway_WCPay;
@@ -37,7 +35,6 @@ use WC_Payments_Utils;
 use Exception;
 use WCPay\Exceptions\Amount_Too_Small_Exception;
 use WCPay\Exceptions\Process_Payment_Exception;
-
 
 /**
  * UPE Payment method extended from WCPay generic Gateway.

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -11,9 +11,9 @@ use WC_Order;
 use WC_Payment_Token_WCPay_SEPA;
 use WC_Payments_Explicit_Price_Formatter;
 use WCPay\Constants\Payment_Method;
-use WCPay\Core\Server\Request\Create_Intent;
+use WCPay\Core\Server\Request\Create_Intention;
 use WCPay\Core\Server\Request\Get_Charge;
-use WCPay\Core\Server\Request\Get_Intent;
+use WCPay\Core\Server\Request\Get_Intention;
 use WCPay\Core\Server\Request\Update_Intention;
 use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
 use WP_User;
@@ -308,7 +308,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		$enabled_payment_methods = $this->get_payment_method_ids_enabled_at_checkout( $order_id, true );
 
 		try {
-			$request = Create_Intent::create();
+			$request = Create_Intention::create();
 			$request->set_amount( $converted_amount );
 			$request->set_currency_code( strtolower( $currency ) );
 			$request->set_payment_method_types( array_values( $enabled_payment_methods ) );
@@ -621,7 +621,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 			// Get payment intent to confirm status.
 			if ( $payment_needed ) {
-				$request = Get_Intent::create();
+				$request = Get_Intention::create();
 				$request->set_intent_id( $intent_id );
 
 				$intent                 = $request->send( 'wcpay_get_intent_request', $order );
@@ -996,7 +996,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 
 			$intent_id = $charge_data['payment_intent'] ?? $order->get_meta( '_intent_id' );
 
-			$request = Get_Intent::create();
+			$request = Get_Intention::create();
 			$request->set_intent_id( $intent_id );
 			$intent = $request->send( 'wcpay_get_intent_request', $order );
 

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Payments
  */
 
+use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Exceptions\Rest_Request_Exception;
 use WCPay\Logger;
@@ -246,7 +247,10 @@ class WC_Payments_Invoice_Service {
 	 */
 	public function get_and_attach_intent_info_to_order( $order, $intent_id ) {
 		try {
-			$intent_object = $this->payments_api_client->get_intent( $intent_id );
+			$request = Get_Intent::create();
+			$request->set_intent_id( $intent_id );
+			$intent_object = $request->send( 'wcpay_get_intent_request', $order );
+
 		} catch ( API_Exception $e ) {
 			$order->add_order_note( __( 'The payment info couldn\'t be added to the order.', 'woocommerce-payments' ) );
 			return;

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\Payments
  */
 
-use WCPay\Core\Server\Request\Get_Intent;
+use WCPay\Core\Server\Request\Get_Intention;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Exceptions\Rest_Request_Exception;
 use WCPay\Logger;
@@ -247,7 +247,7 @@ class WC_Payments_Invoice_Service {
 	 */
 	public function get_and_attach_intent_info_to_order( $order, $intent_id ) {
 		try {
-			$request = Get_Intent::create();
+			$request = Get_Intention::create();
 			$request->set_intent_id( $intent_id );
 			$intent_object = $request->send( 'wcpay_get_intent_request', $order );
 

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -247,8 +247,7 @@ class WC_Payments_Invoice_Service {
 	 */
 	public function get_and_attach_intent_info_to_order( $order, $intent_id ) {
 		try {
-			$request = Get_Intention::create();
-			$request->set_intent_id( $intent_id );
+			$request       = Get_Intention::create( $intent_id );
 			$intent_object = $request->send( 'wcpay_get_intent_request', $order );
 
 		} catch ( API_Exception $e ) {

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2281,7 +2281,7 @@ class WC_Payments_API_Client {
 	 *
 	 * @return array
 	 */
-	private function add_additional_info_to_charge( array $charge ) : array {
+	public function add_additional_info_to_charge( array $charge ) : array {
 		$charge = $this->add_order_info_to_object( $charge['id'], $charge );
 		$charge = $this->add_formatted_address_to_charge_object( $charge );
 

--- a/includes/woopay/services/class-checkout-service.php
+++ b/includes/woopay/services/class-checkout-service.php
@@ -10,6 +10,7 @@ namespace WCPay\WooPay\Service;
 use WC_Payments_Features;
 use WCPay\Core\Server\Request;
 use WCPay\Core\Server\Request\WooPay_Create_And_Confirm_Intention;
+use WCPay\Core\Server\Request\WooPay_Create_And_Confirm_Setup_Intention;
 use WCPay\Payment_Information;
 
 /**
@@ -29,6 +30,25 @@ class Checkout_Service {
 	public function create_intention_request( Request $base_request, Payment_Information $payment_information ) {
 		$request = WooPay_Create_And_Confirm_Intention::extend( $base_request );
 		$request->set_has_woopay_subscription( '1' === $payment_information->get_order()->get_meta( '_woopay_has_subscription' ) );
+		$request->set_is_platform_payment_method( $this->is_platform_payment_method( $payment_information->is_using_saved_payment_method() ) );
+		return $request;
+	}
+
+	/**
+	 * Create woopay setup and confirm intent request from base create and confirm request.
+	 *
+	 * @param Request             $base_request Base request.
+	 * @param Payment_Information $payment_information Using saved payment method.
+	 * @param bool                $save_in_platform_account Should save in platform account.
+	 * @param bool                $save_payment_method_to_platform Should save in platform.
+	 *
+	 * @return WooPay_Create_And_Confirm_Setup_Intention
+	 * @throws \WCPay\Core\Exceptions\Server\Request\Extend_Request_Exception
+	 */
+	public function create_and_confirm_setup_intention_request( Request $base_request, Payment_Information $payment_information, bool $save_in_platform_account, bool $save_payment_method_to_platform ) {
+		$request = WooPay_Create_And_Confirm_Setup_Intention::extend( $base_request );
+		$request->set_save_in_platform_account( $save_in_platform_account );
+		$request->set_save_payment_method_to_platform( $save_payment_method_to_platform );
 		$request->set_is_platform_payment_method( $this->is_platform_payment_method( $payment_information->is_using_saved_payment_method() ) );
 		return $request;
 	}
@@ -83,5 +103,6 @@ class Checkout_Service {
 	 */
 	public function init() {
 		add_filter( 'wcpay_create_intention_request', [ $this, 'create_intention_request' ], 10, 3 );
+		add_filter( 'wcpay_create_and_confirm_setup_intention_request', [ $this, 'create_and_confirm_setup_intention_request' ], 10, 3 );
 	}
 }

--- a/includes/woopay/services/class-checkout-service.php
+++ b/includes/woopay/services/class-checkout-service.php
@@ -103,6 +103,6 @@ class Checkout_Service {
 	 */
 	public function init() {
 		add_filter( 'wcpay_create_intention_request', [ $this, 'create_intention_request' ], 10, 3 );
-		add_filter( 'wcpay_create_and_confirm_setup_intention_request', [ $this, 'create_and_confirm_setup_intention_request' ], 10, 3 );
+		add_filter( 'wcpay_create_and_confirm_setup_intention_request', [ $this, 'create_and_confirm_setup_intention_request' ], 10, 4 );
 	}
 }

--- a/tests/WCPAY_UnitTestCase.php
+++ b/tests/WCPAY_UnitTestCase.php
@@ -42,8 +42,15 @@ class WCPAY_UnitTestCase extends WP_UnitTestCase {
 		$http_mock       = $http_mock ? $http_mock : $this->createMock( WC_Payments_Http::class );
 		$api_client_mock = $api_client_mock ? $api_client_mock : $this->createMock( WC_Payments_API_Client::class );
 
+		if ( ! is_array( $request_class_constructor_arguments ) ) {
+			$request_class_constructor_arguments = [ $request_class_constructor_arguments ]; // Convert to array for constructor args.
+		}
+		// Inject dependecies of base request class.
+		array_unshift( $request_class_constructor_arguments, $http_mock );
+		array_unshift( $request_class_constructor_arguments, $api_client_mock );
+
 		$request = $this->getMockBuilder( $request_class )
-			->setConstructorArgs( $request_class_constructor_arguments ? [ $api_client_mock, $http_mock ] : [ $api_client_mock, $http_mock, $request_class_constructor_arguments ] )
+			->setConstructorArgs( $request_class_constructor_arguments )
 			->getMock();
 
 		$api_client_mock->expects( $this->exactly( $total_api_calls ) )

--- a/tests/WCPAY_UnitTestCase.php
+++ b/tests/WCPAY_UnitTestCase.php
@@ -28,16 +28,17 @@ class WCPAY_UnitTestCase extends WP_UnitTestCase {
 	 * If the given request class does not have a specific `format_response` method, you can provide
 	 * the expexted response here. If there is a `format_response` method, mock it manually.
 	 *
-	 * @param  string                 $request_class                       The class of the mocked request.
-	 * @param  int                    $total_api_calls                     Number of same api calls that will be executed. Used when you want to send multiple request, using the same instance of class, i.e. retry mechanism.
-	 * @param  mixed                  $response                            The expected response.
-	 * @param  WC_Payments_API_Client $api_client_mock                     Specific API client mock if necessary.
-	 * @param  WC_Payments_Http       $http_mock          Specific HTTP mock if necessary.
+	 * @param  string                 $request_class      The class of the mocked request.
+	 * @param  int                    $total_api_calls    Number of same api calls that will be executed. Used when you want to send multiple request, using the same instance of class, i.e. retry mechanism.
 	 * @param  mixed $request_class_constructor_arguments Constructor arguments for requests that have custom constructors that doesn't match with abstract constructor from request class.
+	 * @param  mixed                  $response           The expected response.
+	 * @param  WC_Payments_API_Client $api_client_mock    Specific API client mock if necessary.
+	 * @param  WC_Payments_Http       $http_mock          Specific HTTP mock if necessary.
+
 	 *
 	 * @return Request                                                      The mocked request.
 	 */
-	protected function mock_wcpay_request( string $request_class, int $total_api_calls = 1, $response = null, $api_client_mock = null, $http_mock = null, $request_class_constructor_arguments = [] ) {
+	protected function mock_wcpay_request( string $request_class, int $total_api_calls = 1, $request_class_constructor_arguments = [], $response = null, $api_client_mock = null, $http_mock = null ) {
 		$http_mock       = $http_mock ? $http_mock : $this->createMock( WC_Payments_Http::class );
 		$api_client_mock = $api_client_mock ? $api_client_mock : $this->createMock( WC_Payments_API_Client::class );
 

--- a/tests/WCPAY_UnitTestCase.php
+++ b/tests/WCPAY_UnitTestCase.php
@@ -29,20 +29,22 @@ class WCPAY_UnitTestCase extends WP_UnitTestCase {
 	 * the expexted response here. If there is a `format_response` method, mock it manually.
 	 *
 	 * @param  string                 $request_class   The class of the mocked request.
+	 * @param  int                    $total_api_calls Number of api calls that will be executed. Used when you want to send multiple request, i.e. retry mechanism.
 	 * @param  mixed                  $response        The expected response.
 	 * @param  WC_Payments_API_Client $api_client_mock Specific API client mock if necessary.
 	 * @param  WC_Payments_Http       $http_mock       Specific HTTP mock if necessary.
+	 * @param  WC_Payments_Http       $http_mock       Specific HTTP mock if necessary.
 	 * @return Request                                 The mocked request.
 	 */
-	protected function mock_wcpay_request( string $request_class, $response = null, $api_client_mock = null, $http_mock = null ) {
+	protected function mock_wcpay_request( string $request_class, int $total_api_calls = 1, $response = null, $api_client_mock = null, $http_mock = null ) {
 		$http_mock       = $http_mock ? $http_mock : $this->createMock( WC_Payments_Http::class );
-		$api_client_mock = $api_client_mock ? $api_client_mock : $this->createMock( WC_Payments_API_Client::class );
+		$api_client_mock = $api_client_mock ? $http_mock : $this->createMock( WC_Payments_API_Client::class );
 
 		$request = $this->getMockBuilder( $request_class )
 			->setConstructorArgs( [ $api_client_mock, $http_mock ] )
 			->getMock();
 
-		$api_client_mock->expects( $this->once() )
+		$api_client_mock->expects( $this->exactly( $total_api_calls ) )
 			->method( 'send_request' )
 			->with(
 				$this->callback(

--- a/tests/WCPAY_UnitTestCase.php
+++ b/tests/WCPAY_UnitTestCase.php
@@ -28,20 +28,21 @@ class WCPAY_UnitTestCase extends WP_UnitTestCase {
 	 * If the given request class does not have a specific `format_response` method, you can provide
 	 * the expexted response here. If there is a `format_response` method, mock it manually.
 	 *
-	 * @param  string                 $request_class   The class of the mocked request.
-	 * @param  int                    $total_api_calls Number of api calls that will be executed. Used when you want to send multiple request, i.e. retry mechanism.
-	 * @param  mixed                  $response        The expected response.
-	 * @param  WC_Payments_API_Client $api_client_mock Specific API client mock if necessary.
-	 * @param  WC_Payments_Http       $http_mock       Specific HTTP mock if necessary.
-	 * @param  WC_Payments_Http       $http_mock       Specific HTTP mock if necessary.
-	 * @return Request                                 The mocked request.
+	 * @param  string                 $request_class                       The class of the mocked request.
+	 * @param  int                    $total_api_calls                     Number of same api calls that will be executed. Used when you want to send multiple request, using the same instance of class, i.e. retry mechanism.
+	 * @param  mixed                  $response                            The expected response.
+	 * @param  WC_Payments_API_Client $api_client_mock                     Specific API client mock if necessary.
+	 * @param  WC_Payments_Http       $http_mock          Specific HTTP mock if necessary.
+	 * @param  mixed $request_class_constructor_arguments Constructor arguments for requests that have custom constructors that doesn't match with abstract constructor from request class.
+	 *
+	 * @return Request                                                      The mocked request.
 	 */
-	protected function mock_wcpay_request( string $request_class, int $total_api_calls = 1, $response = null, $api_client_mock = null, $http_mock = null ) {
+	protected function mock_wcpay_request( string $request_class, int $total_api_calls = 1, $response = null, $api_client_mock = null, $http_mock = null, $request_class_constructor_arguments = [] ) {
 		$http_mock       = $http_mock ? $http_mock : $this->createMock( WC_Payments_Http::class );
 		$api_client_mock = $api_client_mock ? $api_client_mock : $this->createMock( WC_Payments_API_Client::class );
 
 		$request = $this->getMockBuilder( $request_class )
-			->setConstructorArgs( [ $api_client_mock, $http_mock ] )
+			->setConstructorArgs( $request_class_constructor_arguments ? [ $api_client_mock, $http_mock ] : [ $api_client_mock, $http_mock, $request_class_constructor_arguments ] )
 			->getMock();
 
 		$api_client_mock->expects( $this->exactly( $total_api_calls ) )

--- a/tests/WCPAY_UnitTestCase.php
+++ b/tests/WCPAY_UnitTestCase.php
@@ -28,29 +28,22 @@ class WCPAY_UnitTestCase extends WP_UnitTestCase {
 	 * If the given request class does not have a specific `format_response` method, you can provide
 	 * the expexted response here. If there is a `format_response` method, mock it manually.
 	 *
-	 * @param  string                 $request_class      The class of the mocked request.
-	 * @param  int                    $total_api_calls    Number of same api calls that will be executed. Used when you want to send multiple request, using the same instance of class, i.e. retry mechanism.
-	 * @param  mixed $request_class_constructor_arguments Constructor arguments for requests that have custom constructors that doesn't match with abstract constructor from request class.
-	 * @param  mixed                  $response           The expected response.
-	 * @param  WC_Payments_API_Client $api_client_mock    Specific API client mock if necessary.
-	 * @param  WC_Payments_Http       $http_mock          Specific HTTP mock if necessary.
+	 * @param  string                 $request_class                The class of the mocked request.
+	 * @param  int                    $total_api_calls              Number of same api calls that will be executed. Used when you want to send multiple request, using the same instance of class, i.e. retry mechanism.
+	 * @param  string|null            $request_class_constructor_id Used when constructor class gets ID (like intent id or charge id) and passes it as a constructor dependency in mocked request class.
+	 * @param  mixed                  $response                     The expected response.
+	 * @param  WC_Payments_API_Client $api_client_mock              Specific API client mock if necessary.
+	 * @param  WC_Payments_Http       $http_mock                    Specific HTTP mock if necessary.
 
 	 *
 	 * @return Request                                                      The mocked request.
 	 */
-	protected function mock_wcpay_request( string $request_class, int $total_api_calls = 1, $request_class_constructor_arguments = [], $response = null, $api_client_mock = null, $http_mock = null ) {
+	protected function mock_wcpay_request( string $request_class, int $total_api_calls = 1, $request_class_constructor_id = null, $response = null, $api_client_mock = null, $http_mock = null ) {
 		$http_mock       = $http_mock ? $http_mock : $this->createMock( WC_Payments_Http::class );
 		$api_client_mock = $api_client_mock ? $api_client_mock : $this->createMock( WC_Payments_API_Client::class );
 
-		if ( ! is_array( $request_class_constructor_arguments ) ) {
-			$request_class_constructor_arguments = [ $request_class_constructor_arguments ]; // Convert to array for constructor args.
-		}
-		// Inject dependecies of base request class.
-		array_unshift( $request_class_constructor_arguments, $http_mock );
-		array_unshift( $request_class_constructor_arguments, $api_client_mock );
-
 		$request = $this->getMockBuilder( $request_class )
-			->setConstructorArgs( $request_class_constructor_arguments )
+			->setConstructorArgs( [ $api_client_mock, $http_mock, $request_class_constructor_id ] )
 			->getMock();
 
 		$api_client_mock->expects( $this->exactly( $total_api_calls ) )

--- a/tests/WCPAY_UnitTestCase.php
+++ b/tests/WCPAY_UnitTestCase.php
@@ -34,7 +34,6 @@ class WCPAY_UnitTestCase extends WP_UnitTestCase {
 	 * @param  mixed                  $response                     The expected response.
 	 * @param  WC_Payments_API_Client $api_client_mock              Specific API client mock if necessary.
 	 * @param  WC_Payments_Http       $http_mock                    Specific HTTP mock if necessary.
-
 	 *
 	 * @return Request                                                      The mocked request.
 	 */

--- a/tests/WCPAY_UnitTestCase.php
+++ b/tests/WCPAY_UnitTestCase.php
@@ -38,7 +38,7 @@ class WCPAY_UnitTestCase extends WP_UnitTestCase {
 	 */
 	protected function mock_wcpay_request( string $request_class, int $total_api_calls = 1, $response = null, $api_client_mock = null, $http_mock = null ) {
 		$http_mock       = $http_mock ? $http_mock : $this->createMock( WC_Payments_Http::class );
-		$api_client_mock = $api_client_mock ? $http_mock : $this->createMock( WC_Payments_API_Client::class );
+		$api_client_mock = $api_client_mock ? $api_client_mock : $this->createMock( WC_Payments_API_Client::class );
 
 		$request = $this->getMockBuilder( $request_class )
 			->setConstructorArgs( [ $api_client_mock, $http_mock ] )
@@ -56,7 +56,7 @@ class WCPAY_UnitTestCase extends WP_UnitTestCase {
 			)
 			->willReturn( $response );
 
-		// An anonoymous callback, which will be used once and disposed.
+		// An anonymous callback, which will be used once and disposed.
 		$fn = function( $existing_request, $class_name ) use ( &$fn, $request ) {
 			if ( ! is_null( $existing_request ) ) {
 				return $existing_request; // Another `mock_wcpay_request` in action.

--- a/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
@@ -8,6 +8,7 @@
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Core\Server\Request\Create_Intention;
 use WCPay\Core\Server\Request\Get_Intention;
+use WCPay\Core\Server\Request\Update_Intention;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Exceptions\Rest_Request_Exception;
 use WCPay\Constants\Payment_Method;
@@ -88,7 +89,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $this->mock_intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -156,7 +157,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $this->mock_intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -229,7 +230,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, 'pm_mock' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -293,7 +294,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $mock_intent->get_id() );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -328,7 +329,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'succeeded' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $this->mock_intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -370,7 +371,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class, 0 );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 0, $this->mock_intent_id );
 
 		$request->expects( $this->never() )
 			->method( 'format_response' );
@@ -410,9 +411,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$get_intent_request = $this->mock_wcpay_request( Get_Intention::class, 1, $this->mock_intent_id );
 
-		$request->expects( $this->once() )
+		$get_intent_request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
@@ -459,7 +460,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $this->mock_intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -506,7 +507,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 	public function test_capture_terminal_payment_handles_exceptions() {
 		$order = $this->create_mock_order();
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $this->mock_intent_id );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willThrowException( new Exception( 'test error' ) );
@@ -559,7 +560,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $this->mock_intent_id );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
@@ -615,7 +616,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $this->mock_intent_id );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
@@ -656,7 +657,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $this->mock_intent_id );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
@@ -694,7 +695,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'succeeded' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $this->mock_intent_id );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
@@ -736,7 +737,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class, 0 );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 0, $this->mock_intent_id );
 		$request->expects( $this->never() )
 			->method( 'format_response' );
 
@@ -772,7 +773,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $this->mock_intent_id );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
@@ -816,7 +817,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $this->mock_intent_id );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
@@ -858,7 +859,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 	public function test_capture_authorization_handles_exceptions() {
 		$order = $this->create_mock_order();
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $this->mock_intent_id );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willThrowException( new Exception( 'test error' ) );

--- a/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
@@ -7,6 +7,7 @@
 
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Core\Server\Request\Create_Intent;
+use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Exceptions\Rest_Request_Exception;
 use WCPay\Constants\Payment_Method;
@@ -87,9 +88,10 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -154,9 +156,10 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -226,9 +229,10 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -289,9 +293,10 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -323,9 +328,10 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'succeeded' ] );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -364,10 +370,10 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$this->mock_api_client
-			->expects( $this->never() )
-			->method( 'get_intent' );
+		$request = $this->mock_wcpay_request( Get_Intent::class, 0 );
 
+		$request->expects( $this->never() )
+			->method( 'format_response' );
 		$this->mock_gateway
 			->expects( $this->never() )
 			->method( 'capture_charge' );
@@ -404,9 +410,10 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -452,9 +459,10 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -498,9 +506,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 	public function test_capture_terminal_payment_handles_exceptions() {
 		$order = $this->create_mock_order();
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willThrowException( new Exception( 'test error' ) );
 
 		$request = new WP_REST_Request( 'POST' );
@@ -551,9 +559,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -607,9 +615,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -648,9 +656,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -686,9 +694,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'succeeded' ] );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -728,9 +736,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$this->mock_api_client
-			->expects( $this->never() )
-			->method( 'get_intent' );
+		$request = $this->mock_wcpay_request( Get_Intent::class, 0 );
+		$request->expects( $this->never() )
+			->method( 'format_response' );
 
 		$this->mock_gateway
 			->expects( $this->never() )
@@ -764,9 +772,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -808,9 +816,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -850,9 +858,9 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 	public function test_capture_authorization_handles_exceptions() {
 		$order = $this->create_mock_order();
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willThrowException( new Exception( 'test error' ) );
 
 		$request = new WP_REST_Request( 'POST' );

--- a/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
@@ -6,8 +6,8 @@
  */
 
 use PHPUnit\Framework\MockObject\MockObject;
-use WCPay\Core\Server\Request\Create_Intent;
-use WCPay\Core\Server\Request\Get_Intent;
+use WCPay\Core\Server\Request\Create_Intention;
+use WCPay\Core\Server\Request\Get_Intention;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Exceptions\Rest_Request_Exception;
 use WCPay\Constants\Payment_Method;
@@ -88,7 +88,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -156,7 +156,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -229,7 +229,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -293,7 +293,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -328,7 +328,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'succeeded' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -370,7 +370,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class, 0 );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 0 );
 
 		$request->expects( $this->never() )
 			->method( 'format_response' );
@@ -410,7 +410,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -459,7 +459,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -506,7 +506,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 	public function test_capture_terminal_payment_handles_exceptions() {
 		$order = $this->create_mock_order();
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willThrowException( new Exception( 'test error' ) );
@@ -559,7 +559,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
@@ -615,7 +615,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
@@ -656,7 +656,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
@@ -694,7 +694,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'succeeded' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
@@ -736,7 +736,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class, 0 );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 0 );
 		$request->expects( $this->never() )
 			->method( 'format_response' );
 
@@ -772,7 +772,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
@@ -816,7 +816,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
@@ -858,7 +858,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 	public function test_capture_authorization_handles_exceptions() {
 		$order = $this->create_mock_order();
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willThrowException( new Exception( 'test error' ) );
@@ -1209,7 +1209,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 		$order  = $this->create_mock_order();
 		$intent = new WC_Payments_API_Intention( 'pi_abcxyz', 5000, 'usd', null, null, new DateTime(), 'requires_payment_method', 'secret' );
 
-		$request = $this->mock_wcpay_request( Create_Intent::class );
+		$request = $this->mock_wcpay_request( Create_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_amount' )
@@ -1268,7 +1268,7 @@ class WC_REST_Payments_Orders_Controller_Test extends WCPAY_UnitTestCase {
 	public function test_create_terminal_intent_will_return_error_response_if_server_request_fails() {
 		$order = $this->create_mock_order();
 
-		$request = $this->mock_wcpay_request( Create_Intent::class );
+		$request = $this->mock_wcpay_request( Create_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )

--- a/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-orders-controller.php
@@ -8,9 +8,7 @@
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Core\Server\Request\Create_Intention;
 use WCPay\Core\Server\Request\Get_Intention;
-use WCPay\Core\Server\Request\Update_Intention;
 use WCPay\Exceptions\API_Exception;
-use WCPay\Exceptions\Rest_Request_Exception;
 use WCPay\Constants\Payment_Method;
 
 /**

--- a/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
@@ -7,6 +7,7 @@
 
 use PHPUnit\Framework\MockObject\MockObject;
 use WC_REST_Payments_Reader_Controller as Controller;
+use WCPay\Core\Server\Request\Get_Charge;
 use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Exceptions\API_Exception;
 
@@ -271,10 +272,14 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willReturn( $payment_intent );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_charge' )
-			->with( 'ch_mock' )
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 1, $charge );
+
+		$charge_request->expects( $this->once() )
+			->method( 'set_charge_id' )
+			->with( 'ch_mock' );
+
+		$charge_request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $charge );
 
 		$this->mock_wcpay_gateway

--- a/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
@@ -262,11 +262,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 		$receipt = 'receipt';
 
-		$request = $this->mock_wcpay_request( Get_Intention::class, 1 );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( 'pi_mock' );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, 'pi_mock' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -426,11 +422,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 	public function test_generate_print_receipt_invalid_payment_error() {
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( 'pi_mock' );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, 'pi_mock' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -462,11 +454,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 	public function test_generate_print_receipt_handle_api_exceptions(): void {
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( 'pi_mock' );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, 'pi_mock' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -501,11 +489,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 		$charge = $this->mock_charge( '42' );
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( 'pi_mock' );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, 'pi_mock' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -547,11 +531,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 		$charge = $this->mock_charge( $order->get_id() );
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( 'pi_mock' );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, 'pi_mock' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -596,11 +576,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 		$settings = $this->mock_settings();
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( 'pi_mock' );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, 'pi_mock' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )

--- a/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
@@ -268,11 +268,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willReturn( $payment_intent );
 
-		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
-
-		$charge_request->expects( $this->once() )
-			->method( 'set_charge_id' )
-			->with( 'ch_mock' );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 1, 'ch_mock' );
 
 		$charge_request->expects( $this->once() )
 			->method( 'format_response' )
@@ -428,7 +424,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willReturn( WC_Helper_Intention::create_intention( [ 'status' => 'processing' ] ) );
 
-		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 0 );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 0, 'ch_mock' );
 
 		$charge_request->expects( $this->never() )
 			->method( 'format_response' );
@@ -460,7 +456,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willThrowException( new API_Exception( 'Something bad happened', 'test error', 500 ) );
 
-		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 0 );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 0, 'ch_mock' );
 
 		$charge_request->expects( $this->never() )
 			->method( 'format_response' );
@@ -495,11 +491,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willReturn( $payment_intent );
 
-		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
-
-		$charge_request->expects( $this->once() )
-			->method( 'set_charge_id' )
-			->with( 'ch_mock' );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 1, 'ch_mock' );
 
 		$charge_request->expects( $this->once() )
 			->method( 'format_response' )
@@ -537,11 +529,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willReturn( $payment_intent );
 
-		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
-
-		$charge_request->expects( $this->once() )
-			->method( 'set_charge_id' )
-			->with( 'ch_mock' );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 1, 'ch_mock' );
 
 		$charge_request->expects( $this->once() )
 			->method( 'format_response' )
@@ -582,11 +570,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willReturn( $payment_intent );
 
-		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
-
-		$charge_request->expects( $this->once() )
-			->method( 'set_charge_id' )
-			->with( 'ch_mock' );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 1, 'ch_mock' );
 
 		$charge_request->expects( $this->once() )
 			->method( 'format_response' )

--- a/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
@@ -272,7 +272,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willReturn( $payment_intent );
 
-		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 1, $charge );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
 
 		$charge_request->expects( $this->once() )
 			->method( 'set_charge_id' )
@@ -436,9 +436,10 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willReturn( WC_Helper_Intention::create_intention( [ 'status' => 'processing' ] ) );
 
-		$this->mock_api_client
-			->expects( $this->never() )
-			->method( 'get_charge' );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 0 );
+
+		$charge_request->expects( $this->never() )
+			->method( 'format_response' );
 
 		$this->mock_wcpay_gateway
 			->expects( $this->never() )
@@ -471,9 +472,10 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willThrowException( new API_Exception( 'Something bad happened', 'test error', 500 ) );
 
-		$this->mock_api_client
-			->expects( $this->never() )
-			->method( 'get_charge' );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 0 );
+
+		$charge_request->expects( $this->never() )
+			->method( 'format_response' );
 
 		$this->mock_wcpay_gateway
 			->expects( $this->never() )
@@ -509,10 +511,14 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willReturn( $payment_intent );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_charge' )
-			->with( 'ch_mock' )
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
+
+		$charge_request->expects( $this->once() )
+			->method( 'set_charge_id' )
+			->with( 'ch_mock' );
+
+		$charge_request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $charge );
 
 		$this->mock_wcpay_gateway
@@ -551,10 +557,14 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willReturn( $payment_intent );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_charge' )
-			->with( 'ch_mock' )
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
+
+		$charge_request->expects( $this->once() )
+			->method( 'set_charge_id' )
+			->with( 'ch_mock' );
+
+		$charge_request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $charge );
 
 		$this->mock_wcpay_gateway
@@ -596,10 +606,14 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willReturn( $payment_intent );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_charge' )
-			->with( 'ch_mock' )
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
+
+		$charge_request->expects( $this->once() )
+			->method( 'set_charge_id' )
+			->with( 'ch_mock' );
+
+		$charge_request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $charge );
 
 		$this->mock_wcpay_gateway

--- a/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
@@ -262,7 +262,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 		$receipt = 'receipt';
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1 );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )

--- a/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
@@ -7,6 +7,7 @@
 
 use PHPUnit\Framework\MockObject\MockObject;
 use WC_REST_Payments_Reader_Controller as Controller;
+use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Exceptions\API_Exception;
 
 require_once WCPAY_ABSPATH . 'includes/in-person-payments/class-wc-payments-printed-receipt-sample-order.php';
@@ -260,10 +261,14 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 		$receipt = 'receipt';
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
-			->with( 'pi_mock' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( 'pi_mock' );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $payment_intent );
 
 		$this->mock_api_client
@@ -414,11 +419,16 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( $mock_receipt, $response_data['html_content'] );
 	}
 
-	public function test_generate_print_receipt_invalid_payment_error(): void {
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
-			->with( 'pi_mock' )
+	public function test_generate_print_receipt_invalid_payment_error() {
+
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( 'pi_mock' );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( WC_Helper_Intention::create_intention( [ 'status' => 'processing' ] ) );
 
 		$this->mock_api_client
@@ -445,10 +455,15 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_generate_print_receipt_handle_api_exceptions(): void {
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
-			->with( 'pi_mock' )
+
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( 'pi_mock' );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willThrowException( new API_Exception( 'Something bad happened', 'test error', 500 ) );
 
 		$this->mock_api_client
@@ -479,10 +494,14 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 		$charge = $this->mock_charge( '42' );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
-			->with( 'pi_mock' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( 'pi_mock' );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $payment_intent );
 
 		$this->mock_api_client
@@ -517,10 +536,14 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 		$charge = $this->mock_charge( $order->get_id() );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
-			->with( 'pi_mock' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( 'pi_mock' );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $payment_intent );
 
 		$this->mock_api_client
@@ -549,7 +572,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 500, $data['status'] );
 	}
 
-	public function test_generate_print_receipt_handle_receipt_service_exception(): void {
+	public function test_generate_print_receipt_handle_receipt_service_exception() {
 		$order = WC_Helper_Order::create_order();
 
 		$payment_intent = WC_Helper_Intention::create_intention();
@@ -558,10 +581,14 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 		$settings = $this->mock_settings();
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
-			->with( 'pi_mock' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( 'pi_mock' );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $payment_intent );
 
 		$this->mock_api_client

--- a/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
@@ -8,7 +8,7 @@
 use PHPUnit\Framework\MockObject\MockObject;
 use WC_REST_Payments_Reader_Controller as Controller;
 use WCPay\Core\Server\Request\Get_Charge;
-use WCPay\Core\Server\Request\Get_Intent;
+use WCPay\Core\Server\Request\Get_Intention;
 use WCPay\Exceptions\API_Exception;
 
 require_once WCPAY_ABSPATH . 'includes/in-person-payments/class-wc-payments-printed-receipt-sample-order.php';
@@ -262,7 +262,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 		$receipt = 'receipt';
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -426,7 +426,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 	public function test_generate_print_receipt_invalid_payment_error() {
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -462,7 +462,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 	public function test_generate_print_receipt_handle_api_exceptions(): void {
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -501,7 +501,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 		$charge = $this->mock_charge( '42' );
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -547,7 +547,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 		$charge = $this->mock_charge( $order->get_id() );
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -596,7 +596,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 
 		$settings = $this->mock_settings();
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )

--- a/tests/unit/core/server/request/test-class-core-cancel-intention-request.php
+++ b/tests/unit/core/server/request/test-class-core-cancel-intention-request.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Class Cancel_Intention_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
+use WCPay\Core\Server\Request\Cancel_Intention;
+
+/**
+ * WCPay\Core\Server\Capture_Intention_Test unit tests.
+ */
+class Cancel_Intention_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_API_Client|MockObject
+	 */
+	private $mock_api_client;
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_Http_Interface|MockObject
+	 */
+	private $mock_wc_payments_http_client;
+
+
+	/**
+	 * Set up the unit tests objects.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->mock_api_client              = $this->createMock( WC_Payments_API_Client::class );
+		$this->mock_wc_payments_http_client = $this->createMock( WC_Payments_Http_Interface::class );
+	}
+
+	public function test_exception_will_throw_if_intent_is_invalid() {
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request = new Cancel_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client, '1' );
+	}
+
+	public function test_capture_intent_request_will_be_created() {
+		$intent_id = 'pi_1';
+
+		$request = new Cancel_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client, $intent_id );
+
+		$this->assertSame( 'POST', $request->get_method() );
+		$this->assertSame( WC_Payments_API_Client::INTENTIONS_API . '/' . $intent_id . '/cancel', $request->get_api() );
+	}
+}

--- a/tests/unit/core/server/request/test-class-core-capture-intention-request.php
+++ b/tests/unit/core/server/request/test-class-core-capture-intention-request.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Class Capture_Intention_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
+use WCPay\Core\Server\Request\Capture_Intention;
+
+/**
+ * WCPay\Core\Server\Capture_Intention_Test unit tests.
+ */
+class Capture_Intention_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_API_Client|MockObject
+	 */
+	private $mock_api_client;
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_Http_Interface|MockObject
+	 */
+	private $mock_wc_payments_http_client;
+
+
+	/**
+	 * Set up the unit tests objects.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->mock_api_client              = $this->createMock( WC_Payments_API_Client::class );
+		$this->mock_wc_payments_http_client = $this->createMock( WC_Payments_Http_Interface::class );
+	}
+
+	public function test_exception_will_throw_if_intent_is_invalid() {
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request = new Capture_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client, '1' );
+	}
+
+	public function test_capture_intent_request_will_be_created() {
+		$amount    = 1;
+		$intent_id = 'pi_1';
+
+		$request = new Capture_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client, $intent_id );
+		$request->set_amount_to_capture( $amount );
+		$request->set_level3( [ 'level3' => 'level3' ] );
+		$params = $request->get_params();
+
+		$this->assertIsArray( $params );
+		$this->assertSame( $amount, $params['amount_to_capture'] );
+		$this->assertArrayHasKey( 'level3', $params );
+		$this->assertSame( 'POST', $request->get_method() );
+		$this->assertSame( WC_Payments_API_Client::INTENTIONS_API . '/' . $intent_id . '/capture', $request->get_api() );
+	}
+}

--- a/tests/unit/core/server/request/test-class-core-create-intention-request.php
+++ b/tests/unit/core/server/request/test-class-core-create-intention-request.php
@@ -50,7 +50,7 @@ class Create_Intention_Test extends WCPAY_UnitTestCase {
 	public function test_exception_will_throw_if_amount_is_not_set() {
 		$request = new Create_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
-		$request->set_currency( 'usd' );
+		$request->set_currency_code( 'usd' );
 		$request->get_params();
 	}
 	public function test_exception_will_throw_if_currency_is_not_set() {
@@ -64,7 +64,7 @@ class Create_Intention_Test extends WCPAY_UnitTestCase {
 		$request = new Create_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->expectException( Immutable_Parameter_Exception::class );
 		$request->set_amount( 1 );
-		$request->set_currency( 'usd' );
+		$request->set_currency_code( 'usd' );
 		add_filter(
 			'test_exception_will_throw_if_immutable_parameter_is_changed_when_filter_is_applied',
 			function() {
@@ -72,7 +72,7 @@ class Create_Intention_Test extends WCPAY_UnitTestCase {
 
 				};
 				$new_class->set_amount( 3 );
-				$new_class->set_currency( 'usd' );
+				$new_class->set_currency_code( 'usd' );
 				return $new_class;
 			}
 		);
@@ -84,7 +84,7 @@ class Create_Intention_Test extends WCPAY_UnitTestCase {
 		$currency = 'usd';
 		$request  = new Create_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$request->set_amount( $amount );
-		$request->set_currency( $currency );
+		$request->set_currency_code( $currency );
 		$this->assertInstanceOf( Create_Intent::class, $request );
 		$params = $request->get_params();
 
@@ -103,7 +103,7 @@ class Create_Intention_Test extends WCPAY_UnitTestCase {
 		$request  = new WooPay_Create_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$request->set_amount( $amount );
 		$request->set_save_payment_method_to_platform( true );
-		$request->set_currency( $currency );
+		$request->set_currency_code( $currency );
 		$this->assertInstanceOf( WooPay_Create_Intent::class, $request );
 		$params = $request->get_params();
 

--- a/tests/unit/core/server/request/test-class-core-create-intention-request.php
+++ b/tests/unit/core/server/request/test-class-core-create-intention-request.php
@@ -8,7 +8,7 @@
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Core\Exceptions\Server\Request\Immutable_Parameter_Exception;
 use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
-use WCPay\Core\Server\Request\Create_Intent;
+use WCPay\Core\Server\Request\Create_Intention;
 use WCPay\Core\Server\Request\WooPay_Create_Intent;
 
 /**
@@ -43,32 +43,32 @@ class Create_Intention_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_exception_will_throw_if_amount_is_negative_number() {
-		$request = new Create_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request = new Create_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
 		$request->set_amount( -1 );
 	}
 	public function test_exception_will_throw_if_amount_is_not_set() {
-		$request = new Create_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request = new Create_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
 		$request->set_currency_code( 'usd' );
 		$request->get_params();
 	}
 	public function test_exception_will_throw_if_currency_is_not_set() {
-		$request = new Create_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request = new Create_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
 		$request->set_amount( 1 );
 		$request->get_params();
 	}
 
 	public function test_exception_will_throw_if_amount_parameter_is_changed_when_filter_is_applied() {
-		$request = new Create_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request = new Create_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->expectException( Immutable_Parameter_Exception::class );
 		$request->set_amount( 1 );
 		$request->set_currency_code( 'usd' );
 		add_filter(
 			'test_exception_will_throw_if_immutable_parameter_is_changed_when_filter_is_applied',
 			function() {
-				$new_class = new class( $this->mock_api_client, $this->mock_wc_payments_http_client) extends Create_Intent {
+				$new_class = new class( $this->mock_api_client, $this->mock_wc_payments_http_client) extends Create_Intention {
 
 				};
 				$new_class->set_amount( 3 );
@@ -79,13 +79,13 @@ class Create_Intention_Test extends WCPAY_UnitTestCase {
 		$request->apply_filters( 'test_exception_will_throw_if_immutable_parameter_is_changed_when_filter_is_applied' );
 	}
 
-	public function test_create_intent_request_will_be_created_() {
+	public function test_create_intent_request_will_be_created() {
 		$amount   = 1;
 		$currency = 'usd';
-		$request  = new Create_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request  = new Create_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$request->set_amount( $amount );
 		$request->set_currency_code( $currency );
-		$this->assertInstanceOf( Create_Intent::class, $request );
+		$this->assertInstanceOf( Create_Intention::class, $request );
 		$params = $request->get_params();
 
 		$this->assertIsArray( $params );
@@ -97,7 +97,7 @@ class Create_Intention_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( WC_Payments_API_Client::INTENTIONS_API, $request->get_api() );
 	}
 
-	public function test_woopay_create_intent_request_will_be_created_() {
+	public function test_woopay_create_intent_request_will_be_created() {
 		$amount   = 1;
 		$currency = 'usd';
 		$request  = new WooPay_Create_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );

--- a/tests/unit/core/server/request/test-class-core-create-setup-intention-request.php
+++ b/tests/unit/core/server/request/test-class-core-create-setup-intention-request.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Class Create_Setup_Intention_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
+use WCPay\Core\Server\Request\Create_Setup_Intention;
+
+/**
+ * WCPay\Core\Server\Create_Setup_Intention_Test unit tests.
+ */
+class Create_Setup_Intention_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_API_Client|MockObject
+	 */
+	private $mock_api_client;
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_Http_Interface|MockObject
+	 */
+	private $mock_wc_payments_http_client;
+
+
+	/**
+	 * Set up the unit tests objects.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->mock_api_client              = $this->createMock( WC_Payments_API_Client::class );
+		$this->mock_wc_payments_http_client = $this->createMock( WC_Payments_Http_Interface::class );
+	}
+
+
+
+	public function test_exception_will_throw_if_customer_id_is_invalid() {
+		$request = new Create_Setup_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request->set_customer( '1' );
+	}
+
+	public function test_exception_will_throw_if_customer_id_is_not_set() {
+		$request = new Create_Setup_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request->set_payment_method_types( [ 'card' ] );
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request->get_params();
+	}
+	public function test_exception_will_throw_if_payment_method_types_is_not_set() {
+		$request = new Create_Setup_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request->set_customer( 'cus_1' );
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request->get_params();
+	}
+	public function test_create_intent_request_will_be_created() {
+		$customer = 'cus_1';
+		$pm       = [ 'card' ];
+		$request  = new Create_Setup_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request->set_customer( 'cus_1' );
+		$request->set_payment_method_types( [ 'card' ] );
+		$this->assertInstanceOf( Create_Setup_Intention::class, $request );
+		$params = $request->get_params();
+
+		$this->assertIsArray( $params );
+		$this->assertArrayHasKey( 'customer', $params );
+		$this->assertSame( $customer, $params['customer'] );
+		$this->assertArrayHasKey( 'payment_method_types', $params );
+		$this->assertSame( $pm, $params['payment_method_types'] );
+		$this->assertSame( 'false', $params['confirm'] );
+		$this->assertSame( 'POST', $request->get_method() );
+		$this->assertSame( WC_Payments_API_Client::SETUP_INTENTS_API, $request->get_api() );
+	}
+
+
+}

--- a/tests/unit/core/server/request/test-class-core-get-charge-request.php
+++ b/tests/unit/core/server/request/test-class-core-get-charge-request.php
@@ -41,20 +41,16 @@ class Get_Charge_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_exception_will_throw_if_charge_id_is_not_set() {
-		$request = new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
-		$request->get_api();
+
+		$request = new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client, null );
 	}
 	public function test_exception_will_throw_if_charge_id_is_invalid() {
-		$request = new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
-		$request->set_charge_id( '1' );
+		$request = new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client, '1' );
 	}
-	public function test_charge_is_immutable_once_set() {
-		$request = new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client );
-		$request->set_charge_id( 'ch_1' );
-		$api = $request->get_api();
-		$request->set_charge_id( 'ch_2' );
-		$this->assertSame( $api, $request->get_api() );
+	public function test_charge_request_class_is_created() {
+		$request = new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client, 'ch_mock' );
+		$this->assertSame( WC_Payments_API_Client::CHARGES_API . '/ch_mock', $request->get_api() );
 	}
 }

--- a/tests/unit/core/server/request/test-class-core-get-charge-request.php
+++ b/tests/unit/core/server/request/test-class-core-get-charge-request.php
@@ -7,12 +7,12 @@
 
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
-use WCPay\Core\Server\Request\Get_Intent;
+use WCPay\Core\Server\Request\Get_Charge;
 
 /**
  * WCPay\Core\Server\Request unit tests.
  */
-class Get_Intention_Test extends WCPAY_UnitTestCase {
+class Get_Charge_Test extends WCPAY_UnitTestCase {
 
 	/**
 	 * Mock WC_Payments_API_Client.
@@ -40,22 +40,21 @@ class Get_Intention_Test extends WCPAY_UnitTestCase {
 		$this->mock_wc_payments_http_client = $this->createMock( WC_Payments_Http_Interface::class );
 	}
 
-	public function test_exception_will_throw_if_payment_intent_is_not_set() {
-		$request = new Get_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
+	public function test_exception_will_throw_if_charge_id_is_not_set() {
+		$request = new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
 		$request->get_api();
 	}
-
-	public function test_exception_will_throw_if_payment_intent_is_invalid() {
-		$request = new Get_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
+	public function test_exception_will_throw_if_charge_id_is_invalid() {
+		$request = new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
-		$request->set_intent_id( '1' );
+		$request->set_charge_id( '1' );
 	}
-	public function test_payment_intent_is_immutable_once_set() {
-		$request = new Get_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
-		$request->set_intent_id( 'pi_1' );
+	public function test_charge_is_immutable_once_set() {
+		$request = new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request->set_charge_id( 'ch_1' );
 		$api = $request->get_api();
-		$request->set_intent_id( 'pi_2' );
+		$request->set_charge_id( 'ch_2' );
 		$this->assertSame( $api, $request->get_api() );
 	}
 }

--- a/tests/unit/core/server/request/test-class-core-get-intention-request.php
+++ b/tests/unit/core/server/request/test-class-core-get-intention-request.php
@@ -7,12 +7,12 @@
 
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
-use WCPay\Core\Server\Request\Get_Intent;
+use WCPay\Core\Server\Request\Get_Intention;
 
 /**
  * WCPay\Core\Server\Request unit tests.
  */
-class Get_Intention_Test extends WCPAY_UnitTestCase {
+class Get_Intentionion_Test extends WCPAY_UnitTestCase {
 
 	/**
 	 * Mock WC_Payments_API_Client.
@@ -41,18 +41,18 @@ class Get_Intention_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_exception_will_throw_if_payment_intent_is_not_set() {
-		$request = new Get_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request = new Get_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
 		$request->get_api();
 	}
 
 	public function test_exception_will_throw_if_payment_intent_is_invalid() {
-		$request = new Get_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request = new Get_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
 		$request->set_intent_id( '1' );
 	}
 	public function test_payment_intent_is_immutable_once_set() {
-		$request = new Get_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request = new Get_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$request->set_intent_id( 'pi_1' );
 		$api = $request->get_api();
 		$request->set_intent_id( 'pi_2' );

--- a/tests/unit/core/server/request/test-class-core-get-intention-request.php
+++ b/tests/unit/core/server/request/test-class-core-get-intention-request.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Class Create_And_Confirm_Intention_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
+use WCPay\Core\Server\Request\Get_Intent;
+
+/**
+ * WCPay\Core\Server\Request unit tests.
+ */
+class Get_Intention_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_API_Client|MockObject
+	 */
+	private $mock_api_client;
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_Http_Interface|MockObject
+	 */
+	private $mock_wc_payments_http_client;
+
+
+	/**
+	 * Set up the unit tests objects.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->mock_api_client              = $this->createMock( WC_Payments_API_Client::class );
+		$this->mock_wc_payments_http_client = $this->createMock( WC_Payments_Http_Interface::class );
+	}
+
+	public function test_exception_will_throw_if_payment_intent_is_not_set() {
+		$request = new Get_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request->get_api();
+	}
+	public function test_payment_intent_is_immutable_once_set() {
+		$request = new Get_Intent( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request->set_intent_id( 'pi_1' );
+		$api = $request->get_api();
+		$request->set_intent_id( 'pi_2' );
+		$this->assertSame( $api, $request->get_api() );
+	}
+}

--- a/tests/unit/core/server/request/test-class-core-get-intention-request.php
+++ b/tests/unit/core/server/request/test-class-core-get-intention-request.php
@@ -12,7 +12,7 @@ use WCPay\Core\Server\Request\Get_Intention;
 /**
  * WCPay\Core\Server\Request unit tests.
  */
-class Get_Intentionion_Test extends WCPAY_UnitTestCase {
+class Get_Intention_Test extends WCPAY_UnitTestCase {
 
 	/**
 	 * Mock WC_Payments_API_Client.
@@ -40,22 +40,13 @@ class Get_Intentionion_Test extends WCPAY_UnitTestCase {
 		$this->mock_wc_payments_http_client = $this->createMock( WC_Payments_Http_Interface::class );
 	}
 
-	public function test_exception_will_throw_if_payment_intent_is_not_set() {
-		$request = new Get_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
-		$this->expectException( Invalid_Request_Parameter_Exception::class );
-		$request->get_api();
-	}
 
 	public function test_exception_will_throw_if_payment_intent_is_invalid() {
-		$request = new Get_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
-		$request->set_intent_id( '1' );
+		$request = new Get_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client, '1' );
 	}
-	public function test_payment_intent_is_immutable_once_set() {
-		$request = new Get_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
-		$request->set_intent_id( 'pi_1' );
-		$api = $request->get_api();
-		$request->set_intent_id( 'pi_2' );
-		$this->assertSame( $api, $request->get_api() );
+	public function test_get_payment_intent_request_will_be_created() {
+		$request = new Get_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client, 'pi_1' );
+		$this->assertSame( WC_Payments_API_Client::INTENTIONS_API . '/pi_1', $request->get_api() );
 	}
 }

--- a/tests/unit/core/server/request/test-class-core-update-intention-request.php
+++ b/tests/unit/core/server/request/test-class-core-update-intention-request.php
@@ -58,7 +58,7 @@ class Update_Intention_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_payment_intent_api_url_when_action_is_set() {
-		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client, 'pi_mock', 'capture' );
+		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client, 'pi_mock' );
 		$this->assertSame( WC_Payments_API_Client::INTENTIONS_API . '/pi_mock/capture', $request->get_api() );
 	}
 

--- a/tests/unit/core/server/request/test-class-core-update-intention-request.php
+++ b/tests/unit/core/server/request/test-class-core-update-intention-request.php
@@ -57,7 +57,7 @@ class Update_Intention_Test extends WCPAY_UnitTestCase {
 		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client, '1' );
 	}
 
-	public function test_create_intent_request_will_be_created() {
+	public function test_update_intent_request_will_be_created() {
 		$amount       = 1;
 		$currency     = 'usd';
 		$cs           = 'cus_1';

--- a/tests/unit/core/server/request/test-class-core-update-intention-request.php
+++ b/tests/unit/core/server/request/test-class-core-update-intention-request.php
@@ -57,11 +57,6 @@ class Update_Intention_Test extends WCPAY_UnitTestCase {
 		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client, '1' );
 	}
 
-	public function test_payment_intent_api_url_when_action_is_set() {
-		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client, 'pi_mock' );
-		$this->assertSame( WC_Payments_API_Client::INTENTIONS_API . '/pi_mock/capture', $request->get_api() );
-	}
-
 	public function test_create_intent_request_will_be_created() {
 		$amount       = 1;
 		$currency     = 'usd';

--- a/tests/unit/core/server/request/test-class-core-update-intention-request.php
+++ b/tests/unit/core/server/request/test-class-core-update-intention-request.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Class Create_Intention_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Core\Exceptions\Server\Request\Immutable_Parameter_Exception;
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
+use WCPay\Core\Server\Request\Update_Intention;
+
+/**
+ * WCPay\Core\Server\Request unit tests.
+ */
+class Update_Intention_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_API_Client|MockObject
+	 */
+	private $mock_api_client;
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_Http_Interface|MockObject
+	 */
+	private $mock_wc_payments_http_client;
+
+
+	/**
+	 * Set up the unit tests objects.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->mock_api_client              = $this->createMock( WC_Payments_API_Client::class );
+		$this->mock_wc_payments_http_client = $this->createMock( WC_Payments_Http_Interface::class );
+	}
+
+	public function test_exception_will_throw_if_amount_is_negative_number() {
+		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request->set_amount( -1 );
+	}
+	public function test_exception_will_throw_if_amount_is_not_set() {
+		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request->get_params();
+	}
+	public function test_exception_will_throw_if_currency_is_not_set() {
+		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request->set_amount( 1 );
+		$request->get_params();
+	}
+
+	public function test_exception_will_throw_if_customer_is_invalid() {
+		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request->set_customer( '1' );
+	}
+
+	public function test_exception_will_throw_if_intent_is_invalid() {
+		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request->set_intent_id( '1' );
+	}
+
+	public function test_exception_will_throw_if_payment_intent_is_not_set() {
+		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request->get_api();
+	}
+	public function test_payment_intent_is_immutable_once_set() {
+		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request->set_intent_id( 'pi_1' );
+		$api = $request->get_api();
+		$request->set_intent_id( 'pi_2' );
+		$this->assertSame( $api, $request->get_api() );
+	}
+
+	public function test_create_intent_request_will_be_created() {
+		$amount       = 1;
+		$currency     = 'usd';
+		$cs           = 'cus_1';
+		$country      = 'usa';
+		$payment_type = 'card';
+		$intent_id    = 'pi_1';
+
+		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request->set_amount( $amount );
+		$request->set_currency_code( $currency );
+		$request->set_intent_id( $intent_id );
+		$request->set_customer( $cs );
+		$request->setup_future_usage();
+		$request->set_metadata( [ 'order_number' => 1 ] );
+		$request->set_level3( [ 'level3' => 'level3' ] );
+		$request->set_selected_upe_payment_method_type( $payment_type, [ $payment_type ] );
+		$request->set_payment_country( $country );
+		$params = $request->get_params();
+
+		$this->assertIsArray( $params );
+		$this->assertSame( $amount, $params['amount'] );
+		$this->assertSame( '', $params['receipt_email'] );
+		$this->assertSame( $currency, $params['currency'] );
+		$this->assertSame( $cs, $params['customer'] );
+		$this->assertSame( 'off_session', $params['setup_future_usage'] );
+		$this->assertArrayHasKey( 'description', $params );
+		$this->assertArrayHasKey( 'metadata', $params );
+		$this->assertSame( 1, $params['metadata']['order_number'] );
+		$this->assertSame( $payment_type, $params['payment_method_types'][0] );
+		$this->assertArrayHasKey( 'level3', $params );
+		$this->assertSame( 'POST', $request->get_method() );
+		$this->assertSame( WC_Payments_API_Client::INTENTIONS_API . '/' . $intent_id, $request->get_api() );
+	}
+}

--- a/tests/unit/core/server/request/test-class-core-update-intention-request.php
+++ b/tests/unit/core/server/request/test-class-core-update-intention-request.php
@@ -72,7 +72,7 @@ class Update_Intention_Test extends WCPAY_UnitTestCase {
 		$request->setup_future_usage();
 		$request->set_metadata( [ 'order_number' => 1 ] );
 		$request->set_level3( [ 'level3' => 'level3' ] );
-		$request->set_selected_upe_payment_method_type( $payment_type, [ $payment_type ] );
+		$request->set_payment_method_types( [ $payment_type ] );
 		$request->set_payment_country( $country );
 		$params = $request->get_params();
 

--- a/tests/unit/core/server/request/test-class-core-update-intention-request.php
+++ b/tests/unit/core/server/request/test-class-core-update-intention-request.php
@@ -42,45 +42,24 @@ class Update_Intention_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_exception_will_throw_if_amount_is_negative_number() {
-		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client, 'pi_mock' );
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
 		$request->set_amount( -1 );
 	}
-	public function test_exception_will_throw_if_amount_is_not_set() {
-		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
-		$this->expectException( Invalid_Request_Parameter_Exception::class );
-		$request->get_params();
-	}
-	public function test_exception_will_throw_if_currency_is_not_set() {
-		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
-		$this->expectException( Invalid_Request_Parameter_Exception::class );
-		$request->set_amount( 1 );
-		$request->get_params();
-	}
-
 	public function test_exception_will_throw_if_customer_is_invalid() {
-		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client, 'pi_mock' );
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
 		$request->set_customer( '1' );
 	}
 
 	public function test_exception_will_throw_if_intent_is_invalid() {
-		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
-		$request->set_intent_id( '1' );
+		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client, '1' );
 	}
 
-	public function test_exception_will_throw_if_payment_intent_is_not_set() {
-		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
-		$this->expectException( Invalid_Request_Parameter_Exception::class );
-		$request->get_api();
-	}
-	public function test_payment_intent_is_immutable_once_set() {
-		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
-		$request->set_intent_id( 'pi_1' );
-		$api = $request->get_api();
-		$request->set_intent_id( 'pi_2' );
-		$this->assertSame( $api, $request->get_api() );
+	public function test_payment_intent_api_url_when_action_is_set() {
+		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client, 'pi_mock', 'capture' );
+		$this->assertSame( WC_Payments_API_Client::INTENTIONS_API . '/pi_mock/capture', $request->get_api() );
 	}
 
 	public function test_create_intent_request_will_be_created() {
@@ -91,10 +70,9 @@ class Update_Intention_Test extends WCPAY_UnitTestCase {
 		$payment_type = 'card';
 		$intent_id    = 'pi_1';
 
-		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request = new Update_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client, $intent_id );
 		$request->set_amount( $amount );
 		$request->set_currency_code( $currency );
-		$request->set_intent_id( $intent_id );
 		$request->set_customer( $cs );
 		$request->setup_future_usage();
 		$request->set_metadata( [ 'order_number' => 1 ] );

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -314,10 +314,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->with( 'cus_mock' );
 
 		$request->expects( $this->once() )
-			->method( 'set_selected_upe_payment_method_type' )
-			->with( '', [] );
-
-		$request->expects( $this->once() )
 			->method( 'setup_future_usage' );
 
 		$request->expects( $this->once() )
@@ -412,8 +408,8 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->with( 'cus_mock' );
 
 		$request->expects( $this->once() )
-			->method( 'set_selected_upe_payment_method_type' )
-			->with( 'giropay', [] );
+			->method( 'set_payment_method_types' )
+			->with( [ 'giropay' ] );
 
 		$request->expects( $this->once() )
 			->method( 'setup_future_usage' );
@@ -504,10 +500,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$request->expects( $this->once() )
 			->method( 'set_customer' )
 			->with( 'cus_mock' );
-
-		$request->expects( $this->once() )
-			->method( 'set_selected_upe_payment_method_type' )
-			->with( '', [] );
 
 		$request->expects( $this->once() )
 			->method( 'set_payment_country' )
@@ -1463,10 +1455,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$request->expects( $this->once() )
 			->method( 'set_amount' )
 			->with( (int) ( $amount * 100 ) );
-
-		$request->expects( $this->once() )
-			->method( 'set_selected_upe_payment_method_type' )
-			->with( '', [] );
 
 		$request->expects( $this->once() )
 			->method( 'set_metadata' )

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -169,7 +169,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					'get_setup_intent',
 					'get_payment_method',
 					'is_server_connected',
-					'get_charge',
 					'get_timeline',
 				]
 			)

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -10,6 +10,7 @@ namespace WCPay\Payment_Methods;
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Constants\Payment_Type;
 use WCPay\Core\Server\Request\Create_Intent;
+use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Core\Server\Request\Update_Intention;
 use WCPay\Exceptions\Amount_Too_Small_Exception;
 use WCPay\Exceptions\API_Exception;
@@ -165,7 +166,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					'create_intention',
 					'create_setup_intention',
 					'update_intention',
-					'get_intent',
 					'get_setup_intent',
 					'get_payment_method',
 					'is_server_connected',
@@ -974,12 +974,15 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 				$this->returnValue( [ $user, $customer_id ] )
 			);
 
-		$this->mock_api_client->expects( $this->once() )
-			->method( 'get_intent' )
-			->with( $intent_id )
-			->will(
-				$this->returnValue( $payment_intent )
-			);
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->will( $this->returnValue( $payment_intent ) );
 
 		$this->set_cart_contains_subscription_items( false );
 
@@ -1021,12 +1024,15 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 				$this->returnValue( [ $user, $customer_id ] )
 			);
 
-		$this->mock_api_client->expects( $this->once() )
-			->method( 'get_intent' )
-			->with( $intent_id )
-			->will(
-				$this->returnValue( $payment_intent )
-			);
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->will( $this->returnValue( $payment_intent ) );
 
 		$this->set_cart_contains_subscription_items( false );
 
@@ -1125,12 +1131,15 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 				$this->returnValue( [ $user, $customer_id ] )
 			);
 
-		$this->mock_api_client->expects( $this->once() )
-			->method( 'get_intent' )
-			->with( $intent_id )
-			->will(
-				$this->returnValue( $payment_intent )
-			);
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->will( $this->returnValue( $payment_intent ) );
 
 		$this->mock_token_service->expects( $this->once() )
 			->method( 'add_payment_method_to_user' )

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -9,6 +9,7 @@ namespace WCPay\Payment_Methods;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Constants\Payment_Type;
+use WCPay\Core\Server\Request\Create_Intent;
 use WCPay\Exceptions\Amount_Too_Small_Exception;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Exceptions\Connection_Exception;
@@ -500,11 +501,43 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$order    = WC_Helper_Order::create_order();
 		$order_id = $order->get_id();
 		$intent   = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'create_intention' )
-			->with( 5000, 'usd', [ 'card' ] )
+		$request  = $this->mock_wcpay_request( Create_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'set_amount' )
+			->with( $intent->get_amount() );
+
+		$request->expects( $this->once() )
+			->method( 'set_currency_code' )
+			->with( strtolower( $intent->get_currency() ) );
+
+		$request->expects( $this->once() )
+			->method( 'set_capture_method' )
+			->with( false );
+
+		$request->expects( $this->once() )
+			->method( 'set_metadata' )
+			->with(
+				$this->callback(
+					function( $metadata ) {
+						return isset( $metadata['order_number'] );
+					}
+				)
+			);
+
+		$request->expects( $this->once() )
+			->method( 'set_payment_method_types' )
+			->with(
+				$this->callback(
+					function( $argument ) {
+						return is_array( $argument ) && ! empty( $argument );
+					}
+				)
+			);
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $intent );
+
 		$this->set_cart_contains_subscription_items( false );
 		$this->set_get_upe_enabled_payment_method_statuses_return_value();
 
@@ -515,17 +548,43 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$order    = WC_Helper_Order::create_order();
 		$order_id = $order->get_id();
 		$intent   = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'create_intention' )
+		$request  = $this->mock_wcpay_request( Create_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'set_amount' )
+			->with( $intent->get_amount() );
+
+		$request->expects( $this->once() )
+			->method( 'set_currency_code' )
+			->with( strtolower( $intent->get_currency() ) );
+
+		$request->expects( $this->once() )
+			->method( 'set_capture_method' )
+			->with( false );
+
+		$request->expects( $this->once() )
+			->method( 'set_metadata' )
 			->with(
-				5000,
-				'usd',
-				[ 'card' ],
-				$order_id,
-				'automatic'
-			)
+				$this->callback(
+					function( $metadata ) {
+						return isset( $metadata['order_number'] );
+					}
+				)
+			);
+
+		$request->expects( $this->once() )
+			->method( 'set_payment_method_types' )
+			->with(
+				$this->callback(
+					function( $argument ) {
+						return is_array( $argument ) && ! empty( $argument );
+					}
+				)
+			);
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $intent );
+
 		$this->set_get_upe_enabled_payment_method_statuses_return_value();
 
 		$this->mock_upe_gateway->create_payment_intent( $order_id );
@@ -536,17 +595,43 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$order_id = $order->get_id();
 		$intent   = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
 		$this->mock_upe_gateway->settings['manual_capture'] = 'no';
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'create_intention' )
+		$request = $this->mock_wcpay_request( Create_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'set_amount' )
+			->with( $intent->get_amount() );
+
+		$request->expects( $this->once() )
+			->method( 'set_currency_code' )
+			->with( strtolower( $intent->get_currency() ) );
+
+		$request->expects( $this->once() )
+			->method( 'set_capture_method' )
+			->with( false );
+
+		$request->expects( $this->once() )
+			->method( 'set_metadata' )
 			->with(
-				5000,
-				'usd',
-				[ 'card' ],
-				$order_id,
-				'automatic'
-			)
+				$this->callback(
+					function( $metadata ) {
+						return isset( $metadata['order_number'] );
+					}
+				)
+			);
+
+		$request->expects( $this->once() )
+			->method( 'set_payment_method_types' )
+			->with(
+				$this->callback(
+					function( $argument ) {
+						return is_array( $argument ) && ! empty( $argument );
+					}
+				)
+			);
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $intent );
+
 		$this->set_get_upe_enabled_payment_method_statuses_return_value();
 
 		$this->mock_upe_gateway->create_payment_intent( $order_id );
@@ -557,17 +642,44 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$order_id = $order->get_id();
 		$intent   = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
 		$this->mock_upe_gateway->settings['manual_capture'] = 'yes';
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'create_intention' )
+		$request = $this->mock_wcpay_request( Create_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_amount' )
+			->with( $intent->get_amount() );
+
+		$request->expects( $this->once() )
+			->method( 'set_currency_code' )
+			->with( strtolower( $intent->get_currency() ) );
+
+		$request->expects( $this->once() )
+			->method( 'set_capture_method' )
+			->with( true );
+
+		$request->expects( $this->once() )
+			->method( 'set_metadata' )
 			->with(
-				5000,
-				'usd',
-				[ 'card' ],
-				$order_id,
-				'manual'
-			)
+				$this->callback(
+					function( $metadata ) {
+						return isset( $metadata['order_number'] );
+					}
+				)
+			);
+
+		$request->expects( $this->once() )
+			->method( 'set_payment_method_types' )
+			->with(
+				$this->callback(
+					function( $argument ) {
+						return is_array( $argument ) && ! empty( $argument );
+					}
+				)
+			);
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $intent );
+
 		$this->set_get_upe_enabled_payment_method_statuses_return_value();
 
 		$this->mock_upe_gateway->create_payment_intent( $order_id );
@@ -1267,11 +1379,43 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'create_intention' )
-			->with( 50, 'usd', [ 'card' ] )
+		$request = $this->mock_wcpay_request( Create_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'set_amount' )
+			->with( $intent->get_amount() );
+
+		$request->expects( $this->once() )
+			->method( 'set_currency_code' )
+			->with( strtolower( $intent->get_currency() ) );
+
+		$request->expects( $this->once() )
+			->method( 'set_capture_method' )
+			->with( false );
+
+		$request->expects( $this->once() )
+			->method( 'set_metadata' )
+			->with(
+				$this->callback(
+					function( $metadata ) {
+						return isset( $metadata['order_number'] );
+					}
+				)
+			);
+
+		$request->expects( $this->once() )
+			->method( 'set_payment_method_types' )
+			->with(
+				$this->callback(
+					function( $argument ) {
+						return is_array( $argument ) && ! empty( $argument );
+					}
+				)
+			);
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $intent );
+
 		$this->set_get_upe_enabled_payment_method_statuses_return_value();
 
 		$this->mock_upe_gateway->create_payment_intent( $order->get_id() );
@@ -1290,13 +1434,42 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$this->mock_api_client
-			->expects( $this->exactly( 2 ) )
-			->method( 'create_intention' )
-			->withConsecutive(
-				[ 45, 'usd', [ 'card' ] ],
-				[ 50, 'usd', [ 'card' ] ]
-			)
+		$request = $this->mock_wcpay_request( Create_Intent::class, 2 );
+
+		$request->expects( $this->exactly( 2 ) )
+			->method( 'set_amount' )
+			->withConsecutive( [ 45 ], [ $intent->get_amount() ] );
+
+		$request->expects( $this->once() )
+			->method( 'set_currency_code' )
+			->with( strtolower( $intent->get_currency() ) );
+
+		$request->expects( $this->once() )
+			->method( 'set_capture_method' )
+			->with( false );
+
+		$request->expects( $this->once() )
+			->method( 'set_metadata' )
+			->with(
+				$this->callback(
+					function( $metadata ) {
+						return isset( $metadata['order_number'] );
+					}
+				)
+			);
+
+		$request->expects( $this->once() )
+			->method( 'set_payment_method_types' )
+			->with(
+				$this->callback(
+					function( $argument ) {
+						return is_array( $argument ) && ! empty( $argument );
+					}
+				)
+			);
+
+		$request->expects( $this->exactly( 2 ) )
+			->method( 'format_response' )
 			->will(
 				$this->onConsecutiveCalls(
 					$this->throwException( new Amount_Too_Small_Exception( 'Error: Amount must be at least $0.50 usd', 50, 'usd', 400 ) ),

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -591,14 +591,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			);
 
 		$request->expects( $this->once() )
-			->method( 'set_payment_method_types' )
-			->with(
-				$this->callback(
-					function( $argument ) {
-						return is_array( $argument ) && ! empty( $argument );
-					}
-				)
-			);
+			->method( 'set_payment_method_types' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -638,14 +631,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			);
 
 		$request->expects( $this->once() )
-			->method( 'set_payment_method_types' )
-			->with(
-				$this->callback(
-					function( $argument ) {
-						return is_array( $argument ) && ! empty( $argument );
-					}
-				)
-			);
+			->method( 'set_payment_method_types' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -685,14 +671,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			);
 
 		$request->expects( $this->once() )
-			->method( 'set_payment_method_types' )
-			->with(
-				$this->callback(
-					function( $argument ) {
-						return is_array( $argument ) && ! empty( $argument );
-					}
-				)
-			);
+			->method( 'set_payment_method_types' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -733,14 +712,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			);
 
 		$request->expects( $this->once() )
-			->method( 'set_payment_method_types' )
-			->with(
-				$this->callback(
-					function( $argument ) {
-						return is_array( $argument ) && ! empty( $argument );
-					}
-				)
-			);
+			->method( 'set_payment_method_types' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -769,14 +741,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->with( 'cus_mock' );
 
 		$request->expects( $this->once() )
-			->method( 'set_payment_method_types' )
-			->with(
-				$this->callback(
-					function( $argument ) {
-						return is_array( $argument ) && ! empty( $argument );
-					}
-				)
-			);
+			->method( 'set_payment_method_types' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -1487,14 +1452,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			);
 
 		$request->expects( $this->once() )
-			->method( 'set_payment_method_types' )
-			->with(
-				$this->callback(
-					function( $argument ) {
-						return is_array( $argument ) && ! empty( $argument );
-					}
-				)
-			);
+			->method( 'set_payment_method_types' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -1543,14 +1501,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			);
 
 		$request->expects( $this->once() )
-			->method( 'set_payment_method_types' )
-			->with(
-				$this->callback(
-					function( $argument ) {
-						return is_array( $argument ) && ! empty( $argument );
-					}
-				)
-			);
+			->method( 'set_payment_method_types' );
 
 		$request->expects( $this->exactly( 2 ) )
 			->method( 'format_response' )

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -9,18 +9,12 @@ namespace WCPay\Payment_Methods;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Constants\Payment_Type;
-use WCPay\Core\Server\Request\Create_Intent;
-use WCPay\Core\Server\Request\Get_Intent;
+use WCPay\Core\Server\Request\Create_Intention;
+use WCPay\Core\Server\Request\Get_Intention;
 use WCPay\Core\Server\Request\Update_Intention;
 use WCPay\Exceptions\Amount_Too_Small_Exception;
-use WCPay\Exceptions\API_Exception;
-use WCPay\Exceptions\Connection_Exception;
-use WCPay\Exceptions\Process_Payment_Exception;
-use WCPay\Logger;
-use WCPay\MultiCurrency\Currency;
 use WCPay\Platform_Checkout\Platform_Checkout_Utilities;
 use WCPay\Session_Rate_Limiter;
-
 use WC_Payment_Gateway_WCPay;
 use WC_Payments_Account;
 use WC_Payments_Action_Scheduler_Service;
@@ -28,14 +22,9 @@ use WC_Payments_API_Client;
 use WC_Payments_Customer_Service;
 use WC_Payments_Token_Service;
 use WC_Payments_Order_Service;
-use WC_Payments;
-use WC_Customer;
 use WC_Helper_Order;
 use WC_Helper_Intention;
 use WC_Helper_Token;
-use WC_Payments_Utils;
-use WC_Subscriptions;
-use WC_Subscriptions_Cart;
 use WCPay\WC_Payments_UPE_Checkout;
 use WCPAY_UnitTestCase;
 use WP_User;
@@ -163,7 +152,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->disableOriginalConstructor()
 			->setMethods(
 				[
-					'create_intention',
 					'create_setup_intention',
 					'update_intention',
 					'get_setup_intent',
@@ -593,7 +581,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$order    = WC_Helper_Order::create_order();
 		$order_id = $order->get_id();
 		$intent   = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
-		$request  = $this->mock_wcpay_request( Create_Intent::class );
+		$request  = $this->mock_wcpay_request( Create_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'set_amount' )
 			->with( $intent->get_amount() );
@@ -640,7 +628,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$order    = WC_Helper_Order::create_order();
 		$order_id = $order->get_id();
 		$intent   = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
-		$request  = $this->mock_wcpay_request( Create_Intent::class );
+		$request  = $this->mock_wcpay_request( Create_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'set_amount' )
 			->with( $intent->get_amount() );
@@ -687,7 +675,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$order_id = $order->get_id();
 		$intent   = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
 		$this->mock_upe_gateway->settings['manual_capture'] = 'no';
-		$request = $this->mock_wcpay_request( Create_Intent::class );
+		$request = $this->mock_wcpay_request( Create_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'set_amount' )
 			->with( $intent->get_amount() );
@@ -734,7 +722,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$order_id = $order->get_id();
 		$intent   = WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] );
 		$this->mock_upe_gateway->settings['manual_capture'] = 'yes';
-		$request = $this->mock_wcpay_request( Create_Intent::class );
+		$request = $this->mock_wcpay_request( Create_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_amount' )
@@ -973,7 +961,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 				$this->returnValue( [ $user, $customer_id ] )
 			);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -1023,7 +1011,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 				$this->returnValue( [ $user, $customer_id ] )
 			);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -1130,7 +1118,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 				$this->returnValue( [ $user, $customer_id ] )
 			);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -1477,7 +1465,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Create_Intent::class );
+		$request = $this->mock_wcpay_request( Create_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'set_amount' )
 			->with( $intent->get_amount() );
@@ -1532,7 +1520,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Create_Intent::class, 2 );
+		$request = $this->mock_wcpay_request( Create_Intention::class, 2 );
 
 		$request->expects( $this->exactly( 2 ) )
 			->method( 'set_amount' )

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -617,23 +617,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->with( strtolower( $intent->get_currency() ) );
 
 		$request->expects( $this->once() )
-			->method( 'set_capture_method' )
-			->with( false );
-
-		$request->expects( $this->once() )
-			->method( 'set_metadata' )
-			->with(
-				$this->callback(
-					function( $metadata ) {
-						return isset( $metadata['order_number'] );
-					}
-				)
-			);
-
-		$request->expects( $this->once() )
-			->method( 'set_payment_method_types' );
-
-		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $intent );
 
@@ -655,23 +638,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$request->expects( $this->once() )
 			->method( 'set_currency_code' )
 			->with( strtolower( $intent->get_currency() ) );
-
-		$request->expects( $this->once() )
-			->method( 'set_capture_method' )
-			->with( false );
-
-		$request->expects( $this->once() )
-			->method( 'set_metadata' )
-			->with(
-				$this->callback(
-					function( $metadata ) {
-						return isset( $metadata['order_number'] );
-					}
-				)
-			);
-
-		$request->expects( $this->once() )
-			->method( 'set_payment_method_types' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -700,19 +666,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$request->expects( $this->once() )
 			->method( 'set_capture_method' )
 			->with( true );
-
-		$request->expects( $this->once() )
-			->method( 'set_metadata' )
-			->with(
-				$this->callback(
-					function( $metadata ) {
-						return isset( $metadata['order_number'] );
-					}
-				)
-			);
-
-		$request->expects( $this->once() )
-			->method( 'set_payment_method_types' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -1434,27 +1387,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->with( $intent->get_amount() );
 
 		$request->expects( $this->once() )
-			->method( 'set_currency_code' )
-			->with( strtolower( $intent->get_currency() ) );
-
-		$request->expects( $this->once() )
-			->method( 'set_capture_method' )
-			->with( false );
-
-		$request->expects( $this->once() )
-			->method( 'set_metadata' )
-			->with(
-				$this->callback(
-					function( $metadata ) {
-						return isset( $metadata['order_number'] );
-					}
-				)
-			);
-
-		$request->expects( $this->once() )
-			->method( 'set_payment_method_types' );
-
-		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $intent );
 
@@ -1485,23 +1417,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$request->expects( $this->once() )
 			->method( 'set_currency_code' )
 			->with( strtolower( $intent->get_currency() ) );
-
-		$request->expects( $this->once() )
-			->method( 'set_capture_method' )
-			->with( false );
-
-		$request->expects( $this->once() )
-			->method( 'set_metadata' )
-			->with(
-				$this->callback(
-					function( $metadata ) {
-						return isset( $metadata['order_number'] );
-					}
-				)
-			);
-
-		$request->expects( $this->once() )
-			->method( 'set_payment_method_types' );
 
 		$request->expects( $this->exactly( 2 ) )
 			->method( 'format_response' )

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -153,7 +153,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->setMethods(
 				[
 					'create_setup_intention',
-					'update_intention',
 					'get_setup_intent',
 					'get_payment_method',
 					'is_server_connected',
@@ -301,7 +300,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Update_Intention::class );
+		$request = $this->mock_wcpay_request( Update_Intention::class, 1, 'pi_mock' );
 
 		$request->expects( $this->once() )
 			->method( 'set_amount' )
@@ -318,10 +317,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$request->expects( $this->once() )
 			->method( 'set_selected_upe_payment_method_type' )
 			->with( '', [] );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( 'pi_mock' );
 
 		$request->expects( $this->once() )
 			->method( 'setup_future_usage' );
@@ -403,7 +398,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Update_Intention::class );
+		$request = $this->mock_wcpay_request( Update_Intention::class, 1, 'pi_mock' );
 
 		$request->expects( $this->once() )
 			->method( 'set_amount' )
@@ -420,10 +415,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$request->expects( $this->once() )
 			->method( 'set_selected_upe_payment_method_type' )
 			->with( 'giropay', [] );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( 'pi_mock' );
 
 		$request->expects( $this->once() )
 			->method( 'setup_future_usage' );
@@ -501,7 +492,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Update_Intention::class );
+		$request = $this->mock_wcpay_request( Update_Intention::class, 1, 'pi_mock' );
 
 		$request->expects( $this->once() )
 			->method( 'set_amount' )
@@ -518,10 +509,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$request->expects( $this->once() )
 			->method( 'set_selected_upe_payment_method_type' )
 			->with( '', [] );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( 'pi_mock' );
 
 		$request->expects( $this->once() )
 			->method( 'set_payment_country' )
@@ -835,7 +822,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 
 		$payment_intent = WC_Helper_Intention::create_intention( [ 'status' => 'processing' ] );
 
-		$request = $this->mock_wcpay_request( Update_Intention::class );
+		$request = $this->mock_wcpay_request( Update_Intention::class, 1, 'pi_mock' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -864,7 +851,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 
 		$payment_intent = WC_Helper_Intention::create_intention( [ 'status' => 'processing' ] );
 
-		$request = $this->mock_wcpay_request( Update_Intention::class );
+		$request = $this->mock_wcpay_request( Update_Intention::class, 1, 'pi_mock' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -890,7 +877,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 
 		$payment_intent = WC_Helper_Intention::create_intention( [ 'status' => 'processing' ] );
 
-		$request = $this->mock_wcpay_request( Update_Intention::class );
+		$request = $this->mock_wcpay_request( Update_Intention::class, 1, 'pi_mock' );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -961,11 +948,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 				$this->returnValue( [ $user, $customer_id ] )
 			);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -1011,11 +994,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 				$this->returnValue( [ $user, $customer_id ] )
 			);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -1118,11 +1097,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 				$this->returnValue( [ $user, $customer_id ] )
 			);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -1598,7 +1573,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 
 		$_POST['wc_payment_intent_id'] = $payment_intent_id;
 
-		$request = $this->mock_wcpay_request( Update_Intention::class );
+		$request = $this->mock_wcpay_request( Update_Intention::class, 1, $payment_intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'set_amount' )
@@ -1607,10 +1582,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$request->expects( $this->once() )
 			->method( 'set_selected_upe_payment_method_type' )
 			->with( '', [] );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $payment_intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'set_metadata' )

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -734,10 +734,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			->with( 'cus_12346' );
 
 		$request->expects( $this->once() )
-			->method( 'set_payment_method_types' )
-			->with( [ 'card' ] );
-
-		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn(
 				new Response(

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -7,7 +7,6 @@
 
 namespace WCPay\Payment_Methods;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Constants\Payment_Type;
 use WCPay\Core\Server\Request\Create_Intention;
 use WCPay\Core\Server\Request\Create_Setup_Intention;
@@ -29,7 +28,6 @@ use WC_Helper_Intention;
 use WC_Helper_Token;
 use WCPay\WC_Payments_UPE_Checkout;
 use WCPAY_UnitTestCase;
-use WP_User;
 use Exception;
 
 /**

--- a/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
@@ -307,11 +307,7 @@ class WC_Payments_Invoice_Service_Test extends WCPAY_UnitTestCase {
 
 		$intent = WC_Helper_Intention::create_intention();
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -332,11 +328,7 @@ class WC_Payments_Invoice_Service_Test extends WCPAY_UnitTestCase {
 		$mock_order = WC_Helper_Order::create_order();
 		$intent_id  = 'pi_paymentIntentID';
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )

--- a/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
@@ -6,6 +6,7 @@
  */
 
 use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Exceptions\API_Exception;
 
 /**
@@ -306,10 +307,14 @@ class WC_Payments_Invoice_Service_Test extends WCPAY_UnitTestCase {
 
 		$intent = WC_Helper_Intention::create_intention();
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
-			->with( $intent_id )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( $intent );
 
 		$this->mock_gateway
@@ -327,10 +332,14 @@ class WC_Payments_Invoice_Service_Test extends WCPAY_UnitTestCase {
 		$mock_order = WC_Helper_Order::create_order();
 		$intent_id  = 'pi_paymentIntentID';
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
-			->with( $intent_id )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->will( $this->throwException( new API_Exception( 'whoops', 'mock_error', 403 ) ) );
 
 		$this->mock_gateway

--- a/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-invoice-service.php
@@ -6,7 +6,7 @@
  */
 
 use PHPUnit\Framework\MockObject\MockObject;
-use WCPay\Core\Server\Request\Get_Intent;
+use WCPay\Core\Server\Request\Get_Intention;
 use WCPay\Exceptions\API_Exception;
 
 /**
@@ -307,7 +307,7 @@ class WC_Payments_Invoice_Service_Test extends WCPAY_UnitTestCase {
 
 		$intent = WC_Helper_Intention::create_intention();
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -332,7 +332,7 @@ class WC_Payments_Invoice_Service_Test extends WCPAY_UnitTestCase {
 		$mock_order = WC_Helper_Order::create_order();
 		$intent_id  = 'pi_paymentIntentID';
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -251,11 +251,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 		$mock_cart
 			->expects( $this->once() )
 			->method( 'empty_cart' );
-		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
-
-		$charge_request->expects( $this->once() )
-			->method( 'set_charge_id' )
-			->with( 'ch_mock' );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 1, 'ch_mock' );
 
 		$charge_request->expects( $this->once() )
 			->method( 'format_response' )
@@ -319,11 +315,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 			->method( 'create_customer_for_user' )
 			->with( $this->isInstanceOf( WP_User::class ) );
 
-		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
-
-		$charge_request->expects( $this->once() )
-			->method( 'set_charge_id' )
-			->with( 'ch_mock' );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 1, 'ch_mock' );
 
 		$charge_request->expects( $this->once() )
 			->method( 'format_response' )
@@ -426,11 +418,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'empty_cart' );
 
-		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
-
-		$charge_request->expects( $this->once() )
-			->method( 'set_charge_id' )
-			->with( 'ch_mock' );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 1, 'ch_mock' );
 
 		$charge_request->expects( $this->once() )
 			->method( 'format_response' )
@@ -824,11 +812,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 			->expects( $this->never() )
 			->method( 'empty_cart' );
 
-		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
-
-		$charge_request->expects( $this->once() )
-			->method( 'set_charge_id' )
-			->with( 'ch_mock' );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 1, 'ch_mock' );
 
 		$charge_request->expects( $this->once() )
 			->method( 'format_response' )
@@ -1193,11 +1177,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willReturn( $intent );
 
-		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
-
-		$charge_request->expects( $this->once() )
-			->method( 'set_charge_id' )
-			->with( 'ch_mock' );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 1, 'ch_mock' );
 
 		$charge_request->expects( $this->once() )
 			->method( 'format_response' )
@@ -1341,11 +1321,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willReturn( $intent );
 
-		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
-
-		$charge_request->expects( $this->once() )
-			->method( 'set_charge_id' )
-			->with( 'ch_mock' );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 1, 'ch_mock' );
 
 		$charge_request->expects( $this->once() )
 			->method( 'format_response' )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -6,6 +6,7 @@
  */
 
 use WCPay\Core\Server\Request\Create_And_Confirm_Intention;
+use WCPay\Core\Server\Request\Get_Charge;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Exceptions\Connection_Exception;
 use WCPay\Session_Rate_Limiter;
@@ -92,7 +93,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 		// Note that we cannot use createStub here since it's not defined in PHPUnit 6.5.
 		$this->mock_api_client = $this->getMockBuilder( 'WC_Payments_API_Client' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'create_and_confirm_intention', 'create_and_confirm_setup_intent', 'get_payment_method', 'is_server_connected', 'get_charge', 'request' ] )
+			->setMethods( [ 'create_and_confirm_intention', 'create_and_confirm_setup_intent', 'get_payment_method', 'is_server_connected', 'request' ] )
 			->getMock();
 
 		// Arrange: Mock WC_Payments_Account instance to use later.
@@ -250,10 +251,14 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 		$mock_cart
 			->expects( $this->once() )
 			->method( 'empty_cart' );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_charge' )
+		$charge_request->expects( $this->once() )
+			->method( 'set_charge_id' )
+			->with( 'ch_mock' );
+
+		$charge_request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( [ 'balance_transaction' => [ 'exchange_rate' => 0.86 ] ] );
 
 		// Act: process a successful payment.
@@ -314,9 +319,14 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 			->method( 'create_customer_for_user' )
 			->with( $this->isInstanceOf( WP_User::class ) );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_charge' )
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
+
+		$charge_request->expects( $this->once() )
+			->method( 'set_charge_id' )
+			->with( 'ch_mock' );
+
+		$charge_request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( [ 'balance_transaction' => [ 'exchange_rate' => 0.86 ] ] );
 
 		// Act: process a successful payment.
@@ -416,9 +426,14 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'empty_cart' );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_charge' )
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
+
+		$charge_request->expects( $this->once() )
+			->method( 'set_charge_id' )
+			->with( 'ch_mock' );
+
+		$charge_request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( [ 'balance_transaction' => [ 'exchange_rate' => 0.86 ] ] );
 
 		// Act: process payment.
@@ -809,9 +824,14 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 			->expects( $this->never() )
 			->method( 'empty_cart' );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_charge' )
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
+
+		$charge_request->expects( $this->once() )
+			->method( 'set_charge_id' )
+			->with( 'ch_mock' );
+
+		$charge_request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn( [ 'balance_transaction' => [ 'exchange_rate' => 0.86 ] ] );
 
 		// Act: process payment.
@@ -1173,6 +1193,16 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willReturn( $intent );
 
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
+
+		$charge_request->expects( $this->once() )
+			->method( 'set_charge_id' )
+			->with( 'ch_mock' );
+
+		$charge_request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( [ 'id' => 'ch_mock' ] );
+
 		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST, $mock_order ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 		// Act: process a successful payment.
@@ -1311,6 +1341,15 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willReturn( $intent );
 
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
+
+		$charge_request->expects( $this->once() )
+			->method( 'set_charge_id' )
+			->with( 'ch_mock' );
+
+		$charge_request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( [ 'id' => 'ch_mock' ] );
 		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST, $mock_order ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 		// Act: process a successful payment.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
@@ -103,10 +103,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->save();
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -172,10 +169,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->save();
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -229,10 +223,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->save();
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -282,10 +273,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->save();
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -408,12 +396,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 		// Arrange: Mock Stripe's call with an empty payment method ID.
 		$this->mock_api_client->method( 'get_payment_method' )->with( '' )->willThrowException( new Exception( 'Missing required parameter: type.' ) );
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
-
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn(
@@ -683,10 +666,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->save();
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -736,10 +716,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 			->method( 'refund_charge' )
 			->willThrowException( new \Exception( 'Test message' ) );
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -764,10 +741,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 
 		$order_id = $order->get_id();
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -798,11 +772,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 
 		$order_id = $order->get_id();
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\Payments\Tests
  */
 
-use WCPay\Core\Server\Request\Get_Intent;
+use WCPay\Core\Server\Request\Get_Intention;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Session_Rate_Limiter;
 
@@ -103,7 +103,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->save();
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
 			->with( $intent_id );
@@ -172,7 +172,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->save();
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
 			->with( $intent_id );
@@ -229,7 +229,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->save();
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
 			->with( $intent_id );
@@ -282,7 +282,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->save();
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
 			->with( $intent_id );
@@ -408,7 +408,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 		// Arrange: Mock Stripe's call with an empty payment method ID.
 		$this->mock_api_client->method( 'get_payment_method' )->with( '' )->willThrowException( new Exception( 'Missing required parameter: type.' ) );
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -683,7 +683,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->save();
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
 			->with( $intent_id );
@@ -736,7 +736,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 			->method( 'refund_charge' )
 			->willThrowException( new \Exception( 'Test message' ) );
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
 			->with( $intent_id );
@@ -764,7 +764,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 
 		$order_id = $order->get_id();
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
 			->with( $intent_id );
@@ -798,7 +798,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 
 		$order_id = $order->get_id();
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Payments\Tests
  */
 
+use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Session_Rate_Limiter;
 
@@ -14,7 +15,7 @@ require_once dirname( __FILE__ ) . '/helpers/class-wc-mock-wc-data-store.php';
 /**
  * WC_Payment_Gateway_WCPay::process_refund unit tests.
  */
-class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WP_UnitTestCase {
+class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 	/**
 	 * System under test.
 	 *
@@ -102,6 +103,15 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->save();
 
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( WC_Helper_Intention::create_intention() );
+
 		$this->mock_api_client->expects( $this->once() )->method( 'refund_charge' )->will(
 			$this->returnValue(
 				[
@@ -162,6 +172,15 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->save();
 
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( WC_Helper_Intention::create_intention() );
+
 		$refund = wc_create_refund( [ 'order_id' => $order->get_id() ] );
 
 		$this->mock_api_client->expects( $this->once() )->method( 'refund_charge' )->will(
@@ -210,6 +229,15 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->save();
 
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( WC_Helper_Intention::create_intention() );
+
 		$this->mock_api_client->expects( $this->once() )->method( 'refund_charge' )->will(
 			$this->returnValue(
 				[
@@ -253,6 +281,15 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_intent_id', $intent_id );
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->save();
+
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( WC_Helper_Intention::create_intention() );
 
 		$this->mock_api_client->expects( $this->once() )->method( 'refund_charge' )->will(
 			$this->returnValue(
@@ -371,9 +408,14 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WP_UnitTestCase {
 		// Arrange: Mock Stripe's call with an empty payment method ID.
 		$this->mock_api_client->method( 'get_payment_method' )->with( '' )->willThrowException( new Exception( 'Missing required parameter: type.' ) );
 
-		$this->mock_api_client
-			->method( 'get_intent' )
-			->with( $intent_id )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn(
 				WC_Helper_Intention::create_intention( [ 'charge' => [ 'payment_method_details' => [ 'type' => 'interac_present' ] ] ] )
 			);
@@ -641,6 +683,15 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WP_UnitTestCase {
 		$order->update_meta_data( '_charge_id', $charge_id );
 		$order->save();
 
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( WC_Helper_Intention::create_intention() );
+
 		$this->mock_api_client->expects( $this->once() )->method( 'refund_charge' )->will(
 			$this->returnValue(
 				[
@@ -685,6 +736,15 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WP_UnitTestCase {
 			->method( 'refund_charge' )
 			->willThrowException( new \Exception( 'Test message' ) );
 
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( WC_Helper_Intention::create_intention() );
+
 		$this->wcpay_gateway->process_refund( $order_id, 19.99 );
 
 		// Reload the order information to get the new meta.
@@ -703,6 +763,15 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WP_UnitTestCase {
 		$order->save();
 
 		$order_id = $order->get_id();
+
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( WC_Helper_Intention::create_intention() );
 
 		$this->mock_api_client
 			->expects( $this->once() )
@@ -728,6 +797,16 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WP_UnitTestCase {
 		$order->save();
 
 		$order_id = $order->get_id();
+
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( WC_Helper_Intention::create_intention() );
 
 		$this->mock_api_client
 			->expects( $this->once() )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -6,6 +6,8 @@
  */
 
 use WCPay\Core\Server\Request\Create_And_Confirm_Intention;
+use WCPay\Core\Server\Request\Create_And_Confirm_Setup_Intention;
+use WCPay\Core\Server\Response;
 use WCPay\Session_Rate_Limiter;
 
 /**
@@ -268,11 +270,19 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 		$subscriptions = [ WC_Helper_Order::create_order( self::USER_ID ) ];
 		$this->mock_wcs_get_subscriptions_for_order( $subscriptions );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'create_and_confirm_setup_intent' )
-			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID )
-			->willReturn( $this->setup_intent );
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Setup_Intention::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_customer' )
+			->with( self::CUSTOMER_ID );
+
+		$request->expects( $this->once() )
+			->method( 'set_payment_method' )
+			->with( self::PAYMENT_METHOD_ID );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( new Response( $this->setup_intent ) );
 
 		$this->mock_token_service
 			->expects( $this->once() )
@@ -304,11 +314,11 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 		$subscriptions = [ WC_Helper_Order::create_order( self::USER_ID ) ];
 		$this->mock_wcs_get_subscriptions_for_order( $subscriptions );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'create_and_confirm_setup_intent' )
-			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID )
-			->willReturn( $this->setup_intent );
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Setup_Intention::class );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( new Response( $this->setup_intent ) );
 
 		$this->mock_token_service
 			->expects( $this->once() )
@@ -432,9 +442,9 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 		$this->mock_wcs_order_contains_subscription( true );
 
 		// The card is already saved and there's no payment needed, so no Setup Intent needs to be created.
-		$this->mock_api_client
-			->expects( $this->never() )
-			->method( 'create_and_confirm_setup_intent' );
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Setup_Intention::class, 0 );
+		$request->expects( $this->never() )
+			->method( 'format_response' );
 
 		// We're not saving a new payment method, so we don't need to add the payment method to
 		// a user account.
@@ -477,11 +487,19 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 		);
 
 		$this->mock_wcs_get_subscriptions_for_order( [] );
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'create_and_confirm_setup_intent' )
-			->with( self::PAYMENT_METHOD_ID, self::CUSTOMER_ID )
-			->willReturn( $this->setup_intent );
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Setup_Intention::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_customer' )
+			->with( self::CUSTOMER_ID );
+
+		$request->expects( $this->once() )
+			->method( 'set_payment_method' )
+			->with( self::PAYMENT_METHOD_ID );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( new Response( $this->setup_intent ) );
 
 		$this->mock_token_service
 			->expects( $this->once() )
@@ -519,9 +537,9 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 		);
 		$this->mock_wcs_get_subscriptions_for_order( [] );
 
-		$this->mock_api_client
-			->expects( $this->never() )
-			->method( 'create_and_confirm_setup_intent' );
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Setup_Intention::class, 0 );
+		$request->expects( $this->never() )
+			->method( 'format_response' );
 
 		$this->mock_token_service
 			->expects( $this->never() )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -7,7 +7,7 @@
 
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Core\Server\Request\Get_Charge;
-use WCPay\Core\Server\Request\Get_Intent;
+use WCPay\Core\Server\Request\Get_Intention;
 use WCPay\Exceptions\Amount_Too_Small_Exception;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Constants\Payment_Type;
@@ -786,7 +786,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -852,7 +852,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -915,7 +915,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -981,7 +981,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -1043,7 +1043,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intent::class, 2 );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 2 );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -1110,7 +1110,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intent::class, 2 );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 2 );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -1173,7 +1173,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'canceled' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intent::class, 2 );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 2 );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -1251,7 +1251,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			'payment_type'   => Payment_Type::SINGLE(),
 		];
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -1311,7 +1311,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -1374,7 +1374,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'cancel_intention' )
 			->will( $this->throwException( new API_Exception( 'test exception', 'test', 123 ) ) );
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'set_intent_id' )
@@ -1413,7 +1413,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'cancel_intention' )
 			->will( $this->throwException( new API_Exception( 'test exception', 'test', 123 ) ) );
 
-		$request = $this->mock_wcpay_request( Get_Intent::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -243,11 +243,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'get_account_default_currency' )
 			->willReturn( 'usd' );
 
-		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
-
-		$charge_request->expects( $this->once() )
-			->method( 'set_charge_id' )
-			->with( 'ch_mock' );
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 1, 'ch_mock' );
 
 		$charge_request->expects( $this->once() )
 			->method( 'format_response' )
@@ -281,12 +277,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'get_account_default_currency' )
 			->willReturn( 'usd' );
 
-		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
-
-		$charge_request->expects( $this->once() )
-			->method( 'set_charge_id' )
-			->with( 'ch_mock' );
-
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 1, 'ch_mock' );
 		$charge_request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn(

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -6,6 +6,7 @@
  */
 
 use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Core\Server\Request\Get_Charge;
 use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Exceptions\Amount_Too_Small_Exception;
 use WCPay\Exceptions\API_Exception;
@@ -130,7 +131,6 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					'get_payment_method',
 					'refund_charge',
 					'list_refunds',
-					'get_charge',
 					'prepare_intention_for_capture',
 					'get_timeline',
 				]
@@ -243,9 +243,14 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'get_account_default_currency' )
 			->willReturn( 'usd' );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_charge' )
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
+
+		$charge_request->expects( $this->once() )
+			->method( 'set_charge_id' )
+			->with( 'ch_mock' );
+
+		$charge_request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn(
 				[
 					'id'                  => 'ch_123456',
@@ -276,9 +281,14 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'get_account_default_currency' )
 			->willReturn( 'usd' );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_charge' )
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class );
+
+		$charge_request->expects( $this->once() )
+			->method( 'set_charge_id' )
+			->with( 'ch_mock' );
+
+		$charge_request->expects( $this->once() )
+			->method( 'format_response' )
 			->willReturn(
 				[
 					'id'                  => 'ch_123456',

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -1753,23 +1753,19 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$request->expects( $this->once() )
 			->method( 'set_amount' )
-			->with( (int) ( $amount * 100 ) )
-			->willReturn( $request );
+			->with( (int) ( $amount * 100 ) );
 
 		$request->expects( $this->once() )
 			->method( 'set_payment_method' )
-			->with( $pm )
-			->willReturn( $request );
+			->with( $pm );
 
 		$request->expects( $this->once() )
 			->method( 'set_customer' )
-			->with( $customer )
-			->willReturn( $request );
+			->with( $customer );
 
 		$request->expects( $this->once() )
 			->method( 'set_capture_method' )
-			->with( false )
-			->willReturn( $request );
+			->with( false );
 
 		$request->expects( $this->once() )
 			->method( 'set_metadata' )
@@ -1785,8 +1781,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 						return true;
 					}
 				)
-			)
-				->willReturn( $request );
+			);
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -2084,8 +2079,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->willReturn( WC_Helper_Intention::create_intention( [ 'status' => 'success' ] ) );
 		$request->expects( $this->once() )
 			->method( 'set_customer' )
-			->with( 'cus_XYZ' )
-			->willReturn( $request );
+			->with( 'cus_XYZ' );
 
 		$order = WC_Helper_Order::create_order();
 		$order->set_currency( 'USD' );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -6,6 +6,7 @@
  */
 
 use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Core\Server\Request\Cancel_Intention;
 use WCPay\Core\Server\Request\Capture_Intention;
 use WCPay\Core\Server\Request\Get_Charge;
 use WCPay\Core\Server\Request\Get_Intention;
@@ -124,7 +125,6 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					'get_account_data',
 					'is_server_connected',
 					'get_blog_id',
-					'cancel_intention',
 					'create_intention',
 					'create_and_confirm_intention',
 					'create_and_confirm_setup_intent',
@@ -1437,9 +1437,9 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$order->update_meta_data( '_intention_status', 'requires_capture' );
 		$order->update_status( 'on-hold' );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'cancel_intention' )
+		$cancel_intent_request = $this->mock_wcpay_request( Cancel_Intention::class, 1, $intent_id );
+		$cancel_intent_request->expects( $this->once() )
+			->method( 'format_response' )
 			->will( $this->throwException( new API_Exception( 'test exception', 'test', 123 ) ) );
 
 		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
@@ -1471,9 +1471,9 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$order->update_meta_data( '_intention_status', 'requires_capture' );
 		$order->update_status( 'on-hold' );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'cancel_intention' )
+		$cancel_intent_request = $this->mock_wcpay_request( Cancel_Intention::class, 1, $intent_id );
+		$cancel_intent_request->expects( $this->once() )
+			->method( 'format_response' )
 			->will( $this->throwException( new API_Exception( 'test exception', 'test', 123 ) ) );
 
 		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -6,6 +6,7 @@
  */
 
 use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Core\Server\Request\Get_Intent;
 use WCPay\Exceptions\Amount_Too_Small_Exception;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Constants\Payment_Type;
@@ -122,7 +123,6 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					'get_blog_id',
 					'capture_intention',
 					'cancel_intention',
-					'get_intent',
 					'create_intention',
 					'create_and_confirm_intention',
 					'create_and_confirm_setup_intent',
@@ -776,9 +776,16 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
-		$this->mock_api_client->expects( $this->once() )->method( 'get_intent' )->with( $intent_id )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( $mock_intent );
+
 		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->will(
 			$this->returnValue( $mock_intent )
 		);
@@ -835,9 +842,16 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$this->mock_api_client->expects( $this->once() )->method( 'get_intent' )->with( $intent_id )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( $mock_intent );
+
 		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->will(
 			$this->returnValue( $mock_intent )
 		);
@@ -891,9 +905,16 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
-		$this->mock_api_client->expects( $this->once() )->method( 'get_intent' )->with( $intent_id )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( $mock_intent );
+
 		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->will(
 			$this->returnValue( $mock_intent )
 		);
@@ -950,9 +971,16 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$this->mock_api_client->expects( $this->once() )->method( 'get_intent' )->with( $intent_id )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( $mock_intent );
+
 		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->will(
 			$this->returnValue( $mock_intent )
 		);
@@ -1005,9 +1033,16 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
-		$this->mock_api_client->expects( $this->atLeastOnce() )->method( 'get_intent' )->with( $intent_id )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$request = $this->mock_wcpay_request( Get_Intent::class, 2 );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->exactly( 2 ) )
+			->method( 'format_response' )
+			->willReturn( $mock_intent );
+
 		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->will(
 			$this->returnValue( $mock_intent )
 		);
@@ -1065,9 +1100,16 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$this->mock_api_client->expects( $this->atLeastOnce() )->method( 'get_intent' )->with( $intent_id )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$request = $this->mock_wcpay_request( Get_Intent::class, 2 );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->exactly( 2 ) )
+			->method( 'format_response' )
+			->willReturn( $mock_intent );
+
 		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->will(
 			$this->returnValue( $mock_intent )
 		);
@@ -1121,9 +1163,16 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'canceled' ] );
 
-		$this->mock_api_client->expects( $this->atLeastOnce() )->method( 'get_intent' )->with( $intent_id )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$request = $this->mock_wcpay_request( Get_Intent::class, 2 );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->exactly( 2 ) )
+			->method( 'format_response' )
+			->willReturn( $mock_intent );
+
 		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->will(
 			$this->returnValue( $mock_intent )
 		);
@@ -1192,9 +1241,16 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			'payment_type'   => Payment_Type::SINGLE(),
 		];
 
-		$this->mock_api_client->expects( $this->once() )->method( 'get_intent' )->with( $intent_id )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( $mock_intent );
+
 		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->with( $intent_id, $merged_metadata )->will(
 			$this->returnValue( $mock_intent )
 		);
@@ -1245,9 +1301,16 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
-		$this->mock_api_client->expects( $this->once() )->method( 'get_intent' )->with( $intent_id )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( $mock_intent );
+
 		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->will(
 			$this->returnValue( $mock_intent )
 		);
@@ -1301,12 +1364,15 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'cancel_intention' )
 			->will( $this->throwException( new API_Exception( 'test exception', 'test', 123 ) ) );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
-			->willReturn(
-				WC_Helper_Intention::create_intention( [ 'status' => 'canceled' ] )
-			);
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_intent_id' )
+			->with( $intent_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( WC_Helper_Intention::create_intention( [ 'status' => 'canceled' ] ) );
 
 		$this->wcpay_gateway->cancel_authorization( $order );
 
@@ -1337,9 +1403,10 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'cancel_intention' )
 			->will( $this->throwException( new API_Exception( 'test exception', 'test', 123 ) ) );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'get_intent' )
+		$request = $this->mock_wcpay_request( Get_Intent::class );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
 			->will( $this->throwException( new API_Exception( 'ignore this', 'test', 123 ) ) );
 
 		$this->wcpay_gateway->cancel_authorization( $order );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -8,9 +8,11 @@
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Core\Server\Request\Cancel_Intention;
 use WCPay\Core\Server\Request\Capture_Intention;
+use WCPay\Core\Server\Request\Create_And_Confirm_Setup_Intention;
 use WCPay\Core\Server\Request\Get_Charge;
 use WCPay\Core\Server\Request\Get_Intention;
 use WCPay\Core\Server\Request\Update_Intention;
+use WCPay\Core\Server\Response;
 use WCPay\Exceptions\Amount_Too_Small_Exception;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Constants\Payment_Type;
@@ -1465,11 +1467,19 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->expects( $this->never() )
 			->method( 'create_customer_for_user' );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'create_and_confirm_setup_intent' )
-			->with( 'pm_mock', 'cus_12345' )
-			->willReturn( [ 'id' => 'pm_mock' ] );
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Setup_Intention::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_customer' )
+			->with( 'cus_12345' );
+
+		$request->expects( $this->once() )
+			->method( 'set_payment_method' )
+			->with( 'pm_mock' );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( new Response( [ 'id' => 'pm_mock' ] ) );
 
 		$result = $this->wcpay_gateway->create_and_confirm_setup_intent();
 
@@ -1489,11 +1499,10 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'create_customer_for_user' )
 			->will( $this->returnValue( 'cus_12345' ) );
 
-		$this->mock_api_client
-			->expects( $this->once() )
-			->method( 'create_and_confirm_setup_intent' )
-			->with( 'pm_mock', 'cus_12345' )
-			->willReturn( [ 'id' => 'pm_mock' ] );
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Setup_Intention::class );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( new Response( [ 'id' => 'pm_mock' ] ) );
 
 		$result = $this->wcpay_gateway->create_and_confirm_setup_intent();
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -1068,7 +1068,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$capture_intent_request->expects( $this->once() )
 			->method( 'format_response' )
-			->willReturn( $this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) ) );
+			->will( $this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) ) );
 
 		$this->mock_wcpay_account
 			->expects( $this->once() )
@@ -1141,7 +1141,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$capture_intent_request->expects( $this->once() )
 			->method( 'format_response' )
-			->willReturn( $this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) ) );
+			->will( $this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) ) );
 
 		$this->mock_wcpay_account
 			->expects( $this->once() )
@@ -1205,7 +1205,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$capture_intent_request->expects( $this->once() )
 			->method( 'format_response' )
-			->willReturn( $this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) ) );
+			->will( $this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) ) );
 
 		$this->mock_wcpay_account
 			->expects( $this->once() )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -1993,50 +1993,6 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->wcpay_gateway->update_order_status_from_intent( $order, $intent_id, $intent_status, $charge_id );
 	}
 
-	public function test_create_intent_success() {
-		$intent_id       = 'pi_mock';
-		$charge_id       = 'ch_mock';
-		$payment_methods = [ 'card_present' ];
-		$capture_method  = 'manual';
-
-		$order = WC_Helper_Order::create_order();
-		$order->update_status( 'on-hold' );
-
-		$this->mock_api_client->expects( $this->once() )->method( 'create_intention' )->will(
-			$this->returnValue( WC_Helper_Intention::create_intention( [ 'status' => 'requires_payment_method' ] ) )
-		);
-
-		$result = $this->wcpay_gateway->create_intent( $order, $payment_methods, $capture_method );
-
-		// Assert the returned data contains fields required by the REST endpoint.
-		$this->assertSame(
-			[
-				'id' => $intent_id,
-			],
-			$result
-		);
-	}
-
-	public function test_create_intent_api_failure() {
-		$payment_methods = [ 'card_present' ];
-		$capture_method  = 'manual';
-
-		$order = WC_Helper_Order::create_order();
-		$order->update_status( 'on-hold' );
-
-		$this->mock_api_client->expects( $this->once() )->method( 'create_intention' )->will(
-			$this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) )
-		);
-
-		$result = $this->wcpay_gateway->create_intent( $order, $payment_methods, $capture_method );
-
-		$this->assertInstanceOf( 'WP_Error', $result );
-		$data = $result->get_error_data();
-		$this->assertArrayHasKey( 'status', $data );
-		$this->assertSame( 500, $data['status'] );
-		$this->assertSame( 'Intent creation failed with the following message: test exception', $result->get_error_message() );
-	}
-
 	public function test_is_platform_checkout_enabled_returns_true() {
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
 		$this->wcpay_gateway->update_option( 'platform_checkout', 'yes' );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -859,14 +859,8 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$update_intent_request = $this->mock_wcpay_request( Update_Intention::class, 1, $intent_id );
 		$update_intent_request->expects( $this->once() )
-			->method( 'set_metadata' )
-			->with(
-				$this->callback(
-					function( $argument ) {
-						return is_array( $argument ) && ! empty( $argument );
-					}
-				)
-			);
+			->method( 'set_metadata' );
+
 		$update_intent_request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
@@ -934,14 +928,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$update_intent_request = $this->mock_wcpay_request( Update_Intention::class, 1, $intent_id );
 		$update_intent_request->expects( $this->once() )
-			->method( 'set_metadata' )
-			->with(
-				$this->callback(
-					function( $argument ) {
-						return is_array( $argument ) && ! empty( $argument );
-					}
-				)
-			);
+			->method( 'set_metadata' );
 		$capture_intent_request = $this->mock_wcpay_request( Capture_Intention::class, 1, $intent_id );
 		$capture_intent_request->expects( $this->once() )
 			->method( 'set_amount_to_capture' )
@@ -1008,14 +995,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$update_intent_request = $this->mock_wcpay_request( Update_Intention::class, 1, $intent_id );
 		$update_intent_request->expects( $this->once() )
-			->method( 'set_metadata' )
-			->with(
-				$this->callback(
-					function( $argument ) {
-						return is_array( $argument ) && ! empty( $argument );
-					}
-				)
-			);
+			->method( 'set_metadata' );
 		$capture_intent_request = $this->mock_wcpay_request( Capture_Intention::class, 1, $intent_id );
 		$capture_intent_request->expects( $this->once() )
 			->method( 'set_amount_to_capture' )
@@ -1078,14 +1058,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$update_intent_request = $this->mock_wcpay_request( Update_Intention::class, 1, $intent_id );
 		$update_intent_request->expects( $this->once() )
-			->method( 'set_metadata' )
-			->with(
-				$this->callback(
-					function( $argument ) {
-						return is_array( $argument ) && ! empty( $argument );
-					}
-				)
-			);
+			->method( 'set_metadata' );
 		$capture_intent_request = $this->mock_wcpay_request( Capture_Intention::class, 1, $intent_id );
 		$capture_intent_request->expects( $this->once() )
 			->method( 'set_amount_to_capture' )
@@ -1153,14 +1126,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$update_intent_request = $this->mock_wcpay_request( Update_Intention::class, 1, $intent_id );
 		$update_intent_request->expects( $this->once() )
-			->method( 'set_metadata' )
-			->with(
-				$this->callback(
-					function( $argument ) {
-						return is_array( $argument ) && ! empty( $argument );
-					}
-				)
-			);
+			->method( 'set_metadata' );
 
 		$update_intent_request->expects( $this->once() )
 			->method( 'format_response' )
@@ -1229,14 +1195,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$update_intent_request = $this->mock_wcpay_request( Update_Intention::class, 1, $intent_id );
 		$update_intent_request->expects( $this->once() )
-			->method( 'set_metadata' )
-			->with(
-				$this->callback(
-					function( $argument ) {
-						return is_array( $argument ) && ! empty( $argument );
-					}
-				)
-			);
+			->method( 'set_metadata' );
 		$capture_intent_request = $this->mock_wcpay_request( Capture_Intention::class, 1, $intent_id );
 		$capture_intent_request->expects( $this->once() )
 			->method( 'set_amount_to_capture' )
@@ -1378,14 +1337,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$update_intent_request = $this->mock_wcpay_request( Update_Intention::class, 1, $intent_id );
 		$update_intent_request->expects( $this->once() )
-			->method( 'set_metadata' )
-			->with(
-				$this->callback(
-					function( $argument ) {
-						return is_array( $argument ) && ! empty( $argument );
-					}
-				)
-			);
+			->method( 'set_metadata' );
 
 		$capture_intent_request = $this->mock_wcpay_request( Capture_Intention::class, 1, $intent_id );
 		$capture_intent_request->expects( $this->once() )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -6,6 +6,7 @@
  */
 
 use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Core\Server\Request\Capture_Intention;
 use WCPay\Core\Server\Request\Get_Charge;
 use WCPay\Core\Server\Request\Get_Intention;
 use WCPay\Core\Server\Request\Update_Intention;
@@ -123,7 +124,6 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					'get_account_data',
 					'is_server_connected',
 					'get_blog_id',
-					'capture_intention',
 					'cancel_intention',
 					'create_intention',
 					'create_and_confirm_intention',
@@ -793,9 +793,14 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					}
 				)
 			);
-		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->returnValue( WC_Helper_Intention::create_intention() )
-		);
+		$capture_intent_request = $this->mock_wcpay_request( Capture_Intention::class, 1, $intent_id );
+		$capture_intent_request->expects( $this->once() )
+			->method( 'set_amount_to_capture' )
+			->with( $mock_intent->get_amount() );
+
+		$capture_intent_request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( WC_Helper_Intention::create_intention() );
 
 		$this->mock_wcpay_account
 			->expects( $this->once() )
@@ -865,9 +870,15 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$update_intent_request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
-		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->returnValue( WC_Helper_Intention::create_intention( [ 'currency' => 'eur' ] ) )
-		);
+
+		$capture_intent_request = $this->mock_wcpay_request( Capture_Intention::class, 1, $intent_id );
+		$capture_intent_request->expects( $this->once() )
+			->method( 'set_amount_to_capture' )
+			->with( $mock_intent->get_amount() );
+
+		$capture_intent_request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( WC_Helper_Intention::create_intention( [ 'currency' => 'eur' ] ) );
 
 		$this->mock_wcpay_account
 			->expects( $this->once() )
@@ -931,9 +942,14 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					}
 				)
 			);
-		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$capture_intent_request = $this->mock_wcpay_request( Capture_Intention::class, 1, $intent_id );
+		$capture_intent_request->expects( $this->once() )
+			->method( 'set_amount_to_capture' )
+			->with( $mock_intent->get_amount() );
+
+		$capture_intent_request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( $mock_intent );
 
 		$this->mock_wcpay_account
 			->expects( $this->once() )
@@ -1000,9 +1016,14 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					}
 				)
 			);
-		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$capture_intent_request = $this->mock_wcpay_request( Capture_Intention::class, 1, $intent_id );
+		$capture_intent_request->expects( $this->once() )
+			->method( 'set_amount_to_capture' )
+			->with( $mock_intent->get_amount() );
+
+		$capture_intent_request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( $mock_intent );
 
 		$this->mock_wcpay_account
 			->expects( $this->once() )
@@ -1065,9 +1086,14 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					}
 				)
 			);
-		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) )
-		);
+		$capture_intent_request = $this->mock_wcpay_request( Capture_Intention::class, 1, $intent_id );
+		$capture_intent_request->expects( $this->once() )
+			->method( 'set_amount_to_capture' )
+			->with( $mock_intent->get_amount() );
+
+		$capture_intent_request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( $this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) ) );
 
 		$this->mock_wcpay_account
 			->expects( $this->once() )
@@ -1140,9 +1166,14 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
-		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) )
-		);
+		$capture_intent_request = $this->mock_wcpay_request( Capture_Intention::class, 1, $intent_id );
+		$capture_intent_request->expects( $this->once() )
+			->method( 'set_amount_to_capture' )
+			->with( $mock_intent->get_amount() );
+
+		$capture_intent_request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( $this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) ) );
 
 		$this->mock_wcpay_account
 			->expects( $this->once() )
@@ -1206,9 +1237,14 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					}
 				)
 			);
-		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) )
-		);
+		$capture_intent_request = $this->mock_wcpay_request( Capture_Intention::class, 1, $intent_id );
+		$capture_intent_request->expects( $this->once() )
+			->method( 'set_amount_to_capture' )
+			->with( $mock_intent->get_amount() );
+
+		$capture_intent_request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( $this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) ) );
 
 		$this->mock_wcpay_account
 			->expects( $this->once() )
@@ -1282,9 +1318,14 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'set_metadata' )
 			->with( $merged_metadata );
 
-		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->returnValue( WC_Helper_Intention::create_intention() )
-		);
+		$capture_intent_request = $this->mock_wcpay_request( Capture_Intention::class, 1, $intent_id );
+		$capture_intent_request->expects( $this->once() )
+			->method( 'set_amount_to_capture' )
+			->with( $mock_intent->get_amount() );
+
+		$capture_intent_request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( WC_Helper_Intention::create_intention() );
 
 		$this->mock_wcpay_account
 			->expects( $this->once() )
@@ -1345,9 +1386,15 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					}
 				)
 			);
-		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
-			$this->returnValue( WC_Helper_Intention::create_intention() )
-		);
+
+		$capture_intent_request = $this->mock_wcpay_request( Capture_Intention::class, 1, $intent_id );
+		$capture_intent_request->expects( $this->once() )
+			->method( 'set_amount_to_capture' )
+			->with( $mock_intent->get_amount() );
+
+		$capture_intent_request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( WC_Helper_Intention::create_intention() );
 
 		$this->mock_wcpay_account
 			->expects( $this->never() )

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -8,6 +8,7 @@
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Core\Server\Request\Get_Charge;
 use WCPay\Core\Server\Request\Get_Intention;
+use WCPay\Core\Server\Request\Update_Intention;
 use WCPay\Exceptions\Amount_Too_Small_Exception;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Constants\Payment_Type;
@@ -131,7 +132,6 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 					'get_payment_method',
 					'refund_charge',
 					'list_refunds',
-					'prepare_intention_for_capture',
 					'get_timeline',
 				]
 			)
@@ -786,19 +786,22 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
-		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$update_intent_request = $this->mock_wcpay_request( Update_Intention::class, 1, $intent_id );
+		$update_intent_request->expects( $this->once() )
+			->method( 'set_metadata' )
+			->with(
+				$this->callback(
+					function( $argument ) {
+						return is_array( $argument ) && ! empty( $argument );
+					}
+				)
+			);
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
 			$this->returnValue( WC_Helper_Intention::create_intention() )
 		);
@@ -852,19 +855,25 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
-		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$update_intent_request = $this->mock_wcpay_request( Update_Intention::class, 1, $intent_id );
+		$update_intent_request->expects( $this->once() )
+			->method( 'set_metadata' )
+			->with(
+				$this->callback(
+					function( $argument ) {
+						return is_array( $argument ) && ! empty( $argument );
+					}
+				)
+			);
+		$update_intent_request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( $mock_intent );
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
 			$this->returnValue( WC_Helper_Intention::create_intention( [ 'currency' => 'eur' ] ) )
 		);
@@ -915,19 +924,22 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
-		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$update_intent_request = $this->mock_wcpay_request( Update_Intention::class, 1, $intent_id );
+		$update_intent_request->expects( $this->once() )
+			->method( 'set_metadata' )
+			->with(
+				$this->callback(
+					function( $argument ) {
+						return is_array( $argument ) && ! empty( $argument );
+					}
+				)
+			);
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
 			$this->returnValue( $mock_intent )
 		);
@@ -981,19 +993,22 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
-		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$update_intent_request = $this->mock_wcpay_request( Update_Intention::class, 1, $intent_id );
+		$update_intent_request->expects( $this->once() )
+			->method( 'set_metadata' )
+			->with(
+				$this->callback(
+					function( $argument ) {
+						return is_array( $argument ) && ! empty( $argument );
+					}
+				)
+			);
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
 			$this->returnValue( $mock_intent )
 		);
@@ -1043,19 +1058,22 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intention::class, 2 );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 2, $intent_id );
 
 		$request->expects( $this->exactly( 2 ) )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
-		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$update_intent_request = $this->mock_wcpay_request( Update_Intention::class, 1, $intent_id );
+		$update_intent_request->expects( $this->once() )
+			->method( 'set_metadata' )
+			->with(
+				$this->callback(
+					function( $argument ) {
+						return is_array( $argument ) && ! empty( $argument );
+					}
+				)
+			);
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
 			$this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) )
 		);
@@ -1110,19 +1128,27 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$request = $this->mock_wcpay_request( Get_Intention::class, 2 );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 2, $intent_id );
 
 		$request->expects( $this->exactly( 2 ) )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
-		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$update_intent_request = $this->mock_wcpay_request( Update_Intention::class, 1, $intent_id );
+		$update_intent_request->expects( $this->once() )
+			->method( 'set_metadata' )
+			->with(
+				$this->callback(
+					function( $argument ) {
+						return is_array( $argument ) && ! empty( $argument );
+					}
+				)
+			);
+
+		$update_intent_request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( $mock_intent );
+
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
 			$this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) )
 		);
@@ -1173,19 +1199,22 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'canceled' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intention::class, 2 );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 2, $intent_id );
 
 		$request->expects( $this->exactly( 2 ) )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
-		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$update_intent_request = $this->mock_wcpay_request( Update_Intention::class, 1, $intent_id );
+		$update_intent_request->expects( $this->once() )
+			->method( 'set_metadata' )
+			->with(
+				$this->callback(
+					function( $argument ) {
+						return is_array( $argument ) && ! empty( $argument );
+					}
+				)
+			);
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
 			$this->throwException( new API_Exception( 'test exception', 'server_error', 500 ) )
 		);
@@ -1251,19 +1280,17 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			'payment_type'   => Payment_Type::SINGLE(),
 		];
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
-		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->with( $intent_id, $merged_metadata )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$update_intent_request = $this->mock_wcpay_request( Update_Intention::class, 1, $intent_id );
+		$update_intent_request->expects( $this->once() )
+			->method( 'set_metadata' )
+			->with( $merged_metadata );
+
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
 			$this->returnValue( WC_Helper_Intention::create_intention() )
 		);
@@ -1311,19 +1338,22 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$mock_intent = WC_Helper_Intention::create_intention( [ 'status' => 'requires_capture' ] );
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $mock_intent );
 
-		$this->mock_api_client->expects( $this->once() )->method( 'prepare_intention_for_capture' )->will(
-			$this->returnValue( $mock_intent )
-		);
+		$update_intent_request = $this->mock_wcpay_request( Update_Intention::class, 1, $intent_id );
+		$update_intent_request->expects( $this->once() )
+			->method( 'set_metadata' )
+			->with(
+				$this->callback(
+					function( $argument ) {
+						return is_array( $argument ) && ! empty( $argument );
+					}
+				)
+			);
 		$this->mock_api_client->expects( $this->once() )->method( 'capture_intention' )->will(
 			$this->returnValue( WC_Helper_Intention::create_intention() )
 		);
@@ -1374,12 +1404,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'cancel_intention' )
 			->will( $this->throwException( new API_Exception( 'test exception', 'test', 123 ) ) );
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
-
-		$request->expects( $this->once() )
-			->method( 'set_intent_id' )
-			->with( $intent_id );
-
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( WC_Helper_Intention::create_intention( [ 'status' => 'canceled' ] ) );
@@ -1413,7 +1438,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'cancel_intention' )
 			->will( $this->throwException( new API_Exception( 'test exception', 'test', 123 ) ) );
 
-		$request = $this->mock_wcpay_request( Get_Intention::class );
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )

--- a/tests/unit/test-class-wc-payments-payment-request-button-handler.php
+++ b/tests/unit/test-class-wc-payments-payment-request-button-handler.php
@@ -89,7 +89,6 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 					'is_server_connected',
 					'capture_intention',
 					'cancel_intention',
-					'create_and_confirm_setup_intent',
 					'get_setup_intent',
 					'get_payment_method',
 					'refund_charge',

--- a/tests/unit/test-class-wc-payments-payment-request-button-handler.php
+++ b/tests/unit/test-class-wc-payments-payment-request-button-handler.php
@@ -89,7 +89,6 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 					'is_server_connected',
 					'capture_intention',
 					'cancel_intention',
-					'get_intent',
 					'create_and_confirm_setup_intent',
 					'get_setup_intent',
 					'get_payment_method',


### PR DESCRIPTION
Fixes #5057

#### Changes proposed in this Pull Request
The following requests have been added using request class:

- Create_Intent
- Update_Intent
- Get_Intent

The examples can be found below.

To start with this request, create a new Create Intent request and fill the data.

Example:

**Create intent**

```php
$currency                 = strtolower( $order->get_currency() );
$$customer_id             = $request->get_param( 'customer_id' );
$metadata                 = $request->get_param( 'metadata' ) ?? [];
$metadata['order_number'] = $order->get_order_number();

$wcpay_server_request = Create_Intent::create();
$wcpay_server_request->set_currency_code( $currency );
$wcpay_server_request->set_amount( WC_Payments_Utils::prepare_amount( $order->get_total(), $currency ) );
if ( $customer_id ) {
	$wcpay_server_request->set_customer( $customer_id );
}
$wcpay_server_request->set_metadata( $metadata );
$wcpay_server_request->set_payment_method_types( $this->get_terminal_intent_payment_method( $request ) );
$wcpay_server_request->set_capture_method( 'manual' === $this->get_terminal_intent_capture_method( $request ) );
$intent = $wcpay_server_request->send( 'create_wcpay_terminal_intent_request', $order );
```
The `create_wcpay_terminal_intent_request` filter have been added where someone could use it according to their needs.

**Update intent**

```php
$request = Update_Intention::create();
$request->set_intent_id( $payment_intent_id );
$request->set_currency_code( strtolower( $currency ) );
$request->set_amount( WC_Payments_Utils::prepare_amount( $amount, $currency ) );
$request->set_metadata( $this->get_metadata_from_order( $order, $payment_type ) );
$request->set_level3( $this->get_level3_data_from_order( $order ) );
$request->set_selected_upe_payment_method_type( (string) $selected_upe_payment_type, $this->get_payment_method_ids_enabled_at_checkout( null, true ) );
if ( $payment_country ) {
	$request->set_payment_country( $payment_country );
}
if ( true === $save_payment_method ) {
	$request->setup_future_usage();
}
if ( $customer_id ) {
	$request->set_customer( $customer_id );
}
$updated_payment_intent = $request->send( 'wcpay_update_intention_request', $order, $payment_intent_id );
```

The `wcpay_update_intention_request` filter have been added where someone could use it according to their needs. In this example, order and `intent_id` have been passed.

**Get intent**

```php
$request = Get_Intent::create();
$request->set_intent_id( $intent_id );
$intent = $request->send( 'wcpay_get_intent_request', $order );
```

The `wcpay_get_intent_request` filter have been added where someone could use it according to their needs. In this example, order have been passed.

For get and update intents requests, the intent id can only be set once to prevent possible issues with data tempering.
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

Make sure that terminal create intent endpoint works correctly.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
