### PR TITLE
Retry API requests on network failures.

### DIFF
--- a/changelog/tweak-api-retry-on-network-failure
+++ b/changelog/tweak-api-retry-on-network-failure
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Retry API requests on network failure if Idempotency-Key header is present.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2116,14 +2116,6 @@ class WC_Payments_API_Client {
 				$response      = apply_filters( 'wcpay_api_request_response', $response, $method, $url, $api );
 				$response_code = wp_remote_retrieve_response_code( $response );
 			} catch ( Connection_Exception $e ) {
-				/**
-				 * Error code 503 indicates there was no response, while 500
-				 * means there was a response and it was an error. We only want
-				 * to retry connection errors here.
-				 */
-				if ( 503 !== $e->get_http_code() ) {
-					throw $e;
-				}
 				$last_exception = $e;
 			}
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -31,8 +31,9 @@ class WC_Payments_API_Client {
 	const GET    = 'GET';
 	const DELETE = 'DELETE';
 
-	const API_TIMEOUT_SECONDS = 70;
-	const API_RETRIES_LIMIT   = 3;
+	const API_TIMEOUT_SECONDS      = 70;
+	const API_RETRIES_LIMIT        = 3;
+	const API_RETRIES_BACKOFF_MSEC = 250;
 
 	const ACCOUNTS_API                 = 'accounts';
 	const CAPABILITIES_API             = 'accounts/capabilities';
@@ -2126,6 +2127,8 @@ class WC_Payments_API_Client {
 				break;
 			}
 
+			// Use exponential backoff to not overload backend.
+			usleep( self::API_RETRIES_BACKOFF_MSEC * ( 2 ** $retries ) );
 			$retries++;
 		}
 

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -117,7 +117,7 @@ class WC_Payments_Http implements WC_Payments_Http_Interface {
 			$exception_http_code = is_array( $response )
 				? 500
 				: 503;
-			throw new Connection_Exception( $message, 'wcpay_http_request_failed', $exception_response_code );
+			throw new Connection_Exception( $message, 'wcpay_http_request_failed', $exception_http_code );
 		}
 
 		return $response;

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -114,10 +114,7 @@ class WC_Payments_Http implements WC_Payments_Http_Interface {
 				__( 'Http request failed. Reason: %1$s', 'woocommerce-payments' ),
 				$response->get_error_message()
 			);
-			$exception_http_code = is_array( $response )
-				? 500
-				: 503;
-			throw new Connection_Exception( $message, 'wcpay_http_request_failed', $exception_http_code );
+			throw new Connection_Exception( $message, 'wcpay_http_request_failed', 500 );
 		}
 
 		return $response;

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -114,7 +114,10 @@ class WC_Payments_Http implements WC_Payments_Http_Interface {
 				__( 'Http request failed. Reason: %1$s', 'woocommerce-payments' ),
 				$response->get_error_message()
 			);
-			throw new Connection_Exception( $message, 'wcpay_http_request_failed', 500 );
+			$exception_http_code = is_array( $response )
+				? 500
+				: 503;
+			throw new Connection_Exception( $message, 'wcpay_http_request_failed', $exception_response_code );
 		}
 
 		return $response;

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -2190,7 +2190,7 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 			->expects( $this->exactly( 4 ) )
 			->method( 'remote_request' )
 			->willThrowException(
-				new Connection_Exception( 'HTTP request failed', 'wcpay_http_request_failed', 503 )
+				new Connection_Exception( 'HTTP request failed', 'wcpay_http_request_failed', 500 )
 			);
 
 		$this->expectException( Connection_Exception::class );

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -6,6 +6,7 @@
  */
 
 use WCPay\Exceptions\API_Exception;
+use WCPay\Exceptions\Connection_Exception;
 use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
 use WCPay\Fraud_Prevention\Buyer_Fingerprinting_Service;
 
@@ -2167,6 +2168,55 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 					],
 				]
 			);
+
+		PHPUnit_Utils::call_method(
+			$this->payments_api_client,
+			'request',
+			[ [], 'intentions', 'POST' ]
+		);
+	}
+
+	/**
+	 * Test that API client will retry request in case of network error
+	 * indiciated by Connection_Exception.
+	 *
+	 * POST calls have `Idempotency-Key` set in the `request`, thus are
+	 * possible to retry.
+	 *
+	 * @throws Exception in case of the test failure.
+	 */
+	public function test_request_retries_post_on_network_failure_exception() {
+		$this->mock_http_client
+			->expects( $this->exactly( 4 ) )
+			->method( 'remote_request' )
+			->willThrowException(
+				new Connection_Exception( 'HTTP request failed', 'wcpay_http_request_failed', 503 )
+			);
+
+		$this->expectException( Connection_Exception::class );
+
+		PHPUnit_Utils::call_method(
+			$this->payments_api_client,
+			'request',
+			[ [], 'intentions', 'POST' ]
+		);
+	}
+
+	/**
+	 * Test that API client will not retry if connection exception indicates there
+	 * was a response.
+	 *
+	 * @throws Exception in case of the test failure.
+	 */
+	public function test_request_doesnt_retry_on_other_exceptions() {
+		$this->mock_http_client
+			->expects( $this->exactly( 1 ) )
+			->method( 'remote_request' )
+			->willThrowException(
+				new Connection_Exception( 'HTTP request failed', 'wcpay_http_request_failed', 500 )
+			);
+
+		$this->expectException( Connection_Exception::class );
 
 		PHPUnit_Utils::call_method(
 			$this->payments_api_client,

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -2213,10 +2213,10 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 			->expects( $this->exactly( 1 ) )
 			->method( 'remote_request' )
 			->willThrowException(
-				new Connection_Exception( 'HTTP request failed', 'wcpay_http_request_failed', 500 )
+				new Exception( 'Random exception' )
 			);
 
-		$this->expectException( Connection_Exception::class );
+		$this->expectException( Exception::class );
 
 		PHPUnit_Utils::call_method(
 			$this->payments_api_client,


### PR DESCRIPTION
Request is considered failed due to network reasons if response code is not set.

Fixes #5189 

#### Changes proposed in this Pull Request

API supports `Idempotency-Key` header with which POST request can be repeated and should not result in creation or repeated updated, but return last successful response instead.

API client already sets `Idempotency-Key` to a unique value for `POST` requests and for other requests it can be added with a `wcpay_api_request_headers` filter.

This PR creates a retry loop in API client which is broken on any of the following occurrences:

 - Response code is present.
 - Request doesn't have an `Idempotency-Key` header.
 - Reached number of possible retries, by default 3.
 - Request processing time is beyond the provided timeout.

#### Testing instructions

 * Covered by unit tests.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
