### PR TITLE
Add `wp-i18n` as one of UPE script's dependencies.

### DIFF
--- a/changelog/fix-5347-undefined-i18n-upe
+++ b/changelog/fix-5347-undefined-i18n-upe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+UPE not loading on checkout page due to undefined i18n.

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -138,7 +138,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			true
 		);
 
-		$script_dependencies = [ 'stripe', 'wc-checkout' ];
+		$script_dependencies = [ 'stripe', 'wc-checkout', 'wp-i18n' ];
 
 		if ( $this->supports( 'tokenization' ) ) {
 			$script_dependencies[] = 'woocommerce-tokenization-form';


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5347

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Add `wp-i18n` as one of UPE script's dependencies.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a clean site. I use JN site.
2. Install WCPay and WCPay Dev.
3. Check `Enable UPE checkout` and `Add UPE additional payment methods` on WCPay Dev.
4. Create a product.
5. Add to cart that product.
6. Go to checkout page.
7. Refresh the page couple of times and make sure you see the error on base branch but not on head branch.
8. Also, compare HTML source of the checkout page and see that `<script id='wcpay-upe-checkout-js-extra'>` block comes after `i18n.min.js` load in head branch but it comes before i18n on base branch.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
