### PR TITLE
Fix fatal errors on the thank-you page due to the strong type check in our filters.

### DIFF
--- a/changelog/fix-5816-error-on-thank-you-page
+++ b/changelog/fix-5816-error-on-thank-you-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fatal errors on the thank-you page due to the strong type check in our filters.

--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -77,7 +77,7 @@ class WC_Payments_Order_Success_Page {
 	 *
 	 * @return string
 	 */
-	public function add_notice_previous_paid_order( string $text ) {
+	public function add_notice_previous_paid_order( $text ) {
 		if ( isset( $_GET[ WC_Payment_Gateway_WCPay::FLAG_PREVIOUS_ORDER_PAID ] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
 			$text .= sprintf(
 				'<div class="woocommerce-info">%s</div>',
@@ -95,7 +95,7 @@ class WC_Payments_Order_Success_Page {
 	 *
 	 * @return string
 	 */
-	public function add_notice_previous_successful_intent( string $text ) {
+	public function add_notice_previous_successful_intent( $text ) {
 		if ( isset( $_GET[ WC_Payment_Gateway_WCPay::FLAG_PREVIOUS_SUCCESSFUL_INTENT ] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
 			$text .= sprintf(
 				'<div class="woocommerce-info">%s</div>',


### PR DESCRIPTION
Fixes #5816

NOTE: I am merging on `trunk` for the 5.6.0 release. We can decide the base/target branch later if needed.

Slack convo: p1679302669351279/1679299525.833519-slack-C01BPL3ALGP

This error can only happen if other extensions provide a filter for `woocommerce_thankyou_order_received_text` and return `null` in that filter. 

#### Changes proposed in this Pull Request

Just remove the type declarations to avoid this error. 
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

To replicate this error: 

- Add this snippet in the woocommerce-payments.php main file or as a snippet somewhere: 

```php
add_filter( 'woocommerce_thankyou_order_received_text', function () {
	return null;
}, 10);
```
- Check out an order, and get the order-received URL, then add `&wcpay_paid_for_previous_order=yes` to the end of this order to see the error. Finally, the link would be like this: `http://localhost:8082/checkout/order-received/655/?key=wc_order_wcslvGuNrnho0&wcpay_paid_for_previous_order=yes`. 

- Apply this fix to confirm that the issue is no longer there.


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.