### PR TITLE
Fix naming of REMOTE_PORT to more self-documented

### DIFF
--- a/changelog/dev-tweak_remote_port_arg_for_xdebug
+++ b/changelog/dev-tweak_remote_port_arg_for_xdebug
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: naming changes to Dockerfile arg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       context: .
       dockerfile: ./docker/wordpress_xdebug/Dockerfile
       args:
-        - REMOTE_PORT=9000 # IDE/Editor's listener port
+        - XDEBUG_REMOTE_PORT=9000 # IDE/Editor's listener port
     container_name: woocommerce_payments_wordpress
     image: woocommerce_payments_wordpress
     restart: always

--- a/docker/README.md
+++ b/docker/README.md
@@ -55,7 +55,7 @@ services:
   wordpress:
     build:
       args:
-        - REMOTE_PORT=9003 # IDE/Editor's listener port
+        - XDEBUG_REMOTE_PORT=9003 # IDE/Editor's listener port
 ```
 I used port `9003` as an example.
 To apply the change, restart your containers using `npm run down && npm run up`

--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -1,8 +1,8 @@
 FROM wordpress:php7.4
-ARG REMOTE_PORT
+ARG XDEBUG_REMOTE_PORT
 RUN pecl install xdebug-2.9.8 \
 	&& echo 'xdebug.remote_enable=1' >> $PHP_INI_DIR/php.ini \
-	&& echo "xdebug.remote_port=$REMOTE_PORT" >> $PHP_INI_DIR/php.ini \
+	&& echo "xdebug.remote_port=$XDEBUG_REMOTE_PORT" >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.remote_host=host.docker.internal' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.remote_autostart=0' >> $PHP_INI_DIR/php.ini \
 	&& docker-php-ext-enable xdebug


### PR DESCRIPTION
#### Description
After the release of https://github.com/Automattic/woocommerce-payments/pull/5269 I got suggestions of how to improve naming of the Dockerfile arg `REMOTE_PORT`.
See paJDYF-6Jo-p2#comment-15513.

#### Changes proposed in this Pull Request

* Changed `REMOTE_PORT` arg to `XDEBUG_REMOTE_PORT` so it's self-documented.

#### Testing instructions

- Run `npm run down` in case your containers are running
- Check out this branch
- Run `npm run up` and wait till containers are up
- Run `docker-compose exec -u www-data wordpress bash`. You'll get inside the container
- Run the next command inside the container `cat /usr/local/etc/php/php.ini`, and check that `xdebug.remote_port` has value `9000`. It's the default value.
- Create `docker.compose.override.yml` with the following contents:
```
version: '3'

services:
  wordpress:
    build:
      args:
        - XDEBUG_REMOTE_PORT=9003 # IDE/Editor's listener port
```
- Run `npm run down`, then `npm run up`.
- Go once again inside the container `docker-compose exec -u www-data wordpress bash` and execute once again `cat /usr/local/etc/php/php.ini`. Check that now the value of `xdebug.remote_port` is `9003`.
- Put some breakpoint (e.g. MultiCurrency.php), go to some page (e.g. Multi currency settings) and check that debugger works with the port you specified.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.