### PR TITLE
Fix credit card and UPE payments on the Pay for order page

### DIFF
--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -139,11 +139,11 @@ jQuery( function ( $ ) {
 	};
 
 	/**
-	 * Finds selected payment gateway and returns matching Stripe payment method for gateway.
+	 * Finds selected UPE payment gateway and returns matching Stripe payment method for gateway.
 	 *
-	 * @return {string} Stripe payment method type
+	 * @return {string} Stripe payment method type in case of type UPE, null otherwise
 	 */
-	const getSelectedGatewayPaymentMethod = () => {
+	const getSelectedUPEGatewayPaymentMethod = () => {
 		const gatewayCardId = getUPEConfig( 'gatewayId' );
 		let selectedGatewayId = null;
 
@@ -453,7 +453,7 @@ jQuery( function ( $ ) {
 	 * @return {boolean} false if incomplete.
 	 */
 	const checkUPEForm = async ( $form, returnUrl = '#' ) => {
-		const paymentMethodType = getSelectedGatewayPaymentMethod();
+		const paymentMethodType = getSelectedUPEGatewayPaymentMethod();
 		const upeComponents = gatewayUPEComponents[ paymentMethodType ];
 		const upeElement = upeComponents.upeElement;
 		const elements = upeComponents.elements;
@@ -513,7 +513,7 @@ jQuery( function ( $ ) {
 
 		try {
 			// Update payment intent with level3 data, customer and maybe setup for future use.
-			const paymentMethodType = getSelectedGatewayPaymentMethod();
+			const paymentMethodType = getSelectedUPEGatewayPaymentMethod();
 			const upeComponents = gatewayUPEComponents[ paymentMethodType ];
 			const updateResponse = await api.updateIntent(
 				upeComponents.paymentIntentId,
@@ -563,7 +563,7 @@ jQuery( function ( $ ) {
 		blockUI( $form );
 
 		try {
-			const paymentMethodType = getSelectedGatewayPaymentMethod();
+			const paymentMethodType = getSelectedUPEGatewayPaymentMethod();
 			const upeComponents = gatewayUPEComponents[ paymentMethodType ];
 			const { error } = await api.getStripe().confirmSetup( {
 				elements: upeComponents.elements,
@@ -769,7 +769,7 @@ jQuery( function ( $ ) {
 		.map( ( method ) => `checkout_place_order_${ method }` )
 		.join( ' ' );
 	$( 'form.checkout' ).on( checkoutEvents, function () {
-		const paymentMethodType = getSelectedGatewayPaymentMethod();
+		const paymentMethodType = getSelectedUPEGatewayPaymentMethod();
 		if ( ! isUsingSavedPaymentMethod( paymentMethodType ) ) {
 			const paymentIntentId =
 				gatewayUPEComponents[ paymentMethodType ].paymentIntentId;
@@ -789,7 +789,7 @@ jQuery( function ( $ ) {
 			return;
 		}
 		if ( ! $( '#wcpay-setup-intent' ).val() ) {
-			const paymentMethodType = getSelectedGatewayPaymentMethod();
+			const paymentMethodType = getSelectedUPEGatewayPaymentMethod();
 			const paymentIntentId =
 				gatewayUPEComponents[ paymentMethodType ].paymentIntentId;
 			if ( isUPEEnabled && paymentIntentId ) {
@@ -801,12 +801,12 @@ jQuery( function ( $ ) {
 
 	// Handle the Pay for Order form if WooCommerce Payments is chosen.
 	$( '#order_review' ).on( 'submit', () => {
-		// Skip handling legacy cards as UPE payment methods.
-		if ( isWCPayChosen() ) {
+		// Skip handling non-UPE payment methods.
+		const upePaymentMethodType = getSelectedUPEGatewayPaymentMethod();
+		if ( null === getSelectedUPEGatewayPaymentMethod() ) {
 			return;
 		}
-		const paymentMethodType = getSelectedGatewayPaymentMethod();
-		if ( ! isUsingSavedPaymentMethod( paymentMethodType ) ) {
+		if ( ! isUsingSavedPaymentMethod( upePaymentMethodType ) ) {
 			if ( isChangingPayment ) {
 				handleUPEAddPayment( $( '#order_review' ) );
 				return false;
@@ -826,7 +826,7 @@ jQuery( function ( $ ) {
 			)
 				? 'always'
 				: 'never';
-			const paymentMethodType = getSelectedGatewayPaymentMethod();
+			const paymentMethodType = getSelectedUPEGatewayPaymentMethod();
 			if ( ! paymentMethodType ) {
 				return;
 			}

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -519,7 +519,7 @@ jQuery( function ( $ ) {
 				upeComponents.paymentIntentId,
 				orderId,
 				savePaymentMethod,
-				$( '#wcpay_selected_upe_payment_type' ).val(),
+				paymentMethodType,
 				$( '#wcpay_payment_country' ).val()
 			);
 
@@ -785,12 +785,7 @@ jQuery( function ( $ ) {
 	// Handle the add payment method form for WooCommerce Payments.
 	$( 'form#add_payment_method' ).on( 'submit', function () {
 		// Skip adding legacy cards as UPE payment methods.
-		if (
-			'woocommerce_payments' ===
-			$(
-				"#add_payment_method input:checked[name='payment_method']"
-			).val()
-		) {
+		if ( isWCPayChosen() ) {
 			return;
 		}
 		if ( ! $( '#wcpay-setup-intent' ).val() ) {
@@ -807,17 +802,11 @@ jQuery( function ( $ ) {
 	// Handle the Pay for Order form if WooCommerce Payments is chosen.
 	$( '#order_review' ).on( 'submit', () => {
 		// Skip handling legacy cards as UPE payment methods.
-		if (
-			'woocommerce_payments' ===
-			$( "#order_review input:checked[name='payment_method']" ).val()
-		) {
+		if ( isWCPayChosen() ) {
 			return;
 		}
 		const paymentMethodType = getSelectedGatewayPaymentMethod();
-		if (
-			! isUsingSavedPaymentMethod( paymentMethodType ) &&
-			isWCPayChosen()
-		) {
+		if ( ! isUsingSavedPaymentMethod( paymentMethodType ) ) {
 			if ( isChangingPayment ) {
 				handleUPEAddPayment( $( '#order_review' ) );
 				return false;

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -806,6 +806,12 @@ jQuery( function ( $ ) {
 
 	// Handle the Pay for Order form if WooCommerce Payments is chosen.
 	$( '#order_review' ).on( 'submit', () => {
+		if (
+			'woocommerce_payments' ===
+			$( "#order_review input:checked[name='payment_method']" ).val()
+		) {
+			return;
+		}
 		const paymentMethodType = getSelectedGatewayPaymentMethod();
 		if (
 			! isUsingSavedPaymentMethod( paymentMethodType ) &&

--- a/client/checkout/classic/upe.js
+++ b/client/checkout/classic/upe.js
@@ -806,6 +806,7 @@ jQuery( function ( $ ) {
 
 	// Handle the Pay for Order form if WooCommerce Payments is chosen.
 	$( '#order_review' ).on( 'submit', () => {
+		// Skip handling legacy cards as UPE payment methods.
 		if (
 			'woocommerce_payments' ===
 			$( "#order_review input:checked[name='payment_method']" ).val()

--- a/tests/e2e/specs/wcpay/shopper/shopper-pay-for-order.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-pay-for-order.spec.js
@@ -1,0 +1,58 @@
+const {
+	createSimpleProduct,
+	uiUnblocked,
+	shopper,
+} = require( '@woocommerce/e2e-utils' );
+const {
+	setupProductCheckout,
+	fillCardDetails,
+	fillCardDetailsPayForOrder,
+} = require( '../../../utils/payments' );
+const config = require( 'config' );
+const { shopperWCP } = require( '../../../utils' );
+
+describe( 'Shopper > Pay for Order', () => {
+	beforeAll( async () => {
+		await shopper.login();
+		await createSimpleProduct();
+		await setupProductCheckout(
+			config.get( 'addresses.customer.billing' )
+		);
+	} );
+
+	afterAll( async () => {
+		await shopper.logout();
+	} );
+
+	it( 'should be able to pay for a failed order', async () => {
+		// try to pay with a declined card
+		const declinedCard = config.get( 'cards.declined' );
+		await fillCardDetails( page, declinedCard );
+		await expect( page ).toClick( '#place_order' );
+		await uiUnblocked();
+		await expect(
+			page
+		).toMatchElement(
+			'div.woocommerce-NoticeGroup > ul.woocommerce-error > li',
+			{ text: 'Error: Your card was declined.' }
+		);
+
+		// after the card has been declined, go to the order page and pay with a basic card
+		await shopperWCP.goToOrders();
+
+		const payButtons = await page.$$(
+			'.woocommerce-button.wp-element-button.button.pay'
+		);
+		const payButton = payButtons.find(
+			async ( button ) =>
+				'Pay' ===
+				( await page.evaluate( ( elem ) => elem.innerText, button ) )
+		);
+		await payButton.click();
+		const card = config.get( 'cards.basic' );
+		await fillCardDetailsPayForOrder( page, card );
+		await expect( page ).toClick( 'button', { text: 'Pay for order' } );
+		await uiUnblocked();
+		await expect( page ).toMatch( 'Order received' );
+	} );
+} );

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -29,6 +29,7 @@ const MY_ACCOUNT_PAYMENT_METHODS = baseUrl + 'my-account/payment-methods';
 const WC_ADMIN_BASE_URL = baseUrl + 'wp-admin/';
 const MY_ACCOUNT_SUBSCRIPTIONS = baseUrl + 'my-account/subscriptions';
 const MY_ACCOUNT_EDIT = baseUrl + 'my-account/edit-account';
+const MY_ACCOUNT_ORDERS = SHOP_MY_ACCOUNT_PAGE + 'orders/';
 const WCPAY_DISPUTES =
 	baseUrl + 'wp-admin/admin.php?page=wc-admin&path=/payments/disputes';
 const WCPAY_DEPOSITS =
@@ -61,6 +62,12 @@ export const RUN_WC_BLOCKS_TESTS = '1' !== process.env.SKIP_WC_BLOCKS_TESTS;
 export const shopperWCP = {
 	goToPaymentMethods: async () => {
 		await page.goto( MY_ACCOUNT_PAYMENT_METHODS, {
+			waitUntil: 'networkidle0',
+		} );
+	},
+
+	goToOrders: async () => {
+		await page.goto( MY_ACCOUNT_ORDERS, {
 			waitUntil: 'networkidle0',
 		} );
 	},

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -89,6 +89,31 @@ export async function clearCardDetails() {
 	await page.keyboard.press( 'Backspace' );
 }
 
+export async function fillCardDetailsPayForOrder( page, card ) {
+	await page.waitForSelector( '.__PrivateStripeElement' );
+	const frameHandle = await page.waitForSelector(
+		'#payment #wcpay-card-element iframe[name^="__privateStripeFrame"]'
+	);
+	const stripeFrame = await frameHandle.contentFrame();
+
+	const cardNumberInput = await stripeFrame.waitForSelector(
+		'[name="cardnumber"]',
+		{ timeout: 30000 }
+	);
+	await cardNumberInput.type( card.number, { delay: 20 } );
+
+	const cardDateInput = await stripeFrame.waitForSelector(
+		'[name="exp-date"]'
+	);
+
+	await cardDateInput.type( card.expires.month + card.expires.year, {
+		delay: 20,
+	} );
+
+	const cardCvcInput = await stripeFrame.waitForSelector( '[name="cvc"]' );
+	await cardCvcInput.type( card.cvc, { delay: 20 } );
+}
+
 // WooCommerce Blocks Checkout
 export async function fillCardDetailsWCB( page, card ) {
 	await page.waitForSelector( '.__PrivateStripeElement' );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5512

#### Changes proposed in this Pull Request
The code that handles payment on the Pay for order page listens to an event in both UPE and classic implementation. When a credit card is used, UPE implementation results in unexpected errors as it doesn't support CC but still tries to do it. This PR fixes the issue by blocking the UPE part execution on the Pay for order page when the legacy credit card is being used.

Update: additionally, this PR fixes UPE checkout from Pay for order page.


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pay for order with CC and confirm that there are no errors
* Pay for order with any of the UPE elements and confirm that there are no errors
* Perform a shortcode checkout purchase with both CC and UPE and confirm that everything works as expected
* Add a CC payment method in My account page and confirm, that the method is successfully added
* Add CC payment method in My account -> Payment methods page and ensure that no errors appear

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
