### PR TITLE
Skip running blocks E2E tests

### DIFF
--- a/.github/workflows/e2e-pull-request.yml
+++ b/.github/workflows/e2e-pull-request.yml
@@ -30,11 +30,8 @@ jobs:
     strategy:
       fail-fast:     false
       matrix:
-        test_groups:   [ 'wcpay', 'subscriptions', 'blocks' ]
+        test_groups:   [ 'wcpay', 'subscriptions' ] # <HACK> Skip running block tests till we hardocde expected strings in error messages.
         test_branches: [ 'merchant', 'shopper' ]
-        exclude:
-          - test_groups: 'blocks'
-            test_branches: 'merchant'
 
     name: WC - latest | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 

--- a/.github/workflows/e2e-pull-request.yml
+++ b/.github/workflows/e2e-pull-request.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast:     false
       matrix:
-        test_groups:   [ 'wcpay', 'subscriptions' ] # <HACK> Skip running block tests till we hardocde expected strings in error messages.
+        test_groups:   [ 'wcpay', 'subscriptions' ] # [TODO] Unskip blocks tests after investigating constant failures.
         test_branches: [ 'merchant', 'shopper' ]
 
     name: WC - latest | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -67,7 +67,7 @@ jobs:
         uses: ./.github/actions/e2e/run-log-tests
 
   # Run tests against WC Checkout blocks & WC latest
-  # <HACK> Skip running block tests till we hardocde expected strings in error messages.
+  # [TODO] Unskip blocks tests after investigating constant failures.
   # blocks-tests:
   #   runs-on: ubuntu-20.04
   #   name: WC - latest | blocks - shopper
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast:     false
       matrix:
-        test_groups:   [ 'wcpay', 'subscriptions' ] # <HACK> Skip running block tests till we hardocde expected strings in error messages.
+        test_groups:   [ 'wcpay', 'subscriptions' ] # [TODO] Unskip blocks tests after investigating constant failures.
         test_branches: [ 'merchant', 'shopper' ]
 
     name: WP - nightly | WC - latest | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -67,27 +67,28 @@ jobs:
         uses: ./.github/actions/e2e/run-log-tests
 
   # Run tests against WC Checkout blocks & WC latest
-  blocks-tests:
-    runs-on: ubuntu-20.04
-    name: WC - latest | blocks - shopper
+  # <HACK> Skip running block tests till we hardocde expected strings in error messages.
+  # blocks-tests:
+  #   runs-on: ubuntu-20.04
+  #   name: WC - latest | blocks - shopper
 
-    env:
-      E2E_WP_VERSION: 'latest'
-      E2E_WC_VERSION: 'latest'
-      E2E_GROUP:  'blocks'
-      E2E_BRANCH: 'shopper'
-      SKIP_WC_SUBSCRIPTIONS_TESTS: 1 #skip installing & running subscriptions tests
-      SKIP_WC_ACTION_SCHEDULER_TESTS: 1 #skip installing & running action scheduler tests
+  #   env:
+  #     E2E_WP_VERSION: 'latest'
+  #     E2E_WC_VERSION: 'latest'
+  #     E2E_GROUP:  'blocks'
+  #     E2E_BRANCH: 'shopper'
+  #     SKIP_WC_SUBSCRIPTIONS_TESTS: 1 #skip installing & running subscriptions tests
+  #     SKIP_WC_ACTION_SCHEDULER_TESTS: 1 #skip installing & running action scheduler tests
 
-    steps:
-      - name: Checkout WCPay repository
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout WCPay repository
+  #       uses: actions/checkout@v2
 
-      - name: Setup E2E environment
-        uses: ./.github/actions/e2e/env-setup
+  #     - name: Setup E2E environment
+  #       uses: ./.github/actions/e2e/env-setup
 
-      - name: Run tests, upload screenshots & logs
-        uses: ./.github/actions/e2e/run-log-tests
+  #     - name: Run tests, upload screenshots & logs
+  #       uses: ./.github/actions/e2e/run-log-tests
 
   # Run tests against WP Nightly & WC latest
   wp-nightly-tests:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -97,11 +97,8 @@ jobs:
     strategy:
       fail-fast:     false
       matrix:
-        test_groups:   [ 'wcpay', 'subscriptions', 'blocks' ]
+        test_groups:   [ 'wcpay', 'subscriptions' ] # <HACK> Skip running block tests till we hardocde expected strings in error messages.
         test_branches: [ 'merchant', 'shopper' ]
-        exclude:
-          - test_groups: 'blocks'
-            test_branches: 'merchant'
 
     name: WP - nightly | WC - latest | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 

--- a/changelog/skip-blocks-e2e-tests
+++ b/changelog/skip-blocks-e2e-tests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Skip running blocks E2E tests, add comment for the same.

--- a/tests/e2e/specs/blocks/shopper/shopper-wc-blocks-checkout-failures.spec.js
+++ b/tests/e2e/specs/blocks/shopper/shopper-wc-blocks-checkout-failures.spec.js
@@ -68,7 +68,7 @@ describeif( RUN_WC_BLOCKS_TESTS )(
 			await expect( page ).toMatchElement(
 				'div.wc-block-components-notices > div > div.components-notice__content',
 				{
-					text: 'Your card was declined.',
+					text: 'Your card has been declined.',
 				}
 			);
 		} );
@@ -205,7 +205,7 @@ describeif( RUN_WC_BLOCKS_TESTS )(
 			);
 			await expect( page ).toMatch(
 				declined3dsCardError,
-				'Your card was declined.'
+				'Your card has been declined.'
 			);
 		} );
 	}

--- a/tests/e2e/specs/blocks/shopper/shopper-wc-blocks-checkout-failures.spec.js
+++ b/tests/e2e/specs/blocks/shopper/shopper-wc-blocks-checkout-failures.spec.js
@@ -68,7 +68,7 @@ describeif( RUN_WC_BLOCKS_TESTS )(
 			await expect( page ).toMatchElement(
 				'div.wc-block-components-notices > div > div.components-notice__content',
 				{
-					text: 'Your card has been declined.',
+					text: 'Your card was declined.',
 				}
 			);
 		} );
@@ -205,7 +205,7 @@ describeif( RUN_WC_BLOCKS_TESTS )(
 			);
 			await expect( page ).toMatch(
 				declined3dsCardError,
-				'Your card has been declined.'
+				'Your card was declined.'
 			);
 		} );
 	}


### PR DESCRIPTION
Fixes #5447 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Currently, the block E2E tests are failing because of a mismatch in error messages expected in tests and the ones coming from Stripe. There was [an issue](https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1633) created for the same in the past but it was closed without any progress and it has resurfaced. 
This is a stop gap solution to skip the blocks tests while we investigate the issue.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure there are no blocks tests in the PR checks that run for this PR.
* Ensure there are no blocks checks in E2E - all pipeline.
    - Go to Actions -> E2E - all -> Run workflow -> Select this branch and notice the generated matrix output.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
