### PR TITLE
Single separator for express checkout methods

### DIFF
--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -146,6 +146,24 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Checks whether Auth & Capture (uncaptured transactions tab, capture from payment details page) is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_auth_and_capture_enabled() {
+		return '1' === get_option( self::AUTH_AND_CAPTURE_FLAG_NAME, '1' );
+	}
+
+	/**
+	 * Checks whether Payment Request is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_payment_request_enabled() {
+		return 'yes' === WC_Payments::get_gateway()->get_option( 'payment_request' );
+	}
+
+	/**
 	 * Checks whether WooPay Express Checkout is enabled.
 	 *
 	 * @return bool
@@ -153,15 +171,6 @@ class WC_Payments_Features {
 	public static function is_woopay_express_checkout_enabled() {
 		// Confirm platform checkout eligibility as well.
 		return '1' === get_option( self::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '0' ) && self::is_platform_checkout_eligible();
-	}
-
-	/**
-	 * Checks whether Auth & Capture (uncaptured transactions tab, capture from payment details page) is enabled.
-	 *
-	 * @return bool
-	 */
-	public static function is_auth_and_capture_enabled() {
-		return '1' === get_option( self::AUTH_AND_CAPTURE_FLAG_NAME, '1' );
 	}
 
 	/**
@@ -175,6 +184,15 @@ class WC_Payments_Features {
 			WC_Payments::get_gateway()->get_payment_method_ids_enabled_at_checkout_filtered_by_fees( null, true ),
 			true
 		);
+	}
+
+	/**
+	 * Checks whether any express checkout method is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_express_checkout_enabled() {
+		return self::is_woopay_express_checkout_enabled() || self::is_payment_request_enabled() || self::is_link_enabled();
 	}
 
 	/**

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -74,16 +74,12 @@ class WC_Payments_Payment_Request_Button_Handler {
 		add_action( 'wp_enqueue_scripts', [ $this, 'scripts' ] );
 
 		add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_payment_request_button_html' ], 1 );
-		add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_payment_request_button_separator_html' ], 2 );
 
 		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_payment_request_button_html' ], 1 );
-		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_payment_request_button_separator_html' ], 2 );
 
-		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_payment_request_button_html' ], 1 );
-		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_payment_request_button_separator_html' ], 2 );
+		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_payment_request_button_html' ], -2 );
 
 		add_action( 'before_woocommerce_pay_form', [ $this, 'display_pay_for_order_page_html' ], 1 );
-		add_action( 'before_woocommerce_pay_form', [ $this, 'display_payment_request_button_separator_html' ], 2 );
 
 		add_action( 'wc_ajax_wcpay_get_cart_details', [ $this, 'ajax_get_cart_details' ] );
 		add_action( 'wc_ajax_wcpay_get_shipping_options', [ $this, 'ajax_get_shipping_options' ] );
@@ -787,18 +783,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 				<!-- A Stripe Element will be inserted here. -->
 			</div>
 		</div>
-		<?php
-	}
-
-	/**
-	 * Display payment request button separator.
-	 */
-	public function display_payment_request_button_separator_html() {
-		if ( ! $this->should_show_payment_request_button() ) {
-			return;
-		}
-		?>
-		<p id="wcpay-payment-request-button-separator" style="margin-top:1.5em;text-align:center;display:none;">&mdash; <?php esc_html_e( 'OR', 'woocommerce-payments' ); ?> &mdash;</p>
 		<?php
 	}
 

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -73,9 +73,9 @@ class WC_Payments_Payment_Request_Button_Handler {
 		add_action( 'template_redirect', [ $this, 'handle_payment_request_redirect' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'scripts' ] );
 
-		add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_payment_request_button_html' ], 1 );
+		add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_payment_request_button_html' ], -2 );
 
-		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_payment_request_button_html' ], 1 );
+		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_payment_request_button_html' ], -2 );
 
 		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_payment_request_button_html' ], -2 );
 

--- a/includes/class-wc-payments-platform-checkout-button-handler.php
+++ b/includes/class-wc-payments-platform-checkout-button-handler.php
@@ -78,13 +78,10 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 		add_filter( 'wcpay_payment_fields_js_config', [ $this, 'add_platform_checkout_config' ] );
 
 		add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_platform_checkout_button_html' ], -2 );
-		add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_platform_checkout_button_separator_html' ], -1 );
 
 		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_platform_checkout_button_html' ], -2 );
-		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_platform_checkout_button_separator_html' ], -1 );
 
 		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_platform_checkout_button_html' ], -2 );
-		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_platform_checkout_button_separator_html' ], -1 );
 	}
 
 	/**

--- a/includes/class-wc-payments-platform-checkout-button-handler.php
+++ b/includes/class-wc-payments-platform-checkout-button-handler.php
@@ -300,16 +300,4 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 		<?php
 	}
 
-	/**
-	 * Display payment request button separator.
-	 */
-	public function display_platform_checkout_button_separator_html() {
-		if ( ! $this->should_show_platform_checkout_button() ) {
-			return;
-		}
-		?>
-		<p id="wcpay-payment-request-button-separator" style="margin-top:1.5em;text-align:center;">&mdash; <?php esc_html_e( 'OR', 'woocommerce-payments' ); ?> &mdash;</p>
-		<?php
-	}
-
 }

