### PR TITLE
Enable WooPay Express Checkout button feature by default

### DIFF
--- a/changelog/task-default-enable-express-checkout
+++ b/changelog/task-default-enable-express-checkout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Enable WooPay Express Checkout button feature by default.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -152,7 +152,7 @@ class WC_Payments_Features {
 	 */
 	public static function is_woopay_express_checkout_enabled() {
 		// Confirm platform checkout eligibility as well.
-		return '1' === get_option( self::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '0' ) && self::is_platform_checkout_eligible();
+		return '1' === get_option( self::WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME, '1' ) && self::is_platform_checkout_eligible();
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
This change will enable the WooPay Express Checkout button feature by default. It should be noted that the server side eligibility is still the determining factor of whether WooPay is enabled or not. This PR just makes it so that once the server side flag is enabled, the default behavior will be the Express Checkout button and not the email input field driven experience.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

The following conditions should be tested:

- Start with a merchant store that has WooPay eligibility set to true on the server side check.
- Remove the `_wcpay_feature_woopay_express_checkout` option from the `wp_options` table in the merchant store database if it is present.
- Confirm that the Express Checkout button settings are displayed on WooCommerce > Settings > Payments > WooCommerce Payments > Express Checkouts section > WooPay customize page (pictured below).
- Confirm that the Express Checkout button is displayed on the pages checked on that settings page (Cart for example).
- From the WooCommerce > Settings > Payments > WooCommerce Payments page disable WooPay.
- Confirm that the Express Checkout button is **not** displayed on the cart page now.
- Re-enable WooPay from the settings page and confirm the button is now visible again on cart.
- Now disable the server side WooPay eligibility for the store.
- Confirm that the button and settings are no longer displayed.

Essentially confirm that if the store is WooPay eligible and WooPay is enabled on the store, it uses the Express Checkout button. And confirm that if the store is not WooPay eligible OR WooPay is not enabled, the Express Checkout button is not displayed.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Settings screen that should display when enabled.**
![Screen Shot 2023-01-19 at 12 52 24 PM](https://user-images.githubusercontent.com/68524302/213522374-426b2743-457b-46c5-8983-1fb92789b940.png)

**Button that should be displayed when enabled.**
![Screen Shot 2023-01-19 at 12 52 40 PM](https://user-images.githubusercontent.com/68524302/213522418-2f50395d-83a8-4c21-b0fd-9ddaee92bace.png)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
