### PR TITLE
fix save user phone value to set the country code properly

### DIFF
--- a/changelog/fix-save-user-phone
+++ b/changelog/fix-save-user-phone
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Setting country code properly in save user form.
+
+

--- a/client/components/platform-checkout/save-user/checkout-page-save-user.js
+++ b/client/components/platform-checkout/save-user/checkout-page-save-user.js
@@ -263,37 +263,37 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 						</span>
 					</div>
 				</div>
-				<div
-					className={ `save-details-form form-row ${
-						isSaveDetailsChecked ? 'visible' : ''
-					}` }
-					data-testid="save-user-form"
-				>
-					<PhoneNumberInput
-						value={
-							null === phoneNumber
-								? getPhoneFieldValue()
-								: phoneNumber
-						}
-						onValueChange={ setPhoneNumber }
-						onValidationChange={ onPhoneValidationChange }
-						inputProps={ {
-							name:
-								'platform_checkout_user_phone_field[no-country-code]',
-						} }
-						isBlocksCheckout={ isBlocksCheckout }
-					/>
-					{ ! isPhoneValid && (
-						<p className="error-text">
-							{ __(
-								'Please enter a valid mobile phone number.',
-								'woocommerce-payments'
-							) }
-						</p>
-					) }
-					<AdditionalInformation />
-					<Agreement />
-				</div>
+				{ isSaveDetailsChecked && (
+					<div
+						className="save-details-form form-row"
+						data-testid="save-user-form"
+					>
+						<PhoneNumberInput
+							value={
+								null === phoneNumber
+									? getPhoneFieldValue()
+									: phoneNumber
+							}
+							onValueChange={ setPhoneNumber }
+							onValidationChange={ onPhoneValidationChange }
+							inputProps={ {
+								name:
+									'platform_checkout_user_phone_field[no-country-code]',
+							} }
+							isBlocksCheckout={ isBlocksCheckout }
+						/>
+						{ ! isPhoneValid && (
+							<p className="error-text">
+								{ __(
+									'Please enter a valid mobile phone number.',
+									'woocommerce-payments'
+								) }
+							</p>
+						) }
+						<AdditionalInformation />
+						<Agreement />
+					</div>
+				) }
 			</div>
 		</Container>
 	);

--- a/client/components/platform-checkout/save-user/test/checkout-page-save-user.test.js
+++ b/client/components/platform-checkout/save-user/test/checkout-page-save-user.test.js
@@ -104,37 +104,39 @@ describe( 'CheckoutPageSaveUser', () => {
 	it( 'should render the save user form when checkbox is checked for classic checkout', () => {
 		render( <CheckoutPageSaveUser /> );
 
-		const saveUserForm = screen.getByTestId( 'save-user-form' );
 		const label = screen.getByLabelText(
 			'Save my information for a faster and secure checkout'
 		);
 
 		expect( label ).not.toBeChecked();
-		expect( saveUserForm.classList.contains( 'visible' ) ).toBe( false );
+		expect(
+			screen.queryByTestId( 'save-user-form' )
+		).not.toBeInTheDocument();
 
 		// click on the checkbox
 		userEvent.click( label );
 
 		expect( label ).toBeChecked();
-		expect( saveUserForm.classList.contains( 'visible' ) ).toBe( true );
+		expect( screen.queryByTestId( 'save-user-form' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should render the save user form when checkbox is checked for blocks checkout', () => {
 		render( <CheckoutPageSaveUser isBlocksCheckout={ true } /> );
 
-		const saveUserForm = screen.getByTestId( 'save-user-form' );
 		const label = screen.getByLabelText(
 			'Save my information for a faster and secure checkout'
 		);
 
 		expect( label ).not.toBeChecked();
-		expect( saveUserForm.classList.contains( 'visible' ) ).toBe( false );
+		expect(
+			screen.queryByTestId( 'save-user-form' )
+		).not.toBeInTheDocument();
 
 		// click on the checkbox
 		userEvent.click( label );
 
 		expect( label ).toBeChecked();
-		expect( saveUserForm.classList.contains( 'visible' ) ).toBe( true );
+		expect( screen.queryByTestId( 'save-user-form' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should not call `extensionCartUpdate` on classic checkout when checkbox is clicked', () => {

--- a/client/settings/phone-input/style.scss
+++ b/client/settings/phone-input/style.scss
@@ -43,16 +43,12 @@
 		transition: max-height 0.5s ease-in-out;
 		margin: 0 !important;
 		padding: 0 !important;
-		max-height: 0;
 		overflow-y: hidden;
+		max-height: 21.875rem;
 
 		&::before,
 		&::after {
 			display: none;
-		}
-
-		&.visible {
-			max-height: 21.875rem;
 		}
 
 		> div {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Currently, the save user form of WooPay gets mounted regardless of the status of the checkbox, but is kept hidden if the checkbox is unchecked. Because of this the initial phone field value is always empty and the initial country code is always `+1`. When a user adds a phone number to the billing address with a different country code and then clicks the save user checkbox, the phone field value looks messy.

If we mount the save user form after the checkbox is checked, then it gets the correct initial values and so the input field is not messed up anymore. Made the changes to mount the form when the checkbox is clicked in this PR.

#### How to reproduce the issue
![phone](https://user-images.githubusercontent.com/33387139/214762460-c219e892-4c9e-4a12-a111-771264f6425e.gif)


#### Testing instructions
- Go to the merchant checkout page
- Add a `US` phone number without the country code and click the save user checkbox. The phone number should have `+1` as the country code.
- Add a `US` phone number with country code and click the save user checkbox. The phone number should have `+1` as the country code.
- Add a Non `US` phone number without a country code and click the save user checkbox. The phone number should have `+1` as the country code but should be marked as invalid.
- Add a Non `US` phone number with the right country code and click the save user checkbox. The phone number should have the right country code.
- Check on both the shortcode and blocks checkout pages.