### PR TITLE
Declare HPOS compatibility in WC Payments

### DIFF
--- a/changelog/fix-5570-declare-hpos-compatibility
+++ b/changelog/fix-5570-declare-hpos-compatibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Declare WooCommerce Payments compatible with High-Performance Order Storage.

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -343,7 +343,7 @@ add_action(
 	'before_woocommerce_init',
 	function() {
 		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
-			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', 'woocommerce-payments/woocommerce-payments.php', false );
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', 'woocommerce-payments/woocommerce-payments.php', true );
 		}
 	}
 );


### PR DESCRIPTION
Fixes #5570 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In WooCommerce Payments 5.4.0, we shipped all of our HPOS-compatible code changes however when you have WC Payments active on a store with HPOS enabled, you will see an error notice saying our plugin is not compatible:

- Notice on plugins page

![image](https://user-images.githubusercontent.com/2275145/219527358-2f3a2692-4142-4031-a112-f6972060ffbb.png)

- Notice on HPOS settings page

![image](https://user-images.githubusercontent.com/2275145/219528318-c0f39298-f53d-49a2-9d89-b77f2e80766c.png)


In this PR, we are declaring WooCommerce Payments compatible with the HPOS feature.


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> **Note**
> HPOS compatibility has already been tested with WooCommerce Payments, therefore the testing needed for these changes is to confirm the WC notices don't say we're not compatible with HPOS.

1. Install and activate the latest WooCommerce
2. Install and activate `develop` of WooCommerce Payments
3. Go to **WooCommerce > Settings > Advanced > Features** and under the High-Performance order storage (COT) setting note the warning message: "This feature shouldn't be enabled, the WooCommerce Payments plugin is active and isn't compatible with it."
4. With this feature enabled, you will also have an error message saying "WooCommerce has detected that some of your active plugins are incompatible with currently enabled WooCommerce features. Please review the details."
5. Check out this branch
6. Confirm all of the warnings and notices calling out WC Payments not being compatible have been removed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
