### PR TITLE
Support custom remote port for xDebug

### DIFF
--- a/changelog/dev-support-custom-remote-port-for-xdebug
+++ b/changelog/dev-support-custom-remote-port-for-xdebug
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Support custom REMOTE_PORT for xDebug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,11 @@ volumes:
 
 services:
   wordpress:
-    build: ./docker/wordpress_xdebug
+    build:
+      context: .
+      dockerfile: ./docker/wordpress_xdebug/Dockerfile
+      args:
+        - REMOTE_PORT=9000 # IDE/Editor's listener port
     container_name: woocommerce_payments_wordpress
     image: woocommerce_payments_wordpress
     restart: always

--- a/docker/README.md
+++ b/docker/README.md
@@ -45,3 +45,17 @@ You will see it give a forwarding address like this one:
 You may need to temporarily set your `siteurl` and `home` `wp_option`s to the new url. You can do this with phpMyAdmin or WP-CLI.
 
 Visit the `<url>` , login and setup WCPay.
+
+### Changing default port for xDebug
+To change the default port for xDebug you should create `docker.compose.override.yml` with the following contents:
+```
+version: '3'
+
+services:
+  wordpress:
+    build:
+      args:
+        - REMOTE_PORT=9003 # IDE/Editor's listener port
+```
+I used port `9003` as an example.
+To make changes work please re-create your containers.

--- a/docker/README.md
+++ b/docker/README.md
@@ -47,7 +47,7 @@ You may need to temporarily set your `siteurl` and `home` `wp_option`s to the ne
 Visit the `<url>` , login and setup WCPay.
 
 ### Changing default port for xDebug
-To change the default port for xDebug you should create `docker.compose.override.yml` with the following contents:
+To change the default port for xDebug you should create `docker-compose.override.yml` with the following contents:
 ```
 version: '3'
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -58,4 +58,4 @@ services:
         - REMOTE_PORT=9003 # IDE/Editor's listener port
 ```
 I used port `9003` as an example.
-To make changes work please re-create your containers.
+To apply the change, restart your containers using `npm run down && npm run up`

--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -1,7 +1,8 @@
 FROM wordpress:php7.4
+ARG REMOTE_PORT
 RUN pecl install xdebug-2.9.8 \
 	&& echo 'xdebug.remote_enable=1' >> $PHP_INI_DIR/php.ini \
-	&& echo 'xdebug.remote_port=9000' >> $PHP_INI_DIR/php.ini \
+	&& echo "xdebug.remote_port=$REMOTE_PORT" >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.remote_host=host.docker.internal' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.remote_autostart=0' >> $PHP_INI_DIR/php.ini \
 	&& docker-php-ext-enable xdebug


### PR DESCRIPTION
#### Description
After having the issues below with different xdebug versions have different ports (xdebug 2 - 9000), (xdebug 3 - 9003):
- p1658160909366479/1658158021.111129-slack-CGGCLBN58
- p1664448490749719-slack-C03KTTK2YMA

we added an idea for hack week - to support a custom port using `docker.compose.override.yml` which git should ignore. So everyone will be able to specify the port that works for them.
> A good solution could be loading a docker compose override, if it exists, that should be ignored. In that way, everyone could make some modifications without having git issues.

#### Changes proposed in this Pull Request

- Add `REMOTE_PORT` argument for `Dockerfile`
- Tweak `docker.compose.yml` to support the newly created argument
- Update `README.md` with a description of how to use it

#### Testing instructions

- Run `npm run down` in case your containers are running
- Check out this branch `dev/support-custom-remote-port-for-xdebug`
- Run `npm run up` and wait till containers are up
- Run `docker-compose exec -u www-data wordpress bash`. You'll get inside the container
- Run the next command inside the container `cat /usr/local/etc/php/php.ini`, and check that `xdebug.remote_port` has value `9000`. It's the default value.
- Create `docker.compose.override.yml` with the following contents:
```
version: '3'

services:
  wordpress:
    build:
      args:
        - REMOTE_PORT=9003 # IDE/Editor's listener port
```
- Run `npm run down`, then `npm run up`.
- Go once again inside the container `docker-compose exec -u www-data wordpress bash` and execute once again `cat /usr/local/etc/php/php.ini`. Check that now the value of `xdebug.remote_port` is `9003`.
- Put some breakpoint (e.g. MultiCurrency.php), go to some page (e.g. Multi currency settings) and check that debugger works with the port you specified.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.