### PR TITLE
Re-enable and fix UPE shopper E2E tests

### DIFF
--- a/changelog/e2e-fix-upe-shopper-tests
+++ b/changelog/e2e-fix-upe-shopper-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: minor e2e test update
+
+

--- a/tests/e2e/specs/upe-split/shopper/shopper-upe-enabled-all-flows.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-upe-enabled-all-flows.spec.js
@@ -22,7 +22,7 @@ const MIN_WAIT_TIME_BETWEEN_PAYMENT_METHODS = 20000;
 const sepaPaymentMethod = '#inspector-checkbox-control-8';
 const card = config.get( 'cards.basic' );
 
-describe.skip( 'Enabled Split UPE', () => {
+describe( 'Enabled Split UPE', () => {
 	beforeAll( async () => {
 		await merchant.login();
 		await merchantWCP.activateSplitUpe();

--- a/tests/e2e/specs/upe-split/shopper/shopper-upe-enabled-all-flows.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-upe-enabled-all-flows.spec.js
@@ -7,16 +7,9 @@ import config from 'config';
  * Internal dependencies
  */
 import { merchantWCP, shopperWCP } from '../../../utils/flows';
-import { checkPageExists } from '../../../utils';
-import {
-	fillCardDetails,
-	fillCardDetailsWCB,
-	setupProductCheckout,
-} from '../../../utils/payments';
+import { fillCardDetails, setupProductCheckout } from '../../../utils/payments';
 const { shopper, merchant } = require( '@woocommerce/e2e-utils' );
 
-const billingDetails = config.get( 'addresses.customer.billing' );
-const productName = config.get( 'products.simple.name' );
 const MIN_WAIT_TIME_BETWEEN_PAYMENT_METHODS = 20000;
 
 const sepaPaymentMethod = '#inspector-checkbox-control-8';
@@ -28,11 +21,6 @@ describe( 'Enabled Split UPE', () => {
 		await merchantWCP.activateSplitUpe();
 		// enable SEPA
 		await merchantWCP.enablePaymentMethod( sepaPaymentMethod );
-		try {
-			await checkPageExists( 'checkout-wcb' );
-		} catch ( error ) {
-			await merchantWCP.addNewPageCheckoutWCB();
-		}
 		await merchant.logout();
 		await shopper.login();
 		await shopperWCP.changeAccountCurrencyTo( 'EUR' );
@@ -46,73 +34,6 @@ describe( 'Enabled Split UPE', () => {
 		await merchantWCP.disablePaymentMethod( sepaPaymentMethod );
 		await merchantWCP.deactivateSplitUpe();
 		await merchant.logout();
-	} );
-
-	describe( 'Blocks checkout', () => {
-		it( 'should checkout and save the card', async () => {
-			await shopper.goToShop();
-			await shopper.addToCartFromShopPage( productName );
-			await shopperWCP.openCheckoutWCB();
-			await shopperWCP.fillBillingDetailsWCB( billingDetails );
-
-			// Fill CC details and save the card while purchasing the product
-			const savePaymentMethodCheckbox = '#checkbox-control-0';
-			await fillCardDetailsWCB( page, card );
-			await expect( page ).toClick( savePaymentMethodCheckbox );
-
-			await page.waitForSelector(
-				'.wc-block-components-main button:not(:disabled)'
-			);
-			await expect( page ).toClick( 'button', { text: 'Place Order' } );
-			await page.waitForSelector( 'div.woocommerce-order' );
-			await expect( page ).toMatch( 'p', {
-				text: 'Thank you. Your order has been received.',
-			} );
-
-			await shopperWCP.goToPaymentMethods();
-			await expect( page ).toMatch( card.label );
-			await expect( page ).toMatch(
-				`${ card.expires.month }/${ card.expires.year }`
-			);
-		} );
-
-		it( 'should process a payment with the saved card from Blocks checkout', async () => {
-			await shopper.goToShop();
-			await shopper.addToCartFromShopPage( productName );
-			await shopperWCP.openCheckoutWCB();
-			await shopperWCP.fillBillingDetailsWCB( billingDetails );
-
-			await shopperWCP.selectSavedPaymentMethod(
-				`${ card.label } (expires ${ card.expires.month }/${ card.expires.year })`
-			);
-			await expect( page ).toClick( 'button', { text: 'Place Order' } );
-			await page.waitForSelector( 'div.woocommerce-order' );
-			await expect( page ).toMatch( 'p', {
-				text: 'Thank you. Your order has been received.',
-			} );
-		} );
-
-		it( 'saved payment method is checked by default when adding a new payment method', async () => {
-			await shopperWCP.goToPaymentMethods();
-			await expect( page ).toClick( 'a', {
-				text: 'Add payment method',
-			} );
-			await page.waitForNavigation( {
-				waitUntil: 'networkidle0',
-			} );
-
-			const isSavedPaymentTokenChecked = await page.$eval(
-				'li.woocommerce-SavedPaymentMethods-token > input',
-				( input ) => input.checked
-			);
-			expect( isSavedPaymentTokenChecked ).toEqual( true );
-		} );
-
-		it( 'should delete the card', async () => {
-			await shopperWCP.goToPaymentMethods();
-			await shopperWCP.deleteSavedPaymentMethod( card.label );
-			await expect( page ).toMatch( 'Payment method deleted' );
-		} );
 	} );
 
 	describe( 'Shortcode checkout', () => {

--- a/tests/e2e/specs/upe/shopper/shopper-upe-enabled-all-flows.spec.js
+++ b/tests/e2e/specs/upe/shopper/shopper-upe-enabled-all-flows.spec.js
@@ -22,7 +22,7 @@ const MIN_WAIT_TIME_BETWEEN_PAYMENT_METHODS = 20000;
 const sepaPaymentMethod = '#inspector-checkbox-control-8';
 const card = config.get( 'cards.basic' );
 
-describe.skip( 'Enabled UPE', () => {
+describe( 'Enabled UPE', () => {
 	beforeAll( async () => {
 		await merchant.login();
 		await merchantWCP.activateUpe();

--- a/tests/e2e/specs/upe/shopper/shopper-upe-enabled-all-flows.spec.js
+++ b/tests/e2e/specs/upe/shopper/shopper-upe-enabled-all-flows.spec.js
@@ -7,16 +7,9 @@ import config from 'config';
  * Internal dependencies
  */
 import { merchantWCP, shopperWCP } from '../../../utils/flows';
-import { checkPageExists } from '../../../utils';
-import {
-	fillCardDetails,
-	fillCardDetailsWCB,
-	setupProductCheckout,
-} from '../../../utils/payments';
+import { fillCardDetails, setupProductCheckout } from '../../../utils/payments';
 const { shopper, merchant } = require( '@woocommerce/e2e-utils' );
 
-const billingDetails = config.get( 'addresses.customer.billing' );
-const productName = config.get( 'products.simple.name' );
 const MIN_WAIT_TIME_BETWEEN_PAYMENT_METHODS = 20000;
 
 const sepaPaymentMethod = '#inspector-checkbox-control-8';
@@ -28,11 +21,6 @@ describe( 'Enabled UPE', () => {
 		await merchantWCP.activateUpe();
 		// enable SEPA
 		await merchantWCP.enablePaymentMethod( sepaPaymentMethod );
-		try {
-			await checkPageExists( 'checkout-wcb' );
-		} catch ( error ) {
-			await merchantWCP.addNewPageCheckoutWCB();
-		}
 		await merchant.logout();
 		await shopper.login();
 		await shopperWCP.changeAccountCurrencyTo( 'EUR' );
@@ -46,73 +34,6 @@ describe( 'Enabled UPE', () => {
 		await merchantWCP.disablePaymentMethod( sepaPaymentMethod );
 		await merchantWCP.deactivateUpe();
 		await merchant.logout();
-	} );
-
-	describe( 'Blocks checkout', () => {
-		it( 'should checkout and save the card', async () => {
-			await shopper.goToShop();
-			await shopper.addToCartFromShopPage( productName );
-			await shopperWCP.openCheckoutWCB();
-			await shopperWCP.fillBillingDetailsWCB( billingDetails );
-
-			// Fill CC details and save the card while purchasing the product
-			const savePaymentMethodCheckbox = '#checkbox-control-0';
-			await fillCardDetailsWCB( page, card );
-			await expect( page ).toClick( savePaymentMethodCheckbox );
-
-			await page.waitForSelector(
-				'.wc-block-components-main button:not(:disabled)'
-			);
-			await expect( page ).toClick( 'button', { text: 'Place Order' } );
-			await page.waitForSelector( 'div.woocommerce-order' );
-			await expect( page ).toMatch( 'p', {
-				text: 'Thank you. Your order has been received.',
-			} );
-
-			await shopperWCP.goToPaymentMethods();
-			await expect( page ).toMatch( card.label );
-			await expect( page ).toMatch(
-				`${ card.expires.month }/${ card.expires.year }`
-			);
-		} );
-
-		it( 'should process a payment with the saved card from Blocks checkout', async () => {
-			await shopper.goToShop();
-			await shopper.addToCartFromShopPage( productName );
-			await shopperWCP.openCheckoutWCB();
-			await shopperWCP.fillBillingDetailsWCB( billingDetails );
-
-			await shopperWCP.selectSavedPaymentMethod(
-				`${ card.label } (expires ${ card.expires.month }/${ card.expires.year })`
-			);
-			await expect( page ).toClick( 'button', { text: 'Place Order' } );
-			await page.waitForSelector( 'div.woocommerce-order' );
-			await expect( page ).toMatch( 'p', {
-				text: 'Thank you. Your order has been received.',
-			} );
-		} );
-
-		it( 'saved payment method is checked by default when adding a new payment method', async () => {
-			await shopperWCP.goToPaymentMethods();
-			await expect( page ).toClick( 'a', {
-				text: 'Add payment method',
-			} );
-			await page.waitForNavigation( {
-				waitUntil: 'networkidle0',
-			} );
-
-			const isSavedPaymentTokenChecked = await page.$eval(
-				'li.woocommerce-SavedPaymentMethods-token > input',
-				( input ) => input.checked
-			);
-			expect( isSavedPaymentTokenChecked ).toEqual( true );
-		} );
-
-		it( 'should delete the card', async () => {
-			await shopperWCP.goToPaymentMethods();
-			await shopperWCP.deleteSavedPaymentMethod( card.label );
-			await expect( page ).toMatch( 'Payment method deleted' );
-		} );
 	} );
 
 	describe( 'Shortcode checkout', () => {

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -33,6 +33,13 @@ export async function fillCardDetails( page, card ) {
 			'[name="cvc"]'
 		);
 		await cardCvcInput.type( card.cvc, { delay: 20 } );
+
+		if ( null !== ( await page.$( '#add_payment_method' ) ) ) {
+			const zip = await stripeFrame.waitForSelector(
+				'[name="postalCode"]'
+			);
+			await zip.type( '90210', { delay: 20 } );
+		}
 	} else {
 		await page.waitForSelector( '.__PrivateStripeElement' );
 		const frameHandle = await page.waitForSelector(


### PR DESCRIPTION
Fixes 1650-gh-automattic/woopay

These e2e tests were skipped [here](https://github.com/Automattic/woocommerce-payments/commit/3d0b8b0f150fa8daee7901d96057ea7093f98500). This ensures that zip code is provided when filling details on the Add Payment Method page.