### PR TITLE
fix: WooPay & Link compatibility notice

### DIFF
--- a/client/settings/express-checkout/index.js
+++ b/client/settings/express-checkout/index.js
@@ -52,7 +52,7 @@ const LinkWoopayCompatibilityConfirmationModal = ( {
 										'woocommerce-payments'
 								  )
 								: __(
-										'Yes, disable Link',
+										'Yes, disable Link by Stripe',
 										'woocommerce-payments'
 								  ) }
 						</Button>
@@ -169,6 +169,10 @@ const ExpressCheckout = () => {
 								<CheckboxControl
 									checked={ isPlatformCheckoutEnabled }
 									onChange={ handleExpressCheckoutChange }
+									label={ __(
+										'WooPay',
+										'woocommerce-payments'
+									) }
 								/>
 							</div>
 							<div className="express-checkout__icon">

--- a/client/settings/express-checkout/index.js
+++ b/client/settings/express-checkout/index.js
@@ -165,7 +165,7 @@ const ExpressCheckout = () => {
 				<ul className="express-checkouts-list">
 					{ isPlatformCheckoutFeatureFlagEnabled && (
 						<li className="express-checkout has-icon-border">
-							<div className="express-checkout__checkbox">
+							<div className="express-checkout__checkbox loadable-checkbox label-hidden">
 								<CheckboxControl
 									checked={ isPlatformCheckoutEnabled }
 									onChange={ handleExpressCheckoutChange }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Adding a notice that is displayed whenever the merchant attempts to enable both WooPay and Link at the same time.

Fixes https://github.com/Automattic/woocommerce-payments/issues/4720

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to the settings page
- Try to enable Link and WooPay at the same time
- A notice should appear
- Enabling/disabling them individually should not display the notice

With this changes, it's still possible that a merchant has both Link and WooPay enabled at the same time. But the number of merchants that had WooPay enabled is so small, that it doesn't matter.

![2023-02-01 16 58 08](https://user-images.githubusercontent.com/273592/216205245-32eb6b01-c5ef-4c25-9fef-ecae7e8c9e4e.gif)


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
