### PR TITLE
Single separator for express checkout methods

### DIFF
--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -146,6 +146,15 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Checks whether Payment Request is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_payment_request_enabled() {
+		return 'yes' === WC_Payments::get_gateway()->get_option( 'payment_request' );
+	}
+
+	/**
 	 * Checks whether WooPay Express Checkout is enabled.
 	 *
 	 * @return bool
@@ -162,6 +171,15 @@ class WC_Payments_Features {
 	 */
 	public static function is_auth_and_capture_enabled() {
 		return '1' === get_option( self::AUTH_AND_CAPTURE_FLAG_NAME, '1' );
+	}
+
+	/**
+	 * Checks whether any express checkout method is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_express_checkout_enabled() {
+		return self::is_woopay_express_checkout_enabled() || self::is_payment_request_enabled();
 	}
 
 	/**

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -146,15 +146,6 @@ class WC_Payments_Features {
 	}
 
 	/**
-	 * Checks whether Payment Request is enabled.
-	 *
-	 * @return bool
-	 */
-	public static function is_payment_request_enabled() {
-		return 'yes' === WC_Payments::get_gateway()->get_option( 'payment_request' );
-	}
-
-	/**
 	 * Checks whether WooPay Express Checkout is enabled.
 	 *
 	 * @return bool
@@ -171,15 +162,6 @@ class WC_Payments_Features {
 	 */
 	public static function is_auth_and_capture_enabled() {
 		return '1' === get_option( self::AUTH_AND_CAPTURE_FLAG_NAME, '1' );
-	}
-
-	/**
-	 * Checks whether any express checkout method is enabled.
-	 *
-	 * @return bool
-	 */
-	public static function is_express_checkout_enabled() {
-		return self::is_woopay_express_checkout_enabled() || self::is_payment_request_enabled();
 	}
 
 	/**

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -73,17 +73,13 @@ class WC_Payments_Payment_Request_Button_Handler {
 		add_action( 'template_redirect', [ $this, 'handle_payment_request_redirect' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'scripts' ] );
 
-		add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_payment_request_button_html' ], 1 );
-		add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_payment_request_button_separator_html' ], 2 );
+		add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_payment_request_button_html' ], -2 );
 
-		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_payment_request_button_html' ], 1 );
-		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_payment_request_button_separator_html' ], 2 );
+		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_payment_request_button_html' ], -2 );
 
-		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_payment_request_button_html' ], 1 );
-		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_payment_request_button_separator_html' ], 2 );
+		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_payment_request_button_html' ], -2 );
 
 		add_action( 'before_woocommerce_pay_form', [ $this, 'display_pay_for_order_page_html' ], 1 );
-		add_action( 'before_woocommerce_pay_form', [ $this, 'display_payment_request_button_separator_html' ], 2 );
 
 		add_action( 'wc_ajax_wcpay_get_cart_details', [ $this, 'ajax_get_cart_details' ] );
 		add_action( 'wc_ajax_wcpay_get_shipping_options', [ $this, 'ajax_get_shipping_options' ] );
@@ -787,18 +783,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 				<!-- A Stripe Element will be inserted here. -->
 			</div>
 		</div>
-		<?php
-	}
-
-	/**
-	 * Display payment request button separator.
-	 */
-	public function display_payment_request_button_separator_html() {
-		if ( ! $this->should_show_payment_request_button() ) {
-			return;
-		}
-		?>
-		<p id="wcpay-payment-request-button-separator" style="margin-top:1.5em;text-align:center;display:none;">&mdash; <?php esc_html_e( 'OR', 'woocommerce-payments' ); ?> &mdash;</p>
 		<?php
 	}
 

