### PR TITLE
Add an alert notice for Norwegian merchants on WooCommerce 7.4 and below

### DIFF
--- a/changelog/add-norway-notice-wcpay
+++ b/changelog/add-norway-notice-wcpay
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a notice for Norwegian merchants using WCPay to update WooCommerce to at least 7.5

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1097,6 +1097,31 @@ class WC_Payments {
 			WC_Payments_Notes_Set_Up_StripeLink::set_gateway( self::get_gateway() );
 			WC_Payments_Notes_Set_Up_StripeLink::possibly_add_note();
 		}
+
+		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '7.4', '<=' ) && get_woocommerce_currency() === 'NOK' ) {
+			/**
+			 * Shows an alert notice for Norwegian merchants on WooCommerce 7.4 and below
+			 */
+			function wcpay_show_old_woocommerce_for_norway_notice() {
+				?>
+				<div class="notice wcpay-notice notice-error">
+					<p>
+					<?php
+					echo WC_Payments_Utils::esc_interpolated_html(
+						/* translators: %s: documentation URL */
+						__( 'The WooCommerce version you have installed is not compatible with WooCommerce Payments for a Norwegian business. Please update WooCommerce to version 7.5 or above. You can do that via the <a1>the plugins page.</a1>', 'woocommerce-payments' ),
+						[
+							'a1' => '<a href="' . admin_url( 'plugins.php' ) . '">',
+						]
+					)
+					?>
+					</p>
+				</div>
+				<?php
+			}
+
+			add_filter( 'admin_notices', 'wcpay_show_old_woocommerce_for_norway_notice' );
+		}
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1098,7 +1098,7 @@ class WC_Payments {
 			WC_Payments_Notes_Set_Up_StripeLink::possibly_add_note();
 		}
 
-		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '7.4', '<=' ) && get_woocommerce_currency() === 'NOK' ) {
+		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '7.5', '<' ) && get_woocommerce_currency() === 'NOK' ) {
 			/**
 			 * Shows an alert notice for Norwegian merchants on WooCommerce 7.4 and below
 			 */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There is a bug when formatting amounts in NOK (Norwegian currency) in WooCommerce 7.4. This PR adds an alert for Norwegian merchants on WooCommerce 7.4 or below and asks them to update for a newer version.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get this PR
* Change store currency to NOK
* Now go to WCPay settings, you should see something like this:

<img width="1018" alt="Screenshot 2023-02-21 at 18 39 44" src="https://user-images.githubusercontent.com/12542046/220657115-915a79d9-0fde-4e3a-9c79-d1f805d694e4.png">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
