### PR TITLE
fix: legacy UPE fallback when SEPA enabled

### DIFF
--- a/changelog/fix-upe-split-sepa-compatibility
+++ b/changelog/fix-upe-split-sepa-compatibility
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Split UPE: fallback to legacy UPE when SEPA is enabled.
+
+

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -35,14 +35,32 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_upe_legacy_enabled() {
-		return '1' === get_option( self::UPE_FLAG_NAME, '0' );
+		$upe_flag_value = '1' === get_option( self::UPE_FLAG_NAME, '0' );
+		if ( $upe_flag_value ) {
+			return true;
+		}
+
+		// if the merchant is not eligible for the Split UPE, but they have the flag enabled, fallback to the "legacy" UPE (for now).
+		return '1' === get_option( self::UPE_SPLIT_FLAG_NAME, '0' ) && ! self::is_upe_split_eligible();
 	}
 
 	/**
 	 * Checks whether the Split-UPE gateway is enabled
 	 */
 	public static function is_upe_split_enabled() {
-		return '1' === get_option( self::UPE_SPLIT_FLAG_NAME, '0' );
+		return '1' === get_option( self::UPE_SPLIT_FLAG_NAME, '0' ) && self::is_upe_split_eligible();
+	}
+
+	/**
+	 * Checks for the requirements to have the split-UPE enabled.
+	 */
+	private static function is_upe_split_eligible() {
+		$account = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
+		if ( empty( $account['capabilities']['sepa_debit_payments'] ) ) {
+			return true;
+		}
+
+		return 'active' !== $account['capabilities']['sepa_debit_payments'];
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -44,6 +44,8 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 		// Restore the cache service in the main class.
 		WC_Payments::set_database_cache( $this->_cache );
+		delete_option( '_wcpay_feature_upe' );
+		delete_option( '_wcpay_feature_upe_split' );
 
 		parent::tear_down();
 	}
@@ -196,6 +198,36 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 	public function test_is_progressive_onboarding_enabled_returns_false_when_flag_is_not_set() {
 		$this->assertFalse( WC_Payments_Features::is_progressive_onboarding_enabled() );
+	}
+
+	public function test_split_upe_disabled_with_ineligible_merchant() {
+		$this->mock_cache->method( 'get' )->willReturn( [ 'capabilities' => [ 'sepa_debit_payments' => 'active' ] ] );
+		update_option( '_wcpay_feature_upe', '0' );
+		update_option( '_wcpay_feature_upe_split', '0' );
+
+		$this->assertFalse( WC_Payments_Features::is_upe_enabled() );
+		$this->assertFalse( WC_Payments_Features::is_upe_legacy_enabled() );
+		$this->assertFalse( WC_Payments_Features::is_upe_split_enabled() );
+	}
+
+	public function test_legacy_upe_enabled_with_split_upe_ineligible_merchant() {
+		$this->mock_cache->method( 'get' )->willReturn( [ 'capabilities' => [ 'sepa_debit_payments' => 'active' ] ] );
+		update_option( '_wcpay_feature_upe', '0' );
+		update_option( '_wcpay_feature_upe_split', '1' );
+
+		$this->assertTrue( WC_Payments_Features::is_upe_enabled() );
+		$this->assertTrue( WC_Payments_Features::is_upe_legacy_enabled() );
+		$this->assertFalse( WC_Payments_Features::is_upe_split_enabled() );
+	}
+
+	public function test_split_upe_enabled_with_eligible_merchant() {
+		$this->mock_cache->method( 'get' )->willReturn( [ 'capabilities' => [ 'sepa_debit_payments' => 'inactive' ] ] );
+		update_option( '_wcpay_feature_upe', '0' );
+		update_option( '_wcpay_feature_upe_split', '1' );
+
+		$this->assertTrue( WC_Payments_Features::is_upe_enabled() );
+		$this->assertFalse( WC_Payments_Features::is_upe_legacy_enabled() );
+		$this->assertTrue( WC_Payments_Features::is_upe_split_enabled() );
 	}
 
 	private function setup_enabled_flags( array $enabled_flags ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5545

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When SEPA is an enabled capability, we need to disable the "Split" UPE, and fallback to the "Legacy" UPE.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- On your store, check/enable the "Split UPE" flag via the WC Pay dev tools: ![bmg5mE.png](https://user-images.githubusercontent.com/273592/218831321-1072fa50-455b-4f24-b241-241b38ef6160.png)
- Enable a few payment methods (make sure your account is not eligible for SEPA)
- Ensure that the "Split UPE" is displayed at checkout
- Go to your account's Stripe settings dashboard ( https://dashboard.stripe.com/test/connect/accounts/${your_account_id}/settings )
- Go to "Settings > Capabilities", ensure that "SEPA Direct Debit Payments" is set to "Active"
- Clear the cache in WCPay DEV and confirm that `'sepa_debit_payments' => 'active'`
- Go to checkout again, the "legacy" UPE is now rendered instead of the "Split" UPE

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.