--- a/includes/class-wc-payments-platform-checkout-button-handler.php
+++ b/includes/class-wc-payments-platform-checkout-button-handler.php
@@ -75,10 +75,7 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 	 * @return bool
 	 */
 	public function is_woopay_enabled() {
-		if ( ! ( $this->is_platform_checkout_eligible && $this->is_platform_checkout_enabled && $this->is_platform_checkout_express_button_enabled ) ) {
-			return false;
-		}
-		return true;
+		return $this->is_platform_checkout_eligible && $this->is_platform_checkout_enabled && $this->is_platform_checkout_express_button_enabled;
 	}
 
 	/**

--- a/includes/class-wc-payments-platform-checkout-button-handler.php
+++ b/includes/class-wc-payments-platform-checkout-button-handler.php
@@ -49,6 +49,39 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 	}
 
 	/**
+	 * Indicates eligibility for WooPay via feature flag.
+	 *
+	 * @var bool
+	 */
+	private $is_platform_checkout_eligible;
+
+	/**
+	 * Indicates whether WooPay is enabled.
+	 *
+	 * @var bool
+	 */
+	private $is_platform_checkout_enabled;
+
+	/**
+	 * Indicates whether WooPay express checkout is enabled.
+	 *
+	 * @var bool
+	 */
+	private $is_platform_checkout_express_button_enabled;
+
+	/**
+	 * Indicates whether WooPay and WooPay express checkout are enabled.
+	 *
+	 * @return bool
+	 */
+	public function is_woopay_enabled() {
+		if ( ! ( $this->is_platform_checkout_eligible && $this->is_platform_checkout_enabled && $this->is_platform_checkout_express_button_enabled ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
 	 * Initialize hooks.
 	 *
 	 * @return  void
@@ -60,11 +93,11 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 		}
 
 		// Checks if WooPay is enabled.
-		$is_platform_checkout_eligible               = WC_Payments_Features::is_platform_checkout_eligible(); // Feature flag.
-		$is_platform_checkout_enabled                = 'yes' === $this->gateway->get_option( 'platform_checkout', 'no' );
-		$is_platform_checkout_express_button_enabled = WC_Payments_Features::is_woopay_express_checkout_enabled();
+		$this->is_platform_checkout_eligible               = WC_Payments_Features::is_platform_checkout_eligible(); // Feature flag.
+		$this->is_platform_checkout_enabled                = 'yes' === $this->gateway->get_option( 'platform_checkout', 'no' );
+		$this->is_platform_checkout_express_button_enabled = WC_Payments_Features::is_woopay_express_checkout_enabled();
 
-		if ( ! ( $is_platform_checkout_eligible && $is_platform_checkout_enabled && $is_platform_checkout_express_button_enabled ) ) {
+		if ( ! $this->is_woopay_enabled() ) {
 			return;
 		}
 
@@ -80,13 +113,10 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 		add_action( 'wc_ajax_wcpay_add_to_cart', [ $this, 'ajax_add_to_cart' ] );
 
 		add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_platform_checkout_button_html' ], -2 );
-		add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_platform_checkout_button_separator_html' ], -1 );
 
 		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_platform_checkout_button_html' ], -2 );
-		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_platform_checkout_button_separator_html' ], -1 );
 
 		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_platform_checkout_button_html' ], -2 );
-		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_platform_checkout_button_separator_html' ], -1 );
 
 		add_action( 'wp_ajax_woopay_express_checkout_button_show_error_notice', [ $this, 'show_error_notice' ] );
 		add_action( 'wp_ajax_nopriv_woopay_express_checkout_button_show_error_notice', [ $this, 'show_error_notice' ] );
@@ -472,6 +502,10 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 			return false;
 		}
 
+		if ( $this->is_pay_for_order_page() ) {
+			return false;
+		}
+
 		/**
 		 * TODO: We need to do some research here and see if there are any product types that we
 		 * absolutely cannot support with WooPay at this time. There are some examples in the
@@ -495,18 +529,6 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 				<?php // The WooPay express checkout button React component will go here. ?>
 			</div>
 		</div>
-		<?php
-	}
-
-	/**
-	 * Display payment request button separator.
-	 */
-	public function display_platform_checkout_button_separator_html() {
-		if ( ! $this->should_show_platform_checkout_button() ) {
-			return;
-		}
-		?>
-		<p id="wcpay-payment-request-button-separator" style="margin-top:1.5em;text-align:center;">&mdash; <?php esc_html_e( 'OR', 'woocommerce-payments' ); ?> &mdash;</p>
 		<?php
 	}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -457,13 +457,15 @@ class WC_Payments {
 			WC_Payments_Subscriptions::init( self::$api_client, self::$customer_service, self::get_gateway(), self::$account );
 		}
 
-		if ( WC_Payments_Features::is_express_checkout_enabled() ) {
+		$is_woopay_express_checkout_enabled = WC_Payments_Features::is_woopay_express_checkout_enabled();
+
+		if ( $is_woopay_express_checkout_enabled || self::get_gateway()->get_option( 'payment_request' ) ) {
 			add_action( 'woocommerce_after_add_to_cart_quantity', [ __CLASS__, 'display_express_checkout_separator_if_necessary' ], -1 );
 			add_action( 'woocommerce_proceed_to_checkout', [ __CLASS__, 'display_express_checkout_separator_if_necessary' ], -1 );
 			add_action( 'woocommerce_checkout_before_customer_details', [ __CLASS__, 'display_express_checkout_separator_if_necessary' ], -1 );
 
-			if ( WC_Payments_Features::is_payment_request_enabled() ) {
-				// Load payment request buttons on the Pay for Order page.
+			if ( self::get_gateway()->get_option( 'payment_request' ) ) {
+				// Load separator on the Pay for Order page.
 				add_action( 'before_woocommerce_pay_form', [ __CLASS__, 'display_express_checkout_separator_if_necessary' ], 2 );
 			}
 		}


### PR DESCRIPTION
Fixes #5518

#### Changes proposed in this Pull Request

This ensures that only a single `-OR-` separator is used with express checkout buttons such as Google Pay, Apple Pay, and WooPay. 

#### Testing instructions

1. Enable 2 or more express checkout methods(Link, WooPay, Payment Request). The WooPay express checkout button can be enabled via the latest version of the WCPay Dev Tools plugin. Configure the express button by selecting **Customize** under the WooPay Express Checkout settings at **Payments  > Settings**. 
2. Visit a product page where only 1 **- OR -** separator should appear.
3. Add a product to the cart and visit the cart page where only 1 **- OR -** separator should appear. 
4. Visit the cart page where only 1 **- OR -** separator should appear.
5. Using the settings found for each express checkout button under its **Customize** option, disable the button on some pages and check that settings are being honored.

**Note**: This work was originally completed in https://github.com/Automattic/woocommerce-payments/pull/5399 and https://github.com/Automattic/woocommerce-payments/pull/5451 and was merged into the [4720/stripe-link-integration](https://github.com/Automattic/woocommerce-payments/tree/4720/stripe-link-integration) branch. Since that branch won't be merged yet, this PR moves the fix into the split-UPE branch.