### PR TITLE
Load Checkout scripts when Cart Total is 0

### DIFF
--- a/changelog/fix-4764-load-js-zero-cart
+++ b/changelog/fix-4764-load-js-zero-cart
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-WCPay Checkout JS is loaded for zero carts

--- a/changelog/fix-5641-check-cart-initialized
+++ b/changelog/fix-5641-check-cart-initialized
@@ -1,5 +1,4 @@
 Significance: patch
 Type: fix
-Comment: It is a fix on top of #5423 which has a changelog
 
-
+WCPay Checkout JS is loaded for zero carts

--- a/changelog/fix-5641-check-cart-initialized
+++ b/changelog/fix-5641-check-cart-initialized
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: It is a fix on top of #5423 which has a changelog
+
+

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -635,12 +635,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		) {
 			WC_Payments::get_gateway()->tokenization_script();
 			$script_handle = 'WCPAY_CHECKOUT';
-			$js_object = 'wcpayConfig';
+			$js_object     = 'wcpayConfig';
 			if ( WC_Payments_Features::is_upe_split_enabled() ) {
-				$script_handle = 'wcpay-upe-checkout';
-				$js_object = 'wcpay_upe_config';
-			}  elseif ( WC_Payments_Features::is_upe_legacy_enabled() ) {
-				$script_handle = 'wcpay-upe-checkout';
+				  $script_handle = 'wcpay-upe-checkout';
+				  $js_object     = 'wcpay_upe_config';
+			} elseif ( WC_Payments_Features::is_upe_legacy_enabled() ) {
+				 $script_handle = 'wcpay-upe-checkout';
 			}
 			wp_localize_script( $script_handle, $js_object, WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() );
 			wp_enqueue_script( $script_handle );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -622,7 +622,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 	/**
 	 * Registers scripts necessary for the gateway, even when cart order total is 0.
-	 * This is done so that if the cart is modified via AJAX on checkout, 
+	 * This is done so that if the cart is modified via AJAX on checkout,
 	 * the scripts are still loaded.
 	 */
 	public function register_scripts_for_zero_order_total() {
@@ -644,7 +644,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				wp_localize_script( 'WCPAY_CHECKOUT', 'wcpayConfig', WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() );
 				wp_enqueue_script( 'WCPAY_CHECKOUT' );
 			}
-		} 
+		}
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -639,7 +639,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			if ( WC_Payments_Features::is_upe_split_enabled() ) {
 				$script_handle = 'wcpay-upe-checkout';
 				$js_object = 'wcpay_upe_config';
-			}  elseif ( WC_Payments_Features::is_upe_legacy_enabled() ) {;
+			}  elseif ( WC_Payments_Features::is_upe_legacy_enabled() ) {
 				$script_handle = 'wcpay-upe-checkout';
 			}
 			wp_localize_script( $script_handle, $js_object, WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -634,16 +634,16 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			! has_block( 'woocommerce/checkout' )
 		) {
 			WC_Payments::get_gateway()->tokenization_script();
-			if ( WC_Payments_Features::is_upe_legacy_enabled() ) {
-				wp_localize_script( 'wcpay-upe-checkout', 'wcpayConfig', WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() );
-				wp_enqueue_script( 'wcpay-upe-checkout' );
-			} elseif ( WC_Payments_Features::is_upe_split_enabled() ) {
-				wp_localize_script( 'wcpay-upe-checkout', 'wcpay_upe_config', WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() );
-				wp_enqueue_script( 'wcpay-upe-checkout' );
-			} else {
-				wp_localize_script( 'WCPAY_CHECKOUT', 'wcpayConfig', WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() );
-				wp_enqueue_script( 'WCPAY_CHECKOUT' );
+			$script_handle = 'WCPAY_CHECKOUT';
+			$js_object = 'wcpayConfig';
+			if ( WC_Payments_Features::is_upe_split_enabled() ) {
+				$script_handle = 'wcpay-upe-checkout';
+				$js_object = 'wcpay_upe_config';
+			}  elseif ( WC_Payments_Features::is_upe_legacy_enabled() ) {;
+				$script_handle = 'wcpay-upe-checkout';
 			}
+			wp_localize_script( $script_handle, $js_object, WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() );
+			wp_enqueue_script( $script_handle );
 		}
 	}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -637,10 +637,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$script_handle = 'WCPAY_CHECKOUT';
 			$js_object     = 'wcpayConfig';
 			if ( WC_Payments_Features::is_upe_split_enabled() ) {
-				  $script_handle = 'wcpay-upe-checkout';
-				  $js_object     = 'wcpay_upe_config';
+				$script_handle = 'wcpay-upe-checkout';
+				$js_object     = 'wcpay_upe_config';
 			} elseif ( WC_Payments_Features::is_upe_legacy_enabled() ) {
-				 $script_handle = 'wcpay-upe-checkout';
+				$script_handle = 'wcpay-upe-checkout';
 			}
 			wp_localize_script( $script_handle, $js_object, WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() );
 			wp_enqueue_script( $script_handle );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -617,7 +617,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		wp_set_script_translations( 'WCPAY_CHECKOUT', 'woocommerce-payments' );
 
