### PR TITLE
Trigger translations after the GitHub release is created in post-release workflow

### DIFF
--- a/.github/workflows/post-release-updates.yml
+++ b/.github/workflows/post-release-updates.yml
@@ -97,7 +97,7 @@ jobs:
 
   trigger-translations:
     name: "Trigger translations update for the release"
-    needs: get-last-released-version
+    needs: [get-last-released-version, create-gh-release]
     runs-on: ubuntu-20.04
     steps:
       - name: "Checkout repository (trunk)"

--- a/changelog/fix-5398-trigger-translations
+++ b/changelog/fix-5398-trigger-translations
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Minor fix for post release workflow regarding translations
+
+


### PR DESCRIPTION
Fixes #5398 

#### Changes proposed in this Pull Request

- The translations step will now run once the GitHub release is created

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
