### PR TITLE
Add merge request trigger to relevant workflows

### DIFF
--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -1,7 +1,8 @@
 name: JS linting and tests
 
 on:
-  pull_request
+  pull_request:
+  merge_group:
 
 jobs:
   lint:

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -1,7 +1,8 @@
 name: PHP linting and tests
 
 on:
-  pull_request
+  pull_request:
+  merge_group:
 
 env:
   WP_VERSION:        latest

--- a/changelog/fix-5572-update-workflows-merge-queue
+++ b/changelog/fix-5572-update-workflows-merge-queue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add merge queue trigger to the relevant workflows.


### PR DESCRIPTION
Fixes #5572 

#### Changes proposed in this Pull Request

We recently [enabled](https://wcpay.wordpress.com/2023/02/16/merge-queue-now-enabled-on-wc-payments-prs/) the Merge Queue feature on the `develop` branch. But it got stuck as the required checks weren't running. This happened because our test workflows are not aware of the merge queue.

This PR resolves the issue by adding `merge_group` to the relevant workflows.

#### Testing instructions

1. Enable merge queue from [here](https://github.com/Automattic/woocommerce-payments/settings/branch_protection_rules/19781153).
2. Create a PR.
3. Choose the `Merge when ready` option for the PR.
4. Make sure that the PR passes the required tests.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
