### PR TITLE
Make custom fees show up correctly in settings tooltip, whenever applicable

### DIFF
--- a/changelog/fix-5255-custom-fee-tooltip-in-settings
+++ b/changelog/fix-5255-custom-fee-tooltip-in-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make the tooltips on UPE settings ( Settings > Payments accepted on checkout ) , show the correct custom rates whenever applicable.

--- a/client/components/account-status/account-fees/index.js
+++ b/client/components/account-status/account-fees/index.js
@@ -13,7 +13,7 @@ import ExpirationDescription from './expiration-description';
 import { getCurrency, formatCurrencyName } from 'utils/currency';
 import {
 	formatAccountFeesDescription,
-	getCurrentFee,
+	getCurrentBaseFee,
 	getTransactionsPaymentMethodName,
 } from 'utils/account-fees';
 
@@ -37,7 +37,7 @@ const AccountFee = ( props ) => {
 	const currencyName = formatCurrencyName( baseFee.currency );
 	const currencyCode = currency?.getCurrencyConfig()?.code;
 	const feeDescription = formatAccountFeesDescription( accountFee );
-	const currentFee = getCurrentFee( accountFee );
+	const currentBaseFee = getCurrentBaseFee( accountFee );
 
 	return (
 		<>
@@ -45,8 +45,8 @@ const AccountFee = ( props ) => {
 			{ currencyName ? `${ currencyName } ` : null }
 			{ currencyCode ? `(${ currencyCode }) ` : null }
 			{ feeDescription }
-			<ExpirationBar feeData={ currentFee } />
-			<ExpirationDescription feeData={ currentFee } />
+			<ExpirationBar feeData={ currentBaseFee } />
+			<ExpirationDescription feeData={ currentBaseFee } />
 		</>
 	);
 };

--- a/client/components/payment-methods-list/payment-method.js
+++ b/client/components/payment-methods-list/payment-method.js
@@ -46,6 +46,7 @@ const PaymentMethod = ( {
 		return onUncheckClick( id );
 	};
 
+	//console.log( accountFees );
 	return (
 		<li
 			className={ classNames(

--- a/client/components/payment-methods-list/payment-method.js
+++ b/client/components/payment-methods-list/payment-method.js
@@ -46,7 +46,6 @@ const PaymentMethod = ( {
 		return onUncheckClick( id );
 	};
 
-	//console.log( accountFees );
 	return (
 		<li
 			className={ classNames(

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -18,28 +18,28 @@ import { PaymentMethod } from 'wcpay/types/payment-methods';
 import { createInterpolateElement } from '@wordpress/element';
 
 const countryFeeStripeDocsBaseLink =
-	'https://woocommerce.com/document/payments/faq/fees/#section-';
+	'https://woocommerce.com/document/payments/faq/fees/#';
 const countryFeeStripeDocsBaseLinkNoCountry =
 	'https://woocommerce.com/document/payments/faq/fees';
-const countryFeeStripeDocsSectionNumbers: Record< string, number > = {
-	AU: 1,
-	AT: 2,
-	BE: 3,
-	CA: 4,
-	FR: 5,
-	DE: 6,
-	HK: 7,
-	IE: 8,
-	IT: 9,
-	NL: 10,
-	NZ: 11,
-	PL: 12,
-	PT: 13,
-	SG: 14,
-	ES: 15,
-	CH: 16,
-	UK: 17,
-	US: 18,
+const countryFeeStripeDocsSectionNumbers: Record< string, string > = {
+	AU: 'australia',
+	AT: 'austria',
+	BE: 'belgium',
+	CA: 'canada',
+	FR: 'france',
+	DE: 'germany',
+	HK: 'hong-kong',
+	IE: 'ireland',
+	IT: 'italy',
+	NL: 'netherlands',
+	NZ: 'new-zealand',
+	PL: 'poland',
+	PT: 'portugal',
+	SG: 'singapore',
+	ES: 'spain',
+	CH: 'switzerland',
+	UK: 'united-kingdom',
+	US: 'united-states',
 };
 
 const stripeFeeSectionExistsForCountry = ( country: string ): boolean => {

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -77,7 +77,7 @@ const getFeeDescriptionString = ( fee: BaseFee ): string => {
 	return '';
 };
 
-export const getCurrentFee = (
+export const getCurrentBaseFee = (
 	accountFees: FeeStructure
 ): BaseFee | DiscountFee => {
 	return accountFees.discount.length
@@ -89,16 +89,15 @@ export const formatMethodFeesTooltip = (
 	accountFees: FeeStructure
 ): JSX.Element => {
 	if ( ! accountFees ) return <></>;
-	// If there is a discount, use that instead of the base fee.
-	const currentFee = getCurrentFee( accountFees );
+	const currentBaseFee = getCurrentBaseFee( accountFees );
 
 	const total = {
 		percentage_rate:
-			currentFee.percentage_rate +
+			currentBaseFee.percentage_rate +
 			accountFees.additional.percentage_rate +
 			accountFees.fx.percentage_rate,
 		fixed_rate:
-			currentFee.fixed_rate +
+			currentBaseFee.fixed_rate +
 			accountFees.additional.fixed_rate +
 			accountFees.fx.fixed_rate,
 		currency: accountFees.base.currency,
@@ -112,7 +111,7 @@ export const formatMethodFeesTooltip = (
 		<div className={ 'wcpay-fees-tooltip' }>
 			<div>
 				<div>Base fee</div>
-				<div>{ getFeeDescriptionString( currentFee ) }</div>
+				<div>{ getFeeDescriptionString( currentBaseFee ) }</div>
 			</div>
 			{ hasFees( accountFees.additional ) ? (
 				<div>
@@ -212,7 +211,7 @@ export const formatAccountFeesDescription = (
 	const baseFee = accountFees.base;
 	const additionalFee = accountFees.additional ?? defaultFee;
 	const fxFee = accountFees.fx ?? defaultFee;
-	const currentFee = getCurrentFee( accountFees );
+	const currentBaseFee = getCurrentBaseFee( accountFees );
 
 	// Default formats will be used if no matching field was passed in the `formats` parameter.
 	const formats = {
@@ -238,11 +237,11 @@ export const formatAccountFeesDescription = (
 		formatCurrency( baseFee.fixed_rate, baseFee.currency )
 	);
 	const isFormattingWithDiscount =
-		currentFee.percentage_rate !== baseFee.percentage_rate ||
-		currentFee.fixed_rate !== baseFee.fixed_rate ||
-		currentFee.currency !== baseFee.currency;
+		currentBaseFee.percentage_rate !== baseFee.percentage_rate ||
+		currentBaseFee.fixed_rate !== baseFee.fixed_rate ||
+		currentBaseFee.currency !== baseFee.currency;
 	if ( isFormattingWithDiscount ) {
-		const discountFee = currentFee as DiscountFee;
+		const discountFee = currentBaseFee as DiscountFee;
 		// TODO: Figure out how the UI should work if there are several "discount" fees stacked.
 		let percentage, fixed;
 
@@ -252,33 +251,33 @@ export const formatAccountFeesDescription = (
 			fixed = baseFee.fixed_rate * ( 1 - discountFee.discount );
 		} else {
 			// Custom base fee (2% + $.20)
-			percentage = currentFee.percentage_rate;
-			fixed = currentFee.fixed_rate;
+			percentage = currentBaseFee.percentage_rate;
+			fixed = currentBaseFee.fixed_rate;
 		}
 
-		let currentFeeDescription = sprintf(
+		let currentBaseFeeDescription = sprintf(
 			formats.fee,
 			formatFee( percentage ),
 			formatCurrency( fixed, baseFee.currency )
 		);
 
 		if ( formats.displayBaseFeeIfDifferent ) {
-			currentFeeDescription = sprintf(
+			currentBaseFeeDescription = sprintf(
 				// eslint-disable-next-line max-len
 				/* translators: %1 Base fee (that don't apply to this account at this moment), %2: Current fee (e.g: "2.9% + $.30 per transaction") */
 				__( '<s>%1$s</s> %2$s', 'woocommerce-payments' ),
 				feeDescription,
-				currentFeeDescription
+				currentBaseFeeDescription
 			);
 		}
 
 		if ( discountFee.discount && 0 < formats.discount.length ) {
-			currentFeeDescription +=
+			currentBaseFeeDescription +=
 				' ' +
 				sprintf( formats.discount, formatFee( discountFee.discount ) );
 		}
 
-		return createInterpolateElement( currentFeeDescription, {
+		return createInterpolateElement( currentBaseFeeDescription, {
 			s: <s />,
 		} );
 	}

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -86,17 +86,19 @@ export const getCurrentFee = (
 };
 
 export const formatMethodFeesTooltip = (
-	accountFees: FeeStructure | undefined
+	accountFees: FeeStructure
 ): JSX.Element => {
 	if ( ! accountFees ) return <></>;
+	// If there is a discount, use that instead of the base fee.
+	const currentFee = getCurrentFee( accountFees );
 
 	const total = {
 		percentage_rate:
-			accountFees.base.percentage_rate +
+			currentFee.percentage_rate +
 			accountFees.additional.percentage_rate +
 			accountFees.fx.percentage_rate,
 		fixed_rate:
-			accountFees.base.fixed_rate +
+			currentFee.fixed_rate +
 			accountFees.additional.fixed_rate +
 			accountFees.fx.fixed_rate,
 		currency: accountFees.base.currency,
@@ -110,7 +112,7 @@ export const formatMethodFeesTooltip = (
 		<div className={ 'wcpay-fees-tooltip' }>
 			<div>
 				<div>Base fee</div>
-				<div>{ getFeeDescriptionString( accountFees.base ) }</div>
+				<div>{ getFeeDescriptionString( currentFee ) }</div>
 			</div>
 			{ hasFees( accountFees.additional ) ? (
 				<div>

--- a/client/utils/test/account-fees.tsx
+++ b/client/utils/test/account-fees.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import {
 	formatAccountFeesDescription,
 	formatMethodFeesDescription,
-	getCurrentFee,
+	getCurrentBaseFee,
 } from '../account-fees';
 import { formatCurrency } from '../currency';
 import { BaseFee, DiscountFee, FeeStructure } from 'wcpay/types/fees';
@@ -59,7 +59,7 @@ const mockAccountFees = (
 };
 
 describe( 'Account fees utility functions', () => {
-	describe( 'getCurrentFee()', () => {
+	describe( 'getCurrentBaseFee()', () => {
 		it( 'returns first discount regardless of amount', () => {
 			const accountFees = mockAccountFees(
 				{
@@ -70,7 +70,7 @@ describe( 'Account fees utility functions', () => {
 				[ { discount: 0.1 }, { discount: 0.2 } ]
 			);
 
-			expect( getCurrentFee( accountFees ) ).toEqual(
+			expect( getCurrentBaseFee( accountFees ) ).toEqual(
 				accountFees.discount[ 0 ]
 			);
 		} );
@@ -81,7 +81,9 @@ describe( 'Account fees utility functions', () => {
 				fixed_rate: 456.78,
 				currency: 'USD',
 			} );
-			expect( getCurrentFee( accountFees ) ).toEqual( accountFees.base );
+			expect( getCurrentBaseFee( accountFees ) ).toEqual(
+				accountFees.base
+			);
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #5255

#### Changes proposed in this Pull Request

The PR makes the tooltips across each payment method within WC Pay settings, show the correct applicable fees. If there is a negotiated custom fee, it will show the custom fee, else it will show the standard base rate. 

#### Screenshots

<details><summary>

##### Before

 </summary>

![before](https://user-images.githubusercontent.com/4162931/208046931-cfd153a8-dfee-4703-a62e-5c1a94a3722a.jpg)

</details>
<details><summary>

##### After

</summary>

![after](https://user-images.githubusercontent.com/4162931/208046955-e5264761-da31-4d9c-9b5e-6b2f061d37f2.jpg)

</details>

#### Testing instructions

1. Assign a custom fee to the merchant account 
2. Browse to `Payments > Settings` and mouse-over the fees pill against any payment methods, as shown in the screenshot. 
3. You should see the custom rates in the tooltip popup. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) 

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
