### PR TITLE
Improve the decision-making process to determine if the save option should be displayed for a UPE payment method.

### DIFF
--- a/client/checkout/blocks/upe-fields.js
+++ b/client/checkout/blocks/upe-fields.js
@@ -318,13 +318,8 @@ const WCPayUPEFields = ( {
 	// Checks whether there are errors within a field, and saves them for later reporting.
 	const upeOnChange = ( event ) => {
 		// Update WC Blocks gateway config based on selected UPE payment method.
-		if (
-			getConfig( 'isSavedCardsEnabled' ) &&
-			! getConfig( 'cartContainsSubscription' )
-		) {
-			gatewayConfig.supports.showSaveOption =
-				paymentMethodsConfig[ event.value.type ].isReusable;
-		}
+		gatewayConfig.supports.showSaveOption =
+			paymentMethodsConfig[ event.value.type ].showSaveOption;
 
 		setIsUPEComplete( event.complete );
 		setSelectedUPEPaymentType( event.value.type );

--- a/client/checkout/blocks/upe.js
+++ b/client/checkout/blocks/upe.js
@@ -96,10 +96,7 @@ Object.entries( enabledPaymentMethodsConfig ).map( ( [ upeName, upeConfig ] ) =>
 		ariaLabel: __( 'WooCommerce Payments', 'woocommerce-payments' ),
 		supports: {
 			showSavedCards: getUPEConfig( 'isSavedCardsEnabled' ) ?? false,
-			showSaveOption:
-				( getUPEConfig( 'isSavedCardsEnabled' ) &&
-					! getUPEConfig( 'cartContainsSubscription' ) ) ??
-				false,
+			showSaveOption: getUPEConfig( 'showSaveOption' ) ?? false,
 			features: getUPEConfig( 'features' ),
 		},
 	} )

--- a/client/checkout/blocks/upe.js
+++ b/client/checkout/blocks/upe.js
@@ -96,7 +96,7 @@ Object.entries( enabledPaymentMethodsConfig ).map( ( [ upeName, upeConfig ] ) =>
 		ariaLabel: __( 'WooCommerce Payments', 'woocommerce-payments' ),
 		supports: {
 			showSavedCards: getUPEConfig( 'isSavedCardsEnabled' ) ?? false,
-			showSaveOption: getUPEConfig( 'showSaveOption' ) ?? false,
+			showSaveOption: upeConfig.showSaveOption ?? false,
 			features: getUPEConfig( 'features' ),
 		},
 	} )

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -183,10 +183,24 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 					]
 				),
 				'icon'                 => $payment_method->get_icon(),
+				'showSaveOption'       => $this->should_upe_payment_method_show_save_option( $payment_method_id ),
 			];
 		}
 
 		return $settings;
+	}
+
+	/**
+	 * Checks if the save option for a payment method should be displayed or not.
+	 *
+	 * @param string $payment_method_id Payment method ID, e.g. sepa_debit or bancontact.
+	 * @return bool - True if the payment method is SEPA and the saved cards feature is enabled for the gateway and there is no subscription item in the cart, false otherwise.
+	 */
+	private function should_upe_payment_method_show_save_option( $payment_method_id ) {
+		if ( Payment_Method::SEPA === $payment_method_id ) {
+			return $this->gateway->is_saved_cards_enabled() && ! $this->gateway->is_subscription_item_in_cart();
+		}
+		return false;
 	}
 
 	/**

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -183,7 +183,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 					]
 				),
 				'icon'                 => $payment_method->get_icon(),
-				'showSaveOption'       => $this->should_upe_payment_method_show_save_option( $payment_method_id ),
+				'showSaveOption'       => $this->should_upe_payment_method_show_save_option( $payment_method ),
 			];
 		}
 
@@ -193,11 +193,11 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 	/**
 	 * Checks if the save option for a payment method should be displayed or not.
 	 *
-	 * @param string $payment_method_id Payment method ID, e.g. sepa_debit or bancontact.
-	 * @return bool - True if the payment method is SEPA and the saved cards feature is enabled for the gateway and there is no subscription item in the cart, false otherwise.
+	 * @param string $payment_method Payment method.
+	 * @return bool - True if the payment method is reusable and the saved cards feature is enabled for the gateway and there is no subscription item in the cart, false otherwise.
 	 */
