### PR TITLE
Fix issue with missing 'dependencies' array key during registration of payment scripts

### DIFF
--- a/changelog/fix-5270-script-asset-dependencies-key-missing
+++ b/changelog/fix-5270-script-asset-dependencies-key-missing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed issue with missing dependencies array key in script loading

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -431,6 +431,17 @@ class WC_Payments_Admin {
 		$script_src_url    = plugins_url( 'dist/index.js', WCPAY_PLUGIN_FILE );
 		$script_asset_path = WCPAY_ABSPATH . 'dist/index.asset.php';
 		$script_asset      = file_exists( $script_asset_path ) ? require $script_asset_path : [ 'dependencies' => [] ];
+
+		// In case when require is not an array, the whole flow will break. In that case  make sure that $script_asset is an array.
+		if ( ! is_array( $script_asset ) ) {
+			$script_asset = [ 'dependencies' => [] ];
+		}
+
+		// If the key is missing, the code that follows could break. Make sure that we have that key.
+		// In case dependencies key is in array, but it is not an array, redeclare it to empty array to prevent unwanted cases.
+		if ( ! array_key_exists( 'dependencies', $script_asset ) || ! is_array( $script_asset['dependencies'] ) ) {
+			$script_asset['dependencies'] = [];
+		}
 		wp_register_script(
 			'WCPAY_DASH_APP',
 			$script_src_url,


### PR DESCRIPTION
Fixes #5270

#### Changes proposed in this Pull Request

In some cases, some plugins can have a conflict with registering a payments scripts, which results in an exception. This PRs solves that issue by checking does a variable that holds dependencies is in correct format (is in array) and does is it have required keys in that array.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. Make sure that you have environment with PHP 8.0
2. Go to the settings page - /wp-admin/admin.php?page=searchwp-settings
3. Make sure that you can see the page without any errors
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
