### PR TITLE
hide capture charge and cancel authorization on status complete/processing

### DIFF
--- a/changelog/fix-4789-status-processing-before-capture
+++ b/changelog/fix-4789-status-processing-before-capture
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Hide capture charge and cancel authorization options on order when order is completed

--- a/changelog/fix-4789-status-processing-before-capture
+++ b/changelog/fix-4789-status-processing-before-capture
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Hide capture charge and cancel authorization options on order when order is completed
+Hide "capture charge" and "cancel authorization" actions on order details page when order status is processing or completed.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2101,7 +2101,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if (
 			in_array(
 				$theorder->get_status(),
-				[ WC_Payments_Order_Service::STATUS_PROCESSING, WC_Payments_Order_Service::STATUS_COMPLETED ],
+				wc_get_is_paid_statuses(),
 				true
 			)
 		) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2098,13 +2098,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		}
 
 		// if order is already completed, we shouldn't capture the charge anymore.
-		if (
-			in_array(
-				$theorder->get_status(),
-				wc_get_is_paid_statuses(),
-				true
-			)
-		) {
+		if ( in_array( $theorder->get_status(), wc_get_is_paid_statuses(), true ) ) {
 			return $actions;
 		}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2097,6 +2097,17 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return $actions;
 		}
 
+		// if order is already completed, we shouldn't capture the charge anymore.
+		if (
+			in_array(
+				$theorder->get_status(),
+				[ WC_Payments_Order_Service::STATUS_PROCESSING, WC_Payments_Order_Service::STATUS_COMPLETED ],
+				true
+			)
+		) {
+			return $actions;
+		}
+
 		$new_actions = [
 			'capture_charge'       => __( 'Capture charge', 'woocommerce-payments' ),
 			'cancel_authorization' => __( 'Cancel authorization', 'woocommerce-payments' ),

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -17,12 +17,11 @@ class WC_Payments_Order_Service {
 	/**
 	 * Order status constants.
 	 */
-	const STATUS_CANCELLED  = 'cancelled';
-	const STATUS_COMPLETED  = 'completed';
-	const STATUS_FAILED     = 'failed';
-	const STATUS_ON_HOLD    = 'on-hold';
-	const STATUS_PENDING    = 'pending';
-	const STATUS_PROCESSING = 'processing';
+	const STATUS_CANCELLED = 'cancelled';
+	const STATUS_COMPLETED = 'completed';
+	const STATUS_FAILED    = 'failed';
+	const STATUS_ON_HOLD   = 'on-hold';
+	const STATUS_PENDING   = 'pending';
 
 	const ADD_FEE_BREAKDOWN_TO_ORDER_NOTES = 'wcpay_add_fee_breakdown_to_order_notes';
 

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -17,11 +17,12 @@ class WC_Payments_Order_Service {
 	/**
 	 * Order status constants.
 	 */
-	const STATUS_CANCELLED = 'cancelled';
-	const STATUS_COMPLETED = 'completed';
-	const STATUS_FAILED    = 'failed';
-	const STATUS_ON_HOLD   = 'on-hold';
-	const STATUS_PENDING   = 'pending';
+	const STATUS_CANCELLED  = 'cancelled';
+	const STATUS_COMPLETED  = 'completed';
+	const STATUS_FAILED     = 'failed';
+	const STATUS_ON_HOLD    = 'on-hold';
+	const STATUS_PENDING    = 'pending';
+	const STATUS_PROCESSING = 'processing';
 
 	const ADD_FEE_BREAKDOWN_TO_ORDER_NOTES = 'wcpay_add_fee_breakdown_to_order_notes';
 


### PR DESCRIPTION
Fixes #4789 

For a shop that has capture later option enabled, the merchant can change the order status from 'On hold' to Processing/ Complete. This could mean that the merchant already received the payment from another source.  If the order is already completed, it makes no sense to charge the client twice, and we need to hide the charge options from the order.

**Original issue:** merchant updated the order to a complete status, and after that tried to capture the charge. The capture was charged, but no logs were added to the order since it had a complete status. This led to a misleading of the merchant. 

#### Changes proposed in this Pull Request
Hide Capture charge and cancel authorization options for an order, when the merchant manually changes the status from 'On Hold' to 'Processing'/'Completed'. 
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `Woocommerce -> Settings -> Payments` and under 'Transactions' section enable `Issue an authorization on checkout, and capture later` for the shop
* Create an order 
* Change the order status from 'On Hold' to 'Processing' . Do NOT capture the charge
* The `Capture charge` and`Cancel authorization` should not be shown.  

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
