### PR TITLE
Pass the platform checkout util instance to the constructor of the express button class

### DIFF
--- a/changelog/update-express-button-class-constructor-arguments
+++ b/changelog/update-express-button-class-constructor-arguments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Pass an instance of Platform_Checkout_Utilities when instantiating WC_Payments_Platform_Checkout_Button_Handler.

--- a/includes/class-wc-payments-platform-checkout-button-handler.php
+++ b/includes/class-wc-payments-platform-checkout-button-handler.php
@@ -37,14 +37,23 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 	private $gateway;
 
 	/**
+	 * Platform_Checkout_Utilities instance.
+	 *
+	 * @var Platform_Checkout_Utilities
+	 */
+	private $platform_checkout_utilities;
+
+	/**
 	 * Initialize class actions.
 	 *
-	 * @param WC_Payments_Account      $account Account information.
-	 * @param WC_Payment_Gateway_WCPay $gateway WCPay gateway.
+	 * @param WC_Payments_Account         $account Account information.
+	 * @param WC_Payment_Gateway_WCPay    $gateway WCPay gateway.
+	 * @param Platform_Checkout_Utilities $platform_checkout_utilities WCPay gateway.
 	 */
-	public function __construct( WC_Payments_Account $account, WC_Payment_Gateway_WCPay $gateway ) {
-		$this->account = $account;
-		$this->gateway = $gateway;
+	public function __construct( WC_Payments_Account $account, WC_Payment_Gateway_WCPay $gateway, Platform_Checkout_Utilities $platform_checkout_utilities ) {
+		$this->account                     = $account;
+		$this->gateway                     = $gateway;
+		$this->platform_checkout_utilities = $platform_checkout_utilities;
 
 		add_action( 'init', [ $this, 'init' ] );
 	}
@@ -481,8 +490,7 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 		}
 
 		// Check if WooPay is available in the user country.
-		$platform_checkout_utilities = new Platform_Checkout_Utilities();
-		if ( ! $platform_checkout_utilities->is_country_available( $this->gateway ) ) {
+		if ( ! $this->platform_checkout_utilities->is_country_available( $this->gateway ) ) {
 			return false;
 		}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -487,7 +487,7 @@ class WC_Payments {
 
 		// Payment Request and Apple Pay.
 		self::$payment_request_button_handler   = new WC_Payments_Payment_Request_Button_Handler( self::$account, self::get_gateway() );
-		self::$platform_checkout_button_handler = new WC_Payments_Platform_Checkout_Button_Handler( self::$account, self::get_gateway() );
+		self::$platform_checkout_button_handler = new WC_Payments_Platform_Checkout_Button_Handler( self::$account, self::get_gateway(), self::$platform_checkout_util );
 		self::$apple_pay_registration           = new WC_Payments_Apple_Pay_Registration( self::$api_client, self::$account, self::get_gateway() );
 
 		add_filter( 'woocommerce_payment_gateways', [ __CLASS__, 'register_gateway' ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Pass an instance of the Platform_Checkout_Utilities class as a parameter when instantiating WC_Payments_Platform_Checkout_Button_Handler. This facilitates mocking the methods of the Platform_Checkout_Utilities class in unit tests.

#### Testing instructions

Only regression tests:

* Enable the WooPay Express button on the checkout, cart, and product pages.
* Confirm you can check out via WooPay using the express button from these three locations.
* Confirm there are no warnings or errors in the logs.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
