### PR TITLE
Retry server redirection responses

### DIFF
--- a/changelog/fix-wcpay-server-api-redirects
+++ b/changelog/fix-wcpay-server-api-redirects
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Retry API requests in case the server responds with the redirection response due to a Cron job.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -651,9 +651,11 @@ class WC_Payments {
 	public static function create_api_client() {
 		require_once __DIR__ . '/wc-payment-api/models/class-wc-payments-api-charge.php';
 		require_once __DIR__ . '/wc-payment-api/models/class-wc-payments-api-intention.php';
+		require_once __DIR__ . '/wc-payment-api/class-wc-payments-api-utils.php';
 		require_once __DIR__ . '/wc-payment-api/class-wc-payments-api-client.php';
 
-		$http_class = self::get_wc_payments_http();
+		$http_class      = self::get_wc_payments_http();
+		$api_utils_class = new WC_Payments_Api_Utils();
 
 		$api_client_class = apply_filters( 'wc_payments_api_client', WC_Payments_API_Client::class );
 		if ( ! class_exists( $api_client_class ) || ! is_subclass_of( $api_client_class, 'WC_Payments_API_Client' ) ) {
@@ -663,7 +665,8 @@ class WC_Payments {
 		return new $api_client_class(
 			'WooCommerce Payments/' . WCPAY_VERSION_NUMBER,
 			$http_class,
-			self::$db_helper
+			self::$db_helper,
+			$api_utils_class
 		);
 	}
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2107,6 +2107,7 @@ class WC_Payments_API_Client {
 		while ( true ) {
 			$response_code  = null;
 			$last_exception = null;
+			$response       = null;
 
 			try {
 				$response = $this->http_client->remote_request(
@@ -2135,7 +2136,7 @@ class WC_Payments_API_Client {
 				break;
 			}
 
-			$url = $this->prepare_url_for_retry( $response_code, $url );
+			$url = $this->prepare_url_for_retry( $response, $url );
 
 			// Use exponential backoff to not overload backend.
 			usleep( self::API_RETRIES_BACKOFF_MSEC * ( 2 ** $retries ) );
@@ -2169,7 +2170,7 @@ class WC_Payments_API_Client {
 	private function prepare_url_for_retry( $response, $url ) {
 		$response_code = wp_remote_retrieve_response_code( $response );
 
-		// If the redirect occurs because of the wp cron job, we just need to retry the existing request and avoid updating it for the sake of simplicity.
+		// If the redirect occurs because of the wp cron job, we need to retry the request with existing URL and avoid updating it for the sake of simplicity.
 		if ( 302 === $response_code && $this->api_utils->is_doing_wp_cron_query_parameter_present( $response ) ) {
 			return $url;
 		}

--- a/includes/wc-payment-api/class-wc-payments-api-utils.php
+++ b/includes/wc-payment-api/class-wc-payments-api-utils.php
@@ -29,17 +29,6 @@ class WC_Payments_Api_Utils {
 	 * @return bool - True if there is the doing_wp_cron query parameter attached to the redirect URL. False otherwise.
 	 */
 	public function is_doing_wp_cron_query_parameter_present( $response ) {
-		return str_contains( $this->get_location_header( $response ), 'doing_wp_cron' );
-	}
-
-	/**
-	 * Gets the Location header from a response.
-	 *
-	 * @param array $response - Response which is used to get the Location header from.
-	 *
-	 * @return string - Location URL which is attached to define the new target URL.
-	 */
-	private function get_location_header( $response ) {
-		return $response['headers']->getAll()['location'];
+		return str_contains( $response['headers']['location'], 'doing_wp_cron' );
 	}
 }

--- a/includes/wc-payment-api/class-wc-payments-api-utils.php
+++ b/includes/wc-payment-api/class-wc-payments-api-utils.php
@@ -29,6 +29,6 @@ class WC_Payments_Api_Utils {
 	 * @return bool - True if there is the doing_wp_cron query parameter attached to the redirect URL. False otherwise.
 	 */
 	public function is_doing_wp_cron_query_parameter_present( $response ) {
-		return str_contains( $response['headers']['location'], 'doing_wp_cron' );
+		return isset( $response['headers']['location'] ) && str_contains( $response['headers']['location'], 'doing_wp_cron' );
 	}
 }

--- a/includes/wc-payment-api/class-wc-payments-api-utils.php
+++ b/includes/wc-payment-api/class-wc-payments-api-utils.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * WC_Payments_Api_Utils class
+ *
+ * @package WooCommerce\Payments
+ */
+
+/**
+ * Helper class to perform operations on a response.
+ */
+class WC_Payments_Api_Utils {
+
+	const HTTP_CODES_TO_RETRY = [ 302 ];
+
+	/**
+	 * Checks if the response code is present and doesn't need a retry.
+	 *
+	 * @param int $response_code - HTTP response code.
+	 * @return bool - True if there is no response code or the response code requires a retry. False otherwise.
+	 */
+	public function is_response_code_present_and_does_not_need_a_retry( $response_code ) {
+		return $response_code && ! in_array( $response_code, self::HTTP_CODES_TO_RETRY, true );
+	}
+
+	/**
+	 * Checks if the Location header contains WP Cron related query parameter.
+	 *
+	 * @param array $response - A presumably redirection response which is used to ensure, if the redirection occurred due to the WP Cron task.
+	 * @return bool - True if there is the doing_wp_cron query parameter attached to the redirect URL. False otherwise.
+	 */
+	public function is_doing_wp_cron_query_parameter_present( $response ) {
+		return str_contains( $this->get_location_header( $response ), 'doing_wp_cron' );
+	}
+
+	/**
+	 * Gets the Location header from a response.
+	 *
+	 * @param array $response - Response which is used to get the Location header from.
+	 *
+	 * @return string - Location URL which is attached to define the new target URL.
+	 */
+	private function get_location_header( $response ) {
+		return $response['headers']->getAll()['location'];
+	}
+}

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -2326,6 +2326,11 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 			->method( 'remote_request' )
 			->willReturn(
 				[
+					'headers'  => new Requests_Utility_CaseInsensitiveDictionary(
+						[
+							'location' => 'new_url',
+						]
+					),
 					'body'     => wp_json_encode( [ 'result' => 'error' ] ),
 					'response' => [
 						'code'    => 302,
@@ -2369,7 +2374,7 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 	 *
 	 * @throws Exception in case of the test failure.
 	 */
-	public function test_get_request_doesnt_retry_with_non_retryable_response_code() {
+	public function test_request_doesnt_retry_get_with_non_retryable_response_code() {
 		$this->mock_http_client
 			->expects( $this->exactly( 1 ) )
 			->method( 'remote_request' )
@@ -2377,11 +2382,13 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 				[
 					'body'     => wp_json_encode( [ 'result' => 'error' ] ),
 					'response' => [
-						'code'    => 300,
-						'message' => 'Multiple Choices',
+						'code'    => 404,
+						'message' => 'Not Found',
 					],
 				]
 			);
+
+		$this->expectException( Exception::class );
 
 		PHPUnit_Utils::call_method(
 			$this->payments_api_client,

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-utils.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-utils.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Class WC_Payments_API_Utils_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * WC_Payments_API_Utils unit tests.
+ */
+class WC_Payments_API_Utils_Test extends WCPAY_UnitTestCase {
+	/**
+	 * Unit under test
+	 *
+	 * @var WC_Payments_Api_Utils
+	 */
+	private $payments_api_utils;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->payments_api_utils = new WC_Payments_Api_Utils();
+	}
+
+	public function test_redirect_needs_a_retry() {
+		$this->assertFalse( $this->payments_api_utils->is_response_code_present_and_does_not_need_a_retry( 302 ) );
+	}
+
+	public function test_network_error_needs_a_retry() {
+		$this->assertFalse( $this->payments_api_utils->is_response_code_present_and_does_not_need_a_retry( 0 ) );
+	}
+
+	public function test_not_found_needs_no_retry() {
+		$this->assertTrue( $this->payments_api_utils->is_response_code_present_and_does_not_need_a_retry( 404 ) );
+	}
+
+	public function test_doing_wp_cron_query_parameter_present_in_location_header() {
+		$this->assertTrue( $this->payments_api_utils->is_doing_wp_cron_query_parameter_present( $this->get_response( true ) ) );
+	}
+
+	public function test_doing_wp_cron_query_parameter_not_present_in_location_header() {
+		$this->assertFalse( $this->payments_api_utils->is_doing_wp_cron_query_parameter_present( $this->get_response( false ) ) );
+	}
+
+	private function get_response( $doing_wp_cron ) {
+		$url                     = '/wp-json/wpcom/v2/sites/test_site/wcpay/payment_methods?test_mode=1&customer=test_customer&type=card&limit=100';
+		$doing_wp_cron_parameter = '&doing_wp_cron=1672335550.5365691184997558593750';
+
+		$url = $doing_wp_cron ? $url . $doing_wp_cron_parameter : $url;
+
+		return [
+			'headers'  => new Requests_Utility_CaseInsensitiveDictionary(
+				[
+					'location' => $url,
+				]
+			),
+			'body'     => wp_json_encode( [ 'url' => false ] ),
+			'response' => [
+				'code'    => 302,
+				'message' => 'Found',
+			],
+		];
+	}
+}

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-utils.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-utils.php
@@ -38,11 +38,13 @@ class WC_Payments_API_Utils_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_doing_wp_cron_query_parameter_present_in_location_header() {
-		$this->assertTrue( $this->payments_api_utils->is_doing_wp_cron_query_parameter_present( $this->get_response( true ) ) );
+		$with_wp_cron_param = true;
+		$this->assertTrue( $this->payments_api_utils->is_doing_wp_cron_query_parameter_present( $this->get_response( $with_wp_cron_param ) ) );
 	}
 
 	public function test_doing_wp_cron_query_parameter_not_present_in_location_header() {
-		$this->assertFalse( $this->payments_api_utils->is_doing_wp_cron_query_parameter_present( $this->get_response( false ) ) );
+		$with_wp_cron_param = false;
+		$this->assertFalse( $this->payments_api_utils->is_doing_wp_cron_query_parameter_present( $this->get_response( $with_wp_cron_param ) ) );
 	}
 
 	private function get_response( $doing_wp_cron ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5115

#### What actually is the issue we try to address
WCPay client does not handle server redirection responses which are redirections because of the `doing_wp_cron` query parameter attached to the URL. There is a list of Cron Events in the WCPay Server (`WP Admin` -> `Tools` -> `Cron Events`) that are executed per the schedule on the local environment. 

After a particular Cron Event is run, the first request to the server always results in an `HTTP 302 Found` response with the empty body and the `Location` key-value pair provided in the header's array. Before this PR, our client code implementation assumed that the `body` part of the request is always non-empty and thus failed [here](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payments-customer-service.php#L223) while trying to get `data` value from the empty string.

<details>
  <summary>Please see what the error looks like from the UI perspective.</summary>


<img width="1090" alt="image" src="https://user-images.githubusercontent.com/22319444/210233294-06830cb4-c1a5-432f-846e-162ad38c3ccf.png">



</details>



#### Changes proposed in this Pull Request
This PR: 
1. Improves the resilience of the WCPay client, which now retries the aforementioned `HTTP 302` server responses and thus fixes the error described in https://github.com/Automattic/woocommerce-payments/issues/5115.
2. Slightly modifies the implementation from https://github.com/Automattic/woocommerce-payments/pull/5309, which now allows the retry mechanism to be applied not only for requests with `Idempotency-Key` header but also for `GET`/`DELETE` requests, which [are idempotent by their nature](https://stripe.com/docs/api/idempotent_requests#:~:text=Sending%20idempotency%20keys%20in%20GET%20and%20DELETE%20requests%20has%20no%20effect%20and%20should%20be%20avoided%2C%20as%20these%20requests%20are%20idempotent%20by%20definition.).

#### Testing instructions
1. Checkout to the latest `develop` without the changes from this PR.
2. Comment out [these lines](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payments-customer-service.php#L215-L220) to avoid fetching payment methods from the db cache. With this prep step, we ensure that each request will eventually hit the server and thus allow us to reproduce the issue and test the fix properly.
3. On the merchant site, go to `My account` -> `Payment methods` and make sure you see the list of payment methods without any errors. 
4. Go to the server's admin panel (`http://localhost:8086/wp-admin/`) and then to `Tools` -> `Cron Events`.
5. Take any hook from the list and click `Edit`.
6. In the `Next Run` section, choose the time in the near future when you would like the event to be run. Let's say you set it to `13:15:00`.
8. Wait until `13:15:00` and refresh the `Payment methods` page after `13:15:00` as the first request on the merchant site. 
9. Confirm that you see the error `Warning: Illegal string offset 'data' in /var/www/html/wp-content/plugins/woocommerce-payments/includes/class-wc-payments-customer-service.php on line 223`
10. Checkout to `fix/wcpay-server-api-redirects`, perform steps 2-8 once again on that branch and confirm that there's no error anymore.
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
