### PR TITLE
Added auth and capture endpoints

### DIFF
--- a/includes/admin/class-wc-rest-payments-authorizations-controller.php
+++ b/includes/admin/class-wc-rest-payments-authorizations-controller.php
@@ -20,6 +20,18 @@ class WC_REST_Payments_Authorizations_Controller extends WC_Payments_REST_Contro
 	protected $rest_base = 'payments/authorizations';
 
 	/**
+	 * Customer service.
+	 *
+	 * @var WC_Payments_Customer_Service $cutomer_service
+	 */
+	protected $customer_service;
+
+	public function __construct( WC_Payments_API_Client $api_client,  WC_Payments_Customer_Service $customer_service ) {
+		parent::__construct( $api_client );
+		$this->customer_service = $customer_service;
+	}
+
+	/**
 	 * Configure REST API routes.
 	 */
 	public function register_routes() {
@@ -29,6 +41,24 @@ class WC_REST_Payments_Authorizations_Controller extends WC_Payments_REST_Contro
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_authorizations' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'create_authorization' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/capture',
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'capture_authorization' ],
 				'permission_callback' => [ $this, 'check_permission' ],
 			]
 		);
@@ -63,6 +93,92 @@ class WC_REST_Payments_Authorizations_Controller extends WC_Payments_REST_Contro
 		$sort      = $request->get_param( 'sort' );
 		$direction = $request->get_param( 'direction' );
 		return $this->forward_request( 'list_authorizations', [ $page, $page_size, $sort, $direction ] );
