### PR TITLE
Fix loading correct script dependencies even re-registering them in the same request

### DIFF
--- a/changelog/fix-5137-confilict-max-mega-menu
+++ b/changelog/fix-5137-confilict-max-mega-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure script dependencies are loaded properly even when trying to register them again in the same request.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -430,7 +430,7 @@ class WC_Payments_Admin {
 	public function register_payments_scripts() {
 		$script_src_url    = plugins_url( 'dist/index.js', WCPAY_PLUGIN_FILE );
 		$script_asset_path = WCPAY_ABSPATH . 'dist/index.asset.php';
-		$script_asset      = file_exists( $script_asset_path ) ? require_once $script_asset_path : [ 'dependencies' => [] ];
+		$script_asset      = file_exists( $script_asset_path ) ? require $script_asset_path : [ 'dependencies' => [] ];
 		wp_register_script(
 			'WCPAY_DASH_APP',
 			$script_src_url,
@@ -539,7 +539,7 @@ class WC_Payments_Admin {
 
 		$tos_script_src_url    = plugins_url( 'dist/tos.js', WCPAY_PLUGIN_FILE );
 		$tos_script_asset_path = WCPAY_ABSPATH . 'dist/tos.asset.php';
-		$tos_script_asset      = file_exists( $tos_script_asset_path ) ? require_once $tos_script_asset_path : [ 'dependencies' => [] ];
+		$tos_script_asset      = file_exists( $tos_script_asset_path ) ? require $tos_script_asset_path : [ 'dependencies' => [] ];
 
 		wp_register_script(
 			'WCPAY_TOS',
@@ -573,7 +573,7 @@ class WC_Payments_Admin {
 
 		$settings_script_src_url    = plugins_url( 'dist/settings.js', WCPAY_PLUGIN_FILE );
 		$settings_script_asset_path = WCPAY_ABSPATH . 'dist/settings.asset.php';
-		$settings_script_asset      = file_exists( $settings_script_asset_path ) ? require_once $settings_script_asset_path : [ 'dependencies' => [] ];
+		$settings_script_asset      = file_exists( $settings_script_asset_path ) ? require $settings_script_asset_path : [ 'dependencies' => [] ];
 		wp_register_script(
 			'WCPAY_ADMIN_SETTINGS',
 			$settings_script_src_url,
@@ -610,7 +610,7 @@ class WC_Payments_Admin {
 
 		$payment_gateways_script_src_url    = plugins_url( 'dist/payment-gateways.js', WCPAY_PLUGIN_FILE );
 		$payment_gateways_script_asset_path = WCPAY_ABSPATH . 'dist/payment-gateways.asset.php';
-		$payment_gateways_script_asset      = file_exists( $payment_gateways_script_asset_path ) ? require_once $payment_gateways_script_asset_path : [ 'dependencies' => [] ];
+		$payment_gateways_script_asset      = file_exists( $payment_gateways_script_asset_path ) ? require $payment_gateways_script_asset_path : [ 'dependencies' => [] ];
 
 		wp_register_script(
 			'WCPAY_PAYMENT_GATEWAYS_PAGE',

--- a/includes/class-wc-payments-platform-checkout-button-handler.php
+++ b/includes/class-wc-payments-platform-checkout-button-handler.php
@@ -114,7 +114,7 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 
 		$script_src_url    = plugins_url( 'dist/platform-checkout-express-button.js', WCPAY_PLUGIN_FILE );
 		$script_asset_path = WCPAY_ABSPATH . 'dist/platform-checkout-express-button.asset.php';
-		$script_asset      = file_exists( $script_asset_path ) ? require_once $script_asset_path : [ 'dependencies' => [] ];
+		$script_asset      = file_exists( $script_asset_path ) ? require $script_asset_path : [ 'dependencies' => [] ];
 
 		wp_register_script( 'WCPAY_PLATFORM_CHECKOUT_EXPRESS_BUTTON', $script_src_url, $script_asset['dependencies'], WC_Payments::get_file_version( 'dist/platform-checkout-express-button.js' ), true );
 

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -489,7 +489,7 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 
 		$script_src_url    = plugins_url( 'dist/subscription-edit-page.js', WCPAY_PLUGIN_FILE );
 		$script_asset_path = WCPAY_ABSPATH . 'dist/subscription-edit-page.asset.php';
-		$script_asset      = file_exists( $script_asset_path ) ? require_once $script_asset_path : [ 'dependencies' => [] ];
+		$script_asset      = file_exists( $script_asset_path ) ? require $script_asset_path : [ 'dependencies' => [] ];
 
 		wp_register_script(
 			'WCPAY_SUBSCRIPTION_EDIT_PAGE',

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -108,7 +108,7 @@ class Analytics {
 	public function register_admin_scripts() {
 		$script_src_url    = plugins_url( 'dist/multi-currency-analytics.js', WCPAY_PLUGIN_FILE );
 		$script_asset_path = WCPAY_ABSPATH . 'dist/multi-currency-analytics.asset.php';
-		$script_asset      = file_exists( $script_asset_path ) ? require_once $script_asset_path : [ 'dependencies' => [] ];
+		$script_asset      = file_exists( $script_asset_path ) ? require $script_asset_path : [ 'dependencies' => [] ];
 
 		wp_register_script(
 			self::SCRIPT_NAME,

--- a/includes/multi-currency/CurrencySwitcherBlock.php
+++ b/includes/multi-currency/CurrencySwitcherBlock.php
@@ -54,7 +54,7 @@ class CurrencySwitcherBlock {
 		// Automatically load dependencies and version.
 		$asset_file_path = WCPAY_ABSPATH . 'dist/multi-currency-switcher-block.asset.php';
 		$asset_file      = file_exists( $asset_file_path )
-			? require_once $asset_file_path
+			? require $asset_file_path
 			: [
 				'dependencies' => [],
 				'version'      => false,

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -1135,7 +1135,7 @@ class MultiCurrency {
 	private function register_admin_scripts() {
 		$script_src_url    = plugins_url( 'dist/multi-currency.js', WCPAY_PLUGIN_FILE );
 		$script_asset_path = WCPAY_ABSPATH . 'dist/multi-currency.asset.php';
-		$script_asset      = file_exists( $script_asset_path ) ? require_once $script_asset_path : [ 'dependencies' => [] ];
+		$script_asset      = file_exists( $script_asset_path ) ? require $script_asset_path : [ 'dependencies' => [] ];
 		wp_register_script(
 			'WCPAY_MULTI_CURRENCY_SETTINGS',
 			$script_src_url,

--- a/includes/platform-checkout-user/class-platform-checkout-save-user.php
+++ b/includes/platform-checkout-user/class-platform-checkout-save-user.php
@@ -45,7 +45,7 @@ class Platform_Checkout_Save_User {
 		$script_src_url    = plugins_url( 'dist/platform-checkout.js', WCPAY_PLUGIN_FILE );
 		$style_url         = plugins_url( 'dist/platform-checkout.css', WCPAY_PLUGIN_FILE );
 		$script_asset_path = WCPAY_ABSPATH . 'dist/platform-checkout.asset.php';
-		$script_asset      = file_exists( $script_asset_path ) ? require_once $script_asset_path : [ 'dependencies' => [] ];
+		$script_asset      = file_exists( $script_asset_path ) ? require $script_asset_path : [ 'dependencies' => [] ];
 
 		wp_register_style(
 			'WCPAY_PLATFORM_CHECKOUT',

--- a/includes/subscriptions/class-wc-payments-subscriptions-empty-state-manager.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-empty-state-manager.php
@@ -50,7 +50,7 @@ class WC_Payments_Subscriptions_Empty_State_Manager {
 
 		$script_src_url    = plugins_url( 'dist/subscriptions-empty-state.js', WCPAY_PLUGIN_FILE );
 		$script_asset_path = WCPAY_ABSPATH . 'dist/subscriptions-empty-state.asset.php';
-		$script_asset      = file_exists( $script_asset_path ) ? require_once $script_asset_path : [ 'dependencies' => [] ];
+		$script_asset      = file_exists( $script_asset_path ) ? require $script_asset_path : [ 'dependencies' => [] ];
 		$wcpay_settings    = [
 			'connectUrl'    => WC_Payments_Account::get_connect_url( 'WC_SUBSCRIPTIONS_TABLE' ),
 			'isConnected'   => $this->account->is_stripe_connected(),

--- a/includes/subscriptions/class-wc-payments-subscriptions-onboarding-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-onboarding-handler.php
@@ -182,7 +182,7 @@ class WC_Payments_Subscriptions_Onboarding_Handler {
 
 		$script_src_url    = plugins_url( 'dist/subscription-product-onboarding-modal.js', WCPAY_PLUGIN_FILE );
 		$script_asset_path = WCPAY_ABSPATH . 'dist/subscription-product-onboarding-modal.asset.php';
-		$script_asset      = file_exists( $script_asset_path ) ? require_once $script_asset_path : [ 'dependencies' => [] ];
+		$script_asset      = file_exists( $script_asset_path ) ? require $script_asset_path : [ 'dependencies' => [] ];
 
 		wp_register_script(
 			'wcpay-subscription-product-onboarding-modal',
@@ -240,7 +240,7 @@ class WC_Payments_Subscriptions_Onboarding_Handler {
 
 		$script_src_url    = plugins_url( 'dist/subscription-product-onboarding-toast.js', WCPAY_PLUGIN_FILE );
 		$script_asset_path = WCPAY_ABSPATH . 'dist/subscription-product-onboarding-toast.asset.php';
-		$script_asset      = file_exists( $script_asset_path ) ? require_once $script_asset_path : [ 'dependencies' => [] ];
+		$script_asset      = file_exists( $script_asset_path ) ? require $script_asset_path : [ 'dependencies' => [] ];
 
 		wp_register_script(
 			'wcpay-subscription-product-onboarding-toast',


### PR DESCRIPTION
Fixes #5137

This issue does not happen in most cases as in a single request, we do not re-register our scripts and their dependencies.

However, with this specific plugin [Max Mega Menu](https://wordpress.org/plugins/megamenu/), they try to enqueue scripts again for `wp-admin/nav-menus.php` page to suit their specific needs: https://plugins.trac.wordpress.org/browser/megamenu/tags/3.0/megamenu.php#L169

That means, this line (and similar ones) will be called twice: 
https://github.com/Automattic/woocommerce-payments/blob/a79c5a70db6bc23c52e6e248d52f9481c220e457/includes/admin/class-wc-payments-admin.php#L433

And then `require_once` will return `true` rather than the file content itself.

#### Changes proposed in this Pull Request

- Simply change `require_once` to `require` can fix this issue. I think that's fine for us to reload in this case. 
- This approach is similar to WooCommerce Blocks plugin - [code ref](https://github.com/woocommerce/woocommerce-blocks/blob/d682079cda7d223a67af9d81e1cb72d8c99b1362/src/Assets/Api.php#L97-L99).

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable debug.log in wp-config.php. https://wordpress.org/support/article/debugging-in-wordpress/
* Install https://wordpress.org/plugins/megamenu/ and activate it.
* Use the `develop` branch.
* Visit http://your-test.site/wp-admin/nav-menus.php
* Check wp-content/debug.log, get this kind of notices/errors. Note: depends on which PHP version you're using, it can be only a notice or a fatal error. 

> PHP Notice:  Trying to access array offset on value of type bool in /var/www/html/wp-content/plugins/woocommerce-payments/includes/admin/class-wc-payments-admin.php on line 437
* Check out this PR. 
* Re-visit http://your-test.site/wp-admin/nav-menus.php
* Confirm: no longer new error/notice in debug.log.
* Visit other WCPay pages under WP Admin > Payments, and the front-end checkout pages: confirm there is no relevant error/issue in debug.log or browser console.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] NO NEED. Covered with tests (or have a good reason not to test in description ☝️)
- [x] NO NEED. Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] NO NEED. Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] NO NEED. Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] NO NEED. Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
