### PR TITLE
Add feature flag for simplify deposits UI.

### DIFF
--- a/changelog/add-5690-simplify-deposits-ui-feature-flag
+++ b/changelog/add-5690-simplify-deposits-ui-feature-flag
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Change is not user facing.
+
+

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -11,6 +11,7 @@ declare const wcpaySettings: {
 		customSearch: boolean;
 		customDepositSchedules: boolean;
 		isAuthAndCaptureEnabled: boolean;
+		simplifyDepositsUi: boolean;
 	};
 	fraudServices: unknown[];
 	isJetpackConnected: boolean;

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -11,7 +11,7 @@ declare const wcpaySettings: {
 		customSearch: boolean;
 		customDepositSchedules: boolean;
 		isAuthAndCaptureEnabled: boolean;
-		simplifyDepositsUi: boolean;
+		simplifyDepositsUi?: boolean;
 	};
 	fraudServices: unknown[];
 	isJetpackConnected: boolean;

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -264,7 +264,7 @@ class WC_Payments_Features {
 				'woopayExpressCheckout'   => self::is_woopay_express_checkout_enabled(),
 				'isAuthAndCaptureEnabled' => self::is_auth_and_capture_enabled(),
 				'progressiveOnboarding'   => self::is_progressive_onboarding_enabled(),
-				'simplifyDepoitsUi'       => self::is_simplify_deposits_ui_enabled(),
+				'simplifyDepositsUi'       => self::is_simplify_deposits_ui_enabled(),
 			]
 		);
 	}

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -264,7 +264,7 @@ class WC_Payments_Features {
 				'woopayExpressCheckout'   => self::is_woopay_express_checkout_enabled(),
 				'isAuthAndCaptureEnabled' => self::is_auth_and_capture_enabled(),
 				'progressiveOnboarding'   => self::is_progressive_onboarding_enabled(),
-				'simplifyDepositsUi'       => self::is_simplify_deposits_ui_enabled(),
+				'simplifyDepositsUi'      => self::is_simplify_deposits_ui_enabled(),
 			]
 		);
 	}

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -19,6 +19,7 @@ class WC_Payments_Features {
 	const WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME = '_wcpay_feature_woopay_express_checkout';
 	const AUTH_AND_CAPTURE_FLAG_NAME        = '_wcpay_feature_auth_and_capture';
 	const PROGRESSIVE_ONBOARDING_FLAG_NAME  = '_wcpay_feature_progressive_onboarding';
+	const SIMPLIFY_DEPOSITS_UI_FLAG_NAME    = '_wcpay_feature_simplify_deposits_ui';
 
 	/**
 	 * Checks whether any UPE gateway is enabled.
@@ -236,6 +237,15 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Checks whether Simplify Deposits UI is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_simplify_deposits_ui_enabled(): bool {
+		return '1' === get_option( self::SIMPLIFY_DEPOSITS_UI_FLAG_NAME, '0' );
+	}
+
+	/**
 	 * Returns feature flags as an array suitable for display on the front-end.
 	 *
 	 * @return bool[]
@@ -254,6 +264,7 @@ class WC_Payments_Features {
 				'woopayExpressCheckout'   => self::is_woopay_express_checkout_enabled(),
 				'isAuthAndCaptureEnabled' => self::is_auth_and_capture_enabled(),
 				'progressiveOnboarding'   => self::is_progressive_onboarding_enabled(),
+				'simplifyDepoitsUi'       => self::is_simplify_deposits_ui_enabled(),
 			]
 		);
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/5690.

#### Changes proposed in this Pull Request

Add a feature flag for simplify deposits UI project pdjTHR-2i5-p2.

ps: I intentionally do not add unit test since this feature flag is somewhat temporary. Let me know if I should add a unit test.

#### Testing instructions

* Install [WP Console](https://wordpress.org/plugins/wp-console/).
* To check in PHP, use `WC_Payments_Features::is_simplify_deposits_ui_enabled()`.
* To check in Javascript, open Payments > Overview page and type `window.wcpaySettings.featureFlags.simplifyDepositsUi` in dev console. If feature flag is disabled, it will return non-true value.
* To enable, run `update_option( '_wcpay_feature_simplify_deposits_ui', '1' );` in WP Console. To disable, set option to '0'.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.