### PR TITLE
Generate mandates only for INR

### DIFF
--- a/changelog/update-generate-mandates-only-for-inr
+++ b/changelog/update-generate-mandates-only-for-inr
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Generate mandate only for orders using INR currency

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -858,7 +858,7 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 			return $result;
 		}
 
-		// Temporally fix – Stripe validates mandate params for cards not
+		// TEMP Fix – Stripe validates mandate params for cards not
 		// issued by Indian banks. Apply them only for INR as Indian banks
 		// only support it for now.
 		$currency = $order->get_currency();
@@ -867,15 +867,23 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 		}
 
 		// Get total by adding only subscriptions and get rid of any other product or fee.
-		$subs_amount = 0;
+		$subs_amount = 0.0;
 		foreach ( $subscriptions as $sub ) {
 			$subs_amount += $sub->get_total();
+		}
+
+		$amount = WC_Payments_Utils::prepare_amount( $subs_amount, $order->get_currency() );
+
+		// TEMP Fix – Prevent stale free subscription data to throw
+		// an error due amount < 1.
+		if ( 0 === $amount ) {
+			return $result;
 		}
 
 		$result['setup_future_usage']                                = 'off_session';
 		$result['payment_method_options']['card']['mandate_options'] = [
 			'reference'       => $order->get_id(),
-			'amount'          => WC_Payments_Utils::prepare_amount( $subs_amount, $order->get_currency() ),
+			'amount'          => $amount,
 			'amount_type'     => 'fixed',
 			'start_date'      => $subscription->get_time( 'date_created' ),
 			'interval'        => $subscription->get_billing_period(),

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -858,6 +858,14 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 			return $result;
 		}
 
+		// Temporally fix – Stripe validates mandate params for cards not
+		// issued by Indian banks. Apply them only for INR as Indian banks
+		// only support it for now.
+		$currency = $order->get_currency();
+		if ( 'INR' !== $currency ) {
+			return $result;
+		}
+
 		// Get total by adding only subscriptions and get rid of any other product or fee.
 		$subs_amount = 0;
 		foreach ( $subscriptions as $sub ) {


### PR DESCRIPTION
Temp fix for #5421

#### Changes proposed in this Pull Request
Workaround for the mentioned issue, while we finish the implementation of missing features for subscription using cards issues by Indian bank. To avoid it affecting any other subscription.

Do not return mandate params when:
- Order currency is other than `INR`.
- Subscription amount is zero.

#### Testing instructions

##### Initial setup
- Enable `Allow Switching` and `Early Renewal` in WooCommerce Subscriptions settings.
- Create three simple subscriptions: free, $100, and $200 USD.
- Create a grouped product and include these three products under `Linked products > grouped products`. This allows switching between the subscriptions.
- Be sure you're listening to Stripe webhooks as the implementation relies on them. (npm run listen)

##### Switching from a free subscription to a paid one
- Place an order in USD for the free subscription.
- Go to **My account → Subscription**, open your new subscription, and click on `Upgrade or Downgrade`. This will take you to the grouped product page where you can select a new plan.
- On the plan selection page, choose a paid subscription.
- Complete the checkout.
- It should work without any issue.

##### Switching between paid subscriptions
- Place an order in USD for the $100 subscription.
- Go to **My account → Subscription**, open your new subscription, and click on `Upgrade or Downgrade`. This will take you to the grouped product page where you can select a new plan.
- On the plan selection page, choose the $200 subscription.
- Complete the checkout.
- It should work without any issue.

##### INR renewal
- Place an order in INR for the $200 USD subscription using card `4000003560000123`.
- Wait a minute for the mandate to be active.
- Go to **WooCommerce → Status → Scheduled Actions → Pending** and filter by `woocommerce_scheduled_subscription_payment`.
- Run the hook where subscription_id matches the subscription you have just created.
- Wait patiently for Stripe webhook 🕙.
- The renewal order notes should match:
<img width="270" alt="203037780-3c213e65-9875-4b3a-b6b9-b8337d6c4feb" src="https://user-images.githubusercontent.com/7670276/214047502-d4a16ec9-3d35-4cbc-852f-d6920f17e790.png">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : [testing instructions](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-5.4.0#generate-mandates-only-for-inr)
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
