### PR TITLE
Set the value of email param in userEmail

### DIFF
--- a/changelog/fix-express-checkout-with-pre-populated-email
+++ b/changelog/fix-express-checkout-with-pre-populated-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay redirection with express checkout when email is prepopulated. The WooPay express checkout is currently behind a feature flag.

--- a/client/checkout/platform-checkout/express-button/express-checkout-iframe.js
+++ b/client/checkout/platform-checkout/express-button/express-checkout-iframe.js
@@ -168,6 +168,7 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 		urlParams.append( 'wcpayVersion', getConfig( 'wcpayVersionNumber' ) );
 
 		if ( email && validateEmail( email ) ) {
+			userEmail = email;
 			urlParams.append( 'email', email );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Redirection to the WooPay express checkout page fails if the email field on the merchant checkout page has a valid and existing WooPay email and the user clicks the WooPay express checkout button. This happens because the email field goes as empty in the `session_init` request.

#### How to reproduce the bug
- Test in the `trunk` branch.
- Enable WooPay express checkout on the merchant site.
- Go to the merchant checkout page after adding some products to the cart.
- Add an existing WooPay email on the email field on the merchant checkout page and click on the express checkout button.
- This will take you to the OTP page.
- Verify OTP and notice that OTP verification succeeded but the redirection to WooPay checkout fails.


#### Testing instructions
- Test in this PR's branch.
- Enable WooPay express checkout on the merchant site.
- Go to the merchant checkout page after adding some products to the cart.
- Add a valid email on the email field on the merchant checkout page empty and click on the express checkout button.
- Add an existing WooPay email on the email field on the merchant checkout page and click on the express checkout button.
- This will take you to the OTP page.
- Verify OTP and make sure that OTP verification succeeds and you are redirected to the WooPay checkout page.
