### PR TITLE
Appending the countries dropdown to body to prevent it being clipped

### DIFF
--- a/changelog/fix-phone-input-dropdown
+++ b/changelog/fix-phone-input-dropdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Appending the countries dropdown to body to prevent it being clipped

--- a/client/settings/phone-input/index.tsx
+++ b/client/settings/phone-input/index.tsx
@@ -77,6 +77,7 @@ const PhoneNumberInput = ( {
 				separateDialCode: true,
 				hiddenInput: 'full',
 				utilsScript: utils,
+				dropdownContainer: document.body,
 			} );
 			setInputInstance( iti );
 

--- a/client/settings/phone-input/style.scss
+++ b/client/settings/phone-input/style.scss
@@ -126,6 +126,11 @@
 // override intl-tel-input styles
 .iti {
 	width: 100%;
+	margin-top: $gap-large;
+
+	&--container {
+		margin-top: 0;
+	}
 }
 
 .no-top-margin .iti {

--- a/client/settings/phone-input/style.scss
+++ b/client/settings/phone-input/style.scss
@@ -126,7 +126,6 @@
 // override intl-tel-input styles
 .iti {
 	width: 100%;
-	margin-top: $gap-large;
 }
 
 .no-top-margin .iti {


### PR DESCRIPTION
Fixes #5514

#### Changes proposed in this Pull Request

Before | After
---- | ----
![image](https://user-images.githubusercontent.com/12385501/220469129-4307f3bd-7939-496f-847a-103be7653b5b.png) | ![image](https://user-images.githubusercontent.com/12385501/220468708-4cc70789-6bef-41a4-a568-1c8fc71472e4.png)
![image](https://user-images.githubusercontent.com/12385501/220469270-5d686679-2db6-4bf9-b70e-d79efd667a79.png) | ![image](https://user-images.githubusercontent.com/12385501/220468894-3acf4e40-0c9a-40a5-9937-fdfd75e319b9.png)

- **Side-effect**: The dropdown will automatically close when scrolling to prevent it from misaligning now that it is position absolute.


#### Testing instructions

1. Enable WooPay.
1. Add a product and go to the shortcode page.
1. Click the Save my info section.
1. Scroll down just enough to see the phone input but not enough for the dropdown to fit below it, and click the flag.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
