### PR TITLE
Pin setup repo composer version

### DIFF
--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -25,5 +25,5 @@ runs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ inputs.php-version }}
-        tools: composer
+        tools: composer:2.5.0
         coverage: none

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
-          tools:       composer
+          tools:       composer:2.5.0
           coverage:    none
       - run: bash bin/phpcs-compat.sh 

--- a/changelog/fix-php-compatibility-workflow
+++ b/changelog/fix-php-compatibility-workflow
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix the PHP compatibility workflow temporarily by pinning composer to 2.5.0
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Context: p1672382544388589/1672371392.316989-slack-CGGCLBN58

Since composer 2.5.1 is not compatible with PHP 7.0, we're pinning composer 2.5.0 for:
- [phpcs workflow](https://github.com/Automattic/woocommerce-payments/blob/521ca129a9dee6ebb6a85df0dbaf679c1a479964/.github/workflows/php-compatibility.yml#L16) cherry-picked from https://github.com/Automattic/woocommerce-payments/pull/5332, and
- [build zip file](https://github.com/Automattic/woocommerce-payments/blob/521ca129a9dee6ebb6a85df0dbaf679c1a479964/.github/workflows/build-zip-file.yml) that uses [setup-repo](https://github.com/Automattic/woocommerce-payments/blob/521ca129a9dee6ebb6a85df0dbaf679c1a479964/.github/actions/setup-repo/action.yml#L28).

#### Testing instructions

* Make sure all GitHub checks are green.
* [Build zip file workflow](https://github.com/Automattic/woocommerce-payments/actions/workflows/build-zip-file.yml) on this PR's head branch should produce a zip file whose `vendor/composer/ClassLoader.php` does not have `private static function initializeIncludeClosure(): void` in it.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

TODO: mention this change in https://github.com/Automattic/woocommerce-payments/issues/5333, so when the problem has been fixed in newer version of composer, we can remove the version pinning.

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.