### PR TITLE
Avoid adding two fee details in the order page

### DIFF
--- a/changelog/fix-5691-two-fee-notes
+++ b/changelog/fix-5691-two-fee-notes
@@ -1,4 +1,5 @@
-Significance: minor
+Significance: patch
 Type: fix
+Comment: Avoid adding two fee details in the order page (regression issue from PR 5321).
 
-Avoid adding two fee details in the order page (regression issue from PR 5321).
+

--- a/changelog/fix-5691-two-fee-notes
+++ b/changelog/fix-5691-two-fee-notes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Avoid adding two fee details in the order page (regression issue from PR 5321).

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -52,6 +52,7 @@ class WC_Payments_Action_Scheduler_Service {
 	public function add_action_scheduler_hooks() {
 		add_action( 'wcpay_track_new_order', [ $this, 'track_new_order_action' ] );
 		add_action( 'wcpay_track_update_order', [ $this, 'track_update_order_action' ] );
+		add_action( WC_Payments_Order_Service::ADD_FEE_BREAKDOWN_TO_ORDER_NOTES, [ $this->order_service, 'add_fee_breakdown_to_order_notes' ], 10, 3 );
 	}
 
 	/**

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -87,8 +87,6 @@ class WC_Payments_Order_Service {
 	 */
 	public function __construct( WC_Payments_API_Client $api_client ) {
 		$this->api_client = $api_client;
-
-		add_action( self::ADD_FEE_BREAKDOWN_TO_ORDER_NOTES, [ $this, 'add_fee_breakdown_to_order_notes' ], 10, 3 );
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -540,7 +540,7 @@ class WC_Payments {
 		// Load WCPay Subscriptions.
 		if ( WC_Payments_Features::is_wcpay_subscriptions_enabled() ) {
 			include_once WCPAY_ABSPATH . '/includes/subscriptions/class-wc-payments-subscriptions.php';
-			WC_Payments_Subscriptions::init( self::$api_client, self::$customer_service, self::get_gateway(), self::$account );
+			WC_Payments_Subscriptions::init( self::$api_client, self::$customer_service, self::$order_service, self::$account );
 		}
 
 		$is_woopay_express_checkout_enabled = WC_Payments_Features::is_woopay_express_checkout_enabled();

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -54,10 +54,10 @@ class WC_Payments_Subscriptions {
 	 *
 	 * @param WC_Payments_API_Client       $api_client       WCPay API client.
 	 * @param WC_Payments_Customer_Service $customer_service WCPay Customer Service.
-	 * @param WC_Payment_Gateway_WCPay     $gateway          WCPay Payment Gateway.
+	 * @param WC_Payments_Order_Service    $order_service    WCPay Order Service.
 	 * @param WC_Payments_Account          $account          WC_Payments_Account.
 	 */
-	public static function init( WC_Payments_API_Client $api_client, WC_Payments_Customer_Service $customer_service, WC_Payment_Gateway_WCPay $gateway, WC_Payments_Account $account ) {
+	public static function init( WC_Payments_API_Client $api_client, WC_Payments_Customer_Service $customer_service, WC_Payments_Order_Service $order_service, WC_Payments_Account $account ) {
 		// Load Services.
 		include_once __DIR__ . '/class-wc-payments-product-service.php';
 		include_once __DIR__ . '/class-wc-payments-invoice-service.php';
@@ -67,7 +67,7 @@ class WC_Payments_Subscriptions {
 		include_once __DIR__ . '/class-wc-payments-subscriptions-empty-state-manager.php';
 
 		self::$product_service      = new WC_Payments_Product_Service( $api_client );
-		self::$order_service        = new WC_Payments_Order_Service( $api_client );
+		self::$order_service        = $order_service;
 		self::$invoice_service      = new WC_Payments_Invoice_Service( $api_client, self::$product_service, self::$order_service );
 		self::$subscription_service = new WC_Payments_Subscription_Service( $api_client, $customer_service, self::$product_service, self::$invoice_service );
 

--- a/includes/subscriptions/class-wc-payments-subscriptions.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions.php
@@ -58,6 +58,9 @@ class WC_Payments_Subscriptions {
 	 * @param WC_Payments_Account          $account          WC_Payments_Account.
 	 */
 	public static function init( WC_Payments_API_Client $api_client, WC_Payments_Customer_Service $customer_service, WC_Payments_Order_Service $order_service, WC_Payments_Account $account ) {
+		// Store dependencies.
+		self::$order_service = $order_service;
+
 		// Load Services.
 		include_once __DIR__ . '/class-wc-payments-product-service.php';
 		include_once __DIR__ . '/class-wc-payments-invoice-service.php';
@@ -65,26 +68,20 @@ class WC_Payments_Subscriptions {
 		include_once __DIR__ . '/class-wc-payments-subscription-change-payment-method-handler.php';
 		include_once __DIR__ . '/class-wc-payments-subscriptions-plugin-notice-manager.php';
 		include_once __DIR__ . '/class-wc-payments-subscriptions-empty-state-manager.php';
+		include_once __DIR__ . '/class-wc-payments-subscriptions-event-handler.php';
+		include_once __DIR__ . '/class-wc-payments-subscriptions-onboarding-handler.php';
+		include_once __DIR__ . '/class-wc-payments-subscription-minimum-amount-handler.php';
 
+		// Instantiate additional classes.
 		self::$product_service      = new WC_Payments_Product_Service( $api_client );
-		self::$order_service        = $order_service;
 		self::$invoice_service      = new WC_Payments_Invoice_Service( $api_client, self::$product_service, self::$order_service );
 		self::$subscription_service = new WC_Payments_Subscription_Service( $api_client, $customer_service, self::$product_service, self::$invoice_service );
-
-		// Load the subscription and invoice incoming event handler.
-		include_once __DIR__ . '/class-wc-payments-subscriptions-event-handler.php';
-		self::$event_handler = new WC_Payments_Subscriptions_Event_Handler( self::$invoice_service, self::$subscription_service );
+		self::$event_handler        = new WC_Payments_Subscriptions_Event_Handler( self::$invoice_service, self::$subscription_service );
 
 		new WC_Payments_Subscription_Change_Payment_Method_Handler();
 		new WC_Payments_Subscriptions_Plugin_Notice_Manager();
-
 		new WC_Payments_Subscriptions_Empty_State_Manager( $account );
-
-		// Load the Subscriptions Onboarding class.
-		include_once __DIR__ . '/class-wc-payments-subscriptions-onboarding-handler.php';
 		new WC_Payments_Subscriptions_Onboarding_Handler( $account );
-
-		include_once __DIR__ . '/class-wc-payments-subscription-minimum-amount-handler.php';
 		new WC_Payments_Subscription_Minimum_Amount_Handler( $api_client );
 	}
 


### PR DESCRIPTION
Fixes #5691

#### Changes proposed in this Pull Request

See my review here https://github.com/Automattic/woocommerce-payments/issues/5691#issuecomment-1461325022 too.

- Convert the order service to a dependency in `WC_Payments_Subscriptions`. Note: I acutally replace `$gateway` dependency with the order service as we're not actually using `$gateway`.
- Move the hook registration for ADD_FEE_BREAKDOWN_TO_ORDER_NOTES to `WC_Payments_Action_Scheduler_Service` so that we can avoid registering hooks in the order service's constructor.

With both changes above, the `WC_Payments_Order_Service` table in my review comment becomes something like this:  

| Class      | Avoid hooks in constructor | Instantiated only once | Need to fix
| ----------- | ----------- |----------- |----------- |
| WC_Payments_Order_Service   | ✅        |✅        | No |


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Git: Check out the current `develop` branch. 
* Buy a product and go through the checkout process.
* Check the order page, and wait for a while. Otherwise, go to WP Admin > Settings > Scheduled Actions, search for `wcpay_add_fee_breakdown_to_order_notes` actions and run the action for this order.
* Confirm: there are two fee-detail notes.
* Git: check out this PR.
* Go through the same steps.
* Confirm: only one fee-details note in the order page.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] NO NEED - Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] NO NEED - Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] NO NEED - Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] NO NEED - Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
