### PR TITLE
Update Subscriptions Core to latest tagged 5.5.0 version

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1004,12 +1004,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "af1d20e53b5c6d791c60944514fa67d0b505f657"
+                "reference": "5f114e1fad79196a24f189236c9e7fb04482b8a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/af1d20e53b5c6d791c60944514fa67d0b505f657",
-                "reference": "af1d20e53b5c6d791c60944514fa67d0b505f657",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/5f114e1fad79196a24f189236c9e7fb04482b8a2",
+                "reference": "5f114e1fad79196a24f189236c9e7fb04482b8a2",
                 "shasum": ""
             },
             "require": {
@@ -1053,7 +1053,7 @@
                 "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/5.5.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2023-03-09T03:46:43+00:00"
+            "time": "2023-03-10T02:33:18+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
See previous version bump #5692 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Subscriptions Core 5.5.0 was re-tagged to include a last-minute change before the version was shipped in WC Subscriptions and WC Payments.

This small PR updates the `composer.lock` to fetch the latest version

