### PR TITLE
fix: add Link and WooPay compatibility tooltip

### DIFF
--- a/client/settings/express-checkout/index.js
+++ b/client/settings/express-checkout/index.js
@@ -4,9 +4,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Card, CheckboxControl } from '@wordpress/components';
+import { Card, CheckboxControl, VisuallyHidden } from '@wordpress/components';
 import interpolateComponents from 'interpolate-components';
 import { useContext } from '@wordpress/element';
+import { Icon, warning } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -24,6 +25,7 @@ import WooIcon from '../../gateway-icons/woo';
 import './style.scss';
 import WCPaySettingsContext from '../wcpay-settings-context';
 import LinkIcon from '../../gateway-icons/link';
+import Tooltip from 'components/tooltip';
 
 const ExpressCheckout = () => {
 	const [
@@ -74,12 +76,45 @@ const ExpressCheckout = () => {
 			<CardBody size={ 0 }>
 				<ul className="express-checkouts-list">
 					{ isPlatformCheckoutFeatureFlagEnabled && (
-						<li className="express-checkout has-icon-border">
+						<li className="express-checkout">
 							<div className="express-checkout__checkbox">
-								<CheckboxControl
-									checked={ isPlatformCheckoutEnabled }
-									onChange={ updateIsPlatformCheckoutEnabled }
-								/>
+								{ isStripeLinkEnabled ? (
+									<Tooltip
+										content={ __(
+											'To enable WooPay, you must first disable Link by Stripe.',
+											'woocommerce-payments'
+										) }
+									>
+										<div className="loadable-checkbox__icon">
+											<Icon
+												icon={ warning }
+												fill={ '#ffc83f' }
+											/>
+											<div
+												className="loadable-checkbox__icon-warning"
+												data-testid="loadable-checkbox-icon-warning"
+											>
+												<VisuallyHidden>
+													{ __(
+														'WooPay cannot be enabled at checkout. Click to expand.',
+														'woocommerce-payments'
+													) }
+												</VisuallyHidden>
+											</div>
+										</div>
+									</Tooltip>
+								) : (
+									<CheckboxControl
+										label={ __(
+											'WooPay',
+											'woocommerce-payments'
+										) }
+										checked={ isPlatformCheckoutEnabled }
+										onChange={
+											updateIsPlatformCheckoutEnabled
+										}
+									/>
+								) }
 							</div>
 							<div className="express-checkout__icon">
 								<WooIcon />
@@ -142,9 +177,13 @@ const ExpressCheckout = () => {
 							</div>
 						</li>
 					) }
-					<li className="express-checkout has-icon-border">
+					<li className="express-checkout">
 						<div className="express-checkout__checkbox">
 							<CheckboxControl
+								label={ __(
+									'Apple Pay / Google Pay',
+									'woocommerce-payments'
+								) }
 								checked={ isPaymentRequestEnabled }
 								onChange={ updateIsPaymentRequestEnabled }
 							/>
@@ -208,16 +247,43 @@ const ExpressCheckout = () => {
 						</div>
 					</li>
 					{ displayLinkPaymentMethod && (
-						<li className="express-checkout has-icon-border">
-							<div className="express-checkout__checkbox loadable-checkbox label-hidden">
-								<CheckboxControl
-									label={ __(
-										'Link by Stripe',
-										'woocommerce-payments'
-									) }
-									checked={ isStripeLinkEnabled }
-									onChange={ updateStripeLinkCheckout }
-								/>
+						<li className="express-checkout">
+							<div className="express-checkout__checkbox">
+								{ isPlatformCheckoutEnabled ? (
+									<Tooltip
+										content={ __(
+											'To enable Link by Stripe, you must first disable WooPay.',
+											'woocommerce-payments'
+										) }
+									>
+										<div className="loadable-checkbox__icon">
+											<Icon
+												icon={ warning }
+												fill={ '#ffc83f' }
+											/>
+											<div
+												className="loadable-checkbox__icon-warning"
+												data-testid="loadable-checkbox-icon-warning"
+											>
+												<VisuallyHidden>
+													{ __(
+														'Link by Stripe cannot be enabled at checkout. Click to expand.',
+														'woocommerce-payments'
+													) }
+												</VisuallyHidden>
+											</div>
+										</div>
+									</Tooltip>
+								) : (
+									<CheckboxControl
+										label={ __(
+											'Link by Stripe',
+											'woocommerce-payments'
+										) }
+										checked={ isStripeLinkEnabled }
+										onChange={ updateStripeLinkCheckout }
+									/>
+								) }
 							</div>
 							<div className="express-checkout__icon">
 								<LinkIcon />

--- a/client/settings/express-checkout/style.scss
+++ b/client/settings/express-checkout/style.scss
@@ -23,6 +23,10 @@
 				align-items: center;
 				justify-content: center;
 
+				label {
+					display: none;
+				}
+
 				.components-base-control__field {
 					margin: 0 4px 0 0;
 				}

--- a/client/settings/express-checkout/test/index.test.js
+++ b/client/settings/express-checkout/test/index.test.js
@@ -50,11 +50,11 @@ describe( 'ExpressCheckout', () => {
 		const updateIsPaymentRequestEnabledHandler = jest.fn();
 
 		useGetAvailablePaymentMethodIds.mockReturnValue( [ 'link', 'card' ] );
-		useEnabledPaymentMethodIds.mockReturnValue( [ [ 'card', 'link' ] ] );
+		useEnabledPaymentMethodIds.mockReturnValue( [ [ 'card' ] ] );
 
 		usePlatformCheckoutEnabledSettings.mockReturnValue(
 			getMockPlatformCheckoutEnabledSettings(
-				false,
+				true,
 				updateIsPlatformCheckoutEnabledHandler
 			)
 		);
@@ -73,19 +73,10 @@ describe( 'ExpressCheckout', () => {
 			</WCPaySettingsContext.Provider>
 		);
 
-		const [
-			platformCheckoutCheckbox,
-			paymentRequestCheckbox,
-		] = screen.queryAllByRole( 'checkbox' );
-
-		userEvent.click( platformCheckoutCheckbox );
-		userEvent.click( paymentRequestCheckbox );
+		userEvent.click( screen.getByLabelText( 'WooPay' ) );
 
 		expect( updateIsPlatformCheckoutEnabledHandler ).toHaveBeenCalledWith(
-			true
-		);
-		expect( updateIsPaymentRequestEnabledHandler ).toHaveBeenCalledWith(
-			true
+			false
 		);
 	} );
 
@@ -171,5 +162,36 @@ describe( 'ExpressCheckout', () => {
 		);
 		const linkCheckbox = container.getByLabelText( 'Link by Stripe' );
 		expect( linkCheckbox ).not.toBeChecked();
+	} );
+
+	it( 'should prevent enabling both Link and WooPay at the same time', async () => {
+		const updateIsPlatformCheckoutEnabledHandler = jest.fn();
+		usePlatformCheckoutEnabledSettings.mockReturnValue(
+			getMockPlatformCheckoutEnabledSettings(
+				false,
+				updateIsPlatformCheckoutEnabledHandler
+			)
+		);
+		const context = { featureFlags: { platformCheckout: true } };
+		useGetAvailablePaymentMethodIds.mockReturnValue( [ 'link', 'card' ] );
+		useEnabledPaymentMethodIds.mockReturnValue( [ [ 'card', 'link' ] ] );
+
+		render(
+			<WCPaySettingsContext.Provider value={ context }>
+				<ExpressCheckout />
+			</WCPaySettingsContext.Provider>
+		);
+
+		expect(
+			screen.queryByText(
+				'WooPay cannot be enabled at checkout. Click to expand.'
+			)
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(
+				'Link by Stripe cannot be enabled at checkout. Click to expand.'
+			)
+		).not.toBeInTheDocument();
+		expect( screen.getByLabelText( 'Link by Stripe' ) ).toBeChecked();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Adding a tooltip that is displayed whenever the merchant attempts to enable both WooPay and Link at the same time.

I didn't run the changelog command because it's not needed - this is getting merged into a larger feature branch

Fixes https://github.com/Automattic/woocommerce-payments/issues/4720

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I recommend reviewing these changes with the "Hide whitespace changes" setting enabled - it'll show you that it's much fewer changes: https://github.com/Automattic/woocommerce-payments/pull/5515/files?w=1

- Go to the settings page
- Try to enable Link and WooPay at the same time
- A tooltip should appear
- Enabling/disabling them individually should not display the notice

With this changes, it's still possible that a merchant has both Link and WooPay enabled at the same time. But the number of merchants that had WooPay enabled is so small, that it doesn't matter.

![2023-02-02 15 13 30](https://user-images.githubusercontent.com/273592/216472277-01e98424-9546-4cad-911c-72933c2cb19d.gif)



-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
