### PR TITLE
Assign callbacks to gateway-specific actions in the abstract checkout class to avoid unnecessary duplication

### DIFF
--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -71,6 +71,8 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 
 		add_action( 'wc_payments_set_gateway', [ $this, 'set_gateway' ] );
 		add_action( 'wc_payments_add_upe_payment_fields', [ $this, 'payment_fields' ] );
+		add_action( 'woocommerce_after_account_payment_methods', [ $this->gateway, 'remove_upe_setup_intent_from_session' ], 10, 0 );
+		add_action( 'woocommerce_subscription_payment_method_updated', [ $this->gateway, 'remove_upe_setup_intent_from_session' ], 10, 0 );
 	}
 
 	/**

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -75,6 +75,11 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 		add_action( 'woocommerce_subscription_payment_method_updated', [ $this->gateway, 'remove_upe_setup_intent_from_session' ], 10, 0 );
 		add_action( 'woocommerce_order_payment_status_changed', [ 'WCPay\Payment_Methods\UPE_Payment_Gateway', 'remove_upe_payment_intent_from_session' ], 10, 0 );
 		add_action( 'wp', [ $this->gateway, 'maybe_process_upe_redirect' ] );
+		add_action( 'wc_ajax_wcpay_log_payment_error', [ $this->gateway, 'log_payment_error_ajax' ] );
+		add_action( 'wp_ajax_save_upe_appearance', [ $this->gateway, 'save_upe_appearance_ajax' ] );
+		add_action( 'wp_ajax_nopriv_save_upe_appearance', [ $this->gateway, 'save_upe_appearance_ajax' ] );
+		add_action( 'switch_theme', [ $this->gateway, 'clear_upe_appearance_transient' ] );
+		add_action( 'woocommerce_woocommerce_payments_updated', [ $this->gateway, 'clear_upe_appearance_transient' ] );
 	}
 
 	/**

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -74,6 +74,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 		add_action( 'woocommerce_after_account_payment_methods', [ $this->gateway, 'remove_upe_setup_intent_from_session' ], 10, 0 );
 		add_action( 'woocommerce_subscription_payment_method_updated', [ $this->gateway, 'remove_upe_setup_intent_from_session' ], 10, 0 );
 		add_action( 'woocommerce_order_payment_status_changed', [ 'WCPay\Payment_Methods\UPE_Payment_Gateway', 'remove_upe_payment_intent_from_session' ], 10, 0 );
+		add_action( 'wp', [ $this->gateway, 'maybe_process_upe_redirect' ] );
 	}
 
 	/**

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -73,6 +73,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 		add_action( 'wc_payments_add_upe_payment_fields', [ $this, 'payment_fields' ] );
 		add_action( 'woocommerce_after_account_payment_methods', [ $this->gateway, 'remove_upe_setup_intent_from_session' ], 10, 0 );
 		add_action( 'woocommerce_subscription_payment_method_updated', [ $this->gateway, 'remove_upe_setup_intent_from_session' ], 10, 0 );
+		add_action( 'woocommerce_order_payment_status_changed', [ 'WCPay\Payment_Methods\UPE_Payment_Gateway', 'remove_upe_payment_intent_from_session' ], 10, 0 );
 	}
 
 	/**

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -131,10 +131,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		if ( ! has_action( 'wp', [ $this, 'maybe_process_upe_redirect' ] ) ) {
 			add_action( 'wp', [ $this, 'maybe_process_upe_redirect' ] );
 		}
-
-		if ( ! has_action( 'woocommerce_order_payment_status_changed', [ __CLASS__, 'remove_upe_payment_intent_from_session' ] ) ) {
-			add_action( 'woocommerce_order_payment_status_changed', [ __CLASS__, 'remove_upe_payment_intent_from_session' ], 10, 0 );
-		}
 	}
 
 	/**

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -127,10 +127,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		if ( ! has_action( 'woocommerce_woocommerce_payments_updated', [ $this, 'clear_upe_appearance_transient' ] ) ) {
 			add_action( 'woocommerce_woocommerce_payments_updated', [ $this, 'clear_upe_appearance_transient' ] );
 		}
-
-		if ( ! has_action( 'wp', [ $this, 'maybe_process_upe_redirect' ] ) ) {
-			add_action( 'wp', [ $this, 'maybe_process_upe_redirect' ] );
-		}
 	}
 
 	/**

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -107,26 +107,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			$this->id           = self::GATEWAY_ID . '_' . $this->stripe_id;
 			$this->method_title = "WooCommerce Payments ($this->title)";
 		}
-
-		if ( ! has_action( 'wc_ajax_wcpay_log_payment_error', [ $this, 'log_payment_error_ajax' ] ) ) {
-			add_action( 'wc_ajax_wcpay_log_payment_error', [ $this, 'log_payment_error_ajax' ] );
-		}
-
-		if ( ! has_action( 'wp_ajax_save_upe_appearance', [ $this, 'save_upe_appearance_ajax' ] ) ) {
-			add_action( 'wp_ajax_save_upe_appearance', [ $this, 'save_upe_appearance_ajax' ] );
-		}
-
-		if ( ! has_action( 'wp_ajax_nopriv_save_upe_appearance', [ $this, 'save_upe_appearance_ajax' ] ) ) {
-			add_action( 'wp_ajax_nopriv_save_upe_appearance', [ $this, 'save_upe_appearance_ajax' ] );
-		}
-
-		if ( ! has_action( 'switch_theme', [ $this, 'clear_upe_appearance_transient' ] ) ) {
-			add_action( 'switch_theme', [ $this, 'clear_upe_appearance_transient' ] );
-		}
-
-		if ( ! has_action( 'woocommerce_woocommerce_payments_updated', [ $this, 'clear_upe_appearance_transient' ] ) ) {
-			add_action( 'woocommerce_woocommerce_payments_updated', [ $this, 'clear_upe_appearance_transient' ] );
-		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5117

#### Changes proposed in this Pull Request
This PR: 
1. Fixes the duplicated notices bug while saving the SEPA payment method (https://github.com/Automattic/woocommerce-payments/issues/5117)
2. Adds callbacks to hooks in the checkout class instead of UPE gateway class which is now initialized multiple times per each payment method. This allows us to avoid the situation when one callback is added to a hook multiple times, whereas only one addition is needed
3. Aligns the setup/payment intents removal methods to remove all the payment intents since we now are invoking them from the checkout class

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions 🔴  🟢 
##### :one: Test hook invocation, responsible for removing setup intent from the session. 

> 💡  Setup intent is removed [when loading the payment methods page](https://github.com/Automattic/woocommerce.com/blob/trunk/themes/woo/woocommerce/myaccount/payment-methods.php#L91) in _My account_. 

1. Go to _My account -> Payment methods_ and add a new SEPA payment method.
5. After adding and redirected back to the tokens list, go and add another SEPA payment method and ensure that there are no failures while adding the payment method. When there are problems with removing the setup intent, errors with the message `You cannot update this SetupIntent because it has already succeeded.` usually appear. In this step, we'd like to confirm that we don't see such errors. 
6. Repeat steps 1-2 with the legacy card.

##### :two: Test payment intent removal callback invocation
Confirm there are no errors in the two following use cases (does not matter if you save the payment method or not):
1. Use shortcode checkout to buy any product with a card twice in a row.
2. Use shortcode checkout to buy any product with the SEPA payment method twice in a row.

##### :three: Test fixed duplicated notices when saving SEPA
1. Go to _My account -> Payment methods_ and add a new SEPA payment method.
2. Ensure that there is only one `Payment method successfully added.` notice after being redirected to the payment method list.

##### :four: Test if appearance callbacks are invoked
To check if `save_upe_appearance_ajax` and `clear_upe_appearance_transient` callbacks are invoked: 
1. Set debug breakpoints in [save_upe_appearance_ajax()](https://github.com/Automattic/woocommerce-payments/blob/27426eaeeacba7002333f44830579afab0e6c729/includes/payment-methods/class-upe-payment-gateway.php#L891) and [clear_upe_appearance_transient()](https://github.com/Automattic/woocommerce-payments/blob/27426eaeeacba7002333f44830579afab0e6c729/includes/payment-methods/class-upe-payment-gateway.php#L924) methods.
2. Change the theme in the admin panel under _Appearance_ and ensure that the `clear_upe_appearance_transient` method is invoked and the debugger stops at the breakpoint. In my case, I switched from Storefront to Twenty Twenty-Two.
3. Go to the store, add a product and proceed to the checkout page.
4. On the shortcode checkout page loading, confirm that the `save_upe_appearance_ajax()` method is invoked and debugger stops at the breakpoint.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
