### PR TITLE
WCPay as a Platform: Fix checkout with WooPay enabled

### DIFF
--- a/changelog/fix-checkout-with-woopay-and-request-classes
+++ b/changelog/fix-checkout-with-woopay-and-request-classes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Updating the WooPay Checkout Utils class to reflect changes in gateways.
+
+

--- a/tests/unit/woopay/services/test-checkout-service.php
+++ b/tests/unit/woopay/services/test-checkout-service.php
@@ -67,9 +67,10 @@ class Checkout_Service_Test extends WCPAY_UnitTestCase {
 		$this->request->set_payment_method( 'pm_1' );
 		$this->request->set_customer( 'cus_1' );
 		$this->request->set_metadata( [ 'order_number' => 1 ] );
-		$request = $this->request->apply_filters( 'wcpay_create_intention_request', $this->payment_information );
+		$request = $this->request->apply_filters( 'wcpay_create_and_confirm_intent_request', $this->payment_information );
 		$this->assertInstanceOf( WooPay_Create_And_Confirm_Intention::class, $request );
 	}
+
 	public function test_create_intention_request_will_use_stripe_platform_on_checkout_page() {
 		// Simulate behavior that current request is platform payment.
 		$class = new class() extends Checkout_Service


### PR DESCRIPTION
## Changes

In p1678357339879439-slack-C022WMN88KG @timur27 discovered that the combination of request classes and checkout with WooPay enabled messed up the `is_platform_checkout` flag.

As described in another thread (p1678372269159389-slack-C022WMN88KG), whenever WooPay is enabled, the checkout scripts are loaded with the platform account. The thread explains the reason behind it.

This PR fixes two things:

1. `WCPay\WooPay\Service\Checkout_Service`'s `is_platform_payment_method` and `should_use_stripe_platform_on_checkout_page` are now updated to follow the methods in the gateway. This is the same logic, but in a more discrete place. In the future we plan to centralize it, but it's currently needed in both places.
2. Attaches the filter to the correct `wcpay_create_and_confirm_intent_request` hook, instead of the outdated `wcpay_create_intention_request`  one.

## Testing instructions

1. Enable WooPay locally.
2. Add a product to the cart.
3. Navigate to the checkout page, and try to check out with a new payment method, and without storing the payment method in WooPay.
4. Try this again while checking `Save my information for a faster checkout`.

Everything should work normally.