### PR TITLE
Skip email step when email field has a value.

### DIFF
--- a/changelog/task-1406-skip-email-step
+++ b/changelog/task-1406-skip-email-step
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Skipping the email input step for WooPay express checkout flow when the email input field has already a value. The WooPay express checkout feature is behind a feature flag currently.

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -7,7 +7,7 @@ import wcpayTracks from 'tracks';
 import request from '../utils/request';
 import showErrorCheckout from '../utils/show-error-checkout';
 import { buildAjaxURL } from '../../payment-request/utils';
-import { getTargetElement } from './utils';
+import { getTargetElement, validateEmail } from './utils';
 
 export const handlePlatformCheckoutEmailInput = async (
 	field,
@@ -423,16 +423,6 @@ export const handlePlatformCheckoutEmailInput = async (
 			.finally( () => {
 				spinner.remove();
 			} );
-	};
-
-	const validateEmail = ( value ) => {
-		/* Borrowed from WooCommerce checkout.js with a slight tweak to add `{2,}` to the end and make the TLD at least 2 characters. */
-		/* eslint-disable */
-		const pattern = new RegExp(
-			/^([a-z\d!#$%&'*+\-\/=?^_`{|}~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+(\.[a-z\d!#$%&'*+\-\/=?^_`{|}~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+)*|"((([ \t]*\r\n)?[ \t]+)?([\x01-\x08\x0b\x0c\x0e-\x1f\x7f\x21\x23-\x5b\x5d-\x7e\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|\\[\x01-\x09\x0b\x0c\x0d-\x7f\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))*(([ \t]*\r\n)?[ \t]+)?")@(([a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|[a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF][a-z\d\-._~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]*[a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])\.)+([a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|[a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF][a-z\d\-._~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]*[0-9a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]){2,}\.?$/i
-		);
-		/* eslint-enable */
-		return pattern.test( value );
 	};
 
 	const closeLoginSessionIframe = () => {

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -7,35 +7,7 @@ import wcpayTracks from 'tracks';
 import request from '../utils/request';
 import showErrorCheckout from '../utils/show-error-checkout';
 import { buildAjaxURL } from '../../payment-request/utils';
-
-// Waits for the element to exist as in the Blocks checkout, sometimes the field is not immediately available.
-const waitForElement = ( selector ) => {
-	return new Promise( ( resolve ) => {
-		if ( document.querySelector( selector ) ) {
-			return resolve( document.querySelector( selector ) );
-		}
-
-		const checkoutBlock = document.querySelector(
-			'[data-block-name="woocommerce/checkout"]'
-		);
-
-		if ( ! checkoutBlock ) {
-			return resolve( null );
-		}
-
-		const observer = new MutationObserver( ( mutationList, obs ) => {
-			if ( document.querySelector( selector ) ) {
-				resolve( document.querySelector( selector ) );
-				obs.disconnect();
-			}
-		} );
-
-		observer.observe( checkoutBlock, {
-			childList: true,
-			subtree: true,
-		} );
-	} );
-};
+import { getTargetElement } from './utils';
 
 export const handlePlatformCheckoutEmailInput = async (
 	field,
@@ -44,7 +16,7 @@ export const handlePlatformCheckoutEmailInput = async (
 ) => {
 	let timer;
 	const waitTime = 500;
-	const platformCheckoutEmailInput = await waitForElement( field );
+	const platformCheckoutEmailInput = await getTargetElement( field );
 	let hasCheckedLoginSession = false;
 
 	// If we can't find the input, return.
@@ -303,7 +275,7 @@ export const handlePlatformCheckoutEmailInput = async (
 	} );
 
 	if ( isBlocksCheckout ) {
-		const formSubmitButton = await waitForElement(
+		const formSubmitButton = await getTargetElement(
 			'button.wc-block-components-checkout-place-order-button'
 		);
 		formSubmitButton.addEventListener( 'click', () => {

--- a/client/checkout/platform-checkout/express-button/express-checkout-iframe.js
+++ b/client/checkout/platform-checkout/express-button/express-checkout-iframe.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { getConfig } from 'utils/checkout';
-import { getTargetElement } from '../utils';
+import { getTargetElement, validateEmail } from '../utils';
 import wcpayTracks from 'tracks';
 
 export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
@@ -167,7 +167,7 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 		);
 		urlParams.append( 'wcpayVersion', getConfig( 'wcpayVersionNumber' ) );
 
-		if ( email ) {
+		if ( email && validateEmail( email ) ) {
 			urlParams.append( 'email', email );
 		}
 

--- a/client/checkout/platform-checkout/express-button/express-checkout-iframe.js
+++ b/client/checkout/platform-checkout/express-button/express-checkout-iframe.js
@@ -3,9 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import { getConfig } from 'utils/checkout';
+import { getTargetElement } from '../utils';
 import wcpayTracks from 'tracks';
 
-export const expressCheckoutIframe = async ( api, context ) => {
+export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
+	const platformCheckoutEmailInput = await getTargetElement( emailSelector );
 	let userEmail = '';
 
 	const parentDiv = document.body;
@@ -250,5 +252,5 @@ export const expressCheckoutIframe = async ( api, context ) => {
 		}
 	} );
 
-	openIframe();
+	openIframe( platformCheckoutEmailInput?.value );
 };

--- a/client/checkout/platform-checkout/express-button/index.js
+++ b/client/checkout/platform-checkout/express-button/index.js
@@ -37,6 +37,7 @@ const renderPlatformCheckoutExpressButton = () => {
 						'data-product_page'
 					)
 				}
+				emailSelector="#billing_email"
 			/>,
 			platformCheckoutContainer
 		);

--- a/client/checkout/platform-checkout/express-button/test/express-checkout-iframe.test.js
+++ b/client/checkout/platform-checkout/express-button/test/express-checkout-iframe.test.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { waitFor } from '@testing-library/react';
+
+/**
  * Internal dependencies
  */
 import { expressCheckoutIframe } from '../express-checkout-iframe';
@@ -16,14 +21,16 @@ describe( 'expressCheckoutIframe', () => {
 		getConfig.mockReturnValue( 'http://example.com' );
 	} );
 
-	test( 'should open the iframe', () => {
-		expressCheckoutIframe( api );
+	test( 'should open the iframe', async () => {
+		expressCheckoutIframe( api, null, '#email' );
 
-		const woopayIframe = document.querySelector( 'iframe' );
+		await waitFor( () => {
+			const woopayIframe = document.querySelector( 'iframe' );
 
-		expect( woopayIframe.className ).toContain(
-			'platform-checkout-otp-iframe'
-		);
-		expect( woopayIframe.src ).toContain( 'http://example.com/otp/' );
+			expect( woopayIframe.className ).toContain(
+				'platform-checkout-otp-iframe'
+			);
+			expect( woopayIframe.src ).toContain( 'http://example.com/otp/' );
+		} );
 	} );
 } );

--- a/client/checkout/platform-checkout/express-button/test/woopay-express-checkout-button.test.js
+++ b/client/checkout/platform-checkout/express-button/test/woopay-express-checkout-button.test.js
@@ -66,6 +66,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 				buttonSettings={ buttonSettings }
 				api={ api }
 				isProductPage={ false }
+				emailSelector="#email"
 			/>
 		);
 
@@ -81,6 +82,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 				buttonSettings={ buttonSettings }
 				api={ api }
 				isProductPage={ false }
+				emailSelector="#email"
 			/>
 		);
 
@@ -91,7 +93,8 @@ describe( 'WoopayExpressCheckoutButton', () => {
 
 		expect( expressCheckoutIframe ).toHaveBeenCalledWith(
 			api,
-			buttonSettings.context
+			buttonSettings.context,
+			'#email'
 		);
 	} );
 
@@ -102,6 +105,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 				buttonSettings={ buttonSettings }
 				api={ api }
 				isProductPage={ false }
+				emailSelector="#email"
 			/>
 		);
 
@@ -121,6 +125,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 					buttonSettings={ buttonSettings }
 					api={ api }
 					isProductPage={ true }
+					emailSelector="#email"
 				/>
 			);
 
@@ -142,6 +147,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 					buttonSettings={ buttonSettings }
 					api={ api }
 					isProductPage={ true }
+					emailSelector="#email"
 				/>
 			);
 
