### PR TITLE
Fix monthly deposit schedule displayed incorrectly as '3rd' or '31st' when schedule set to 'Last day of the month'

### DIFF
--- a/changelog/fix-5616-deposits-monthly-schedule-anchor-incorrect
+++ b/changelog/fix-5616-deposits-monthly-schedule-anchor-incorrect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix deposit schedule monthly anchor label when set to 'last day of the month'.

--- a/client/deposits/utils/index.js
+++ b/client/deposits/utils/index.js
@@ -48,6 +48,32 @@ export const getNextDepositLabelFormatted = ( deposit ) => {
 	return baseLabel;
 };
 
+export const getDepositMonthlyAnchorLabel = ( {
+	monthlyAnchor,
+	capitalize = true,
+} ) => {
+	// If locale is set up as en_US or en_GB the ordinal will not show up
+	// More details can be found in https://github.com/WordPress/gutenberg/issues/15221/
+	// Using 'en' as the locale should be enough to workaround it
+	// TODO: Remove workaround when issue is resolved
+	const fixedLocale = moment.locale().startsWith( 'en' )
+		? 'en'
+		: moment.locale();
+
+	let label = moment()
+		.locale( fixedLocale )
+		.date( monthlyAnchor )
+		.format( 'Do' );
+
+	if ( 31 === monthlyAnchor ) {
+		label = __( 'Last day of the month', 'woocommerce-payments' );
+	}
+	if ( ! capitalize ) {
+		label = label.toLowerCase();
+	}
+	return label;
+};
+
 const formatDepositSchedule = ( schedule ) => {
 	switch ( schedule.interval ) {
 		case 'manual':
@@ -67,23 +93,16 @@ const formatDepositSchedule = ( schedule ) => {
 					.format( 'dddd' )
 			);
 		case 'monthly':
-			// If locale is set up as en_US or en_GB the ordinal will not show up
-			// More details can be found in https://github.com/WordPress/gutenberg/issues/15221/
-			// Using 'en' as the locale should be enough to workaround it
-			// TODO: Remove workaround when issue is resolved
-			const fixedLocale = moment.locale().startsWith( 'en' )
-				? 'en'
-				: moment.locale();
 			return sprintf(
 				/** translators: %s day of the month */
 				__(
 					'Deposits set to monthly on the %s.',
 					'woocommerce-payments'
 				),
-				moment()
-					.locale( fixedLocale )
-					.date( schedule.monthly_anchor )
-					.format( 'Do' )
+				getDepositMonthlyAnchorLabel( {
+					monthlyAnchor: schedule.monthly_anchor,
+					capitalize: false,
+				} )
 			);
 	}
 };

--- a/client/deposits/utils/test/index.js
+++ b/client/deposits/utils/test/index.js
@@ -114,6 +114,16 @@ describe( 'Deposits Overview Utils / getDepositScheduleDescriptor', () => {
 		);
 	} );
 
