### PR TITLE
Add icons to payment methods in blocks

### DIFF
--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -42,16 +42,12 @@ registerPaymentMethod( {
 	savedTokenComponent: <SavedTokenHandler api={ api } />,
 	canMakePayment: () => !! api.getStripe(),
 	paymentMethodId: PAYMENT_METHOD_NAME_CARD,
-	// <span> element is an inline element which doesn't take the whole width
-	// of the parent component by default. This is why we need to `width: 95%` -
-	// so that the image can be aligned to the right side of the line with the help
-	// of the `float: right` property.
+	// see .wc-block-checkout__payment-method styles in blocks/style.scss
 	label: (
 		<>
-			<span style={ { width: '95%' } }>
+			<span>
 				{ __( 'Credit card', 'woocommerce-payments' ) }
 				<img
-					style={ { float: 'right' } }
 					src={ getConfig( 'icon' ) }
 					alt={ __( 'Credit card', 'woocommerce-payments' ) }
 				/>

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -42,7 +42,22 @@ registerPaymentMethod( {
 	savedTokenComponent: <SavedTokenHandler api={ api } />,
 	canMakePayment: () => !! api.getStripe(),
 	paymentMethodId: PAYMENT_METHOD_NAME_CARD,
-	label: __( 'Credit card', 'woocommerce-payments' ),
+	// <span> element is an inline element which doesn't take the whole width
+	// of the parent component by default. This is why we need to `width: 95%` -
+	// so that the image can be aligned to the right side of the line with the help
+	// of the `float: right` property.
+	label: (
+		<>
+			<span style={ { width: '95%' } }>
+				{ __( 'Credit card', 'woocommerce-payments' ) }
+				<img
+					style={ { float: 'right' } }
+					src={ getConfig( 'icon' ) }
+					alt={ __( 'Credit card', 'woocommerce-payments' ) }
+				/>
+			</span>
+		</>
+	),
 	ariaLabel: __( 'Credit card', 'woocommerce-payments' ),
 	supports: {
 		showSavedCards: getConfig( 'isSavedCardsEnabled' ) ?? false,

--- a/client/checkout/blocks/style.scss
+++ b/client/checkout/blocks/style.scss
@@ -39,4 +39,15 @@ button.wcpay-stripelink-modal-trigger:hover {
 	background-color: transparent;
 	border-color: transparent;
 }
+
+.wc-block-checkout__payment-method
+	.wc-block-components-radio-control__label
+	span {
+	width: 95%;
+
+	img {
+		float: right;
+	}
+}
+
 @import '../platform-checkout/style';

--- a/client/checkout/blocks/upe.js
+++ b/client/checkout/blocks/upe.js
@@ -84,7 +84,18 @@ Object.entries( enabledPaymentMethodsConfig ).map( ( [ upeName, upeConfig ] ) =>
 		savedTokenComponent: <SavedTokenHandler api={ api } />,
 		canMakePayment: () => !! api.getStripe(),
 		paymentMethodId: upeMethods[ upeName ],
-		label: upeConfig.title,
+		label: (
+			<>
+				<span style={ { width: '90%' } }>
+					{ upeConfig.title }
+					<img
+						style={ { float: 'right' } }
+						src={ upeConfig.icon }
+						alt={ upeConfig.title }
+					/>
+				</span>
+			</>
+		),
 		ariaLabel: __( 'WooCommerce Payments', 'woocommerce-payments' ),
 		supports: {
 			showSavedCards: getUPEConfig( 'isSavedCardsEnabled' ) ?? false,

--- a/client/checkout/blocks/upe.js
+++ b/client/checkout/blocks/upe.js
@@ -84,9 +84,13 @@ Object.entries( enabledPaymentMethodsConfig ).map( ( [ upeName, upeConfig ] ) =>
 		savedTokenComponent: <SavedTokenHandler api={ api } />,
 		canMakePayment: () => !! api.getStripe(),
 		paymentMethodId: upeMethods[ upeName ],
+		// <span> element is an inline element which doesn't take the whole width
+		// of the parent component by default. This is why we need to `width: 95%` -
+		// so that the image can be aligned to the right side of the line with the help
+		// of the `float: right` property.
 		label: (
 			<>
-				<span style={ { width: '90%' } }>
+				<span style={ { width: '95%' } }>
 					{ upeConfig.title }
 					<img
 						style={ { float: 'right' } }

--- a/client/checkout/blocks/upe.js
+++ b/client/checkout/blocks/upe.js
@@ -84,19 +84,12 @@ Object.entries( enabledPaymentMethodsConfig ).map( ( [ upeName, upeConfig ] ) =>
 		savedTokenComponent: <SavedTokenHandler api={ api } />,
 		canMakePayment: () => !! api.getStripe(),
 		paymentMethodId: upeMethods[ upeName ],
-		// <span> element is an inline element which doesn't take the whole width
-		// of the parent component by default. This is why we need to `width: 95%` -
-		// so that the image can be aligned to the right side of the line with the help
-		// of the `float: right` property.
+		// see .wc-block-checkout__payment-method styles in blocks/style.scss
 		label: (
 			<>
-				<span style={ { width: '95%' } }>
+				<span>
 					{ upeConfig.title }
-					<img
-						style={ { float: 'right' } }
-						src={ upeConfig.icon }
-						alt={ upeConfig.title }
-					/>
+					<img src={ upeConfig.icon } alt={ upeConfig.title } />
 				</span>
 			</>
 		),

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2034,6 +2034,18 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * The get_icon() method from the WC_Payment_Gateway class wraps the icon URL into a prepared HTML element, but there are situations when this
+	 * element needs to be rendered differently on the UI (e.g. additional styles or `display` property).
+	 *
+	 * This is why we need a usual getter like this to provide a raw icon URL to the UI, which will render it according to particular requirements.
+	 *
+	 * @return string Returns the payment method icon URL.
+	 */
+	public function get_icon_url() {
+		return $this->icon;
+	}
+
+	/**
 	 * Handles connected account update when plugin settings saved.
 	 *
 	 * Adds error message to display in admin notices in case of failure.

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -127,6 +127,7 @@ class WC_Payments_Checkout {
 			'userExistsEndpoint'             => get_rest_url( null, '/wc/v3/users/exists' ),
 			'platformCheckoutSignatureNonce' => wp_create_nonce( 'platform_checkout_signature_nonce' ),
 			'platformCheckoutMerchantId'     => Jetpack_Options::get_option( 'id' ),
+			'icon'                           => $this->gateway->get_icon_url(),
 		];
 
 		/**

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -182,6 +182,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 						'a'      => '<a href="https://woocommerce.com/document/payments/testing/#test-cards" target="_blank">',
 					]
 				),
+				'icon'                 => $payment_method->get_icon(),
 			];
 		}
 

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -141,6 +141,11 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 	private $return_url = 'test_url';
 
 	/**
+	 * @var string Mocked value of return_url.
+	 */
+	private $icon_url = 'test_icon_url';
+
+	/**
 	 * Mocked object to be used as response from process_payment_using_saved_method()
 	 *
 	 * @var array
@@ -246,7 +251,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		foreach ( $this->payment_method_classes as $payment_method_id => $payment_method_class ) {
 			$mock_payment_method = $this->getMockBuilder( $payment_method_class )
 				->setConstructorArgs( [ $this->mock_token_service ] )
-				->setMethods( [ 'is_subscription_item_in_cart' ] )
+				->setMethods( [ 'is_subscription_item_in_cart', 'get_icon' ] )
 				->getMock();
 			$this->mock_payment_methods[ $mock_payment_method->get_id() ] = $mock_payment_method;
 
@@ -1216,8 +1221,6 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_payment_methods_show_correct_default_outputs() {
-		// Setup $this->mock_payment_methods.
-
 		$mock_token = WC_Helper_Token::create_token( 'pm_mock' );
 		$this->mock_token_service->expects( $this->any() )
 			->method( 'add_payment_method_to_user' )
@@ -1641,6 +1644,13 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					]
 				)
 			);
+
+		$this->mock_payment_methods[ Payment_Method::LINK ]->expects( $this->any() )
+			->method( 'get_icon' )
+			->will(
+				$this->returnValue( $this->icon_url )
+			);
+
 		$mock_upe_gateway
 			->method( 'wc_payments_get_payment_method_by_id' )
 			->willReturnMap(
@@ -1666,6 +1676,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					'upePaymentIntentData' => null,
 					'upeSetupIntentData'   => null,
 					'testingInstructions'  => '',
+					'icon'                 => $this->icon_url,
 				],
 			]
 		);

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2096,6 +2096,12 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( $this->payments_checkout->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
 	}
 
+	public function test_return_icon_url() {
+		$returned_icon = $this->payments_checkout->get_payment_fields_js_config()['icon'];
+		$this->assertNotNull( $returned_icon );
+		$this->assertStringContainsString( 'assets/images/payment-methods/cc.svg', $returned_icon );
+	}
+
 	public function is_platform_checkout_falsy_value_provider() {
 		return [
 			[ '0' ],


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5259

#### Changes proposed in this Pull Request
This PR adds payment methods' icons on the Blocks checkout page. The set of icons used is the same that was added in https://github.com/Automattic/woocommerce-payments/pull/4860.

<details>
  <summary>Here's how it looks right now on the Blocks checkout page</summary>


<img width="477" alt="image" src="https://user-images.githubusercontent.com/22319444/211521231-9b88eef0-8ab6-4596-ac65-f1ba1da518f1.png">




</details>

#### Testing instructions
After checking out the `add/icons-to-payment-methods-in-blocks` branch
1. Go to the WCPay Settings in the admin panel of the merchant site and enable all the possible UPE payment methods from the list
2. On the merchant site, set the currency to USD
3. Add a product to the cart and open the Blocks checkout page
4. Confirm that CC icons appear
5. Set the currency to EUR so that UPE methods are enabled
6. Open the Blocks checkout page and confirm that there is an icon present for each UPE payment method and the CC as well
7. Confirm that the icons from Blocks checkout are the same as on the shortcode checkout page
8. Exit the full-screen mode of your browser, resize the browser window on your laptop and while doing so, ensure that the spacing between an icon and the end of the line in Blocks checkout remains unchanged and, overall, confirm that no unexpected styling issues appear
9. Perform step `8` on Firefox and Safari (assuming that the initial test was performed on Chrome browser).


-------------------

- [ ] Run `npm run changelog` to add a changelog file, and choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
