### PR TITLE
Prevent WooPay modal from showing when editing theme

### DIFF
--- a/changelog/fix-5658-woopay-modal-on-theme-editor
+++ b/changelog/fix-5658-woopay-modal-on-theme-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+prevent WooPay modal from showing up when editing the theme via wp-admin

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -23,6 +23,7 @@ import enqueueFraudScripts from 'fraud-scripts';
 import paymentRequestPaymentMethod from '../../payment-request/blocks';
 import { handlePlatformCheckoutEmailInput } from '../platform-checkout/email-input-iframe';
 import wooPayExpressCheckoutPaymentMethod from '../platform-checkout/express-button/woopay-express-checkout-payment-method';
+import { isPreviewing } from '../preview';
 
 // Create an API object, which will be used throughout the checkout.
 const api = new WCPayAPI(
@@ -65,26 +66,11 @@ registerPaymentMethod( {
 	},
 } );
 
-/**
- * Checks whether we're in a preview context.
- *
- * @return {boolean} Whether we're in a preview context.
- */
-const isPreviewing = () => {
-	const searchParams = new URLSearchParams( window.location.search );
-
-	// Check for the URL parameter used in the iframe of the customize.php page
-	// and for the is_preview() value for posts.
-	return (
-		null !== searchParams.get( 'customize_messenger_channel' ) ||
-		getConfig( 'isPreview' )
-	);
-};
-
 // Call handlePlatformCheckoutEmailInput if platform checkout is enabled and this is the checkout page.
-if ( getConfig( 'isPlatformCheckoutEnabled' ) && ! isPreviewing() ) {
+if ( getConfig( 'isPlatformCheckoutEnabled' ) ) {
 	if (
-		document.querySelector( '[data-block-name="woocommerce/checkout"]' )
+		document.querySelector( '[data-block-name="woocommerce/checkout"]' ) &&
+		! isPreviewing()
 	) {
 		handlePlatformCheckoutEmailInput( '#email', api, true );
 	}

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -65,8 +65,24 @@ registerPaymentMethod( {
 	},
 } );
 
+/**
+ * Checks whether we're in a preview context.
+ *
+ * @return {boolean} Whether we're in a preview context.
+ */
+const isPreviewing = () => {
+	const searchParams = new URLSearchParams( window.location.search );
+
+	// Check for the URL parameter used in the iframe of the customize.php page
+	// and for the is_preview() value for posts.
+	return (
+		null !== searchParams.get( 'customize_messenger_channel' ) ||
+		getConfig( 'isPreview' )
+	);
+};
+
 // Call handlePlatformCheckoutEmailInput if platform checkout is enabled and this is the checkout page.
-if ( getConfig( 'isPlatformCheckoutEnabled' ) ) {
+if ( getConfig( 'isPlatformCheckoutEnabled' ) && ! isPreviewing() ) {
 	if (
 		document.querySelector( '[data-block-name="woocommerce/checkout"]' )
 	) {

--- a/client/checkout/classic/index.js
+++ b/client/checkout/classic/index.js
@@ -10,6 +10,7 @@ import { handlePlatformCheckoutEmailInput } from '../platform-checkout/email-inp
 import WCPayAPI from './../api';
 import enqueueFraudScripts from 'fraud-scripts';
 import { isWCPayChosen } from '../utils/upe';
+import { isPreviewing } from '../preview';
 import {
 	getFingerprint,
 	appendFingerprintInputToForm,
@@ -546,22 +547,6 @@ jQuery( function ( $ ) {
 			maybeShowAuthenticationModal();
 		}
 	} );
-
-	/**
-	 * Checks whether we're in a preview context.
-	 *
-	 * @return {boolean} Whether we're in a preview context.
-	 */
-	const isPreviewing = () => {
-		const searchParams = new URLSearchParams( window.location.search );
-
-		// Check for the URL parameter used in the iframe of the customize.php page
-		// and for the is_preview() value for posts.
-		return (
-			null !== searchParams.get( 'customize_messenger_channel' ) ||
-			getConfig( 'isPreview' )
-		);
-	};
 
 	if ( getConfig( 'isPlatformCheckoutEnabled' ) && ! isPreviewing() ) {
 		handlePlatformCheckoutEmailInput( '#billing_email', api );

--- a/client/checkout/preview.js
+++ b/client/checkout/preview.js
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies
+ */
+
+import { getConfig } from 'utils/checkout';
+
+/**
+ * Checks whether we're in a preview context.
+ *
+ * @return {boolean} Whether we're in a preview context.
+ */
+export const isPreviewing = () => {
+	const searchParams = new URLSearchParams( window.location.search );
+
+	// Check for the URL parameter used in the iframe of the customize.php page
+	// and for the is_preview() value for posts.
+	return (
+		null !== searchParams.get( 'customize_messenger_channel' ) ||
+		getConfig( 'isPreview' )
+	);
+};


### PR DESCRIPTION
Fixes #5658

#### Changes proposed in this Pull Request
This PR fixes a bug that would make the WooPay otp/redirect modal to show up when editing the theme in wp-admin when using the blocks checkout

#### Testing instructions
- Go to wp-admin > WooCommerce > settings > advanced
- Set the checkout page to the Blocks checkout page
- Go to Appearance > Customize > WooCommerce > Checkout
- The WooPay redirect/OTP modal must not show up
- As a customer try to checkout via WooPay in the blocks checkout page

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
