### PR TITLE
Add tracks for split UPE enable/disable.

### DIFF
--- a/changelog/5396-add-tracks-for-split-upe
+++ b/changelog/5396-add-tracks-for-split-upe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Added tracking for the split UPE feature flag.

--- a/client/settings/wcpay-upe-toggle/provider.js
+++ b/client/settings/wcpay-upe-toggle/provider.js
@@ -9,7 +9,6 @@ import { useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import WcPayUpeContext from './context';
-import wcpayTracks from '../../tracks';
 import { NAMESPACE, STORE_NAME } from '../../data/constants';
 import { useEnabledPaymentMethodIds } from '../../data';
 
@@ -42,12 +41,6 @@ const WcPayUpeContextProvider = ( {
 					// new "toggles" will continue being "split" UPE
 					setUpeType( value ? 'split' : '' );
 					setIsUpeEnabled( Boolean( value ) );
-
-					// Track enabling/disabling UPE.
-					const event = Boolean( value )
-						? wcpayTracks.events.UPE_ENABLED
-						: wcpayTracks.events.UPE_DISABLED;
-					wcpayTracks.recordEvent( event );
 
 					// the backend already takes care of this,
 					// we're just duplicating the effort

--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -60,8 +60,6 @@ const events = {
 	CONNECT_ACCOUNT_LEARN_MORE: 'wcpay_welcome_learn_more',
 	CONNECT_ACCOUNT_STRIPE_CONNECTED: 'wcpay_stripe_connected',
 	CONNECT_ACCOUNT_KYC_MODAL_OPENED: 'wcpay_connect_account_kyc_modal_opened',
-	UPE_ENABLED: 'wcpay_upe_enabled',
-	UPE_DISABLED: 'wcpay_upe_disabled',
 	MULTI_CURRENCY_ENABLED_CURRENCIES_UPDATED:
 		'wcpay_multi_currency_enabled_currencies_updated',
 	PAYMENT_REQUEST_SETTINGS_CHANGE: 'wcpay_payment_request_settings_change',

--- a/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
@@ -118,15 +118,30 @@ class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
 
 		if ( $is_upe_enabled ) {
 			update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
+
+			// WooCommerce core only includes Tracks in admin, not the REST API, so we need to use this wc_admin method
+			// that includes WC_Tracks in case it's not loaded.
+			if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
+				wc_admin_record_tracks_event( 'wcpay_split_upe_enabled' );
+			}
+
 			return;
 		}
 
 		// If the legacy UPE flag has been enabled, we need to disable the legacy UPE flag.
 		if ( '1' === get_option( WC_Payments_Features::UPE_FLAG_NAME ) ) {
 			update_option( WC_Payments_Features::UPE_FLAG_NAME, 'disabled' );
+
+			if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
+				wc_admin_record_tracks_event( 'wcpay_upe_disabled' );
+			}
 		} else {
 			// marking the flag as "disabled", so that we can keep track that the merchant explicitly disabled it.
 			update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, 'disabled' );
+
+			if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
+				wc_admin_record_tracks_event( 'wcpay_split_upe_disabled' );
+			}
 		}
 
 		// resetting a few other things:

--- a/includes/notes/class-wc-payments-notes-additional-payment-methods.php
+++ b/includes/notes/class-wc-payments-notes-additional-payment-methods.php
@@ -116,7 +116,7 @@ class WC_Payments_Notes_Additional_Payment_Methods {
 		if ( ! WC_Payments_Features::is_upe_enabled() && class_exists( 'WC_Tracks' ) ) {
 			// We're not using Tracker::track_admin() here because
 			// WC_Pay\record_tracker_events() is never triggered due to the redirect below.
-			WC_Tracks::record_event( 'wcpay_upe_enabled' );
+			WC_Tracks::record_event( 'wcpay_split_upe_enabled' );
 		}
 
 		// Enable UPE, deletes the note and redirect to onboarding task.


### PR DESCRIPTION
Fixes #5396 

#### Changes proposed in this Pull Request
With the switch made to have the split UPE be the new default experience, this PR updates the tracking to reflect the new feature flag. We're now tracking `wcpay_split_upe_enabled` and `wcpay_split_upe_disabled` instead of `wcpay_upe_enabled` and `wcpay_upe_disabled`. The one instance where we'll still be tracking `wcpay_upe_disabled` is when the store already had (legacy) UPE enabled prior to the update but chooses to disable it.

This PR also moves the tracking from JS to PHP since there's more logic involved to know which event we need to track. That required more information that's readily available in PHP but would need to be passed to the frontend for JS to do the tracking.

#### Testing instructions

**To test that the legacy UPE disable is correctly tracked:**
1. Delete the `_wcpay_feature_upe_split` option if it exists.
2. Update the `_wcpay_feature_upe` option to be `1`.
3. Disable UPE via the payments settings screen (`wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments`)
4. Ensure that the `wcadmin_wcpay_upe_disabled` event was tracked.

**To test that the split UPE enable is correctly tracked:**
1. Delete the `_wcpay_feature_upe` option if it exists.
2. Delete the `_wcpay_feature_upe_split` option if it exists.
3. Enable UPE via the payments settings screen (`wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments`)
4. Ensure that the `wcadmin_wcpay_split_upe_enabled` event was tracked.

**To test that the split UPE enable is correctly tracked:**
1. Delete the `_wcpay_feature_upe` option if it exists.
2. Update the `_wcpay_feature_upe_split` to `1` if needed.
3. Disable UPE via the payments settings screen (`wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments`)
4. Ensure that the `wcadmin_wcpay_split_upe_disabled` event was tracked.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
