### PR TITLE
Remove Settings submenu UPE notification badge

### DIFF
--- a/changelog/fix-4508-remove-settings-submenu-ufe-notification-badge
+++ b/changelog/fix-4508-remove-settings-submenu-ufe-notification-badge
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Remove the UFE notification badge on the Payments > Settings menu item
+Remove the UPE notification badge on the Payments > Settings menu item

--- a/changelog/fix-4508-remove-settings-submenu-ufe-notification-badge
+++ b/changelog/fix-4508-remove-settings-submenu-ufe-notification-badge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove the UFE notification badge on the Payments > Settings menu item

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -847,13 +847,7 @@ class WC_Payments_Admin {
 	 * @return string
 	 */
 	private function get_settings_menu_item_name() {
-		$label = __( 'Settings', 'woocommerce' ); // PHPCS:Ignore WordPress.WP.I18n.TextDomainMismatch
-
-		if ( WC_Payments_Features::is_upe_settings_preview_enabled() && ! WC_Payments_Features::is_upe_enabled() ) {
-			$label .= self::MENU_NOTIFICATION_BADGE;
-		}
-
-		return $label;
+		return __( 'Settings', 'woocommerce' ); // PHPCS:Ignore WordPress.WP.I18n.TextDomainMismatch
 	}
 
 	/**

--- a/tests/unit/admin/test-class-wc-payments-admin.php
+++ b/tests/unit/admin/test-class-wc-payments-admin.php
@@ -144,6 +144,7 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		return [
 			[ false, false ],
 			[ false, true ],
+			[ true, false ],
 			[ true, true ],
 		];
 	}

--- a/tests/unit/admin/test-class-wc-payments-admin.php
+++ b/tests/unit/admin/test-class-wc-payments-admin.php
@@ -74,24 +74,6 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		parent::tear_down();
 	}
 
-	public function test_it_renders_settings_badge_if_upe_settings_preview_is_enabled_and_upe_is_not() {
-		global $submenu;
-
-		$this->mock_current_user_is_admin();
-
-		update_option( '_wcpay_feature_upe_settings_preview', '1' );
-		update_option( '_wcpay_feature_upe', '0' );
-
-		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'try_is_stripe_connected' )->willReturn( true );
-		$this->payments_admin->add_payments_menu();
-
-		$item_names_by_urls = wp_list_pluck( $submenu['wc-admin&path=/payments/overview'], 0, 2 );
-		$settings_item_name = $item_names_by_urls[ WC_Payments_Admin_Settings::get_settings_url() ];
-
-		$this->assertEquals( 'Settings' . WC_Payments_Admin::MENU_NOTIFICATION_BADGE, $settings_item_name );
-	}
-
 	/**
 	 * @dataProvider feature_flag_combinations_not_causing_settings_badge_render_provider
 	 *


### PR DESCRIPTION
Fixes #4508

#### Changes proposed in this Pull Request

Title: Remove the conditional badge insertion

Description: The badge HTML markup was added in a pretty hardcoded way straight into the menu item name. The badge addition was conditioned on the UPE preview being enabled and UPE not being activated. 
The fix is straightforward: remove the entire condition and make the Settings submenu item name a simple static string.

Regarding testing, an existing PHP unit test tested the badge presence - that test is not needed anymore. Instead, _any combination_ of `_wcpay_feature_upe_settings_preview` and `_wcpay_feature_upe` options values should not trigger the badge rendering.

#### Testing instructions

* On a dev site with WooCommerce Payments, checkout this PR's branch: `fix/4508-remove-settings-submenu-ufe-notification-badge`
* Don't enable additional UPE payment methods and finish the KYC flow to enable your account, or ensure that `Enable UPE checkout` is not checked in the WCPay Dev Utils.
* In the site's WP Admin, hover the mouse cursor over the **Payments** menu item, and the Settings submenu **should not** have a badge.

Before:
![181799436-ec54665a-bbd1-4250-a16e-222b01706038](https://user-images.githubusercontent.com/8830539/206704313-77c44d11-4943-4141-aa01-ff669c21f9e3.png)

After:
<img width="365" alt="Markup 2022-12-09 at 14 40 55" src="https://user-images.githubusercontent.com/8830539/206704721-fd3acca0-0774-46e1-9201-00eeffd4dcd0.png">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
