### PR TITLE
Prevent auto-scroll on the checkout page on page load when WooPay is enabled

### DIFF
--- a/changelog/as-prevent-auto-scroll-woopay-checkout
+++ b/changelog/as-prevent-auto-scroll-woopay-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent auto-scroll on page load when WooPay is enabled.

--- a/client/checkout/platform-checkout/email-input-iframe.js
+++ b/client/checkout/platform-checkout/email-input-iframe.js
@@ -443,7 +443,9 @@ export const handlePlatformCheckoutEmailInput = async (
 	const closeLoginSessionIframe = () => {
 		loginSessionIframeWrapper.remove();
 		loginSessionIframe.classList.remove( 'open' );
-		platformCheckoutEmailInput.focus();
+		platformCheckoutEmailInput.focus( {
+			preventScroll: true,
+		} );
 
 		// Check the initial value of the email input and trigger input validation.
 		if ( validateEmail( platformCheckoutEmailInput.value ) ) {


### PR DESCRIPTION
Fixes 1641-gh-Automattic/woopay


#### Changes proposed in this Pull Request
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR prevents the auto-scroll from happening when the email input is focused on page load.

Initially, there was another auto-scroll triggered by the Coupon input that was fixed in https://github.com/woocommerce/woocommerce-blocks/pull/8525. This PR fixes the second auto-scroll triggered by the focus event on email input.



<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

Check the following video to see the original issue this PR fixes: 

https://user-images.githubusercontent.com/1025173/221721870-f2d0dece-caa4-4d57-9ab4-52175af78012.mp4



&nbsp;
**Now with the fix applied:**


https://user-images.githubusercontent.com/1025173/221723478-ea18fb41-f1d4-402f-87eb-31379366bcca.mp4

&nbsp;
&nbsp;
&nbsp;
```
- User visits checkout page
    - shortcode checkout
        - with fix    : ✅ focuses, no scroll.
        - without fix : ❌ focuses, auto-scroll.
    - block checkout
        - with fix    : ✅ focuses, no scroll.
        - without fix : ❌ focuses, auto-scroll.
- WooPay user exists
    - shortcode checkout
        - with fix    : ✅ focuses, auto-scroll, modal is opened.
        - without fix : ✅ focuses, auto-scroll, modal is opened.
    - block checkout
        - with fix    : ✅ focuses, auto-scroll, modal is opened.
        - without fix : ✅ focuses, auto-scroll, modal is opened.
- User is logged in WooPay
    - shortcode checkout
        - with fix    : ✅ no auto-scroll, modal is opened, auto redirect.
        - without fix :  ✅ no auto-scroll, modal is opened, auto redirect.
    - block checkout
        - with fix    : ✅ no auto-scroll, modal is opened, auto redirect.
        - without fix : ✅ no auto-scroll, modal is opened, auto redirect.

```


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.