### PR TITLE
Increase OTP popup height

### DIFF
--- a/changelog/tweak-popup-height
+++ b/changelog/tweak-popup-height
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Increased the height of WooPay OTP popup to accomodate contents better in viewport.
+
+

--- a/client/checkout/platform-checkout/style.scss
+++ b/client/checkout/platform-checkout/style.scss
@@ -100,7 +100,7 @@
 		.platform-checkout-otp-iframe {
 			transition: none;
 			height: 90vh;
-			max-height: 600px;
+			max-height: 650px;
 			position: absolute;
 			max-width: 374px;
 			border-radius: 8px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Increased the WooPay OTP popup's height by `50px` to make it visually better and accommodate the contents better in the popup viewport.