### PR TITLE
Update subscriptions-core to 5.3.1

### DIFF
--- a/changelog/subscriptions-core-5.3.1
+++ b/changelog/subscriptions-core-5.3.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update subscriptions-core to 5.3.1.

--- a/changelog/subscriptions-core-5.3.1-1
+++ b/changelog/subscriptions-core-5.3.1-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fatal error when loading the Edit Subscription page with custom admin billing or shipping fields.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
       "automattic/jetpack-sync": "1.30.5",
       "automattic/jetpack-tracking": "1.14.5",
       "myclabs/php-enum": "1.7.7",
-      "woocommerce/subscriptions-core": "5.3.0"
+      "woocommerce/subscriptions-core": "5.3.1"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee0e616f719539b151c9c42e436fc31f",
+    "content-hash": "d032c145eb48f2cef46bbb7b18e2d19e",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1060,16 +1060,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "5.3.0",
+            "version": "5.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "d37bd4db47ccaf156fc57b4dc61761f9ab56d686"
+                "reference": "d9befd7c6c62ada15dab9bc095084ab8746b0fa9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/d37bd4db47ccaf156fc57b4dc61761f9ab56d686",
-                "reference": "d37bd4db47ccaf156fc57b4dc61761f9ab56d686",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/d9befd7c6c62ada15dab9bc095084ab8746b0fa9",
+                "reference": "d9befd7c6c62ada15dab9bc095084ab8746b0fa9",
                 "shasum": ""
             },
             "require": {
@@ -1110,10 +1110,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/5.3.0",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/5.3.1",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2023-01-27T00:00:35+00:00"
+            "time": "2023-02-01T00:09:00+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update woocommerce/subscriptions-core library to [5.3.1](https://github.com/Automattic/woocommerce-subscriptions-core/releases/tag/5.3.1).

This patch release of subscriptions-core fixes a fatal error that can occur on the Edit Subscription page when custom billing or shipping fields exist.
See PR https://github.com/Automattic/woocommerce-subscriptions-core/pull/403.

```
* Fix - Fatal error when loading the Edit Subscription page with custom admin billing or shipping fields. #403
```

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), _Not Applicable_
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
