### PR TITLE
Add `wp-i18n` as one of the split UPE script's dependencies

### DIFF
--- a/changelog/fix-5347-undefined-i18n-split-upe
+++ b/changelog/fix-5347-undefined-i18n-split-upe
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add wp-i18n as split UPE script dependency to load split UPE elements.

--- a/includes/payment-methods/class-upe-split-payment-gateway.php
+++ b/includes/payment-methods/class-upe-split-payment-gateway.php
@@ -113,7 +113,7 @@ class UPE_Split_Payment_Gateway extends UPE_Payment_Gateway {
 			true
 		);
 
-		$script_dependencies = [ 'stripe', 'wc-checkout' ];
+		$script_dependencies = [ 'stripe', 'wc-checkout', 'wp-i18n' ];
 
 		if ( $this->supports( 'tokenization' ) ) {
 			$script_dependencies[] = 'woocommerce-tokenization-form';


### PR DESCRIPTION
Fixes [#1657](https://app.zenhub.com/workspaces/heisenberg-63586f2ec60359001310fa6a/issues/gh/automattic/woopay/1657)

#### Changes proposed in this Pull Request
Add wp-i18n as one of split UPE script's dependencies.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to WCPay Dev
* Check Enable Split UPE checkout
* Check Add UPE additional payment methods
* Go to the merchant site, add a product to the cart, open the shortcode checkout
* Refresh the page couple of times and make sure you see the error on `develop` branch but not on `fix/5347-undefined-i18n-split-upe` branch

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
