### PR TITLE
Revert "Fix translations in the deactivating WCPay Subscriptions warning file"

### DIFF
--- a/changelog/fix-5266-webhook-processing
+++ b/changelog/fix-5266-webhook-processing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Make the webhook processing respect the test/live mode setting for the gateway

--- a/changelog/fix-setting-default-payment-method-subscriptions
+++ b/changelog/fix-setting-default-payment-method-subscriptions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Updates subscriptions' payment token when a new default payment method is set.

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -137,10 +137,6 @@ class WC_Payments_Webhook_Processing_Service {
 			. var_export( WC_Payments_Utils::redact_array( $event_body, WC_Payments_API_Client::API_KEYS_TO_REDACT ), true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 		);
 
-		if ( $this->is_webhook_mode_mismatch( $event_body ) ) {
-			return;
-		};
-
 		try {
 			do_action( 'woocommerce_payments_before_webhook_delivery', $event_type, $event_body );
 		} catch ( Exception $e ) {
@@ -200,34 +196,6 @@ class WC_Payments_Webhook_Processing_Service {
 		} catch ( Exception $e ) {
 			Logger::error( $e );
 		}
-	}
-
-	/**
-	 * Check webhook mode against the gateway mode.
-	 *
-	 * @param array $event_body The event that triggered the webhook.
-	 *
-	 * @return bool Indicates whether the event's mode is different from the gateway's mode
-	 * @throws Invalid_Webhook_Data_Exception Event mode does not match the gateway mode.
-	 */
-	private function is_webhook_mode_mismatch( array $event_body ): bool {
-		$is_gateway_live_mode = ! $this->wcpay_gateway->is_in_test_mode();
-		$is_event_live_mode   = $this->read_webhook_property( $event_body, 'livemode' );
-
-		if ( $is_gateway_live_mode !== $is_event_live_mode ) {
-			$event_id = $this->read_webhook_property( $event_body, 'id' );
-
-			Logger::error(
-				sprintf(
-					'Webhook event mode did not match the gateway mode (event ID: %s)',
-					$event_id
-				)
-			);
-
-			return true;
-		}
-
-		return false;
 	}
 
 	/**
@@ -638,7 +606,7 @@ class WC_Payments_Webhook_Processing_Service {
 	 * @param array  $array Array to read from.
 	 * @param string $key   ID to fetch on.
 	 *
-	 * @return string|array|int|bool
+	 * @return string|array|int
 	 * @throws Invalid_Webhook_Data_Exception Thrown if ID not set.
 	 */
 	private function read_webhook_property( $array, $key ) {

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -171,9 +171,6 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 		 */
 		add_action( 'template_redirect', [ $this, 'remove_order_pay_var' ], 99 );
 		add_action( 'template_redirect', [ $this, 'restore_order_pay_var' ], 101 );
-
-		// Update subscriptions token when user sets a default payment method.
-		add_filter( 'woocommerce_subscriptions_update_subscription_token', [ $this, 'update_subscription_token' ], 10, 3 );
 	}
 
 	/**
@@ -789,28 +786,6 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 		if ( isset( $this->order_pay_var ) ) {
 			$wp->query_vars['order-pay'] = $this->order_pay_var;
 		}
-	}
-
-	/**
-	 * Update the specified subscription's payment token with a new token.
-	 *
-	 * @param bool             $updated      Whether the token was updated.
-	 * @param WC_Subscription  $subscription The subscription whose payment token need to be updated.
-	 * @param WC_Payment_Token $new_token    The new payment token to be used for the specified subscription.
-	 *
-	 * @return bool Whether this function updates the token or not.
-	 */
-	public function update_subscription_token( $updated, $subscription, $new_token ) {
-		if ( $this->id !== $new_token->get_gateway_id() ) {
-			return $updated;
-		}
-
-		$subscription->set_payment_method( $this->id );
-		$subscription->update_meta_data( '_payment_method_id', $new_token->get_token() );
-		$subscription->add_payment_token( $new_token );
-		$subscription->save();
-
-		return true;
 	}
 
 	/**

--- a/includes/subscriptions/templates/html-wcpay-deactivate-warning.php
+++ b/includes/subscriptions/templates/html-wcpay-deactivate-warning.php
@@ -20,7 +20,8 @@
 					<p>
 						<?php
 							printf(
-								// translators: $1 $2 $3 placeholders are opening and closing HTML link tags, linking to documentation. $4 $5 placeholders are opening and closing strong HTML tags.
+								// Translators: $1 $2 $3 are placeholders are opening and closing HTML link tags, linking to documentation.
+								// Translators: $4 $5 placeholders are opening and closing strong HTML tags.
 								esc_html__( 'Your store has active subscriptions using the built-in WooCommerce Payments functionality. Due to the %1$soff-site billing engine%3$s these subscriptions use, %4$sthey will continue to renew even after you deactivate WooCommerce Payments%5$s. %2$sLearn more%3$s.', 'woocommerce-payments' ),
 								'<a href="https://woocommerce.com/document/payments/subscriptions/comparison/#billing-engine">',
 								'<a href="https://woocommerce.com/document/woocommerce-payments/built-in-subscriptions/deactivate/#existing-subscriptions">',
@@ -33,7 +34,7 @@
 					</p>
 						<?php
 							printf(
-								// translators: $1 $2 placeholders are opening and closing HTML link tags, linking to documentation.
+								// Translators: $1 $2 placeholders are opening and closing HTML link tags, linking to documentation.
 								esc_html__( 'If you do not want these subscriptions to continue to be billed, you should %1$scancel all subscriptions%2$s prior to deactivating WooCommerce Payments. ', 'woocommerce-payments' ),
 								'<a href="https://woocommerce.com/document/subscriptions/store-manager-guide/#cancel-or-suspend-subscription">',
 								'</a>'

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -796,48 +796,6 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 		);
 	}
 
-	public function test_update_subscription_token_from_wcpay_to_wcpay() {
-		$subscription = WC_Helper_Order::create_order( self::USER_ID );
-		$token1       = WC_Helper_Token::create_token( self::PAYMENT_METHOD_ID, self::USER_ID );
-		$token2       = WC_Helper_Token::create_token( self::PAYMENT_METHOD_ID, self::USER_ID );
-
-		$subscription->set_payment_method( $this->wcpay_gateway->id );
-		$subscription->update_meta_data( '_payment_method_id', $token1->get_token() );
-		$subscription->add_payment_token( $token1 );
-		$subscription->save();
-
-		$updated             = $this->wcpay_gateway->update_subscription_token( false, $subscription, $token2 );
-		$subscription_tokens = $subscription->get_payment_tokens();
-
-		$this->assertSame( $token2->get_id(), end( $subscription_tokens ) );
-		$this->assertSame( $updated, true );
-		$this->assertSame( $token2->get_token(), $subscription->get_meta_data( '_payment_method_id' )[0]->get_data()['value'] );
-	}
-
-	public function test_update_subscription_token_from_non_wcpay_to_wcpay() {
-		$subscription = WC_Helper_Order::create_order( self::USER_ID );
-		$token        = WC_Helper_Token::create_token( self::PAYMENT_METHOD_ID, self::USER_ID );
-
-		$subscription->set_payment_method( 'bacs' );
-		$subscription->save();
-
-		$updated             = $this->wcpay_gateway->update_subscription_token( false, $subscription, $token );
-		$subscription_tokens = $subscription->get_payment_tokens();
-
-		$this->assertSame( $token->get_id(), end( $subscription_tokens ) );
-		$this->assertSame( $updated, true );
-	}
-
-	public function test_update_subscription_token_not_wcpay() {
-		$subscription    = WC_Helper_Order::create_order( self::USER_ID );
-		$non_wcpay_token = WC_Helper_Token::create_token( self::PAYMENT_METHOD_ID, self::USER_ID, 'not_woocommerce_payments' );
-
-		$updated             = $this->wcpay_gateway->update_subscription_token( false, $subscription, $non_wcpay_token );
-		$subscription_tokens = $subscription->get_payment_tokens();
-
-		$this->assertSame( $updated, false );
-	}
-
 	private function mock_wcs_get_subscriptions_for_order( $subscriptions ) {
 		WC_Subscriptions::set_wcs_get_subscriptions_for_order(
 			function ( $order ) use ( $subscriptions ) {

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -134,8 +134,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_noop_webhook() {
 		// Setup test request data.
-		$this->event_body['type']     = 'unknown.webhook.event';
-		$this->event_body['livemode'] = true;
+		$this->event_body['type'] = 'unknown.webhook.event';
 
 		// Run the test.
 		$result = $this->webhook_processing_service->process( $this->event_body );
@@ -157,72 +156,11 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
-	 * Test a webhook with a test event for a gateway with live mode.
-	 */
-	public function test_webhook_with_test_event_and_live_gateway() {
-		$this->event_body['type']     = 'wcpay.notification';
-		$this->event_body['id']       = 'testID';
-		$this->event_body['livemode'] = false;
-		$this->event_body['data']     = [
-			'title'   => 'test',
-			'content' => 'hello',
-		];
-
-		$this->mock_wcpay_gateway
-			->expects( $this->once() )
-			->method( 'is_in_test_mode' )
-			->willReturn( false );
-
-		$this->mock_remote_note_service
-			->expects( $this->never() )
-			->method( 'put_note' )
-			->with(
-				[
-					'title'   => 'test',
-					'content' => 'hello',
-				]
-			);
-
-		$this->webhook_processing_service->process( $this->event_body );
-	}
-
-	/**
-	 * Test a webhook with a live event for a gateway in test mode.
-	 */
-	public function test_webhook_with_live_event_and_test_gateway() {
-		$this->event_body['type']     = 'wcpay.notification';
-		$this->event_body['id']       = 'testID';
-		$this->event_body['livemode'] = true;
-		$this->event_body['data']     = [
-			'title'   => 'test',
-			'content' => 'hello',
-		];
-		$this->mock_wcpay_gateway
-			->expects( $this->once() )
-			->method( 'is_in_test_mode' )
-			->willReturn( true );
-
-		$this->mock_remote_note_service
-			->expects( $this->never() )
-			->method( 'put_note' )
-			->with(
-				[
-					'title'   => 'test',
-					'content' => 'hello',
-				]
-			);
-
-		// Run the test.
-		$this->webhook_processing_service->process( $this->event_body );
-	}
-
-	/**
 	 * Test a webhook with no object property.
 	 */
 	public function test_webhook_with_no_object_property() {
 		// Setup test request data.
-		$this->event_body['type']     = 'charge.refund.updated';
-		$this->event_body['livemode'] = true;
+		$this->event_body['type'] = 'charge.refund.updated';
 		unset( $this->event_body['data']['object'] );
 
 		$this->expectException( Invalid_Webhook_Data_Exception::class );
@@ -238,8 +176,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_webhook_with_no_data_property() {
 		// Setup test request data.
-		$this->event_body['type']     = 'charge.refund.updated';
-		$this->event_body['livemode'] = true;
+		$this->event_body['type'] = 'charge.refund.updated';
 		unset( $this->event_body['data'] );
 
 		$this->expectException( Invalid_Webhook_Data_Exception::class );
@@ -255,7 +192,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	public function test_valid_failed_refund_webhook_sets_failed_meta() {
 		// Setup test request data.
 		$this->event_body['type']           = 'charge.refund.updated';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'status'   => 'failed',
 			'charge'   => 'test_charge_id',
@@ -296,7 +232,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	public function test_valid_failed_refund_webhook_deletes_wc_refund() {
 		// Setup test request data.
 		$this->event_body['type']           = 'charge.refund.updated';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'status'   => 'failed',
 			'charge'   => 'test_charge_id',
@@ -342,7 +277,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	public function test_non_failed_refund_update_webhook_does_not_set_failed_meta() {
 		// Setup test request data.
 		$this->event_body['type']           = 'charge.refund.updated';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'status' => 'success',
 		];
@@ -367,7 +301,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	public function test_valid_failed_refund_update_webhook() {
 		// Setup test request data.
 		$this->event_body['type']           = 'charge.refund.updated';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'status'   => 'failed',
 			'charge'   => 'test_charge_id',
@@ -401,7 +334,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	public function test_valid_failed_refund_update_webhook_non_usd() {
 		// Setup test request data.
 		$this->event_body['type']           = 'charge.refund.updated';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'status'   => 'failed',
 			'charge'   => 'test_charge_id',
@@ -433,7 +365,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	public function test_valid_failed_refund_update_webhook_zero_decimal_currency() {
 		// Setup test request data.
 		$this->event_body['type']           = 'charge.refund.updated';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'status'   => 'failed',
 			'charge'   => 'test_charge_id',
@@ -465,7 +396,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	public function test_valid_failed_refund_update_webhook_with_unknown_charge_id() {
 		// Setup test request data.
 		$this->event_body['type']           = 'charge.refund.updated';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'status'   => 'failed',
 			'charge'   => 'unknown_charge_id',
@@ -493,7 +423,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	public function test_non_failed_refund_update_webhook() {
 		// Setup test request data.
 		$this->event_body['type']           = 'charge.refund.updated';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'status' => 'updated',
 			'charge' => 'test_charge_id',
@@ -514,9 +443,8 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_remote_note_puts_note() {
 		// Setup test request data.
-		$this->event_body['type']     = 'wcpay.notification';
-		$this->event_body['livemode'] = true;
-		$this->event_body['data']     = [
+		$this->event_body['type'] = 'wcpay.notification';
+		$this->event_body['data'] = [
 			'title'   => 'test',
 			'content' => 'hello',
 		];
@@ -540,9 +468,8 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_remote_note_fails_returns_expected_webhook_exception() {
 		// Setup test request data.
-		$this->event_body['type']     = 'wcpay.notification';
-		$this->event_body['livemode'] = true;
-		$this->event_body['data']     = [
+		$this->event_body['type'] = 'wcpay.notification';
+		$this->event_body['data'] = [
 			'foo' => 'bar',
 		];
 		$this->mock_remote_note_service
@@ -575,9 +502,8 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		);
 
 		// Setup test request data.
-		$this->event_body['type']     = 'wcpay.notification';
-		$this->event_body['livemode'] = true;
-		$this->event_body['data']     = [
+		$this->event_body['type'] = 'wcpay.notification';
+		$this->event_body['data'] = [
 			'title'   => 'test',
 			'content' => 'hello',
 		];
@@ -599,7 +525,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_payment_intent_successful_and_completes_order() {
 		$this->event_body['type']           = 'payment_intent.succeeded';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'id'       => $id            = 'pi_123123123123123', // payment_intent's ID.
 			'object'   => 'payment_intent',
@@ -668,7 +593,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_payment_intent_successful_and_completes_order_without_intent_id() {
 		$this->event_body['type']           = 'payment_intent.succeeded';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'id'       => $id            = 'pi_123123123123123', // payment_intent's ID.
 			'object'   => 'payment_intent',
@@ -745,7 +669,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_payment_intent_successful_when_retrying() {
 		$this->event_body['type']           = 'payment_intent.succeeded';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'id'       => $id            = 'pi_123123123123123', // payment_intent's ID.
 			'object'   => 'payment_intent',
@@ -815,7 +738,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_payment_intent_successful_and_send_card_reader_receipt() {
 		$this->event_body['type']           = 'payment_intent.succeeded';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'id'       => 'pi_123123123123123', // payment_intent's ID.
 			'object'   => 'payment_intent',
@@ -897,7 +819,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_payment_intent_successful_and_save_mandate() {
 		$this->event_body['type']           = 'payment_intent.succeeded';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'id'       => $id            = 'pi_123123123123123', // payment_intent's ID.
 			'object'   => 'payment_intent',
@@ -972,7 +893,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_payment_intent_fails_and_fails_order() {
 		$this->event_body['type']           = 'payment_intent.payment_failed';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'id'                 => 'pi_123123123123123', // Payment_intent's ID.
 			'object'             => 'payment_intent',
@@ -1054,7 +974,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_payment_intent_without_charges_fails_and_fails_order() {
 		$this->event_body['type']           = 'payment_intent.payment_failed';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'id'                 => 'pi_123123123123123', // Payment_intent's ID.
 			'object'             => 'payment_intent',
@@ -1128,7 +1047,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	public function test_dispute_created_order_note() {
 		// Setup test request data.
 		$this->event_body['type']           = 'charge.dispute.created';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'id'     => 'test_dispute_id',
 			'charge' => 'test_charge_id',
@@ -1165,7 +1083,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	public function test_dispute_closed_order_note() {
 		// Setup test request data.
 		$this->event_body['type']           = 'charge.dispute.closed';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'id'     => 'test_dispute_id',
 			'charge' => 'test_charge_id',
@@ -1202,7 +1119,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	public function test_dispute_updated_order_note() {
 		// Setup test request data.
 		$this->event_body['type']           = 'charge.dispute.updated';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'id'     => 'test_dispute_id',
 			'charge' => 'test_charge_id',
@@ -1233,7 +1149,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	public function test_dispute_funds_withdrawn_order_note() {
 		// Setup test request data.
 		$this->event_body['type']           = 'charge.dispute.funds_withdrawn';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'id'     => 'test_dispute_id',
 			'charge' => 'test_charge_id',
@@ -1264,7 +1179,6 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	public function test_dispute_funds_reinstated_order_note() {
 		// Setup test request data.
 		$this->event_body['type']           = 'charge.dispute.funds_reinstated';
-		$this->event_body['livemode']       = true;
 		$this->event_body['data']['object'] = [
 			'id'     => 'test_dispute_id',
 			'charge' => 'test_charge_id',


### PR DESCRIPTION
Reverts Automattic/woocommerce-payments#5298

After I merged these translation fixes into the release branch, I realized it contained other commit changes which weren't intended. I'm going to revert that and make sure only the translation fixes are included