### PR TITLE
Fix TOS acceptance can prevent saving settings or accessing account dashboard

### DIFF
--- a/changelog/fix-5275-treat-merchant-that-left-kyc-early-as-new-users
+++ b/changelog/fix-5275-treat-merchant-that-left-kyc-early-as-new-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix TOS acceptance can prevent saving settings or accessing account dashboard

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -219,7 +219,7 @@ class WC_Payments_Admin {
 		global $submenu;
 
 		try {
-			$should_render_full_menu = $this->account->try_is_stripe_connected();
+			$should_render_full_menu = $this->account->is_stripe_account_valid();
 		} catch ( Exception $e ) {
 			// There is an issue with connection but render full menu anyways to provide access to settings.
 			$should_render_full_menu = true;

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -152,6 +152,28 @@ class WC_Payments_Account {
 	}
 
 	/**
+	 * Checks if the account is valid: which means it's connected and has valid card_payments capability status (requested, pending_verification, active and other valid ones).
+	 * Card_payments capability is crucial for account to function properly. If it is unrequested, we shouldn't show
+	 * any other options for the merchants since it'll lead to various errors.
+	 *
+	 * @see https://github.com/Automattic/woocommerce-payments/issues/5275
+	 *
+	 * @return bool True if the account have valid stripe account, false otherwise.
+	 */
+	public function is_stripe_account_valid(): bool {
+		if ( ! $this->is_stripe_connected() ) {
+			return false;
+		}
+		$account = $this->get_cached_account_data();
+
+		if ( ! isset( $account['capabilities']['card_payments'] ) ) {
+			return false;
+		}
+
+		return 'unrequested' !== $account['capabilities']['card_payments'];
+	}
+
+	/**
 	 * Checks if the account has been rejected, assumes the value of false on any account retrieval error.
 	 * Returns false if the account is not connected.
 	 *

--- a/tests/unit/admin/test-class-wc-payments-admin.php
+++ b/tests/unit/admin/test-class-wc-payments-admin.php
@@ -89,7 +89,7 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		update_option( '_wcpay_feature_upe', $is_upe_enabled ? '1' : '0' );
 
 		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'try_is_stripe_connected' )->willReturn( true );
+		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( true );
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls = wp_list_pluck( $submenu['wc-admin&path=/payments/overview'], 0, 2 );
@@ -103,7 +103,7 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		$this->mock_current_user_is_admin();
 
 		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'try_is_stripe_connected' )->willReturn( true );
+		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( true );
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls = wp_list_pluck( $menu, 0, 2 );
@@ -116,7 +116,7 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		$this->mock_current_user_is_admin();
 
 		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'try_is_stripe_connected' )->willReturn( false );
+		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( false );
 		update_option( 'wcpay_activation_timestamp', time() - ( 3 * DAY_IN_SECONDS ) );
 		$this->payments_admin->add_payments_menu();
 
@@ -130,7 +130,7 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		$this->mock_current_user_is_admin();
 
 		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'try_is_stripe_connected' )->willReturn( false );
+		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( false );
 		update_option( 'wcpay_menu_badge_hidden', 'no' );
 		update_option( 'wcpay_activation_timestamp', time() - ( DAY_IN_SECONDS * 2 ) );
 		$this->payments_admin->add_payments_menu();
@@ -252,7 +252,7 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		$this->mock_current_user_is_admin();
 
 		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'try_is_stripe_connected' )->willReturn( true );
+		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( true );
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls = wp_list_pluck( $submenu[ WC_Payments_Admin::PAYMENTS_SUBMENU_SLUG ], 0, 2 );
@@ -293,7 +293,7 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		$this->mock_current_user_is_admin();
 
 		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'try_is_stripe_connected' )->willReturn( true );
+		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( true );
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls = wp_list_pluck( $submenu[ WC_Payments_Admin::PAYMENTS_SUBMENU_SLUG ], 0, 2 );
@@ -336,7 +336,7 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		$this->mock_current_user_is_admin();
 
 		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'try_is_stripe_connected' )->willReturn( true );
+		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( true );
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls = wp_list_pluck( $submenu[ WC_Payments_Admin::PAYMENTS_SUBMENU_SLUG ], 0, 2 );
@@ -381,7 +381,7 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		$this->mock_current_user_is_admin();
 
 		// Make sure we render the menu with submenu items.
-		$this->mock_account->method( 'try_is_stripe_connected' )->willReturn( true );
+		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( true );
 		$this->payments_admin->add_payments_menu();
 
 		$item_names_by_urls     = wp_list_pluck( $submenu[ WC_Payments_Admin::PAYMENTS_SUBMENU_SLUG ], 0, 2 );


### PR DESCRIPTION
Fixes #5275 

#### Changes proposed in this Pull Request

This PR is aimed at allowing our merchants to finish the Stripe KYC if they have left it immediately (before entering their phone number and 2FA, selecting country).

When they do so, they are not currently able to generate login links to finish the onboarding in Stripe Express or proceed with the Stripe KYC.

After discussions in the related issue and in the slack thread p1673966872738579-slack-C03KTTK2YMA we ended up with the following solution: treat our customers as new, and navigate them to the connect page. And if possible, don't create a new Stripe account for them.

I was able to modify the codebase to support the described solution and not create a new Stripe account for our merchants every time.

#### Testing instructions

* Checkout to `develop`.
* Remove current Stripe account if it exists locally and start onboarding a new one by clicking Finish Setup on the payments connect page.
* Leave the onboarding immediately (click "back" and refresh the page or just close the page).
* Confirm that the following behavior happens:
  * payments/connect page is not available (not allowed);
  * payments menu has a submenu (settings, overview, etc);
  * trying to update your details on payments/overview page produces an error `There was a problem redirecting you to the account dashboard. Please try again`.
* Checkout to `fix/5275-treat-merchant-that-left-kyc-early-as-new-users`.
* After page refresh, confirm that the payments menu does not have a submenu. Payments settings and overview shouldn't be available.
* Navigate to the payments connect page by clicking on the Payments menu. Verify it can be opened and click Finish Setup.
* Write down / memorize the stripe account id (we'll need it to compare during next steps). Leave the onboarding immediately by clicking "Back" in the browser (and refresh the page).
* You should get back to the payments connect page again. Click Finish Setup and verify that it's **the same Stripe account**.
* Now enter your phone, pass 2FA and select a country. Click continue and leave the onboarding.
* Verify you are able to open the payments overview page.
* Verify you can generate a login link by clicking Update near `Update WooCommerce Payments business details` task. Stripe Express dashboard should open.
* Verify you can save account settings in Payments->Settings (after setting up customer bank statement).
* Update all the details in Stripe Express and verify that account can accept payments and support deposits (account status is complete).
* Check happy path without leaving the Stripe KYC: onboard one more Stripe account (in this branch), but now don't leave the Stripe KYC, fill it out successfully and check that the account status is complete.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-5.4.0#fix-tos-acceptance-can-prevent-saving-settings-or-accessing-the-account-dashboard-pr-5414
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.