### PR TITLE
Removed PHP ENUM dependency due to conflicts with multiple PHP versions

### DIFF
--- a/changelog/fix-5533-remove-enum-dependecy
+++ b/changelog/fix-5533-remove-enum-dependecy
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Removed PHP ENUM dependency due to conflicts with multiple PHP versions.
+Replace PHP dependency myclabs/php-enum with a built-in solution due to conflicts with multiple PHP versions.

--- a/changelog/fix-5533-remove-enum-dependecy
+++ b/changelog/fix-5533-remove-enum-dependecy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Removed PHP ENUM dependency due to conflicts with multiple PHP versions.

--- a/changelog/fix-5533-update-enum-composer-package
+++ b/changelog/fix-5533-update-enum-composer-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Bump of PHP enum package to support the newest versions of PHP

--- a/changelog/fix-5533-update-enum-composer-package
+++ b/changelog/fix-5533-update-enum-composer-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Bump of PHP enum package to support the newest versions of PHP

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
       "automattic/jetpack-identity-crisis": "0.8.4",
       "automattic/jetpack-sync": "1.30.5",
       "automattic/jetpack-tracking": "1.14.5",
-      "myclabs/php-enum": "1.8.4",
       "woocommerce/subscriptions-core": "5.3.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
       "automattic/jetpack-identity-crisis": "0.8.4",
       "automattic/jetpack-sync": "1.30.5",
       "automattic/jetpack-tracking": "1.14.5",
-      "myclabs/php-enum": "1.7.7",
+      "myclabs/php-enum": "1.8.4",
       "woocommerce/subscriptions-core": "5.3.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d032c145eb48f2cef46bbb7b18e2d19e",
+    "content-hash": "1a2f83250b38b7e43870816a53b5a293",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1000,32 +1000,35 @@
         },
         {
             "name": "myclabs/php-enum",
-            "version": "1.7.7",
+            "version": "1.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/php-enum.git",
-                "reference": "d178027d1e679832db9f38248fcc7200647dc2b7"
+                "reference": "a867478eae49c9f59ece437ae7f9506bfaa27483"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/d178027d1e679832db9f38248fcc7200647dc2b7",
-                "reference": "d178027d1e679832db9f38248fcc7200647dc2b7",
+                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/a867478eae49c9f59ece437ae7f9506bfaa27483",
+                "reference": "a867478eae49c9f59ece437ae7f9506bfaa27483",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": ">=7.1"
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7",
+                "phpunit/phpunit": "^9.5",
                 "squizlabs/php_codesniffer": "1.*",
-                "vimeo/psalm": "^3.8"
+                "vimeo/psalm": "^4.6.2"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "MyCLabs\\Enum\\": "src/"
-                }
+                },
+                "classmap": [
+                    "stubs/Stringable.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1044,7 +1047,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/php-enum/issues",
-                "source": "https://github.com/myclabs/php-enum/tree/1.7.7"
+                "source": "https://github.com/myclabs/php-enum/tree/1.8.4"
             },
             "funding": [
                 {
@@ -1056,7 +1059,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-14T18:14:52+00:00"
+            "time": "2022-08-04T09:53:51+00:00"
         },
         {
             "name": "woocommerce/subscriptions-core",
@@ -6581,5 +6584,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a2f83250b38b7e43870816a53b5a293",
+    "content-hash": "7c15a2dc7f955c3192ef8ebdb555e880",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -997,69 +997,6 @@
                 }
             ],
             "time": "2021-01-14T11:07:16+00:00"
