### PR TITLE
Add a session check before trying to get items from the session

### DIFF
--- a/changelog/fix-add-session-check-subs-compatibility
+++ b/changelog/fix-add-session-check-subs-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add check for session before getting properties from session to avoid fatals in WooCommerce Subscriptions Mulit-Currency compatibility.

--- a/changelog/fix-add-session-check-subs-compatibility
+++ b/changelog/fix-add-session-check-subs-compatibility
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Add check for session before getting properties from session to avoid fatals in WooCommerce Subscriptions Mulit-Currency compatibility.
+Add check for session before getting properties from session to avoid fatals in WooCommerce Subscriptions Multi-Currency compatibility.

--- a/includes/multi-currency/Compatibility/WooCommerceSubscriptions.php
+++ b/includes/multi-currency/Compatibility/WooCommerceSubscriptions.php
@@ -159,7 +159,7 @@ class WooCommerceSubscriptions extends BaseCompatibility {
 		}
 
 		// The running_override_selected_currency_filters property has been added here due to if it isn't, it will create an infinite loop of calls.
-		if ( WC()->session->get( 'order_awaiting_payment' ) ) {
+		if ( isset( WC()->session ) && WC()->session->get( 'order_awaiting_payment' ) ) {
 			$this->running_override_selected_currency_filters = true;
 			$order = wc_get_order( WC()->session->get( 'order_awaiting_payment' ) );
 			$this->running_override_selected_currency_filters = false;


### PR DESCRIPTION
Fixes issue where we were trying to get a property from the session, but the session may not exist.

#### Changes proposed in this Pull Request

* Add a session check before trying to get a property from the session.

#### Testing instructions

* Tests should pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
