### PR TITLE
Update GitHub workflow runner images from Ubuntu 18.04 to 20.04

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -24,7 +24,7 @@ jobs:
   woocommerce-compatibility:
     name: "WC compatibility"
     needs: generate-matrix
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       WP_VERSION: ${{ matrix.wordpress }}
       WC_VERSION: ${{ matrix.woocommerce }}
@@ -55,7 +55,7 @@ jobs:
   # a dedicated job, as allowed to fail
   compatibility-woocommerce-beta:
     name:    Environment - WC beta
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -35,9 +35,9 @@ jobs:
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     steps:
       # clone the repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # enable dependencies caching
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
@@ -69,9 +69,9 @@ jobs:
       GUTENBERG_VERSION: ${{ matrix.gutenberg }}
     steps:
       # clone the repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # enable dependencies caching
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   woocommerce-coverage:
     name:    Code coverage
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast:    false
       max-parallel: 10

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,9 +19,9 @@ jobs:
       WC_VERSION: ${{ matrix.woocommerce }}
     steps:
       # clone the repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # enable dependencies caching
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -9,16 +9,16 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       # clone the repository
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
       # enable dependencies caching
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.npm/
           key:  ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
@@ -30,16 +30,16 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       # clone the repository
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
       # enable dependencies caching
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.npm/
           key:  ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   lint:
     name:    JS linting
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
 
   test:
     name:    JS testing
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       # clone the repository
       - uses: actions/checkout@v2

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -7,7 +7,7 @@ jobs:
   # Check for version-specific PHP compatibility
   php-compatibility:
     name: PHP Compatibility
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
@@ -15,4 +15,4 @@ jobs:
           php-version: '7.4'
           tools:       composer:2.5.0
           coverage:    none
-      - run: bash bin/phpcs-compat.sh 
+      - run: bash bin/phpcs-compat.sh

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -9,7 +9,7 @@ jobs:
     name: PHP Compatibility
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -37,6 +37,16 @@ jobs:
       max-parallel: 10
       matrix:
         php: [ '7.2', '7.3', '7.4' ]
+
+    services:
+      mysql:
+        image: mariadb:latest
+        ports:
+          - 3306
+        env:
+          MYSQL_DATABASE: woocommerce_test
+          MYSQL_ROOT_PASSWORD: root
+
     steps:
       # clone the repository
       - uses: actions/checkout@v2

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -37,16 +37,6 @@ jobs:
       max-parallel: 10
       matrix:
         php: [ '7.2', '7.3', '7.4' ]