+	test( 'renders deposit schedule for monthly interval', () => {
+		const depositSchedule = getDepositSchedule( {
+			interval: 'monthly',
+			monthly_anchor: 31,
+		} );
+		expect( depositSchedule ).toEqual(
+			'Deposits set to monthly on the last day of the month.'
+		);
+	} );
+
 	test( 'renders weekly anchor for non en locales', () => {
 		momentLib.locale( 'de' );
 		const depositSchedule = getDepositSchedule( {

--- a/client/deposits/utils/test/index.js
+++ b/client/deposits/utils/test/index.js
@@ -12,6 +12,7 @@ import {
 	getBalanceDepositCount,
 	getNextDepositLabelFormatted,
 	getDepositScheduleDescriptor,
+	getDepositMonthlyAnchorLabel,
 } from './..';
 
 function getDepositSchedule(
@@ -186,5 +187,63 @@ describe( 'Deposits Overview Utils / getNextDepositLabelFormatted', () => {
 		expect( getNextDepositLabelFormatted( deposit ) ).toEqual(
 			'Est. Apr 18, 2019 - In transit'
 		);
+	} );
+} );
+
+describe( 'Deposits Overview Utils / getDepositMonthlyAnchorLabel', () => {
+	const expectedLabels = [
+		{ label: '1st', value: 1 },
+		{ label: '2nd', value: 2 },
+		{ label: '3rd', value: 3 },
+		{ label: '4th', value: 4 },
+		{ label: '5th', value: 5 },
+		{ label: '6th', value: 6 },
+		{ label: '7th', value: 7 },
+		{ label: '8th', value: 8 },
+		{ label: '9th', value: 9 },
+		{ label: '10th', value: 10 },
+		{ label: '11th', value: 11 },
+		{ label: '12th', value: 12 },
+		{ label: '13th', value: 13 },
+		{ label: '14th', value: 14 },
+		{ label: '15th', value: 15 },
+		{ label: '16th', value: 16 },
+		{ label: '17th', value: 17 },
+		{ label: '18th', value: 18 },
+		{ label: '19th', value: 19 },
+		{ label: '20th', value: 20 },
+		{ label: '21st', value: 21 },
+		{ label: '22nd', value: 22 },
+		{ label: '23rd', value: 23 },
+		{ label: '24th', value: 24 },
+		{ label: '25th', value: 25 },
+		{ label: '26th', value: 26 },
+		{ label: '27th', value: 27 },
+		{ label: '28th', value: 28 },
+		{
+			label: 'Last day of the month',
+			value: 31,
+		},
+	];
+
+	test( 'returns the expected label', () => {
+		momentLib.locale( 'en' );
+		expectedLabels.forEach( ( expectedLabel ) => {
+			expect(
+				getDepositMonthlyAnchorLabel( {
+					monthlyAnchor: expectedLabel.value,
+				} )
+			).toEqual( expectedLabel.label );
+		} );
+	} );
+
+	test( 'returns a lowercase value with false capitalize argument', () => {
+		momentLib.locale( 'en' );
+		expect(
+			getDepositMonthlyAnchorLabel( {
+				monthlyAnchor: 31,
+				capitalize: false,
+			} )
+		).toEqual( 'last day of the month' );
 	} );
 } );

--- a/client/settings/deposits/index.js
+++ b/client/settings/deposits/index.js
@@ -14,6 +14,7 @@ import HelpOutlineIcon from 'gridicons/dist/help-outline';
 /**
  * Internal dependencies
  */
+import { getDepositMonthlyAnchorLabel } from 'wcpay/deposits/utils';
 import WCPaySettingsContext from '../wcpay-settings-context';
 import CardBody from '../card-body';
 import {
@@ -36,40 +37,14 @@ const daysOfWeek = [
 	{ label: __( 'Friday', 'woocommerce-payments' ), value: 'friday' },
 ];
 
+// Monthly deposit schedule anchors: 1-28 labelled with ordinal suffix and 31 labelled as "Last day of the month".
 const monthlyAnchors = [
-	{ label: __( '1st', 'woocommerce-payments' ), value: 1 },
-	{ label: __( '2nd', 'woocommerce-payments' ), value: 2 },
-	{ label: __( '3rd', 'woocommerce-payments' ), value: 3 },
-	{ label: __( '4th', 'woocommerce-payments' ), value: 4 },
-	{ label: __( '5th', 'woocommerce-payments' ), value: 5 },
-	{ label: __( '6th', 'woocommerce-payments' ), value: 6 },
-	{ label: __( '7th', 'woocommerce-payments' ), value: 7 },
-	{ label: __( '8th', 'woocommerce-payments' ), value: 8 },
-	{ label: __( '9th', 'woocommerce-payments' ), value: 9 },
-	{ label: __( '10th', 'woocommerce-payments' ), value: 10 },
-	{ label: __( '11th', 'woocommerce-payments' ), value: 11 },
-	{ label: __( '12th', 'woocommerce-payments' ), value: 12 },
-	{ label: __( '13th', 'woocommerce-payments' ), value: 13 },
-	{ label: __( '14th', 'woocommerce-payments' ), value: 14 },
-	{ label: __( '15th', 'woocommerce-payments' ), value: 15 },
-	{ label: __( '16th', 'woocommerce-payments' ), value: 16 },
-	{ label: __( '17th', 'woocommerce-payments' ), value: 17 },
-	{ label: __( '18th', 'woocommerce-payments' ), value: 18 },
-	{ label: __( '19th', 'woocommerce-payments' ), value: 19 },
-	{ label: __( '20th', 'woocommerce-payments' ), value: 20 },
-	{ label: __( '21st', 'woocommerce-payments' ), value: 21 },
-	{ label: __( '22nd', 'woocommerce-payments' ), value: 22 },
-	{ label: __( '23rd', 'woocommerce-payments' ), value: 23 },
-	{ label: __( '24th', 'woocommerce-payments' ), value: 24 },
-	{ label: __( '25th', 'woocommerce-payments' ), value: 25 },
-	{ label: __( '26th', 'woocommerce-payments' ), value: 26 },
-	{ label: __( '27th', 'woocommerce-payments' ), value: 27 },
-	{ label: __( '28th', 'woocommerce-payments' ), value: 28 },
-	{
-		label: __( 'Last day of the month', 'woocommerce-payments' ),
-		value: 31,
-	},
-];
+	...Array.from( { length: 28 }, ( _, i ) => i + 1 ),
+	31,
+].map( ( anchor ) => ( {
+	value: anchor,
+	label: getDepositMonthlyAnchorLabel( { monthlyAnchor: anchor } ),
+} ) );
 
 const CustomizeDepositSchedule = () => {
 	const [


### PR DESCRIPTION
Fixes #5616
Fixes #5662

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR correctly renders the monthly deposit schedule as `monthly on the last day of the month` on the **Payments → Overview** screen when the schedule has been set to 'Last day of the month'.

<img width="687" alt="image" src="https://user-images.githubusercontent.com/3147296/221473878-048cc262-341d-44de-90d6-0fa916100760.png">

Logic for determining the monthly anchor label was used across 2 files ([1](https://github.com/Automattic/woocommerce-payments/blob/8085bf0057dc1e7c5453a7cdfd3d6be2a883daa0/client/deposits/utils/index.js/#L77-L87), [2](https://github.com/Automattic/woocommerce-payments/blob/8085bf0057dc1e7c5453a7cdfd3d6be2a883daa0/client/settings/deposits/index.js/#L39-L72)), therefore I've combined this logic into the `getDepositMonthlyAnchorLabel` function:

https://github.com/Automattic/woocommerce-payments/blob/eec5e7874dd0be58b9fb7010c1130b57007f1e4c/client/deposits/utils/index.js#L51-L54

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to **Payments → Settings**.
2. Set the deposit schedule to **Last day of the month** and click save. Also ensure all select input options are rendered correctly (1st-28th + 'Last day of the month').

   <img width="1078" alt="image" src="https://user-images.githubusercontent.com/3147296/221476668-6c3ae83a-0dfb-46da-aff6-bd43f76237ff.png">

4. Go to **Payments → Overview**.
5. Check that the deposit schedule is displayed as "Deposits set to monthly on the last day of the month."
6. Repeat steps 2-5 with various `daily`, `weekly` and `monthly` schedules, ensuring that the expected label is displayed on the **Payments → Overview** screen.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests **Yes**
- [x] Tested on mobile **Yes**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
