### PR TITLE
Use the correct key for blocks payment method registration

### DIFF
--- a/client/checkout/blocks/upe-fields.js
+++ b/client/checkout/blocks/upe-fields.js
@@ -72,6 +72,7 @@ const WCPayUPEFields = ( {
 	},
 	emitResponse,
 	paymentMethodId,
+	upeMethods,
 	paymentIntentId,
 	paymentIntentSecret,
 	errorMessage,
@@ -92,7 +93,7 @@ const WCPayUPEFields = ( {
 	const testingInstructionsIfAppropriate = isTestMode
 		? testingInstructions
 		: '';
-	const gatewayConfig = getPaymentMethods()[ paymentMethodId ];
+	const gatewayConfig = getPaymentMethods()[ upeMethods[ paymentMethodId ] ];
 	const customerData = useCustomerData();
 
 	useEffect( () => {
@@ -206,7 +207,7 @@ const WCPayUPEFields = ( {
 	useEffect(
 		() =>
 			onPaymentProcessing( () => {
-				if ( paymentMethodId !== activePaymentMethod ) {
+				if ( upeMethods[ paymentMethodId ] !== activePaymentMethod ) {
 					return;
 				}
 

--- a/client/checkout/blocks/upe.js
+++ b/client/checkout/blocks/upe.js
@@ -64,10 +64,11 @@ const api = new WCPayAPI(
 
 Object.entries( enabledPaymentMethodsConfig ).map( ( [ upeName, upeConfig ] ) =>
 	registerPaymentMethod( {
-		name: upeName,
+		name: upeMethods[ upeName ],
 		content: (
 			<WCPayUPEFields
 				paymentMethodId={ upeName }
+				upeMethods={ upeMethods }
 				api={ api }
 				testingInstructions={ upeConfig.testingInstructions }
 			/>
@@ -75,6 +76,7 @@ Object.entries( enabledPaymentMethodsConfig ).map( ( [ upeName, upeConfig ] ) =>
 		edit: (
 			<WCPayUPEFields
 				paymentMethodId={ upeName }
+				upeMethods={ upeMethods }
 				api={ api }
 				testingInstructions={ upeConfig.testingInstructions }
 			/>


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5261

#### Changes proposed in this Pull Request

There are two types of payment method ID in our system. I'll use SEPA for demonstration purposes. 
1. `sepa_debit`
2. `woocommerce_payments_sepa_debit` 

The first one is the Stripe payment method type ID. It should be used when e.g., we create a payment intent. The second one is the internal WCPay payment method ID.

The problem this PR fixes is that we used Stripe payment method type ID (`sepa_debit`) in the places where the WCPay payment method ID (`woocommerce_payments_sepa_debit`) was needed. Effectively, [the payment method was not found](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/assets/js/base/context/providers/cart-checkout/checkout-processor.ts#L116-L122) by the WooCommerce Blocks implementation and we were seeing the `No payment method provided ` error on the UI.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
1. Pay with a saved SEPA payment method in Blocks checkout and confirm there are no errors 
2. Pay with a new SEPA payment method in Blocks checkout and confirm there are no errors

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