-        },
-        {
-            "name": "myclabs/php-enum",
-            "version": "1.8.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/myclabs/php-enum.git",
-                "reference": "a867478eae49c9f59ece437ae7f9506bfaa27483"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/a867478eae49c9f59ece437ae7f9506bfaa27483",
-                "reference": "a867478eae49c9f59ece437ae7f9506bfaa27483",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "php": "^7.3 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "1.*",
-                "vimeo/psalm": "^4.6.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "MyCLabs\\Enum\\": "src/"
-                },
-                "classmap": [
-                    "stubs/Stringable.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP Enum contributors",
-                    "homepage": "https://github.com/myclabs/php-enum/graphs/contributors"
-                }
-            ],
-            "description": "PHP Enum implementation",
-            "homepage": "http://github.com/myclabs/php-enum",
-            "keywords": [
-                "enum"
-            ],
-            "support": {
-                "issues": "https://github.com/myclabs/php-enum/issues",
-                "source": "https://github.com/myclabs/php-enum/tree/1.8.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/mnapoli",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/php-enum",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-08-04T09:53:51+00:00"
         },
         {
             "name": "woocommerce/subscriptions-core",

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -314,6 +314,7 @@ class WC_Payments {
 		include_once __DIR__ . '/exceptions/class-process-payment-exception.php';
 		include_once __DIR__ . '/exceptions/class-invalid-webhook-data-exception.php';
 		include_once __DIR__ . '/exceptions/class-invalid-price-exception.php';
+		include_once __DIR__ . '/constants/class-base-constant.php';
 		include_once __DIR__ . '/constants/class-order-status.php';
 		include_once __DIR__ . '/constants/class-payment-type.php';
 		include_once __DIR__ . '/constants/class-payment-initiated-by.php';

--- a/includes/constants/class-base-constant.php
+++ b/includes/constants/class-base-constant.php
@@ -61,7 +61,7 @@ abstract class Base_Constant {
 	 * @return bool
 	 */
 	final public function equals( $variable = null ): bool {
-		return $this->get_value() === $variable->get_value() && static::class === \get_class( $variable );
+		return $variable instanceof Base_Constant && $this->get_value() === $variable->get_value() && static::class === \get_class( $variable );
 	}
 
 	/**

--- a/includes/constants/class-base-constant.php
+++ b/includes/constants/class-base-constant.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Class Base_Constant
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Constants;
+
+use ReflectionClass;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+
+/**
+ * Base constant class to hold common logic for all constants.
+ */
+abstract class Base_Constant {
+
+	/**
+	 * Enum value
+	 *
+	 * @var mixed
+	 */
+	protected $value;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param mixed $value Constant from class.
+	 */
+	public function __construct( $value ) {
+		if ( $value instanceof static ) {
+			$value = $value->get_value();
+		}
+		$this->value = $value;
+	}
+
+	/**
+	 * Get enum class value.
+	 *
+	 * @return mixed
+	 */
+	public function get_value() {
+		return $this->value;
+	}
+
+	/**
+	 * Compare to enums.
+	 *
+	 * @param mixed $variable Constant object to compare.
+	 *
+	 * @return bool
+	 */
+	final public function equals( $variable = null ): bool {
+		return $variable instanceof self && $this->get_value() === $variable->get_value() && static::class === \get_class( $variable );
+	}
+
+	/**
+	 * Find constant in class by value.
+	 *
+	 * @param string $value Value to find.
+	 *
+	 * @return int|string
+	 * @throws \InvalidArgumentException
+	 */
+	public static function search( string $value ) {
+		$class = new ReflectionClass( static::class );
+		$key   = array_search( $value, $class->getConstants(), true );
+		if ( false === $key ) {
+			throw new \InvalidArgumentException( "Constant with value '$value' does not exist." );
+		}
+		return $key;
+	}
+
+	/**
+	 * Used to created enum from constant names like CLASS::ConstantName().
+	 *
+	 * @param string $name Name of property or function.
+	 * @param array  $arguments Arguments of static call.
+	 *
+	 * @return static
+	 * @throws \InvalidArgumentException
+	 */
+	public static function __callStatic( $name, $arguments ) {
+		$class         = static::class;
+		$constant_name = $class . '::' . $name;
+		if ( ! defined( $constant_name ) ) {
+			throw new \InvalidArgumentException( "Constant with name '$name' does not exist." );
+		}
+
+		return new static( $name );
+	}
+
+	/**
+	 * Get real enum value.
+	 *
+	 * @return mixed|string
+	 */
+	public function __toString() {
+		return constant( \get_class( $this ) . '::' . $this->value );
+	}
+}

--- a/includes/constants/class-base-constant.php
+++ b/includes/constants/class-base-constant.php
@@ -30,11 +30,17 @@ abstract class Base_Constant {
 	 * Class constructor.
 	 *
 	 * @param mixed $value Constant from class.
+	 * @throws \InvalidArgumentException
 	 */
 	public function __construct( $value ) {
 		if ( $value instanceof static ) {
 			$value = $value->get_value();
+		} else {
+			if ( ! defined( static::class . "::$value" ) ) {
+				throw new \InvalidArgumentException( "Constant with name '$value' does not exist." );
+			}
 		}
+
 		$this->value = $value;
 	}
 
@@ -55,7 +61,7 @@ abstract class Base_Constant {
 	 * @return bool
 	 */
 	final public function equals( $variable = null ): bool {
-		return $variable instanceof self && $this->get_value() === $variable->get_value() && static::class === \get_class( $variable );
+		return $this->get_value() === $variable->get_value() && static::class === \get_class( $variable );
 	}
 
 	/**
@@ -72,6 +78,7 @@ abstract class Base_Constant {
 		if ( false === $key ) {
 			throw new \InvalidArgumentException( "Constant with value '$value' does not exist." );
 		}
+
 		return $key;
 	}
 
@@ -85,12 +92,6 @@ abstract class Base_Constant {
 	 * @throws \InvalidArgumentException
 	 */
 	public static function __callStatic( $name, $arguments ) {
-		$class         = static::class;
-		$constant_name = $class . '::' . $name;
-		if ( ! defined( $constant_name ) ) {
-			throw new \InvalidArgumentException( "Constant with name '$name' does not exist." );
-		}
-
 		return new static( $name );
 	}
 
@@ -100,6 +101,6 @@ abstract class Base_Constant {
 	 * @return mixed|string
 	 */
 	public function __toString() {
-		return constant( \get_class( $this ) . '::' . $this->value );
+		return constant( \get_class( $this ) . '::' . $this->get_value() );
 	}
 }

--- a/includes/constants/class-order-status.php
+++ b/includes/constants/class-order-status.php
@@ -11,14 +11,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-use MyCLabs\Enum\Enum;
-
 /**
  * This class gives a list of all the possible order status constants.
  *
  * @psalm-immutable
  */
-class Order_Status extends Enum {
+class Order_Status extends Base_Constant {
 	const CANCELLED  = 'cancelled';
 	const COMPLETED  = 'completed';
 	const FAILED     = 'failed';

--- a/includes/constants/class-payment-capture-type.php
+++ b/includes/constants/class-payment-capture-type.php
@@ -11,15 +11,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-use MyCLabs\Enum\Enum;
-
 /**
  * Enum used in WCPay\Payment_Information to determine whether a payment was
  * initated by a merchant or a customer.
  *
  * @psalm-immutable
  */
-class Payment_Capture_Type extends Enum {
+class Payment_Capture_Type extends Base_Constant {
 	const AUTOMATIC = 'automatic_capture';
 	const MANUAL    = 'manual_capture';
 }

--- a/includes/constants/class-payment-initiated-by.php
+++ b/includes/constants/class-payment-initiated-by.php
@@ -11,15 +11,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-use MyCLabs\Enum\Enum;
-
 /**
  * Enum used in WCPay\Payment_Information to determine whether a payment was
  * initated by a merchant or a customer.
  *
  * @psalm-immutable
  */
-class Payment_Initiated_By extends Enum {
+class Payment_Initiated_By extends Base_Constant {
 	const MERCHANT = 'initiated_by_merchant';
 	const CUSTOMER = 'initiated_by_customer';
 }

--- a/includes/constants/class-payment-intent-status.php
+++ b/includes/constants/class-payment-intent-status.php
@@ -11,15 +11,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-use MyCLabs\Enum\Enum;
-
 /**
  * This class gives a list of all Payment Intent status name constants.
  * ref: https://stripe.com/docs/api/payment_intents/object#payment_intent_object-status
  *
  * @psalm-immutable
  */
-class Payment_Intent_Status extends Enum {
+class Payment_Intent_Status extends Base_Constant {
 	const REQUIRES_PAYMENT_METHOD = 'requires_payment_method';
 	const REQUIRES_CONFIRMATION   = 'requires_confirmation';
 	const REQUIRES_ACTION         = 'requires_action';

--- a/includes/constants/class-payment-method.php
+++ b/includes/constants/class-payment-method.php
@@ -11,15 +11,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-use MyCLabs\Enum\Enum;
-
 /**
  * Possible enum values for the type of the PaymentMethod.
  * https://stripe.com/docs/api/payment_methods/object#payment_method_object-type
  *
  * @psalm-immutable
  */
-class Payment_Method extends Enum {
+class Payment_Method extends Base_Constant {
 	const BANCONTACT      = 'bancontact';
 	const BASC            = 'bacs_debit';
 	const BECS            = 'au_becs_debit';

--- a/includes/constants/class-payment-type.php
+++ b/includes/constants/class-payment-type.php
@@ -11,15 +11,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-use MyCLabs\Enum\Enum;
-
 /**
  * Enum used in WCPay\Payment_Information to determine whether a payment
  * is a single payment or a part of a recurring series.
  *
  * @psalm-immutable
  */
-class Payment_Type extends Enum {
+class Payment_Type extends Base_Constant {
 	const SINGLE    = 'single';
 	const RECURRING = 'recurring';
 }

--- a/tests/unit/test-class-base-constant.php
+++ b/tests/unit/test-class-base-constant.php
@@ -18,11 +18,6 @@ class Base_Constant_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( $class->get_value(), 'BASC' );
 		$this->assertSame( (string) $class, 'bacs_debit' );
 	}
-
-	public function test_get_const_name_by_value() {
-		$this->assertSame( Payment_Method::search( 'bacs_debit' ), 'BASC' );
-	}
-
 	public function test_base_constant_equals_function_will_return_true_if_classes_are_same_type_and_value() {
 		$class_a = Payment_Method::BASC();
 		$class_b = Payment_Method::BASC();

--- a/tests/unit/test-class-base-constant.php
+++ b/tests/unit/test-class-base-constant.php
@@ -29,6 +29,13 @@ class Base_Constant_Test extends WCPAY_UnitTestCase {
 		$class_b = Payment_Method::SEPA();
 		$this->assertFalse( $class_a->equals( $class_b ) );
 	}
+	public function test_base_constant_equals_function_will_return_false_if_passed_argument_is_not_instance_of_base_class() {
+		$class_a = Payment_Method::BASC();
+		$class_b = new class() {
+
+		};
+		$this->assertFalse( $class_a->equals( $class_b ) );
+	}
 
 	public function test_exception_will_be_thrown_if_constant_not_exist_in_class() {
 		$this->expectException( \InvalidArgumentException::class );

--- a/tests/unit/test-class-base-constant.php
+++ b/tests/unit/test-class-base-constant.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Class Base_Constant_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\Constants\Payment_Method;
+
+/**
+ * Base_Constant unit tests.
+ */
+class Base_Constant_Test extends WCPAY_UnitTestCase {
+
+	public function test_base_constant_will_create_constant() {
+		$class = Payment_Method::BASC();
+		$this->assertInstanceOf( Payment_Method::class, $class );
+		$this->assertSame( $class->get_value(), 'BASC' );
+		$this->assertSame( (string) $class, 'bacs_debit' );
+	}
+
+	public function test_get_const_name_by_value() {
+		$this->assertSame( Payment_Method::search( 'bacs_debit' ), 'BASC' );
+	}
+
+	public function test_base_constant_equals_function_will_return_true_if_classes_are_same_type_and_value() {
+		$class_a = Payment_Method::BASC();
+		$class_b = Payment_Method::BASC();
+		$this->assertTrue( $class_a->equals( $class_b ) );
+	}
+
+	public function test_base_constant_equals_function_will_return_false_if_classes_are_not_same_type_or_value() {
+		$class_a = Payment_Method::BASC();
+		$class_b = Payment_Method::SEPA();
+		$this->assertFalse( $class_a->equals( $class_b ) );
+	}
+
+	public function test_exception_will_be_thrown_if_constant_not_exist_in_class() {
+		$this->expectException( \InvalidArgumentException::class );
+		Payment_Method::FOO();
+	}
+
+	public function test_class_will_return_const_name_if_searched_by_correct_const_value() {
+		$name = Payment_Method::search( 'bacs_debit' );
+		$this->assertSame( $name, 'BASC' );
+	}
+
+	public function test_class_will_throw_exception_if_searched_by_value_that_does_not_exist() {
+		$this->expectException( \InvalidArgumentException::class );
+		Payment_Method::search( 'foo' );
+	}
+}

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -68,7 +68,7 @@ register_activation_hook( __FILE__, 'wcpay_activated' );
 register_deactivation_hook( __FILE__, 'wcpay_deactivated' );
 
 // The JetPack autoloader might not catch up yet when activating the plugin. If so, we'll stop here to avoid JetPack connection failures.
-$is_autoloading_ready = class_exists( Automattic\Jetpack\Connection\Rest_Authentication::class ) && class_exists( MyCLabs\Enum\Enum::class );
+$is_autoloading_ready = class_exists( Automattic\Jetpack\Connection\Rest_Authentication::class );
 if ( ! $is_autoloading_ready ) {
 	return;
 }


### PR DESCRIPTION
Fixes #5533 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

In newer versions of PHP (8.1 and 8.2), the enum package we use could throw warnings and errors because the package uses some deprecated functions which cause some errors and warnings. To overcome this issue, the ENUM package has been removed and implemented a built-in solution that mimics the package functionalities.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

Make sure that all tests are passing.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
