### PR TITLE
Remove wp components dependency

### DIFF
--- a/changelog/fix-remove-wp-components-dependency
+++ b/changelog/fix-remove-wp-components-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove unnecessary style dependency from WooPay checkbox.

--- a/includes/platform-checkout-user/class-platform-checkout-save-user.php
+++ b/includes/platform-checkout-user/class-platform-checkout-save-user.php
@@ -54,7 +54,7 @@ class Platform_Checkout_Save_User {
 		wp_register_style(
 			'WCPAY_PLATFORM_CHECKOUT',
 			$style_url,
-			[ 'wp-components' ],
+			[],
 			\WC_Payments::get_file_version( 'dist/platform-checkout.css' )
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
This is a minor fix to address an issue we encountered with theming. When using the Tsubaki theme with WooPay enabled the mini cart was not displaying correctly. I discovered that this was due to the inclusion of the WP comonents styles which was listed as a dependency for the WooPay Checkbox. Upon digging further I found that the need for this dependency had been removed in #4076, but the dependency itself was never removed. This PR now removes it.

**Before**

![Screen Shot 2023-02-17 at 2 20 42 PM](https://user-images.githubusercontent.com/68524302/219768289-27bb9e1c-09c8-4187-ad59-738ce8d6386d.png)


**After**

![Screen Shot 2023-02-17 at 2 20 21 PM](https://user-images.githubusercontent.com/68524302/219768313-1d376342-7040-439f-9258-d62ad6ebe234.png)


<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You will need access to the Tsubaki theme to confirm it fixes the mini cart display.
* You will need to build the scripts to get the updated dependencies before testing.

1. With the Tsubaki theme installed add a product to the cart and click on the mini cart to confirm proper display.
2. Complete a checkout with the checkbox saved and confirm the checkbox is still displayed correctly and a new WooPay user is created as expected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
