### PR TITLE
Fix WooPay settings warning visibility

### DIFF
--- a/changelog/fix-woopay-settings-notice
+++ b/changelog/fix-woopay-settings-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay settings notice visibility

--- a/client/settings/express-checkout-settings/general-payment-request-button-settings.js
+++ b/client/settings/express-checkout-settings/general-payment-request-button-settings.js
@@ -7,6 +7,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { RadioControl, Notice } from '@wordpress/components';
 import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
+import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ import PaymentRequestButtonPreview from './payment-request-button-preview';
 import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
 import interpolateComponents from 'interpolate-components';
 import { getPaymentRequestData } from '../../payment-request/utils';
+import WCPaySettingsContext from '../wcpay-settings-context';
 import {
 	usePaymentRequestButtonType,
 	usePaymentRequestButtonSize,
@@ -130,6 +132,11 @@ const GeneralPaymentRequestButtonSettings = ( { type } ) => {
 	const [ theme, setTheme ] = usePaymentRequestButtonTheme();
 	const [ isPlatformCheckoutEnabled ] = usePlatformCheckoutEnabledSettings();
 	const [ isPaymentRequestEnabled ] = usePaymentRequestEnabledSettings();
+	const {
+		featureFlags: {
+			platformCheckout: isPlatformCheckoutFeatureFlagEnabled,
+		},
+	} = useContext( WCPaySettingsContext );
 
 	const stripePromise = useMemo( () => {
 		const stripeSettings = getPaymentRequestData( 'stripe' );
@@ -140,11 +147,18 @@ const GeneralPaymentRequestButtonSettings = ( { type } ) => {
 	}, [] );
 
 	const otherButtons =
-		'woopay' === type ? __( 'Apple Pay / Google Pay buttons', 'woocommerce-payments' ) : __( 'WooPay button', 'woocommerce-payments' );
+		'woopay' === type
+			? __( 'Apple Pay / Google Pay buttons', 'woocommerce-payments' )
+			: __( 'WooPay button', 'woocommerce-payments' );
+
+	const showWarning =
+		isPlatformCheckoutEnabled &&
+		isPaymentRequestEnabled &&
+		isPlatformCheckoutFeatureFlagEnabled;
 
 	return (
 		<CardBody>
-			{ isPlatformCheckoutEnabled && isPaymentRequestEnabled && (
+			{ showWarning && (
 				<Notice
 					status="warning"
 					isDismissible={ false }
@@ -161,6 +175,7 @@ const GeneralPaymentRequestButtonSettings = ( { type } ) => {
 							size={ 20 }
 						/>
 						{ sprintf(
+							/* translators: %s type of button to which the settings will be applied */
 							__(
 								'These settings will also apply to the %s on your store.',
 								'woocommerce-payments'

--- a/client/settings/express-checkout-settings/general-payment-request-button-settings.js
+++ b/client/settings/express-checkout-settings/general-payment-request-button-settings.js
@@ -140,7 +140,7 @@ const GeneralPaymentRequestButtonSettings = ( { type } ) => {
 	}, [] );
 
 	const otherButtons =
-		'woopay' === type ? 'Apple Pay / Google Pay buttons' : 'WooPay button';
+		'woopay' === type ? __( 'Apple Pay / Google Pay buttons', 'woocommerce-payments' ) : __( 'WooPay button', 'woocommerce-payments' );
 
 	return (
 		<CardBody>

--- a/client/settings/express-checkout-settings/general-payment-request-button-settings.js
+++ b/client/settings/express-checkout-settings/general-payment-request-button-settings.js
@@ -20,6 +20,8 @@ import {
 	usePaymentRequestButtonType,
 	usePaymentRequestButtonSize,
 	usePaymentRequestButtonTheme,
+	usePaymentRequestEnabledSettings,
+	usePlatformCheckoutEnabledSettings,
 } from 'wcpay/data';
 
 const makeButtonSizeText = ( string ) =>
@@ -126,6 +128,8 @@ const GeneralPaymentRequestButtonSettings = ( { type } ) => {
 	const [ buttonType, setButtonType ] = usePaymentRequestButtonType();
 	const [ size, setSize ] = usePaymentRequestButtonSize();
 	const [ theme, setTheme ] = usePaymentRequestButtonTheme();
+	const [ isPlatformCheckoutEnabled ] = usePlatformCheckoutEnabledSettings();
+	const [ isPaymentRequestEnabled ] = usePaymentRequestEnabledSettings();
 
 	const stripePromise = useMemo( () => {
 		const stripeSettings = getPaymentRequestData( 'stripe' );
@@ -136,34 +140,36 @@ const GeneralPaymentRequestButtonSettings = ( { type } ) => {
 	}, [] );
 
 	const otherButtons =
-		'woopay' === type ? 'Apple Pay / Google Pay' : 'WooPay';
+		'woopay' === type ? 'Apple Pay / Google Pay buttons' : 'WooPay button';
 
 	return (
 		<CardBody>
-			<Notice
-				status="warning"
-				isDismissible={ false }
-				className="express-checkout__notice"
-			>
-				<span>
-					<NoticeOutlineIcon
-						style={ {
-							color: '#BD8600',
-							fill: 'currentColor',
-							marginBottom: '-5px',
-							marginRight: '16px',
-						} }
-						size={ 20 }
-					/>
-					{ sprintf(
-						__(
-							'These settings will also apply to the %s buttons on your store.',
-							'woocommerce-payments'
-						),
-						otherButtons
-					) }
-				</span>
-			</Notice>
+			{ isPlatformCheckoutEnabled && isPaymentRequestEnabled && (
+				<Notice
+					status="warning"
+					isDismissible={ false }
+					className="express-checkout__notice"
+				>
+					<span>
+						<NoticeOutlineIcon
+							style={ {
+								color: '#BD8600',
+								fill: 'currentColor',
+								marginBottom: '-5px',
+								marginRight: '16px',
+							} }
+							size={ 20 }
+						/>
+						{ sprintf(
+							__(
+								'These settings will also apply to the %s on your store.',
+								'woocommerce-payments'
+							),
+							otherButtons
+						) }
+					</span>
+				</Notice>
+			) }
 			<h4>{ __( 'Call to action', 'woocommerce-payments' ) }</h4>
 			<RadioControl
 				className="payment-method-settings__cta-selection"

--- a/client/settings/express-checkout-settings/test/payment-request-settings.test.js
+++ b/client/settings/express-checkout-settings/test/payment-request-settings.test.js
@@ -17,6 +17,7 @@ import {
 	usePaymentRequestButtonType,
 	usePaymentRequestButtonSize,
 	usePaymentRequestButtonTheme,
+	usePlatformCheckoutEnabledSettings,
 } from '../../../data';
 
 jest.mock( '../../../data', () => ( {
@@ -25,6 +26,7 @@ jest.mock( '../../../data', () => ( {
 	usePaymentRequestButtonType: jest.fn().mockReturnValue( [ 'buy' ] ),
 	usePaymentRequestButtonSize: jest.fn().mockReturnValue( [ 'default' ] ),
 	usePaymentRequestButtonTheme: jest.fn().mockReturnValue( [ 'dark' ] ),
+	usePlatformCheckoutEnabledSettings: jest.fn(),
 } ) );
 
 jest.mock( '../payment-request-button-preview' );
@@ -42,6 +44,8 @@ const getMockPaymentRequestEnabledSettings = (
 	isEnabled,
 	updateIsPaymentRequestEnabledHandler
 ) => [ isEnabled, updateIsPaymentRequestEnabledHandler ];
+
+const getMockPlatformCheckoutEnabledSettings = ( isEnabled ) => [ isEnabled ];
 
 const getMockPaymentRequestLocations = (
 	isCheckoutEnabled,
@@ -65,6 +69,10 @@ describe( 'PaymentRequestSettings', () => {
 
 		usePaymentRequestLocations.mockReturnValue(
 			getMockPaymentRequestLocations( true, true, true, jest.fn() )
+		);
+
+		usePlatformCheckoutEnabledSettings.mockReturnValue(
+			getMockPlatformCheckoutEnabledSettings( true )
 		);
 	} );
 

--- a/client/settings/index.js
+++ b/client/settings/index.js
@@ -38,9 +38,12 @@ if ( expressCheckoutSettingsContainer ) {
 	const methodId = expressCheckoutSettingsContainer.dataset.methodId;
 
 	ReactDOM.render(
-		<ErrorBoundary>
-			<ExpressCheckoutSettings methodId={ methodId } />
-		</ErrorBoundary>,
+		<WCPaySettingsContext.Provider value={ wcpaySettings }>
+			<ErrorBoundary>
+				<ExpressCheckoutSettings methodId={ methodId } />
+			</ErrorBoundary>
+			,
+		</WCPaySettingsContext.Provider>,
 		expressCheckoutSettingsContainer
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

WooPay settings warning appears in the Apple/Google Pay settings page even when WooPay is disabled.

![SCR-20230223-l5e](https://user-images.githubusercontent.com/6216000/221031615-cc597776-900a-4622-b101-2c08537e7627.png)


Changes here makes the warning to only appear on stores that has Woopay enabled.
<!--

Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
**Test on a new store**
* On a brand new store with only WCPay enabled, go to Payments -> Settings
* Select 'Customize' button in the Apple Pay / Google Pay section in Express checkouts section
* Notice that above notice does not appear.

 **Test on a WooPay eligible store**

* Make the store eligible for WooPay
* Go to Payments -> Settings -> Express Checkouts section
* With WooPay disabled in express checkouts, select Customize on Apple Pay / Google Pay section
* Above notice should not appear
* Go to WooPay's customize button 
* Above notice should not appear

**Test with WooPay and PRBs enabled**

* Enable WooPay and Google/Apple Pay 
* Notice that warnings appear on Customize page of both WooPay and Google/Apple Pay

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
