### PR TITLE
Fix WooPay request on stores with WooPay disabled

### DIFF
--- a/changelog/fix-fix-woopay-request-on-stores-with-woopay-disabled
+++ b/changelog/fix-fix-woopay-request-on-stores-with-woopay-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay request on stores with WooPay disabled

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1595,7 +1595,7 @@ class WC_Payments {
 	 * @return void
 	 */
 	public static function display_express_checkout_separator_if_necessary() {
-		$woopay          = self::$platform_checkout_button_handler->should_show_platform_checkout_button() && self::$platform_checkout_button_handler->is_woopay_enabled();
+		$woopay          = self::$platform_checkout_button_handler->is_woopay_enabled() && self::$platform_checkout_button_handler->should_show_platform_checkout_button();
 		$payment_request = self::$payment_request_button_handler->should_show_payment_request_button();
 		$should_hide     = $payment_request && ! $woopay;
 		if ( $woopay || $payment_request ) {


### PR DESCRIPTION
Fixes 1709-gh-Automattic/woopay

#### Changes proposed in this Pull Request

Fix a bug that makes stores with WooPay disabled request for WooPay available countries.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

* Before checking out to this branch:
* Access [phpMyAdmin](http://localhost:8083/index.php?route=/table/sql&db=wordpress&table=wp_options) and run this query:

```
DELETE FROM `wp_options` WHERE `option_name` = 'woocommerce_woocommerce_payments_woopay_available_countries_last_check'
```

* Comment [these lines](https://github.com/Automattic/woocommerce-payments/blob/019f8df238729c05456208a04a4a4b4f5d0e46f1/includes/platform-checkout/class-platform-checkout-utilities.php#L139-L141) to ignore test mode.
* Make [this function](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payments-features.php#L176) return false to disable WooPay eligibility or disable WooPay via checkbox.
* Access the product, cart or checkout page.
* Run this query on phpMyAdmin:

```
SELECT * FROM `wp_options` WHERE `option_name` = 'woocommerce_woocommerce_payments_woopay_available_countries_last_check'
```

* There should be one result, meaning the request was made without WooPay eligibility.
* Checkout to this branch.
* Run this query on phpMyAdmin again:

```
DELETE FROM `wp_options` WHERE `option_name` = 'woocommerce_woocommerce_payments_woopay_available_countries_last_check'
```

* Access the product, cart or checkout page.
* Run this query on phpMyAdmin:

```
SELECT * FROM `wp_options` WHERE `option_name` = 'woocommerce_woocommerce_payments_woopay_available_countries_last_check'
```

* There should be 0 results, meaning the request was not made.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