-
-    services:
-      mysql:
-        image: mariadb:latest
-        ports:
-          - 3306
-        env:
-          MYSQL_DATABASE: woocommerce_test
-          MYSQL_ROOT_PASSWORD: root
-
     steps:
       # clone the repository
       - uses: actions/checkout@v2

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       # clone the repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # enable dependencies caching
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
@@ -39,9 +39,9 @@ jobs:
         php: [ '7.2', '7.3', '7.4' ]
     steps:
       # clone the repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # enable dependencies caching
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   lint:
     name:    PHP linting
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
 
   test:
     name:    PHP testing
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast:    false
       max-parallel: 10

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -129,6 +129,13 @@ configure_wp() {
 	wait_db
 
 	if [[ ! -f "$WP_CORE_DIR/wp-config.php" ]]; then
+		echo "-------------------------------------"
+		echo "DB Config:"
+		echo "Username: $DB_USER"
+		echo "Password: $DB_PASS"
+		echo "DB Name: $DB_NAME"
+		echo "DB Host: $DB_HOST"
+		echo "-------------------------------------"
 		wp core config --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
 	fi
 

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -129,13 +129,6 @@ configure_wp() {
 	wait_db
 
 	if [[ ! -f "$WP_CORE_DIR/wp-config.php" ]]; then
-		echo "-------------------------------------"
-		echo "DB Config:"
-		echo "Username: $DB_USER"
-		echo "Password: $DB_PASS"
-		echo "DB Name: $DB_NAME"
-		echo "DB Host: $DB_HOST"
-		echo "-------------------------------------"
 		wp core config --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
 	fi
 

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -130,6 +130,9 @@ configure_wp() {
 
 	if [[ ! -f "$WP_CORE_DIR/wp-config.php" ]]; then
 		wp config create --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
+		# Enable WP Debug
+		wp config set WP_DEBUG true
+		wp config set WP_DEBUG_DISPLAY true
 	fi
 
 	# Add db-error.php for detailed logging

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -132,6 +132,9 @@ configure_wp() {
 		wp config create --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
 	fi
 
+	# Add db-error.php for detailed logging
+	echo '<?php global $wpdb; $wpdb->print_error(); ?>' >  $WP_CORE_DIR/wp-content/db-error.php
+
     # MySQL default reporting level has changed in PHP 8.1, here we forcing it to be the same in all tested PHP versions
     sed $ioption -E "s/(Happy publishing.+)/\1\nmysqli_report(MYSQLI_REPORT_OFF);/" "$WP_CORE_DIR/wp-config.php"
 

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -129,7 +129,7 @@ configure_wp() {
 	wait_db
 
 	if [[ ! -f "$WP_CORE_DIR/wp-config.php" ]]; then
-		wp core config --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
+		wp config create --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
 	fi
 
     # MySQL default reporting level has changed in PHP 8.1, here we forcing it to be the same in all tested PHP versions

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -130,9 +130,6 @@ configure_wp() {
 
 	if [[ ! -f "$WP_CORE_DIR/wp-config.php" ]]; then
 		wp config create --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
-		# Enable WP Debug
-		wp config set WP_DEBUG true
-		wp config set WP_DEBUG_DISPLAY true
 	fi
 
     # MySQL default reporting level has changed in PHP 8.1, here we forcing it to be the same in all tested PHP versions

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -129,7 +129,7 @@ configure_wp() {
 	wait_db
 
 	if [[ ! -f "$WP_CORE_DIR/wp-config.php" ]]; then
-		wp config create --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
+		wp core config --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
 	fi
 
     # MySQL default reporting level has changed in PHP 8.1, here we forcing it to be the same in all tested PHP versions

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -130,6 +130,7 @@ configure_wp() {
 
 	if [[ ! -f "$WP_CORE_DIR/wp-config.php" ]]; then
 		wp config create --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
+		cat $WP_CORE_DIR/wp-config.php
 	fi
 
     # MySQL default reporting level has changed in PHP 8.1, here we forcing it to be the same in all tested PHP versions

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -135,9 +135,6 @@ configure_wp() {
 		wp config set WP_DEBUG_DISPLAY true
 	fi
 
-	# Add db-error.php for detailed logging
-	echo '<?php global $wpdb; $wpdb->print_error(); ?>' >  $WP_CORE_DIR/wp-content/db-error.php
-
     # MySQL default reporting level has changed in PHP 8.1, here we forcing it to be the same in all tested PHP versions
     sed $ioption -E "s/(Happy publishing.+)/\1\nmysqli_report(MYSQLI_REPORT_OFF);/" "$WP_CORE_DIR/wp-config.php"
 

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -130,7 +130,6 @@ configure_wp() {
 
 	if [[ ! -f "$WP_CORE_DIR/wp-config.php" ]]; then
 		wp config create --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
-		cat $WP_CORE_DIR/wp-config.php
 	fi
 
     # MySQL default reporting level has changed in PHP 8.1, here we forcing it to be the same in all tested PHP versions

--- a/bin/run-ci-tests.bash
+++ b/bin/run-ci-tests.bash
@@ -9,6 +9,6 @@ WCPAY_DIR="$GITHUB_WORKSPACE"
 
 composer self-update 2.0.6 && composer install --no-progress
 sudo systemctl start mysql.service
-bash bin/install-wp-tests.sh woocommerce_test root root 127.0.0.1 $WP_VERSION $WC_VERSION false $GUTENBERG_VERSION
+bash bin/install-wp-tests.sh woocommerce_test root root localhost $WP_VERSION $WC_VERSION false $GUTENBERG_VERSION
 echo 'Running the tests...'
 bash bin/phpunit.sh

--- a/bin/run-ci-tests.bash
+++ b/bin/run-ci-tests.bash
@@ -9,7 +9,6 @@ WCPAY_DIR="$GITHUB_WORKSPACE"
 
 composer self-update 2.0.6 && composer install --no-progress
 sudo systemctl start mysql.service
-mysql -uroot -proot -e "SHOW VARIABLES LIKE 'version%'"
 bash bin/install-wp-tests.sh woocommerce_test root root localhost $WP_VERSION $WC_VERSION false $GUTENBERG_VERSION
 echo 'Running the tests...'
 bash bin/phpunit.sh

--- a/bin/run-ci-tests.bash
+++ b/bin/run-ci-tests.bash
@@ -9,6 +9,6 @@ WCPAY_DIR="$GITHUB_WORKSPACE"
 
 composer self-update 2.0.6 && composer install --no-progress
 sudo systemctl start mysql.service
-bash bin/install-wp-tests.sh woocommerce_test root root localhost $WP_VERSION $WC_VERSION false $GUTENBERG_VERSION
+bash bin/install-wp-tests.sh woocommerce_test root root 127.0.0.1 $WP_VERSION $WC_VERSION false $GUTENBERG_VERSION
 echo 'Running the tests...'
 bash bin/phpunit.sh

--- a/bin/run-ci-tests.bash
+++ b/bin/run-ci-tests.bash
@@ -9,6 +9,7 @@ WCPAY_DIR="$GITHUB_WORKSPACE"
 
 composer self-update 2.0.6 && composer install --no-progress
 sudo systemctl start mysql.service
+mysql -uroot -proot -e "SHOW VARIABLES LIKE 'version%'"
 bash bin/install-wp-tests.sh woocommerce_test root root localhost $WP_VERSION $WC_VERSION false $GUTENBERG_VERSION
 echo 'Running the tests...'
 bash bin/phpunit.sh

--- a/bin/run-ci-tests.bash
+++ b/bin/run-ci-tests.bash
@@ -7,8 +7,21 @@ IFS=$'\n\t'
 # set environment variables
 WCPAY_DIR="$GITHUB_WORKSPACE"
 
+echo 'Updating composer version & Install dependencies...'
 composer self-update 2.0.6 && composer install --no-progress
+
+echo 'Starting MySQL service...'
 sudo systemctl start mysql.service
+
+# On GitHub actions, set MySQL authentication to mysql_native_password instead of caching_sha2_password
+# to prevent DB connection problems with PHP versions less than 7.4
+if [[ -n $CI ]]; then
+	echo "Configuring MySQL to use mysql_native_password"
+	mysql -uroot -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
+fi
+
+echo 'Setting up test environment...'
 bash bin/install-wp-tests.sh woocommerce_test root root localhost $WP_VERSION $WC_VERSION false $GUTENBERG_VERSION
+
 echo 'Running the tests...'
 bash bin/phpunit.sh

--- a/changelog/update-gh-workflow-ubuntu-image
+++ b/changelog/update-gh-workflow-ubuntu-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update GH workflow runner images from Ubuntu 18.04 to 20.04


### PR DESCRIPTION
Fixes #5596 

#### Changes proposed in this Pull Request

1. Updates the runner images of workflows using Ubuntu 18.04 to Ubuntu 20.04, to prevent failures during scheduled brownouts as part of deprecating Ubuntu 18.04.
2. Updates workflow actions like `checkout`, `cache`, `node` etc. to the `v3`, to prevent deprecation warnings.
3. For unit tests running on GH actions, updates MySQL authentication to use `mysql_native_password` to prevent DB connection problem with PHP versions less than 7.4

#### Testing instructions

* All workflow runs on this PR should work as expected and shouldn't fail with the error - `This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on April 1st, 2023.`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
