### PR TITLE
Allow cards to be saved via My Account

### DIFF
--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -761,6 +761,15 @@ jQuery( function ( $ ) {
 
 	// Handle the add payment method form for WooCommerce Payments.
 	$( 'form#add_payment_method' ).on( 'submit', function () {
+		// Skip adding legacy cards as UPE payment methods.
+		if (
+			'woocommerce_payments' ===
+			$(
+				"#add_payment_method input:checked[name='payment_method']"
+			).val()
+		) {
+			return;
+		}
 		if ( ! $( '#wcpay-setup-intent' ).val() ) {
 			const paymentMethodType = getSelectedGatewayPaymentMethod();
 			const paymentIntentId =


### PR DESCRIPTION
Fixes #5116 

#### Changes proposed in this Pull Request

When the UPE is enabled, `upe.js` is enqueued which attempts to take over submissions of the Add Payment Method form. Because we're using the legacy card element, an error is thrown when the card payment method isn't found in the `gatewayUPEComponents` array. Because the normal, non-UPE, `checkout.js` is still enqueued, we can continue relying on it to handle payment method creation for cards from the My Account page.

#### Testing instructions

1. Enable the UPE in the WooCommerce Payments settings
2. Navigate to My Account > Payment Methods > Add Payment Method
3. Add a new credit card and verify that it was successful(no errors on page.)
4. Add a new UPE method(SEPA) and verify that it was successful(no errors on page.)

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
