### PR TITLE
Fix Tooltip rates display when there is a promo fee active

### DIFF
--- a/changelog/fix-5367-fix-promo-tooltip-rate-display
+++ b/changelog/fix-5367-fix-promo-tooltip-rate-display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make the tooltip and fee description pill in Payments > Settings, show the correct Base rate when we have promotional rates applied.

--- a/client/components/payment-methods-list/payment-method.js
+++ b/client/components/payment-methods-list/payment-method.js
@@ -17,6 +17,7 @@ import { upeCapabilityStatuses } from 'wcpay/additional-methods-setup/constants'
 import {
 	formatMethodFeesDescription,
 	formatMethodFeesTooltip,
+	formatPillFeesDescription,
 } from 'wcpay/utils/account-fees';
 import './payment-method.scss';
 import { useManualCapture } from 'wcpay/data';
@@ -161,7 +162,7 @@ const PaymentMethod = ( {
 								) }
 							>
 								<span>
-									{ formatMethodFeesDescription(
+									{ formatPillFeesDescription(
 										accountFees[ id ]
 									) }
 								</span>

--- a/client/components/payment-methods-list/payment-method.js
+++ b/client/components/payment-methods-list/payment-method.js
@@ -17,7 +17,6 @@ import { upeCapabilityStatuses } from 'wcpay/additional-methods-setup/constants'
 import {
 	formatMethodFeesDescription,
 	formatMethodFeesTooltip,
-	formatPillFeesDescription,
 } from 'wcpay/utils/account-fees';
 import './payment-method.scss';
 import { useManualCapture } from 'wcpay/data';
@@ -162,7 +161,7 @@ const PaymentMethod = ( {
 								) }
 							>
 								<span>
-									{ formatPillFeesDescription(
+									{ formatMethodFeesDescription(
 										accountFees[ id ]
 									) }
 								</span>

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -317,6 +317,17 @@ export const formatMethodFeesDescription = (
 	} );
 };
 
+export const formatPillFeesDescription = (
+	accountFees: FeeStructure
+): string => {
+	const pillBaseFee = getTooltipAndPillBaseFee( accountFees );
+	return sprintf(
+		__( 'From %1$f%% + %2$s', 'woocommerce-payments' ),
+		formatFee( pillBaseFee.percentage_rate ),
+		formatCurrency( pillBaseFee.fixed_rate, pillBaseFee.currency )
+	);
+};
+
 export const getTransactionsPaymentMethodName = (
 	paymentMethod: PaymentMethod
 ): string => {

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -85,9 +85,7 @@ export const getCurrentBaseFee = (
 		: accountFees.base;
 };
 
-export const getTooltipAndPillBaseFee = (
-	accountFees: FeeStructure
-): BaseFee => {
+const getTooltipAndPillBaseFee = ( accountFees: FeeStructure ): BaseFee => {
 	const tooltipAndPillBaseFee = getCurrentBaseFee( accountFees );
 
 	if ( ! tooltipAndPillBaseFee.percentage_rate ) {

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -85,7 +85,9 @@ export const getCurrentBaseFee = (
 		: accountFees.base;
 };
 
-const getTooltipAndPillBaseFee = ( accountFees: FeeStructure ): BaseFee => {
+export const getTooltipAndPillBaseFee = (
+	accountFees: FeeStructure
+): BaseFee => {
 	const tooltipAndPillBaseFee = getCurrentBaseFee( accountFees );
 
 	if ( ! tooltipAndPillBaseFee.percentage_rate ) {

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -85,22 +85,36 @@ export const getCurrentBaseFee = (
 		: accountFees.base;
 };
 
+export const getTooltipAndPillBaseFee = (
+	accountFees: FeeStructure
+): BaseFee => {
+	const tooltipAndPillBaseFee = getCurrentBaseFee( accountFees );
+
+	if ( ! tooltipAndPillBaseFee.percentage_rate ) {
+		tooltipAndPillBaseFee.percentage_rate =
+			accountFees.base.percentage_rate;
+	}
+
+	if ( ! tooltipAndPillBaseFee.fixed_rate ) {
+		tooltipAndPillBaseFee.fixed_rate = accountFees.base.fixed_rate;
+	}
+
+	return tooltipAndPillBaseFee;
+};
+
 export const formatMethodFeesTooltip = (
 	accountFees: FeeStructure
 ): JSX.Element => {
 	if ( ! accountFees ) return <></>;
-	const effectiveBaseFee = {
-		...accountFees.base,
-		...accountFees.discount[ 0 ],
-	};
+	const tooltipAndPillBaseFee = getTooltipAndPillBaseFee( accountFees );
 
 	const total = {
 		percentage_rate:
-			effectiveBaseFee.percentage_rate +
+			tooltipAndPillBaseFee.percentage_rate +
 			accountFees.additional.percentage_rate +
 			accountFees.fx.percentage_rate,
 		fixed_rate:
-			effectiveBaseFee.fixed_rate +
+			tooltipAndPillBaseFee.fixed_rate +
 			accountFees.additional.fixed_rate +
 			accountFees.fx.fixed_rate,
 		currency: accountFees.base.currency,
@@ -114,7 +128,7 @@ export const formatMethodFeesTooltip = (
 		<div className={ 'wcpay-fees-tooltip' }>
 			<div>
 				<div>Base fee</div>
-				<div>{ getFeeDescriptionString( effectiveBaseFee ) }</div>
+				<div>{ getFeeDescriptionString( tooltipAndPillBaseFee ) }</div>
 			</div>
 			{ hasFees( accountFees.additional ) ? (
 				<div>

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -106,11 +106,13 @@ export const formatMethodFeesTooltip = (
 ): JSX.Element => {
 	if ( ! accountFees ) return <></>;
 	const currentBaseFee = getCurrentBaseFee( accountFees );
+	// If the current fee doesn't have a fixed or percentage rate, use the base fee's rate. Eg. when there is a promotional discount fee applied. Use this to calculate the total fee too.
 	const currentFeeWithBaseFallBack = getCurrentFeeWithBaseFallback(
 		currentBaseFee,
 		accountFees.base
 	);
 
+	// Use the current fee with the base fallback, if applicable, to calculate the total fee. Eg. when we have a promotional discount fee applied.
 	const total = {
 		percentage_rate:
 			currentFeeWithBaseFallBack.percentage_rate +

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -95,7 +95,6 @@ export const formatMethodFeesTooltip = (
 		? currentBaseFee
 		: accountFees.base;
 
-	// Use the current fee with the base fallback, if applicable, to calculate the total fee. Eg. when we have a promotional discount fee applied.
 	const total = {
 		percentage_rate:
 			currentFeeWithBaseFallBack.percentage_rate +

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -89,15 +89,18 @@ export const formatMethodFeesTooltip = (
 	accountFees: FeeStructure
 ): JSX.Element => {
 	if ( ! accountFees ) return <></>;
-	const currentBaseFee = getCurrentBaseFee( accountFees );
+	const effectiveBaseFee = {
+		...accountFees.base,
+		...accountFees.discount[ 0 ],
+	};
 
 	const total = {
 		percentage_rate:
-			currentBaseFee.percentage_rate +
+			effectiveBaseFee.percentage_rate +
 			accountFees.additional.percentage_rate +
 			accountFees.fx.percentage_rate,
 		fixed_rate:
-			currentBaseFee.fixed_rate +
+			effectiveBaseFee.fixed_rate +
 			accountFees.additional.fixed_rate +
 			accountFees.fx.fixed_rate,
 		currency: accountFees.base.currency,
@@ -111,7 +114,7 @@ export const formatMethodFeesTooltip = (
 		<div className={ 'wcpay-fees-tooltip' }>
 			<div>
 				<div>Base fee</div>
-				<div>{ getFeeDescriptionString( currentBaseFee ) }</div>
+				<div>{ getFeeDescriptionString( effectiveBaseFee ) }</div>
 			</div>
 			{ hasFees( accountFees.additional ) ? (
 				<div>

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -85,32 +85,15 @@ export const getCurrentBaseFee = (
 		: accountFees.base;
 };
 
-// If the current fee doesn't have a fixed or percentage rate, use the base fee's rate. Eg. when there is a promotional discount fee applied.
-const getCurrentFeeWithBaseFallback = (
-	currentFee: BaseFee | DiscountFee,
-	baseFee: BaseFee
-) => {
-	if ( ! currentFee.percentage_rate ) {
-		currentFee.percentage_rate = baseFee.percentage_rate;
-	}
-
-	if ( ! currentFee.fixed_rate ) {
-		currentFee.fixed_rate = baseFee.fixed_rate;
-	}
-
-	return currentFee;
-};
-
 export const formatMethodFeesTooltip = (
 	accountFees: FeeStructure
 ): JSX.Element => {
 	if ( ! accountFees ) return <></>;
 	const currentBaseFee = getCurrentBaseFee( accountFees );
 	// If the current fee doesn't have a fixed or percentage rate, use the base fee's rate. Eg. when there is a promotional discount fee applied. Use this to calculate the total fee too.
-	const currentFeeWithBaseFallBack = getCurrentFeeWithBaseFallback(
-		currentBaseFee,
-		accountFees.base
-	);
+	const currentFeeWithBaseFallBack = currentBaseFee.percentage_rate
+		? currentBaseFee
+		: accountFees.base;
 
 	// Use the current fee with the base fallback, if applicable, to calculate the total fee. Eg. when we have a promotional discount fee applied.
 	const total = {

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -319,17 +319,6 @@ export const formatMethodFeesDescription = (
 	} );
 };
 
-export const formatPillFeesDescription = (
-	accountFees: FeeStructure
-): string => {
-	const pillBaseFee = getTooltipAndPillBaseFee( accountFees );
-	return sprintf(
-		__( 'From %1$f%% + %2$s', 'woocommerce-payments' ),
-		formatFee( pillBaseFee.percentage_rate ),
-		formatCurrency( pillBaseFee.fixed_rate, pillBaseFee.currency )
-	);
-};
-
 export const getTransactionsPaymentMethodName = (
 	paymentMethod: PaymentMethod
 ): string => {

--- a/client/utils/test/__snapshots__/account-fees.tsx.snap
+++ b/client/utils/test/__snapshots__/account-fees.tsx.snap
@@ -1,178 +1,172 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Account fees utility functions formatMethodFeesTooltip() displays base fee, when only promo discount without percentage or fixed 1`] = `
-<body>
-  <div>
-    <div
-      class="wcpay-fees-tooltip"
-    >
+<div>
+  <div
+    class="wcpay-fees-tooltip"
+  >
+    <div>
       <div>
-        <div>
-          Base fee
-        </div>
-        <div>
-          12.3% + $4.57
-        </div>
+        Base fee
       </div>
       <div>
-        <div>
-          International payment method fee
-        </div>
-        <div>
-          1%
-        </div>
-      </div>
-      <div>
-        <div>
-          Foreign exchange fee
-        </div>
-        <div>
-          1%
-        </div>
-      </div>
-      <div>
-        <div>
-          Total per transaction
-        </div>
-        <div
-          class="wcpay-fees-tooltip__bold"
-        >
-          14.3% + $4.57
-        </div>
-      </div>
-      <div
-        class="wcpay-fees-tooltip__hint-text"
-      >
-        <span>
-          <a
-            href="https://woocommerce.com/document/payments/faq/fees/#united-states"
-            rel="noreferrer"
-            target="_blank"
-          >
-            Learn more
-          </a>
-           about WooCommerce Payments Fees in your country
-        </span>
+        12.3% + $4.57
       </div>
     </div>
+    <div>
+      <div>
+        International payment method fee
+      </div>
+      <div>
+        1%
+      </div>
+    </div>
+    <div>
+      <div>
+        Foreign exchange fee
+      </div>
+      <div>
+        1%
+      </div>
+    </div>
+    <div>
+      <div>
+        Total per transaction
+      </div>
+      <div
+        class="wcpay-fees-tooltip__bold"
+      >
+        14.3% + $4.57
+      </div>
+    </div>
+    <div
+      class="wcpay-fees-tooltip__hint-text"
+    >
+      <span>
+        <a
+          href="https://woocommerce.com/document/payments/faq/fees/#united-states"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Learn more
+        </a>
+         about WooCommerce Payments Fees in your country
+      </span>
+    </div>
   </div>
-</body>
+</div>
 `;
 
 exports[`Account fees utility functions formatMethodFeesTooltip() displays base percentage and fixed fee - no custom fee nor discount 1`] = `
-<body>
-  <div>
-    <div
-      class="wcpay-fees-tooltip"
-    >
+<div>
+  <div
+    class="wcpay-fees-tooltip"
+  >
+    <div>
       <div>
-        <div>
-          Base fee
-        </div>
-        <div>
-          12.3% + $4.57
-        </div>
+        Base fee
       </div>
       <div>
-        <div>
-          International payment method fee
-        </div>
-        <div>
-          1%
-        </div>
-      </div>
-      <div>
-        <div>
-          Foreign exchange fee
-        </div>
-        <div>
-          1%
-        </div>
-      </div>
-      <div>
-        <div>
-          Total per transaction
-        </div>
-        <div
-          class="wcpay-fees-tooltip__bold"
-        >
-          14.3% + $4.57
-        </div>
-      </div>
-      <div
-        class="wcpay-fees-tooltip__hint-text"
-      >
-        <span>
-          <a
-            href="https://woocommerce.com/document/payments/faq/fees/#united-states"
-            rel="noreferrer"
-            target="_blank"
-          >
-            Learn more
-          </a>
-           about WooCommerce Payments Fees in your country
-        </span>
+        12.3% + $4.57
       </div>
     </div>
+    <div>
+      <div>
+        International payment method fee
+      </div>
+      <div>
+        1%
+      </div>
+    </div>
+    <div>
+      <div>
+        Foreign exchange fee
+      </div>
+      <div>
+        1%
+      </div>
+    </div>
+    <div>
+      <div>
+        Total per transaction
+      </div>
+      <div
+        class="wcpay-fees-tooltip__bold"
+      >
+        14.3% + $4.57
+      </div>
+    </div>
+    <div
+      class="wcpay-fees-tooltip__hint-text"
+    >
+      <span>
+        <a
+          href="https://woocommerce.com/document/payments/faq/fees/#united-states"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Learn more
+        </a>
+         about WooCommerce Payments Fees in your country
+      </span>
+    </div>
   </div>
-</body>
+</div>
 `;
 
 exports[`Account fees utility functions formatMethodFeesTooltip() displays custom fee details, when applicable 1`] = `
-<body>
-  <div>
-    <div
-      class="wcpay-fees-tooltip"
-    >
+<div>
+  <div
+    class="wcpay-fees-tooltip"
+  >
+    <div>
       <div>
-        <div>
-          Base fee
-        </div>
-        <div>
-          10.1% + $4.01
-        </div>
+        Base fee
       </div>
       <div>
-        <div>
-          International payment method fee
-        </div>
-        <div>
-          1%
-        </div>
-      </div>
-      <div>
-        <div>
-          Foreign exchange fee
-        </div>
-        <div>
-          1%
-        </div>
-      </div>
-      <div>
-        <div>
-          Total per transaction
-        </div>
-        <div
-          class="wcpay-fees-tooltip__bold"
-        >
-          12.1% + $4.01
-        </div>
-      </div>
-      <div
-        class="wcpay-fees-tooltip__hint-text"
-      >
-        <span>
-          <a
-            href="https://woocommerce.com/document/payments/faq/fees/#united-states"
-            rel="noreferrer"
-            target="_blank"
-          >
-            Learn more
-          </a>
-           about WooCommerce Payments Fees in your country
-        </span>
+        10.1% + $4.01
       </div>
     </div>
+    <div>
+      <div>
+        International payment method fee
+      </div>
+      <div>
+        1%
+      </div>
+    </div>
+    <div>
+      <div>
+        Foreign exchange fee
+      </div>
+      <div>
+        1%
+      </div>
+    </div>
+    <div>
+      <div>
+        Total per transaction
+      </div>
+      <div
+        class="wcpay-fees-tooltip__bold"
+      >
+        12.1% + $4.01
+      </div>
+    </div>
+    <div
+      class="wcpay-fees-tooltip__hint-text"
+    >
+      <span>
+        <a
+          href="https://woocommerce.com/document/payments/faq/fees/#united-states"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Learn more
+        </a>
+         about WooCommerce Payments Fees in your country
+      </span>
+    </div>
   </div>
-</body>
+</div>
 `;

--- a/client/utils/test/__snapshots__/account-fees.tsx.snap
+++ b/client/utils/test/__snapshots__/account-fees.tsx.snap
@@ -1,7 +1,502 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Account fees utility functions formatMethodFeesTooltip() displays base fee, when only promo discount without percentage or fixed 1`] = `[Function]`;
+exports[`Account fees utility functions formatMethodFeesTooltip() displays base fee, when only promo discount without percentage or fixed 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="wcpay-fees-tooltip"
+      >
+        <div>
+          <div>
+            Base fee
+          </div>
+          <div>
+            12.3% + $4.57
+          </div>
+        </div>
+        <div>
+          <div>
+            International payment method fee
+          </div>
+          <div>
+            1%
+          </div>
+        </div>
+        <div>
+          <div>
+            Foreign exchange fee
+          </div>
+          <div>
+            1%
+          </div>
+        </div>
+        <div>
+          <div>
+            Total per transaction
+          </div>
+          <div
+            class="wcpay-fees-tooltip__bold"
+          >
+            14.3% + $4.57
+          </div>
+        </div>
+        <div
+          class="wcpay-fees-tooltip__hint-text"
+        >
+          <span>
+            <a
+              href="https://woocommerce.com/document/payments/faq/fees/#united-states"
+              rel="noreferrer"
+              target="_blank"
+            >
+              Learn more
+            </a>
+             about WooCommerce Payments Fees in your country
+          </span>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="wcpay-fees-tooltip"
+    >
+      <div>
+        <div>
+          Base fee
+        </div>
+        <div>
+          12.3% + $4.57
+        </div>
+      </div>
+      <div>
+        <div>
+          International payment method fee
+        </div>
+        <div>
+          1%
+        </div>
+      </div>
+      <div>
+        <div>
+          Foreign exchange fee
+        </div>
+        <div>
+          1%
+        </div>
+      </div>
+      <div>
+        <div>
+          Total per transaction
+        </div>
+        <div
+          class="wcpay-fees-tooltip__bold"
+        >
+          14.3% + $4.57
+        </div>
+      </div>
+      <div
+        class="wcpay-fees-tooltip__hint-text"
+      >
+        <span>
+          <a
+            href="https://woocommerce.com/document/payments/faq/fees/#united-states"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Learn more
+          </a>
+           about WooCommerce Payments Fees in your country
+        </span>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
 
-exports[`Account fees utility functions formatMethodFeesTooltip() displays base percentage and fixed fee - no custom fee nor discount 1`] = `[Function]`;
+exports[`Account fees utility functions formatMethodFeesTooltip() displays base percentage and fixed fee - no custom fee nor discount 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="wcpay-fees-tooltip"
+      >
+        <div>
+          <div>
+            Base fee
+          </div>
+          <div>
+            12.3% + $4.57
+          </div>
+        </div>
+        <div>
+          <div>
+            International payment method fee
+          </div>
+          <div>
+            1%
+          </div>
+        </div>
+        <div>
+          <div>
+            Foreign exchange fee
+          </div>
+          <div>
+            1%
+          </div>
+        </div>
+        <div>
+          <div>
+            Total per transaction
+          </div>
+          <div
+            class="wcpay-fees-tooltip__bold"
+          >
+            14.3% + $4.57
+          </div>
+        </div>
+        <div
+          class="wcpay-fees-tooltip__hint-text"
+        >
+          <span>
+            <a
+              href="https://woocommerce.com/document/payments/faq/fees/#united-states"
+              rel="noreferrer"
+              target="_blank"
+            >
+              Learn more
+            </a>
+             about WooCommerce Payments Fees in your country
+          </span>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="wcpay-fees-tooltip"
+    >
+      <div>
+        <div>
+          Base fee
+        </div>
+        <div>
+          12.3% + $4.57
+        </div>
+      </div>
+      <div>
+        <div>
+          International payment method fee
+        </div>
+        <div>
+          1%
+        </div>
+      </div>
+      <div>
+        <div>
+          Foreign exchange fee
+        </div>
+        <div>
+          1%
+        </div>
+      </div>
+      <div>
+        <div>
+          Total per transaction
+        </div>
+        <div
+          class="wcpay-fees-tooltip__bold"
+        >
+          14.3% + $4.57
+        </div>
+      </div>
+      <div
+        class="wcpay-fees-tooltip__hint-text"
+      >
+        <span>
+          <a
+            href="https://woocommerce.com/document/payments/faq/fees/#united-states"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Learn more
+          </a>
+           about WooCommerce Payments Fees in your country
+        </span>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
 
-exports[`Account fees utility functions formatMethodFeesTooltip() displays custom fee details, when applicable 1`] = `[Function]`;
+exports[`Account fees utility functions formatMethodFeesTooltip() displays custom fee details, when applicable 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="wcpay-fees-tooltip"
+      >
+        <div>
+          <div>
+            Base fee
+          </div>
+          <div>
+            10.1% + $4.01
+          </div>
+        </div>
+        <div>
+          <div>
+            International payment method fee
+          </div>
+          <div>
+            1%
+          </div>
+        </div>
+        <div>
+          <div>
+            Foreign exchange fee
+          </div>
+          <div>
+            1%
+          </div>
+        </div>
+        <div>
+          <div>
+            Total per transaction
+          </div>
+          <div
+            class="wcpay-fees-tooltip__bold"
+          >
+            12.1% + $4.01
+          </div>
+        </div>
+        <div
+          class="wcpay-fees-tooltip__hint-text"
+        >
+          <span>
+            <a
+              href="https://woocommerce.com/document/payments/faq/fees/#united-states"
+              rel="noreferrer"
+              target="_blank"
+            >
+              Learn more
+            </a>
+             about WooCommerce Payments Fees in your country
+          </span>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="wcpay-fees-tooltip"
+    >
+      <div>
+        <div>
+          Base fee
+        </div>
+        <div>
+          10.1% + $4.01
+        </div>
+      </div>
+      <div>
+        <div>
+          International payment method fee
+        </div>
+        <div>
+          1%
+        </div>
+      </div>
+      <div>
+        <div>
+          Foreign exchange fee
+        </div>
+        <div>
+          1%
+        </div>
+      </div>
+      <div>
+        <div>
+          Total per transaction
+        </div>
+        <div
+          class="wcpay-fees-tooltip__bold"
+        >
+          12.1% + $4.01
+        </div>
+      </div>
+      <div
+        class="wcpay-fees-tooltip__hint-text"
+      >
+        <span>
+          <a
+            href="https://woocommerce.com/document/payments/faq/fees/#united-states"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Learn more
+          </a>
+           about WooCommerce Payments Fees in your country
+        </span>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/client/utils/test/__snapshots__/account-fees.tsx.snap
+++ b/client/utils/test/__snapshots__/account-fees.tsx.snap
@@ -1,65 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Account fees utility functions formatMethodFeesTooltip() displays base fee, when only promo discount without percentage or fixed 1`] = `
-Object {
-  "asFragment": [Function],
-  "baseElement": <body>
-    <div>
-      <div
-        class="wcpay-fees-tooltip"
-      >
-        <div>
-          <div>
-            Base fee
-          </div>
-          <div>
-            12.3% + $4.57
-          </div>
-        </div>
-        <div>
-          <div>
-            International payment method fee
-          </div>
-          <div>
-            1%
-          </div>
-        </div>
-        <div>
-          <div>
-            Foreign exchange fee
-          </div>
-          <div>
-            1%
-          </div>
-        </div>
-        <div>
-          <div>
-            Total per transaction
-          </div>
-          <div
-            class="wcpay-fees-tooltip__bold"
-          >
-            14.3% + $4.57
-          </div>
-        </div>
-        <div
-          class="wcpay-fees-tooltip__hint-text"
-        >
-          <span>
-            <a
-              href="https://woocommerce.com/document/payments/faq/fees/#united-states"
-              rel="noreferrer"
-              target="_blank"
-            >
-              Learn more
-            </a>
-             about WooCommerce Payments Fees in your country
-          </span>
-        </div>
-      </div>
-    </div>
-  </body>,
-  "container": <div>
+<body>
+  <div>
     <div
       class="wcpay-fees-tooltip"
     >
@@ -112,121 +55,13 @@ Object {
         </span>
       </div>
     </div>
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
+  </div>
+</body>
 `;
 
 exports[`Account fees utility functions formatMethodFeesTooltip() displays base percentage and fixed fee - no custom fee nor discount 1`] = `
-Object {
-  "asFragment": [Function],
-  "baseElement": <body>
-    <div>
-      <div
-        class="wcpay-fees-tooltip"
-      >
-        <div>
-          <div>
-            Base fee
-          </div>
-          <div>
-            12.3% + $4.57
-          </div>
-        </div>
-        <div>
-          <div>
-            International payment method fee
-          </div>
-          <div>
-            1%
-          </div>
-        </div>
-        <div>
-          <div>
-            Foreign exchange fee
-          </div>
-          <div>
-            1%
-          </div>
-        </div>
-        <div>
-          <div>
-            Total per transaction
-          </div>
-          <div
-            class="wcpay-fees-tooltip__bold"
-          >
-            14.3% + $4.57
-          </div>
-        </div>
-        <div
-          class="wcpay-fees-tooltip__hint-text"
-        >
-          <span>
-            <a
-              href="https://woocommerce.com/document/payments/faq/fees/#united-states"
-              rel="noreferrer"
-              target="_blank"
-            >
-              Learn more
-            </a>
-             about WooCommerce Payments Fees in your country
-          </span>
-        </div>
-      </div>
-    </div>
-  </body>,
-  "container": <div>
+<body>
+  <div>
     <div
       class="wcpay-fees-tooltip"
     >
@@ -279,121 +114,13 @@ Object {
         </span>
       </div>
     </div>
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
+  </div>
+</body>
 `;
 
 exports[`Account fees utility functions formatMethodFeesTooltip() displays custom fee details, when applicable 1`] = `
-Object {
-  "asFragment": [Function],
-  "baseElement": <body>
-    <div>
-      <div
-        class="wcpay-fees-tooltip"
-      >
-        <div>
-          <div>
-            Base fee
-          </div>
-          <div>
-            10.1% + $4.01
-          </div>
-        </div>
-        <div>
-          <div>
-            International payment method fee
-          </div>
-          <div>
-            1%
-          </div>
-        </div>
-        <div>
-          <div>
-            Foreign exchange fee
-          </div>
-          <div>
-            1%
-          </div>
-        </div>
-        <div>
-          <div>
-            Total per transaction
-          </div>
-          <div
-            class="wcpay-fees-tooltip__bold"
-          >
-            12.1% + $4.01
-          </div>
-        </div>
-        <div
-          class="wcpay-fees-tooltip__hint-text"
-        >
-          <span>
-            <a
-              href="https://woocommerce.com/document/payments/faq/fees/#united-states"
-              rel="noreferrer"
-              target="_blank"
-            >
-              Learn more
-            </a>
-             about WooCommerce Payments Fees in your country
-          </span>
-        </div>
-      </div>
-    </div>
-  </body>,
-  "container": <div>
+<body>
+  <div>
     <div
       class="wcpay-fees-tooltip"
     >
@@ -446,57 +173,6 @@ Object {
         </span>
       </div>
     </div>
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
+  </div>
+</body>
 `;

--- a/client/utils/test/__snapshots__/account-fees.tsx.snap
+++ b/client/utils/test/__snapshots__/account-fees.tsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Account fees utility functions formatMethodFeesTooltip() displays base fee, when only promo discount without percentage or fixed 1`] = `[Function]`;
+
+exports[`Account fees utility functions formatMethodFeesTooltip() displays base percentage and fixed fee - no custom fee nor discount 1`] = `[Function]`;
+
+exports[`Account fees utility functions formatMethodFeesTooltip() displays custom fee details, when applicable 1`] = `[Function]`;

--- a/client/utils/test/account-fees.tsx
+++ b/client/utils/test/account-fees.tsx
@@ -303,11 +303,9 @@ describe( 'Account fees utility functions', () => {
 				currency: 'USD',
 			};
 
-			const renderMethodFeesTooltip = () => {
-				return render( formatMethodFeesTooltip( methodFees ) );
-			};
-
-			expect( renderMethodFeesTooltip() ).toMatchSnapshot();
+			expect(
+				render( formatMethodFeesTooltip( methodFees ) ).baseElement
+			).toMatchSnapshot();
 		} );
 
 		it( 'displays custom fee details, when applicable', () => {
@@ -332,11 +330,9 @@ describe( 'Account fees utility functions', () => {
 				currency: 'USD',
 			};
 
-			const renderMethodFeesTooltip = () => {
-				return render( formatMethodFeesTooltip( methodFees ) );
-			};
-
-			expect( renderMethodFeesTooltip() ).toMatchSnapshot();
+			expect(
+				render( formatMethodFeesTooltip( methodFees ) ).baseElement
+			).toMatchSnapshot();
 		} );
 
 		it( 'displays base fee, when only promo discount without percentage or fixed', () => {
@@ -361,11 +357,9 @@ describe( 'Account fees utility functions', () => {
 				currency: 'USD',
 			};
 
-			const renderMethodFeesTooltip = () => {
-				return render( formatMethodFeesTooltip( methodFees ) );
-			};
-
-			expect( renderMethodFeesTooltip() ).toMatchSnapshot();
+			expect(
+				render( formatMethodFeesTooltip( methodFees ) ).baseElement
+			).toMatchSnapshot();
 		} );
 	} );
 } );

--- a/client/utils/test/account-fees.tsx
+++ b/client/utils/test/account-fees.tsx
@@ -307,7 +307,7 @@ describe( 'Account fees utility functions', () => {
 				return render( formatMethodFeesTooltip( methodFees ) );
 			};
 
-			expect( renderMethodFeesTooltip ).toMatchSnapshot();
+			expect( renderMethodFeesTooltip() ).toMatchSnapshot();
 		} );
 
 		it( 'displays custom fee details, when applicable', () => {
@@ -336,7 +336,7 @@ describe( 'Account fees utility functions', () => {
 				return render( formatMethodFeesTooltip( methodFees ) );
 			};
 
-			expect( renderMethodFeesTooltip ).toMatchSnapshot();
+			expect( renderMethodFeesTooltip() ).toMatchSnapshot();
 		} );
 
 		it( 'displays base fee, when only promo discount without percentage or fixed', () => {
@@ -365,7 +365,7 @@ describe( 'Account fees utility functions', () => {
 				return render( formatMethodFeesTooltip( methodFees ) );
 			};
 
-			expect( renderMethodFeesTooltip ).toMatchSnapshot();
+			expect( renderMethodFeesTooltip() ).toMatchSnapshot();
 		} );
 	} );
 } );

--- a/client/utils/test/account-fees.tsx
+++ b/client/utils/test/account-fees.tsx
@@ -303,9 +303,11 @@ describe( 'Account fees utility functions', () => {
 				currency: 'USD',
 			};
 
-			expect(
-				render( formatMethodFeesTooltip( methodFees ) ).baseElement
-			).toMatchSnapshot();
+			const { container } = render(
+				formatMethodFeesTooltip( methodFees )
+			);
+
+			expect( container ).toMatchSnapshot();
 		} );
 
 		it( 'displays custom fee details, when applicable', () => {
@@ -330,9 +332,11 @@ describe( 'Account fees utility functions', () => {
 				currency: 'USD',
 			};
 
-			expect(
-				render( formatMethodFeesTooltip( methodFees ) ).baseElement
-			).toMatchSnapshot();
+			const { container } = render(
+				formatMethodFeesTooltip( methodFees )
+			);
+
+			expect( container ).toMatchSnapshot();
 		} );
 
 		it( 'displays base fee, when only promo discount without percentage or fixed', () => {
@@ -357,9 +361,11 @@ describe( 'Account fees utility functions', () => {
 				currency: 'USD',
 			};
 
-			expect(
-				render( formatMethodFeesTooltip( methodFees ) ).baseElement
-			).toMatchSnapshot();
+			const { container } = render(
+				formatMethodFeesTooltip( methodFees )
+			);
+
+			expect( container ).toMatchSnapshot();
 		} );
 	} );
 } );

--- a/client/utils/test/account-fees.tsx
+++ b/client/utils/test/account-fees.tsx
@@ -10,7 +10,6 @@ import React from 'react';
 import {
 	formatAccountFeesDescription,
 	formatMethodFeesDescription,
-	formatPillFeesDescription,
 	getCurrentBaseFee,
 	getTooltipAndPillBaseFee,
 } from '../account-fees';
@@ -312,50 +311,6 @@ describe( 'Account fees utility functions', () => {
 			expect(
 				getTooltipAndPillBaseFee( accountFees ).percentage_rate
 			).toEqual( 0.11 );
-		} );
-	} );
-
-	describe( 'formatPillFeesDescription()', () => {
-		it( 'returns pill description with base rates if there are no discounts', () => {
-			const accountFees = mockAccountFees( {
-				percentage_rate: 0.123,
-				fixed_rate: 456.78,
-				currency: 'USD',
-			} );
-
-			expect( formatPillFeesDescription( accountFees ) ).toEqual(
-				'From 12.3% + $4.57'
-			);
-		} );
-
-		it( 'returns pill description with base rates if there is a promo discount', () => {
-			const accountFees = mockAccountFees(
-				{
-					percentage_rate: 0.123,
-					fixed_rate: 456.78,
-					currency: 'USD',
-				},
-				[ { discount: 0.1 } ]
-			);
-
-			expect( formatPillFeesDescription( accountFees ) ).toEqual(
-				'From 12.3% + $4.57'
-			);
-		} );
-
-		it( 'returns pill description with custom rates if there is a custom fee present', () => {
-			const accountFees = mockAccountFees(
-				{
-					percentage_rate: 0.123,
-					fixed_rate: 456.78,
-					currency: 'USD',
-				},
-				[ { percentage_rate: 0.11, fixed_rate: 375.77 } ]
-			);
-
-			expect( formatPillFeesDescription( accountFees ) ).toEqual(
-				'From 11% + $3.76'
-			);
 		} );
 	} );
 } );

--- a/client/utils/test/account-fees.tsx
+++ b/client/utils/test/account-fees.tsx
@@ -3,6 +3,7 @@
  */
 import { sprintf } from '@wordpress/i18n';
 import React from 'react';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -302,40 +303,69 @@ describe( 'Account fees utility functions', () => {
 				currency: 'USD',
 			};
 
-			expect( formatMethodFeesTooltip( methodFees ) ).toEqual(
-				<div className="wcpay-fees-tooltip">
-					<div>
-						<div>Base fee</div>
-						<div>12.3% + $4.57</div>
-					</div>
-					<div>
-						<div>International payment method fee</div>
-						<div>1%</div>
-					</div>
-					<div>
-						<div>Foreign exchange fee</div>
-						<div>1%</div>
-					</div>
-					<div>
-						<div>Total per transaction</div>
-						<div className="wcpay-fees-tooltip__bold">
-							14.3% + $4.57
-						</div>
-					</div>
-					<div className="wcpay-fees-tooltip__hint-text">
-						<span>
-							<a
-								href="https://woocommerce.com/document/payments/faq/fees/#united-states"
-								target="_blank"
-								rel="noreferrer"
-							>
-								Learn more
-							</a>
-							about WooCommerce Payments Fees in your country
-						</span>
-					</div>
-				</div>
+			const renderMethodFeesTooltip = () => {
+				return render( formatMethodFeesTooltip( methodFees ) );
+			};
+
+			expect( renderMethodFeesTooltip ).toMatchSnapshot();
+		} );
+
+		it( 'displays custom fee details, when applicable', () => {
+			const methodFees = mockAccountFees(
+				{
+					percentage_rate: 0.123,
+					fixed_rate: 456.78,
+					currency: 'USD',
+				},
+				[ { percentage_rate: 0.101, fixed_rate: 400.78 } ]
 			);
+
+			methodFees.additional = {
+				percentage_rate: 0.01,
+				fixed_rate: 0,
+				currency: 'USD',
+			};
+
+			methodFees.fx = {
+				percentage_rate: 0.01,
+				fixed_rate: 0,
+				currency: 'USD',
+			};
+
+			const renderMethodFeesTooltip = () => {
+				return render( formatMethodFeesTooltip( methodFees ) );
+			};
+
+			expect( renderMethodFeesTooltip ).toMatchSnapshot();
+		} );
+
+		it( 'displays base fee, when only promo discount without percentage or fixed', () => {
+			const methodFees = mockAccountFees(
+				{
+					percentage_rate: 0.123,
+					fixed_rate: 456.78,
+					currency: 'USD',
+				},
+				[ { discount: 0.2 } ]
+			);
+
+			methodFees.additional = {
+				percentage_rate: 0.01,
+				fixed_rate: 0,
+				currency: 'USD',
+			};
+
+			methodFees.fx = {
+				percentage_rate: 0.01,
+				fixed_rate: 0,
+				currency: 'USD',
+			};
+
+			const renderMethodFeesTooltip = () => {
+				return render( formatMethodFeesTooltip( methodFees ) );
+			};
+
+			expect( renderMethodFeesTooltip ).toMatchSnapshot();
 		} );
 	} );
 } );

--- a/client/utils/test/account-fees.tsx
+++ b/client/utils/test/account-fees.tsx
@@ -10,7 +10,9 @@ import React from 'react';
 import {
 	formatAccountFeesDescription,
 	formatMethodFeesDescription,
+	formatPillFeesDescription,
 	getCurrentBaseFee,
+	getTooltipAndPillBaseFee,
 } from '../account-fees';
 import { formatCurrency } from '../currency';
 import { BaseFee, DiscountFee, FeeStructure } from 'wcpay/types/fees';
@@ -262,6 +264,97 @@ describe( 'Account fees utility functions', () => {
 		it( 'returns "missing fees" if no fees are supplied', () => {
 			expect( formatMethodFeesDescription( undefined ) ).toEqual(
 				'missing fees'
+			);
+		} );
+	} );
+
+	describe( 'getTooltipAndPillBaseFee()', () => {
+		it( 'returns base fee if there are no discounts', () => {
+			const accountFees = mockAccountFees( {
+				percentage_rate: 0.123,
+				fixed_rate: 456.78,
+				currency: 'USD',
+			} );
+
+			expect( getTooltipAndPillBaseFee( accountFees ) ).toEqual(
+				accountFees.base
+			);
+		} );
+
+		it( 'returns base fee percentage rate and base fixed rate if there is a promo discount ', () => {
+			const accountFees = mockAccountFees(
+				{
+					percentage_rate: 0.123,
+					fixed_rate: 456.78,
+					currency: 'USD',
+				},
+				[ { discount: 0.1 } ]
+			);
+
+			expect(
+				getTooltipAndPillBaseFee( accountFees ).percentage_rate
+			).toEqual( 0.123 );
+			expect(
+				getTooltipAndPillBaseFee( accountFees ).fixed_rate
+			).toEqual( 456.78 );
+		} );
+
+		it( 'returns custom fee percentage rate if there is a custom rate present ', () => {
+			const accountFees = mockAccountFees(
+				{
+					percentage_rate: 0.123,
+					fixed_rate: 456.78,
+					currency: 'USD',
+				},
+				[ { percentage_rate: 0.11 } ]
+			);
+
+			expect(
+				getTooltipAndPillBaseFee( accountFees ).percentage_rate
+			).toEqual( 0.11 );
+		} );
+	} );
+
+	describe( 'formatPillFeesDescription()', () => {
+		it( 'returns pill description with base rates if there are no discounts', () => {
+			const accountFees = mockAccountFees( {
+				percentage_rate: 0.123,
+				fixed_rate: 456.78,
+				currency: 'USD',
+			} );
+
+			expect( formatPillFeesDescription( accountFees ) ).toEqual(
+				'From 12.3% + $4.57'
+			);
+		} );
+
+		it( 'returns pill description with base rates if there is a promo discount', () => {
+			const accountFees = mockAccountFees(
+				{
+					percentage_rate: 0.123,
+					fixed_rate: 456.78,
+					currency: 'USD',
+				},
+				[ { discount: 0.1 } ]
+			);
+
+			expect( formatPillFeesDescription( accountFees ) ).toEqual(
+				'From 12.3% + $4.57'
+			);
+		} );
+
+		it( 'returns pill description with custom rates if there is a custom fee present', () => {
+			const accountFees = mockAccountFees(
+				{
+					percentage_rate: 0.123,
+					fixed_rate: 456.78,
+					currency: 'USD',
+				},
+				[ { percentage_rate: 0.11, fixed_rate: 375.77 } ]
+			);
+
+			expect( formatPillFeesDescription( accountFees ) ).toEqual(
+				'From 11% + $3.76'
 			);
 		} );
 	} );

--- a/client/utils/test/account-fees.tsx
+++ b/client/utils/test/account-fees.tsx
@@ -11,7 +11,6 @@ import {
 	formatAccountFeesDescription,
 	formatMethodFeesDescription,
 	getCurrentBaseFee,
-	getTooltipAndPillBaseFee,
 } from '../account-fees';
 import { formatCurrency } from '../currency';
 import { BaseFee, DiscountFee, FeeStructure } from 'wcpay/types/fees';
@@ -264,53 +263,6 @@ describe( 'Account fees utility functions', () => {
 			expect( formatMethodFeesDescription( undefined ) ).toEqual(
 				'missing fees'
 			);
-		} );
-	} );
-
-	describe( 'getTooltipAndPillBaseFee()', () => {
-		it( 'returns base fee if there are no discounts', () => {
-			const accountFees = mockAccountFees( {
-				percentage_rate: 0.123,
-				fixed_rate: 456.78,
-				currency: 'USD',
-			} );
-
-			expect( getTooltipAndPillBaseFee( accountFees ) ).toEqual(
-				accountFees.base
-			);
-		} );
-
-		it( 'returns base fee percentage rate and base fixed rate if there is a promo discount ', () => {
-			const accountFees = mockAccountFees(
-				{
-					percentage_rate: 0.123,
-					fixed_rate: 456.78,
-					currency: 'USD',
-				},
-				[ { discount: 0.1 } ]
-			);
-
-			expect(
-				getTooltipAndPillBaseFee( accountFees ).percentage_rate
-			).toEqual( 0.123 );
-			expect(
-				getTooltipAndPillBaseFee( accountFees ).fixed_rate
-			).toEqual( 456.78 );
-		} );
-
-		it( 'returns custom fee percentage rate if there is a custom rate present ', () => {
-			const accountFees = mockAccountFees(
-				{
-					percentage_rate: 0.123,
-					fixed_rate: 456.78,
-					currency: 'USD',
-				},
-				[ { percentage_rate: 0.11 } ]
-			);
-
-			expect(
-				getTooltipAndPillBaseFee( accountFees ).percentage_rate
-			).toEqual( 0.11 );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #5367

#### Changes proposed in this Pull Request

The PR does the following changes: 

* It makes the tool tip show correct `Base` and `Total per transaction` fees within `Payments > Settings > Payment Methods` section.  There was a bug that made the tool tip have the fees missing whenever there was a promotional fee applied. 
* The PR also fixes the Pill component to show custom base fees, if applicable. Else it will show the rack rate base fee ( currently 2.9% + $0.30 

#### Assumption 

If there is a promo fee applied, the discount object would contain a `discount` property, and no `percentage_rate` nor `fixed_rate` .  Hence, the PR uses the absence of these as a way to identify a promo in action vs a custom fee. Kindly let me know if this is valid. Happy to rework, otherwise. Indicating [reference here](https://github.com/Automattic/woocommerce-payments/blob/67788e6cbf069e843d709e18e20d3d849eb8a7fd/client/utils/account-fees.tsx#L251)

#### Screenshots

<details><summary>

##### Before: 

</summary>
<img width="437" alt="image" src="https://user-images.githubusercontent.com/4162931/211346645-8ce4a6e7-4599-4bb6-8d77-43b130f7793b.png">

</details>
<details><summary>

##### After: 

</summary>

<img width="437" alt="image" src="https://user-images.githubusercontent.com/4162931/211347252-a419a5c8-856f-4388-b31f-edd1972bc9b7.png">

</details>

#### Testing instructions

* Checkout to this branch and apply a promo fee to the test site - say - `wcpay-promo-2022-us-incentive-20-off`
* Browse to `Payments > Settings > Payment Methods` section
* The Pill should read `From 2.9% + $0.30` ( rack rate base fees ) 
* Mouse over the pill, and you should see the same rate as Base fee, and correctly calculated `Total per transaction fee`
* As an added check, browse to `Payments > Overview` . The `Account Details` section should show a sub-section of `Active discounts`. This section would show the discounted rate ( with rack rates struck off ), and a progress bar indicating utilization of volume limit. 
* Change the fees to a custom fee and repeat the test steps above
* This time the pill, and the tooltip mouseover, should both show the custom base fee. ( check screenshot below ) 
<img width="422" alt="image" src="https://user-images.githubusercontent.com/4162931/211350105-fccdca9f-8f01-4bc3-8edb-898048170bff.png">


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile - not applicable.

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
