### PR TITLE
Add IP country to payment fingerprint data

### DIFF
--- a/changelog/add-server-3127-ip-country-fingerprint
+++ b/changelog/add-server-3127-ip-country-fingerprint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add shopper IP country to fraud prevention metadata sent to the server

--- a/includes/fraud-prevention/class-buyer-fingerprinting-service.php
+++ b/includes/fraud-prevention/class-buyer-fingerprinting-service.php
@@ -65,6 +65,7 @@ class Buyer_Fingerprinting_Service {
 		return [
 			'fraud_prevention_data_shopper_ip_hash' => $this->hash_data_for_fraud_prevention( WC_Geolocation::get_ip_address() ),
 			'fraud_prevention_data_shopper_ua_hash' => $fingerprint,
+			'fraud_prevention_data_ip_country'      => WC_Geolocation::geolocate_ip( '', true )['country'],
 		];
 	}
 }

--- a/tests/unit/fraud-prevention/test-class-buyer-fingerprinting-service.php
+++ b/tests/unit/fraud-prevention/test-class-buyer-fingerprinting-service.php
@@ -45,11 +45,19 @@ class Buyer_Fingerprinting_Service_Test extends WCPAY_UnitTestCase {
 
 	public function test_it_hashes_order_info() {
 		$fingerprint = 'abc123';
+		$ip_country  = 'GB';
+		add_filter(
+			'woocommerce_geolocate_ip',
+			function() use ( $ip_country ) {
+				return $ip_country;
+			}
+		);
 
 		$order_hashes          = $this->buyer_fingerprinting_service->get_hashed_data_for_customer( $fingerprint );
 		$expected_hashed_array = [
 			'fraud_prevention_data_shopper_ip_hash' => hash( 'sha512', '127.0.0.1', false ),
 			'fraud_prevention_data_shopper_ua_hash' => $fingerprint,
+			'fraud_prevention_data_ip_country'      => $ip_country,
 		];
 
 		$this->assertSame( $order_hashes, $expected_hashed_array );


### PR DESCRIPTION
Fixes Automattic/woocommerce-payments-server#3127

#### Changes proposed in this Pull Request

This PR adds the shopper's country code calculated from their IP address to the payment fingerprint metadata on the intents created for the shopper.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch.
* Create an order and pay it.
* Go to your test account on Stripe, check the last payment. 
* Check if the fraud fingerprint metadata on Stripe payment intent created contains your computer's country code as your IP country with the key `fraud_prevention_data_ip_country`.
<img width="1510" alt="image" src="https://user-images.githubusercontent.com/3295/226479266-6ef5bec6-06f2-4ffb-b733-4d613e8e927b.png">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
