### PR TITLE
Add Apple Pay and Google Pay to payment method list in gateway description

### DIFF
--- a/changelog/update-gateway-descriptions-add-apple-google-pay
+++ b/changelog/update-gateway-descriptions-add-apple-google-pay
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add Apple Pay and Google Pay as supported payment methods in gateway descriptions.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -198,7 +198,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$this->method_description = WC_Payments_Utils::esc_interpolated_html(
 			/* translators: tosLink: Link to terms of service page, privacyLink: Link to privacy policy page */
 			__(
-				'Payments made simple, with no monthly fees – designed exclusively for WooCommerce stores. Accept credit cards, debit cards, and other popular payment methods.<br/><br/>
+				'WooCommerce Payments gives your store flexibility to accept credit cards, debit cards, and Apple Pay. Enable popular local payment methods and other digital wallets like Google Pay to give customers even more choice.<br/><br/>
 			By using WooCommerce Payments you agree to be bound by our <tosLink>Terms of Service</tosLink>  and acknowledge that you have read our <privacyLink>Privacy Policy</privacyLink>',
 				'woocommerce-payments'
 			),

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -95,6 +95,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	) {
 		parent::__construct( $payments_api_client, $account, $customer_service, $token_service, $action_scheduler_service, $failed_transaction_rate_limiter, $order_service );
 		$this->title           = __( 'WooCommerce Payments', 'woocommerce-payments' );
+		$this->description     = '';
 		$this->checkout_title  = __( 'Popular payment methods', 'woocommerce-payments' );
 		$this->payment_methods = $payment_methods;
 

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -94,12 +94,8 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		WC_Payments_Order_Service $order_service
 	) {
 		parent::__construct( $payments_api_client, $account, $customer_service, $token_service, $action_scheduler_service, $failed_transaction_rate_limiter, $order_service );
-		$this->method_title       = __( 'WooCommerce Payments', 'woocommerce-payments' );
-		$this->method_description = __( 'WooCommerce Payments gives your store flexibility to accept credit cards, debit cards, and Apple Pay. Enable popular local payment methods and other digital wallets like Google Pay to give customers even more choice.', 'woocommerce-payments' );
-		$this->title              = __( 'WooCommerce Payments', 'woocommerce-payments' );
-		$this->description        = '';
-		$this->checkout_title     = __( 'Popular payment methods', 'woocommerce-payments' );
-		$this->payment_methods    = $payment_methods;
+		$this->checkout_title  = __( 'Popular payment methods', 'woocommerce-payments' );
+		$this->payment_methods = $payment_methods;
 
 		add_action( 'wc_ajax_wcpay_create_payment_intent', [ $this, 'create_payment_intent_ajax' ] );
 		add_action( 'wc_ajax_wcpay_update_payment_intent', [ $this, 'update_payment_intent_ajax' ] );

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -94,6 +94,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 		WC_Payments_Order_Service $order_service
 	) {
 		parent::__construct( $payments_api_client, $account, $customer_service, $token_service, $action_scheduler_service, $failed_transaction_rate_limiter, $order_service );
+		$this->title           = __( 'WooCommerce Payments', 'woocommerce-payments' );
 		$this->checkout_title  = __( 'Popular payment methods', 'woocommerce-payments' );
 		$this->payment_methods = $payment_methods;
 

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -95,7 +95,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	) {
 		parent::__construct( $payments_api_client, $account, $customer_service, $token_service, $action_scheduler_service, $failed_transaction_rate_limiter, $order_service );
 		$this->method_title       = __( 'WooCommerce Payments', 'woocommerce-payments' );
-		$this->method_description = __( 'Payments made simple, with no monthly fees - designed exclusively for WooCommerce stores. Accept credit cards, debit cards, and other popular payment methods.', 'woocommerce-payments' );
+		$this->method_description = __( 'WooCommerce Payments gives your store flexibility to accept credit cards, debit cards, and Apple Pay. Enable popular local payment methods and other digital wallets like Google Pay to give customers even more choice.', 'woocommerce-payments' );
 		$this->title              = __( 'WooCommerce Payments', 'woocommerce-payments' );
 		$this->description        = '';
 		$this->checkout_title     = __( 'Popular payment methods', 'woocommerce-payments' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Match the descriptions of both gateways (WCPay and UPE) to the text on the official website.
* The revised text includes Apple Pay and Google Pay.

#### Testing instructions

* Go to WP Admin → WooCommerce → Settings → Payments → All payment methods.
* Check the description for WooCommerce Payments.
* The description should be the same with UPE enabled and disabled.

Before, with UPE disabled:

<img width="1355" alt="image" src="https://user-images.githubusercontent.com/1288616/212042663-9d5d9b62-39c9-48d7-bc34-eece339e2ebc.png">

Before, with UPE enabled:

<img width="1357" alt="image" src="https://user-images.githubusercontent.com/1288616/212042812-9243bcd6-0906-4fa7-886a-15cdb3977dfa.png">

After, with UPE disabled:

<img width="1359" alt="image" src="https://user-images.githubusercontent.com/1288616/212045790-84d7d286-5f94-4820-a0d2-5e74056e609b.png">

After, with UPE enabled:

<img width="1356" alt="image" src="https://user-images.githubusercontent.com/1288616/212042513-e068f5af-8f1c-4791-a674-de5a479c197a.png">


#### Additional context

paJDYF-5Wk-p2


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (does not apply)
- [ ] Tested on mobile (does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.