### PR TITLE
Use consistent timezone in tests

### DIFF
--- a/changelog/feature-consistent-timezone-tests
+++ b/changelog/feature-consistent-timezone-tests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Made timezones consistent in tests by generating dynamically.

--- a/client/data/transactions/test/resolvers.js
+++ b/client/data/transactions/test/resolvers.js
@@ -15,6 +15,7 @@ import {
 	updateTransactionsSummary,
 } from '../actions';
 import { getTransactions, getTransactionsSummary } from '../resolvers';
+import { getUserTimeZone } from 'wcpay/utils/test-utils';
 
 const errorResponse = { code: 'error' };
 
@@ -43,7 +44,9 @@ describe( 'getTransactions resolver', () => {
 		'page=1&pagesize=25&sort=date&direction=desc' +
 		'&match=all&date_before=2020-04-29%2003%3A59%3A59&date_after=2020-04-29%2004%3A00%3A00' +
 		'&date_between%5B0%5D=2020-04-28%2004%3A00%3A00&date_between%5B1%5D=2020-04-30%2003%3A59%3A59&type_is=charge' +
-		'&type_is_not=dispute&loan_id_is=mock_flxln_id&deposit_id=mock_po_id&search=Test%20user&user_timezone=-05%3A00';
+		`&type_is_not=dispute&loan_id_is=mock_flxln_id&deposit_id=mock_po_id&search=Test%20user&user_timezone=${ encodeURIComponent(
+			getUserTimeZone()
+		) }`;
 	let generator = null;
 
 	beforeEach( () => {
@@ -89,7 +92,9 @@ describe( 'getTransactionsSummary resolver', () => {
 	const expectedQueryString =
 		'match=all&date_before=2020-04-29%2003%3A59%3A59&date_after=2020-04-29%2004%3A00%3A00' +
 		'&date_between%5B0%5D=2020-04-28%2004%3A00%3A00&date_between%5B1%5D=2020-04-30%2003%3A59%3A59&type_is=charge' +
-		'&type_is_not=dispute&loan_id_is=mock_flxln_id&deposit_id=mock_po_id&search=Test%20user&user_timezone=-05%3A00';
+		`&type_is_not=dispute&loan_id_is=mock_flxln_id&deposit_id=mock_po_id&search=Test%20user&user_timezone=${ encodeURIComponent(
+			getUserTimeZone()
+		) }`;
 	let generator = null;
 
 	beforeEach( () => {

--- a/client/transactions/list/test/index.tsx
+++ b/client/transactions/list/test/index.tsx
@@ -10,6 +10,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { dateI18n } from '@wordpress/date';
 import { downloadCSVFile } from '@woocommerce/csv-export';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
+import { getUserTimeZone } from 'wcpay/utils/test-utils';
 import moment from 'moment';
 import os from 'os';
 
@@ -519,8 +520,9 @@ describe( 'Transactions list', () => {
 				expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
 				expect( mockApiFetch ).toHaveBeenCalledWith( {
 					method: 'POST',
-					path:
-						'/wc/v3/payments/transactions/download?user_email=mock%40example.com&user_timezone=-05%3A00',
+					path: `/wc/v3/payments/transactions/download?user_email=mock%40example.com&user_timezone=${ encodeURIComponent(
+						getUserTimeZone()
+					) }`,
 				} );
 			} );
 		} );
@@ -574,8 +576,9 @@ describe( 'Transactions list', () => {
 				expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
 				expect( mockApiFetch ).toHaveBeenCalledWith( {
 					method: 'POST',
-					path:
-						'/wc/v3/payments/transactions/download?user_email=mock%40example.com&deposit_id=po_mock&user_timezone=-05%3A00',
+					path: `/wc/v3/payments/transactions/download?user_email=mock%40example.com&deposit_id=po_mock&user_timezone=${ encodeURIComponent(
+						getUserTimeZone()
+					) }`,
 				} );
 			} );
 		} );

--- a/client/utils/test-utils.js
+++ b/client/utils/test-utils.js
@@ -15,3 +15,7 @@ export function getUnformattedAmount( formattedAmount ) {
 export function formatDate( date, format ) {
 	return dateI18n( format, moment.utc( date ).toISOString(), true );
 }
+
+export function getUserTimeZone() {
+	return moment( new Date() ).format( 'Z' );
+}


### PR DESCRIPTION
Fixes #5063 

#### Changes proposed in this Pull Request
- Generate user timezone dynamically in tests for matching query string.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* JS test pipeline should be green.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
