### PR TITLE
Handle request errors in the initPlatformCheckout initiated by the email input

### DIFF
--- a/changelog/fix-init-platform-checkout-error-handling
+++ b/changelog/fix-init-platform-checkout-error-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Display an error when the request for initiating the platform checkout fails.

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -511,21 +511,34 @@ export const handlePlatformCheckoutEmailInput = async (
 				api.initPlatformCheckout(
 					'',
 					e.data.platformCheckoutUserSession
-				).then( ( response ) => {
-					if ( 'success' === response.result ) {
-						loginSessionIframeWrapper.classList.add(
-							'platform-checkout-login-session-iframe-wrapper'
-						);
-						loginSessionIframe.classList.add( 'open' );
-						wcpayTracks.recordUserEvent(
-							wcpayTracks.events.PLATFORM_CHECKOUT_AUTO_REDIRECT
-						);
+				)
+					.then( ( response ) => {
+						if ( 'success' === response.result ) {
+							loginSessionIframeWrapper.classList.add(
+								'platform-checkout-login-session-iframe-wrapper'
+							);
+							loginSessionIframe.classList.add( 'open' );
+							wcpayTracks.recordUserEvent(
+								wcpayTracks.events
+									.PLATFORM_CHECKOUT_AUTO_REDIRECT
+							);
+							spinner.remove();
+							window.location = response.url;
+						} else {
+							closeLoginSessionIframe();
+						}
+					} )
+					.catch( ( err ) => {
+						// Only show the error if it's not an AbortError,
+						// it occurs when the fetch request is aborted because user
+						// clicked the Place Order button while loading.
+						if ( 'AbortError' !== err.name ) {
+							showErrorMessage();
+						}
+					} )
+					.finally( () => {
 						spinner.remove();
-						window.location = response.url;
-					} else {
-						closeLoginSessionIframe();
-					}
-				} );
+					} );
 				break;
 			case 'close_auto_redirection_modal':
 				hasCheckedLoginSession = true;

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -551,14 +551,19 @@ export const handlePlatformCheckoutEmailInput = async (
 				api.initPlatformCheckout(
 					platformCheckoutEmailInput.value,
 					e.data.platformCheckoutUserSession
-				).then( ( response ) => {
-					if ( 'success' === response.result ) {
-						window.location = response.url;
-					} else {
+				)
+					.then( ( response ) => {
+						if ( 'success' === response.result ) {
+							window.location = response.url;
+						} else {
+							showErrorMessage();
+							closeIframe( false );
+						}
+					} )
+					.catch( () => {
 						showErrorMessage();
 						closeIframe( false );
-					}
-				} );
+					} );
 				break;
 			case 'otp_validation_failed':
 				wcpayTracks.recordUserEvent(


### PR DESCRIPTION
Fixes #5538

#### Changes proposed in this Pull Request

Catch errors in the promise returned by `initPlatformCheckout` initiated by the checkout page email input.

- Add a `catch` block for the promise returned by `initPlatformCheckout` triggered by the email input.
- Handle an erroring promise by displaying an error message and removing indications of an in-progress process.

#### Testing instructions

Force an error in the wcpay_init_platform_checkout request: Add wp_send_json_error( 'something', 403 ); in the first line inside [this function](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payments.php#L1084).

**When logged out from WooPay**

1. Make sure you're logged out from WooPay
2. On the merchant store, go to the checkout page
3. Enter an email address that exists in WooPay
4. Enter the OTP code
5. When the wcpay_init_platform_checkout request fails, confirm that the OTP modal closes and that the generic error message for WooPay shows up

https://user-images.githubusercontent.com/41606954/218338768-63d40203-26e6-44ed-95ae-f90cc77e0f4a.mp4

**When already logged into WooPay**

1. Log into WooPay via its login page ( {woopay url}/account/login/ )
2. On the merchant store, go to the checkout page
3. Wait for the automatic redirection to take place
4. When the wcpay_init_platform_checkout request fails, confirm that the spinning loader is removed and that the generic error message for WooPay shows up

https://user-images.githubusercontent.com/41606954/218338894-8196df9b-1854-422e-b0e7-56b8427ad522.mp4

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.