### PR TITLE
Fix isUsingSavedPaymentMethod logic on the checkout processing with the split UPE enabled

### DIFF
--- a/changelog/fix-shortcode-upe-split
+++ b/changelog/fix-shortcode-upe-split
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix handling saved tokens for payment gateways while using shortcode checkout

--- a/client/checkout/classic/test/upe-split.test.js
+++ b/client/checkout/classic/test/upe-split.test.js
@@ -1,0 +1,74 @@
+/**
+ * Internal dependencies
+ */
+import { isUsingSavedPaymentMethod } from '../upe-split';
+
+describe( 'testing isUsingSavedPaymentMethod', () => {
+	let container;
+
+	beforeAll( () => {
+		container = document.createElement( 'div' );
+		container.innerHTML = `
+			<label>
+				<input type="radio" id="wc-woocommerce_payments-payment-token-new" value="new">
+				Use a new payment method
+			</label>
+			<label>
+				<input type="radio" id="wc-woocommerce_payments_sepa_debit-payment-token-new" value="new">
+				Use a new payment method
+			</label>
+		`;
+		document.body.appendChild( container );
+	} );
+
+	afterAll( () => {
+		document.body.removeChild( container );
+		container = null;
+	} );
+
+	test( 'new CC is selected', () => {
+		const input = document.querySelector(
+			'#wc-woocommerce_payments-payment-token-new'
+		);
+		input.checked = true;
+		const paymentMethodType = 'card';
+
+		expect( isUsingSavedPaymentMethod( paymentMethodType ) ).toBe( false );
+	} );
+
+	test( 'saved CC is selected', () => {
+		const input = document.querySelector(
+			'#wc-woocommerce_payments-payment-token-new'
+		);
+		input.checked = false;
+		const paymentMethodType = 'card';
+
+		expect( isUsingSavedPaymentMethod( paymentMethodType ) ).toBe( true );
+	} );
+
+	test( 'new SEPA is selected', () => {
+		const input = document.querySelector(
+			'#wc-woocommerce_payments_sepa_debit-payment-token-new'
+		);
+		input.checked = true;
+		const paymentMethodType = 'sepa_debit';
+
+		expect( isUsingSavedPaymentMethod( paymentMethodType ) ).toBe( false );
+	} );
+
+	test( 'saved SEPA is selected', () => {
+		const input = document.querySelector(
+			'#wc-woocommerce_payments_sepa_debit-payment-token-new'
+		);
+		input.checked = false;
+		const paymentMethodType = 'sepa_debit';
+
+		expect( isUsingSavedPaymentMethod( paymentMethodType ) ).toBe( true );
+	} );
+
+	test( 'non-tokenized payment gateway is selected', () => {
+		const paymentMethodType = 'sofort';
+
+		expect( isUsingSavedPaymentMethod( paymentMethodType ) ).toBe( false );
+	} );
+} );

--- a/client/checkout/classic/test/upe-split.test.js
+++ b/client/checkout/classic/test/upe-split.test.js
@@ -3,7 +3,7 @@
  */
 import { isUsingSavedPaymentMethod } from '../upe-split';
 
