### PR TITLE
Fix new user not being saved in platform

### DIFF
--- a/changelog/fix-5784
+++ b/changelog/fix-5784
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix new user not being saved in platform

--- a/includes/core/server/request/class-woopay-create-and-confirm-intention.php
+++ b/includes/core/server/request/class-woopay-create-and-confirm-intention.php
@@ -34,4 +34,13 @@ class WooPay_Create_And_Confirm_Intention extends Create_And_Confirm_Intention {
 		$this->set_param( 'woopay_has_subscription', $has );
 	}
 
+	/**
+	 * Save payment method to platform.
+	 *
+	 * @param bool $save save payment method to platform.
+	 */
+	public function set_save_payment_method_to_platform( $save = true ) {
+		$this->set_param( 'save_payment_method_to_platform', $save );
+	}
+
 }

--- a/includes/core/server/request/class-woopay-create-and-confirm-intention.php
+++ b/includes/core/server/request/class-woopay-create-and-confirm-intention.php
@@ -12,8 +12,9 @@ namespace WCPay\Core\Server\Request;
  */
 class WooPay_Create_And_Confirm_Intention extends Create_And_Confirm_Intention {
 	const DEFAULT_PARAMS = [
-		'is_platform_payment_method' => false,
-		'woopay_has_subscription'    => false,
+		'is_platform_payment_method'      => false,
+		'woopay_has_subscription'         => false,
+		'save_payment_method_to_platform' => false,
 	];
 
 	/**

--- a/includes/core/server/request/class-woopay-create-and-confirm-setup-intention.php
+++ b/includes/core/server/request/class-woopay-create-and-confirm-setup-intention.php
@@ -11,7 +11,7 @@ namespace WCPay\Core\Server\Request;
  * Request class for creating woopay setup intents.
  */
 class WooPay_Create_And_Confirm_Setup_Intention extends Create_And_Confirm_Setup_Intention {
-	const DEFAULTS = [
+	const DEFAULT_PARAMS = [
 		'save_in_platform_account'        => false,
 		'is_platform_payment_method'      => false,
 		'save_payment_method_to_platform' => false,

--- a/includes/woopay/services/class-checkout-service.php
+++ b/includes/woopay/services/class-checkout-service.php
@@ -30,6 +30,7 @@ class Checkout_Service {
 	public function create_intention_request( Request $base_request, Payment_Information $payment_information ) {
 		$request = WooPay_Create_And_Confirm_Intention::extend( $base_request );
 		$request->set_has_woopay_subscription( '1' === $payment_information->get_order()->get_meta( '_woopay_has_subscription' ) );
+		$request->set_save_payment_method_to_platform( $payment_information->should_save_payment_method_to_platform() );
 		$request->set_is_platform_payment_method( $this->is_platform_payment_method( $payment_information->is_using_saved_payment_method() ) );
 		return $request;
 	}


### PR DESCRIPTION
Fixes #5784 

#### Changes proposed in this Pull Request
Add the `set_save_payment_method_to_platform` to the `WooPay_Create_And_Confirm_Intention`


#### Testing instructions
1. Purchase a product as a new user
2. Make sure to add the country code for the phone number (ex.+14706629035)
3. Check the `Save my information for a faster and secure checkout` box
4. Go to WooPay site and search for the new user
5. See the new user gets created


*

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
