### PR TITLE
e2e test for setting subscriptions default payment method

### DIFF
--- a/tests/e2e/specs/wcpay/shopper/shopper-myaccount-payment-methods-set-default.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-myaccount-payment-methods-set-default.spec.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+
+const { shopper } = require( '@woocommerce/e2e-utils' );
+
+/**
+ * Internal dependencies
+ */
+import { shopperWCP } from '../../../utils/flows';
+
+import { /*RUN_SUBSCRIPTIONS_TESTS,*/ describeif } from '../../../utils';
+const { withRestApi } = require( '@woocommerce/e2e-utils' );
+import { fillCardDetails, setupCheckout } from '../../../utils/payments';
+
+const customerBilling = config.get(
+	'addresses.subscriptions-customer.billing'
+);
+const card = config.get( 'cards.basic' );
+
+const a = true;
+
+describeif( a )( 'Setting Default Payment Method', () => {
+	it( 'using a basic card', async () => {
+		await withRestApi.deleteCustomerByEmail( customerBilling.email );
+
+		await shopper.login();
+
+		// Purchase multiple subscriptions.
+		for ( let i = 0; 2 > i; i++ ) {
+			await shopperWCP.addToCartBySlug(
+				'subscription-signup-fee-product'
+			);
+			await setupCheckout( customerBilling );
+			await fillCardDetails( page, card );
+			await shopper.placeOrder();
+		}
+
+		await shopperWCP.goToPaymentMethods();
+		await shopperWCP.addNewPaymentMethod( 'basic', card );
+
+		await expect( page ).toMatchElement(
+			'.woocommerce-MyAccount-content .woocommerce-info',
+			{
+				text:
+					'Would you like to update your subscriptions to use this new payment method',
+			}
+		);
+
+		await shopperWCP.logout();
+	} );
+} );

--- a/tests/e2e/specs/wcpay/shopper/shopper-myaccount-payment-methods-set-default.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-myaccount-payment-methods-set-default.spec.js
@@ -10,7 +10,7 @@ const { shopper } = require( '@woocommerce/e2e-utils' );
  */
 import { shopperWCP } from '../../../utils/flows';
 
-import { /*RUN_SUBSCRIPTIONS_TESTS,*/ describeif } from '../../../utils';
+import { RUN_SUBSCRIPTIONS_TESTS, describeif } from '../../../utils';
 const { withRestApi } = require( '@woocommerce/e2e-utils' );
 import { fillCardDetails, setupCheckout } from '../../../utils/payments';
 
@@ -19,9 +19,7 @@ const customerBilling = config.get(
 );
 const card = config.get( 'cards.basic' );
 
-const a = true;
-
-describeif( a )( 'Setting Default Payment Method', () => {
+describeif( RUN_SUBSCRIPTIONS_TESTS )( 'Setting Default Payment Method', () => {
 	it( 'using a basic card', async () => {
 		await withRestApi.deleteCustomerByEmail( customerBilling.email );
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
