### PR TITLE
Fixes jumping focus on split UPE blocks gateway select

### DIFF
--- a/changelog/fix-5557-blocks-checkout-focus-changes-on-gateway-select
+++ b/changelog/fix-5557-blocks-checkout-focus-changes-on-gateway-select
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes focus change on gateway select with split UPE enabled.

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -523,7 +523,7 @@ export default class WCPayAPI {
 	 * Saves the calculated UPE appearance values in a transient.
 	 *
 	 * @param {Object} appearance The UPE appearance object with style values
-	 * @param {boolean} isBlocksCheckout True if save request is for Blocks Checkout. Default false.
+	 * @param {string} isBlocksCheckout 'true' if save request is for Blocks Checkout. Default 'false'.
 	 *
 	 * @return {Promise} The final promise for the request to the server.
 	 */

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -527,7 +527,7 @@ export default class WCPayAPI {
 	 *
 	 * @return {Promise} The final promise for the request to the server.
 	 */
-	saveUPEAppearance( appearance, isBlocksCheckout = false ) {
+	saveUPEAppearance( appearance, isBlocksCheckout = 'false' ) {
 		return this.request( getConfig( 'ajaxUrl' ), {
 			is_blocks_checkout: isBlocksCheckout,
 			appearance: JSON.stringify( appearance ),

--- a/client/checkout/blocks/upe-fields.js
+++ b/client/checkout/blocks/upe-fields.js
@@ -385,7 +385,7 @@ const ConsumableWCPayFields = ( { api, ...props } ) => {
 		async function generateUPEAppearance() {
 			// Generate UPE input styles.
 			const upeAppearance = getAppearance( true );
-			await api.saveUPEAppearance( upeAppearance, true );
+			await api.saveUPEAppearance( upeAppearance, 'true' );
 
 			// Update appearance state
 			setAppearance( upeAppearance );

--- a/client/checkout/blocks/upe-split-fields.js
+++ b/client/checkout/blocks/upe-split-fields.js
@@ -397,7 +397,7 @@ const ConsumableWCPayFields = ( { api, ...props } ) => {
 		async function generateUPEAppearance() {
 			// Generate UPE input styles.
 			const upeAppearance = getAppearance( true );
-			await api.saveUPEAppearance( upeAppearance, true );
+			await api.saveUPEAppearance( upeAppearance, 'true' );
 
 			// Update appearance state
 			setAppearance( upeAppearance );


### PR DESCRIPTION
Fixes #5557 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
# Fixing the frustrating focus forever

## The problem

When the split UPE is enabled, for some reason whenever a new split UPE gateway is selected in the blocks checkout, the page springs upwards and the focus is shifted to some secret spot near the top of the checkout page. This is very irritating.

## _Why_ is this happening?

The UPE checkout scrapes computed styles from the checkout page in order to customise the appearance of the payment element in a way that is coherent with the rest of the checkout page. This is done by adding hidden elements to the DOM, then using `window.getComputedStyle` on these hidden elements to compute the style applied to these elements. 

`window.getComputedStyle` can only provide a snapshot of the current styles applied to an element, so element pseudo states (e.g. hover, **focus**, etc.) must be manually triggered in order to compute these styles. This means that in order to compute the styles of a hidden element in a pseudo state--for example, the focus state of an element--this pseudo state must _actually be triggered_ prior to reading the styling with `window.getComputedStyle`.

We can see this focus being triggered [here](https://github.com/Automattic/woocommerce-payments/blob/develop/client/checkout/upe-styles/index.js#L245-L247) when input focus styles are computed [here](https://github.com/Automattic/woocommerce-payments/blob/develop/client/checkout/upe-styles/index.js#L322-L326). Unfortunately, this is unavoidable, as it is apparently not possible to compute pseudo state styles without actually triggering the pseudo state. 

But why does this happen so frequently _every single time_ a payment gateway is selected while using the split UPE? We should be [caching these styles](https://github.com/Automattic/woocommerce-payments/blob/develop/client/checkout/blocks/upe-split-fields.js#L400), so that they [only need to be computed once](https://github.com/Automattic/woocommerce-payments/blob/develop/client/checkout/blocks/upe-split-fields.js#L406-L408) instead of being computed numerous times for each separate payment element. However, if you test on `develop`, you will be bemused and likely not amused to discover that, for some reason, this caching does not appear to occur on the blocks checkout and `getUPEConfig( 'wcBlocksUPEAppearance' )` always returns `null`. 

Blistering barnacles! What the devil is this madness?

## The solution

So it turned out that this value for `$_POST[ 'is_blocks_checkout' ]` was always unset in the AJAX request to save the UPE appearance, because apparently [if we send the value as a boolean](https://github.com/Automattic/woocommerce-payments/blob/develop/client/checkout/api/index.js#L532), this is ignored by the request. If you hunt around to find this AJAX request in your network tab, you will find that the `is_blocks_checkout` parameter is always missing. 

Changing this parameter's value from a boolean value to a string, returns the parameter to the request and allows it to be parsed correctly by `rest_sanitize_boolean` on the admin AJAX endpoint. We could also send `0` or `1` as values, but I choose boolean strings just because (I'll willingly bend on this delicate declaration if implored!). 

Now the page will jump once (unavoidably and just as in the regular UPE checkout) and then never again! Huzzah!

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

1. Enable split gateway UPE feature, remove SEPA capability if necessary, and add additional payment methods.
2. Proceed to blocks checkout. 
3. Toggle between various split UPE payment gateways.
4. Note that page will jump **at most** one time and more likely never.
5. Check that regular UPE blocks checkout and regular non-UPE checkout still cache the appearance as expected. 
6. Thank your lucky stars.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
