### PR TITLE
Separate authorizations cache summary for live mode and test mode

### DIFF
--- a/changelog/add-auhtorizations-cache-test-mode
+++ b/changelog/add-auhtorizations-cache-test-mode
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Separate authorizations cache for test and live mode

--- a/changelog/add-auhtorizations-cache-test-mode
+++ b/changelog/add-auhtorizations-cache-test-mode
@@ -1,4 +1,4 @@
 Significance: minor
 Type: dev
 
-Separate authorizations cache for test and live mode
+Show correct authorizations count when switching between live and test modes

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -1024,8 +1024,11 @@ class WC_Payments_Admin {
 	 * @return int The number of uncaptured transactions.
 	 */
 	private function get_uncaptured_transactions_count() {
+		$test_mode = $this->wcpay_gateway->is_in_test_mode();
+		$cache_key = $test_mode ? DATABASE_CACHE::AUTHORIZATION_SUMMARY_KEY_TEST_MODE : DATABASE_CACHE::AUTHORIZATION_SUMMARY_KEY;
+
 		$authorization_summary = $this->database_cache->get_or_add(
-			Database_Cache::AUTHORIZATION_SUMMARY_KEY,
+			$cache_key,
 			[ $this->payments_api_client, 'get_authorizations_summary' ],
 			// We'll consider all array values to be valid as the cache is only invalidated when it is deleted or it expires.
 			'is_array'

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -38,6 +38,13 @@ class Database_Cache {
 	const AUTHORIZATION_SUMMARY_KEY = 'wcpay_authorization_summary_cache';
 
 	/**
+	 * Cache key for authorization summary data like count, total amount, etc in test mode.
+	 *
+	 * @var string
+	 */
+	const AUTHORIZATION_SUMMARY_KEY_TEST_MODE = 'wcpay_test_authorization_summary_cache';
+
+	/**
 	 * Refresh disabled flag, controlling the behaviour of the get_or_add function.
 	 *
 	 * @var bool

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -321,6 +321,7 @@ class WC_Payments_Webhook_Processing_Service {
 
 		// Clear the authorization summary cache to trigger a fetch of new data.
 		$this->database_cache->delete( DATABASE_CACHE::AUTHORIZATION_SUMMARY_KEY );
+		$this->database_cache->delete( DATABASE_CACHE::AUTHORIZATION_SUMMARY_KEY_TEST_MODE );
 	}
 
 	/**
@@ -333,6 +334,7 @@ class WC_Payments_Webhook_Processing_Service {
 	private function process_webhook_payment_intent_canceled( $event_body ) {
 		// Clear the authorization summary cache to trigger a fetch of new data.
 		$this->database_cache->delete( DATABASE_CACHE::AUTHORIZATION_SUMMARY_KEY );
+		$this->database_cache->delete( DATABASE_CACHE::AUTHORIZATION_SUMMARY_KEY_TEST_MODE );
 	}
 
 	/**
@@ -345,6 +347,7 @@ class WC_Payments_Webhook_Processing_Service {
 	private function process_webhook_payment_intent_amount_capturable_updated( $event_body ) {
 		// Clear the authorization summary cache to trigger a fetch of new data.
 		$this->database_cache->delete( DATABASE_CACHE::AUTHORIZATION_SUMMARY_KEY );
+		$this->database_cache->delete( DATABASE_CACHE::AUTHORIZATION_SUMMARY_KEY_TEST_MODE );
 	}
 
 	/**
@@ -445,6 +448,7 @@ class WC_Payments_Webhook_Processing_Service {
 
 		// Clear the authorization summary cache to trigger a fetch of new data.
 		$this->database_cache->delete( DATABASE_CACHE::AUTHORIZATION_SUMMARY_KEY );
+		$this->database_cache->delete( DATABASE_CACHE::AUTHORIZATION_SUMMARY_KEY_TEST_MODE );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5212 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

This separates the cache key for authorizations for live vs test mode. Also, whenever a transaction/authorization is updated, this change deletes **both** live and test caches. **I personally don't think there is a big gain in trying to detect which cache to delete**.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get this PR
* Make sure your store is in test mode and has "Issue an authorization on checkout, and capture later" turned on (from Payments > Settings)
* Make sure your local Stripe listener is turned on. ie: `./local/bin/listen-to-webhooks.sh` from the server repo
* Try to shop for an item, and pay via a test card
* Back to your WP Admin, you should see a new authorization in the Uncaptured tab (Payments > Transactions). Also, the Transactions menu in the left side menu should display a badge with `1` or more if you have more than one.
* Now, back to Payments > Settings, **turn off the test mode**.
* Refresh the page, the badge next to Transactions should be removed now. The Uncaptured transactions tab should have 0
* To double check, back to Payments > Settings, **turn on the test mode**.
* Transactions menu should have the badge once again.

You can see this video for reference:


https://user-images.githubusercontent.com/12542046/205909864-1548edc3-109c-442d-90e6-f638fa464390.mov


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
