### PR TITLE
WooPay enablement converts legacy UPE to split UPE 

### DIFF
--- a/changelog/add-5612-enabling-woopay-converts-legacy-upe-to-split
+++ b/changelog/add-5612-enabling-woopay-converts-legacy-upe-to-split
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+When enabling WooPay, if legacy UPE is enabled, upgrades feature flag to split UPE instead.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1762,7 +1762,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$this->update_option( 'platform_checkout', $is_platform_checkout_enabled ? 'yes' : 'no' );
 			if ( ! $is_platform_checkout_enabled ) {
 				Platform_Checkout_Order_Status_Sync::remove_webhook();
-			} elseif ( WC_Payments_Features::is_upe_legacy_enabled() && WC_Payments_Features::is_upe_split_eligible() ) {
+			} elseif ( WC_Payments_Features::is_upe_legacy_enabled() ) {
 				update_option( WC_Payments_Features::UPE_FLAG_NAME, '0' );
 				update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1762,9 +1762,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$this->update_option( 'platform_checkout', $is_platform_checkout_enabled ? 'yes' : 'no' );
 			if ( ! $is_platform_checkout_enabled ) {
 				Platform_Checkout_Order_Status_Sync::remove_webhook();
-			} elseif ( WC_Payments_Features::is_upe_legacy_enabled() ) {
-				$this->update_option( WC_Payments_Features::UPE_FLAG_NAME, '0' );
-				$this->update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
+			} elseif ( WC_Payments_Features::is_upe_legacy_enabled() && WC_Payments_Features::is_upe_split_eligible() ) {
+				update_option( WC_Payments_Features::UPE_FLAG_NAME, '0' );
+				update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
 
 				if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
 					wc_admin_record_tracks_event( 'wcpay_split_upe_enabled' );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1763,8 +1763,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			if ( ! $is_platform_checkout_enabled ) {
 				Platform_Checkout_Order_Status_Sync::remove_webhook();
 			} elseif ( WC_Payments_Features::is_upe_legacy_enabled() ) {
-				update_option( WC_Payments_Features::UPE_FLAG_NAME, '0' );
-				update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
+				$this->update_option( WC_Payments_Features::UPE_FLAG_NAME, '0' );
+				$this->update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
 
 				if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
 					wc_admin_record_tracks_event( 'wcpay_split_upe_enabled' );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1765,6 +1765,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			} elseif ( WC_Payments_Features::is_upe_legacy_enabled() ) {
 				update_option( WC_Payments_Features::UPE_FLAG_NAME, '0' );
 				update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
+
+				if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
+					wc_admin_record_tracks_event( 'wcpay_split_upe_enabled' );
+				}
 			}
 		}
 	}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1762,6 +1762,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$this->update_option( 'platform_checkout', $is_platform_checkout_enabled ? 'yes' : 'no' );
 			if ( ! $is_platform_checkout_enabled ) {
 				Platform_Checkout_Order_Status_Sync::remove_webhook();
+			} elseif ( WC_Payments_Features::is_upe_legacy_enabled() ) {
+				update_option( WC_Payments_Features::UPE_FLAG_NAME, '0' );
+				update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
 			}
 		}
 	}

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -623,6 +623,19 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( 'no', $this->gateway->get_option( 'saved_cards' ) );
 	}
 
+	public function test_enable_platform_checkout_converts_upe_flag() {
+		$this->gateway->update_option( '_wcpay_feature_upe', '1' );
+		$this->gateway->update_option( '_wcpay_feature_upe_split', '0' );
+		$this->gateway->update_option( 'platform_checkout', 'no' );
+
+		$request = new WP_REST_Request();
+		$request->set_param( 'is_platform_checkout_enabled', true );
+
+		$this->controller->update_settings( $request );
+
+		$this->assertEquals( '0', $this->gateway->get_option( '_wcpay_feature_upe' ) );
+		$this->assertEquals( '1', $this->gateway->get_option( '_wcpay_feature_upe_split' ) );
+	}
 
 	public function deposit_schedules_data_provider() {
 		return [

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -624,8 +624,8 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_enable_platform_checkout_converts_upe_flag() {
-		$this->gateway->update_option( '_wcpay_feature_upe', '1' );
-		$this->gateway->update_option( '_wcpay_feature_upe_split', '0' );
+		update_option( '_wcpay_feature_upe', '1' );
+		update_option( '_wcpay_feature_upe_split', '0' );
 		$this->gateway->update_option( 'platform_checkout', 'no' );
 
 		$request = new WP_REST_Request();
@@ -633,8 +633,8 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 
 		$this->controller->update_settings( $request );
 
-		$this->assertEquals( '0', $this->gateway->get_option( '_wcpay_feature_upe' ) );
-		$this->assertEquals( '1', $this->gateway->get_option( '_wcpay_feature_upe_split' ) );
+		$this->assertEquals( '0', get_option( '_wcpay_feature_upe' ) );
+		$this->assertEquals( '1', get_option( '_wcpay_feature_upe_split' ) );
 	}
 
 	public function deposit_schedules_data_provider() {


### PR DESCRIPTION
Fixes #5612 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
# Enabling WooPay automatically enables split UPE for legacy UPE users
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

When WooPay is enabled from the WCPay settings. If the legacy UPE flag (`_wcpay_feature_upe`) is switched on, we must toggle this flag off, and toggle the split UPE flag (`_wcpay_feature_upe_split`) on instead.

WIP (maybe?).

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
1. Ensure legacy UPE is enabled on site.
2. Enable WooPay from WCPay settings.
3. Legacy UPE should be automatically disabled and split UPE should be enabled instead.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