-	private function should_upe_payment_method_show_save_option( $payment_method_id ) {
-		if ( Payment_Method::SEPA === $payment_method_id ) {
+	private function should_upe_payment_method_show_save_option( $payment_method ) {
+		if ( $payment_method->is_reusable() ) {
 			return $this->gateway->is_saved_cards_enabled() && ! $this->gateway->is_subscription_item_in_cart();
 		}
 		return false;

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -16,6 +16,7 @@ use WCPay\Constants\Payment_Method;
 use WCPay\Fraud_Prevention\Fraud_Prevention_Service;
 use WCPay\Payment_Methods\UPE_Payment_Gateway;
 use WCPay\Platform_Checkout\Platform_Checkout_Utilities;
+use WCPay\Payment_Methods\UPE_Payment_Method;
 
 
 /**
@@ -193,7 +194,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 	/**
 	 * Checks if the save option for a payment method should be displayed or not.
 	 *
-	 * @param string $payment_method Payment method.
+	 * @param UPE_Payment_Method $payment_method UPE Payment Method instance.
 	 * @return bool - True if the payment method is reusable and the saved cards feature is enabled for the gateway and there is no subscription item in the cart, false otherwise.
 	 */
 	private function should_upe_payment_method_show_save_option( $payment_method ) {

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -1958,6 +1958,62 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( $upe_checkout->get_payment_fields_js_config()['paymentMethodsConfig'][ Payment_Method::SEPA ]['showSaveOption'], false );
 	}
 
+	public function test_no_save_option_for_sepa_due_to_saved_cards_disabled() {
+		$mock_upe_gateway = $this->getMockBuilder( UPE_Payment_Gateway::class )
+			->setConstructorArgs(
+				[
+					$this->mock_api_client,
+					$this->mock_wcpay_account,
+					$this->mock_customer_service,
+					$this->mock_token_service,
+					$this->mock_action_scheduler_service,
+					$this->mock_payment_methods[ Payment_Method::SEPA ],
+					$this->mock_rate_limiter,
+					$this->order_service,
+				]
+			)
+			->setMethods(
+				[
+					'get_payment_method_ids_enabled_at_checkout',
+					'wc_payments_get_payment_method_by_id',
+					'is_saved_cards_enabled',
+					'is_subscription_item_in_cart',
+				]
+			)
+			->getMock();
+
+		// saved cards disabled.
+		$mock_upe_gateway
+			->method( 'is_saved_cards_enabled' )
+			->will(
+				$this->returnValue( false )
+			);
+
+		// no subscription item in cart.
+		$mock_upe_gateway
+			->method( 'is_subscription_item_in_cart' )
+			->will(
+				$this->returnValue( false )
+			);
+
+		$mock_upe_gateway->method( 'get_payment_method_ids_enabled_at_checkout' )
+			->willReturn( [ Payment_Method::SEPA ] );
+
+		$mock_upe_gateway
+			->method( 'wc_payments_get_payment_method_by_id' )
+			->with( Payment_Method::SEPA )
+			->willReturn( $this->mock_payment_methods[ Payment_Method::SEPA ] );
+
+		$upe_checkout = new WC_Payments_UPE_Checkout(
+			$mock_upe_gateway,
+			$this->mock_platform_checkout_utilities,
+			$this->mock_wcpay_account,
+			$this->mock_customer_service
+		);
+
+		$this->assertSame( $upe_checkout->get_payment_fields_js_config()['paymentMethodsConfig'][ Payment_Method::SEPA ]['showSaveOption'], false );
+	}
+
 	public function test_save_option_for_sepa_debit() {
 		$mock_upe_gateway = $this->getMockBuilder( UPE_Payment_Gateway::class )
 			->setConstructorArgs(

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -1849,6 +1849,171 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		}
 	}
 
+	public function test_no_save_option_for_non_sepa_upe() {
+		$payment_methods_with_no_save_option = [
+			Payment_Method::BANCONTACT,
+			Payment_Method::EPS,
+			Payment_Method::GIROPAY,
+			Payment_Method::IDEAL,
+			Payment_Method::P24,
+			Payment_Method::SOFORT,
+		];
+
+		foreach ( $payment_methods_with_no_save_option as $payment_method ) {
+			$mock_upe_gateway = $this->getMockBuilder( UPE_Payment_Gateway::class )
+				->setConstructorArgs(
+					[
+						$this->mock_api_client,
+						$this->mock_wcpay_account,
+						$this->mock_customer_service,
+						$this->mock_token_service,
+						$this->mock_action_scheduler_service,
+						$this->mock_payment_methods[ $payment_method ],
+						$this->mock_rate_limiter,
+						$this->order_service,
+					]
+				)
+				->setMethods(
+					[
+						'get_payment_method_ids_enabled_at_checkout',
+						'wc_payments_get_payment_method_by_id',
+						'is_saved_cards_enabled',
+						'is_subscription_item_in_cart',
+					]
+				)
+				->getMock();
+
+			$mock_upe_gateway->method( 'get_payment_method_ids_enabled_at_checkout' )
+				->willReturn( [ $payment_method ] );
+
+			$mock_upe_gateway
+				->method( 'wc_payments_get_payment_method_by_id' )
+				->with( $payment_method )
+				->willReturn( $this->mock_payment_methods[ $payment_method ] );
+
+			$upe_checkout = new WC_Payments_UPE_Checkout(
+				$mock_upe_gateway,
+				$this->mock_platform_checkout_utilities,
+				$this->mock_wcpay_account,
+				$this->mock_customer_service
+			);
+
+			$this->assertSame( $upe_checkout->get_payment_fields_js_config()['paymentMethodsConfig'][ $payment_method ]['showSaveOption'], false );
+		}
+	}
+
+	public function test_no_save_option_for_sepa_due_to_subscription_cart() {
+		$mock_upe_gateway = $this->getMockBuilder( UPE_Payment_Gateway::class )
+			->setConstructorArgs(
+				[
+					$this->mock_api_client,
+					$this->mock_wcpay_account,
+					$this->mock_customer_service,
+					$this->mock_token_service,
+					$this->mock_action_scheduler_service,
+					$this->mock_payment_methods[ Payment_Method::SEPA ],
+					$this->mock_rate_limiter,
+					$this->order_service,
+				]
+			)
+			->setMethods(
+				[
+					'get_payment_method_ids_enabled_at_checkout',
+					'wc_payments_get_payment_method_by_id',
+					'is_saved_cards_enabled',
+					'is_subscription_item_in_cart',
+				]
+			)
+			->getMock();
+
+		// saved cards enabled.
+		$mock_upe_gateway
+			->method( 'is_saved_cards_enabled' )
+			->will(
+				$this->returnValue( true )
+			);
+
+		// there is a subscription item in cart, which should disable the save option checkbox for a payment method.
+		$mock_upe_gateway
+			->method( 'is_subscription_item_in_cart' )
+			->will(
+				$this->returnValue( true )
+			);
+
+		$mock_upe_gateway->method( 'get_payment_method_ids_enabled_at_checkout' )
+			->willReturn( [ Payment_Method::SEPA ] );
+
+		$mock_upe_gateway
+			->method( 'wc_payments_get_payment_method_by_id' )
+			->with( Payment_Method::SEPA )
+			->willReturn( $this->mock_payment_methods[ Payment_Method::SEPA ] );
+
+		$upe_checkout = new WC_Payments_UPE_Checkout(
+			$mock_upe_gateway,
+			$this->mock_platform_checkout_utilities,
+			$this->mock_wcpay_account,
+			$this->mock_customer_service
+		);
+
+		$this->assertSame( $upe_checkout->get_payment_fields_js_config()['paymentMethodsConfig'][ Payment_Method::SEPA ]['showSaveOption'], false );
+	}
+
+	public function test_save_option_for_sepa_debit() {
+		$mock_upe_gateway = $this->getMockBuilder( UPE_Payment_Gateway::class )
+			->setConstructorArgs(
+				[
+					$this->mock_api_client,
+					$this->mock_wcpay_account,
+					$this->mock_customer_service,
+					$this->mock_token_service,
+					$this->mock_action_scheduler_service,
+					$this->mock_payment_methods[ Payment_Method::SEPA ],
+					$this->mock_rate_limiter,
+					$this->order_service,
+				]
+			)
+			->setMethods(
+				[
+					'get_payment_method_ids_enabled_at_checkout',
+					'wc_payments_get_payment_method_by_id',
+					'is_saved_cards_enabled',
+					'is_subscription_item_in_cart',
+				]
+			)
+			->getMock();
+
+		$mock_upe_gateway->method( 'get_payment_method_ids_enabled_at_checkout' )
+			->willReturn( [ Payment_Method::SEPA ] );
+
+		$mock_upe_gateway
+			->method( 'wc_payments_get_payment_method_by_id' )
+			->with( Payment_Method::SEPA )
+			->willReturn( $this->mock_payment_methods[ Payment_Method::SEPA ] );
+
+		// saved cards enabled.
+		$mock_upe_gateway
+			->method( 'is_saved_cards_enabled' )
+			->will(
+				$this->returnValue( true )
+			);
+
+		// no subscription items in cart.
+		$mock_upe_gateway
+			->method( 'is_subscription_item_in_cart' )
+			->will(
+				$this->returnValue( false )
+			);
+
+		$upe_checkout = new WC_Payments_UPE_Checkout(
+			$mock_upe_gateway,
+			$this->mock_platform_checkout_utilities,
+			$this->mock_wcpay_account,
+			$this->mock_customer_service
+		);
+
+		$this->assertSame( $upe_checkout->get_payment_fields_js_config()['paymentMethodsConfig'][ Payment_Method::SEPA ]['showSaveOption'], true );
+	}
+
 	public function test_remove_link_payment_method_if_card_disabled() {
 		$mock_upe_gateway = $this->getMockBuilder( UPE_Payment_Gateway::class )
 			->setConstructorArgs(
@@ -1973,6 +2138,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					'upeSetupIntentData'   => null,
 					'testingInstructions'  => '',
 					'icon'                 => $this->icon_url,
+					'showSaveOption'       => false,
 				],
 			]
 		);

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -2194,7 +2194,7 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					'upeSetupIntentData'   => null,
 					'testingInstructions'  => '',
 					'icon'                 => $this->icon_url,
-					'showSaveOption'       => false,
+					'showSaveOption'       => true,
 				],
 			]
 		);


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5495

