### PR TITLE
Ensure Subscription integration hooks during initialization is only run once

### DIFF
--- a/changelog/fix-upe-renewal-multi-charges
+++ b/changelog/fix-upe-renewal-multi-charges
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix subscription renewal creating multiple charges with UPE.

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -103,7 +103,7 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 
 		/*
 		 * Base set of subscription features to add.
-		 * The WCPay payment gateway supports these feautres
+		 * The WCPay payment gateway supports these features
 		 * for both WCPay Subscriptions and WooCommerce Subscriptions.
 		 */
 		$payment_gateway_features = [

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-payment-method-order-note.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-payment-method-order-note.php
@@ -75,6 +75,16 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Payment_Method_Order_Note_Test exte
 	 */
 	private $mock_wcpay_account;
 
+	public function tear_down() {
+		parent::tear_down();
+
+		// So that the gateway hooks are re-attached for the next test, we need to reset the flag that prevents the integration hooks from being attached.
+		$reflection = new \ReflectionClass( $this->wcpay_gateway );
+		$property   = $reflection->getProperty( 'has_attached_integration_hooks' );
+		$property->setAccessible( true );
+		$property->setValue( $this->wcpay_gateway, false );
+	}
+
 	public function set_up() {
 		parent::set_up();
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -680,7 +680,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 		remove_all_actions( 'woocommerce_admin_order_data_after_billing_address' );
 
 		WC_Subscriptions::$version = '3.0.7';
-		new \WC_Payment_Gateway_WCPay(
+
+		$payment_gateway = new \WC_Payment_Gateway_WCPay(
 			$this->mock_api_client,
 			$this->mock_wcpay_account,
 			$this->mock_customer_service,
@@ -689,6 +690,13 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 			$this->mock_session_rate_limiter,
 			$this->order_service
 		);
+
+		// Ensure the has_attached_integration_hooks property is set to false so callbacks can be attached in maybe_init_subscriptions().
+		$ref = new ReflectionProperty( $payment_gateway, 'has_attached_integration_hooks' );
+		$ref->setAccessible( true );
+		$ref->setValue( null, false );
+
+		$payment_gateway->maybe_init_subscriptions();
 
 		$this->assertTrue( has_action( 'woocommerce_admin_order_data_after_billing_address' ) );
 	}


### PR DESCRIPTION
Fixes #5615

#### Changes proposed in this Pull Request

<sup>❗ **Problem description largley copied from https://github.com/Automattic/woocommerce-payments/pull/5619**</sup>

This PR addresses the issue that was discovered in https://github.com/Automattic/woocommerce-payments/issues/5615. In short, the issue was that subscription renewals were being charged multiple times. It was discovered that it was running a separate transaction for as many UPE payment methods that were available + 1. 

We discovered this was due to the fact that the `woocommerce_scheduled_subscription_payment_woocommerce_payments` action was being added for every payment method class. This was happening since each class was ultimately inheriting from `WC_Payment_Gateway_WCPay` which calls `maybe_init_subscriptions()` in it's constructor and each class was calling it's parent constructor within its own constructor.

To address this issue, this PR introduces an early exit criteria to `maybe_init_subscriptions()` which will prevent multiple calls from attaching multiple callbacks. This approach was originally suggested by @hsingyuc [here](https://github.com/Automattic/woocommerce-payments/pull/5619/files#r1119448666).

These callbacks were only intended to be run once, not once for each payment method (including all the UPE ones). What's more, at the current time, it is only intended to run while `woocommerce_payments` is the method ID (via `$this->id`). As has been discussed in these two Slack threads:

- p1677546873476009/1677504529.971689-slack-C04RDE70TUJ
- p1677540409817719/1677504089.424059-slack-C04RDE70TUJ

As UPE support for subscriptions is rolled out, it's possible this will extend to other payment methods with different IDs, however to get ahead of that and to avoid forgetting and reintroducing this duplication, I've also made sure that we only attach the callbacks for the `woocommerce_payments` ID and I've left a comment to be explicit about the care needed if this is broadened in the future.

#### Testing instructions

<sup>❗ **Testing instructions copied from https://github.com/Automattic/woocommerce-payments/pull/5619**</sup>

The following test should all be performed under each of these four scenarios:
- No UPE at all.
- Legacy UPE.
- Split UPE without WooPay.
- Split UPE with WooPay.

1. Configure store for the current scenario you are testing above.
2. If not already present, install the WC Subscriptions plugin and add a subscription product.
3. Go to checkout a subscription product using a CC.
4. Confirm subscription checkout was successful and a subscription was created.
5. Now as merchant admin, go into the subscription that was created and under the subscription actions, choose "Process Renewal" and hit Update.
6. Confirm that the renewal order was created and paid under the subscription order page under "Related Orders".
7. Log into the Stripe dashboard and view the test merchant account's payments and confirm that there is only one charge for the renewal.

After confirmation of the above, run an additional test with a subscription and SEPA.
1. Enable SEPA on your merchant account from the Stripe dashboard.
2. Restart your local WCPay server memcache instance to clear cached account data.
3. Refresh account data on merchant store with the dev tools.
4. Under Payment settings, make sure SEPA is enabled.
5. Checkout with a subscription product and repeat steps 5, 6, and 7 from above.

**Note:** While the scenarios above will cover the primary expected areas of impact, it wouldn't hurt to confirm some processes with WooPay enabled and disabled in non-UPE and legacy UPE as well.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.