### PR TITLE
fix: legacy card with split UPE

### DIFF
--- a/changelog/fix-legacy-card-with-split-upe
+++ b/changelog/fix-legacy-card-with-split-upe
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixes legacy card payment with split UPE (when WooPay is enabled).
+
+

--- a/client/checkout/classic/upe-split.js
+++ b/client/checkout/classic/upe-split.js
@@ -759,8 +759,8 @@ jQuery( function ( $ ) {
 		PAYMENT_METHOD_NAME_P24,
 		PAYMENT_METHOD_NAME_SEPA,
 		PAYMENT_METHOD_NAME_SOFORT,
-		PAYMENT_METHOD_NAME_CARD,
-	];
+		paymentMethodsConfig.card !== undefined && PAYMENT_METHOD_NAME_CARD,
+	].filter( Boolean );
 	const checkoutEvents = wcpayPaymentMethods
 		.map( ( method ) => `checkout_place_order_${ method }` )
 		.join( ' ' );

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -180,7 +180,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 		$enabled_payment_methods = $this->gateway->get_payment_method_ids_enabled_at_checkout();
 
 		foreach ( $enabled_payment_methods as $payment_method_id ) {
-			if ( WC_Payments_Features::is_upe_split_enabled() && $this->is_woopay_enabled() && 'card' === $payment_method_id ) {
+			if ( 'card' === $payment_method_id && WC_Payments_Features::is_upe_split_enabled() && $this->is_woopay_enabled() ) {
 				continue;
 			}
 			// Link by Stripe should be validated with available fees.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Additional testing showed that there were some fixes needed with the Split UPE.

This is a continuation of https://github.com/Automattic/woocommerce-payments/pull/5541

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout with Legacy UPE
* Checkout with Split UPE & WooPay disabled & Link disabled
* Checkout with Split UPE & WooPay disabled & Link enabled
* Checkout with Split UPE & WooPay enabled & Link disabled

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
