### PR TITLE
Fixes the save cards checkbox appearance for WCPay gateway

### DIFF
--- a/changelog/fix-save-card-checkbox-appearance
+++ b/changelog/fix-save-card-checkbox-appearance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid rendering save cards checkbox for logged out users

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -202,7 +202,9 @@ class WC_Payments_Checkout {
 				<?php
 				if ( $this->gateway->is_saved_cards_enabled() ) {
 					$force_save_payment = ( $display_tokenization && ! apply_filters( 'wc_payments_display_save_payment_method_checkbox', $display_tokenization ) ) || is_add_payment_method_page();
-					$this->gateway->save_payment_method_checkbox( $force_save_payment );
+					if ( is_user_logged_in() || $force_save_payment ) {
+						$this->gateway->save_payment_method_checkbox( $force_save_payment );
+					}
 				}
 				?>
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -320,6 +320,42 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->wcpay_gateway->payment_fields();
 	}
 
+	public function test_save_card_checkbox_not_displayed_for_non_logged_in_users() {
+		$this->wcpay_gateway->update_option( 'saved_cards', 'yes' );
+		wp_set_current_user( 0 );
+
+		$this->refresh_payments_checkout();
+
+		// Use a callback to get and test the output (also suppresses the output buffering being printed to the CLI).
+		$this->setOutputCallback(
+			function ( $output ) {
+				$result = preg_match_all( '/.*<input.*id="wc-woocommerce_payments-new-payment-method".*\/>.*/', $output );
+
+				$this->assertSame( 0, $result );
+			}
+		);
+
+		$this->wcpay_gateway->payment_fields();
+	}
+
+	public function test_save_card_checkbox_displayed_for_logged_in_users() {
+		$this->wcpay_gateway->update_option( 'saved_cards', 'yes' );
+		wp_set_current_user( 1 );
+
+		$this->refresh_payments_checkout();
+
+		// Use a callback to get and test the output (also suppresses the output buffering being printed to the CLI).
+		$this->setOutputCallback(
+			function ( $output ) {
+				$result = preg_match_all( '/.*<input.*id="wc-woocommerce_payments-new-payment-method".*\/>.*/', $output );
+
+				$this->assertSame( 1, $result );
+			}
+		);
+
+		$this->wcpay_gateway->payment_fields();
+	}
+
 	public function test_fraud_prevention_token_added_when_enabled() {
 		$token_value                   = 'test-token';
 		$fraud_prevention_service_mock = $this->get_fraud_prevention_service_mock();


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5655

#### Changes proposed in this Pull Request
This PR adds the check that prevents displaying the save checkbox if a user is not logged in. The logic is now the same as in [the UPE checkout](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payments-upe-checkout.php#L307-L309).


<table>
<tr>
<th>Before the fix (logged out)</th>
<th>After the fix (logged out)</th>
<tr>
<td>


<img width="328" alt="image" src="https://user-images.githubusercontent.com/22319444/222108298-0befad48-880d-4a32-8b03-3cc5ef1fe55a.png">


</td>
<td>

<img width="326" alt="image" src="https://user-images.githubusercontent.com/22319444/222109175-a0c567d3-37f2-44f4-ba37-508ed3260eb2.png">

</td>
</table>


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. As an admin, Disable UPE
2. Ensure you are logged out
3. Proceed to the checkout page with a simple product and confirm that there is no checkbox under the CC gateway fields
4. Log in as an existing user, proceed to the checkout page and confirm that the checkbox now appears

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
