### PR TITLE
WCPay as a Platform: Fixing the request for listing disputes

### DIFF
--- a/changelog/fix-5642-disputes-page
+++ b/changelog/fix-5642-disputes-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fixing the broken search on the Disputes page.

--- a/includes/core/server/request/class-list-disputes.php
+++ b/includes/core/server/request/class-list-disputes.php
@@ -10,6 +10,7 @@ namespace WCPay\Core\Server\Request;
 use Exception;
 use WC_Payments_API_Client;
 use WC_Payments_DB;
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
 use WCPay\Core\Server\Response;
 use WCPay\Logger;
 use WP_REST_Request;
@@ -119,11 +120,18 @@ class List_Disputes extends Paginated {
 	/**
 	 * Set search.
 	 *
-	 * @param string $search Search term.
-	 *
+	 * @param string|array $search Search term or terms.
 	 * @return void
+	 * @throws Invalid_Request_Parameter_Exception Whenever the parameter is not a string or array.
 	 */
-	public function set_search( string $search ) {
+	public function set_search( $search ) {
+		if ( ! is_string( $search ) && ! is_array( $search ) ) {
+			throw new Invalid_Request_Parameter_Exception(
+				__( 'The search parameter must be a string, or an array of strings.', 'woocommerce-payments' ),
+				'wcpay_core_invalid_request_parameter_invalid_search'
+			);
+		}
+
 		$this->set_param( 'search', $search );
 	}
 

--- a/includes/core/server/request/class-list-disputes.php
+++ b/includes/core/server/request/class-list-disputes.php
@@ -120,7 +120,7 @@ class List_Disputes extends Paginated {
 	/**
 	 * Set search.
 	 *
-	 * @param string|array $search Search term or terms.
+	 * @param string|string[] $search Search term or terms.
 	 * @return void
 	 * @throws Invalid_Request_Parameter_Exception Whenever the parameter is not a string or array.
 	 */


### PR DESCRIPTION
Fixes #5642 

#### Changes proposed in this Pull Request

While introducing [request classes for paginated requests](https://github.com/Automattic/woocommerce-payments/pull/5281), we coded the `search` parameter of the transactions list query to be a string, however it turns out to be an array. This PR fixes that.

#### Testing instructions

1. Purchase a product using a dispute-specific test card.
2. Open the link from the email you received in 'Dispute created notifications' testing instructions.
3. Go to "Payments > Disputes" page.
4. At this point you should see at least one dispute.
5. Use the *Show* dropdown, and change it to "Needs Response".
7. Observe that, "Error retrieving disputes." snackbar notification displayed **without this PR**.
8. Check out this PR, and notice that disputes load correctly.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 

**Post merge**

This is a fixed bug, which is a part of critical flows. There is no need to add new testing instructions.