### PR TITLE
Fix express checkout button order

### DIFF
--- a/changelog/fix-express-checkout-button-order
+++ b/changelog/fix-express-checkout-button-order
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This tweaks changes made in PR 5520.
+
+

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -65,8 +65,6 @@ registerPaymentMethod( {
 	},
 } );
 
-registerExpressPaymentMethod( paymentRequestPaymentMethod( api ) );
-
 // Call handlePlatformCheckoutEmailInput if platform checkout is enabled and this is the checkout page.
 if ( getConfig( 'isPlatformCheckoutEnabled' ) ) {
 	if (
@@ -79,6 +77,8 @@ if ( getConfig( 'isPlatformCheckoutEnabled' ) ) {
 		registerExpressPaymentMethod( wooPayExpressCheckoutPaymentMethod() );
 	}
 }
+
+registerExpressPaymentMethod( paymentRequestPaymentMethod( api ) );
 
 window.addEventListener( 'load', () => {
 	enqueueFraudScripts( getConfig( 'fraudServices' ) );

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -73,11 +73,11 @@ class WC_Payments_Payment_Request_Button_Handler {
 		add_action( 'template_redirect', [ $this, 'handle_payment_request_redirect' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'scripts' ] );
 
-		add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_payment_request_button_html' ], -2 );
+		add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_payment_request_button_html' ], 1 );
 
-		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_payment_request_button_html' ], -2 );
+		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_payment_request_button_html' ], 1 );
 
-		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_payment_request_button_html' ], -2 );
+		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_payment_request_button_html' ], 1 );
 
 		add_action( 'before_woocommerce_pay_form', [ $this, 'display_pay_for_order_page_html' ], 1 );
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -474,9 +474,9 @@ class WC_Payments {
 		$is_woopay_express_checkout_enabled = WC_Payments_Features::is_woopay_express_checkout_enabled();
 
 		if ( $is_woopay_express_checkout_enabled || self::get_gateway()->get_option( 'payment_request' ) ) {
-			add_action( 'woocommerce_after_add_to_cart_quantity', [ __CLASS__, 'display_express_checkout_separator_if_necessary' ], -1 );
-			add_action( 'woocommerce_proceed_to_checkout', [ __CLASS__, 'display_express_checkout_separator_if_necessary' ], -1 );
-			add_action( 'woocommerce_checkout_before_customer_details', [ __CLASS__, 'display_express_checkout_separator_if_necessary' ], -1 );
+			add_action( 'woocommerce_after_add_to_cart_quantity', [ __CLASS__, 'display_express_checkout_separator_if_necessary' ], 2 );
+			add_action( 'woocommerce_proceed_to_checkout', [ __CLASS__, 'display_express_checkout_separator_if_necessary' ], 2 );
+			add_action( 'woocommerce_checkout_before_customer_details', [ __CLASS__, 'display_express_checkout_separator_if_necessary' ], 2 );
 
 			if ( self::get_gateway()->get_option( 'payment_request' ) ) {
 				// Load separator on the Pay for Order page.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

#5520 introduced changes to the separator displayed between express checkout buttons and the CTA button (or checkout form depending on the page) but the order of the buttons changed. This PR fixes the order so that the WooPay button is listed first.

| Before | After |
|-----|-----|
| <img width="300" alt="after" src="https://user-images.githubusercontent.com/1558827/219767953-4b4af3b5-d5d6-46dd-9df2-3b8c85205fec.png"> | <img width="300" alt="after" src="https://user-images.githubusercontent.com/1558827/219767976-5a26e276-4a76-474f-827c-328f4e352ca4.png"> |

#### Testing instructions

* Apply patch
* Enable WooPay as well as Apple Pay and Google Pay.
* Visit any page that shows the express payment buttons (single product, cart, checkout) and ensure that WooPay is listed first. 
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
