### PR TITLE
Right align customize button on the settings page

### DIFF
--- a/changelog/fix-5601
+++ b/changelog/fix-5601
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Right align cutomize button on the settings page

--- a/client/settings/express-checkout/style.scss
+++ b/client/settings/express-checkout/style.scss
@@ -71,7 +71,7 @@
 			}
 
 			&__link {
-				margin-left: 16px;
+				margin-left: auto;
 				padding: 12px;
 				border: 1px solid #007cba;
 				border-radius: 2px;


### PR DESCRIPTION
Fixes #5601 

#### Changes proposed in this Pull Request
Update the margin so that when the content width is different, the customize button is still right aligned. 

**Before**
<img width="831" alt="Screen Shot 2023-02-26 at 10 03 26 PM" src="https://user-images.githubusercontent.com/56378160/221494276-3a2cc411-b368-430c-bf9a-322b68d0cad6.png">

**After**
<img width="674" alt="Screen Shot 2023-02-26 at 10 22 17 PM" src="https://user-images.githubusercontent.com/56378160/221494287-7eeecbed-d5bb-4d9c-b3c6-8b31230747d6.png">


#### Testing instructions
1. Go to WooCommerce -> Settings -> Payments -> Express checkouts
2. Check the customize button is right-aligned


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
