### PR TITLE
Add Feature Flag for Development of Progressive Onboarding

### DIFF
--- a/changelog/dev-5486-po-feature-flag
+++ b/changelog/dev-5486-po-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Adding a feature flag to allow further development of onboarding UX - currently this will have no effect on live stores.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -17,6 +17,7 @@ class WC_Payments_Features {
 	const WCPAY_SUBSCRIPTIONS_FLAG_NAME     = '_wcpay_feature_subscriptions';
 	const WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME = '_wcpay_feature_woopay_express_checkout';
 	const AUTH_AND_CAPTURE_FLAG_NAME        = '_wcpay_feature_auth_and_capture';
+	const PROGRESSIVE_ONBOARDING_FLAG_NAME  = '_wcpay_feature_progressive_onboarding';
 
 	/**
 	 * Checks whether the UPE gateway is enabled
@@ -165,6 +166,15 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Checks whether Progressive Onboarding is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_progressive_onboarding_enabled(): bool {
+		return '1' === get_option( self::PROGRESSIVE_ONBOARDING_FLAG_NAME, '0' );
+	}
+
+	/**
 	 * Returns feature flags as an array suitable for display on the front-end.
 	 *
 	 * @return bool[]
@@ -182,6 +192,7 @@ class WC_Payments_Features {
 				'clientSecretEncryption'  => self::is_client_secret_encryption_enabled(),
 				'woopayExpressCheckout'   => self::is_woopay_express_checkout_enabled(),
 				'isAuthAndCaptureEnabled' => self::is_auth_and_capture_enabled(),
+				'progressiveOnboarding'   => self::is_progressive_onboarding_enabled(),
 			]
 		);
 	}

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -158,7 +158,7 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 	public function test_is_woopay_express_checkout_enabled_returns_false_when_platform_checkout_eligible_is_false() {
 		add_filter(
-			'pre_option__wcpay_feature_woopay_express_checkout',
+			'pre_option__' . WC_Payments_Features::PROGRESSIVE_ONBOARDING_FLAG_NAME,
 			function ( $pre_option, $option, $default ) {
 				return '1';
 			},
@@ -171,7 +171,7 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 	public function test_is_progressive_onboarding_enabled_returns_true() {
 		add_filter(
-			'pre_option__wcpay_feature_progressive_onboarding',
+			'pre_option_' . WC_Payments_Features::PROGRESSIVE_ONBOARDING_FLAG_NAME,
 			function ( $pre_option, $option, $default ) {
 				return '1';
 			},
@@ -183,7 +183,7 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 	public function test_is_progressive_onboarding_enabled_returns_false_when_flag_is_false() {
 		add_filter(
-			'pre_option__wcpay_feature_progressive_onboarding',
+			'pre_option_' . WC_Payments_Features::PROGRESSIVE_ONBOARDING_FLAG_NAME,
 			function ( $pre_option, $option, $default ) {
 				return '0';
 			},

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -5,10 +5,18 @@
  * @package WooCommerce\Payments\Tests
  */
 
+use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Database_Cache;
+
 /**
  * WC_Payments_Features unit tests.
  */
 class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * @var Database_Cache|MockObject
+	 */
+	protected $mock_cache;
 
 	const FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING = [
 		'_wcpay_feature_upe'                        => 'upe',
@@ -18,6 +26,7 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		'_wcpay_feature_account_overview_task_list' => 'accountOverviewTaskList',
 		'_wcpay_feature_custom_deposit_schedules'   => 'customDepositSchedules',
 		'_wcpay_feature_auth_and_capture'           => 'isAuthAndCaptureEnabled',
+		'_wcpay_feature_progressive_onboarding'     => 'progressiveOnboarding',
 	];
 
 	public function set_up() {
@@ -158,6 +167,35 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		);
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => false ] );
 		$this->assertFalse( WC_Payments_Features::is_woopay_express_checkout_enabled() );
+	}
+
+	public function test_is_progressive_onboarding_enabled_returns_true() {
+		add_filter(
+			'pre_option__wcpay_feature_progressive_onboarding',
+			function ( $pre_option, $option, $default ) {
+				return '1';
+			},
+			10,
+			3
+		);
+		$this->assertTrue( WC_Payments_Features::is_progressive_onboarding_enabled() );
+	}
+
+	public function test_is_progressive_onboarding_enabled_returns_false_when_flag_is_false() {
+		add_filter(
+			'pre_option__wcpay_feature_progressive_onboarding',
+			function ( $pre_option, $option, $default ) {
+				return '0';
+			},
+			10,
+			3
+		);
+		$this->assertFalse( WC_Payments_Features::is_progressive_onboarding_enabled() );
+		$this->assertArrayNotHasKey( 'progressiveOnboarding', WC_Payments_Features::to_array() );
+	}
+
+	public function test_is_progressive_onboarding_enabled_returns_false_when_flag_is_not_set() {
+		$this->assertFalse( WC_Payments_Features::is_progressive_onboarding_enabled() );
 	}
 
 	private function setup_enabled_flags( array $enabled_flags ) {


### PR DESCRIPTION
Fixes #5486 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

- Adds a feature flag for progressive onboarding.
- Currently this is not used, but it will be used by future PRs working on the PO project. 

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

* Check that the change makes sense and tests pass.
* Test the Dev Tools PR (https://github.com/Automattic/woocommerce-payments-dev-tools/pull/81) to ensure that the flag name matches and the flag can get set on/off correctly.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : 'QA Testing Not Applicable
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
