### PR TITLE
Fix fatal error when editing a page that contains a Checkout block

### DIFF
--- a/changelog/fix-edit-checkout-page-error
+++ b/changelog/fix-edit-checkout-page-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Check whether we have an instance of WC_Cart before invoking its methods on checkout

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -672,6 +672,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			! ( WC_Payments_Features::is_upe_legacy_enabled() && ! WC_Payments_Features::is_upe_split_enabled() ) &&
 			( is_checkout() || has_block( 'woocommerce/checkout' ) ) &&
 			! is_wc_endpoint_url( 'order-pay' ) &&
+			WC()->cart instanceof WC_Cart &&
 			! WC()->cart->is_empty() &&
 			WC()->cart->needs_payment()
 		) {


### PR DESCRIPTION
Fixes #5806

#### Changes proposed in this Pull Request

Add a check to confirm `WC()->cart` returns an instance of `WC_Cart` before invoking its methods in `WC_Payment_Gateway_WCPay::should_use_stripe_platform_on_checkout_page()`

#### Testing instructions

1. Install and activate Blocks 9.7.0 or newer
2. Edit a page where you had a checkout block (or add this block to a page)
3. Confirm no error is triggered

**Regression tests**
1. Confirm things work fine with Blocks < 9.7.0
2. Confirm you can place an order 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
