### PR TITLE
Fix duplicated 5.5.0 changelog entries

### DIFF
--- a/changelog/fix-remove-duplicate-entries-readme-changelog
+++ b/changelog/fix-remove-duplicate-entries-readme-changelog
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Changelog entries cleanup in readme.txt
+
+

--- a/readme.txt
+++ b/readme.txt
@@ -135,33 +135,7 @@ Please note that our support for the checkout block is still experimental and th
 
 = 5.4.0 - 2023-02-01 =
 * Add - Add logging and order notes when WCPay Subscriptions are suspended or put on-hold.
-* Add - Highlight subscriptions with overdue payment in list view with red icon == Changelog ==
-
-= 5.5.0 - 2023-02-22 =
-* Add - Added learn more link to deposits page
-* Add - Added tracking for the split UPE feature flag.
-* Add - Declare WooCommerce Payments compatible with High-Performance Order Storage.
-* Add - New support phone and email fields the general settings page.
-* Add - Pass settings fields of the plugins that use newsletter block to woopay.
-* Add - Pass the namespaces from the Store API checkout schema data to WooPay
-* Add - Pass the store's test mode value to WooPay requests to the OTP endpoint.
-* Add - The UPE is now the default checkout experience for newly onboarded merchants. It can sbe disabled with these instructions: https://woocommerce.com/?p=3337362#disabling
-* Fix - Add wp-i18n as split UPE script dependency to load split UPE elements.
-* Fix - Disable WooPay for unavailable countries
-* Fix - Display an error when the request for initiating the platform checkout fails.
-* Fix - External link accessibilty text style
-* Fix - Fixes Stripe Link compatibility with split UPE payment gateway
-* Fix - For stores using HPOS, ensure the originating subscription's currency is used when initiating a subscription switch.
-* Fix - Make sure available payment methods are provided for the automatic subscription renewals.
-* Fix - Point the "Learn more" link to a more appropriate document in the Apple Pay domain registration failure notification.
-* Fix - Re-enabled email triggered WooPay flow with Express Checkout flow. WooPay Express Checkout is currently behind a feature flag.
-* Fix - Remove unnecessary style dependency from WooPay checkbox.
-* Fix - Track user viewport and url when using WooPay
-* Update - Removed saved methods listing in My Account Add Payment Method page
-* Update - Updated the Express checkout settings page
-* Update - WooPay CTA text in shortcode checkout
-* Dev - Adding a feature flag to allow further development of onboarding UX - currently this will have no effect on live stores.
-* Dev - Merge progressive onboarding prototype under a feature flag tooltip.
+* Add - Highlight subscriptions with overdue payment in list view with red icon & tooltip.
 * Add - More context to the business details to show the actual message from Stripe, shows a modal if there is more than one error from Stripe.
 * Add - New wcs_set_order_address() helper function to set an array of address fields on an order or subscription.
 * Add - Skipping the email input step for WooPay express checkout flow when the email input field has already a value. The WooPay express checkout feature is behind a feature flag currently.
@@ -204,33 +178,7 @@ Please note that our support for the checkout block is still experimental and th
 * Dev - Fix phpcs violations in the `WC_Subscriptions_Tracker` and `WCS_Admin_System_Status` classes to improve code quality.
 * Dev - Introduced a new `untrash_order()` in the `WCS_Orders_Table_Subscription_Data_Store` class to fix untrashing subscriptions on stores that have HPOS enabled.
 * Dev - Introduced a WCS_Object_Data_Cache_Manager and WCS_Object_Data_Cache_Manager_Many_To_One class as HPOS equivalents of the WCS_Post_Meta_Cache_Manager classes.
-* Dev - Moved the trash, untrash == Changelog ==
-
-= 5.5.0 - 2023-02-22 =
-* Add - Added learn more link to deposits page
-* Add - Added tracking for the split UPE feature flag.
-* Add - Declare WooCommerce Payments compatible with High-Performance Order Storage.
-* Add - New support phone and email fields the general settings page.
-* Add - Pass settings fields of the plugins that use newsletter block to woopay.
-* Add - Pass the namespaces from the Store API checkout schema data to WooPay
-* Add - Pass the store's test mode value to WooPay requests to the OTP endpoint.
-* Add - The UPE is now the default checkout experience for newly onboarded merchants. It can sbe disabled with these instructions: https://woocommerce.com/?p=3337362#disabling
-* Fix - Add wp-i18n as split UPE script dependency to load split UPE elements.
-* Fix - Disable WooPay for unavailable countries
-* Fix - Display an error when the request for initiating the platform checkout fails.
-* Fix - External link accessibilty text style
-* Fix - Fixes Stripe Link compatibility with split UPE payment gateway
-* Fix - For stores using HPOS, ensure the originating subscription's currency is used when initiating a subscription switch.
-* Fix - Make sure available payment methods are provided for the automatic subscription renewals.
-* Fix - Point the "Learn more" link to a more appropriate document in the Apple Pay domain registration failure notification.
-* Fix - Re-enabled email triggered WooPay flow with Express Checkout flow. WooPay Express Checkout is currently behind a feature flag.
-* Fix - Remove unnecessary style dependency from WooPay checkbox.
-* Fix - Track user viewport and url when using WooPay
-* Update - Removed saved methods listing in My Account Add Payment Method page
-* Update - Updated the Express checkout settings page
-* Update - WooPay CTA text in shortcode checkout
-* Dev - Adding a feature flag to allow further development of onboarding UX - currently this will have no effect on live stores.
-* Dev - Merge progressive onboarding prototype under a feature flag delete related `add_actions()` in the `WC_Subscriptions_Manager` class to be added on the `woocommerce_loaded` action.
+* Dev - Moved the trash, untrash & delete related `add_actions()` in the `WC_Subscriptions_Manager` class to be added on the `woocommerce_loaded` action.
 * Dev - Remove deprecated `strptime` function in favour of `DateTime::createFromFormat`.
 * Dev - Skip running blocks E2E tests, add comment for the same.
 * Dev - unified express checkout settings


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

Problems began from 5.4.0, as explained in https://github.com/Automattic/woocommerce-payments/issues/5647#issuecomment-1458147304

For now, I cleaned the changelog entries in `readme.txt` (mainly remove useless `5.5.0` entries)

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
