### PR TITLE
Fix WooPay Express Checkout button error message display

### DIFF
--- a/changelog/fix-woopay-express-checkout-button-error-message-display
+++ b/changelog/fix-woopay-express-checkout-button-error-message-display
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Updates the way error notices are displayed for the WooPay express checkout button. This feature is behind a feature flag and is not yet public.
+
+

--- a/client/checkout/platform-checkout/express-button/express-checkout-iframe.js
+++ b/client/checkout/platform-checkout/express-button/express-checkout-iframe.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { getConfig } from 'utils/checkout';
 import wcpayTracks from 'tracks';
 
-export const expressCheckoutIframe = async ( api ) => {
+export const expressCheckoutIframe = async ( api, context ) => {
 	let userEmail = '';
 
 	const parentDiv = document.body;
@@ -99,13 +99,51 @@ export const expressCheckoutIframe = async ( api ) => {
 	// Add the iframe to the wrapper.
 	iframeWrapper.insertBefore( iframe, null );
 
-	// Error message to display when there's an error contacting WooPay.
-	const errorMessage = document.createElement( 'div' );
-	errorMessage.style[ 'white-space' ] = 'normal';
-	errorMessage.textContent = __(
-		'WooPay is unavailable at this time. Please complete your checkout below. Sorry for the inconvenience.',
-		'woocommerce-payments'
-	);
+	const showErrorMessage = () => {
+		// Set the notice text.
+		const errorMessage = __(
+			'WooPay is unavailable at this time. Sorry for the inconvenience.',
+			'woocommerce-payments'
+		);
+
+		// Handle Blocks Cart and Checkout notices.
+		if ( wp.data.dispatch( 'core/notices' ) && 'product' !== context ) {
+			// This handles adding the error notice to the cart page.
+			wp.data
+				.dispatch( 'core/notices' )
+				?.createNotice( 'error', errorMessage, {
+					context: `wc/${ context }`,
+				} );
+		} else {
+			// We're either on a shortcode cart/checkout or single product page.
+			fetch( getConfig( 'ajaxUrl' ), {
+				method: 'POST',
+				body: new URLSearchParams( {
+					action: 'woopay_express_checkout_button_show_error_notice',
+					_ajax_nonce: getConfig( 'platformCheckoutButtonNonce' ),
+					context,
+					message: errorMessage,
+				} ),
+			} )
+				.then( ( response ) => response.json() )
+				.then( ( response ) => {
+					if ( response.success ) {
+						// We need to manually add the notice to the page.
+						const noticesWrapper = document.querySelector(
+							'.woocommerce-notices-wrapper'
+						);
+						const wrapper = document.createElement( 'div' );
+						wrapper.innerHTML = response.data.notice;
+						noticesWrapper.insertBefore( wrapper, null );
+
+						noticesWrapper.scrollIntoView( {
+							behavior: 'smooth',
+							block: 'center',
+						} );
+					}
+				} );
+		}
+	};
 
 	const closeIframe = () => {
 		window.removeEventListener( 'resize', getWindowSize );
@@ -142,10 +180,6 @@ export const expressCheckoutIframe = async ( api ) => {
 
 		// Focus the iframe.
 		iframe.focus();
-	};
-
-	const showErrorMessage = () => {
-		parentDiv.insertBefore( errorMessage );
 	};
 
 	document.addEventListener( 'keyup', ( event ) => {

--- a/client/checkout/platform-checkout/express-button/express-checkout-iframe.js
+++ b/client/checkout/platform-checkout/express-button/express-checkout-iframe.js
@@ -107,7 +107,7 @@ export const expressCheckoutIframe = async ( api, context ) => {
 		);
 
 		// Handle Blocks Cart and Checkout notices.
-		if ( wp.data.dispatch( 'core/notices' ) && 'product' !== context ) {
+		if ( wcSettings.wcBlocksConfig && 'product' !== context ) {
 			// This handles adding the error notice to the cart page.
 			wp.data
 				.dispatch( 'core/notices' )

--- a/client/checkout/platform-checkout/express-button/test/woopay-express-checkout-button.test.js
+++ b/client/checkout/platform-checkout/express-button/test/woopay-express-checkout-button.test.js
@@ -89,7 +89,10 @@ describe( 'WoopayExpressCheckoutButton', () => {
 		} );
 		userEvent.click( expressButton );
 
-		expect( expressCheckoutIframe ).toHaveBeenCalledWith( api );
+		expect( expressCheckoutIframe ).toHaveBeenCalledWith(
+			api,
+			buttonSettings.context
+		);
 	} );
 
 	test( 'should not call `expressCheckoutIframe` on button click when `isPreview` is true', () => {
@@ -171,7 +174,10 @@ describe( 'WoopayExpressCheckoutButton', () => {
 			expect( mockAddToCart ).toHaveBeenCalled();
 
 			await waitFor( () => {
-				expect( expressCheckoutIframe ).toHaveBeenCalledWith( api );
+				expect( expressCheckoutIframe ).toHaveBeenCalledWith(
+					api,
+					buttonSettings.context
+				);
 			} );
 		} );
 	} );

--- a/client/checkout/platform-checkout/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/platform-checkout/express-button/woopay-express-checkout-button.js
@@ -59,13 +59,13 @@ export const WoopayExpressCheckoutButton = ( {
 		if ( isProductPage ) {
 			addToCart()
 				.then( () => {
-					expressCheckoutIframe( api );
+					expressCheckoutIframe( api, context );
 				} )
 				.catch( () => {
 					// handle error.
 				} );
 		} else {
-			expressCheckoutIframe( api );
+			expressCheckoutIframe( api, context );
 		}
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If the WooPay service is unavailable, this PR adds notices to the appropriate `woocommerce-notices-wrapper` container instead of trying to place them under the email input field as it's not always available. For blocks cart/checkout pages, it adds them to the notices store and they are displayed immediately. For the shortcode cart/checkout and single product pages, it makes an ajax call to retrieve the HTML generated by `wc_add_notice()` and then adds that HTMl to the container. Let me know if there's a better way to achieve this for the non-blocks pages.

#### Testing instructions

* To test this, I was adding the following snippet to the top of `openIframe()` in `client/checkout/platform-checkout/express-button/express-button-iframe.js`. It causes the error notice to be added instead of needing to create a scenario where WooPay is unavailable.
```
showErrorMessage();
return;
```

* Check the single product page to ensure that the error notice is added in the correct location when the WooPay express checkout button is clicked.
* Check the shortcode cart page to ensure that the error notice is added in the correct location when the WooPay express checkout button is clicked.
* Check the shortcode checkout page to ensure that the error notice is added in the correct location when the WooPay express checkout button is clicked.
* Check the block cart page to ensure that the error notice is added in the correct location when the WooPay express checkout button is clicked.
* Check the block checkout page to ensure that the error notice is added in the correct location when the WooPay express checkout button is clicked.

It should look like this:
<img width="200" alt="cart-shortcode" src="https://user-images.githubusercontent.com/1558827/213021737-249448a3-899c-4d92-899a-68c0da4f06c3.png"> <img width="200" alt="checkout-shortcode" src="https://user-images.githubusercontent.com/1558827/213021740-5bc87660-b7cd-4e64-a28d-4ad165fafe31.png"> <img width="200" alt="cart-block" src="https://user-images.githubusercontent.com/1558827/213021741-608bc8a3-45da-4a13-8df3-3a0b36c60648.png"> <img width="200" alt="checkout-block" src="https://user-images.githubusercontent.com/1558827/213021743-f2b01a47-cb63-41d5-acc7-9311468e9c2c.png"> <img width="200" alt="single-product" src="https://user-images.githubusercontent.com/1558827/213021745-38b74f1e-b523-4d3a-8e3f-99f0ec9f8f37.png">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
