### PR TITLE
Fix WooPay express checkout button rendering on cart shortcode

### DIFF
--- a/changelog/fix-woopay-express-checkout-button-on-shortcode-cart
+++ b/changelog/fix-woopay-express-checkout-button-on-shortcode-cart
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This fix is in relation to the WooPay express checkout button which is currently behind a feature flag and is not public.
+
+

--- a/client/checkout/platform-checkout/express-button/index.js
+++ b/client/checkout/platform-checkout/express-button/index.js
@@ -44,11 +44,9 @@ const renderPlatformCheckoutExpressButton = () => {
 	}
 };
 
-jQuery( ( $ ) => {
-	$( window ).on( 'load', () => {
-		renderPlatformCheckoutExpressButton();
-	} );
+window.addEventListener( 'load', renderPlatformCheckoutExpressButton );
 
+jQuery( ( $ ) => {
 	$( document.body ).on( 'updated_cart_totals', () => {
 		renderPlatformCheckoutExpressButton();
 	} );

--- a/client/checkout/platform-checkout/express-button/index.js
+++ b/client/checkout/platform-checkout/express-button/index.js
@@ -1,3 +1,4 @@
+/* global jQuery */
 /**
  * External dependencies
  */
@@ -43,6 +44,12 @@ const renderPlatformCheckoutExpressButton = () => {
 	}
 };
 
-window.addEventListener( 'load', () => {
-	renderPlatformCheckoutExpressButton();
+jQuery( ( $ ) => {
+	$( window ).on( 'load', () => {
+		renderPlatformCheckoutExpressButton();
+	} );
+
+	$( document.body ).on( 'updated_cart_totals', () => {
+		renderPlatformCheckoutExpressButton();
+	} );
 } );

--- a/tests/js/jest-test-file-setup.js
+++ b/tests/js/jest-test-file-setup.js
@@ -83,3 +83,5 @@ setLocaleData(
 	{ '': { domain: 'woocommerce-payments', lang: 'en_US' } },
 	'woocommerce-payments'
 );
+
+global.jQuery = jest.fn();


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR fixes an issue with the WooPay express checkout button on the cart shortcode page. If the cart totals were updated, the button would not be re-rendered after the updated cart was shown. It renders the button during the `load` event on `window` and then uses the `updated_cart_totals` event to re-render.


#### Testing instructions

* Make sure the WooPay express button is enabled and is set to show on the cart page.
* Add a product to the cart and view cart.
* Update the item quantity or update the shipping method to make sure the button is re-rendered.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
