### PR TITLE
Log error message when calling redirect_to_login fails

### DIFF
--- a/changelog/add-log-error-maybe_handle_onboarding
+++ b/changelog/add-log-error-maybe_handle_onboarding
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Log error message when calling redirect_to_login fails.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -726,6 +726,8 @@ class WC_Payments_Account {
 			try {
 				$this->redirect_to_login();
 			} catch ( Exception $e ) {
+				Logger::error( 'Failed redirect_to_login: ' . $e );
+
 				wp_safe_redirect(
 					add_query_arg(
 						[ 'wcpay-login-error' => '1' ],


### PR DESCRIPTION
Fixes #
p1677774670256519-slack-C7U3Y3VMY

Issue: 

> The site should be in dev mode but appears broken. Payments are disabled and trying to "Edit details" cause the error "There was a problem redirecting you to the account dashboard. Please try again." at the top of the page.


#### Changes proposed in this Pull Request

Just log an error message so it makes things easier to troubleshoot the issue as suggested by @leonardola 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

A simple test for this: 

- Change this relevant endpoint on your local server 2f536-pb/#diff to simulate an error from the server.
- Go to WP Admin > Payments, and click on "Edit details".
- See the error.
- Expectation: see a new log entry start with `Failed redirect_to_login` in the latest WCPay log file under wp-content/uploads/wc-logs/

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] **NO NEED**. Covered with tests (or have a good reason not to test in description ☝️)
- [x] **NO NEED**. Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] **NO NEED**. Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] **NO NEED**. Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] **NO NEED**. Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.