### PR TITLE
Fix ActionScheduler fatal error

### DIFF
--- a/changelog/fix-action-scheduler-fatal-error
+++ b/changelog/fix-action-scheduler-fatal-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent occasional fatal erros when creating customers via ActionScheduler jobs

--- a/changelog/fix-action-scheduler-fatal-error
+++ b/changelog/fix-action-scheduler-fatal-error
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Prevent occasional fatal erros when creating customers via ActionScheduler jobs
+Prevent occasional fatal errors when creating customers via ActionScheduler jobs

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -138,8 +138,10 @@ class WC_Payments_Customer_Service {
 			$this->update_user_customer_id( $user->ID, $customer_id );
 		}
 
-		// Save the customer id in the session for non logged in users to reuse it in payments.
-		WC()->session->set( self::CUSTOMER_ID_SESSION_KEY, $customer_id );
+		if ( isset( WC()->session ) ) {
+			// Save the customer id in the session for non logged in users to reuse it in payments.
+			WC()->session->set( self::CUSTOMER_ID_SESSION_KEY, $customer_id );
+		}
 
 		return $customer_id;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- Check if `WC()->session` is set before adding customer ID to the browser session when creating a customer object.

Some time between the release of WCPay 4.5.1 and 5.2.1 -- maybe because of some differences in WooCommerce versions? We're not sure why -- ActionScheduler jobs that created customers started resulting in fatal errors because the `WC()->session` object is not available in AS jobs.

Context in p1673303308974939-slack-CGGCLBN58?thread_ts=1673293381.897259&cid=CGGCLBN58

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> **Note**
> You can skip step (2) if your account on the test store already has a Stripe customer ID associated with it.

1. Make sure you're using the UPE checkout.
2. Add any amount of products to your cart and successfully complete a checkout of any amount.
3. Re-onboard WCPay to connect the store to a new WCPay account.
4. Add any amount of products to your cart and try to complete a checkout.
5. You should see a `No such customer` error:

<img width="1063" alt="image" src="https://user-images.githubusercontent.com/13835680/211488046-813e3170-74be-4005-9330-ed699af78ec0.png">

6. Wait a couple seconds and then retry the payment.
7. It should now be successful.

On `develop` the payment retry will fail in step (6) and the AS job scheduled by the failed payment in step (4) will fail to run due to a fatal error that you can see in the logs.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
