### PR TITLE
Add hard-coded card errors

### DIFF
--- a/.github/workflows/e2e-pull-request.yml
+++ b/.github/workflows/e2e-pull-request.yml
@@ -30,8 +30,11 @@ jobs:
     strategy:
       fail-fast:     false
       matrix:
-        test_groups:   [ 'wcpay', 'subscriptions' ] # [TODO] Unskip blocks tests after investigating constant failures.
+        test_groups:   [ 'wcpay', 'subscriptions', 'blocks' ]
         test_branches: [ 'merchant', 'shopper' ]
+        exclude:
+          - test_groups: 'blocks'
+            test_branches: 'merchant'
 
     name: WC - latest | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -67,28 +67,27 @@ jobs:
         uses: ./.github/actions/e2e/run-log-tests
 
   # Run tests against WC Checkout blocks & WC latest
-  # [TODO] Unskip blocks tests after investigating constant failures.
-  # blocks-tests:
-  #   runs-on: ubuntu-20.04
-  #   name: WC - latest | blocks - shopper
+  blocks-tests:
+    runs-on: ubuntu-20.04
+    name: WC - latest | blocks - shopper
 
-  #   env:
-  #     E2E_WP_VERSION: 'latest'
-  #     E2E_WC_VERSION: 'latest'
-  #     E2E_GROUP:  'blocks'
-  #     E2E_BRANCH: 'shopper'
-  #     SKIP_WC_SUBSCRIPTIONS_TESTS: 1 #skip installing & running subscriptions tests
-  #     SKIP_WC_ACTION_SCHEDULER_TESTS: 1 #skip installing & running action scheduler tests
+    env:
+      E2E_WP_VERSION: 'latest'
+      E2E_WC_VERSION: 'latest'
+      E2E_GROUP:  'blocks'
+      E2E_BRANCH: 'shopper'
+      SKIP_WC_SUBSCRIPTIONS_TESTS: 1 #skip installing & running subscriptions tests
+      SKIP_WC_ACTION_SCHEDULER_TESTS: 1 #skip installing & running action scheduler tests
 
-  #   steps:
-  #     - name: Checkout WCPay repository
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout WCPay repository
+        uses: actions/checkout@v2
 
-  #     - name: Setup E2E environment
-  #       uses: ./.github/actions/e2e/env-setup
+      - name: Setup E2E environment
+        uses: ./.github/actions/e2e/env-setup
 
-  #     - name: Run tests, upload screenshots & logs
-  #       uses: ./.github/actions/e2e/run-log-tests
+      - name: Run tests, upload screenshots & logs
+        uses: ./.github/actions/e2e/run-log-tests
 
   # Run tests against WP Nightly & WC latest
   wp-nightly-tests:
@@ -97,8 +96,11 @@ jobs:
     strategy:
       fail-fast:     false
       matrix:
-        test_groups:   [ 'wcpay', 'subscriptions' ] # [TODO] Unskip blocks tests after investigating constant failures.
+        test_groups:   [ 'wcpay', 'subscriptions', 'blocks' ]
         test_branches: [ 'merchant', 'shopper' ]
+        exclude:
+          - test_groups: 'blocks'
+            test_branches: 'merchant'
 
     name: WP - nightly | WC - latest | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 

--- a/changelog/fix-inconsistent-errors
+++ b/changelog/fix-inconsistent-errors
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Adding static card error messages.

