### PR TITLE
Fix failing unit tests for Cancelled status in WC beta

### DIFF
--- a/changelog/fix-failing-unit-tests-cancelled
+++ b/changelog/fix-failing-unit-tests-cancelled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix failing unit tests due to spelling change in WooCommerce core.

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -392,8 +392,9 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_mark_payment_capture_expired() {
 		// Arrange: Set the intent and order statuses.
-		$intent_status = Payment_Intent_Status::CANCELED;  // Stripe uses single 'l'.
-		$order_status  = Order_Status::CANCELLED; // WooCommerce uses double 'l'.
+		$intent_status     = Payment_Intent_Status::CANCELED;  // Stripe uses single 'l'.
+		$order_status      = Order_Status::CANCELLED; // WooCommerce uses double 'l'.
+		$wc_order_statuses = wc_get_order_statuses(); // WooCommerce uses single 'l' for US English.
 
 		// Act: Attempt to mark the payment/order expired/cancelled.
 		$this->order_service->mark_payment_capture_expired( $this->order, $this->intent_id, $intent_status, $this->charge_id );
@@ -406,7 +407,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 
 		// Assert: Check that the notes were updated.
 		$notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
-		$this->assertStringContainsString( 'Pending payment to Cancelled', $notes[1]->content );
+		$this->assertStringContainsString( 'Pending payment to ' . $wc_order_statuses['wc-cancelled'], $notes[1]->content );
 		$this->assertStringContainsString( 'Payment authorization has <strong>expired</strong>', $notes[0]->content );
 		$this->assertStringContainsString( '/payments/transactions/details&id=pi_123" target="_blank" rel="noopener noreferrer">pi_123', $notes[0]->content );
 
@@ -424,8 +425,9 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_mark_payment_capture_cancelled() {
 		// Arrange: Set the intent and order statuses.
-		$intent_status = Payment_Intent_Status::CANCELED;  // Stripe uses single 'l'.
-		$order_status  = Order_Status::CANCELLED; // WooCommerce uses double 'l'.
+		$intent_status     = Payment_Intent_Status::CANCELED;  // Stripe uses single 'l'.
+		$order_status      = Order_Status::CANCELLED; // WooCommerce uses double 'l' in the background.
+		$wc_order_statuses = wc_get_order_statuses(); // WooCommerce uses single 'l' for US English.
 
 		// Act: Attempt to mark the payment/order expired/cancelled.
 		$this->order_service->mark_payment_capture_cancelled( $this->order, $this->intent_id, $intent_status );
@@ -438,7 +440,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 
 		// Assert: Check that the notes were updated.
 		$notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
-		$this->assertStringContainsString( 'Pending payment to Cancelled', $notes[1]->content );
+		$this->assertStringContainsString( 'Pending payment to ' . $wc_order_statuses['wc-cancelled'], $notes[1]->content );
 		$this->assertStringContainsString( 'Payment authorization was successfully <strong>cancelled</strong>', $notes[0]->content );
 
 		// Assert: Check that the order was unlocked.


### PR DESCRIPTION
[WooCommerce core is changing "Cancelled" to "Canceled" for US English](https://github.com/woocommerce/woocommerce/pull/36294). This is causing some unit tests to fail. This PR will add a call to get the order statuses, then use what's in that array to check for the correct spelling in order notes.

#### Changes proposed in this Pull Request

* Add call to `wc_get_order_statuses` to get the order statuses.
* Replace "Cancelled" in string to be a call to the proper order status from the status array.

#### Testing instructions

* Tests should pass both with current versions and with beta versions.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