+	}
+
+	/**
+	 * Create authorizations.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 * @throws \WCPay\Exceptions\API_Exception
+	 */
+	public function create_authorization( $request ) {
+		$order_id = $request->get_param( 'order_id' );
+
+		$order = wc_get_order( $order_id );
+		if ( ! is_a( $order, WC_Order::class ) ) {
+			return rest_ensure_response( new WP_Error( 'wcpay_authorization_order_not_exist', 'Invalid order' ) );
+		}
+		$order_data = $order->get_meta('_authorization_id');
+		if ( $order_data ) {
+			return rest_ensure_response( new WP_Error( 'wcpay_authorization_exist', 'Order already have authorization' ) );
+		}
+		$customer_id = $this->customer_service->get_customer_id_by_user_id( $order->get_user_id() );
+
+		if ( ! $customer_id) {
+			return rest_ensure_response( new WP_Error( 'wcpay_authorization_missing_customer', 'Missing customer from order' ) );
+		}
+
+		$payment_methods = $this->customer_service->get_payment_methods_for_customer( $customer_id );
+
+		$payment_method = $payment_methods[0] ?? null;
+
+		if ( ! $payment_method ) {
+			return rest_ensure_response( new WP_Error( 'wcpay_authorization_missing_payment_method', 'Payment method missing.' ) );
+		}
+
+		$currency = strtolower( $order->get_currency() );
+		$amount = WC_Payments_Utils::prepare_amount( $order->get_total(), $currency );
+		$authorization =  $this->api_client->create_authorization( $amount, $order_id, $currency, $customer_id, $payment_method['id'], $order->get_order_number());
+		$order->add_meta_data('_authorization_id', $authorization->get_id() );
+		$order->save();
+
+		return rest_ensure_response( $authorization );
+	}
+
+	/**
+	 * Create authorizations.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 * @throws \WCPay\Exceptions\API_Exception
+	 */
+	public function capture_authorization( $request ) {
+		$authorization_id = $request->get_param( 'id' );
+		$order_id = $request->get_param( 'order_id' );
+
+		if ( ! $order_id ) {
+			if ( ! $authorization_id ) {
+				return rest_ensure_response( new WP_Error( 'wcpay_authorization_invalid_parameter', 'Order id or authorization ID needs to be passed.' ) );
+			}
+			$authorization = $this->api_client->get_authorization( $authorization_id, false );
+			$order_id = $authorization['metadata']['order_id'] ?? null;
+			if ( null === $order_id ) {
+				return rest_ensure_response( new WP_Error( 'wcpay_authorization_invalid_authorization', 'This authorization cannot be captured.' ) );
+			}
+		}
+
+		$order = wc_get_order( $order_id );
+		if ( ! is_a( $order, WC_Order::class ) ) {
+			return rest_ensure_response( new WP_Error( 'wcpay_authorization_order_not_exist', 'Invalid order' ) );
+		}
+		$order_authorization_id = $order->get_meta('_authorization_id');
+		if ( ! $order_authorization_id ) {
+			return rest_ensure_response( new WP_Error( 'wcpay_authorization_does_not_exist', 'Order does not have authorization' ) );
+		}
+		if ( $authorization_id && $order_authorization_id !== $authorization_id ) {
+			return rest_ensure_response( new WP_Error( 'wcpay_authorization_invalid_id', 'Invalid authorization id' ) );
+		}
+		$currency = strtolower( $order->get_currency() );
+		$amount = WC_Payments_Utils::prepare_amount( $order->get_total(), $currency );
+
+		$capture =  $this->api_client->capture_authorization( $authorization_id, $amount );
+		$order->add_meta_data('_capture_id', $capture->get_id() ); //in case if it's different from original authorization id.
+		$order->update_status( 'completed' ); // Mark order as completed.
+
+		return rest_ensure_response( $capture );
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -306,6 +306,8 @@ class WC_Payments {
 		include_once __DIR__ . '/platform-checkout/class-platform-checkout-order-status-sync.php';
 		include_once __DIR__ . '/class-wc-payment-token-wcpay-link.php';
 
+		include_once __DIR__. '/wc-payment-api/models/class-wc-payments-api-authorization.php';
+
 		// Load customer multi-currency if feature is enabled.
 		if ( WC_Payments_Features::is_customer_multi_currency_enabled() ) {
 			include_once __DIR__ . '/multi-currency/wc-payments-multi-currency.php';
@@ -788,7 +790,7 @@ class WC_Payments {
 		$payment_intents_controller->register_routes();
 
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-authorizations-controller.php';
-		$authorizations_controller = new WC_REST_Payments_Authorizations_Controller( self::$api_client );
+		$authorizations_controller = new WC_REST_Payments_Authorizations_Controller( self::$api_client, self::$customer_service, );
 		$authorizations_controller->register_routes();
 	}
 

--- a/includes/multi-currency/Compatibility/WooCommerceSubscriptions.php
+++ b/includes/multi-currency/Compatibility/WooCommerceSubscriptions.php
@@ -159,7 +159,7 @@ class WooCommerceSubscriptions extends BaseCompatibility {
 		}
 
 		// The running_override_selected_currency_filters property has been added here due to if it isn't, it will create an infinite loop of calls.
-		if ( WC()->session->get( 'order_awaiting_payment' ) ) {
+		if (  WC()->session && WC()->session->get( 'order_awaiting_payment' ) ) {
 			$this->running_override_selected_currency_filters = true;
 			$order = wc_get_order( WC()->session->get( 'order_awaiting_payment' ) );
 			$this->running_override_selected_currency_filters = false;

--- a/includes/wc-payment-api/models/class-wc-payments-api-authorization.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-authorization.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * WC_Payments_API_Authorization class
+ *
+ * @package WooCommerce\Payments
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * A authorization object used by the WooCommerce Payments API.
+ */
+class WC_Payments_API_Authorization implements \JsonSerializable {
+	/**
+	 * Charge ID
+	 *
+	 * @var string
+	 */
+	private $id;
+
+	/**
+	 * Charge amount
+	 *
+	 * @var int
+	 */
+	private $amount;
+
+	/**
+	 * Status
+	 *
+	 * @var bool
+	 */
+	private $status;
+
+	/**
+	 * WC_Payments_API_Charge constructor.
+	 *
+	 * @param string $id        - ID.
+	 * @param integer $amount   - Amount.
+	 * @param string $status    - Status.
+	 */
+	public function __construct(
+		string $id,
+		int $amount,
+		string $status
+	) {
+		$this->id       = $id;
+		$this->amount   = $amount;
+		$this->status   = $status;
+
+	}
+
+	/**
+	 * Gets ID
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return $this->id;
+	}
+
+	/**
+	 * Gets amount
+	 *
+	 * @return int
+	 */
+	public function get_amount() {
+		return $this->amount;
+	}
+
+	/**
+	 * Gets status
+	 *
+	 * @return string
+	 */
+	public function get_status() {
+		return $this->status;
+	}
+
+
+
+	/**
+	 * Defines which data will be serialized to JSON
+	 */
+	public function jsonSerialize(): array {
+		return [
+			'id'                     => $this->get_id(),
+			'amount'                 => $this->get_amount(),
+			'status'                 => $this->get_status(),
+		];
+	}
+}

--- a/includes/wc-payment-api/models/class-wc-payments-api-customer.php
+++ b/includes/wc-payment-api/models/class-wc-payments-api-customer.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * WC_Payments_API_Customer class
+ *
+ * @package WooCommerce\Payments
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * A authorization object used by the WooCommerce Payments API.
+ */
+class WC_Payments_API_Customer {
+	/**
+	 * ID
+	 *
+	 * @var string
+	 */
+	private $id;
+
+	/**
+	 * Name
+	 *
+	 * @var string
+	 */
+	private $name;
+
+	/**
+	 * pPayment method
+	 *
+	 * @var bool
+	 */
+	private $default_payment_method;
+
+	/**
+	 * WC_Payments_API_Charge constructor.
+	 *
+	 * @param string $id        - ID.
+	 * @param string $name   - Amount.
+	 * @param string $default_payment_method    - Payment method.
+	 */
+	public function __construct(
+		string $id,
+		string $name,
+		string $default_payment_method
+	) {
+		$this->id       = $id;
+		$this->name   = $name;
+		$this->default_payment_method   = $default_payment_method;
+
+	}
+
+	/**
+	 * Gets ID
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return $this->id;
+	}
+
+	/**
+	 * Gets name
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return $this->name;
+	}
+
+	/**
+	 * Gets default payment method
+	 *
+	 * @return string
+	 */
+	public function get_default_payment_method() {
+		return $this->default_payment_method;
+	}
+}


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

Two new REST API endpoints are added that adds functionality of auth and capture. Auth and capture are basically stripe Payment intents where you can charge or capture the funds later (when needed). First API endpoint creates new Payment Intent from the order (all validations are also performed like does order already have authorization, ...). After that, after authorization is created, another API endpoint is created where you confirm or capture the funds from the Payment Intent that is created in the first step.

These endpoints will allow us more control in processing orders outside of WooCommerce Payments UI.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