--- a/includes/class-wc-payments-stripe-link-button-handler.php
+++ b/includes/class-wc-payments-stripe-link-button-handler.php
@@ -55,7 +55,6 @@ class WC_Payments_Stripe_Link_Button_Handler {
 		}
 
 		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_button_html' ], -2 );
-		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_button_separator_html' ], -1 );
 
 		// Don't load for change payment method page.
 		if ( isset( $_GET['change_payment_method'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification

--- a/includes/class-wc-payments-stripe-link-button-handler.php
+++ b/includes/class-wc-payments-stripe-link-button-handler.php
@@ -84,23 +84,6 @@ class WC_Payments_Stripe_Link_Button_Handler {
 	}
 
 	/**
-	 * Display payment request button separator.
-	 */
-	public function display_button_separator_html() {
-		if ( ! WC_Payments_Features::is_link_enabled() ) {
-			return;
-		}
-
-		if ( ! $this->is_checkout() ) {
-			return;
-		}
-		?>
-		<p id="wcpay-payment-request-button-separator" style="margin-top:1.5em;text-align:center;">&mdash; <?php esc_html_e( 'OR', 'woocommerce-payments' ); ?> &mdash;</p>
-		<?php
-	}
-
-
-	/**
 	 * Checks if this is the checkout page or content contains a cart block.
 	 *
 	 * @return boolean

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -470,6 +470,10 @@ class WC_Payments {
 			add_action( 'woocommerce_after_add_to_cart_quantity', [ __CLASS__, 'display_express_checkout_button_separator_html' ], -1 );
 			add_action( 'woocommerce_proceed_to_checkout', [ __CLASS__, 'display_express_checkout_button_separator_html' ], -1 );
 			add_action( 'woocommerce_checkout_before_customer_details', [ __CLASS__, 'display_express_checkout_button_separator_html' ], -1 );
+
+			if ( WC_Payments_Features::is_payment_request_enabled() ) {
+				add_action( 'before_woocommerce_pay_form', [ __CLASS__, 'display_express_checkout_button_separator_html' ], 2 );
+			}
 		}
 
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -466,6 +466,12 @@ class WC_Payments {
 			WC_Payments_Subscriptions::init( self::$api_client, self::$customer_service, self::get_gateway(), self::$account );
 		}
 
+		if ( WC_Payments_Features::is_express_checkout_enabled() ) {
+			add_action( 'woocommerce_after_add_to_cart_quantity', [ __CLASS__, 'display_express_checkout_button_separator_html' ], -1 );
+			add_action( 'woocommerce_proceed_to_checkout', [ __CLASS__, 'display_express_checkout_button_separator_html' ], -1 );
+			add_action( 'woocommerce_checkout_before_customer_details', [ __CLASS__, 'display_express_checkout_button_separator_html' ], -1 );
+		}
+
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ __CLASS__, 'set_plugin_activation_timestamp' ] );
 
@@ -1397,5 +1403,19 @@ class WC_Payments {
 		if ( ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) && file_exists( WCPAY_ABSPATH . 'dist/runtime.js' ) ) {
 			wp_enqueue_script( 'WCPAY_RUNTIME', plugins_url( 'dist/runtime.js', WCPAY_PLUGIN_FILE ), [], self::get_file_version( 'dist/runtime.js' ), true );
 		}
+	}
+
+	/**
+	 * Display payment request button separator.
+	 */
+	public static function display_express_checkout_button_separator_html() {
+		$should_hide = WC_Payments_Features::is_payment_request_enabled() && ! WC_Payments_Features::is_woopay_express_checkout_enabled() && ! WC_Payments_Features::is_link_enabled();
+
+		if ( WC_Payments_Features::is_payment_request_enabled() && ! self::$payment_request_button_handler->should_show_payment_request_button() ) {
+			return;
+		}
+		?>
+		<p id="wcpay-payment-request-button-separator" style="margin-top:1.5em;text-align:center;<?php echo $should_hide ? 'display:none;' : ''; ?>">&mdash; <?php esc_html_e( 'OR', 'woocommerce-payments' ); ?> &mdash;</p>
+		<?php
 	}
 }


### PR DESCRIPTION
Fixes #5339  

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

This branch is based off of `4720/stripe-link-intgration`. Since that hasn't yet been merged, it seems more feasible to merge it into that branch instead of `poc/upe-instances-multiplied`. 

This ensures that only a single **- OR -** separator is displayed after express checkout buttons rather than duplicated/stacked separators. The separator will appear on the product page, cart page, and checkout page.

![image](https://user-images.githubusercontent.com/3473953/212183184-0aa5fb81-1b96-4174-83d5-98efd0403876.png)

#### Testing instructions

1. Enable 2 or more express checkout methods(Link, WooPay, Payment Request). The WooPay express checkout button can be enabled via the latest version of the WCPay Dev Tools plugin. Configure the express button by selecting **Customize** under the WooPay Express Checkout settings at **Payments  > Settings**. 
2. Visit a product page where only 1 **- OR -** separator should appear.
3. Add a product to the cart and visit the cart page where only 1 **- OR -** separator should appear. 
4. Visit the cart page where only 1 **- OR -** separator should appear.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