-describe( 'testing isUsingSavedPaymentMethod', () => {
+describe( 'isUsingSavedPaymentMethod', () => {
 	let container;
 
 	beforeAll( () => {

--- a/client/checkout/classic/upe-split.js
+++ b/client/checkout/classic/upe-split.js
@@ -700,39 +700,6 @@ jQuery( function ( $ ) {
 	};
 
 	/**
-	 * Checks if the customer is using a saved payment method.
-	 *
-	 * @param {string} paymentMethodType Stripe payment method type ID.
-	 * @return {boolean} Boolean indicating whether or not a saved payment method is being used.
-	 */
-	function isUsingSavedPaymentMethod( paymentMethodType ) {
-		const ccSavedPaymentMethodSelector =
-			'#wc-woocommerce_payments-payment-token-new';
-		const sepaPaymentMethodSelector =
-			'#wc-woocommerce_payments_sepa_debit-payment-token-new';
-		const tokenizedPaymentMethods = [ 'sepa_debit', 'card' ];
-
-		// The payment method used cannot be saved, which means that we are not using saved tokens for sure.
-		if ( ! tokenizedPaymentMethods.includes( paymentMethodType ) ) {
-			return false;
-		}
-
-		if ( 'sepa_debit' === paymentMethodType ) {
-			return (
-				$( sepaPaymentMethodSelector ).length &&
-				! $( sepaPaymentMethodSelector ).is( ':checked' )
-			);
-		}
-
-		if ( 'card' === paymentMethodType ) {
-			return (
-				$( ccSavedPaymentMethodSelector ).length &&
-				! $( ccSavedPaymentMethodSelector ).is( ':checked' )
-			);
-		}
-	}
-
-	/**
 	 * Returns the cached setup intent.
 	 *
 	 * @param {string} paymentMethodType Stripe payment method type ID.
@@ -871,3 +838,36 @@ jQuery( function ( $ ) {
 		}
 	} );
 } );
+
+/**
+ * Checks if the customer is using a saved payment method.
+ *
+ * @param {string} paymentMethodType Stripe payment method type ID.
+ * @return {boolean} Boolean indicating whether or not a saved payment method is being used.
+ */
+export function isUsingSavedPaymentMethod( paymentMethodType ) {
+	const ccSavedPaymentMethodSelector =
+		'#wc-woocommerce_payments-payment-token-new';
+	const sepaPaymentMethodSelector =
+		'#wc-woocommerce_payments_sepa_debit-payment-token-new';
+	const tokenizedPaymentMethods = [ 'sepa_debit', 'card' ];
+
+	// The payment method used cannot be saved, which means that we are not using saved tokens for sure.
+	if ( ! tokenizedPaymentMethods.includes( paymentMethodType ) ) {
+		return false;
+	}
+
+	if ( 'sepa_debit' === paymentMethodType ) {
+		return (
+			null !== document.querySelector( sepaPaymentMethodSelector ) &&
+			! document.querySelector( sepaPaymentMethodSelector ).checked
+		);
+	}
+
+	if ( 'card' === paymentMethodType ) {
+		return (
+			null !== document.querySelector( ccSavedPaymentMethodSelector ) &&
+			! document.querySelector( ccSavedPaymentMethodSelector ).checked
+		);
+	}
+}

--- a/client/checkout/classic/upe-split.js
+++ b/client/checkout/classic/upe-split.js
@@ -843,31 +843,18 @@ jQuery( function ( $ ) {
  * Checks if the customer is using a saved payment method.
  *
  * @param {string} paymentMethodType Stripe payment method type ID.
- * @return {boolean} Boolean indicating whether or not a saved payment method is being used.
+ * @return {boolean} Boolean indicating whether a saved payment method is being used.
  */
 export function isUsingSavedPaymentMethod( paymentMethodType ) {
-	const ccSavedPaymentMethodSelector =
-		'#wc-woocommerce_payments-payment-token-new';
-	const sepaPaymentMethodSelector =
-		'#wc-woocommerce_payments_sepa_debit-payment-token-new';
-	const tokenizedPaymentMethods = [ 'sepa_debit', 'card' ];
+	const prefix = '#wc-woocommerce_payments';
+	const suffix = '-payment-token-new';
+	const savedPaymentSelector =
+		'card' === paymentMethodType
+			? prefix + suffix
+			: prefix + '_' + paymentMethodType + suffix;
 
-	// The payment method used cannot be saved, which means that we are not using saved tokens for sure.
-	if ( ! tokenizedPaymentMethods.includes( paymentMethodType ) ) {
-		return false;
-	}
-
-	if ( 'sepa_debit' === paymentMethodType ) {
-		return (
-			null !== document.querySelector( sepaPaymentMethodSelector ) &&
-			! document.querySelector( sepaPaymentMethodSelector ).checked
-		);
-	}
-
-	if ( 'card' === paymentMethodType ) {
-		return (
-			null !== document.querySelector( ccSavedPaymentMethodSelector ) &&
-			! document.querySelector( ccSavedPaymentMethodSelector ).checked
-		);
-	}
+	return (
+		null !== document.querySelector( savedPaymentSelector ) &&
+		! document.querySelector( savedPaymentSelector ).checked
+	);
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5593

#### Changes proposed in this Pull Request
This PR improves the logic for identifying if a saved payment method is used during the split UPE shortcode checkout. Previously, only some of the payment gateway selectors were verified without checking which payment method has been selected, which led to unexpected behavior.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
##### Split UPE
As an admin, enable the split UPE feature. Rollback [this](https://github.com/Automattic/woocommerce-payments/commit/ca9580b7fda77341bb9155270f7c86aeab0952bb) commit on your local environment to be able to test SEPA as well. Use the shortcode checkout. Login as the existing user.

0. Disable WooPay and Link
1. Pay with a new CC
2. Pay with a saved CC 
3. Pay with a new SEPA 
4. Pay with a saved SEPA
5. Pay with any other UPE payment gateway - they are all non-tokenized, which means they cannot be saved. This flow should work as expected as well. 
6. Enable WooPay and perform steps 1-5 again. 
7. There's no need to perform steps 1-5 with WooPay disabled and Link enabled, because Link enabled uses a split UPE gateway for card, which is equal to when WooPay & Link are disabled (step 0).

##### Legacy UPE
1. Although the changes affect only `upe-split.js` script, I'd like to ask you to perform a few critical flows to ensure, that everything works as expected. 

##### Logged out
Log out and: 
1. Pay with CC 
2. Pay with SEPA
3. Pay with one of the rest UPE gateways

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
