### PR TITLE
Revert release 5.2.1.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,5 @@
 *** WooCommerce Payments Changelog ***
 
-= 5.2.1 - 2022-12-30 =
-* Fix - UPE not loading on checkout page due to undefined i18n.
-
 = 5.2.0 - 2022-12-21 =
 * Add - Add WooPay Express Checkout button iframe functionality.
 * Add - When deactivating WCPay plugin, warn merchant that active WCPay Subscriptions will continue collecting payment.

--- a/changelog/fix-5197-required-checks-not-triggered-for-pr-created-by-workflow
+++ b/changelog/fix-5197-required-checks-not-triggered-for-pr-created-by-workflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+PR created by the code freeze workflow is now done by botwoo to allow PR checks to be triggered

--- a/changelog/fix-5347-undefined-i18n-upe
+++ b/changelog/fix-5347-undefined-i18n-upe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+UPE not loading on checkout page due to undefined i18n.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "woocommerce-payments",
-  "version": "5.2.1",
+  "version": "5.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "woocommerce-payments",
-      "version": "5.2.1",
+      "version": "5.2.0",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-payments",
-  "version": "5.2.1",
+  "version": "5.2.0",
   "main": "webpack.config.js",
   "author": "Automattic",
   "license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: payment gateway, payment, apple pay, credit card, google pay
 Requires at least: 5.9
 Tested up to: 6.1
 Requires PHP: 7.0
-Stable tag: 5.2.1
+Stable tag: 5.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -97,9 +97,6 @@ Please note that our support for the checkout block is still experimental and th
 4. Manage Disputes
 
 == Changelog ==
-
-= 5.2.1 - 2022-12-30 =
-* Fix - UPE not loading on checkout page due to undefined i18n.
 
 = 5.2.0 - 2022-12-21 =
 * Add - Add WooPay Express Checkout button iframe functionality.

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -12,7 +12,7 @@
  * WC tested up to: 7.2.0
  * Requires at least: 5.9
  * Requires PHP: 7.0
- * Version: 5.2.1
+ * Version: 5.2.0
  *
  * @package WooCommerce\Payments
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Revert https://github.com/Automattic/woocommerce-payments/pull/5349 as I merged it too soon.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
