### PR TITLE
Make the new split UPE the default experience.

### DIFF
--- a/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
@@ -117,12 +117,17 @@ class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
 		$is_upe_enabled = $request->get_param( 'is_upe_enabled' );
 
 		if ( $is_upe_enabled ) {
-			update_option( WC_Payments_Features::UPE_FLAG_NAME, '1' );
+			update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
 			return;
 		}
 
-		// marking the flag as "disabled", so that we can keep track that the merchant explicitly disabled it.
-		update_option( WC_Payments_Features::UPE_FLAG_NAME, 'disabled' );
+		// If the legacy UPE flag has been enabled, we need to disable the legacy UPE flag.
+		if ( '1' === get_option( WC_Payments_Features::UPE_FLAG_NAME ) ) {
+			update_option( WC_Payments_Features::UPE_FLAG_NAME, 'disabled' );
+		} else {
+			// marking the flag as "disabled", so that we can keep track that the merchant explicitly disabled it.
+			update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, 'disabled' );
+		}
 
 		// resetting a few other things:
 		// removing the UPE payment methods and _only_ leaving "card",

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1073,6 +1073,9 @@ class WC_Payments_Account {
 		// user might not have agreed to TOS yet.
 		update_option( '_wcpay_onboarding_stripe_connected', [ 'is_existing_stripe_account' => false ] );
 
+		// Automatically enable split UPE for new stores.
+		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
+
 		wp_safe_redirect(
 			add_query_arg(
 				[

--- a/includes/migrations/class-track-upe-status.php
+++ b/includes/migrations/class-track-upe-status.php
@@ -31,7 +31,7 @@ class Track_Upe_Status {
 			return;
 		}
 
-		$upe_value = get_option( \WC_Payments_Features::UPE_FLAG_NAME, 'not-set' );
+		$upe_value = get_option( \WC_Payments_Features::UPE_SPLIT_FLAG_NAME, 'not-set' );
 
 		// Don't trigger the track event when the flag isn't set.
 		if ( 'not-set' !== $upe_value ) {

--- a/includes/notes/class-wc-payments-notes-additional-payment-methods.php
+++ b/includes/notes/class-wc-payments-notes-additional-payment-methods.php
@@ -120,7 +120,7 @@ class WC_Payments_Notes_Additional_Payment_Methods {
 		}
 
 		// Enable UPE, deletes the note and redirect to onboarding task.
-		update_option( WC_Payments_Features::UPE_FLAG_NAME, '1' );
+		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
 		self::possibly_delete_note();
 
 		$wcpay_settings_url = admin_url( 'admin.php?page=wc-admin&path=/payments/additional-payment-methods' );

--- a/tests/unit/migrations/test-class-track-upe-status.php
+++ b/tests/unit/migrations/test-class-track-upe-status.php
@@ -23,6 +23,8 @@ class Track_Upe_Status_Test extends WCPAY_UnitTestCase {
 		parent::set_up();
 
 		delete_option( Track_Upe_Status::IS_TRACKED_OPTION );
+		delete_option( WC_Payments_Features::UPE_FLAG_NAME );
+		delete_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME );
 	}
 
 	/**
@@ -39,7 +41,7 @@ class Track_Upe_Status_Test extends WCPAY_UnitTestCase {
 	 * Make sure the 'wcpay_upe_enabled' event is registered when upe is enabled.
 	 */
 	public function test_track_enabled_on_upgrade() {
-		update_option( WC_Payments_Features::UPE_FLAG_NAME, '1' );
+		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
 
 		Track_Upe_Status::maybe_track();
 
@@ -54,7 +56,7 @@ class Track_Upe_Status_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_track_disabled_on_upgrade() {
-		update_option( WC_Payments_Features::UPE_FLAG_NAME, 'disabled' );
+		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, 'disabled' );
 
 		Track_Upe_Status::maybe_track();
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5503

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
