### PR TITLE
Remove payment methods listing on the My Account Add Payment Method page

### DIFF
--- a/changelog/fix-4543-payment-method-display
+++ b/changelog/fix-4543-payment-method-display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Removed saved methods listing in My Account Add Payment Method page

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -183,7 +183,10 @@ class WC_Payments_Checkout {
 
 			if ( $display_tokenization ) {
 				$this->gateway->tokenization_script();
-				$this->gateway->saved_payment_methods();
+				//avoid showing saved payment methods on my-accounts add payment method page.
+				if(! is_add_payment_method_page() ) {
+					$this->gateway->saved_payment_methods();
+				}
 			}
 			?>
 

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -183,8 +183,8 @@ class WC_Payments_Checkout {
 
 			if ( $display_tokenization ) {
 				$this->gateway->tokenization_script();
-				//avoid showing saved payment methods on my-accounts add payment method page.
-				if(! is_add_payment_method_page() ) {
+				// avoid showing saved payment methods on my-accounts add payment method page.
+				if ( ! is_add_payment_method_page() ) {
 					$this->gateway->saved_payment_methods();
 				}
 			}

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -236,8 +236,8 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 
 			if ( $display_tokenization ) {
 				$this->gateway->tokenization_script();
-				//avoid showing saved payment methods on my-accounts add payment method page.
-				if(! is_add_payment_method_page() ) {
+				// avoid showing saved payment methods on my-accounts add payment method page.
+				if ( ! is_add_payment_method_page() ) {
 					$this->gateway->saved_payment_methods();
 				}
 			}

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -236,7 +236,10 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 
 			if ( $display_tokenization ) {
 				$this->gateway->tokenization_script();
-				$this->gateway->saved_payment_methods();
+				//avoid showing saved payment methods on my-accounts add payment method page.
+				if(! is_add_payment_method_page() ) {
+					$this->gateway->saved_payment_methods();
+				}
 			}
 			?>
 


### PR DESCRIPTION
Fixes #4543

My Account -> Payment Methods -> Add Payment Method, displays the list of saved payment method along with the option to Add New Payment Method.
If the user selected one of the existing  payment methods and clicks on "Add Payment Method",  "Your card number is incomplete" error is displayed.

Since the Payment Methods are already listed in My Account -> Payment Methods, it is redundant to show them in this page.

#### Changes proposed in this Pull Request
- The saved payment methods are not displayed in My Account -> Payment Methods -> Add Payment Method page

#### Testing instructions
- Follow testing instructions on #4543. Payment Methods not displayed and issue is avoided.
- Other pages where the same form is used, like Checkout, should not be affected.
- Test for all flavours of checkout e.g. UPE, classic, Blocks etc.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : (https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions-for-WC-Payments-5.5.0#remove-payment-method-listing-on-my-account-page-pr-5529)
- [x] Not applicable Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