--- a/changelog/skip-blocks-e2e-tests
+++ b/changelog/skip-blocks-e2e-tests
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Skip running blocks E2E tests, add comment for the same.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -242,6 +242,7 @@ class WC_Payments {
 
 		include_once __DIR__ . '/exceptions/class-base-exception.php';
 		include_once __DIR__ . '/exceptions/class-api-exception.php';
+		include_once __DIR__ . '/exceptions/class-card-error.php';
 		include_once __DIR__ . '/exceptions/class-connection-exception.php';
 
 		self::$api_client = self::create_api_client();

--- a/includes/exceptions/class-card-error.php
+++ b/includes/exceptions/class-card-error.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Class Card_Error
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Exceptions;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class representing Card_Error exception.
+ */
+class Card_Error extends API_Exception {
+	/**
+	 * Error codes, which are also card errors, though there is no `decline_code`.
+	 */
+	const ERROR_CODES = [
+		'expired_card',
+		'incorrect_cvc',
+		'processing_error',
+		'incorrect_number',
+	];
+
+	/**
+	 * Holds the decline code for card errors.
+	 *
+	 * @var string
+	 */
+	private $decline_code;
+
+	/**
+	 * Constructor
+	 *
+	 * @param string     $message      The Exception message to throw.
+	 * @param string     $error_code   Error code returned by the server, for example wcpay_account_not_found.
+	 * @param string     $decline_code Card decline code, ex. `insufficient_funds`.
+	 * @param int        $http_code    HTTP response code.
+	 * @param string     $error_type   Error type attribute.
+	 * @param int        $code         The Exception code.
+	 * @param \Throwable $previous     The previous exception used for the exception chaining.
+	 */
+	public function __construct( $message, $error_code, $decline_code, $http_code, $error_type = null, $code = 0, $previous = null ) {
+		$this->decline_code = $decline_code;
+
+		parent::__construct( $message, $error_code, $http_code, $error_type, $code, $previous );
+	}
+
+	/**
+	 * Returns the decline code of the card error.
+	 *
+	 * @return string
+	 */
+	public function get_decline_code() {
+		return $this->decline_code;
+	}
+
+	/**
+	 * Returns a localized message.
+	 *
+	 * @return string
+	 */
+	public function getLocalizedMessage() {
+		switch ( $this->get_decline_code() ) {
+			case 'insufficient_funds':
+				return __( 'Error: Your card has insufficient funds.', 'woocommerce-payments' );
+
+			case 'expired_card':
+				return __( 'Error: Your card has expired.', 'woocommerce-payments' );
+
+			case 'incorrect_cvc':
+				return __( 'Error: Your card\'s security code is incorrect.', 'woocommerce-payments' );
+
+			case 'processing_error':
+				return __( 'Error: An error occurred while processing your card. Try again in a little bit.', 'woocommerce-payments' );
+
+			case 'incorrect_number':
+				return __( 'Error: Your card number is invalid.', 'woocommerce-payments' );
+
+			// Some card errors do not have specific customer-facing representations.
+			case 'lost_card':
+			case 'generic_decline':
+			case 'stolen_card':
+			default:
+				return __( 'Error: Your card was declined.', 'woocommerce-payments' );
+		}
+	}
+
+	/**
+	 * Checks if an error code is a card error.
+	 *
+	 * @param string $error_code The error code to check.
+	 * @return bool              Whether the error code responds to a card error.
+	 */
+	public static function is_card_error( $error_code ) {
+		return in_array( $error_code, static::ERROR_CODES, true );
+	}
+}

--- a/tests/e2e/specs/blocks/shopper/shopper-wc-blocks-checkout-failures.spec.js
+++ b/tests/e2e/specs/blocks/shopper/shopper-wc-blocks-checkout-failures.spec.js
@@ -64,7 +64,7 @@ describeif( RUN_WC_BLOCKS_TESTS )(
 				text: 'Place Order',
 			} );
 			await uiUnblocked();
