### PR TITLE
Fix saving both protection level and settings in one call

### DIFF
--- a/changelog/fix-advanced-settings-not-saving
+++ b/changelog/fix-advanced-settings-not-saving
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: It contains a fix to the advanced fraud protection page saving settings.
+
+

--- a/client/settings/fraud-protection/advanced-settings/cards/order-items-threshold.js
+++ b/client/settings/fraud-protection/advanced-settings/cards/order-items-threshold.js
@@ -15,17 +15,16 @@ import FraudProtectionRuleDescription from '../rule-description';
 import FraudPreventionSettingsContext from '../context';
 
 const OrderItemsThresholdCustomForm = ( { setting } ) => {
-	const {
-		advancedFraudProtectionSettings,
-		setAdvancedFraudProtectionSettings,
-	} = useContext( FraudPreventionSettingsContext );
+	const { protectionSettingsUI, setProtectionSettingsUI } = useContext(
+		FraudPreventionSettingsContext
+	);
 
 	const minItemsTemp = parseInt(
-		advancedFraudProtectionSettings[ setting ].min_items,
+		protectionSettingsUI[ setting ].min_items,
 		10
 	);
 	const maxItemsTemp = parseInt(
-		advancedFraudProtectionSettings[ setting ].max_items,
+		protectionSettingsUI[ setting ].max_items,
 		10
 	);
 
@@ -37,15 +36,15 @@ const OrderItemsThresholdCustomForm = ( { setting } ) => {
 	);
 
 	useEffect( () => {
-		advancedFraudProtectionSettings[ setting ].min_items = minItemsCount;
-		advancedFraudProtectionSettings[ setting ].max_items = maxItemsCount;
-		setAdvancedFraudProtectionSettings( advancedFraudProtectionSettings );
+		protectionSettingsUI[ setting ].min_items = minItemsCount;
+		protectionSettingsUI[ setting ].max_items = maxItemsCount;
+		setProtectionSettingsUI( protectionSettingsUI );
 	}, [
 		setting,
 		minItemsCount,
 		maxItemsCount,
-		advancedFraudProtectionSettings,
-		setAdvancedFraudProtectionSettings,
+		protectionSettingsUI,
+		setProtectionSettingsUI,
 	] );
 
 	const isItemRangeEmpty =

--- a/client/settings/fraud-protection/advanced-settings/cards/purchase-price-threshold.js
+++ b/client/settings/fraud-protection/advanced-settings/cards/purchase-price-threshold.js
@@ -19,31 +19,30 @@ const getFloatValue = ( value ) => {
 };
 
 const PurchasePriceThresholdCustomForm = ( { setting } ) => {
-	const {
-		advancedFraudProtectionSettings,
-		setAdvancedFraudProtectionSettings,
-	} = useContext( FraudPreventionSettingsContext );
+	const { protectionSettingsUI, setProtectionSettingsUI } = useContext(
+		FraudPreventionSettingsContext
+	);
 
 	const minAmountTemp = parseFloat(
-		advancedFraudProtectionSettings[ setting ].min_amount
+		protectionSettingsUI[ setting ].min_amount
 	);
 	const maxAmountTemp = parseFloat(
-		advancedFraudProtectionSettings[ setting ].max_amount
+		protectionSettingsUI[ setting ].max_amount
 	);
 
 	const [ minAmount, setMinAmount ] = useState( minAmountTemp ?? '' );
 	const [ maxAmount, setMaxAmount ] = useState( maxAmountTemp ?? '' );
 
 	useEffect( () => {
-		advancedFraudProtectionSettings[ setting ].min_amount = minAmount;
-		advancedFraudProtectionSettings[ setting ].max_amount = maxAmount;
-		setAdvancedFraudProtectionSettings( advancedFraudProtectionSettings );
+		protectionSettingsUI[ setting ].min_amount = minAmount;
+		protectionSettingsUI[ setting ].max_amount = maxAmount;
+		setProtectionSettingsUI( protectionSettingsUI );
 	}, [
 		setting,
 		minAmount,
 		maxAmount,
-		advancedFraudProtectionSettings,
-		setAdvancedFraudProtectionSettings,
+		protectionSettingsUI,
+		setProtectionSettingsUI,
 	] );
 
 	const areInputsEmpty =

--- a/client/settings/fraud-protection/advanced-settings/cards/test/address-mismatch.test.js
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/address-mismatch.test.js
@@ -18,8 +18,8 @@ describe( 'Address mismatch card', () => {
 	};
 	const setSettings = jest.fn();
 	const contextValue = {
-		advancedFraudProtectionSettings: settings,
-		setAdvancedFraudProtectionSettings: setSettings,
+		protectionSettingsUI: settings,
+		setProtectionSettingsUI: setSettings,
 	};
 	test( 'renders correctly', () => {
 		settings.address_mismatch.enabled = false;

--- a/client/settings/fraud-protection/advanced-settings/cards/test/avs-mismatch.test.js
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/avs-mismatch.test.js
@@ -26,8 +26,8 @@ describe( 'AVS mismatch card', () => {
 		};
 		const setSettings = jest.fn();
 		const contextValue = {
-			advancedFraudProtectionSettings: settings,
-			setAdvancedFraudProtectionSettings: setSettings,
+			protectionSettingsUI: settings,
+			setProtectionSettingsUI: setSettings,
 		};
 		const { container } = render(
 			<FraudPreventionSettingsContext.Provider value={ contextValue }>
@@ -55,8 +55,8 @@ describe( 'AVS mismatch card', () => {
 		};
 		const setSettings = jest.fn();
 		const contextValue = {
-			advancedFraudProtectionSettings: settings,
-			setAdvancedFraudProtectionSettings: setSettings,
+			protectionSettingsUI: settings,
+			setProtectionSettingsUI: setSettings,
 		};
 		const { container } = render(
 			<FraudPreventionSettingsContext.Provider value={ contextValue }>

--- a/client/settings/fraud-protection/advanced-settings/cards/test/cvc-verification.test.js
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/cvc-verification.test.js
@@ -26,8 +26,8 @@ describe( 'CVC verification card', () => {
 		};
 		const setSettings = jest.fn();
 		const contextValue = {
-			advancedFraudProtectionSettings: settings,
-			setAdvancedFraudProtectionSettings: setSettings,
+			protectionSettingsUI: settings,
+			setProtectionSettingsUI: setSettings,
 		};
 		const { container } = render(
 			<FraudPreventionSettingsContext.Provider value={ contextValue }>

--- a/client/settings/fraud-protection/advanced-settings/cards/test/international-billing-address.test.js
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/international-billing-address.test.js
@@ -18,8 +18,8 @@ describe( 'International billing address card', () => {
 	};
 	const setSettings = jest.fn();
 	const contextValue = {
-		advancedFraudProtectionSettings: settings,
-		setAdvancedFraudProtectionSettings: setSettings,
+		protectionSettingsUI: settings,
+		setProtectionSettingsUI: setSettings,
 	};
 	test( 'renders correctly', () => {
 		const { container } = render(

--- a/client/settings/fraud-protection/advanced-settings/cards/test/international-ip-address.test.js
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/international-ip-address.test.js
@@ -18,8 +18,8 @@ describe( 'International IP address card', () => {
 	};
 	const setSettings = jest.fn();
 	const contextValue = {
-		advancedFraudProtectionSettings: settings,
-		setAdvancedFraudProtectionSettings: setSettings,
+		protectionSettingsUI: settings,
+		setProtectionSettingsUI: setSettings,
 	};
 	test( 'renders correctly', () => {
 		const { container } = render(

--- a/client/settings/fraud-protection/advanced-settings/cards/test/order-items-threshold.test.js
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/order-items-threshold.test.js
@@ -22,8 +22,8 @@ describe( 'Order items threshold card', () => {
 	};
 	const setSettings = jest.fn();
 	const contextValue = {
-		advancedFraudProtectionSettings: settings,
-		setAdvancedFraudProtectionSettings: setSettings,
+		protectionSettingsUI: settings,
+		setProtectionSettingsUI: setSettings,
 	};
 	test( 'renders correctly', () => {
 		const { container } = render(

--- a/client/settings/fraud-protection/advanced-settings/cards/test/purchase-price-threshold.test.js
+++ b/client/settings/fraud-protection/advanced-settings/cards/test/purchase-price-threshold.test.js
@@ -22,8 +22,8 @@ describe( 'Purchase price threshold card', () => {
 	};
 	const setSettings = jest.fn();
 	const contextValue = {
-		advancedFraudProtectionSettings: settings,
-		setAdvancedFraudProtectionSettings: setSettings,
+		protectionSettingsUI: settings,
+		setProtectionSettingsUI: setSettings,
 	};
 	test( 'renders correctly', () => {
 		const { container } = render(

--- a/client/settings/fraud-protection/advanced-settings/context.js
+++ b/client/settings/fraud-protection/advanced-settings/context.js
@@ -4,8 +4,8 @@
 import { createContext } from 'react';
 
 const FraudPreventionSettingsContext = createContext( {
-	advancedFraudProtectionSettings: false,
-	setAdvancedFraudProtectionSettings: () => {},
+	protectionSettingsUI: false,
+	setProtectionSettingsUI: () => {},
 } );
 
 export default FraudPreventionSettingsContext;

--- a/client/settings/fraud-protection/advanced-settings/index.js
+++ b/client/settings/fraud-protection/advanced-settings/index.js
@@ -12,7 +12,11 @@ import { dispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { useCurrentProtectionLevel, useSettings } from '../../../data';
+import {
+	useCurrentProtectionLevel,
+	useAdvancedFraudProtectionSettings,
+	useSettings,
+} from '../../../data';
 import ErrorBoundary from '../../../components/error-boundary';
 import { getAdminUrl } from '../../../utils';
 import SettingsLayout from 'wcpay/settings/settings-layout';
@@ -58,23 +62,23 @@ const SaveFraudProtectionSettingsButton = ( { children } ) => {
 };
 
 const FraudProtectionAdvancedSettingsPage = () => {
-	const { settings, saveSettings, isLoading } = useSettings();
+	const { saveSettings, isLoading, isSaving } = useSettings();
 	const [
 		currentProtectionLevel,
 		updateProtectionLevel,
 	] = useCurrentProtectionLevel();
-	const [ isSavingSettings, setIsSavingSettings ] = useState( false );
-	const [ validationError, setValidationError ] = useState( null );
 	const [
 		advancedFraudProtectionSettings,
-		setAdvancedFraudProtectionSettings,
-	] = useState( {} );
+		updateAdvancedFraudProtectionSettings,
+	] = useAdvancedFraudProtectionSettings();
+	const [ validationError, setValidationError ] = useState( null );
+	const [ protectionSettingsUI, setProtectionSettingsUI ] = useState( {} );
 
 	useEffect( () => {
-		setAdvancedFraudProtectionSettings(
-			readRuleset( settings.advanced_fraud_protection_settings )
+		setProtectionSettingsUI(
+			readRuleset( advancedFraudProtectionSettings )
 		);
-	}, [ settings ] );
+	}, [ advancedFraudProtectionSettings ] );
 
 	useLayoutEffect( () => {
 		const saveButton = document.querySelector(
@@ -105,10 +109,9 @@ const FraudProtectionAdvancedSettingsPage = () => {
 	};
 
 	const handleSaveSettings = async () => {
-		if ( validateSettings( advancedFraudProtectionSettings ) ) {
-			setIsSavingSettings( true );
+		if ( validateSettings( protectionSettingsUI ) ) {
 			if ( ProtectionLevel.ADVANCED !== currentProtectionLevel ) {
-				await updateProtectionLevel( ProtectionLevel.ADVANCED );
+				updateProtectionLevel( ProtectionLevel.ADVANCED );
 				dispatch( 'core/notices' ).createSuccessNotice(
 					__(
 						'Current protection level is set to "advanced".',
@@ -116,11 +119,10 @@ const FraudProtectionAdvancedSettingsPage = () => {
 					)
 				);
 			}
-			settings.advanced_fraud_protection_settings = writeRuleset(
-				advancedFraudProtectionSettings
+			updateAdvancedFraudProtectionSettings(
+				writeRuleset( protectionSettingsUI )
 			);
-			await saveSettings( settings );
-			setIsSavingSettings( false );
+			await saveSettings();
 		} else {
 			window.scrollTo( {
 				top: 0,
@@ -143,8 +145,8 @@ const FraudProtectionAdvancedSettingsPage = () => {
 	return (
 		<FraudPreventionSettingsContext.Provider
 			value={ {
-				advancedFraudProtectionSettings,
-				setAdvancedFraudProtectionSettings,
+				protectionSettingsUI,
+				setProtectionSettingsUI,
 			} }
 		>
 			<SettingsLayout displayBanner={ false }>
@@ -171,8 +173,7 @@ const FraudProtectionAdvancedSettingsPage = () => {
 								</Notice>
 							</div>
 						) }
-						{ 'error' ===
-							settings.advanced_fraud_protection_settings && (
+						{ 'error' === advancedFraudProtectionSettings && (
 							<div className="fraud-protection-advanced-settings-error-notice">
 								<Notice status="error" isDismissible={ false }>
 									{ __(
@@ -211,13 +212,12 @@ const FraudProtectionAdvancedSettingsPage = () => {
 				<div className="fraud-protection-header-save-button">
 					<Button
 						isPrimary
-						isBusy={ isSavingSettings }
+						isBusy={ isSaving }
 						onClick={ handleSaveSettings }
 						disabled={
-							isSavingSettings ||
+							isSaving ||
 							isLoading ||
-							'error' ===
-								settings.advanced_fraud_protection_settings
+							'error' === advancedFraudProtectionSettings
 						}
 					>
 						{ __( 'Save Changes', 'woocommerce-payments' ) }

--- a/client/settings/fraud-protection/advanced-settings/rule-toggle.js
+++ b/client/settings/fraud-protection/advanced-settings/rule-toggle.js
@@ -18,55 +18,39 @@ const FraudProtectionRuleToggle = ( {
 	helpText,
 	children,
 } ) => {
-	const {
-		advancedFraudProtectionSettings,
-		setAdvancedFraudProtectionSettings,
-	} = useContext( FraudPreventionSettingsContext );
+	const { protectionSettingsUI, setProtectionSettingsUI } = useContext(
+		FraudPreventionSettingsContext
+	);
 
 	const [ toggleState, setToggleState ] = useState( false );
 	const [ checkState, setCheckState ] = useState( false );
 
 	// Set initial states from saved settings.
 	useEffect( () => {
-		if (
-			advancedFraudProtectionSettings &&
-			advancedFraudProtectionSettings[ setting ]
-		) {
-			setToggleState(
-				advancedFraudProtectionSettings[ setting ].enabled
-			);
-			setCheckState( advancedFraudProtectionSettings[ setting ].block );
+		if ( protectionSettingsUI && protectionSettingsUI[ setting ] ) {
+			setToggleState( protectionSettingsUI[ setting ].enabled );
+			setCheckState( protectionSettingsUI[ setting ].block );
 		}
-	}, [
-		advancedFraudProtectionSettings,
-		setToggleState,
-		setCheckState,
-		setting,
-	] );
+	}, [ protectionSettingsUI, setToggleState, setCheckState, setting ] );
 
 	// Set global object values from input changes.
 	useEffect( () => {
-		if (
-			advancedFraudProtectionSettings &&
-			advancedFraudProtectionSettings[ setting ]
-		) {
-			advancedFraudProtectionSettings[ setting ].enabled = toggleState;
-			advancedFraudProtectionSettings[ setting ].block = checkState;
-			setAdvancedFraudProtectionSettings(
-				advancedFraudProtectionSettings
-			);
+		if ( protectionSettingsUI && protectionSettingsUI[ setting ] ) {
+			protectionSettingsUI[ setting ].enabled = toggleState;
+			protectionSettingsUI[ setting ].block = checkState;
+			setProtectionSettingsUI( protectionSettingsUI );
 		}
 	}, [
 		setting,
 		toggleState,
 		checkState,
-		advancedFraudProtectionSettings,
-		setAdvancedFraudProtectionSettings,
+		protectionSettingsUI,
+		setProtectionSettingsUI,
 	] );
 
 	// Render view.
 	return (
-		advancedFraudProtectionSettings && (
+		protectionSettingsUI && (
 			<div className="fraud-protection-rule-toggle">
 				<strong>
 					{ __( 'Enable filtering', 'woocommerce-payments' ) }

--- a/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.js.snap
+++ b/client/settings/fraud-protection/advanced-settings/test/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Advanced fraud protection settings doesn't save when there's validation errors 1`] = `
+exports[`Advanced fraud protection settings doesn't save when there's a validation error 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
@@ -19,7 +19,7 @@ Object {
       id="a11y-speak-assertive"
       style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-      Settings were not saved. Maximum purchase price must be greater than the minimum purchase price.
+      There was an error retrieving your fraud protection settings. Please refresh the page to try again.
     </div>
     <div
       aria-atomic="true"

--- a/client/settings/fraud-protection/advanced-settings/test/index.test.js
+++ b/client/settings/fraud-protection/advanced-settings/test/index.test.js
@@ -8,11 +8,16 @@ import { render, waitFor } from '@testing-library/react';
  * Internal dependencies
  */
 import FraudProtectionAdvancedSettingsPage from '..';
-import { useCurrentProtectionLevel, useSettings } from '../../../../data';
+import {
+	useAdvancedFraudProtectionSettings,
+	useCurrentProtectionLevel,
+	useSettings,
+} from '../../../../data';
 
 jest.mock( '../../../../data', () => ( {
 	useSettings: jest.fn(),
 	useCurrentProtectionLevel: jest.fn(),
+	useAdvancedFraudProtectionSettings: jest.fn(),
 } ) );
 
 // Workaround for mocking @wordpress/data.
@@ -35,6 +40,12 @@ let defaultSettings = [];
 describe( 'Advanced fraud protection settings', () => {
 	beforeEach( () => {
 		window.scrollTo = jest.fn();
+		const protectionSettings = {
+			state: {},
+			updateState: jest.fn( ( settings ) => {
+				protectionSettings.state = settings;
+			} ),
+		};
 		const protectionLevelState = {
 			state: 'standard',
 			updateState: jest.fn( ( level ) => {
@@ -44,6 +55,10 @@ describe( 'Advanced fraud protection settings', () => {
 		useCurrentProtectionLevel.mockReturnValue( [
 			protectionLevelState.state,
 			protectionLevelState.updateState,
+		] );
+		useAdvancedFraudProtectionSettings.mockReturnValue( [
+			protectionSettings.state,
+			protectionSettings.updateState,
 		] );
 	} );
 	afterEach( () => {
@@ -58,6 +73,7 @@ describe( 'Advanced fraud protection settings', () => {
 			saveSettings: jest.fn(),
 			isLoading: false,
 		} );
+		useAdvancedFraudProtectionSettings.mockReturnValue( [ {}, jest.fn() ] );
 		const container = render( <FraudProtectionAdvancedSettingsPage /> );
 		expect( container ).toMatchSnapshot();
 	} );
@@ -69,6 +85,10 @@ describe( 'Advanced fraud protection settings', () => {
 			saveSettings: jest.fn(),
 			isLoading: false,
 		} );
+		useAdvancedFraudProtectionSettings.mockReturnValue( [
+			'error',
+			jest.fn(),
+		] );
 		const container = render(
 			<div>
 				<div className="woocommerce-layout__header-wrapper">
@@ -81,10 +101,9 @@ describe( 'Advanced fraud protection settings', () => {
 		expect( container.baseElement ).toHaveTextContent(
 			/There was an error retrieving your fraud protection settings/i
 		);
-		const saveButton = await container.findByText( 'Save Changes' );
-		expect( saveButton ).toBeDisabled();
+		expect( await container.findByText( 'Save Changes' ) ).toBeDisabled();
 	} );
-	test( "doesn't save when there's validation errors", async () => {
+	test( "doesn't save when there's a validation error", async () => {
 		defaultSettings.push( {
 			key: 'purchase_price_threshold',
 			outcome: 'block',
@@ -96,12 +115,17 @@ describe( 'Advanced fraud protection settings', () => {
 				],
 			},
 		} );
+		useAdvancedFraudProtectionSettings.mockReturnValue( [
+			defaultSettings,
+			jest.fn(),
+		] );
 		useSettings.mockReturnValue( {
 			settings: {
 				advanced_fraud_protection_settings: defaultSettings,
 			},
 			saveSettings: jest.fn(),
 			isLoading: false,
+			isSaving: false,
 		} );
 		const settingsMock = useSettings();
 		const container = render(
@@ -114,9 +138,7 @@ describe( 'Advanced fraud protection settings', () => {
 		);
 		const saveButton = await container.findByText( 'Save Changes' );
 		saveButton.click();
-		await waitFor( () => {
-			expect( settingsMock.saveSettings.mock.calls.length ).toBe( 0 );
-		} );
+		expect( settingsMock.saveSettings.mock.calls.length ).toBe( 0 );
 		expect( container ).toMatchSnapshot();
 		expect(
 			document.querySelectorAll(
@@ -143,6 +165,10 @@ describe( 'Advanced fraud protection settings', () => {
 			saveSettings: jest.fn(),
 			isLoading: false,
 		} );
+		useAdvancedFraudProtectionSettings.mockReturnValue( [
+			defaultSettings,
+			jest.fn(),
+		] );
 		const settingsMock = useSettings();
 		const container = render(
 			<div>
@@ -193,6 +219,10 @@ describe( 'Advanced fraud protection settings', () => {
 			saveSettings: jest.fn(),
 			isLoading: false,
 		} );
+		useAdvancedFraudProtectionSettings.mockReturnValue( [
+			defaultSettings,
+			jest.fn(),
+		] );
 		const settingsMock = useSettings();
 		const container = render(
 			<div>
@@ -247,6 +277,10 @@ describe( 'Advanced fraud protection settings', () => {
 			saveSettings: jest.fn(),
 			isLoading: false,
 		} );
+		useAdvancedFraudProtectionSettings.mockReturnValue( [
+			defaultSettings,
+			jest.fn(),
+		] );
 		const settingsMock = useSettings();
 		const container = render(
 			<div>

--- a/client/settings/fraud-protection/advanced-settings/test/rule-toggle.test.js
+++ b/client/settings/fraud-protection/advanced-settings/test/rule-toggle.test.js
@@ -15,13 +15,13 @@ describe( 'Fraud protection rule toggle tests', () => {
 
 	beforeEach( () => {
 		mockContext = {
-			advancedFraudProtectionSettings: {
+			protectionSettingsUI: {
 				test_rule: {
 					enabled: false,
 					block: false,
 				},
 			},
-			setAdvancedFraudProtectionSettings: jest.fn(),
+			setProtectionSettingsUI: jest.fn(),
 		};
 	} );
 
@@ -55,7 +55,7 @@ describe( 'Fraud protection rule toggle tests', () => {
 		).not.toBeInTheDocument();
 	} );
 	test( 'renders correctly when enabled', () => {
-		mockContext.advancedFraudProtectionSettings.test_rule.enabled = true;
+		mockContext.protectionSettingsUI.test_rule.enabled = true;
 		const container = render(
 			<FraudPreventionSettingsContext.Provider value={ mockContext }>
 				<FraudProtectionRuleToggle
@@ -80,8 +80,8 @@ describe( 'Fraud protection rule toggle tests', () => {
 		expect( container.queryByText( 'test content' ) ).toBeInTheDocument();
 	} );
 	test( 'renders correctly when enabled and blocked', () => {
-		mockContext.advancedFraudProtectionSettings.test_rule.enabled = true;
-		mockContext.advancedFraudProtectionSettings.test_rule.block = true;
+		mockContext.protectionSettingsUI.test_rule.enabled = true;
+		mockContext.protectionSettingsUI.test_rule.block = true;
 		const container = render(
 			<FraudPreventionSettingsContext.Provider value={ mockContext }>
 				<FraudProtectionRuleToggle
@@ -119,19 +119,19 @@ describe( 'Fraud protection rule toggle tests', () => {
 		);
 		const activationToggle = container.getByLabelText( 'Test rule toggle' );
 		expect(
-			mockContext.advancedFraudProtectionSettings.test_rule.enabled
+			mockContext.protectionSettingsUI.test_rule.enabled
 		).toBeFalsy();
 		activationToggle.click();
 		expect(
-			mockContext.advancedFraudProtectionSettings.test_rule.enabled
+			mockContext.protectionSettingsUI.test_rule.enabled
 		).toBeTruthy();
 		activationToggle.click();
 		expect(
-			mockContext.advancedFraudProtectionSettings.test_rule.enabled
+			mockContext.protectionSettingsUI.test_rule.enabled
 		).toBeFalsy();
 	} );
 	test( 'sets the value correctly when block is selected', () => {
-		mockContext.advancedFraudProtectionSettings.test_rule.enabled = true;
+		mockContext.protectionSettingsUI.test_rule.enabled = true;
 		const container = render(
 			<FraudPreventionSettingsContext.Provider value={ mockContext }>
 				<FraudProtectionRuleToggle
@@ -144,16 +144,10 @@ describe( 'Fraud protection rule toggle tests', () => {
 			</FraudPreventionSettingsContext.Provider>
 		);
 		const activationToggle = container.getByLabelText( 'Block Payment' );
-		expect(
-			mockContext.advancedFraudProtectionSettings.test_rule.block
-		).toBeFalsy();
+		expect( mockContext.protectionSettingsUI.test_rule.block ).toBeFalsy();
 		activationToggle.click();
-		expect(
-			mockContext.advancedFraudProtectionSettings.test_rule.block
-		).toBeTruthy();
+		expect( mockContext.protectionSettingsUI.test_rule.block ).toBeTruthy();
 		activationToggle.click();
-		expect(
-			mockContext.advancedFraudProtectionSettings.test_rule.block
-		).toBeFalsy();
+		expect( mockContext.protectionSettingsUI.test_rule.block ).toBeFalsy();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the direct usage of the `settings` object returned from `useSettings` call, and replaces them with `useAdvancedFraudSettings`. This way when multiple things change on the settings object, with a single `saveSettings` call, all can be updated with one request. 

PR contains the update of the context variables to separate UI state and global Settings state., it may look crowded in terms of file count, but actually most are the test fixes.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Build the assets with `npm run build:client`
* Check if the saved predefs load correctly in the advanced config page.
* Check if the modifications are saved
* Check the settings stay intact after reloading the page on the browser.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
