### PR TITLE
Re-activate e2e tests for the shortcode split UPE

### DIFF
--- a/changelog/fix-shortcode-upe-split
+++ b/changelog/fix-shortcode-upe-split
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixes the split UPE shortcode checkout

--- a/changelog/fix-shortcode-upe-split
+++ b/changelog/fix-shortcode-upe-split
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes the split UPE shortcode checkout

--- a/changelog/reenable-split-upe-e2e-tests
+++ b/changelog/reenable-split-upe-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Re-enable split UPE E2E tests and ensure they pass.

--- a/tests/e2e/specs/upe-split/shopper/shopper-upe-enabled-all-flows.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-upe-enabled-all-flows.spec.js
@@ -41,9 +41,6 @@ describe( 'Enabled Split UPE', () => {
 			await setupProductCheckout(
 				config.get( 'addresses.customer.billing' )
 			);
-			// TODO re-activate two lines below as soon as SEPA will be supported in the split UPE.
-			// await shopper.goToCheckout();
-			// await uiUnblocked();
 			await shopperWCP.selectNewPaymentMethod();
 			await fillCardDetails( page, card );
 			await shopperWCP.toggleSavePaymentMethod();

--- a/tests/e2e/specs/upe-split/shopper/shopper-upe-enabled-all-flows.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-upe-enabled-all-flows.spec.js
@@ -41,6 +41,9 @@ describe( 'Enabled Split UPE', () => {
 			await setupProductCheckout(
 				config.get( 'addresses.customer.billing' )
 			);
+			// TODO re-activate two lines below as soon as SEPA will be supported in the split UPE.
+			// await shopper.goToCheckout();
+			// await uiUnblocked();
 			await shopperWCP.selectNewPaymentMethod();
 			await fillCardDetails( page, card );
 			await shopperWCP.toggleSavePaymentMethod();

--- a/tests/e2e/specs/upe-split/shopper/shopper-upe-enabled-all-flows.spec.js
+++ b/tests/e2e/specs/upe-split/shopper/shopper-upe-enabled-all-flows.spec.js
@@ -36,14 +36,11 @@ describe( 'Enabled Split UPE', () => {
 		await merchant.logout();
 	} );
 
-	// the tests are a bit flakey, so disabling for now.
-	describe.skip( 'Shortcode checkout', () => {
+	describe( 'Shortcode checkout', () => {
 		it( 'should save the card', async () => {
 			await setupProductCheckout(
 				config.get( 'addresses.customer.billing' )
 			);
-			await shopper.goToCheckout();
-			await uiUnblocked();
 			await shopperWCP.selectNewPaymentMethod();
 			await fillCardDetails( page, card );
 			await shopperWCP.toggleSavePaymentMethod();


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR removes the redundant setup logic in the shortcode split UPE test, which, in turn, fixes the test being flaky.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* All E2E test groups should be green.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
