### PR TITLE
Make sure get woopay available countries return an array

### DIFF
--- a/changelog/y
+++ b/changelog/y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix get woopay available countries return type

--- a/includes/platform-checkout/class-platform-checkout-utilities.php
+++ b/includes/platform-checkout/class-platform-checkout-utilities.php
@@ -115,6 +115,10 @@ class Platform_Checkout_Utilities {
 		$response      = \Automattic\Jetpack\Connection\Client::remote_request( $args );
 		$response_body = wp_remote_retrieve_body( $response );
 
+		// phpcs:ignore
+		/**
+		 * @psalm-suppress UndefinedDocblockClass
+		 */
 		if ( is_wp_error( $response ) || ! is_array( $response_body ) || ! empty( $response['code'] ) || $response['code'] >= 300 || $response['code'] < 200 ) {
 			Logger::error( 'HTTP_REQUEST_ERROR ' . var_export( $response, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
 		} else {

--- a/includes/platform-checkout/class-platform-checkout-utilities.php
+++ b/includes/platform-checkout/class-platform-checkout-utilities.php
@@ -79,7 +79,7 @@ class Platform_Checkout_Utilities {
 		if ( $last_check && gmdate( 'Y-m-d' ) === $last_check ) {
 			$available_countries = get_option( self::AVAILABLE_COUNTRIES_KEY, '["US"]' );
 
-			return json_decode( $available_countries, true );
+			return json_decode( $available_countries ?? [], true );
 		}
 
 		$platform_checkout_host = defined( 'PLATFORM_CHECKOUT_HOST' ) ? PLATFORM_CHECKOUT_HOST : 'https://pay.woo.com';
@@ -114,7 +114,7 @@ class Platform_Checkout_Utilities {
 
 		update_option( self::AVAILABLE_COUNTRIES_LAST_CHECK_KEY, gmdate( 'Y-m-d' ) );
 
-		return json_decode( $available_countries, true );
+		return json_decode( $available_countries ?? [], true );
 	}
 
 	/**


### PR DESCRIPTION
Fixes issue in Slack thread: p1677260988832549/1677234092.205529-slack-C7U3Y3VMY

https://d.pr/i/Uc4nFV

#### Changes proposed in this Pull Request
- Since we expect `get_woopay_available_countries` to return an array, we should check if `$available_countries` is not an array, then we return an empty array
- Before, we only checked if the response was an array but didn't check if the response **body** was an array.  Now we check the response body and if the response code is less than 200 or greater than 300.

#### Testing instructions
1. Use a bad URL for `PLATFORM_CHECKOUT_HOST` in your config file
2. Set merchant address as UK or any non US address
3. Check the product page
4. See that no error exists

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.