### PR TITLE
chore: remove split UPE early access pills

### DIFF
--- a/changelog/chore-remove-early-access-pills-for-split-upe
+++ b/changelog/chore-remove-early-access-pills-for-split-upe
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Remove "early access" pill when Split UPE is enabled.
+
+

--- a/client/additional-methods-setup/index.js
+++ b/client/additional-methods-setup/index.js
@@ -13,12 +13,18 @@ import WcPayUpeContextProvider from '../settings/wcpay-upe-toggle/provider';
 import WCPaySettingsContext from '../settings/wcpay-settings-context';
 
 const AdditionalMethodsPage = () => {
-	const { isUpeEnabled } = window.wcpaySettings.additionalMethodsSetup;
+	const {
+		isUpeEnabled,
+		upeType,
+	} = window.wcpaySettings.additionalMethodsSetup;
 
 	return (
 		<Page>
 			<WCPaySettingsContext.Provider value={ window.wcpaySettings }>
-				<WcPayUpeContextProvider defaultIsUpeEnabled={ isUpeEnabled }>
+				<WcPayUpeContextProvider
+					defaultIsUpeEnabled={ isUpeEnabled }
+					defaultUpeType={ upeType }
+				>
 					<UpePreviewMethodSelector />
 				</WcPayUpeContextProvider>
 			</WCPaySettingsContext.Provider>

--- a/client/additional-methods-setup/upe-preview-methods-selector/enable-upe-preview-task.js
+++ b/client/additional-methods-setup/upe-preview-methods-selector/enable-upe-preview-task.js
@@ -18,7 +18,7 @@ import Pill from '../../components/pill';
 import './enable-upe-preview-task.scss';
 
 const EnableUpePreviewTask = () => {
-	const { setIsUpeEnabled, status } = useContext( WcPayUpeContext );
+	const { setIsUpeEnabled, status, upeType } = useContext( WcPayUpeContext );
 
 	const { setCompleted } = useContext( WizardTaskContext );
 
@@ -30,17 +30,29 @@ const EnableUpePreviewTask = () => {
 
 	return (
 		<WizardTaskItem
-			title={ interpolateComponents( {
-				mixedString: __(
-					'{{wrapper}}Enable the new WooCommerce Payments checkout experience{{/wrapper}} ' +
-						'{{earlyAccessWrapper}}Early access{{/earlyAccessWrapper}}',
-					'woocommerce-payments'
-				),
-				components: {
-					wrapper: <span />,
-					earlyAccessWrapper: <Pill />,
-				},
-			} ) }
+			title={
+				'split' === upeType
+					? interpolateComponents( {
+							mixedString: __(
+								'{{wrapper}}Enable the new WooCommerce Payments checkout experience{{/wrapper}}',
+								'woocommerce-payments'
+							),
+							components: {
+								wrapper: <span />,
+							},
+					  } )
+					: interpolateComponents( {
+							mixedString: __(
+								'{{wrapper}}Enable the new WooCommerce Payments checkout experience{{/wrapper}} ' +
+									'{{earlyAccessWrapper}}Early access{{/earlyAccessWrapper}}',
+								'woocommerce-payments'
+							),
+							components: {
+								wrapper: <span />,
+								earlyAccessWrapper: <Pill />,
+							},
+					  } )
+			}
 			index={ 1 }
 		>
 			<CollapsibleBody className="enable-upe-preview__body">

--- a/client/additional-methods-setup/upe-preview-methods-selector/enable-upe-preview-task.js
+++ b/client/additional-methods-setup/upe-preview-methods-selector/enable-upe-preview-task.js
@@ -34,7 +34,7 @@ const EnableUpePreviewTask = () => {
 				'split' === upeType
 					? interpolateComponents( {
 							mixedString: __(
-								'{{wrapper}}Enable the new WooCommerce Payments checkout experience{{/wrapper}}',
+								'{{wrapper}}Enable the improved WooCommerce Payments checkout experience{{/wrapper}}',
 								'woocommerce-payments'
 							),
 							components: {
@@ -57,24 +57,42 @@ const EnableUpePreviewTask = () => {
 		>
 			<CollapsibleBody className="enable-upe-preview__body">
 				<p className="wcpay-wizard-task__description-element is-muted-color">
-					{ interpolateComponents( {
-						mixedString: __(
-							'Get early access to additional payment methods and an improved checkout experience, ' +
-								'coming soon to WooCommerce payments. {{learnMoreLink /}}',
-							'woocommerce-payments'
-						),
-						components: {
-							learnMoreLink: (
-								// eslint-disable-next-line max-len
-								<ExternalLink href="https://woocommerce.com/document/payments/additional-payment-methods/#introduction">
-									{ __(
-										'Learn more',
-										'woocommerce-payments'
-									) }
-								</ExternalLink>
-							),
-						},
-					} ) }
+					{ 'split' === upeType
+						? interpolateComponents( {
+								mixedString: __(
+									'Get access to additional payment methods and an improved checkout experience. {{learnMoreLink /}}',
+									'woocommerce-payments'
+								),
+								components: {
+									learnMoreLink: (
+										// eslint-disable-next-line max-len
+										<ExternalLink href="https://woocommerce.com/document/payments/additional-payment-methods/#introduction">
+											{ __(
+												'Learn more',
+												'woocommerce-payments'
+											) }
+										</ExternalLink>
+									),
+								},
+						  } )
+						: interpolateComponents( {
+								mixedString: __(
+									'Get early access to additional payment methods and an improved checkout experience, ' +
+										'coming soon to WooCommerce payments. {{learnMoreLink /}}',
+									'woocommerce-payments'
+								),
+								components: {
+									learnMoreLink: (
+										// eslint-disable-next-line max-len
+										<ExternalLink href="https://woocommerce.com/document/payments/additional-payment-methods/#introduction">
+											{ __(
+												'Learn more',
+												'woocommerce-payments'
+											) }
+										</ExternalLink>
+									),
+								},
+						  } ) }
 				</p>
 				<div className="enable-upe-preview__advantages-wrapper">
 					<Card className="enable-upe-preview__advantage">

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -90,7 +90,7 @@ const UpeSetupBanner = () => {
 				<p>
 					{ __(
 						/* eslint-disable-next-line max-len */
-						'Get early access to additional payment methods and an improved checkout experience, coming soon to WooCommerce Payments.',
+						'Get access to additional payment methods and an improved checkout experience.',
 						'woocommerce-payments'
 					) }
 				</p>

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -81,7 +81,6 @@ const UpeSetupBanner = () => {
 		<>
 			<CardDivider />
 			<CardBody className="payment-methods__express-checkouts">
-				<Pill>{ __( 'Early access', 'woocommerce-payments' ) }</Pill>
 				<h3>
 					{ __(
 						'Enable the new WooCommerce Payments checkout experience',
@@ -193,7 +192,7 @@ const PaymentMethods = () => {
 		featureFlags: { upeSettingsPreview: isUpeSettingsPreviewEnabled },
 	} = useContext( WCPaySettingsContext );
 
-	const { isUpeEnabled, status } = useContext( WcPayUpeContext );
+	const { isUpeEnabled, status, upeType } = useContext( WcPayUpeContext );
 	const [ openModalIdentifier, setOpenModalIdentifier ] = useState( '' );
 
 	return (
@@ -229,10 +228,18 @@ const PaymentMethods = () => {
 									'Payment methods',
 									'woocommerce-payments'
 								) }
-							</span>{ ' ' }
-							<Pill>
-								{ __( 'Early access', 'woocommerce-payments' ) }
-							</Pill>
+							</span>
+							{ 'split' !== upeType && (
+								<>
+									{ ' ' }
+									<Pill>
+										{ __(
+											'Early access',
+											'woocommerce-payments'
+										) }
+									</Pill>
+								</>
+							) }
 						</h4>
 						<PaymentMethodsDropdownMenu
 							setOpenModal={ setOpenModalIdentifier }

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -113,6 +113,7 @@ const SettingsManager = () => {
 		featureFlags: {
 			upeSettingsPreview: isUPESettingsPreviewEnabled,
 			upe: isUpeEnabled,
+			upeType,
 		},
 	} = useContext( WCPaySettingsContext );
 	const [ isTransactionInputsValid, setTransactionInputsValid ] = useState(
@@ -134,6 +135,7 @@ const SettingsManager = () => {
 						<ErrorBoundary>
 							<WcPayUpeContextProvider
 								defaultIsUpeEnabled={ isUpeEnabled }
+								defaultUpeType={ upeType }
 							>
 								<PaymentMethods />
 							</WcPayUpeContextProvider>

--- a/client/settings/wcpay-upe-toggle/context.js
+++ b/client/settings/wcpay-upe-toggle/context.js
@@ -7,6 +7,7 @@ const WcPayUpeContext = createContext( {
 	isUpeEnabled: false,
 	setIsUpeEnabled: () => null,
 	status: 'resolved',
+	upeType: '',
 } );
 
 export default WcPayUpeContext;

--- a/client/settings/wcpay-upe-toggle/provider.js
+++ b/client/settings/wcpay-upe-toggle/provider.js
@@ -13,9 +13,16 @@ import wcpayTracks from '../../tracks';
 import { NAMESPACE, STORE_NAME } from '../../data/constants';
 import { useEnabledPaymentMethodIds } from '../../data';
 
-const WcPayUpeContextProvider = ( { children, defaultIsUpeEnabled } ) => {
+const WcPayUpeContextProvider = ( {
+	children,
+	defaultIsUpeEnabled,
+	defaultUpeType,
+} ) => {
 	const [ isUpeEnabled, setIsUpeEnabled ] = useState(
 		Boolean( defaultIsUpeEnabled )
+	);
+	const [ upeType, setUpeType ] = useState(
+		defaultIsUpeEnabled ? defaultUpeType || 'legacy' : ''
 	);
 	const [ status, setStatus ] = useState( 'resolved' );
 	const [ , setEnabledPaymentMethods ] = useEnabledPaymentMethodIds();
@@ -32,6 +39,8 @@ const WcPayUpeContextProvider = ( { children, defaultIsUpeEnabled } ) => {
 				data: { is_upe_enabled: Boolean( value ) },
 			} )
 				.then( () => {
+					// new "toggles" will continue being "split" UPE
+					setUpeType( value ? 'split' : '' );
 					setIsUpeEnabled( Boolean( value ) );
 
 					// Track enabling/disabling UPE.
@@ -56,14 +65,20 @@ const WcPayUpeContextProvider = ( { children, defaultIsUpeEnabled } ) => {
 		[
 			setStatus,
 			setIsUpeEnabled,
+			setUpeType,
 			setEnabledPaymentMethods,
 			updateAvailablePaymentMethodIds,
 		]
 	);
 
 	const contextValue = useMemo(
-		() => ( { isUpeEnabled, setIsUpeEnabled: updateFlag, status } ),
-		[ isUpeEnabled, updateFlag, status ]
+		() => ( {
+			isUpeEnabled,
+			setIsUpeEnabled: updateFlag,
+			status,
+			upeType,
+		} ),
+		[ isUpeEnabled, updateFlag, status, upeType ]
 	);
 
 	return (

--- a/client/settings/wcpay-upe-toggle/test/provider.test.js
+++ b/client/settings/wcpay-upe-toggle/test/provider.test.js
@@ -54,6 +54,7 @@ describe( 'WcPayUpeContextProvider', () => {
 			isUpeEnabled: false,
 			setIsUpeEnabled: expect.any( Function ),
 			status: 'resolved',
+			upeType: '',
 		} );
 		expect( apiFetch ).not.toHaveBeenCalled();
 	} );
@@ -106,12 +107,14 @@ describe( 'WcPayUpeContextProvider', () => {
 			isUpeEnabled: false,
 			setIsUpeEnabled: expect.any( Function ),
 			status: 'resolved',
+			upeType: '',
 		} );
 
 		expect( childrenMock ).toHaveBeenCalledWith( {
 			isUpeEnabled: false,
 			setIsUpeEnabled: expect.any( Function ),
 			status: 'pending',
+			upeType: '',
 		} );
 
 		await waitFor( () =>
@@ -129,6 +132,7 @@ describe( 'WcPayUpeContextProvider', () => {
 			isUpeEnabled: true,
 			setIsUpeEnabled: expect.any( Function ),
 			status: 'resolved',
+			upeType: 'split',
 		} );
 		expect( setEnabledPaymentMethodIds ).not.toHaveBeenCalled();
 	} );
@@ -165,12 +169,14 @@ describe( 'WcPayUpeContextProvider', () => {
 			isUpeEnabled: true,
 			setIsUpeEnabled: expect.any( Function ),
 			status: 'resolved',
+			upeType: 'legacy',
 		} );
 
 		expect( childrenMock ).toHaveBeenCalledWith( {
 			isUpeEnabled: true,
 			setIsUpeEnabled: expect.any( Function ),
 			status: 'pending',
+			upeType: 'legacy',
 		} );
 
 		await waitFor( () =>
@@ -188,6 +194,7 @@ describe( 'WcPayUpeContextProvider', () => {
 			isUpeEnabled: false,
 			setIsUpeEnabled: expect.any( Function ),
 			status: 'resolved',
+			upeType: '',
 		} );
 		expect( setEnabledPaymentMethodIds ).toHaveBeenCalledWith( [ 'card' ] );
 		expect( updateAvailablePaymentMethodIds ).toHaveBeenCalledWith( [

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -520,6 +520,7 @@ class WC_Payments_Admin {
 			'wpcomReconnectUrl'          => $this->payments_api_client->is_server_connected() && ! $this->payments_api_client->has_server_connection_owner() ? WC_Payments_Account::get_wpcom_reconnect_url() : null,
 			'additionalMethodsSetup'     => [
 				'isUpeEnabled' => WC_Payments_Features::is_upe_enabled(),
+				'upeType'      => WC_Payments_Features::get_enabled_upe_type(),
 			],
 			'multiCurrencySetup'         => [
 				'isSetupCompleted' => get_option( 'wcpay_multi_currency_setup_completed' ),

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -750,6 +750,7 @@ class WC_Payments_Admin {
 			[
 				'paymentTimeline' => self::version_compare( WC_ADMIN_VERSION_NUMBER, '1.4.0', '>=' ),
 				'customSearch'    => self::version_compare( WC_ADMIN_VERSION_NUMBER, '1.3.0', '>=' ),
+				'upeType'         => WC_Payments_Features::get_enabled_upe_type(),
 			],
 			WC_Payments_Features::to_array()
 		);

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -235,7 +235,6 @@ class WC_Payments_Features {
 		return array_filter(
 			[
 				'upe'                     => self::is_upe_enabled(),
-				'upeType'                 => self::get_enabled_upe_type(),
 				'upeSettingsPreview'      => self::is_upe_settings_preview_enabled(),
 				'multiCurrency'           => self::is_customer_multi_currency_enabled(),
 				'accountOverviewTaskList' => self::is_account_overview_task_list_enabled(),

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -137,7 +137,7 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_account_overview_task_list_enabled() {
-		return get_option( '_wcpay_feature_account_overview_task_list', '1' );
+		return '1' === get_option( '_wcpay_feature_account_overview_task_list', '1' );
 	}
 
 	/**

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -30,6 +30,23 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Returns the "type" of UPE that ill be displayed at checkout.
+	 *
+	 * @return string
+	 */
+	public static function get_enabled_upe_type() {
+		if ( self::is_upe_split_enabled() ) {
+			return 'split';
+		}
+
+		if ( self::is_upe_legacy_enabled() ) {
+			return 'legacy';
+		}
+
+		return '';
+	}
+
+	/**
 	 * Checks whether the legacy UPE gateway is enabled
 	 *
 	 * @return bool
@@ -218,6 +235,7 @@ class WC_Payments_Features {
 		return array_filter(
 			[
 				'upe'                     => self::is_upe_enabled(),
+				'upeType'                 => self::get_enabled_upe_type(),
 				'upeSettingsPreview'      => self::is_upe_settings_preview_enabled(),
 				'multiCurrency'           => self::is_customer_multi_currency_enabled(),
 				'accountOverviewTaskList' => self::is_account_overview_task_list_enabled(),

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -30,7 +30,7 @@ class WC_Payments_Features {
 	}
 
 	/**
-	 * Returns the "type" of UPE that ill be displayed at checkout.
+	 * Returns the "type" of UPE that will be displayed at checkout.
 	 *
 	 * @return string
 	 */

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -50,26 +50,16 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		parent::tear_down();
 	}
 
-	/**
-	 * @dataProvider enabled_flags_provider
-	 */
-	public function test_it_returns_expected_to_array_result( array $enabled_flags ) {
+	public function test_it_returns_expected_to_array_result() {
+		$enabled_flags = array_keys( self::FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING );
 		$this->setup_enabled_flags( $enabled_flags );
 
-		$expected = [];
+		$flags = WC_Payments_Features::to_array();
+
 		foreach ( $enabled_flags as $flag ) {
-			$frontend_key              = self::FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING[ $flag ];
-			$expected[ $frontend_key ] = true;
+			$frontend_key = self::FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING[ $flag ];
+			$this->assertTrue( $flags[ $frontend_key ], "Failed asserting that $frontend_key is true." );
 		}
-
-		$this->assertEquals( $expected, WC_Payments_Features::to_array() );
-	}
-
-	public function enabled_flags_provider() {
-		return [
-			'no flags'  => [ [] ],
-			'all flags' => [ array_keys( self::FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING ) ],
-		];
 	}
 
 	public function test_customer_multi_currency_is_enabled_by_default() {

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -50,16 +50,26 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		parent::tear_down();
 	}
 
-	public function test_it_returns_expected_to_array_result() {
-		$enabled_flags = array_keys( self::FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING );
+	/**
+	 * @dataProvider enabled_flags_provider
+	 */
+	public function test_it_returns_expected_to_array_result( array $enabled_flags ) {
 		$this->setup_enabled_flags( $enabled_flags );
 
-		$flags = WC_Payments_Features::to_array();
-
+		$expected = [];
 		foreach ( $enabled_flags as $flag ) {
-			$frontend_key = self::FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING[ $flag ];
-			$this->assertTrue( $flags[ $frontend_key ], "Failed asserting that $frontend_key is true." );
+			$frontend_key              = self::FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING[ $flag ];
+			$expected[ $frontend_key ] = true;
 		}
+
+		$this->assertEquals( $expected, WC_Payments_Features::to_array() );
+	}
+
+	public function enabled_flags_provider() {
+		return [
+			'no flags'  => [ [] ],
+			'all flags' => [ array_keys( self::FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING ) ],
+		];
 	}
 
 	public function test_customer_multi_currency_is_enabled_by_default() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Removing the "Early access" pill and _some_ of the "Early access" verbiage.
Technically speaking, if you have SEPA enabled and you disable and subsequently enable the UPE, you might not see the "early access" pill until you refresh the page. But it's a minor thing - we'll enable the "Split UPE" for SEPA later, it's such a minor case that it's not worth worry about.

Legacy UPE or Split UPE with SEPA enabled:
![Screen Shot 2023-02-14 at 7 27 18 PM](https://user-images.githubusercontent.com/273592/218925477-d399c326-80bb-44e7-83a6-78798951ebb2.png)

Split UPE:
![Screen Shot 2023-02-14 at 7 27 30 PM](https://user-images.githubusercontent.com/273592/218925574-801d17b1-3987-4570-819f-d8976a6ba401.png)

UPE disabled:
![Screen Shot 2023-02-14 at 7 28 06 PM](https://user-images.githubusercontent.com/273592/218925657-54db0d92-9d3b-4083-94ac-80253cf450c0.png)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use WC Payments Dev Tools
- Enable the "Legacy UPE" , settings page should look like this:
![Screen Shot 2023-02-14 at 7 27 18 PM](https://user-images.githubusercontent.com/273592/218925477-d399c326-80bb-44e7-83a6-78798951ebb2.png)
- Enable the "Split UPE" , settings page should look like this:
![Screen Shot 2023-02-14 at 7 27 30 PM](https://user-images.githubusercontent.com/273592/218925574-801d17b1-3987-4570-819f-d8976a6ba401.png)
- Enable the UPE, settings page should look like this:
![Screen Shot 2023-02-14 at 7 28 06 PM](https://user-images.githubusercontent.com/273592/218925657-54db0d92-9d3b-4083-94ac-80253cf450c0.png)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
