### PR TITLE
Avoid Transactions list to have its layout modified when hovering over conversion icon

### DIFF
--- a/changelog/fix-5651-transaction-page-layout-tooltip-shown
+++ b/changelog/fix-5651-transaction-page-layout-tooltip-shown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes a problem where the Transactions table would have its layout modified when hovering over the currency conversion icon

--- a/client/transactions/list/converted-amount.tsx
+++ b/client/transactions/list/converted-amount.tsx
@@ -35,6 +35,7 @@ const ConversionIndicator = ( {
 		<span
 			className="conversion-indicator"
 			data-testid="conversion-indicator"
+			style={ { height: '18px', width: '18px' } }
 		>
 			<SyncIcon size={ 18 } />
 		</span>

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -13,8 +13,6 @@ $space-header-item: 12px;
 
 		.conversion-indicator {
 			margin-right: 6px;
-			height: 18px; /* Set a fixed height for the popover to be positioned properly */
-			width: 18px; /* Set a fixed width for the popover to be positioned properly */
 			fill: $studio-gray-30;
 		}
 	}

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -14,10 +14,6 @@ $space-header-item: 12px;
 		.conversion-indicator {
 			margin-right: 6px;
 			fill: $studio-gray-30;
-
-			.components-popover__content {
-				z-index: 9999;
-			}
 		}
 	}
 

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -14,6 +14,10 @@ $space-header-item: 12px;
 		.conversion-indicator {
 			margin-right: 6px;
 			fill: $studio-gray-30;
+
+			.components-popover__content {
+				z-index: 9999;
+			}
 		}
 	}
 

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -13,7 +13,8 @@ $space-header-item: 12px;
 
 		.conversion-indicator {
 			margin-right: 6px;
-			height: 18px;
+			height: 18px; /* Set a fixed height for the popover to be positioned properly */
+			width: 18px; /* Set a fixed width for the popover to be positioned properly */
 			fill: $studio-gray-30;
 		}
 	}

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -15,6 +15,10 @@ $space-header-item: 12px;
 			margin-right: 6px;
 			fill: $studio-gray-30;
 		}
+
+		.components-popover__content {
+			position: absolute;
+		}
 	}
 
 	// slight adjustment to align header items with sorting button to account for icon width

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -15,10 +15,6 @@ $space-header-item: 12px;
 			margin-right: 6px;
 			fill: $studio-gray-30;
 		}
-
-		.components-popover__content {
-			position: absolute;
-		}
 	}
 
 	// slight adjustment to align header items with sorting button to account for icon width

--- a/client/transactions/list/style.scss
+++ b/client/transactions/list/style.scss
@@ -15,6 +15,11 @@ $space-header-item: 12px;
 			margin-right: 6px;
 			fill: $studio-gray-30;
 		}
+
+		.components-popover__content {
+			position: relative;
+			top: -( $gap * 2 ); // Positioning the tooltip in a higher position to avoid having it cropped by the bottom of the table
+		}
 	}
 
 	// slight adjustment to align header items with sorting button to account for icon width

--- a/client/transactions/list/test/__snapshots__/converted-amount.tsx.snap
+++ b/client/transactions/list/test/__snapshots__/converted-amount.tsx.snap
@@ -8,6 +8,7 @@ exports[`ConvertedAmount renders an amount with conversion icon and tooltip 1`] 
     <span
       class="conversion-indicator"
       data-testid="conversion-indicator"
+      style="height: 18px; width: 18px;"
     >
       <svg
         class="gridicon gridicons-sync"
@@ -36,6 +37,7 @@ exports[`ConvertedAmount renders an amount with conversion icon and tooltip 2`] 
     <span
       class="conversion-indicator"
       data-testid="conversion-indicator"
+      style="height: 18px; width: 18px;"
     >
       <svg
         class="gridicon gridicons-sync"

