### PR TITLE
Fixes to the Currency Rates API

### DIFF
--- a/changelog/dev-currency-rate-fixes
+++ b/changelog/dev-currency-rate-fixes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update currency_rate endpoint to not make a request if currency_from value is not valid/expected value.

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -369,7 +369,7 @@ class MultiCurrency {
 			Database_Cache::CURRENCIES_KEY,
 			function() {
 				try {
-					$currency_data = $this->payments_api_client->get_currency_rates( get_woocommerce_currency() );
+					$currency_data = $this->payments_api_client->get_currency_rates( strtolower( get_woocommerce_currency() ) );
 					return [
 						'currencies' => $currency_data,
 						'updated'    => time(),

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -1079,6 +1079,14 @@ class WC_Payments_API_Client {
 	 * @throws API_Exception - Error contacting the API.
 	 */
 	public function get_currency_rates( string $currency_from, $currencies_to = null ) {
+		if ( empty( $currency_from ) ) {
+			throw new API_Exception(
+				__( 'Currency From parameter is required', 'woocommerce-payments' ),
+				'wcpay_mandatory_currency_from_missing',
+				400
+			);
+		}
+
 		$query_body = [ 'currency_from' => $currency_from ];
 
 		if ( null !== $currencies_to ) {

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -638,7 +638,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 
 		$this->init_multi_currency( null, true, null, $mock_database_cache );
 
-		$currency_from = get_woocommerce_currency();
+		$currency_from = strtolower( get_woocommerce_currency() );
 		$currencies_to = get_woocommerce_currencies();
 		unset( $currencies_to[ $currency_from ] );
 


### PR DESCRIPTION
Small fixes to the currency rates API for hack week

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

This PR is trying to address unnecessary requests to the currency rates endpoints on the server causing non-200 responses. After looking at the endpoint, the only case in which it could throw a non-200 response are due to an invalid account making the request (which is handled by another check in our code), or if the `currency_from` param is invalid. This PR doesn't make the request if the `currency_from` value is either not set, or not the expected value.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow the steps on the [server PR](https://github.com/Automattic/woocommerce-payments-server/pull/2737).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