-			await page.waitForSelector( 'div.wc-block-components-notices' );
+			await page.waitForSelector( 'div.wc-block-components-notices', 30 );
 			await expect( page ).toMatchElement(
 				'div.wc-block-components-notices > div > div.components-notice__content',
 				{
@@ -80,7 +80,7 @@ describeif( RUN_WC_BLOCKS_TESTS )(
 				text: 'Place Order',
 			} );
 			await uiUnblocked();
-			await page.waitForSelector( 'div.wc-block-components-notices' );
+			await page.waitForSelector( 'div.wc-block-components-notices', 30 );
 			await expect( page ).toMatchElement(
 				'div.wc-block-components-notices > div > div.components-notice__content',
 				{
@@ -96,7 +96,7 @@ describeif( RUN_WC_BLOCKS_TESTS )(
 				text: 'Place Order',
 			} );
 			await uiUnblocked();
-			await page.waitForSelector( 'div.wc-block-components-notices' );
+			await page.waitForSelector( 'div.wc-block-components-notices', 30 );
 			await expect(
 				page
 			).toMatchElement(
@@ -112,7 +112,7 @@ describeif( RUN_WC_BLOCKS_TESTS )(
 				text: 'Place Order',
 			} );
 			await uiUnblocked();
-			await page.waitForSelector( 'div.wc-block-components-notices' );
+			await page.waitForSelector( 'div.wc-block-components-notices', 30 );
 			await expect( page ).toMatchElement(
 				'div.wc-block-components-notices > div > div.components-notice__content',
 				{
@@ -128,7 +128,7 @@ describeif( RUN_WC_BLOCKS_TESTS )(
 				text: 'Place Order',
 			} );
 			await uiUnblocked();
-			await page.waitForSelector( 'div.wc-block-components-notices' );
+			await page.waitForSelector( 'div.wc-block-components-notices', 30 );
 			await expect( page ).toMatchElement(
 				'div.wc-block-components-notices > div > div.components-notice__content',
 				{
@@ -144,7 +144,7 @@ describeif( RUN_WC_BLOCKS_TESTS )(
 				text: 'Place Order',
 			} );
 			await uiUnblocked();
-			await page.waitForSelector( 'div.wc-block-components-notices' );
+			await page.waitForSelector( 'div.wc-block-components-notices', 30 );
 			await expect( page ).toMatchElement(
 				'div.wc-block-components-notices > div > div.components-notice__content',
 				{
@@ -162,7 +162,7 @@ describeif( RUN_WC_BLOCKS_TESTS )(
 				text: 'Place Order',
 			} );
 			await uiUnblocked();
-			await page.waitForSelector( 'div.wc-block-components-notices' );
+			await page.waitForSelector( 'div.wc-block-components-notices', 30 );
 			await expect( page ).toMatchElement(
 				'div.wc-block-components-notices > div > div.components-notice__content',
 				{
@@ -181,7 +181,7 @@ describeif( RUN_WC_BLOCKS_TESTS )(
 				text: 'Place Order',
 			} );
 			await uiUnblocked();
-			await page.waitForSelector( 'div.wc-block-components-notices' );
+			await page.waitForSelector( 'div.wc-block-components-notices', 30 );
 			// Verify the error message
 			await expect( page ).toMatchElement(
 				'div.wc-block-components-notices > div > div.components-notice__content',
@@ -198,7 +198,7 @@ describeif( RUN_WC_BLOCKS_TESTS )(
 				text: 'Place Order',
 			} );
 			await confirmCardAuthentication( page, '3DS' );
-			await page.waitForSelector( 'div.wc-block-components-notices' );
+			await page.waitForSelector( 'div.wc-block-components-notices', 30 );
 			const declined3dsCardError = await page.$eval(
 				'div.wc-block-components-notices > div > div.components-notice__content',
 				( el ) => el.innerText


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add hard-coded card errors through a new `Card_Error` exception. This way messages will be static, and E2E tests will not fail.

Since the first commit of the PR fixed E2E tests, this PR also reverts https://github.com/Automattic/woocommerce-payments/pull/5446.

#### Testing instructions

1. Make sure all tests are passing.
2. Use cards, which will be declined from https://stripe.com/docs/testing#declined-payments to make sure you're seeing the right error message.
    - While doing this, I'd recommend adding a breakpoint on [this line](https://github.com/Automattic/woocommerce-payments/blob/fix/inconsistent-errors/includes/exceptions/class-card-error.php#L65) and comparing the API error message to the one, which is being returned.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (does not apply)