### PR TITLE
Let code freeze workflow pass botwoo token secret to release-pr workflow

### DIFF
--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -75,8 +75,7 @@ jobs:
     uses: ./.github/workflows/release-pr.yml
     with:
       releaseVersion: ${{ needs.check-code-freeze.outputs.nextReleaseVersion }}
-    secrets:
-      BOTWOO_TOKEN: ${{ secrets.BOTWOO_TOKEN }}
+    secrets: inherit
 
   slack-notification:
     name: "Send notification to Slack"

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       skipSlackPing:
-        description: "If true, the Slack ping will be skipped"
+        description: "Skip the Slack ping"
         type: boolean
         required: false
         default: false
@@ -75,6 +75,8 @@ jobs:
     uses: ./.github/workflows/release-pr.yml
     with:
       releaseVersion: ${{ needs.check-code-freeze.outputs.nextReleaseVersion }}
+    secrets:
+      BOTWOO_TOKEN: ${{ secrets.BOTWOO_TOKEN }}
 
   slack-notification:
     name: "Send notification to Slack"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -13,10 +13,6 @@ on:
         required: false
         default: "next wednesday"
         type: string
-    secrets:
-      BOTWOO_TOKEN:
-        description: 'The botwoo token passed from the caller workflow'
-        required: true
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: "next wednesday"
         type: string
+    secrets:
+      BOTWOO_TOKEN:
+        description: 'The botwoo token passed from the caller workflow'
+        required: true
+
   workflow_dispatch:
     inputs:
       releaseVersion:

--- a/changelog/fix-release-code-freeze-workflow-secret
+++ b/changelog/fix-release-code-freeze-workflow-secret
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+

--- a/changelog/fix-release-code-freeze-workflow-secret
+++ b/changelog/fix-release-code-freeze-workflow-secret
@@ -1,4 +1,5 @@
 Significance: patch
 Type: fix
+Comment: Fix for a GitHub Actions workflow related to code freeze. Botwoo token secret needed to be passed to the nested workflow.
 
 


### PR DESCRIPTION
Fixes #5305 

#### Changes proposed in this Pull Request

- Pass the BOTWOO_TOKEN secret from the code freeze workflow to the release-pr workflow

GitHub docs for reference:
- https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-secrets-to-nested-workflows
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets

#### Testing instructions

Hard to test the code freeze workflow without temporarily altering it, because the first job `check-code-freeze` will always output that it is not the time of freeze for now.

- I altered the workflow temporarily on a branch to always call the nested workflow with the release version 7.2.6
- It successfully created a PR with `botwoo` as the author; see the run: https://github.com/Automattic/woocommerce-payments/actions/runs/3729740012

I also tested the nested workflow again directly to ensure it still works:
- it created a PR for release 7.2.7 successfully; see the run: https://github.com/Automattic/woocommerce-payments/actions/runs/3729820808

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
