### PR TITLE
Hotfix Ensure Subscription Initialization is only run once

### DIFF
--- a/changelog/hotfix-upe-renewals-multi-charge
+++ b/changelog/hotfix-upe-renewals-multi-charge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix subscription renewal creating multiple charges with UPE.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -382,9 +382,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// Load the settings.
 		$this->init_settings();
 
-		// Check if subscriptions are enabled and add support for them.
-		$this->maybe_init_subscriptions();
-
 		// If the setting to enable saved cards is enabled, then we should support tokenization and adding payment methods.
 		if ( $this->is_saved_cards_enabled() ) {
 			array_push( $this->supports, 'tokenization', 'add_payment_method' );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -409,6 +409,8 @@ class WC_Payments {
 			self::$wc_payments_checkout = new WC_Payments_Checkout( self::$legacy_card_gateway, self::$platform_checkout_util, self::$account, self::$customer_service );
 		}
 
+		self::$card_gateway->maybe_init_subscriptions();
+
 		self::$webhook_processing_service  = new WC_Payments_Webhook_Processing_Service( self::$api_client, self::$db_helper, self::$account, self::$remote_note_service, self::$order_service, self::$in_person_payments_receipts_service, self::get_gateway(), self::$customer_service, self::$database_cache );
 		self::$webhook_reliability_service = new WC_Payments_Webhook_Reliability_Service( self::$api_client, self::$action_scheduler_service, self::$webhook_processing_service );
 

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -133,7 +133,9 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 		add_filter( 'woocommerce_email_classes', [ $this, 'add_emails' ], 20 );
 		add_filter( 'woocommerce_available_payment_gateways', [ $this, 'prepare_order_pay_page' ] );
 
-		add_action( 'woocommerce_scheduled_subscription_payment_' . $this->id, [ $this, 'scheduled_subscription_payment' ], 10, 2 );
+		if ( ! has_action( 'woocommerce_scheduled_subscription_payment_' . $this->id ) ) {
+			add_action( 'woocommerce_scheduled_subscription_payment_' . $this->id, [ $this, 'scheduled_subscription_payment' ], 10, 2 );
+		}
 		add_action( 'woocommerce_subscription_failing_payment_method_updated_' . $this->id, [ $this, 'update_failing_payment_method' ], 10, 2 );
 		add_filter( 'wc_payments_display_save_payment_method_checkbox', [ $this, 'display_save_payment_method_checkbox' ], 10 );
 

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -118,7 +118,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$mock_rate_limiter        = $this->createMock( Session_Rate_Limiter::class );
 		$order_service            = new WC_Payments_Order_Service( $this->mock_api_client );
 
-		$this->gateway    = new WC_Payment_Gateway_WCPay(
+		$this->gateway = new WC_Payment_Gateway_WCPay(
 			$this->mock_api_client,
 			$this->mock_wcpay_account,
 			$customer_service,
@@ -127,6 +127,8 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 			$mock_rate_limiter,
 			$order_service
 		);
+		$this->gateway->maybe_init_subscriptions();
+
 		$this->controller = new WC_REST_Payments_Settings_Controller( $this->mock_api_client, $this->gateway );
 
 		$mock_payment_methods   = [];
@@ -165,6 +167,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 			$mock_rate_limiter,
 			$order_service
 		);
+		$this->mock_upe_payment_gateway->maybe_init_subscriptions();
 
 		$this->upe_controller = new WC_REST_Payments_Settings_Controller( $this->mock_api_client, $this->mock_upe_payment_gateway );
 
@@ -179,6 +182,7 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 			$mock_rate_limiter,
 			$order_service
 		);
+		$this->mock_upe_split_payment_gateway->maybe_init_subscriptions();
 
 		$this->upe_split_controller = new WC_REST_Payments_Settings_Controller( $this->mock_api_client, $this->mock_upe_split_payment_gateway );
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-payment-method-order-note.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-payment-method-order-note.php
@@ -115,6 +115,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Payment_Method_Order_Note_Test exte
 			$this->mock_session_rate_limiter,
 			$this->mock_order_service
 		);
+		$this->wcpay_gateway->maybe_init_subscriptions();
 
 		$this->renewal_order = WC_Helper_Order::create_order( self::USER_ID );
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -113,6 +113,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 			$this->mock_session_rate_limiter,
 			$this->order_service
 		);