--- a/client/transactions/list/test/__snapshots__/index.tsx.snap
+++ b/client/transactions/list/test/__snapshots__/index.tsx.snap
@@ -665,6 +665,7 @@ exports[`Transactions list renders correctly when can filter by several currenci
                       <span
                         class="conversion-indicator"
                         data-testid="conversion-indicator"
+                        style="height: 18px; width: 18px;"
                       >
                         <svg
                           class="gridicon gridicons-sync"
@@ -1546,6 +1547,7 @@ exports[`Transactions list renders correctly when filtered by currency 1`] = `
                       <span
                         class="conversion-indicator"
                         data-testid="conversion-indicator"
+                        style="height: 18px; width: 18px;"
                       >
                         <svg
                           class="gridicon gridicons-sync"
@@ -2290,6 +2292,7 @@ exports[`Transactions list renders correctly when filtered by deposit 1`] = `
                       <span
                         class="conversion-indicator"
                         data-testid="conversion-indicator"
+                        style="height: 18px; width: 18px;"
                       >
                         <svg
                           class="gridicon gridicons-sync"
@@ -3108,6 +3111,7 @@ exports[`Transactions list subscription column renders correctly 1`] = `
                       <span
                         class="conversion-indicator"
                         data-testid="conversion-indicator"
+                        style="height: 18px; width: 18px;"
                       >
                         <svg
                           class="gridicon gridicons-sync"
@@ -4037,6 +4041,7 @@ exports[`Transactions list when not filtered by deposit renders correctly 1`] = 
                       <span
                         class="conversion-indicator"
                         data-testid="conversion-indicator"
+                        style="height: 18px; width: 18px;"
                       >
                         <svg
                           class="gridicon gridicons-sync"
@@ -4960,6 +4965,7 @@ exports[`Transactions list when not filtered by deposit renders table summary on
                       <span
                         class="conversion-indicator"
                         data-testid="conversion-indicator"
+                        style="height: 18px; width: 18px;"
                       >
                         <svg
                           class="gridicon gridicons-sync"

--- a/client/transactions/list/test/converted-amount.tsx
+++ b/client/transactions/list/test/converted-amount.tsx
@@ -74,9 +74,18 @@ describe( 'ConvertedAmount', () => {
 
 		expect( container ).toMatchSnapshot(); // Before tooltip appears.
 
-		fireEvent.mouseEnter( getByTestId( 'conversion-indicator' ) );
+		const conversionIndicator = getByTestId( 'conversion-indicator' );
 
+		expect( conversionIndicator ).toBeInTheDocument();
+		expect( conversionIndicator ).toHaveStyle( 'width: 18px' );
+		expect( conversionIndicator ).toHaveStyle( 'height: 18px' );
+
+		fireEvent.mouseEnter( conversionIndicator );
 		expect( await findByText( 'Converted from MOK 2.00' ) ).toBeVisible();
 		expect( container ).toMatchSnapshot(); // After tooltip appears.
+
+		// Making sure the element layout doesn't get changed after adding the Tooltip
+		expect( conversionIndicator ).toHaveStyle( 'width: 18px' );
+		expect( conversionIndicator ).toHaveStyle( 'height: 18px' );
 	} );
 } );


### PR DESCRIPTION
Fixes #5651 

#### Changes proposed in this Pull Request

Title: Avoid Transactions list to have its layout modified when hovering over the conversion icon

The Tooltip component is currently modifying the width of the row where the element is displayed when there is a transaction in a different currency than the store currency (with Multicurrency enabled).

There is also a movement from the index.scss file in order to declare the width and the height of the element inside of the Component, as it's part of its nature and needed for testing purposes.

https://user-images.githubusercontent.com/6216000/222036570-c1b52a26-22a3-4454-881f-6b3a989cc2f8.mov

With the change

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/2612426/222131046-0a324b32-f078-4cbb-b13a-2b2e09b21e90.png">

#### Testing instructions
Out of this branch:


  - Enable multi-currency, and make a purchase with a different currency than that of the store's currency
  - Go to Payments -> Transactions
  - Hover over the icon in the Amount field entry
  - Notice the changing table layout

Changing to this branch:

Repeat the same steps but notice that the layout is not changed anymore, and no other row gets displaced because of that.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) :  'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable. Not applicable
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable. Not applicable
