### PR TITLE
Allow i18n for UPE checkout blocks error message

### DIFF
--- a/changelog/fix-4612-checkout-blocks-upe-error-message-i18n
+++ b/changelog/fix-4612-checkout-blocks-upe-error-message-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow the "Your payment information is incomplete." UPE checkout block message to be translated.

--- a/client/checkout/blocks/upe-fields.js
+++ b/client/checkout/blocks/upe-fields.js
@@ -15,6 +15,7 @@ import {
 } from '@woocommerce/blocks-registry';
 import { useEffect, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -210,7 +211,10 @@ const WCPayUPEFields = ( {
 				if ( ! isUPEComplete ) {
 					return {
 						type: 'error',
-						message: 'Your payment information is incomplete.',
+						message: __(
+							'Your payment information is incomplete.',
+							'woocommerce-payments'
+						),
 					};
 				}
 

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -1,6 +1,11 @@
 /* global jQuery */
 
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
@@ -395,7 +400,12 @@ jQuery( function ( $ ) {
 	 */
 	const checkUPEForm = async ( $form, returnUrl = '#' ) => {
 		if ( ! upeElement ) {
-			showErrorCheckout( 'Your payment information is incomplete.' );
+			showErrorCheckout(
+				__(
+					'Your payment information is incomplete.',
+					'woocommerce-payments'
+				)
+			);
 			return false;
 		}
 		if ( ! isUPEComplete ) {


### PR DESCRIPTION
Fixes #4612 

#### Changes proposed in this Pull Request

**Title:** Allow i18n for UPE checkout blocks error message

**Description:** 

The "Your payment information is incomplete." message string displayed by the UPE checkout blocks could not be translated via the `.pot` file (either through using an editor or a dedicated translation plugin).

I wrapped the string in a `__()` call so it is picked up by the `.pot` generation task and included in the `languages/woocommerce-payments.pot` file.

#### Testing instructions

1. Install any translation plugin (e.g. [Loco Translate](https://wordpress.org/plugins/loco-translate/)).
2. Add a new language to your site via the installed translation plugin.
3. Search the string `Your payment information is incomplete.` under the **WooCommerce Payments** plugin or the `woocommerce-payments` text domain (depending on how your chosen translation plugin works).
4. You should be able to add your translation of it.

Here is how it looks in Loco Translate:
![LocoTranslate-4612-issue](https://user-images.githubusercontent.com/8830539/206390356-9c12d90e-9479-49af-9b20-d8670d9d662b.png)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is insignificant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests - no need for tests
- [x] Tested on mobile - does not apply

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
