### PR TITLE
Settings page payment method updates

### DIFF
--- a/changelog/update-settings-page-apple-google-pay
+++ b/changelog/update-settings-page-apple-google-pay
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Updated express payment method UI in settings page

--- a/client/settings/express-checkout-settings/platform-checkout-settings.js
+++ b/client/settings/express-checkout-settings/platform-checkout-settings.js
@@ -73,7 +73,7 @@ const PlatformCheckoutSettings = ( { section } ) => {
 					/>
 					<h4>
 						{ __(
-							'Enable WooPay on selected pages',
+							'Enable WooPay button on selected pages',
 							'woocommerce-payments'
 						) }
 					</h4>

--- a/client/settings/express-checkout/index.js
+++ b/client/settings/express-checkout/index.js
@@ -198,57 +198,93 @@ const ExpressCheckout = () => {
 								onChange={ updateIsPaymentRequestEnabled }
 							/>
 						</div>
-						<div className="express-checkout__icons">
-							<div className="express-checkout__icon">
-								<ApplePay />
-							</div>
-							<div className="express-checkout__icon">
-								<GooglePay />
-							</div>
-						</div>
-						<div className="express-checkout__label-container">
-							<div className="express-checkout__label">
-								{ __(
-									'Apple Pay / Google Pay',
-									'woocommerce-payments'
-								) }
-							</div>
-							<div className="express-checkout__description">
-								{
-									/* eslint-disable jsx-a11y/anchor-has-content */
-									interpolateComponents( {
-										mixedString: __(
-											'Boost sales by offering a fast, simple, and secure checkout experience.' +
-												'By enabling this feature, you agree to {{stripeLink}}Stripe{{/stripeLink}}, ' +
-												"{{appleLink}}Apple{{/appleLink}}, and {{googleLink}}Google{{/googleLink}}'s terms of use.",
+						<div>
+							<div className="express-checkout__subgroup">
+								<div className="express-checkout__icon">
+									<ApplePay />
+								</div>
+								<div className="express-checkout__label-container">
+									<div className="express-checkout__label">
+										{ __(
+											'Apple Pay',
 											'woocommerce-payments'
-										),
-										components: {
-											stripeLink: (
-												<a
-													target="_blank"
-													rel="noreferrer"
-													href="https://stripe.com/apple-pay/legal"
-												/>
-											),
-											appleLink: (
-												<a
-													target="_blank"
-													rel="noreferrer"
-													href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/"
-												/>
-											),
-											googleLink: (
-												<a
-													target="_blank"
-													rel="noreferrer"
-													href="https://androidpay.developers.google.com/terms/sellertos"
-												/>
-											),
-										},
-									} )
-									/* eslint-enable jsx-a11y/anchor-has-content */
-								}
+										) }
+									</div>
+									<div className="express-checkout__description">
+										{
+											/* eslint-disable jsx-a11y/anchor-has-content */
+											interpolateComponents( {
+												mixedString: __(
+													'Apple Pay is an easy and secure way for customers to pay on your store. ' +
+														'By enabling this feature, you agree to {{stripeLink}}Stripe{{/stripeLink}} and' +
+														"{{appleLink}} Apple{{/appleLink}}'s terms of use.",
+													'woocommerce-payments'
+												),
+												components: {
+													stripeLink: (
+														<a
+															target="_blank"
+															rel="noreferrer"
+															href="https://stripe.com/apple-pay/legal"
+														/>
+													),
+													appleLink: (
+														<a
+															target="_blank"
+															rel="noreferrer"
+															/* eslint-disable-next-line max-len */
+															href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/"
+														/>
+													),
+												},
+											} )
+											/* eslint-enable jsx-a11y/anchor-has-content */
+										}
+									</div>
+								</div>
+							</div>
+							<div className="express-checkout__subgroup">
+								<div className="express-checkout__icon">
+									<GooglePay />
+								</div>
+								<div className="express-checkout__label-container">
+									<div className="express-checkout__label">
+										{ __(
+											'Google Pay',
+											'woocommerce-payments'
+										) }
+									</div>
+									<div className="express-checkout__description">
+										{
+											/* eslint-disable jsx-a11y/anchor-has-content */
+											interpolateComponents( {
+												mixedString: __(
+													'Offer customers a fast, secure checkout experience with Google Pay. ' +
+														'By enabling this feature, you agree to {{stripeLink}}Stripe{{/stripeLink}}, ' +
+														"and {{googleLink}}Google{{/googleLink}}'s terms of use.",
+													'woocommerce-payments'
+												),
+												components: {
+													stripeLink: (
+														<a
+															target="_blank"
+															rel="noreferrer"
+															href="https://stripe.com/apple-pay/legal"
+														/>
+													),
+													googleLink: (
+														<a
+															target="_blank"
+															rel="noreferrer"
+															href="https://androidpay.developers.google.com/terms/sellertos"
+														/>
+													),
+												},
+											} )
+											/* eslint-enable jsx-a11y/anchor-has-content */
+										}
+									</div>
+								</div>
 							</div>
 						</div>
 						<div className="express-checkout__link">

--- a/client/settings/express-checkout/index.js
+++ b/client/settings/express-checkout/index.js
@@ -220,7 +220,8 @@ const ExpressCheckout = () => {
 												? 'Apple Pay is an easy and secure way for customers to pay on your store. '
 												: interpolateComponents( {
 														mixedString: __(
-															'Apple Pay is an easy and secure way for customers to pay on your store. ' +
+															/* eslint-disable-next-line max-len */
+															'Apple Pay is an easy and secure way for customers to pay on your store. {{br/}}' +
 																/* eslint-disable-next-line max-len */
 																'By enabling this feature, you agree to {{stripeLink}}Stripe{{/stripeLink}} and' +
 																"{{appleLink}} Apple{{/appleLink}}'s terms of use.",
@@ -242,6 +243,7 @@ const ExpressCheckout = () => {
 																	href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/"
 																/>
 															),
+															br: <br />,
 														},
 												  } )
 											/* eslint-enable jsx-a11y/anchor-has-content */
@@ -267,7 +269,8 @@ const ExpressCheckout = () => {
 												? 'Offer customers a fast, secure checkout experience with Google Pay. '
 												: interpolateComponents( {
 														mixedString: __(
-															'Offer customers a fast, secure checkout experience with Google Pay. ' +
+															/* eslint-disable-next-line max-len */
+															'Offer customers a fast, secure checkout experience with Google Pay. {{br/}}' +
 																/* eslint-disable-next-line max-len */
 																'By enabling this feature, you agree to {{stripeLink}}Stripe{{/stripeLink}}, ' +
 																"and {{googleLink}}Google{{/googleLink}}'s terms of use.",
@@ -288,6 +291,7 @@ const ExpressCheckout = () => {
 																	href="https://androidpay.developers.google.com/terms/sellertos"
 																/>
 															),
+															br: <br />,
 														},
 												  } )
 											/* eslint-enable jsx-a11y/anchor-has-content */

--- a/client/settings/express-checkout/index.js
+++ b/client/settings/express-checkout/index.js
@@ -127,48 +127,51 @@ const ExpressCheckout = () => {
 								<div className="express-checkout__description">
 									{
 										/* eslint-disable jsx-a11y/anchor-has-content */
-										interpolateComponents( {
-											mixedString: __(
-												'Boost conversion and customer loyalty by offering a single click, secure way to pay. ' +
-													'By using {{wooPayLink}}WooPay{{/wooPayLink}}, you agree to our ' +
-													'{{tosLink}}WooCommerce Terms of Service{{/tosLink}} ' +
-													'and and {{privacyLink}}Privacy Policy{{/privacyLink}}. ' +
-													'You understand you will be sharing data with us. ' +
-													'{{trackingLink}}Click here{{/trackingLink}} to learn more about the ' +
-													'data you will be sharing and opt-out options.',
-												'woocommerce-payments'
-											),
-											components: {
-												wooPayLink: (
-													<a
-														target="_blank"
-														rel="noreferrer"
-														href="https://woocommerce.com/document/woopay-merchant-documentation/"
-													/>
-												),
-												tosLink: (
-													<a
-														target="_blank"
-														rel="noreferrer"
-														href="https://wordpress.com/tos/"
-													/>
-												),
-												privacyLink: (
-													<a
-														target="_blank"
-														rel="noreferrer"
-														href="https://automattic.com/privacy/"
-													/>
-												),
-												trackingLink: (
-													<a
-														target="_blank"
-														rel="noreferrer"
-														href="https://woocommerce.com/usage-tracking/"
-													/>
-												),
-											},
-										} )
+										isPlatformCheckoutEnabled
+											? 'Boost conversion and customer loyalty by offering a single click, secure way to pay.'
+											: interpolateComponents( {
+													mixedString: __(
+														/* eslint-disable-next-line max-len */
+														'Boost conversion and customer loyalty by offering a single click, secure way to pay. ' +
+															'By using {{wooPayLink}}WooPay{{/wooPayLink}}, you agree to our ' +
+															'{{tosLink}}WooCommerce Terms of Service{{/tosLink}} ' +
+															'and and {{privacyLink}}Privacy Policy{{/privacyLink}}. ' +
+															'You understand you will be sharing data with us. ' +
+															'{{trackingLink}}Click here{{/trackingLink}} to learn more about the ' +
+															'data you will be sharing and opt-out options.',
+														'woocommerce-payments'
+													),
+													components: {
+														wooPayLink: (
+															<a
+																target="_blank"
+																rel="noreferrer"
+																href="https://woocommerce.com/document/woopay-merchant-documentation/"
+															/>
+														),
+														tosLink: (
+															<a
+																target="_blank"
+																rel="noreferrer"
+																href="https://wordpress.com/tos/"
+															/>
+														),
+														privacyLink: (
+															<a
+																target="_blank"
+																rel="noreferrer"
+																href="https://automattic.com/privacy/"
+															/>
+														),
+														trackingLink: (
+															<a
+																target="_blank"
+																rel="noreferrer"
+																href="https://woocommerce.com/usage-tracking/"
+															/>
+														),
+													},
+											  } )
 										/* eslint-enable jsx-a11y/anchor-has-content */
 									}
 								</div>
@@ -213,31 +216,34 @@ const ExpressCheckout = () => {
 									<div className="express-checkout__description">
 										{
 											/* eslint-disable jsx-a11y/anchor-has-content */
-											interpolateComponents( {
-												mixedString: __(
-													'Apple Pay is an easy and secure way for customers to pay on your store. ' +
-														'By enabling this feature, you agree to {{stripeLink}}Stripe{{/stripeLink}} and' +
-														"{{appleLink}} Apple{{/appleLink}}'s terms of use.",
-													'woocommerce-payments'
-												),
-												components: {
-													stripeLink: (
-														<a
-															target="_blank"
-															rel="noreferrer"
-															href="https://stripe.com/apple-pay/legal"
-														/>
-													),
-													appleLink: (
-														<a
-															target="_blank"
-															rel="noreferrer"
-															/* eslint-disable-next-line max-len */
-															href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/"
-														/>
-													),
-												},
-											} )
+											isPaymentRequestEnabled
+												? 'Apple Pay is an easy and secure way for customers to pay on your store. '
+												: interpolateComponents( {
+														mixedString: __(
+															'Apple Pay is an easy and secure way for customers to pay on your store. ' +
+																/* eslint-disable-next-line max-len */
+																'By enabling this feature, you agree to {{stripeLink}}Stripe{{/stripeLink}} and' +
+																"{{appleLink}} Apple{{/appleLink}}'s terms of use.",
+															'woocommerce-payments'
+														),
+														components: {
+															stripeLink: (
+																<a
+																	target="_blank"
+																	rel="noreferrer"
+																	href="https://stripe.com/apple-pay/legal"
+																/>
+															),
+															appleLink: (
+																<a
+																	target="_blank"
+																	rel="noreferrer"
+																	/* eslint-disable-next-line max-len */
+																	href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/"
+																/>
+															),
+														},
+												  } )
 											/* eslint-enable jsx-a11y/anchor-has-content */
 										}
 									</div>
@@ -257,30 +263,33 @@ const ExpressCheckout = () => {
 									<div className="express-checkout__description">
 										{
 											/* eslint-disable jsx-a11y/anchor-has-content */
-											interpolateComponents( {
-												mixedString: __(
-													'Offer customers a fast, secure checkout experience with Google Pay. ' +
-														'By enabling this feature, you agree to {{stripeLink}}Stripe{{/stripeLink}}, ' +
-														"and {{googleLink}}Google{{/googleLink}}'s terms of use.",
-													'woocommerce-payments'
-												),
-												components: {
-													stripeLink: (
-														<a
-															target="_blank"
-															rel="noreferrer"
-															href="https://stripe.com/apple-pay/legal"
-														/>
-													),
-													googleLink: (
-														<a
-															target="_blank"
-															rel="noreferrer"
-															href="https://androidpay.developers.google.com/terms/sellertos"
-														/>
-													),
-												},
-											} )
+											isPaymentRequestEnabled
+												? 'Offer customers a fast, secure checkout experience with Google Pay. '
+												: interpolateComponents( {
+														mixedString: __(
+															'Offer customers a fast, secure checkout experience with Google Pay. ' +
+																/* eslint-disable-next-line max-len */
+																'By enabling this feature, you agree to {{stripeLink}}Stripe{{/stripeLink}}, ' +
+																"and {{googleLink}}Google{{/googleLink}}'s terms of use.",
+															'woocommerce-payments'
+														),
+														components: {
+															stripeLink: (
+																<a
+																	target="_blank"
+																	rel="noreferrer"
+																	href="https://stripe.com/apple-pay/legal"
+																/>
+															),
+															googleLink: (
+																<a
+																	target="_blank"
+																	rel="noreferrer"
+																	href="https://androidpay.developers.google.com/terms/sellertos"
+																/>
+															),
+														},
+												  } )
 											/* eslint-enable jsx-a11y/anchor-has-content */
 										}
 									</div>
@@ -349,33 +358,36 @@ const ExpressCheckout = () => {
 								<div className="express-checkout__description">
 									{
 										/* eslint-disable jsx-a11y/anchor-has-content */
-										interpolateComponents( {
-											mixedString: __(
-												'Link autofills your customers’ payment and shipping details to ' +
-													'deliver an easy and seamless checkout experience. ' +
-													'New payment experience (UPE) needs to be enabled for Link. ' +
-													'By enabling this feature, you agree to the ' +
-													'{{stripeLinkTerms}}Link by Stripe terms{{/stripeLinkTerms}}, ' +
-													'and {{privacyPolicy}}Privacy Policy{{/privacyPolicy}}.',
-												'woocommerce-payments'
-											),
-											components: {
-												stripeLinkTerms: (
-													<a
-														target="_blank"
-														rel="noreferrer"
-														href="https://link.co/terms"
-													/>
-												),
-												privacyPolicy: (
-													<a
-														target="_blank"
-														rel="noreferrer"
-														href="https://link.co/privacy"
-													/>
-												),
-											},
-										} )
+										isStripeLinkEnabled
+											? /* eslint-disable-next-line max-len */
+											  'Link autofills your customers’ payment and shipping details to deliver an easy and seamless checkout experience.'
+											: interpolateComponents( {
+													mixedString: __(
+														'Link autofills your customers’ payment and shipping details to ' +
+															'deliver an easy and seamless checkout experience. ' +
+															'New payment experience (UPE) needs to be enabled for Link. ' +
+															'By enabling this feature, you agree to the ' +
+															'{{stripeLinkTerms}}Link by Stripe terms{{/stripeLinkTerms}}, ' +
+															'and {{privacyPolicy}}Privacy Policy{{/privacyPolicy}}.',
+														'woocommerce-payments'
+													),
+													components: {
+														stripeLinkTerms: (
+															<a
+																target="_blank"
+																rel="noreferrer"
+																href="https://link.co/terms"
+															/>
+														),
+														privacyPolicy: (
+															<a
+																target="_blank"
+																rel="noreferrer"
+																href="https://link.co/privacy"
+															/>
+														),
+													},
+											  } )
 										/* eslint-enable jsx-a11y/anchor-has-content */
 									}
 								</div>

--- a/client/settings/express-checkout/index.js
+++ b/client/settings/express-checkout/index.js
@@ -128,7 +128,10 @@ const ExpressCheckout = () => {
 									{
 										/* eslint-disable jsx-a11y/anchor-has-content */
 										isPlatformCheckoutEnabled
-											? 'Boost conversion and customer loyalty by offering a single click, secure way to pay.'
+											? __(
+													'Boost conversion and customer loyalty by offering a single click, secure way to pay.',
+													'woocommerce-payments'
+											  )
 											: interpolateComponents( {
 													mixedString: __(
 														/* eslint-disable-next-line max-len */
@@ -217,7 +220,10 @@ const ExpressCheckout = () => {
 										{
 											/* eslint-disable jsx-a11y/anchor-has-content */
 											isPaymentRequestEnabled
-												? 'Apple Pay is an easy and secure way for customers to pay on your store. '
+												? __(
+														'Apple Pay is an easy and secure way for customers to pay on your store. ',
+														'woocommerce-payments'
+												  )
 												: interpolateComponents( {
 														mixedString: __(
 															/* eslint-disable-next-line max-len */
@@ -266,7 +272,10 @@ const ExpressCheckout = () => {
 										{
 											/* eslint-disable jsx-a11y/anchor-has-content */
 											isPaymentRequestEnabled
-												? 'Offer customers a fast, secure checkout experience with Google Pay. '
+												? __(
+														'Offer customers a fast, secure checkout experience with Google Pay. ',
+														'woocommerce-payments'
+												  )
 												: interpolateComponents( {
 														mixedString: __(
 															/* eslint-disable-next-line max-len */
@@ -363,8 +372,11 @@ const ExpressCheckout = () => {
 									{
 										/* eslint-disable jsx-a11y/anchor-has-content */
 										isStripeLinkEnabled
-											? /* eslint-disable-next-line max-len */
-											  'Link autofills your customers’ payment and shipping details to deliver an easy and seamless checkout experience.'
+											? /* eslint-disable max-len */
+											  __(
+													'Link autofills your customers’ payment and shipping details to deliver an easy and seamless checkout experience.',
+													'woocommerce-payments'
+											  )
 											: interpolateComponents( {
 													mixedString: __(
 														'Link autofills your customers’ payment and shipping details to ' +
@@ -393,6 +405,7 @@ const ExpressCheckout = () => {
 													},
 											  } )
 										/* eslint-enable jsx-a11y/anchor-has-content */
+										/* eslint-enable max-len */
 									}
 								</div>
 							</div>

--- a/client/settings/express-checkout/style.scss
+++ b/client/settings/express-checkout/style.scss
@@ -16,6 +16,7 @@
 
 			&__description {
 				color: #757575;
+				font-size: 12px;
 			}
 
 			&:not( :last-child ) {
@@ -74,6 +75,7 @@
 				padding: 12px;
 				border: 1px solid #007cba;
 				border-radius: 2px;
+				font-size: 12px;
 
 				a {
 					text-decoration: none;
@@ -82,6 +84,7 @@
 			}
 			&__subgroup {
 				display: flex;
+				align-items: center;
 				&:not( :last-child ) {
 					margin-bottom: 1.4em;
 				}

--- a/client/settings/express-checkout/style.scss
+++ b/client/settings/express-checkout/style.scss
@@ -80,6 +80,12 @@
 					white-space: nowrap;
 				}
 			}
+			&__subgroup {
+				display: flex;
+				&:not( :last-child ) {
+					margin-bottom: 1.4em;
+				}
+			}
 		}
 	}
 }

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import React, { useContext, useState } from 'react';
-import { ExternalLink } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -50,9 +49,13 @@ const ExpressCheckoutDescription = () => (
 				'woocommerce-payments'
 			) }
 		</p>
-		<ExternalLink href="https://woocommerce.com/document/payments/settings-guide/#section-4">
-			{ __( 'Learn more', 'woocommerce-payments' ) }
-		</ExternalLink>
+		<a
+			target="_blank"
+			rel="noreferrer"
+			href="https://woocommerce.com/document/payments/settings-guide/#section-4"
+		>
+			Learn more
+		</a>
 	</>
 );
 
@@ -77,9 +80,13 @@ const TransactionsDescription = () => (
 				'woocommerce-payments'
 			) }
 		</p>
-		<ExternalLink href="https://woocommerce.com/document/payments/faq/">
-			{ __( 'View frequently asked questions', 'woocommerce-payments' ) }
-		</ExternalLink>
+		<a
+			target="_blank"
+			rel="noreferrer"
+			href="https://woocommerce.com/document/payments/faq/"
+		>
+			View frequently asked questions
+		</a>
 	</>
 );
 
@@ -98,12 +105,13 @@ const DepositsDescription = () => {
 					depositDelayDays
 				) }
 			</p>
-			<ExternalLink href="https://woocommerce.com/document/payments/faq/deposit-schedule/#section-2">
-				{ __(
-					'Learn more about pending schedules',
-					'woocommerce-payments'
-				) }
-			</ExternalLink>
+			<a
+				target="_blank"
+				rel="noreferrer"
+				href="https://woocommerce.com/document/payments/faq/deposit-schedule/#section-2"
+			>
+				Learn more about pending schedules
+			</a>
 		</>
 	);
 };

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React, { useContext, useState } from 'react';
+import { ExternalLink } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -49,13 +50,9 @@ const ExpressCheckoutDescription = () => (
 				'woocommerce-payments'
 			) }
 		</p>
-		<a
-			target="_blank"
-			rel="noreferrer"
-			href="https://woocommerce.com/document/payments/settings-guide/#section-4"
-		>
-			Learn more
-		</a>
+		<ExternalLink href="https://woocommerce.com/document/payments/settings-guide/#section-4">
+			{ __( 'Learn more', 'woocommerce-payments' ) }
+		</ExternalLink>
 	</>
 );
 
@@ -80,13 +77,9 @@ const TransactionsDescription = () => (
 				'woocommerce-payments'
 			) }
 		</p>
-		<a
-			target="_blank"
-			rel="noreferrer"
-			href="https://woocommerce.com/document/payments/faq/"
-		>
-			View frequently asked questions
-		</a>
+		<ExternalLink href="https://woocommerce.com/document/payments/faq/">
+			{ __( 'View frequently asked questions', 'woocommerce-payments' ) }
+		</ExternalLink>
 	</>
 );
 
@@ -105,13 +98,12 @@ const DepositsDescription = () => {
 					depositDelayDays
 				) }
 			</p>
-			<a
-				target="_blank"
-				rel="noreferrer"
-				href="https://woocommerce.com/document/payments/faq/deposit-schedule/#section-2"
-			>
-				Learn more about pending schedules
-			</a>
+			<ExternalLink href="https://woocommerce.com/document/payments/faq/deposit-schedule/#section-2">
+				{ __(
+					'Learn more about pending schedules',
+					'woocommerce-payments'
+				) }
+			</ExternalLink>
 		</>
 	);
 };


### PR DESCRIPTION
Fixes #5561 

#### Changes proposed in this Pull Request
* Update description of WooPay, Apple Pay, Google Pay and Stripe Link
* Separate Apple Pay and Google Pay into two rows
* Hide ToS text of all payment types when the payment type is activated.
* Change express button checkbox label (slack: p1676572820945739-slack-C022WMN88KG)
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Before
![SCR-20230215-j9j](https://user-images.githubusercontent.com/6216000/219137910-d0da7343-e103-450a-bcb9-0003aa5f32c1.png)

Now (no payment type is active)
![SCR-20230216-e9u](https://user-images.githubusercontent.com/6216000/219424606-973879a2-02a3-44bf-8510-055b5dd82400.png)


Now (with payment types active)
![SCR-20230216-ea0](https://user-images.githubusercontent.com/6216000/219424735-410cd0a3-cf43-4810-b7e5-ff222614ae8a.png)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to wp-admin > Payments > Settings > Express Checkout and make sure the ui looks the same as the design in the figma file ( C1r0Vzxh1mhbDJJnbjHp5q-fi-1724%3A75157&t=K8SIbOcPhjwYD6bJ-0 )
* Ensure that activating a payment type hides the ToS text from its description.
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.