### PR TITLE
Display the platform checkout block when necessary

### DIFF
--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -46,7 +46,10 @@ registerPaymentMethod( {
 	ariaLabel: __( 'Credit card', 'woocommerce-payments' ),
 	supports: {
 		showSavedCards: getConfig( 'isSavedCardsEnabled' ) ?? false,
-		showSaveOption: getConfig( 'isSavedCardsEnabled' ) ?? false,
+		showSaveOption:
+			( getConfig( 'isSavedCardsEnabled' ) &&
+				! getConfig( 'isPlatformCheckoutEnabled' ) ) ??
+			false,
 		features: getConfig( 'features' ),
 	},
 } );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -620,7 +620,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if (
 			WC_Payments_Features::is_platform_checkout_eligible() &&
 			'yes' === $this->get_option( 'platform_checkout', 'no' ) &&
-			! WC_Payments_Features::is_upe_enabled() &&
 			( is_checkout() || has_block( 'woocommerce/checkout' ) ) &&
 			! is_wc_endpoint_url( 'order-pay' ) &&
 			! WC()->cart->is_empty() &&

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -342,7 +342,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	/**
 	 * Whether we should use the platform account to initialize Stripe on the checkout page.
 	 *
-	 * @return bool True if the card payment method is used, false otherwise.
+	 * @return bool Result of the WCPay gateway checks if the card payment method is used, false otherwise.
 	 */
 	public function should_use_stripe_platform_on_checkout_page() {
 		if ( 'card' === $this->stripe_id ) {

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -340,6 +340,18 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	}
 
 	/**
+	 * Whether we should use the platform account to initialize Stripe on the checkout page.
+	 *
+	 * @return bool True if the card payment method is used, false otherwise.
+	 */
+	public function should_use_stripe_platform_on_checkout_page() {
+		if ( 'card' === $this->stripe_id ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	 * Handle AJAX request for creating a setup intent without confirmation for Stripe UPE.
 	 *
 	 * @throws Add_Payment_Method_Exception - If nonce or setup intent is invalid.

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -346,7 +346,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	 */
 	public function should_use_stripe_platform_on_checkout_page() {
 		if ( 'card' === $this->stripe_id ) {
-			return true;
+			return parent::should_use_stripe_platform_on_checkout_page();
 		}
 		return false;
 	}

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -329,6 +329,11 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		}
 	}
 
+	public function test_should_not_use_stripe_platform_on_checkout_page_for_upe() {
+		$payment_gateway = $this->mock_payment_gateways[ Payment_Method::SEPA ];
+		$this->assertFalse( $payment_gateway->should_use_stripe_platform_on_checkout_page() );
+	}
+
 	public function test_update_payment_intent_adds_customer_save_payment_and_level3_data() {
 		$order               = WC_Helper_Order::create_order();
 		$order_id            = $order->get_id();

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2068,6 +2068,18 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->assertTrue( $this->payments_checkout->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
 	}
 
+	public function test_should_use_stripe_platform_on_checkout_page_not_platform_checkout_eligible() {
+		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => false ] );
+		$this->assertFalse( $this->wcpay_gateway->should_use_stripe_platform_on_checkout_page() );
+	}
+
+	public function test_should_use_stripe_platform_on_checkout_page_not_platform_checkout() {
+		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
+		$this->wcpay_gateway->update_option( 'platform_checkout', 'no' );
+
+		$this->assertFalse( $this->wcpay_gateway->should_use_stripe_platform_on_checkout_page() );
+	}
+
 	public function test_force_network_saved_cards_is_returned_as_true_if_should_use_stripe_platform() {
 		$mock_wcpay_gateway = $this->get_partial_mock_for_gateway( [ 'should_use_stripe_platform_on_checkout_page' ] );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5337


#### Definitions
**_save to platform_** - the checkbox to save the user's payment information to the platform
**_save to store_** - the checkbox to save the user's payment information to the store
#### Pre-briefing
Regarding saving payment information on the checkout, two possible checkboxes are available for users. 
<table>
<tr>
<th>Platform checkout enabled (save to platform) </th>
<th>Platform checkout disabled (save to store) </th>
<tr>
<td>


<img width="335" alt="image" src="https://user-images.githubusercontent.com/22319444/212280356-a306d0c2-11bc-4bee-9dc3-d7a846c6307f.png">

</td>
<td>

<img width="289" alt="image" src="https://user-images.githubusercontent.com/22319444/212280476-014a84e5-78a0-4e60-8cd3-7f4733560401.png">


</td>
</tr>
</table>

Both are valid, regardless of whether Blocks or shortcode checkout is used. Moreover, after all the efforts upon split UPE, it's finally possible for users to checkout with WooPay while having the UPE enabled simultaneously. 


#### Changes proposed in this Pull Request
This PR makes it possible to: 
1. Display _**save to platform**_ for CC when WooPay is enabled. This applies both to Blocks and shortcode checkouts and all the possible UPE settings (on/off).
2. Avoid displaying _**save to store**_  for CC whenever the previous step comes true.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
> 💡 Keep your payment settings on the merchant site open to always have quick access to settings that we'll need to change often during our testing.

> 💡 Login as an existing user on the merchant store.

#### WooPay and UPE disabled
1. Disable WooPay and UPE in the admin panel `Payment` -> `Settings`.
2. Go to the merchant site, and add a product to the cart. 
3. Confirm that _**save to store**_ works as expected in shortcode by checking it, placing an order, and confirming that the card was successfully saved in the store
4. Confirm that _**save to store**_ works as expected in Blocks by checking it, placing an order, and confirming that the card was successfully saved in the store
5. Ensure that _**save to platform**_ is displayed neither on shortcode nor in Blocks when CC is selected.

#### WooPay disabled, and UPE enabled
1. Disable WooPay and enable UPE with any payment methods in the admin panel `Payment` -> `Settings`.
2. Go to the merchant site, and add a product to the cart. 
3. Confirm that _**save to store**_ works as expected in the shortcode by checking it, placing an order, and confirming that the card was successfully saved in the store. Perform the same for the SEPA.
4. Confirm that _**save to store**_ works as expected in Blocks by checking it, placing an order, and confirming that the card was successfully saved in the store. Perform the same for the SEPA.
5. Ensure that _**save to platform**_ is displayed neither on shortcode nor in Blocks when CC is selected.

> Note 💡 Before moving forward with the next two test groups, run `npm run listen` in WCPay Server for it to listen to the customer creation hooks. Also, start your Jurassic tube and perform the test with the public URL to make all the integration happen (Stripe and platform user creation).

#### WooPay enabled and UPE disabled
1. Enable WooPay and disable UPE in the admin panel `Payment` -> `Settings`.
2. Go to the merchant site, and add a product to the cart. 
3. Confirm that _**save to platform**_ works as expected in shortcode by checking it, placing an order, and confirming that the user was successfully created in Stripe and on the platform.
4. Confirm that _**save to platform**_ works as expected in Blocks by checking it, placing an order, and confirming that the user was successfully created in Stripe and on the platform.
5. Ensure that _**save to store**_ is displayed neither on shortcode nor in Blocks when CC is selected.

#### WooPay and UPE enabled
1. Enable WooPay and UPE methods in the admin panel `Payment` -> `Settings`.
2. Go to the merchant site, and add a product to the cart. 
3. Confirm that _**save to platform**_ works as expected for CC in the shortcode by checking it, placing an order, and confirming that the card was successfully saved in the store.
4. Confirm that _**save to platform**_ works as expected for CC in Blocks by checking it, placing an order, and confirming that the card was successfully saved in the store.
5. Ensure that for SEPA the _**save to store**_ checkbox is displayed and not _**save to platform**_
6. Ensure that _**save to store**_ is displayed neither on shortcode nor in Blocks when CC is selected.


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
