### PR TITLE
Fix bug with showing WC tasks when there is no WCPay account

### DIFF
--- a/changelog/fix-4748-check-if-account-status-is-not-error
+++ b/changelog/fix-4748-check-if-account-status-is-not-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix bug with showing WC tasks when there is no WCPay account

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -65,6 +65,7 @@ export const getTasks = ( {
 	isAccountOverviewTasksEnabled,
 	numDisputesNeedingResponse = 0,
 } ) => {
+	// Do not proceed further if we don't have account status.
 	if ( accountStatus.error ) {
 		return [];
 	}

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -65,6 +65,9 @@ export const getTasks = ( {
 	isAccountOverviewTasksEnabled,
 	numDisputesNeedingResponse = 0,
 } ) => {
+	if ( accountStatus.error ) {
+		return [];
+	}
 	const {
 		status,
 		currentDeadline,

--- a/client/overview/task-list/tasks.js
+++ b/client/overview/task-list/tasks.js
@@ -65,18 +65,15 @@ export const getTasks = ( {
 	isAccountOverviewTasksEnabled,
 	numDisputesNeedingResponse = 0,
 } ) => {
-	// Do not proceed further if we don't have account status.
-	if ( accountStatus.error ) {
-		return [];
-	}
 	const {
 		status,
 		currentDeadline,
 		pastDue,
 		accountLink,
 		requirements,
-		progressiveOnboarding: { isEnabled: isPoEnabled },
+		progressiveOnboarding,
 	} = accountStatus;
+	const isPoEnabled = progressiveOnboarding?.isEnabled;
 	const accountRestrictedSoon = 'restricted_soon' === status;
 	const accountDetailsPastDue = 'restricted' === status && pastDue;
 	const errorMessages = getErrorMessagesFromRequirements( requirements );

--- a/client/overview/task-list/test/tasks.js
+++ b/client/overview/task-list/test/tasks.js
@@ -151,6 +151,23 @@ describe( 'getTasks()', () => {
 		);
 	} );
 
+	it( 'returns the expected keys when the account is not onboarded', () => {
+		const tasks = getTasks( {
+			isAccountOverviewTasksEnabled: true,
+			showUpdateDetailsTask: true,
+			wpcomReconnectUrl: 'http://example.com',
+			accountStatus: {
+				error: true,
+			},
+		} );
+
+		expect( tasks ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( { key: 'reconnect-wpcom-user' } ),
+			] )
+		);
+	} );
+
 	it( 'returns the expected keys when the account overview flag is disabled', () => {
 		const tasks = getTasks( {
 			showUpdateDetailsTask: true,


### PR DESCRIPTION
Fixes bug related to merge of #4748 

#### Description
GlobalStep found an error p1678777814525669-slack-C011ENB20Q1. When there is no WCPay account onboarded (right after install of WCPay), the task list in WC Home is not shown.

#### Changes proposed in this Pull Request

- Change the deconstruction of the params so the code will execute in any case. For example, Reconnect WPCOM task will be available even if there is no WCPay account (nothing new, was working like that before).
- Add test to cover this case

#### Testing instructions

**Develop**
* Remove the account from local
* Clear the cache
* Open WC Home and check there are no WC tasks at all

**The fix**
* Check out the branch `fix/4748-check-if-account-status-is-not-error`
* Build the changes locally `npm run watch`
* Open WC Home and check there are WC Tasks but without WCPay tasks
* Onboard the account
* Check that task list is still visible

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.