### PR TITLE
Fix margins on payment methods at checkout

### DIFF
--- a/client/checkout/classic/style.scss
+++ b/client/checkout/classic/style.scss
@@ -23,6 +23,7 @@
 	border: 1px solid #ddd;
 	padding: 5px 7px;
 	min-height: 29px;
+	margin-bottom: 0.5em;
 }
 
 .wcpay-upe-element {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -472,6 +472,20 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Overrides the parent method by adding an additional check to see if the tokens list is empty.
+	 * If it is, the method avoids displaying the HTML element with an empty line to maintain a clean user interface and remove unnecessary space.
+	 *
+	 * @return void
+	 */
+	public function saved_payment_methods() {
+		if ( empty( $this->get_tokens() ) ) {
+			return;
+		}
+
+		return parent::saved_payment_methods();
+	}
+
+	/**
 	 * Checks if the setting to allow the user to save cards is enabled.
 	 *
 	 * @return bool Whether the setting to allow saved cards is enabled or not.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -482,7 +482,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return;
 		}
 
-		return parent::saved_payment_methods();
+		parent::saved_payment_methods();
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -616,7 +616,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		?>
 		<div <?php echo $should_hide ? 'style="display:none;"' : ''; /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>>
 			<p class="form-row woocommerce-SavedPaymentMethods-saveNew">
-				<input id="<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $id ); ?>" type="checkbox" value="true" style="width:auto;" <?php echo $force_checked ? 'checked' : ''; /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?> />
+				<input id="<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $id ); ?>" type="checkbox" value="true" style="width:auto; vertical-align: middle; position: relative; bottom: 1px;" <?php echo $force_checked ? 'checked' : ''; /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?> />
 				<label for="<?php echo esc_attr( $id ); ?>" style="display:inline;">
 					<?php echo esc_html( apply_filters( 'wc_payments_save_to_account_text', __( 'Save payment information to my account for future purchases.', 'woocommerce-payments' ) ) ); ?>
 				</label>

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -256,7 +256,8 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 			}
 			?>
 
-			<fieldset id="wc-<?php echo esc_attr( $this->gateway->id ); ?>-upe-form" class="wc-upe-form wc-payment-form">
+			<!--The padding for this area is set at 7px to align with the 7px padding on the CC fieldset-->
+			<fieldset style="padding: 7px" id="wc-<?php echo esc_attr( $this->gateway->id ); ?>-upe-form" class="wc-upe-form wc-payment-form">
 				<div class="wcpay-upe-element" data-payment-method-type="<?php echo esc_attr( $this->gateway->get_selected_stripe_payment_type_id() ); ?>"></div>
 				<?php
 					$is_enabled_for_saved_payments = $this->gateway->is_enabled_for_saved_payments();


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5272

#### Changes proposed in this Pull Request
This PR 
* aligns the UPE fieldset elements with the CC styles 
* prevents the display of empty HTML elements for saved payment methods when there are no saved tokens 
* adds spacing between the card input field and the save payment method checkbox while aligning it with the SEPA


<table>
<tr>
<th>Before</th>
<th>After</th>
<tr>
<td>


![image](https://user-images.githubusercontent.com/22319444/213217853-9a86b518-cd52-4a49-ac60-06deffa4bc48.png)

</td>
<td>

![image](https://user-images.githubusercontent.com/22319444/213212463-9d23c4c8-ac70-41e1-b93d-cc95b790c824.png)

</td>
</table>

<table>
</tr>
<tr>
<th>Before</th>
<th>After</th>
<tr>
<td>


![image](https://user-images.githubusercontent.com/22319444/213216288-d6a7af11-1419-41dd-8222-ae9b7f81c106.png)

</td>
<td>

![image](https://user-images.githubusercontent.com/22319444/213229045-575847ea-5d6f-4464-b5c3-92111fc6a797.png)

</td>
</tr>
</table>




<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. Make sure that the styling shown in the screenshots above is implemented in the shortcode checkout when checking out `fix/payment-method-styles` and the acceptance criteria described [here](https://github.com/Automattic/woocommerce-payments/issues/5272) are all met.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