@@ -162,6 +168,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 					buttonSettings={ buttonSettings }
 					api={ api }
 					isProductPage={ true }
+					emailSelector="#email"
 				/>
 			);
 
@@ -176,7 +183,8 @@ describe( 'WoopayExpressCheckoutButton', () => {
 			await waitFor( () => {
 				expect( expressCheckoutIframe ).toHaveBeenCalledWith(
 					api,
-					buttonSettings.context
+					buttonSettings.context,
+					'#email'
 				);
 			} );
 		} );

--- a/client/checkout/platform-checkout/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/platform-checkout/express-button/woopay-express-checkout-button.js
@@ -17,6 +17,7 @@ export const WoopayExpressCheckoutButton = ( {
 	buttonSettings,
 	api,
 	isProductPage = false,
+	emailSelector = '#email',
 } ) => {
 	const {
 		type: buttonType,
@@ -59,13 +60,13 @@ export const WoopayExpressCheckoutButton = ( {
 		if ( isProductPage ) {
 			addToCart()
 				.then( () => {
-					expressCheckoutIframe( api, context );
+					expressCheckoutIframe( api, context, emailSelector );
 				} )
 				.catch( () => {
 					// handle error.
 				} );
 		} else {
-			expressCheckoutIframe( api, context );
+			expressCheckoutIframe( api, context, emailSelector );
 		}
 	};
 

--- a/client/checkout/platform-checkout/express-button/woopay-express-checkout-payment-method.js
+++ b/client/checkout/platform-checkout/express-button/woopay-express-checkout-payment-method.js
@@ -24,12 +24,14 @@ const wooPayExpressCheckoutPaymentMethod = () => ( {
 		<WoopayExpressCheckoutButton
 			buttonSettings={ getConfig( 'platformCheckoutButton' ) }
 			api={ api }
+			emailSelector="#email"
 		/>
 	),
 	edit: (
 		<WoopayExpressCheckoutButton
 			buttonSettings={ getConfig( 'platformCheckoutButton' ) }
 			isPreview={ true }
+			emailSelector="#email"
 		/>
 	),
 	canMakePayment: () => true,

--- a/client/checkout/platform-checkout/utils.js
+++ b/client/checkout/platform-checkout/utils.js
@@ -1,0 +1,28 @@
+// Waits for the element to exist as in the Blocks checkout, sometimes the field is not immediately available.
+export const getTargetElement = ( selector ) => {
+	return new Promise( ( resolve ) => {
+		if ( document.querySelector( selector ) ) {
+			return resolve( document.querySelector( selector ) );
+		}
+
+		const checkoutBlock = document.querySelector(
+			'[data-block-name="woocommerce/checkout"]'
+		);
+
+		if ( ! checkoutBlock ) {
+			return resolve( null );
+		}
+
+		const observer = new MutationObserver( ( mutationList, obs ) => {
+			if ( document.querySelector( selector ) ) {
+				resolve( document.querySelector( selector ) );
+				obs.disconnect();
+			}
+		} );
+
+		observer.observe( checkoutBlock, {
+			childList: true,
+			subtree: true,
+		} );
+	} );
+};

--- a/client/checkout/platform-checkout/utils.js
+++ b/client/checkout/platform-checkout/utils.js
@@ -1,5 +1,8 @@
 // Waits for the element to exist as in the Blocks checkout, sometimes the field is not immediately available.
 export const getTargetElement = ( selector ) => {
+	if ( ! selector ) {
+		return null;
+	}
 	return new Promise( ( resolve ) => {
 		if ( document.querySelector( selector ) ) {
 			return resolve( document.querySelector( selector ) );

--- a/client/checkout/platform-checkout/utils.js
+++ b/client/checkout/platform-checkout/utils.js
@@ -29,3 +29,13 @@ export const getTargetElement = ( selector ) => {
 		} );
 	} );
 };
+
+export const validateEmail = ( value ) => {
+	/* Borrowed from WooCommerce checkout.js with a slight tweak to add `{2,}` to the end and make the TLD at least 2 characters. */
+	/* eslint-disable */
+	const pattern = new RegExp(
+		/^([a-z\d!#$%&'*+\-\/=?^_`{|}~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+(\.[a-z\d!#$%&'*+\-\/=?^_`{|}~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+)*|"((([ \t]*\r\n)?[ \t]+)?([\x01-\x08\x0b\x0c\x0e-\x1f\x7f\x21\x23-\x5b\x5d-\x7e\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|\\[\x01-\x09\x0b\x0c\x0d-\x7f\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))*(([ \t]*\r\n)?[ \t]+)?")@(([a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|[a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF][a-z\d\-._~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]*[a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])\.)+([a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|[a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF][a-z\d\-._~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]*[0-9a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]){2,}\.?$/i
+	);
+	/* eslint-enable */
+	return pattern.test( value );
+};

--- a/client/checkout/platform-checkout/woopay-check-email-input.js
+++ b/client/checkout/platform-checkout/woopay-check-email-input.js
@@ -5,7 +5,7 @@ import { getConfig } from 'wcpay/utils/checkout';
 import wcpayTracks from 'tracks';
 import request from '../utils/request';
 import { buildAjaxURL } from '../../payment-request/utils';
-import { getTargetElement } from './utils';
+import { getTargetElement, validateEmail } from './utils';
 
 export const woopayCheckEmailInput = async ( field ) => {
 	let timer;
@@ -92,16 +92,6 @@ export const woopayCheckEmailInput = async ( field ) => {
 				dispatchUserExistEvent( data[ 'user-exists' ] );
 			} )
 			.catch( () => {} );
-	};
-
-	const validateEmail = ( value ) => {
-		/* Borrowed from WooCommerce checkout.js with a slight tweak to add `{2,}` to the end and make the TLD at least 2 characters. */
-		/* eslint-disable */
-		const pattern = new RegExp(
-			/^([a-z\d!#$%&'*+\-\/=?^_`{|}~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+(\.[a-z\d!#$%&'*+\-\/=?^_`{|}~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+)*|"((([ \t]*\r\n)?[ \t]+)?([\x01-\x08\x0b\x0c\x0e-\x1f\x7f\x21\x23-\x5b\x5d-\x7e\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|\\[\x01-\x09\x0b\x0c\x0d-\x7f\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))*(([ \t]*\r\n)?[ \t]+)?")@(([a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|[a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF][a-z\d\-._~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]*[a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])\.)+([a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|[a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF][a-z\d\-._~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]*[0-9a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]){2,}\.?$/i
-		);
-		/* eslint-enable */
-		return pattern.test( value );
 	};
 
 	platformCheckoutEmailInput.addEventListener( 'input', ( e ) => {

--- a/client/checkout/platform-checkout/woopay-check-email-input.js
+++ b/client/checkout/platform-checkout/woopay-check-email-input.js
@@ -5,40 +5,12 @@ import { getConfig } from 'wcpay/utils/checkout';
 import wcpayTracks from 'tracks';
 import request from '../utils/request';
 import { buildAjaxURL } from '../../payment-request/utils';
-
-// Waits for the element to exist as in the Blocks checkout, sometimes the field is not immediately available.
-const waitForElement = ( selector ) => {
-	return new Promise( ( resolve ) => {
-		if ( document.querySelector( selector ) ) {
-			return resolve( document.querySelector( selector ) );
-		}
-
-		const checkoutBlock = document.querySelector(
-			'[data-block-name="woocommerce/checkout"]'
-		);
-
-		if ( ! checkoutBlock ) {
-			return resolve( null );
-		}
-
-		const observer = new MutationObserver( ( mutationList, obs ) => {
-			if ( document.querySelector( selector ) ) {
-				resolve( document.querySelector( selector ) );
-				obs.disconnect();
-			}
-		} );
-
-		observer.observe( checkoutBlock, {
-			childList: true,
-			subtree: true,
-		} );
-	} );
-};
+import { getTargetElement } from './utils';
 
 export const woopayCheckEmailInput = async ( field ) => {
 	let timer;
 	const waitTime = 500;
-	const platformCheckoutEmailInput = await waitForElement( field );
+	const platformCheckoutEmailInput = await getTargetElement( field );
 
 	// If we can't find the input, return.
 	if ( ! platformCheckoutEmailInput ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Checking the email input field on the merchant checkout page and sending that with the iframe src if the field has a value. This skips the email step in WooPay express checkout flow.

#### Testing instructions
- Enable WooPay express checkout on the merchant site.
- Go to the merchant checkout page after adding some products to the cart.
- Keep the email field on the merchant checkout page empty and click on the express checkout button.
- This should take you to the email input step of WooPay.
- Add a valid email on the email field on the merchant checkout page empty and click on the express checkout button.
- This should skip the email input step of WooPay and take you to the next page.
- Check the express checkout button on the cart and individual product pages. The express checkout button should always open the email input step of WooPay.
- Now disable WooPay express checkout on the merchant site.
- Ensure that the email triggered popup works as before and functionally nothing has changed there.