### PR TITLE
Bump  WC versions for 5.3.0 release

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -4,7 +4,7 @@ on:
   pull_request
 
 env:
-  WC_L2_VERSION: '7.0.1'
+  WC_L2_VERSION: '7.1.0'
   WP_L2_VERSION: '5.9'
 
 jobs:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -4,7 +4,7 @@ on:
   pull_request
 
 env:
-  WC_L2_VERSION: '7.1.0'
+  WC_L2_VERSION: '7.1.1'
   WP_L2_VERSION: '5.9'
 
 jobs:
@@ -20,7 +20,7 @@ jobs:
           WC_VERSIONS=$( echo "[\"$WC_L2_VERSION\", \"latest\", \"beta\"]" )
           MATRIX_INCLUDE=$( echo "[{\"woocommerce\":\"$WC_L2_VERSION\",\"wordpress\":\"$WP_L2_VERSION\",\"gutenberg\":\"13.6.0\",\"php\":\"7.2\"}]" )
           echo "matrix={\"woocommerce\":$WC_VERSIONS,\"wordpress\":[\"latest\"],\"gutenberg\":[\"latest\"],\"php\":[\"7.4\"], \"include\":$MATRIX_INCLUDE}" >> $GITHUB_OUTPUT
-  
+
   woocommerce-compatibility:
     name: "WC compatibility"
     needs: generate-matrix

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -23,7 +23,7 @@ env:
   E2E_SLACK_TOKEN:       ${{ secrets.E2E_SLACK_TOKEN }}
   E2E_USE_LOCAL_SERVER:  false
   E2E_RESULT_FILEPATH:   'tests/e2e/results.json'
-  WC_L2_VERSION: '7.1.0'
+  WC_L2_VERSION: '7.1.1'
 
 
 jobs:
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast:     false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
-    
+
     name: WC - ${{ matrix.woocommerce }} | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 
     env:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -23,7 +23,7 @@ env:
   E2E_SLACK_TOKEN:       ${{ secrets.E2E_SLACK_TOKEN }}
   E2E_USE_LOCAL_SERVER:  false
   E2E_RESULT_FILEPATH:   'tests/e2e/results.json'
-  WC_L2_VERSION: '7.0.1'
+  WC_L2_VERSION: '7.1.0'
 
 
 jobs:

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   WP_VERSION:        latest
-  WC_L2_VERSION: '7.1.0'  # the min supported version as per L-2 policy
+  WC_L2_VERSION: '7.1.1'  # the min supported version as per L-2 policy
   GUTENBERG_VERSION: latest
 
 jobs:

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   WP_VERSION:        latest
-  WC_L2_VERSION: '7.0.1'  # the min supported version as per L-2 policy
+  WC_L2_VERSION: '7.1.0'  # the min supported version as per L-2 policy
   GUTENBERG_VERSION: latest
 
 jobs:

--- a/changelog/dev-bump-versions-5.3.0
+++ b/changelog/dev-bump-versions-5.3.0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Bump minimum required version of WooCommerce to 7.1.1.

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ Our global support team is available to answer questions you may have about WooC
 = Requirements =
 
 * WordPress 5.9 or newer.
-* WooCommerce 7.0 or newer.
+* WooCommerce 7.1 or newer.
 * PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
 
 = Try it now =

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,8 +8,8 @@
  * Woo: 5278104:bf3cf30871604e15eec560c962593c1f
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
- * WC requires at least: 7.0
- * WC tested up to: 7.2.0
+ * WC requires at least: 7.1
+ * WC tested up to: 7.3.0
  * Requires at least: 5.9
  * Requires PHP: 7.0
  * Version: 5.2.0


### PR DESCRIPTION
Bump WC/WP versions according to the L-2 policy (see 7bje6-p2 and https://wordpress.org/news/category/releases/).

WC 7.3.0 is scheduled for release on Jan 10th according to 7bje6-p2.