-		if ( ! WC()->cart->needs_payment() && is_checkout() && ! has_block( 'woocommerce/checkout' ) ) {
+		// load the scripts even if cart does not need payment.
+		if (
+			isset( WC()->cart ) &&
+			! WC()->cart->is_empty() &&
+			! WC()->cart->needs_payment() &&
+			is_checkout() &&
+			! has_block( 'woocommerce/checkout' )
+		) {
 			WC_Payments::get_gateway()->tokenization_script();
 			WC_Payments::get_wc_payments_checkout()->enqueue_payment_scripts();
 		}

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -80,16 +80,8 @@ class WC_Payments_Checkout {
 	 * Enqueues and localizes WCPay's checkout scripts.
 	 */
 	public function enqueue_payment_scripts() {
-		if ( WC_Payments_Features::is_upe_legacy_enabled() ) {
-			wp_localize_script( 'wcpay-upe-checkout', 'wcpayConfig', WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() );
-			wp_enqueue_script( 'wcpay-upe-checkout' );
-		} elseif ( WC_Payments_Features::is_upe_split_enabled() ) {
-			wp_localize_script( 'wcpay-upe-checkout', 'wcpay_upe_config', WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() );
-			wp_enqueue_script( 'wcpay-upe-checkout' );
-		} else {
-			wp_localize_script( 'WCPAY_CHECKOUT', 'wcpayConfig', WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() );
-			wp_enqueue_script( 'WCPAY_CHECKOUT' );
-		}
+		wp_localize_script( 'WCPAY_CHECKOUT', 'wcpayConfig', WC_Payments::get_wc_payments_checkout()->get_payment_fields_js_config() );
+		wp_enqueue_script( 'WCPAY_CHECKOUT' );
 	}
 
 	/**

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -138,17 +138,6 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			true
 		);
 
-		// load the scripts even if cart does not need payment.
-		if (
-			isset( WC()->cart ) &&
-			! WC()->cart->is_empty() &&
-			! WC()->cart->needs_payment() &&
-			is_checkout() &&
-			! has_block( 'woocommerce/checkout' )
-		) {
-			WC_Payments::get_gateway()->tokenization_script();
-			WC_Payments::get_wc_payments_checkout()->enqueue_payment_scripts();
-		}
 	}
 
 	/**

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -138,7 +138,14 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			true
 		);
 
-		if ( ! WC()->cart->needs_payment() && is_checkout() && ! has_block( 'woocommerce/checkout' ) ) {
+		// load the scripts even if cart does not need payment.
+		if (
+			isset( WC()->cart ) &&
+			! WC()->cart->is_empty() &&
+			! WC()->cart->needs_payment() &&
+			is_checkout() &&
+			! has_block( 'woocommerce/checkout' )
+		) {
 			WC_Payments::get_gateway()->tokenization_script();
 			WC_Payments::get_wc_payments_checkout()->enqueue_payment_scripts();
 		}

--- a/includes/payment-methods/class-upe-split-payment-gateway.php
+++ b/includes/payment-methods/class-upe-split-payment-gateway.php
@@ -127,7 +127,14 @@ class UPE_Split_Payment_Gateway extends UPE_Payment_Gateway {
 			true
 		);
 
-		if ( ! WC()->cart->needs_payment() && is_checkout() && ! has_block( 'woocommerce/checkout' ) ) {
+		// load the scripts even if cart does not need payment.
+		if (
+			isset( WC()->cart ) &&
+			! WC()->cart->is_empty() &&
+			! WC()->cart->needs_payment() &&
+			is_checkout() &&
+			! has_block( 'woocommerce/checkout' )
+		) {
 			WC_Payments::get_gateway()->tokenization_script();
 			WC_Payments::get_wc_payments_checkout()->enqueue_payment_scripts();
 		}

--- a/includes/payment-methods/class-upe-split-payment-gateway.php
+++ b/includes/payment-methods/class-upe-split-payment-gateway.php
@@ -31,6 +31,7 @@ use WC_Payment_Token_CC;
 use WC_Payments_Token_Service;
 use WC_Payment_Token_WCPay_SEPA;
 use WC_Payments_Utils;
+use WC_Payments_Features;
 use WP_User;
 
 
@@ -127,17 +128,6 @@ class UPE_Split_Payment_Gateway extends UPE_Payment_Gateway {
 			true
 		);
 
-		// load the scripts even if cart does not need payment.
-		if (
-			isset( WC()->cart ) &&
-			! WC()->cart->is_empty() &&
-			! WC()->cart->needs_payment() &&
-			is_checkout() &&
-			! has_block( 'woocommerce/checkout' )
-		) {
-			WC_Payments::get_gateway()->tokenization_script();
-			WC_Payments::get_wc_payments_checkout()->enqueue_payment_scripts();
-		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5641, #4764, #5277

#### Changes proposed in this Pull Request

- Reverts #5423. Deleted the changelog as well.
- Fixes the original issues #4764 and #5277 by loading the checkout scripts even when cart total is 0. This allows the Checkout form to be displayed if the cart is updated via AJAX on Checkout page.

#### Testing instructions

Testing instructions of #5641, #4764, #5277

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