#### Changes proposed in this Pull Request
This PR enhances the logic for displaying the "Save payment method" checkbox for each UPE payment method. Before this change, the `showSaveOption` flag was set to `true` for all UPE methods, even though only SEPA can be saved. The checkbox was previously visible but then quickly hidden.

This PR moves the logic for the "Save payment method" checkbox to the back-end. The flag `showSaveOption` is now set there, making future adjustments to this feature more convenient. 

Finally, this PR considers the type of UPE payment method, ensuring that the `showSaveOption` flag is set to `false` for all methods other than SEPA.

The updated UPE logic is:
* For SEPA: run checks (returns `true` if "save cards" is enabled and cart does not have a subscription product, `false` otherwise)
* For all other non-SEPA UPE methods: return `false`.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Clear the cache of your browser and ideally, run `npm run build` and `npm run start`.
* Turn on all the available UPE methods, login to the existing account on the merchant site. 
* Go to the Blocks checkout and confirm that there's no checkbox to save the payment method, which quickly disappears after mounting a component for everything but SEPA and CC.
* Go to the shortcode checkout and confirm that the save checkbox is available only for SEPA and CC as well. 
* Place two orders from shortcode and blocks by using SEPA and saving it. Confirm that the payment method was successfully saved. 
* Add a subscription product to the cart and confirm if SEPA on the blocks checkout doesn't have the save checkbox available
* Select different payment methods and ensure that the save checkbox logic is correct and remains the same
* Try to break things by doing any other actions.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