+		$this->wcpay_gateway->maybe_init_subscriptions();
 	}
 
 	public static function tear_down_after_class() {
@@ -680,7 +681,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 		remove_all_actions( 'woocommerce_admin_order_data_after_billing_address' );
 
 		WC_Subscriptions::$version = '3.0.7';
-		new \WC_Payment_Gateway_WCPay(
+		$gateway                   = new \WC_Payment_Gateway_WCPay(
 			$this->mock_api_client,
 			$this->mock_wcpay_account,
 			$this->mock_customer_service,
@@ -689,6 +690,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 			$this->mock_session_rate_limiter,
 			$this->order_service
 		);
+		$gateway->maybe_init_subscriptions();
 
 		$this->assertTrue( has_action( 'woocommerce_admin_order_data_after_billing_address' ) );
 	}
@@ -697,7 +699,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 		remove_all_actions( 'woocommerce_admin_order_data_after_billing_address' );
 
 		WC_Subscriptions::$version = '3.0.8';
-		new \WC_Payment_Gateway_WCPay(
+		$gateway                   = new \WC_Payment_Gateway_WCPay(
 			$this->mock_api_client,
 			$this->mock_wcpay_account,
 			$this->mock_customer_service,
@@ -706,6 +708,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 			$this->mock_session_rate_limiter,
 			$this->order_service
 		);
+		$gateway->maybe_init_subscriptions();
 
 		$this->assertFalse( has_action( 'woocommerce_admin_order_data_after_billing_address' ) );
 	}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -166,6 +166,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			$this->mock_rate_limiter,
 			$this->order_service
 		);
+		$this->wcpay_gateway->maybe_init_subscriptions();
 
 		$this->platform_checkout_utilities = new Platform_Checkout_Utilities();
 

--- a/tests/unit/test-class-wc-payments-payment-request-button-handler.php
+++ b/tests/unit/test-class-wc-payments-payment-request-button-handler.php
@@ -144,7 +144,7 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 		$mock_rate_limiter             = $this->createMock( Session_Rate_Limiter::class );
 		$mock_order_service            = $this->createMock( WC_Payments_Order_Service::class );
 
-		return new WC_Payment_Gateway_WCPay(
+		$gateway = new WC_Payment_Gateway_WCPay(
 			$this->mock_api_client,
 			$this->mock_wcpay_account,
 			$mock_customer_service,
@@ -153,6 +153,8 @@ class WC_Payments_Payment_Request_Button_Handler_Test extends WCPAY_UnitTestCase
 			$mock_rate_limiter,
 			$mock_order_service
 		);
+		$gateway->maybe_init_subscriptions();
+		return $gateway;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5615 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
This PR addresses the issue that was discovered in #5615. In short, the issue was that subscription renewals were running multiple charges for each renewal. It was discovered that it was running transactions for as many UPE payment methods that were available + 1. We discovered this was due to the fact that the `woocommerce_scheduled_subscription_payment_woocommerce_payments` action was being added for every payment method class. This was happening since each class was ultimately inheriting from `WC_Payment_Gateway_WCPay` which calls `maybe_init_subscriptions` in it's constructor and each class was calling it's parent contructor within it's own constructor.

To address this issue we took two steps, one to explicity avoid this renewal duplicate charge issue and one to avoid any other oddities that might have been waiting in hiding due to the multiple calls to `maybe_init_subscriptions`. 

- Addressing the renewal duplicate charge issue explicitly involved checking for the existence of the `woocommerce_scheduled_subscription_payment_woocommerce_payments` before adding it. In this way we ensure that the action is only ever added once (and thus only ever called once).
- Avoiding any further oddites involved removing the `maybe_init_subscriptions` from the `WC_Payment_Gateway_WCPay` constructor and instead calling it explicitly once all the of the enabled / relevant gateways have been instantiated.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
The following test should all be performed under each of these four scenarios:
- No UPE at all.
- Legacy UPE.
- Split UPE without WooPay.
- Split UPE with WooPay.

1. Configure store for the current scenario you are testing above.
2. If not already present, install the WC Subscriptions plugin and add a subscription product.
3. Go to checkout a subscription product using a CC.
4. Confirm subscription checkout was successful and a subscription was created.
5. Now as merchant admin, go into the subscription that was created and under the subscription actions, choose "Process Renewal" and hit Update.
6. Confirm that the renewal order was created and paid under the subscription order page under "Related Orders".
7. Log into the Stripe dashboard and view the test merchant account's payments and confirm that there is only one charge for the renewal.

After confirmation of the above, run an additional test with a subscription and SEPA.
1. Enable SEPA on your merchant account from the Stripe dashboard.
2. Restart your local WCPay server memcache instance to clear cached account data.
3. Refresh account data on merchant store with the dev tools.
4. Under Payment settings, make sure SEPA is enabled.
5. Checkout with a subscription product and repeat steps 5, 6, and 7 from above.

**Note:** While the scenarios above will cover the primary expected areas of impact, it wouldn't hurt to confirm some processes with WooPay enabled and disabled in non-UPE and legacy UPE as well.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
