### PR TITLE
Add fraud and risk tools feature flag

### DIFF
--- a/changelog/add-3046-add-fraud-and-risk-tools-feature-flag
+++ b/changelog/add-3046-add-fraud-and-risk-tools-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add a feature flag for fraud and risk tools features.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -495,48 +495,49 @@ class WC_Payments_Admin {
 		$account_status_data = $this->account->get_account_status_data();
 
 		$wcpay_settings = [
-			'connectUrl'                 => WC_Payments_Account::get_connect_url(),
-			'connect'                    => [
+			'connectUrl'                       => WC_Payments_Account::get_connect_url(),
+			'connect'                          => [
 				'country'            => WC()->countries->get_base_country(),
 				'availableCountries' => WC_Payments_Utils::supported_countries(),
 				'availableStates'    => WC()->countries->get_states(),
 			],
-			'testMode'                   => WC_Payments::mode()->is_test(),
+			'testMode'                         => WC_Payments::mode()->is_test(),
 			// set this flag for use in the front-end to alter messages and notices if on-boarding has been disabled.
-			'onBoardingDisabled'         => WC_Payments_Account::is_on_boarding_disabled(),
-			'errorMessage'               => $error_message,
-			'featureFlags'               => $this->get_frontend_feature_flags(),
-			'isSubscriptionsActive'      => class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '2.2.0', '>=' ),
+			'onBoardingDisabled'               => WC_Payments_Account::is_on_boarding_disabled(),
+			'errorMessage'                     => $error_message,
+			'featureFlags'                     => $this->get_frontend_feature_flags(),
+			'isSubscriptionsActive'            => class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '2.2.0', '>=' ),
 			// used in the settings page by the AccountFees component.
-			'zeroDecimalCurrencies'      => WC_Payments_Utils::zero_decimal_currencies(),
-			'fraudServices'              => $this->account->get_fraud_services_config(),
-			'isJetpackConnected'         => $this->payments_api_client->is_server_connected(),
-			'isJetpackIdcActive'         => Jetpack_Identity_Crisis::has_identity_crisis(),
-			'accountStatus'              => $account_status_data,
-			'accountFees'                => $this->account->get_fees(),
-			'accountLoans'               => $this->account->get_capital(),
-			'accountEmail'               => $this->account->get_account_email(),
-			'showUpdateDetailsTask'      => $this->get_should_show_update_business_details_task( $account_status_data ),
-			'wpcomReconnectUrl'          => $this->payments_api_client->is_server_connected() && ! $this->payments_api_client->has_server_connection_owner() ? WC_Payments_Account::get_wpcom_reconnect_url() : null,
-			'additionalMethodsSetup'     => [
+			'zeroDecimalCurrencies'            => WC_Payments_Utils::zero_decimal_currencies(),
+			'fraudServices'                    => $this->account->get_fraud_services_config(),
+			'isJetpackConnected'               => $this->payments_api_client->is_server_connected(),
+			'isJetpackIdcActive'               => Jetpack_Identity_Crisis::has_identity_crisis(),
+			'accountStatus'                    => $account_status_data,
+			'accountFees'                      => $this->account->get_fees(),
+			'accountLoans'                     => $this->account->get_capital(),
+			'accountEmail'                     => $this->account->get_account_email(),
+			'showUpdateDetailsTask'            => $this->get_should_show_update_business_details_task( $account_status_data ),
+			'wpcomReconnectUrl'                => $this->payments_api_client->is_server_connected() && ! $this->payments_api_client->has_server_connection_owner() ? WC_Payments_Account::get_wpcom_reconnect_url() : null,
+			'additionalMethodsSetup'           => [
 				'isUpeEnabled' => WC_Payments_Features::is_upe_enabled(),
 				'upeType'      => WC_Payments_Features::get_enabled_upe_type(),
 			],
-			'multiCurrencySetup'         => [
+			'multiCurrencySetup'               => [
 				'isSetupCompleted' => get_option( 'wcpay_multi_currency_setup_completed' ),
 			],
-			'isMultiCurrencyEnabled'     => WC_Payments_Features::is_customer_multi_currency_enabled(),
-			'isClientEncryptionEligible' => WC_Payments_Features::is_client_secret_encryption_eligible(),
-			'shouldUseExplicitPrice'     => WC_Payments_Explicit_Price_Formatter::should_output_explicit_price(),
-			'overviewTasksVisibility'    => [
+			'isMultiCurrencyEnabled'           => WC_Payments_Features::is_customer_multi_currency_enabled(),
+			'isClientEncryptionEligible'       => WC_Payments_Features::is_client_secret_encryption_eligible(),
+			'shouldUseExplicitPrice'           => WC_Payments_Explicit_Price_Formatter::should_output_explicit_price(),
+			'overviewTasksVisibility'          => [
 				'dismissedTodoTasks'     => get_option( 'woocommerce_dismissed_todo_tasks', [] ),
 				'deletedTodoTasks'       => get_option( 'woocommerce_deleted_todo_tasks', [] ),
 				'remindMeLaterTodoTasks' => get_option( 'woocommerce_remind_me_later_todo_tasks', [] ),
 			],
-			'currentUserEmail'           => $current_user_email,
-			'currencyData'               => $currency_data,
-			'restUrl'                    => get_rest_url( null, '' ), // rest url to concatenate when merchant use Plain permalinks.
-			'numDisputesNeedingResponse' => $this->get_disputes_awaiting_response_count(),
+			'currentUserEmail'                 => $current_user_email,
+			'currencyData'                     => $currency_data,
+			'restUrl'                          => get_rest_url( null, '' ), // rest url to concatenate when merchant use Plain permalinks.
+			'numDisputesNeedingResponse'       => $this->get_disputes_awaiting_response_count(),
+			'isFraudProtectionSettingsEnabled' => WC_Payments_Features::is_fraud_protection_settings_enabled(),
 		];
 
 		wp_localize_script(

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -227,6 +227,15 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Checks whether the Fraud Protection settings section display flag is enabled.
+	 *
+	 * @return  bool
+	 */
+	public static function is_fraud_protection_settings_enabled(): bool {
+		return '1' === get_option( 'wcpay_fraud_protection_settings_active', '0' );
+	}
+
+	/**
 	 * Returns feature flags as an array suitable for display on the front-end.
 	 *
 	 * @return bool[]

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -227,7 +227,7 @@ class WC_Payments_Features {
 	}
 
 	/**
-	 * Checks whether the Fraud Protection settings section display flag is enabled.
+	 * Checks whether the Fraud and Risk Tools feature flag is enabled.
 	 *
 	 * @return  bool
 	 */

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -230,6 +230,34 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		$this->assertTrue( WC_Payments_Features::is_upe_split_enabled() );
 	}
 
+	public function test_is_fraud_protection_settings_enabled_returns_true() {
+		add_filter(
+			'pre_option_wcpay_fraud_protection_settings_active',
+			function ( $pre_option, $option, $default ) {
+				return '1';
+			},
+			10,
+			3
+		);
+		$this->assertTrue( WC_Payments_Features::is_fraud_protection_settings_enabled() );
+	}
+
+	public function test_is_fraud_protection_settings_enabled_returns_false_when_flag_is_false() {
+		add_filter(
+			'pre_option_wcpay_fraud_protection_settings_active',
+			function ( $pre_option, $option, $default ) {
+				return '0';
+			},
+			10,
+			3
+		);
+		$this->assertFalse( WC_Payments_Features::is_fraud_protection_settings_enabled() );
+	}
+
+	public function test_is_fraud_protection_settings_enabled_returns_false_when_flag_is_not_set() {
+		$this->assertFalse( WC_Payments_Features::is_fraud_protection_settings_enabled() );
+	}
+
 	private function setup_enabled_flags( array $enabled_flags ) {
 		foreach ( array_keys( self::FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING ) as $flag ) {
 			add_filter(


### PR DESCRIPTION
Fixes [server issue #3046](https://github.com/Automattic/woocommerce-payments-server/issues/3046).

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

Add a feature flag for fraud and risk tools features on the client.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR adds code to allow you to enable or disable loading of fraud and risk tools related code in the WCPay client. We are adding this feature flag code separately as we expect to have more than one client PR that will rely on this feature flag during the continued development of fraud and risk tools. 

If you previously tested PR #5450, please ensure you don't have the feature flag's option active in your client's database prior to testing: `npm run wp option delete wcpay_fraud_protection_settings_active`.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch.
* All tests should pass.
* Apply the patch included below to add a simple fraud protection dummy section to the WCPay settings page.
* Visit the WCPay settings screen: `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments`
* Scroll to the bottom of the page. The last section you should see is the "Deposits" section. The fraud protection dummy section should not be rendered.

![deposits-screenshot](https://user-images.githubusercontent.com/60988591/221912353-1b9ccb68-7fa7-432d-8e93-dd6124c025e0.png)

* Run the following command to enable the section to be rendered: `npm run wp option add wcpay_fraud_protection_settings_active 1`
* Refresh the settings page and scroll to the bottom. The fraud protection dummy section should now be rendered below the deposits section.

![deposits-fraud-protection-screenshot](https://user-images.githubusercontent.com/60988591/221913204-a7502dd5-0929-402e-ade4-38e30ca43d63.png)

* Run the following command to prevent the section from being rendered: `npm run wp option update wcpay_fraud_protection_settings_active 0`
* Refresh the settings page and scroll to the bottom. The fraud protection dummy section should not be rendered below the deposits section.
* Delete the option from the database: `npm run wp option delete wcpay_fraud_protection_settings_active`
* Refresh the page to test that the fraud protection dummy section still does not render.

<details><summary><h4>Patch</h4></summary>

```patch
diff --git a/client/settings/settings-manager/index.js b/client/settings/settings-manager/index.js
index d6e0878b..0344d48f 100644
--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React, { useContext, useState } from 'react';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, Card } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -108,6 +108,22 @@ const DepositsDescription = () => {
 	);
 };
 
+const FraudProtectionDescription = () => {
+	return (
+		<>
+			<h2>{ __( 'Fraud Protection', 'woocommerce-payments' ) }</h2>
+			<p>
+				{ __(
+					'If this section is visible then the feature flag is enabled.',
+					'woocommerce-payments'
+				) }
+			</p>
+		</>
+	);
+};
+
+const fraudProtectionStyle = { padding: '0 0 0 24px' };
+
 const SettingsManager = () => {
 	const {
 		featureFlags: {
@@ -174,6 +190,28 @@ const SettingsManager = () => {
 					</LoadableSettingsSection>
 				</div>
 			</SettingsSection>
+			{ wcpaySettings.isFraudProtectionSettingsEnabled && (
+				<SettingsSection description={ FraudProtectionDescription }>
+					<LoadableSettingsSection numLines={ 20 }>
+						<ErrorBoundary>
+							<Card>
+								<h4 style={ fraudProtectionStyle }>
+									{ __(
+										'Testing Fraud & Risk Feature Flag',
+										'woocommerce-payments'
+									) }
+								</h4>
+								<p style={ fraudProtectionStyle }>
+									{ __(
+										'If this section is visible then the feature flag is enabled.',
+										'woocommerce-payment'
+									) }
+								</p>
+							</Card>
+						</ErrorBoundary>
+					</LoadableSettingsSection>
+				</SettingsSection>
+			) }
 			<AdvancedSettings />
 			<SaveSettingsSection disabled={ ! isTransactionInputsValid } />
 		</SettingsLayout>
```
</details>

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
