### PR TITLE
Use a proper mechanism to determine when the page is loaded after paying for order

### DIFF
--- a/changelog/fix-flaky-e2e-test
+++ b/changelog/fix-flaky-e2e-test
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Fixes a flaky e2e test.

--- a/tests/e2e/specs/wcpay/shopper/shopper-pay-for-order.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-pay-for-order.spec.js
@@ -52,7 +52,9 @@ describe( 'Shopper > Pay for Order', () => {
 		const card = config.get( 'cards.basic' );
 		await fillCardDetailsPayForOrder( page, card );
 		await expect( page ).toClick( 'button', { text: 'Pay for order' } );
-		await uiUnblocked();
+		await page.waitForNavigation( {
+			waitUntil: 'networkidle0',
+		} );
 		await expect( page ).toMatch( 'Order received' );
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woopay/issues/1691

#### Changes proposed in this Pull Request
This PR replaces `uiUnblocked();` with `waitUntil: 'networkidle0',` in the E2E test for the _Pay for order_ page. The former was wrongly used, as it should be considered an option for checking a loading state within the page, but not the page reload. In the effect, it seems that the test was looking for `Order received` text too early. Since `networkidle0` is generally considered the most reliable option for determining when a page is fully loaded and ready for further testing, it should be the solution. The post-fix test runs described below confirm this.

#### My results
I've run a command that consequently runs the test 20 times to gather some metrics of the problem and confirm the test's flaky-ness.

Before the fix, 20 test runs gave us:
* 12 successful results
* 3 failures because of the connection reset (these failures can be ignored)
* 5 failures due to `TimeoutError: Text not found "Order received"`

After the fix: 
* 17 successful runs
* 3 failures because of the connection reset (these failures can be ignored)

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
1️⃣ On your local environment, checkout to `develop` and run the following command in your terminal:

```
for i in {1..20}; do
  npm run test:e2e tests/e2e/specs/wcpay/shopper/shopper-pay-for-order.spec.js
done
```

2️⃣ After the run, confirm that some part has failed because of `TimeoutError: Text not found "Order received"`. 
3️⃣ Checkout to `fix/flaky-e2e-test`, run the command from step 1️⃣ once more
4️⃣ Confirm that there are no failing tests with the message `TimeoutError: Text not found "Order received"`
5️⃣ Run [this job](https://github.com/Automattic/woocommerce-payments/actions/runs/4304845140/jobs/7506799139) 1-2 times from GH Actions and confirm it's green. 


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
