### PR TITLE
Automatically disable Link when WooPay is also enabled

### DIFF
--- a/changelog/fix-5648-disable-link-when-woopay-is-active
+++ b/changelog/fix-5648-disable-link-when-woopay-is-active
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent WooPay and Link to be enabled at the same time

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -643,8 +643,9 @@ class WC_Payments {
 
 			$payment_methods = self::$card_gateway->get_payment_method_ids_enabled_at_checkout();
 
-			if ( in_array( 'link', $payment_methods, true ) && self::$platform_checkout_button_handler->is_woopay_enabled() ) {
-				$key = array_search( 'link', $payment_methods, true );
+			$key = array_search( 'link', $payment_methods, true );
+
+			if ( $key !== false && self::$platform_checkout_button_handler->is_woopay_enabled() ) {
 				unset( $payment_methods[ $key ] );
 
 				self::get_gateway()->update_option( 'upe_enabled_payment_method_ids', $payment_methods );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -640,6 +640,16 @@ class WC_Payments {
 	 */
 	public static function register_gateway( $gateways ) {
 		if ( WC_Payments_Features::is_upe_split_enabled() ) {
+
+			$payment_methods = self::$card_gateway->get_payment_method_ids_enabled_at_checkout();
+
+			if ( in_array( 'link', $payment_methods, true ) && self::$platform_checkout_button_handler->is_woopay_enabled() ) {
+				$key = array_search( 'link', $payment_methods, true );
+				unset( $payment_methods[ $key ] );
+
+				self::get_gateway()->update_option( 'upe_enabled_payment_method_ids', $payment_methods );
+			}
+
 			if ( self::$platform_checkout_button_handler->is_woopay_enabled() ) {
 				$gateways[] = self::$legacy_card_gateway;
 			} else {
@@ -647,7 +657,7 @@ class WC_Payments {
 			}
 			$all_upe_gateways = [];
 			$reusable_methods = [];
-			foreach ( self::$card_gateway->get_payment_method_ids_enabled_at_checkout() as $payment_method_id ) {
+			foreach ( $payment_methods as $payment_method_id ) {
 				if ( 'card' === $payment_method_id || 'link' === $payment_method_id ) {
 					continue;
 				}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -645,7 +645,7 @@ class WC_Payments {
 
 			$key = array_search( 'link', $payment_methods, true );
 
-			if ( $key !== false && self::$platform_checkout_button_handler->is_woopay_enabled() ) {
+			if ( false !== $key && self::$platform_checkout_button_handler->is_woopay_enabled() ) {
 				unset( $payment_methods[ $key ] );
 
 				self::get_gateway()->update_option( 'upe_enabled_payment_method_ids', $payment_methods );


### PR DESCRIPTION
Fixes #5648

#### Changes proposed in this Pull Request
This PR disables Link when WooPay is active. To allow merchants to later choose between WooPay or Link.

#### Testing instructions
- While on `trunk` branch
- Enable UPE and Split UPE via Dev Tools
- Enable WooPay and Link at the same time. To allow this, remove [these lines](https://github.com/Automattic/woocommerce-payments/blob/trunk/client/settings/express-checkout/index.js#L82-L107) and [these lines](https://github.com/Automattic/woocommerce-payments/blob/trunk/client/settings/express-checkout/index.js#L325-L350)
- Now revert the changes in the code
- Reload the settings page and you should see the following

https://user-images.githubusercontent.com/6342964/221988548-2e7aca8a-f957-4962-90b7-71388cf38b50.mov

- Checkout to this PR branch and [re]load any page
- Now Link should be inactive and it is now possible do disable WooPay and then enable Link if necessary.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
