### PR TITLE
Update Business Details task needs more context

### DIFF
--- a/changelog/add-5069-update-business-details-task
+++ b/changelog/add-5069-update-business-details-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+More context to the business details to show the actual message from Stripe, shows a modal if there is more than one error from Stripe.

--- a/client/card-readers/list/list-item.tsx
+++ b/client/card-readers/list/list-item.tsx
@@ -14,8 +14,8 @@ const CardReaderListItem: React.FunctionComponent< {
 	const { id, device_type: deviceType, is_active: isActive } = reader;
 
 	const status = isActive
-		? __( 'Active', 'woocomerce-payments' )
-		: __( 'Inactive', 'woocomerce-payments' );
+		? __( 'Active', 'woocommerce-payments' )
+		: __( 'Inactive', 'woocommerce-payments' );
 
 	return (
 		<li className={ classNames( 'card-readers-item', id ) }>

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -27,8 +27,8 @@ declare const wcpaySettings: {
 		pastDue?: boolean;
 		accountLink: string;
 		hasSubmittedVatData?: boolean;
-		requirements: {
-			errors: Array< RequirementError >;
+		requirements?: {
+			errors?: Array< RequirementError >;
 		};
 	};
 	accountLoans: {

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -1,3 +1,9 @@
+declare interface RequirementError {
+	code: string;
+	reason: string;
+	requirement: string;
+}
+
 declare const wcpaySettings: {
 	connectUrl: string;
 	isSubscriptionsActive: boolean;
@@ -10,10 +16,21 @@ declare const wcpaySettings: {
 	isJetpackConnected: boolean;
 	isJetpackIdcActive: boolean;
 	accountStatus: {
+		email?: string;
 		error?: boolean;
 		status?: string;
 		country?: string;
+		paymentsEnabled?: boolean;
+		deposits?: Array< any >;
+		depositsStatus?: string;
+		currentDeadline?: bigint;
+		pastDue?: boolean;
+		accountLink: string;
 		hasSubmittedVatData?: boolean;
+		requirements?: {
+			currentlyDue?: Array< string >;
+			errors?: Array< RequirementError >;
+		};
 	};
 	accountLoans: {
 		has_active_loan: boolean;

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -27,9 +27,8 @@ declare const wcpaySettings: {
 		pastDue?: boolean;
 		accountLink: string;
 		hasSubmittedVatData?: boolean;
-		requirements?: {
-			currentlyDue?: Array< string >;
-			errors?: Array< RequirementError >;
+		requirements: {
+			errors: Array< RequirementError >;
 		};
 	};
 	accountLoans: {

--- a/client/overview/modal/update-business-details/index.scss
+++ b/client/overview/modal/update-business-details/index.scss
@@ -9,7 +9,6 @@
 
 	.components-notice {
 		margin: $gap 0 0;
-		padding: $gap-small $gap-small 0;
 	}
 
 	hr {

--- a/client/overview/modal/update-business-details/index.scss
+++ b/client/overview/modal/update-business-details/index.scss
@@ -1,0 +1,3 @@
+.wcpay-update-business-details-modal__footer {
+	font-size: 12px;
+}

--- a/client/overview/modal/update-business-details/index.scss
+++ b/client/overview/modal/update-business-details/index.scss
@@ -1,3 +1,23 @@
-.wcpay-update-business-details-modal__footer {
-	font-size: 12px;
+.wcpay-update-business-details-modal {
+	max-width: 700px !important;
+
+	&.components-modal__frame {
+		@media ( max-width: 600px ) {
+			max-width: 700px;
+		}
+	}
+
+	.components-notice {
+		margin: $gap 0 0;
+		padding: $gap-small $gap-small 0;
+	}
+
+	hr {
+		margin: $gap-large -32px 0;
+	}
+
+	.wcpay-update-business-details-modal__footer {
+		@include modal-footer-buttons;
+		margin-top: $gap-large;
+	}
 }

--- a/client/overview/modal/update-business-details/index.tsx
+++ b/client/overview/modal/update-business-details/index.tsx
@@ -51,17 +51,28 @@ const UpdateBusinessDetailsModal = ( {
 						<div className="wcpay-update-business-details-modal__body">
 							<p>
 								{ accountStatus === 'restricted_soon' &&
-								currentDeadline
-									? sprintf(
-											strings.restrictedSoonDescription,
-											dateI18n(
-												'ga M j, Y',
-												moment(
-													currentDeadline * 1000
-												).toISOString()
-											)
-									  )
-									: strings.restrictedDescription }
+								currentDeadline ? (
+									<>
+										<p>
+											{
+												strings.restrictedSoonDescription
+											}
+										</p>
+										<p>
+											{ sprintf(
+												strings.restrictedSoonUpdateBy,
+												dateI18n(
+													'ga M j, Y',
+													moment(
+														currentDeadline * 1000
+													).toISOString()
+												)
+											) }
+										</p>
+									</>
+								) : (
+									<p>{ strings.restrictedDescription }</p>
+								) }
 							</p>
 
 							{ errorMessages.map( ( errorMessage, index ) => (

--- a/client/overview/modal/update-business-details/index.tsx
+++ b/client/overview/modal/update-business-details/index.tsx
@@ -11,65 +11,54 @@ import './index.scss';
 import strings from './strings';
 import { createInterpolateElement } from '@wordpress/element';
 
-interface UpdateBusinessDetailsModalProps {
-	isModalOpen: boolean;
-	setModalOpen: any; // TODO: figure out the type for this
-	errorReasons: Array< string >;
+interface Props {
+	handleModalSubmit: () => void;
+	handleModalClose: () => void;
+	errorMessages: Array< string >;
 	accountStatus: string;
+	accountLink: string;
 }
 
 const UpdateBusinessDetailsModal = ( {
-	isModalOpen,
-	setModalOpen,
-	errorReasons,
+	handleModalSubmit,
+	handleModalClose,
+	errorMessages,
 	accountStatus,
-}: UpdateBusinessDetailsModalProps ): any => {
-	const onClose = () => {
-		setModalOpen( false );
-	};
-
-	const onSubmit = () => {
-		return true;
-	};
-
-	const generateNotice = ( errorMessage: string ): JSX.Element => {
-		return (
-			<Notice status="warning" isDismissible={ false }>
-				{ errorMessage }
-			</Notice>
-		);
-	};
-
+}: Props ): any => {
 	return (
-		isModalOpen && (
-			<Modal
-				title={ strings.updateBusinessDetails }
-				isDismissible={ true }
-				className="update-business-details-modal"
-				shouldCloseOnClickOutside={ false }
-				onRequestClose={ onClose }
-			>
-				<p>
-					{ accountStatus === 'restricted'
-						? strings.restrictedDescription
-						: createInterpolateElement(
-								strings.restrictedSoonDescription,
-								{ '%d': '12th January 2023' }
-						  ) }
-				</p>
+		<Modal
+			title={ strings.updateBusinessDetails }
+			isDismissible={ true }
+			className="update-business-details-modal"
+			shouldCloseOnClickOutside={ false }
+			onRequestClose={ handleModalClose }
+		>
+			<p>
+				{ accountStatus === 'restricted'
+					? strings.restrictedDescription
+					: createInterpolateElement(
+							strings.restrictedSoonDescription,
+							{ '%d': '12th January 2023' }
+					  ) }
+			</p>
 
-				{ errorReasons.forEach( generateNotice ) }
 
-				<div className="wcpay-update-business-details-modal__footer">
-					<Button isSecondary onClick={ onClose }>
-						{ strings.cancel }
-					</Button>
-					<Button isPrimary onClick={ onSubmit }>
-						{ strings.updateBusinessDetails }
-					</Button>
-				</div>
-			</Modal>
-		)
+			{ errorMessages.map( ( errorMessage ) => (
+				// eslint-disable-next-line react/jsx-key
+				<Notice status="warning" isDismissible={ false }>
+					{ errorMessage }
+				</Notice>
+			) ) }
+
+			<div className="wcpay-update-business-details-modal__footer">
+				<Button isSecondary onClick={ handleModalClose }>
+					{ strings.cancel }
+				</Button>
+				<Button isPrimary onClick={ handleModalSubmit }>
+					{ strings.updateBusinessDetails }
+				</Button>
+			</div>
+		</Modal>
 	);
 };
 

--- a/client/overview/modal/update-business-details/index.tsx
+++ b/client/overview/modal/update-business-details/index.tsx
@@ -49,25 +49,20 @@ const UpdateBusinessDetailsModal = ( {
 				>
 					<div className="wcpay-update-business-details-modal__wrapper">
 						<div className="wcpay-update-business-details-modal__body">
-							{ accountStatus === 'restricted_soon' &&
-							currentDeadline ? (
-								<>
-									<p>{ strings.restrictedSoonDescription }</p>
-									<p>
-										{ sprintf(
-											strings.restrictedSoonUpdateBy,
+							<p>
+								{ accountStatus === 'restricted_soon' &&
+								currentDeadline
+									? sprintf(
+											strings.restrictedSoonDescription,
 											dateI18n(
 												'ga M j, Y',
 												moment(
 													currentDeadline * 1000
 												).toISOString()
 											)
-										) }
-									</p>
-								</>
-							) : (
-								<p>{ strings.restrictedDescription }</p>
-							) }
+									  )
+									: strings.restrictedDescription }
+							</p>
 
 							{ errorMessages.map( ( errorMessage, index ) => (
 								<Notice

--- a/client/overview/modal/update-business-details/index.tsx
+++ b/client/overview/modal/update-business-details/index.tsx
@@ -49,31 +49,25 @@ const UpdateBusinessDetailsModal = ( {
 				>
 					<div className="wcpay-update-business-details-modal__wrapper">
 						<div className="wcpay-update-business-details-modal__body">
-							<p>
-								{ accountStatus === 'restricted_soon' &&
-								currentDeadline ? (
-									<>
-										<p>
-											{
-												strings.restrictedSoonDescription
-											}
-										</p>
-										<p>
-											{ sprintf(
-												strings.restrictedSoonUpdateBy,
-												dateI18n(
-													'ga M j, Y',
-													moment(
-														currentDeadline * 1000
-													).toISOString()
-												)
-											) }
-										</p>
-									</>
-								) : (
-									<p>{ strings.restrictedDescription }</p>
-								) }
-							</p>
+							{ accountStatus === 'restricted_soon' &&
+							currentDeadline ? (
+								<>
+									<p>{ strings.restrictedSoonDescription }</p>
+									<p>
+										{ sprintf(
+											strings.restrictedSoonUpdateBy,
+											dateI18n(
+												'ga M j, Y',
+												moment(
+													currentDeadline * 1000
+												).toISOString()
+											)
+										) }
+									</p>
+								</>
+							) : (
+								<p>{ strings.restrictedDescription }</p>
+							) }
 
 							{ errorMessages.map( ( errorMessage, index ) => (
 								<Notice

--- a/client/overview/modal/update-business-details/index.tsx
+++ b/client/overview/modal/update-business-details/index.tsx
@@ -9,56 +9,85 @@ import { Button, Modal, Notice } from '@wordpress/components';
  */
 import './index.scss';
 import strings from './strings';
-import { createInterpolateElement } from '@wordpress/element';
+import { useState } from '@wordpress/element';
+import { dateI18n } from '@wordpress/date';
+import { sprintf } from '@wordpress/i18n';
+import moment from 'moment/moment';
 
 interface Props {
-	handleModalSubmit: () => void;
-	handleModalClose: () => void;
 	errorMessages: Array< string >;
 	accountStatus: string;
 	accountLink: string;
+	currentDeadline?: number | null;
 }
 
 const UpdateBusinessDetailsModal = ( {
-	handleModalSubmit,
-	handleModalClose,
 	errorMessages,
 	accountStatus,
+	accountLink,
+	currentDeadline,
 }: Props ): any => {
+	const [ isModalOpen, setModalOpen ] = useState( true );
+
+	const closeModal = () => {
+		setModalOpen( false );
+	};
+
+	const openAccountLink = () => {
+		window.open( accountLink, '_blank' );
+	};
+
 	return (
-		<Modal
-			title={ strings.updateBusinessDetails }
-			isDismissible={ true }
-			className="update-business-details-modal"
-			shouldCloseOnClickOutside={ false }
-			onRequestClose={ handleModalClose }
-		>
-			<p>
-				{ accountStatus === 'restricted'
-					? strings.restrictedDescription
-					: createInterpolateElement(
-							strings.restrictedSoonDescription,
-							{ '%d': '12th January 2023' }
-					  ) }
-			</p>
+		<>
+			{ isModalOpen && (
+				<Modal
+					title={ strings.updateBusinessDetails }
+					isDismissible={ true }
+					className="wcpay-update-business-details-modal"
+					shouldCloseOnClickOutside={ false }
+					onRequestClose={ closeModal }
+				>
+					<div className="wcpay-update-business-details-modal__wrapper">
+						<div className="wcpay-update-business-details-modal__body">
+							<p>
+								{ accountStatus === 'restricted_soon' &&
+								currentDeadline
+									? sprintf(
+											strings.restrictedSoonDescription,
+											dateI18n(
+												'ga M j, Y',
+												moment(
+													currentDeadline * 1000
+												).toISOString()
+											)
+									  )
+									: strings.restrictedDescription }
+							</p>
 
+							{ errorMessages.map( ( errorMessage, index ) => (
+								<Notice
+									key={ index }
+									status="warning"
+									isDismissible={ false }
+								>
+									{ errorMessage }
+								</Notice>
+							) ) }
+						</div>
+					</div>
+					<hr />
+					<div className="wcpay-update-business-details-modal__footer">
+						<Button isSecondary onClick={ closeModal }>
+							{ strings.cancel }
+						</Button>
 
-			{ errorMessages.map( ( errorMessage ) => (
-				// eslint-disable-next-line react/jsx-key
-				<Notice status="warning" isDismissible={ false }>
-					{ errorMessage }
-				</Notice>
-			) ) }
-
-			<div className="wcpay-update-business-details-modal__footer">
-				<Button isSecondary onClick={ handleModalClose }>
-					{ strings.cancel }
-				</Button>
-				<Button isPrimary onClick={ handleModalSubmit }>
-					{ strings.updateBusinessDetails }
-				</Button>
-			</div>
-		</Modal>
+						<Button isPrimary onClick={ openAccountLink }>
+							{ strings.updateBusinessDetails }
+						</Button>
+					</div>
+				</Modal>
+			) }
+		</>
 	);
 };
 

--- a/client/overview/modal/update-business-details/index.tsx
+++ b/client/overview/modal/update-business-details/index.tsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Button, Modal, Notice } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './index.scss';
+import strings from './strings';
+import { createInterpolateElement } from '@wordpress/element';
+
+interface UpdateBusinessDetailsModalProps {
+	isModalOpen: boolean;
+	setModalOpen: any; // TODO: figure out the type for this
+	errorReasons: Array< string >;
+	accountStatus: string;
+}
+
+const UpdateBusinessDetailsModal = ( {
+	isModalOpen,
+	setModalOpen,
+	errorReasons,
+	accountStatus,
+}: UpdateBusinessDetailsModalProps ): any => {
+	const onClose = () => {
+		setModalOpen( false );
+	};
+
+	const onSubmit = () => {
+		return true;
+	};
+
+	const generateNotice = ( errorMessage: string ): JSX.Element => {
+		return (
+			<Notice status="warning" isDismissible={ false }>
+				{ errorMessage }
+			</Notice>
+		);
+	};
+
+	return (
+		isModalOpen && (
+			<Modal
+				title={ strings.updateBusinessDetails }
+				isDismissible={ true }
+				className="update-business-details-modal"
+				shouldCloseOnClickOutside={ false }
+				onRequestClose={ onClose }
+			>
+				<p>
+					{ accountStatus === 'restricted'
+						? strings.restrictedDescription
+						: createInterpolateElement(
+								strings.restrictedSoonDescription,
+								{ '%d': '12th January 2023' }
+						  ) }
+				</p>
+
+				{ errorReasons.forEach( generateNotice ) }
+
+				<div className="wcpay-update-business-details-modal__footer">
+					<Button isSecondary onClick={ onClose }>
+						{ strings.cancel }
+					</Button>
+					<Button isPrimary onClick={ onSubmit }>
+						{ strings.updateBusinessDetails }
+					</Button>
+				</div>
+			</Modal>
+		)
+	);
+};
+
+export default UpdateBusinessDetailsModal;

--- a/client/overview/modal/update-business-details/strings.tsx
+++ b/client/overview/modal/update-business-details/strings.tsx
@@ -18,7 +18,12 @@ export default {
 	),
 
 	restrictedSoonDescription: __(
-		'Additional information is required to verify your business. Update by %s to avoid a disruption in deposits.',
+		'Additional information is required to verify your business.',
+		'woocommerce-payments'
+	),
+
+	restrictedSoonUpdateBy: __(
+		'Update by %s to avoid a disruption in deposits.',
 		'woocommerce-payments'
 	),
 

--- a/client/overview/modal/update-business-details/strings.tsx
+++ b/client/overview/modal/update-business-details/strings.tsx
@@ -18,12 +18,7 @@ export default {
 	),
 
 	restrictedSoonDescription: __(
-		'Additional information is required to verify your business.',
-		'woocommerce-payments'
-	),
-
-	restrictedSoonUpdateBy: __(
-		'Update by %s to avoid a disruption in deposits.',
+		'Additional information is required to verify your business. Update by %s to avoid a disruption in deposits.',
 		'woocommerce-payments'
 	),
 

--- a/client/overview/modal/update-business-details/strings.tsx
+++ b/client/overview/modal/update-business-details/strings.tsx
@@ -1,0 +1,31 @@
+/* eslint-disable max-len */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default {
+	button: __( 'Finish setup', 'woocommerce-payments' ),
+
+	heading: __(
+		'Update WooCommerce Payments business details',
+		'woocommerce-payments'
+	),
+
+	restrictedDescription: __(
+		'Payments and deposits are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.',
+		'woocommerce-payments'
+	),
+
+	restrictedSoonDescription: __(
+		'Additional information is required to verify your business. Update by %s to avoid a disruption in deposits.',
+		'woocommerce-payments'
+	),
+
+	updateBusinessDetails: __(
+		'Update business details',
+		'woocommerce-payments '
+	),
+
+	cancel: __( 'Cancel', 'woocommerce-payments' ),
+};

--- a/client/overview/modal/update-business-details/test/__snapshots__/index.tsx.snap
+++ b/client/overview/modal/update-business-details/test/__snapshots__/index.tsx.snap
@@ -143,10 +143,7 @@ exports[`Overview: update business details modal renders correctly when opened f
         class="wcpay-update-business-details-modal__body"
       >
         <p>
-          Additional information is required to verify your business.
-        </p>
-        <p>
-          Update by 7pm Dec 31, 2021 to avoid a disruption in deposits.
+          Additional information is required to verify your business. Update by 7pm Dec 31, 2021 to avoid a disruption in deposits.
         </p>
         <div
           class="components-notice is-warning"

--- a/client/overview/modal/update-business-details/test/__snapshots__/index.tsx.snap
+++ b/client/overview/modal/update-business-details/test/__snapshots__/index.tsx.snap
@@ -1,0 +1,280 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Overview: update business details modal renders correctly when opened for restricted account 1`] = `
+<div
+  aria-labelledby="components-modal-header-0"
+  class="components-modal__frame wcpay-update-business-details-modal"
+  role="dialog"
+  tabindex="-1"
+>
+  <div
+    class="components-modal__content"
+    role="document"
+  >
+    <div
+      class="components-modal__header"
+    >
+      <div
+        class="components-modal__header-heading-container"
+      >
+        <h1
+          class="components-modal__header-heading"
+          id="components-modal-header-0"
+        >
+          Update business details
+        </h1>
+      </div>
+      <button
+        aria-label="Close dialog"
+        class="components-button has-icon"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          role="img"
+          size="24"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="wcpay-update-business-details-modal__wrapper"
+    >
+      <div
+        class="wcpay-update-business-details-modal__body"
+      >
+        <p>
+          Payments and deposits are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.
+        </p>
+        <div
+          class="components-notice is-warning"
+        >
+          <div
+            class="components-notice__content"
+          >
+            The provided document was from an unsupported country.
+          </div>
+        </div>
+        <div
+          class="components-notice is-warning"
+        >
+          <div
+            class="components-notice__content"
+          >
+            The representative must have an address in the same country as the company.
+          </div>
+        </div>
+      </div>
+    </div>
+    <hr />
+    <div
+      class="wcpay-update-business-details-modal__footer"
+    >
+      <button
+        class="components-button is-secondary"
+        type="button"
+      >
+        Cancel
+      </button>
+      <button
+        class="components-button is-primary"
+        type="button"
+      >
+        Update business details
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Overview: update business details modal renders correctly when opened for restricted soon account with current deadline 1`] = `
+<div
+  aria-labelledby="components-modal-header-1"
+  class="components-modal__frame wcpay-update-business-details-modal"
+  role="dialog"
+  tabindex="-1"
+>
+  <div
+    class="components-modal__content"
+    role="document"
+  >
+    <div
+      class="components-modal__header"
+    >
+      <div
+        class="components-modal__header-heading-container"
+      >
+        <h1
+          class="components-modal__header-heading"
+          id="components-modal-header-1"
+        >
+          Update business details
+        </h1>
+      </div>
+      <button
+        aria-label="Close dialog"
+        class="components-button has-icon"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          role="img"
+          size="24"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="wcpay-update-business-details-modal__wrapper"
+    >
+      <div
+        class="wcpay-update-business-details-modal__body"
+      >
+        <p>
+          Additional information is required to verify your business. Update by 7pm Dec 31, 2021 to avoid a disruption in deposits.
+        </p>
+        <div
+          class="components-notice is-warning"
+        >
+          <div
+            class="components-notice__content"
+          >
+            The provided document was from an unsupported country.
+          </div>
+        </div>
+        <div
+          class="components-notice is-warning"
+        >
+          <div
+            class="components-notice__content"
+          >
+            The representative must have an address in the same country as the company.
+          </div>
+        </div>
+      </div>
+    </div>
+    <hr />
+    <div
+      class="wcpay-update-business-details-modal__footer"
+    >
+      <button
+        class="components-button is-secondary"
+        type="button"
+      >
+        Cancel
+      </button>
+      <button
+        class="components-button is-primary"
+        type="button"
+      >
+        Update business details
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Overview: update business details modal renders correctly when opened for restricted soon account without current deadline 1`] = `
+<div
+  aria-labelledby="components-modal-header-2"
+  class="components-modal__frame wcpay-update-business-details-modal"
+  role="dialog"
+  tabindex="-1"
+>
+  <div
+    class="components-modal__content"
+    role="document"
+  >
+    <div
+      class="components-modal__header"
+    >
+      <div
+        class="components-modal__header-heading-container"
+      >
+        <h1
+          class="components-modal__header-heading"
+          id="components-modal-header-2"
+        >
+          Update business details
+        </h1>
+      </div>
+      <button
+        aria-label="Close dialog"
+        class="components-button has-icon"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          role="img"
+          size="24"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="wcpay-update-business-details-modal__wrapper"
+    >
+      <div
+        class="wcpay-update-business-details-modal__body"
+      >
+        <p>
+          Payments and deposits are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.
+        </p>
+        <div
+          class="components-notice is-warning"
+        >
+          <div
+            class="components-notice__content"
+          >
+            The provided document was from an unsupported country.
+          </div>
+        </div>
+        <div
+          class="components-notice is-warning"
+        >
+          <div
+            class="components-notice__content"
+          >
+            The representative must have an address in the same country as the company.
+          </div>
+        </div>
+      </div>
+    </div>
+    <hr />
+    <div
+      class="wcpay-update-business-details-modal__footer"
+    >
+      <button
+        class="components-button is-secondary"
+        type="button"
+      >
+        Cancel
+      </button>
+      <button
+        class="components-button is-primary"
+        type="button"
+      >
+        Update business details
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/client/overview/modal/update-business-details/test/__snapshots__/index.tsx.snap
+++ b/client/overview/modal/update-business-details/test/__snapshots__/index.tsx.snap
@@ -50,9 +50,7 @@ exports[`Overview: update business details modal renders correctly when opened f
         class="wcpay-update-business-details-modal__body"
       >
         <p>
-          <p>
-            Payments and deposits are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.
-          </p>
+          Payments and deposits are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.
         </p>
         <div
           class="components-notice is-warning"
@@ -145,12 +143,10 @@ exports[`Overview: update business details modal renders correctly when opened f
         class="wcpay-update-business-details-modal__body"
       >
         <p>
-          <p>
-            Additional information is required to verify your business.
-          </p>
-          <p>
-            Update by 7pm Dec 31, 2021 to avoid a disruption in deposits.
-          </p>
+          Additional information is required to verify your business.
+        </p>
+        <p>
+          Update by 7pm Dec 31, 2021 to avoid a disruption in deposits.
         </p>
         <div
           class="components-notice is-warning"
@@ -243,9 +239,7 @@ exports[`Overview: update business details modal renders correctly when opened f
         class="wcpay-update-business-details-modal__body"
       >
         <p>
-          <p>
-            Payments and deposits are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.
-          </p>
+          Payments and deposits are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.
         </p>
         <div
           class="components-notice is-warning"

--- a/client/overview/modal/update-business-details/test/__snapshots__/index.tsx.snap
+++ b/client/overview/modal/update-business-details/test/__snapshots__/index.tsx.snap
@@ -50,7 +50,9 @@ exports[`Overview: update business details modal renders correctly when opened f
         class="wcpay-update-business-details-modal__body"
       >
         <p>
-          Payments and deposits are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.
+          <p>
+            Payments and deposits are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.
+          </p>
         </p>
         <div
           class="components-notice is-warning"
@@ -143,7 +145,12 @@ exports[`Overview: update business details modal renders correctly when opened f
         class="wcpay-update-business-details-modal__body"
       >
         <p>
-          Additional information is required to verify your business. Update by 7pm Dec 31, 2021 to avoid a disruption in deposits.
+          <p>
+            Additional information is required to verify your business.
+          </p>
+          <p>
+            Update by 7pm Dec 31, 2021 to avoid a disruption in deposits.
+          </p>
         </p>
         <div
           class="components-notice is-warning"
@@ -236,7 +243,9 @@ exports[`Overview: update business details modal renders correctly when opened f
         class="wcpay-update-business-details-modal__body"
       >
         <p>
-          Payments and deposits are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.
+          <p>
+            Payments and deposits are disabled for this account until missing information is updated. Please update the following information in the Stripe dashboard.
+          </p>
         </p>
         <div
           class="components-notice is-warning"

--- a/client/overview/modal/update-business-details/test/index.tsx
+++ b/client/overview/modal/update-business-details/test/index.tsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import UpdateBusinessDetailsModal from '..';
+
+// Utility function for accessing the modal content in assertions
+const modalContent = () => {
+	const selector = '.wcpay-update-business-details-modal';
+	return document.body.querySelector( selector );
+};
+
+const mockErrorMessages = [
+	'The provided document was from an unsupported country.',
+	'The representative must have an address in the same country as the company.',
+];
+
+const mockAccountLink = 'http://express.stripe.com/dashboard';
+const mockCurrentDeadline = 1640995200;
+
+describe( 'Overview: update business details modal', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders correctly when opened for restricted account', () => {
+		render(
+			<UpdateBusinessDetailsModal
+				errorMessages={ mockErrorMessages }
+				accountStatus={ 'restricted' }
+				accountLink={ mockAccountLink }
+			/>
+		);
+
+		expect( modalContent() ).toMatchSnapshot();
+	} );
+
+	test( 'renders correctly when opened for restricted soon account with current deadline', () => {
+		render(
+			<UpdateBusinessDetailsModal
+				errorMessages={ mockErrorMessages }
+				accountStatus={ 'restricted_soon' }
+				accountLink={ mockAccountLink }
+				currentDeadline={ mockCurrentDeadline }
+			/>
+		);
+
+		expect( modalContent() ).toMatchSnapshot();
+	} );
+
+	test( 'renders correctly when opened for restricted soon account without current deadline', () => {
+		render(
+			<UpdateBusinessDetailsModal
+				errorMessages={ mockErrorMessages }
+				accountStatus={ 'restricted_soon' }
+				accountLink={ mockAccountLink }
+			/>
+		);
+
+		expect( modalContent() ).toMatchSnapshot();
+	} );
+} );

--- a/client/overview/task-list/index.js
+++ b/client/overview/task-list/index.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Card, CardBody, CardHeader } from '@wordpress/components';
 import { Badge } from '@woocommerce/components';

--- a/client/overview/task-list/index.js
+++ b/client/overview/task-list/index.js
@@ -9,7 +9,6 @@ import { Badge } from '@woocommerce/components';
 import { CollapsibleList, TaskItem, Text } from '@woocommerce/experimental';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
-
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
 const TaskList = ( { overviewTasksVisibility, tasks } ) => {

--- a/client/overview/task-list/strings.tsx
+++ b/client/overview/task-list/strings.tsx
@@ -1,0 +1,287 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import React from 'react';
+
+export default {
+	// Error codes/messages from Stripe. See: https://stripe.com/docs/api/accounts/object#account_object-requirements-errors-suggestion-message
+	errors: {
+		invalid_address_city_state_postal_code: __(
+			'The combination of the city, state, and postal code in the provided address could not be validated.',
+			'woocommerce-payments'
+		),
+		invalid_street_address: __(
+			'The street name and/or number for the provided address could not be validated.',
+			'woocommerce-payments'
+		),
+		invalid_tos_acceptance: createInterpolateElement(
+			__(
+				'The existing terms of service signature has been invalidated because the account’s tax ID has changed. The account needs to accept the terms of service again. For more information, see <a>this documentation</a>.',
+				'woocommerce-payments'
+			),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href="https://stripe.com/docs/connect/update-verified-information"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		),
+		invalid_representative_country: __(
+			'The representative must have an address in the same country as the company.',
+			'woocommerce-payments'
+		),
+		verification_document_address_mismatch: __(
+			'The address on the document did not match the address on the account. Upload a document with a matching address or update the address on the account.',
+			'woocommerce-payments'
+		),
+		verification_document_address_missing: __(
+			'The company address was missing on the document. Upload a document that includes the address.',
+			'woocommerce-payments'
+		),
+		verification_document_corrupt: __(
+			'The uploaded file for the document was invalid or corrupt. Upload a new file of the document.',
+			'woocommerce-payments'
+		),
+		verification_document_country_not_supported: __(
+			'The provided document was from an unsupported country.',
+			'woocommerce-payments'
+		),
+		verification_document_dob_mismatch: __(
+			'The date of birth (DOB) on the document did not match the DOB on the account. Upload a document with a matching DOB or update the DOB on the account.',
+			'woocommerce-payments'
+		),
+		verification_document_duplicate_type: __(
+			'The same type of document was used twice. Two unique types of documents are required for verification. Upload two different documents.',
+			'woocommerce-payments'
+		),
+		verification_document_expired: __(
+			'The document could not be used for verification because it has expired. If it’s an identity document, its expiration date must be after the date the document was submitted. If it’s an address document, the issue date must be within the last six months.',
+			'woocommerce-payments'
+		),
+		verification_document_failed_copy: __(
+			'The document could not be verified because it was detected as a copy (e.g., photo or scan). Upload the original document.',
+			'woocommerce-payments'
+		),
+		verification_document_failed_greyscale: __(
+			'The document could not be used for verification because it was in greyscale. Upload a color copy of the document.',
+			'woocommerce-payments'
+		),
+		verification_document_failed_other: createInterpolateElement(
+			__(
+				'The document could not be verified for an unknown reason. Ensure that the document follows the <a>guidelines for document uploads</a>',
+				'woocommerce-payments'
+			),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href="https://stripe.com/docs/connect/identity-verification-api#acceptable-verification-documents"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		),
+		verification_document_failed_test_mode: createInterpolateElement(
+			__(
+				'A test data helper was supplied to simulate verification failure. Refer to the documentation for <a>test file tokens</a>.',
+				'woocommerce-payments'
+			),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href="https://stripe.com/docs/connect/testing#test-file-tokens"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		),
+		verification_document_fraudulent: __(
+			'The document was identified as altered or falsified.',
+			'woocommerce-payments'
+		),
+		verification_document_id_number_mismatch: __(
+			'The company ID number on the account could not be verified. Correct any errors in the ID number field or upload a document that includes the ID number.',
+			'woocommerce-payments'
+		),
+		verification_document_id_number_missing: __(
+			'The company ID number was missing on the document. Upload a document that includes the ID number.',
+			'woocommerce-payments'
+		),
+		verification_document_incomplete: __(
+			'The document was cropped or missing important information. Upload a complete scan of the document.',
+			'woocommerce-payments'
+		),
+		verification_document_invalid: createInterpolateElement(
+			__(
+				'The uploaded file was not one of the valid document types. Ensure that the document follows the <a>guidelines for document uploads</a>.',
+				'woocommerce-payments'
+			),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href="https://stripe.com/docs/connect/identity-verification-api#acceptable-verification-documents"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		),
+		verification_document_issue_or_expiry_date_missing: __(
+			'The issue or expiry date is missing on the document. Upload a document that includes the issue and expiry dates.'
+		),
+		verification_document_manipulated: __(
+			'The document was identified as altered or falsified.',
+			'woocommerce-payments'
+		),
+		verification_document_missing_back: __(
+			'The uploaded file was missing the back of the document. Upload a complete scan of the document.',
+			'woocommerce-payments'
+		),
+		verification_document_missing_front: __(
+			'The uploaded file was missing the front of the document. Upload a complete scan of the document.',
+			'woocommerce-payments'
+		),
+		verification_document_name_mismatch: __(
+			'The name on the document did not match the name on the account. Upload a document with a matching name or update the name on the account.',
+			'woocommerce-payments'
+		),
+		verification_document_name_missing: __(
+			'The company name was missing on the document. Upload a document that includes the company name.',
+			'woocommerce-payments'
+		),
+		verification_document_nationality_mismatch: __(
+			'The nationality on the document did not match the person’s stated nationality. Update the person’s stated nationality, or upload a document that matches it.',
+			'woocommerce-payments'
+		),
+		verification_document_not_readable: createInterpolateElement(
+			__(
+				'The document could not be read. Ensure that the document follows the <a>guidelines for document uploads</a>.',
+				'woocommerce-payments'
+			),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href="https://stripe.com/docs/connect/identity-verification-api#acceptable-verification-documents"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		),
+		verification_document_not_signed: __(
+			'A valid signature is missing on the document. Upload a document that includes a valid signature.',
+			'woocommerce-payments'
+		),
+		verification_document_not_uploaded: __(
+			'No document was uploaded. Upload the document again.',
+			'woocommerce-payments'
+		),
+		verification_document_photo_mismatch: __(
+			'The document was identified as altered or falsified.',
+			'woocommerce-payments'
+		),
+		verification_document_too_large: __(
+			'The uploaded file exceeded the 10 MB size limit. Resize the document and upload the new file.',
+			'woocommerce-payments'
+		),
+		verification_document_type_not_supported: createInterpolateElement(
+			__(
+				'The provided document type was not accepted. Ensure that the document follows the <a>guidelines for document uploads</a>.',
+				'woocommerce-payments'
+			),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href="https://stripe.com/docs/connect/identity-verification-api#acceptable-verification-documents"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		),
+		verification_failed_address_match: __(
+			'The address on the account could not be verified. Correct any errors in the address field or upload a document that includes the address.',
+			'woocommerce-payments'
+		),
+		verification_failed_business_iec_number: __(
+			'The Importer Exporter Code (IEC) number could not be verified. Correct any errors in the company’s IEC number field. (India only)',
+			'woocommerce-payments'
+		),
+		verification_failed_document_match: __(
+			'The document could not be verified. Upload a document that includes the company name, ID number, and address fields.',
+			'woocommerce-payments'
+		),
+		verification_failed_id_number_match: __(
+			'The company ID number on the account could not be verified. Correct any errors in the ID number field or upload a document that includes the ID number.',
+			'woocommerce-payments'
+		),
+		verification_failed_keyed_identity: __(
+			'The person’s keyed-in identity information could not be verified. Correct any errors or upload a document that matches the identity fields (e.g., name and date of birth) entered.',
+			'woocommerce-payments'
+		),
+		verification_failed_keyed_match: __(
+			'The keyed-in information on the account could not be verified. Correct any errors in the company name, ID number, or address fields. You can also upload a document that includes those fields.',
+			'woocommerce-payments'
+		),
+		verification_failed_name_match: __(
+			'The company name on the account could not be verified. Correct any errors in the company name field or upload a document that includes the company name.',
+			'woocommerce-payments'
+		),
+		verification_failed_residential_address: __(
+			'We could not verify that the person resides at the provided address. The address must be a valid physical address where the individual resides and cannot be a P.O. Box.',
+			'woocommerce-payments'
+		),
+		verification_failed_tax_id_match: __(
+			'The tax ID on the account cannot be verified by the IRS. Either correct any possible errors in the company name or tax ID, or upload a document that contains those fields.',
+			'woocommerce-payments'
+		),
+		verification_failed_tax_id_not_issued: createInterpolateElement(
+			__(
+				'The tax ID on the account was not recognized by the IRS. Refer to the support article for <a>newly-issued tax ID numbers</a>.',
+				'woocommerce-payments'
+			),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href="https://support.stripe.com/questions/newly-issued-us-tax-id-number-tin-not-verifying"
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		),
+		verification_failed_other: __(
+			'Verification failed for an unknown reason. Correct any errors and resubmit the required fields.',
+			'woocommerce-payments'
+		),
+		verification_missing_owners: __(
+			'We have identified owners that haven’t been added on the account. Add any missing owners to the account.',
+			'woocommerce-payments'
+		),
+		verification_missing_executives: __(
+			'We have identified executives that haven’t been added on the account. Add any missing executives to the account.',
+			'woocommerce-payments'
+		),
+		verification_requires_additional_memorandum_of_associations: __(
+			'We have identified holding companies with significant percentage ownership. Upload a Memorandum of Association for each of the holding companies.',
+			'woocommerce-payments'
+		),
+		invalid_dob_age_under_18: __(
+			'Underage. Age must be at least 18.',
+			'woocommerce-payments'
+		),
+	},
+};

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -49,6 +49,7 @@ export const getTasks = ( {
 	}
 
 	return [
+		// TODO: If more than one error exists, show the modal, if only one error exists, show the error directly to the user here.
 		isAccountOverviewTasksEnabled &&
 			showUpdateDetailsTask && {
 				key: 'update-business-details',

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -40,7 +40,7 @@ const renderModal = ( errorMessages, status, accountLink, currentDeadline ) => {
 };
 
 const getErrorMessagesFromRequirements = ( requirements ) => [
-	...new Set( requirements?.errors.map( ( error ) => error.reason ) ),
+	...new Set( requirements?.errors?.map( ( error ) => error.reason ) ),
 ];
 
 export const getTasks = ( {

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -12,6 +12,7 @@ import moment from 'moment';
 /**
  * Internal dependencies.
  */
+import strings from './strings';
 import wcpayTracks from 'tracks';
 import { getAdminUrl } from 'wcpay/utils';
 import UpdateBusinessDetailsModal from '../modal/update-business-details';
@@ -48,7 +49,11 @@ const getErrorMessagesFromRequirements = ( requirements ) => [
 			?.filter(
 				( error ) => ! requirementBlacklist.includes( error.code )
 			)
-			?.map( ( error ) => error.reason )
+			?.map( ( error ) =>
+				error.code in strings.errors
+					? strings.errors[ error.code ]
+					: error.reason
+			)
 	),
 ];
 

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -16,6 +16,33 @@ import wcpayTracks from 'tracks';
 import { getAdminUrl } from 'wcpay/utils';
 import UpdateBusinessDetailsModal from '../modal/update-business-details';
 
+const renderModal = ( errorMessages, status, accountLink, currentDeadline ) => {
+	let container = document.querySelector(
+		'#wcpay-update-business-details-container'
+	);
+
+	if ( ! container ) {
+		container = document.createElement( 'div' );
+		container.id = 'wcpay-update-business-details-container';
+		document.body.appendChild( container );
+	}
+
+	ReactDOM.render(
+		<UpdateBusinessDetailsModal
+			key={ Date.now() }
+			errorMessages={ errorMessages }
+			accountStatus={ status }
+			accountLink={ accountLink }
+			currentDeadline={ currentDeadline }
+		/>,
+		container
+	);
+};
+
+const getErrorMessagesFromRequirements = ( requirements ) => [
+	...new Set( requirements?.errors.map( ( error ) => error.reason ) ),
+];
+
 export const getTasks = ( {
 	accountStatus,
 	showUpdateDetailsTask,
@@ -23,37 +50,6 @@ export const getTasks = ( {
 	isAccountOverviewTasksEnabled,
 	numDisputesNeedingResponse = 0,
 } ) => {
-	const renderModal = (
-		errorMessages,
-		status,
-		accountLink,
-		currentDeadline
-	) => {
-		const container = document.createElement( 'div' );
-		container.id = 'wcpay-update-business-details-container';
-		document.body.appendChild( container );
-		ReactDOM.render(
-			<UpdateBusinessDetailsModal
-				errorMessages={ errorMessages }
-				accountStatus={ status }
-				accountLink={ accountLink }
-				currentDeadline={ currentDeadline }
-			/>,
-			container
-		);
-	};
-
-	const getErrorMessagesFromRequirements = ( requirements ) => {
-		if ( 'errors' in requirements ) {
-			const errorMessages = requirements.errors.map( ( error ) => {
-				return error.reason;
-			} );
-			return [ ...new Set( errorMessages ) ];
-		}
-
-		return [];
-	};
-
 	const {
 		status,
 		currentDeadline,
@@ -108,7 +104,6 @@ export const getTasks = ( {
 	}
 
 	return [
-		// TODO: If more than one error exists, show the modal, if only one error exists, show the error directly to the user here.
 		isAccountOverviewTasksEnabled &&
 			showUpdateDetailsTask && {
 				key: 'update-business-details',

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -39,7 +39,7 @@ const renderModal = ( errorMessages, status, accountLink, currentDeadline ) => {
 	);
 };
 
-// Requirements we don't want to show to the user because they are too generic/not useful.
+// Requirements we don't want to show to the user because they are too generic/not useful. These refer to Stripe error codes.
 const requirementBlacklist = [ 'invalid_value_other' ];
 
 const getErrorMessagesFromRequirements = ( requirements ) => [

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -39,8 +39,17 @@ const renderModal = ( errorMessages, status, accountLink, currentDeadline ) => {
 	);
 };
 
+// Requirements we don't want to show to the user because they are too generic/not useful.
+const requirementBlacklist = [ 'invalid_value_other' ];
+
 const getErrorMessagesFromRequirements = ( requirements ) => [
-	...new Set( requirements?.errors?.map( ( error ) => error.reason ) ),
+	...new Set(
+		requirements?.errors
+			?.filter(
+				( error ) => ! requirementBlacklist.includes( error.code )
+			)
+			?.map( ( error ) => error.reason )
+	),
 ];
 
 export const getTasks = ( {

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -3,9 +3,10 @@
 /**
  * External dependencies
  */
+import React from 'react';
+import ReactDOM from 'react-dom';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { dateI18n } from '@wordpress/date';
-import { useState } from '@wordpress/element';
 import moment from 'moment';
 
 /**
@@ -13,6 +14,7 @@ import moment from 'moment';
  */
 import wcpayTracks from 'tracks';
 import { getAdminUrl } from 'wcpay/utils';
+import UpdateBusinessDetailsModal from '../modal/update-business-details';
 
 export const getTasks = ( {
 	accountStatus,
@@ -21,8 +23,25 @@ export const getTasks = ( {
 	isAccountOverviewTasksEnabled,
 	numDisputesNeedingResponse = 0,
 } ) => {
-	// TODO: Figure out how to open the modal from this context?
-	// const [ isModalOpen, setModalOpen ] = useState( false );
+	const renderModal = (
+		errorMessages,
+		status,
+		accountLink,
+		currentDeadline
+	) => {
+		const container = document.createElement( 'div' );
+		container.id = 'wcpay-update-business-details-container';
+		document.body.appendChild( container );
+		ReactDOM.render(
+			<UpdateBusinessDetailsModal
+				errorMessages={ errorMessages }
+				accountStatus={ status }
+				accountLink={ accountLink }
+				currentDeadline={ currentDeadline }
+			/>,
+			container
+		);
+	};
 
 	const getErrorMessagesFromRequirements = ( requirements ) => {
 		if ( 'errors' in requirements ) {
@@ -105,13 +124,18 @@ export const getTasks = ( {
 						? undefined
 						: () => {
 								if ( hasMultipleErrors ) {
-									setModalOpen( true );
+									renderModal(
+										errorMessages,
+										status,
+										accountLink,
+										currentDeadline
+									);
 								} else {
 									window.open( accountLink, '_blank' );
 								}
 						  },
 				actionLabel: hasMultipleErrors
-					? __( 'More details', 'woocommerce-payments')
+					? __( 'More details', 'woocommerce-payments' )
 					: __( 'Update', 'woocommerce-payments' ),
 				visible: true,
 				type: 'extension',

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -196,12 +196,11 @@ class WC_Payments_Account {
 			'deposits'            => $account['deposits'] ?? [],
 			'depositsStatus'      => $account['deposits']['status'] ?? $account['deposits_status'] ?? '',
 			'currentDeadline'     => $account['current_deadline'] ?? false,
-			'pastDue'             => true,
+			'pastDue'             => $account['has_overdue_requirements'] ?? false,
 			'accountLink'         => $this->get_login_url(),
 			'hasSubmittedVatData' => $account['has_submitted_vat_data'] ?? false,
 			'requirements'        => [
-				'currentlyDue' => $account['requirements']['currently_due'] ?? [],
-				'errors'       => $account['requirements']['errors'] ?? [],
+				'errors' => $account['requirements']['errors'] ?? [],
 			],
 		];
 	}

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -199,6 +199,10 @@ class WC_Payments_Account {
 			'pastDue'             => $account['has_overdue_requirements'] ?? false,
 			'accountLink'         => $this->get_login_url(),
 			'hasSubmittedVatData' => $account['has_submitted_vat_data'] ?? false,
+			'requirements'        => [
+				'currentlyDue' => $account['requirements']['currently_due'] ?? [],
+				'errors'       => $account['requirements']['errors'] ?? [],
+			],
 		];
 	}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -196,7 +196,7 @@ class WC_Payments_Account {
 			'deposits'            => $account['deposits'] ?? [],
 			'depositsStatus'      => $account['deposits']['status'] ?? $account['deposits_status'] ?? '',
 			'currentDeadline'     => $account['current_deadline'] ?? false,
-			'pastDue'             => $account['has_overdue_requirements'] ?? false,
+			'pastDue'             => true,
 			'accountLink'         => $this->get_login_url(),
 			'hasSubmittedVatData' => $account['has_submitted_vat_data'] ?? false,
 			'requirements'        => [


### PR DESCRIPTION
Fixes #5069 

#### Changes proposed in this Pull Request

* Update to pass account business errors from Stripe through to the frontend.
* Adds a new modal which will display in the Update Business Details task if more than one error is returned from Stripe.
* Update the task to show the error message in the case of only one error.
* Slightly changes the behaviour depending on whether the account is restricted or restricted soon, to use more clear wording.
* Filter out errors which are vague or unhelpful (currently only one, the `invalid_value_other` code).

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Screenshots

Restricted account with 1 error:

<img width="766" alt="Screenshot 2023-01-18 at 12 01 24" src="https://user-images.githubusercontent.com/11770181/213172062-dc60890a-73d2-4165-90d9-8595f9757026.png">

Restricted account with multiple errors:

<img width="768" alt="Screenshot 2023-01-18 at 12 01 38" src="https://user-images.githubusercontent.com/11770181/213172111-5d2fd46d-a809-4cc9-af2c-a3d67fe6ec15.png">

The New Modal:

<img width="807" alt="Screenshot 2023-01-18 at 12 01 41" src="https://user-images.githubusercontent.com/11770181/213172182-2702c8dc-e7fe-455f-a261-b5cebbd29a73.png">


#### Questions

* Are translations a problem here? We are directly pulling these messages from Stripe. Perhaps we should store the messages on our client to utilise translatable strings? The problem with doing this is that we risk being out of sync with Stripe, if they add or change error messages.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out the server PR (server/2846) and refresh the cache on the client.
* For this PR, we will manually change the data returned from the server to test the different possibilities. I will post the different scenarios below, but for each scenario, replace the array [here](https://github.com/Automattic/woocommerce-payments/blob/114b69231ba44e7e21cf62426620f4fca0b60f60/includes/class-wc-payments-account.php#L191-L206) with the test code, and then ensure the expected behaviour occurs.

**Scenario 1: Restricted Account with Multiple Errors**

* Use the following code:
```php
		return [
			'email'               => $account['email'] ?? '',
			'country'             => $account['country'] ?? 'US',
			'status'              => 'restricted',
			'paymentsEnabled'     => $account['payments_enabled'],
			'deposits'            => $account['deposits'] ?? [],
			'depositsStatus'      => $account['deposits']['status'] ?? $account['deposits_status'] ?? '',
			'currentDeadline'     => $account['current_deadline'] ?? false,
			'pastDue'             => true,
			'accountLink'         => $this->get_login_url(),
			'hasSubmittedVatData' => $account['has_submitted_vat_data'] ?? false,
			'requirements'        => [
				'currentlyDue' => $account['requirements']['currently_due'] ?? [],
				'errors'       => [
										[
						'code'   => 'verification_failed_keyed_identity',
						'reason' => 'The identity information you entered cannot be verified. Please correct any errors or upload a document that matches the identity fields (e.g., name and date of birth) that you entered.',
						'requirement' => 'individual.verification.document',
					],
					[
						'code'   => 'verification_failed_tax_id_match',
						'reason' => 'The tax ID on the account has changed. Please accept the terms of service again.',
						'requirement' => 'tos_acceptance.date',
					],
					[
						'code'   => 'verification_failed_tax_id_match',
						'reason' => 'The tax ID on the account has changed. Please accept the terms of service again.',
						'requirement' => 'tos_acceptance.ip',
					],
					[
						'code' => 'invalid_value_other',
						'reason' => 'This error shouldn\'t display at all',
						'requirement' => 'tos_acceptance.ip',
					],
					[
						'code' => 'invalid_tos_acceptance',
						'reason' => 'This error message should come from our translatable strings',
						'requirement' => 'tos_acceptance.ip',
					],
					[
						'code' => 'new_error_key',
						'reason' => 'This error message should display because we have no matching entry in translatable strings.',
						'requirement' => 'tos_acceptance.ip',
					],
                              ],
			],
		];
```

* The task should be visible on the `Payments/Overview` page, and it should have the `More details` button, which should open a modal with 2 errors displayed (we filter out duplicate error messages).
* Clicking confirm on the modal should open the Stripe Express dashboard. Clicking cancel should close the modal.


**Scenario 2: Restricted Account with Single Error**

```php
		return [
			'email'               => $account['email'] ?? '',
			'country'             => $account['country'] ?? 'US',
			'status'              => 'restricted',
			'paymentsEnabled'     => $account['payments_enabled'],
			'deposits'            => $account['deposits'] ?? [],
			'depositsStatus'      => $account['deposits']['status'] ?? $account['deposits_status'] ?? '',
			'currentDeadline'     => $account['current_deadline'] ?? false,
			'pastDue'             => true,
			'accountLink'         => $this->get_login_url(),
			'hasSubmittedVatData' => $account['has_submitted_vat_data'] ?? false,
			'requirements'        => [
				'currentlyDue' => $account['requirements']['currently_due'] ?? [],
				'errors'       =>  [
					[
						'code'   => 'verification_failed_keyed_identity',
						'reason' => 'The identity information you entered cannot be verified. Please correct any errors or upload a document that matches the identity fields (e.g., name and date of birth) that you entered.',
						'requirement' => 'individual.verification.document',
					],
                              ],
			],
		];
```

* The task should be visible on the `Payments/Overview` page, and it should have the `Update` button. The text should match the error message above.
* The `Update` button should open the Stripe Express Dashboard


**Scenario 3: Restricted Account with No Errors**

```php
		return [
			'email'               => $account['email'] ?? '',
			'country'             => $account['country'] ?? 'US',
			'status'              => 'restricted',
			'paymentsEnabled'     => $account['payments_enabled'],
			'deposits'            => $account['deposits'] ?? [],
			'depositsStatus'      => $account['deposits']['status'] ?? $account['deposits_status'] ?? '',
			'currentDeadline'     => $account['current_deadline'] ?? false,
			'pastDue'             => true,
			'accountLink'         => $this->get_login_url(),
			'hasSubmittedVatData' => $account['has_submitted_vat_data'] ?? false,
			'requirements'        => [
				'currentlyDue' => $account['requirements']['currently_due'] ?? [],
				'errors'       => $account['requirements']['errors'] ?? [],
			],
		];
```

* The task should be visible on the `Payments/Overview` page, and it should have the `Update` button. The text should be a generic message about updating business details.
* The `Update` button should open the Stripe Express Dashboard

**Scenario 4: Restricted Soon Account with Multiple Errors**

```php
		return [
			'email'               => $account['email'] ?? '',
			'country'             => $account['country'] ?? 'US',
			'status'              => 'restricted',
			'paymentsEnabled'     => $account['payments_enabled'],
			'deposits'            => $account['deposits'] ?? [],
			'depositsStatus'      => $account['deposits']['status'] ?? $account['deposits_status'] ?? '',
			'currentDeadline'     => 1674648153,
			'pastDue'             => false,
			'accountLink'         => $this->get_login_url(),
			'hasSubmittedVatData' => $account['has_submitted_vat_data'] ?? false,
			'requirements'        => [
				'currentlyDue' => $account['requirements']['currently_due'] ?? [],
				'errors'       => [
						[
						'code'   => 'verification_failed_keyed_identity',
						'reason' => 'The identity information you entered cannot be verified. Please correct any errors or upload a document that matches the identity fields (e.g., name and date of birth) that you entered.',
						'requirement' => 'individual.verification.document',
					],
					[
						'code'   => 'verification_failed_tax_id_match',
						'reason' => 'The tax ID on the account has changed. Please accept the terms of service again.',
						'requirement' => 'tos_acceptance.date',
					],
					[
						'code'   => 'verification_failed_tax_id_match',
						'reason' => 'The tax ID on the account has changed. Please accept the terms of service again.',
						'requirement' => 'tos_acceptance.ip',
					],
					[
						'code' => 'invalid_value_other',
						'reason' => 'This error shouldn\'t display at all',
						'requirement' => 'tos_acceptance.ip',
					],
					[
						'code' => 'invalid_tos_acceptance',
						'reason' => 'This error message should come from our translatable strings',
						'requirement' => 'tos_acceptance.ip',
					],
					[
						'code' => 'new_error_key',
						'reason' => 'This error message should display because we have no matching entry in translatable strings.',
						'requirement' => 'tos_acceptance.ip',
					],
                              ],
			],
		];
```

* The task should be visible on the `Payments/Overview` page, and it should have the `More details` button, which should open a modal with 2 errors displayed (we filter out duplicate error messages). It should also show the date to update by.
* Clicking confirm on the modal should open the Stripe Express dashboard. Clicking cancel should close the modal.


**Scenario 5: Restricted Soon Account with Single Error**

```php
		return [
			'email'               => $account['email'] ?? '',
			'country'             => $account['country'] ?? 'US',
			'status'              => 'restricted',
			'paymentsEnabled'     => $account['payments_enabled'],
			'deposits'            => $account['deposits'] ?? [],
			'depositsStatus'      => $account['deposits']['status'] ?? $account['deposits_status'] ?? '',
			'currentDeadline'     => $account['current_deadline'] ?? false,
			'pastDue'             => false,
			'accountLink'         => $this->get_login_url(),
			'hasSubmittedVatData' => $account['has_submitted_vat_data'] ?? false,
			'requirements'        => [
				'currentlyDue' => $account['requirements']['currently_due'] ?? [],
				'errors'       => [
					[
						'code'   => 'verification_failed_keyed_identity',
						'reason' => 'The identity information you entered cannot be verified. Please correct any errors or upload a document that matches the identity fields (e.g., name and date of birth) that you entered.',
						'requirement' => 'individual.verification.document',
					],
                              ],
			],
		];
```

* The task should be visible on the `Payments/Overview` page, and it should have the `Update` button. The text should match the error message above and also have the date needed to update by.
* The `Update` button should open the Stripe Express Dashboard

**Scenario 6: Restricted Soon Account with No Errors**

```php
		return [
			'email'               => $account['email'] ?? '',
			'country'             => $account['country'] ?? 'US',
			'status'              => 'restricted_soon',
			'paymentsEnabled'     => $account['payments_enabled'],
			'deposits'            => $account['deposits'] ?? [],
			'depositsStatus'      => $account['deposits']['status'] ?? $account['deposits_status'] ?? '',
			'currentDeadline'     => 1674648153,
			'pastDue'             => true,
			'accountLink'         => $this->get_login_url(),
			'hasSubmittedVatData' => $account['has_submitted_vat_data'] ?? false,
			'requirements'        => [
				'currentlyDue' => $account['requirements']['currently_due'] ?? [],
				'errors'       => $account['requirements']['errors'] ?? [],
			],
		];
```

* The task should be visible on the `Payments/Overview` page, and it should have the `Update` button. The text should be a generic message about updating business details with the date to update by.
* The `Update` button should open the Stripe Express Dashboard

**Scenario 7: Account in Good Standing**

* Use a normal, active Stripe account which is not restricted. 
* Use the default code, shared below: 
```php
		return [
			'email'               => $account['email'] ?? '',
			'country'             => $account['country'] ?? 'US',
			'status'              => $account['status'],
			'paymentsEnabled'     => $account['payments_enabled'],
			'deposits'            => $account['deposits'] ?? [],
			'depositsStatus'      => $account['deposits']['status'] ?? $account['deposits_status'] ?? '',
			'currentDeadline'     => $account['current_deadline'] ?? false,
			'pastDue'             => true,
			'accountLink'         => $this->get_login_url(),
			'hasSubmittedVatData' => $account['has_submitted_vat_data'] ?? false,
			'requirements'        => [
				'currentlyDue' => $account['requirements']['currently_due'] ?? [],
				'errors'       => $account['requirements']['errors'] ?? [],
			],
		];
```
* The task should not appear.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
