### PR TITLE
Add docs for the mode class

### DIFF
--- a/includes/core/README.md
+++ b/includes/core/README.md
@@ -1,3 +1,4 @@
 # WooCommerce Payments Core API
 
-This directory contains everything, which is used to connect WooCommerce Payments with everything, which extends it.
+This directory does and should contain the necessary code used to connect WooCommerce Payments with everything, which extends it.
+


### PR DESCRIPTION
Parially fixes https://github.com/automattic/woocommerce-payments-meta/issues/51

#### Changes proposed in this Pull Request

Add docs for the `WC_Payments::mode()` class/object.