### PR TITLE
Allow Get_Charge to handle py_ objects.

### DIFF
--- a/changelog/fix-5341-py-charges
+++ b/changelog/fix-5341-py-charges
@@ -1,5 +1,5 @@
 Significance: patch
 Type: dev
-Comment: Will be released with another PR.
+Comment: This PR fixes a bug from the unreleased https://github.com/Automattic/woocommerce-payments/pull/5321. There is no external changelog needed, as the bug was never released.
 
 

--- a/changelog/fix-5341-py-charges
+++ b/changelog/fix-5341-py-charges
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Will be released with another PR.
+
+

--- a/includes/core/server/request/class-get-charge.php
+++ b/includes/core/server/request/class-get-charge.php
@@ -24,7 +24,11 @@ class Get_Charge extends Request {
 	 * @throws Invalid_Request_Parameter_Exception
 	 */
 	protected function set_id( string $id ) {
-		$this->validate_stripe_id( $id, [ 'ch' ] );
+		/**
+		 * `py_XYZ` objects are identical to charges, and sometimes occur
+		 * whenever the payment was made in a non-deposit currency.
+		 */
+		$this->validate_stripe_id( $id, [ 'ch', 'py' ] );
 		$this->id = $id;
 	}
 

--- a/tests/unit/core/server/request/test-class-core-get-charge-request.php
+++ b/tests/unit/core/server/request/test-class-core-get-charge-request.php
@@ -57,7 +57,7 @@ class Get_Charge_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_charge_request_class_is_created() {
-		new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client, 'ch_mock' );
+		$request = new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client, 'ch_mock' );
 		$this->assertSame( WC_Payments_API_Client::CHARGES_API . '/ch_mock', $request->get_api() );
 	}
 }

--- a/tests/unit/core/server/request/test-class-core-get-charge-request.php
+++ b/tests/unit/core/server/request/test-class-core-get-charge-request.php
@@ -53,7 +53,7 @@ class Get_Charge_Test extends WCPAY_UnitTestCase {
 
 	public function test_py_prefix_will_not_throw_exception() {
 		new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client, 'py_xyz' );
-		$this->expectNotToPerformAssertions(); // We're not asserting anything, just not expecting an exception.
+		$this->addToAssertionCount( 1 ); // We're not asserting anything, just not expecting an exception.
 	}
 
 	public function test_charge_request_class_is_created() {

--- a/tests/unit/core/server/request/test-class-core-get-charge-request.php
+++ b/tests/unit/core/server/request/test-class-core-get-charge-request.php
@@ -43,14 +43,21 @@ class Get_Charge_Test extends WCPAY_UnitTestCase {
 	public function test_exception_will_throw_if_charge_id_is_not_set() {
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
 
-		$request = new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client, null );
+		new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client, null );
 	}
+
 	public function test_exception_will_throw_if_charge_id_is_invalid() {
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
-		$request = new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client, '1' );
+		new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client, '1' );
 	}
+
+	public function test_py_prefix_will_not_throw_exception() {
+		new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client, 'py_xyz' );
+		$this->addToAssertionCount( 1 ); // We're not asserting anything, just not expecting an exception.
+	}
+
 	public function test_charge_request_class_is_created() {
-		$request = new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client, 'ch_mock' );
+		new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client, 'ch_mock' );
 		$this->assertSame( WC_Payments_API_Client::CHARGES_API . '/ch_mock', $request->get_api() );
 	}
 }

--- a/tests/unit/core/server/request/test-class-core-get-charge-request.php
+++ b/tests/unit/core/server/request/test-class-core-get-charge-request.php
@@ -53,7 +53,7 @@ class Get_Charge_Test extends WCPAY_UnitTestCase {
 
 	public function test_py_prefix_will_not_throw_exception() {
 		new Get_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client, 'py_xyz' );
-		$this->addToAssertionCount( 1 ); // We're not asserting anything, just not expecting an exception.
+		$this->expectNotToPerformAssertions(); // We're not asserting anything, just not expecting an exception.
 	}
 
 	public function test_charge_request_class_is_created() {


### PR DESCRIPTION
Fixes #5341

#### Changes proposed in this Pull Request

Allow `py_XXXXXX` identifiers to be used to retrieve charges.

#### Testing instructions

Same testing instructions as [the issue](https://github.com/Automattic/woocommerce-payments/issues/5341). 

The highlight (I missed it initially):

- `py_` objects [can be treated identically to charges](https://stackoverflow.com/questions/71347993/where-is-paymentpy-api-doc-in-stripe).
- To force the creation of a `py_` charge, you need:
    - A Stripe account with a default currency (as set in the Stripe dashboard) different from the payment method. `USD` is a good one to use.
    - A payment method, which uses a currency without an associated account, ex. P24.

Whenever a P24 payment is made, the funds need to be converted to a currency, which can be deposited. If the only available deposit currency is USD, then this will happen.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)