### PR TITLE
Fix PHP Compatibility workflow

### DIFF
--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
-          tools:       composer
+          tools:       composer:2.5.0
           coverage:    none
       - run: bash bin/phpcs-compat.sh 

--- a/changelog/fix-php-compatibility-workflow
+++ b/changelog/fix-php-compatibility-workflow
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix the PHP compatibility workflow temporarily by pinning composer to 2.5.0
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Pin composer to 2.5.0 for php compatibility workflow

As mentioned in p1671787204927939/1671784565.257749-slack-C04D1QU76PK, it seems that the 2.5.1 version released for the composer causes an issue.
For now, we will pin version 2.5.0 to let the workflow run properly.

#### Testing instructions

* The PHP compatibility workflow should run fine on this PR (it does: https://github.com/Automattic/woocommerce-payments/actions/runs/3764648097)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.