### PR TITLE
Prevent immutable server response wearnings

### DIFF
--- a/changelog/fix-5343-immutable-server-response
+++ b/changelog/fix-5343-immutable-server-response
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This will be released with Platform Phase 1.
+
+

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2618,12 +2618,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			}
 
 			$setup_intent = $this->create_and_confirm_setup_intent();
+			$setup_intent = $setup_intent->to_array(); // No longer working with a server response object.
 
 			if ( $setup_intent['client_secret'] ) {
 				$setup_intent['client_secret'] = WC_Payments_Utils::encrypt_client_secret( $this->account->get_stripe_account_id(), $setup_intent['client_secret'] );
 			}
 
-			wp_send_json_success( $setup_intent->to_array(), 200 );
+			wp_send_json_success( $setup_intent, 200 );
 		} catch ( Exception $e ) {
 			// Send back error so it can be displayed to the customer.
 			wp_send_json_error(


### PR DESCRIPTION
Fixes #5343.

#### Changes proposed in this Pull Request

Convert the server response object to an array early in `WC_Payment_Gateway_WCPay::create_setup_intent_ajax()` to prevent exceptions when trying to modify it.

#### Testing instructions

Clearly described in the issue.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)