### PR TITLE
Pass the namespaces in the Store API checkout schema to WooPay

### DIFF
--- a/changelog/add-checkout-schema-data-woopay
+++ b/changelog/add-checkout-schema-data-woopay
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Pass the Store API checkout schema data to WooPay
+Pass the namespaces from the Store API checkout schema data to WooPay

--- a/changelog/add-checkout-schema-data-woopay
+++ b/changelog/add-checkout-schema-data-woopay
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Pass the Store API checkout schema data to WooPay

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1137,7 +1137,7 @@ class WC_Payments {
 				'ship_to_billing_address_only'   => wc_ship_to_billing_address_only(),
 				'return_url'                     => wc_get_cart_url(),
 				'blocks_data'                    => $blocks_data_extractor->get_data(),
-				'checkout_schema'                => $blocks_data_extractor->get_checkout_schema(),
+				'checkout_schema_namespaces'     => $blocks_data_extractor->get_checkout_schema_namespaces(),
 			],
 			'user_session'         => isset( $_REQUEST['user_session'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['user_session'] ) ) : null,
 		];

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1137,6 +1137,7 @@ class WC_Payments {
 				'ship_to_billing_address_only'   => wc_ship_to_billing_address_only(),
 				'return_url'                     => wc_get_cart_url(),
 				'blocks_data'                    => $blocks_data_extractor->get_data(),
+				'checkout_schema'                => $blocks_data_extractor->get_checkout_schema(),
 			],
 			'user_session'         => isset( $_REQUEST['user_session'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['user_session'] ) ) : null,
 		];

--- a/includes/compat/blocks/class-blocks-data-extractor.php
+++ b/includes/compat/blocks/class-blocks-data-extractor.php
@@ -135,9 +135,17 @@ class Blocks_Data_Extractor {
 	/**
 	 * Retrieves the Store API checkout schema.
 	 *
-	 * @return object
+	 * @return object|array
 	 */
 	public function get_checkout_schema() {
-		return StoreApi::container()->get( ExtendSchema::class )->get_endpoint_schema( CheckoutSchema::IDENTIFIER );
+		if (
+			class_exists( StoreApi::class ) &&
+			class_exists( ExtendSchema::class ) &&
+			class_exists( CheckoutSchema::class )
+		) {
+			return StoreApi::container()->get( ExtendSchema::class )->get_endpoint_schema( CheckoutSchema::IDENTIFIER );
+		}
+
+		return [];
 	}
 }

--- a/includes/compat/blocks/class-blocks-data-extractor.php
+++ b/includes/compat/blocks/class-blocks-data-extractor.php
@@ -141,9 +141,9 @@ class Blocks_Data_Extractor {
 		$namespaces = [];
 
 		if (
-			class_exists( StoreApi::class ) &&
-			class_exists( ExtendSchema::class ) &&
-			class_exists( CheckoutSchema::class )
+			class_exists( 'Automattic\WooCommerce\StoreApi\StoreApi' ) &&
+			class_exists( 'Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema' ) &&
+			class_exists( 'Automattic\WooCommerce\Blocks\StoreApi\Schemas\CheckoutSchema' )
 		) {
 			try {
 				$checkout_schema = StoreApi::container()->get( ExtendSchema::class )->get_endpoint_schema( CheckoutSchema::IDENTIFIER );

--- a/includes/compat/blocks/class-blocks-data-extractor.php
+++ b/includes/compat/blocks/class-blocks-data-extractor.php
@@ -7,6 +7,9 @@
 
 namespace WCPay;
 
+use Automattic\WooCommerce\StoreApi\StoreApi;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CheckoutSchema;
 use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
 
 defined( 'ABSPATH' ) || exit; // block direct access.
@@ -127,5 +130,14 @@ class Blocks_Data_Extractor {
 		$this->unregister_blocks( $blocks );
 
 		return $blocks_data;
+	}
+
+	/**
+	 * Retrieves the Store API checkout schema.
+	 *
+	 * @return object
+	 */
+	public function get_checkout_schema() {
+		return StoreApi::container()->get( ExtendSchema::class )->get_endpoint_schema( CheckoutSchema::IDENTIFIER );
 	}
 }

--- a/includes/compat/blocks/class-blocks-data-extractor.php
+++ b/includes/compat/blocks/class-blocks-data-extractor.php
@@ -133,19 +133,27 @@ class Blocks_Data_Extractor {
 	}
 
 	/**
-	 * Retrieves the Store API checkout schema.
+	 * Retrieves the namespaces in the Store API checkout schema.
 	 *
-	 * @return object|array
+	 * @return array
 	 */
-	public function get_checkout_schema() {
+	public function get_checkout_schema_namespaces() : array {
+		$namespaces = [];
+
 		if (
 			class_exists( StoreApi::class ) &&
 			class_exists( ExtendSchema::class ) &&
 			class_exists( CheckoutSchema::class )
 		) {
-			return StoreApi::container()->get( ExtendSchema::class )->get_endpoint_schema( CheckoutSchema::IDENTIFIER );
+			try {
+				$checkout_schema = StoreApi::container()->get( ExtendSchema::class )->get_endpoint_schema( CheckoutSchema::IDENTIFIER );
+			} catch ( \Exception $e ) {
+				return $namespaces;
+			}
+
+			$namespaces = array_keys( (array) $checkout_schema );
 		}
 
-		return [];
+		return $namespaces;
 	}
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -73,4 +73,9 @@
       <code>\Automattic\WooCommerce\Utilities\OrderUtil</code>
     </UndefinedClass>
   </file>
+  <file src="includes/compat/blocks/class-blocks-data-extractor.php">
+    <UndefinedClass occurrences="1">
+      <code>CheckoutSchema</code>
+    </UndefinedClass>
+  </file>
 </files>


### PR DESCRIPTION
Part of the fix for Automattic/woopay#1613

#### Changes proposed in this Pull Request

* Pass the namespaces from the Store API checkout schema data to WooPay

#### Testing instructions

Testing instructions in Automattic/woopay#1625

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
