### PR TITLE
Add settings page scroll into view

### DIFF
--- a/changelog/add-add-settings-page-scroll-into-view
+++ b/changelog/add-add-settings-page-scroll-into-view
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add settings page scroll into view

--- a/client/settings/express-checkout/index.js
+++ b/client/settings/express-checkout/index.js
@@ -79,7 +79,7 @@ const ExpressCheckout = () => {
 					{ isPlatformCheckoutFeatureFlagEnabled && (
 						<li
 							className="express-checkout"
-							id="express-checkout-woopay"
+							id="express-checkouts-woopay"
 						>
 							<div className="express-checkout__checkbox">
 								{ isStripeLinkEnabled ? (
@@ -198,7 +198,7 @@ const ExpressCheckout = () => {
 					) }
 					<li
 						className="express-checkout"
-						id="express-checkout-apple-google-pay"
+						id="express-checkouts-apple-google-pay"
 					>
 						<div className="express-checkout__checkbox">
 							<CheckboxControl
@@ -328,7 +328,7 @@ const ExpressCheckout = () => {
 					{ displayLinkPaymentMethod && (
 						<li
 							className="express-checkout"
-							id="express-checkout-link"
+							id="express-checkouts-link"
 						>
 							<div className="express-checkout__checkbox">
 								{ isPlatformCheckoutEnabled ? (

--- a/client/settings/express-checkout/index.js
+++ b/client/settings/express-checkout/index.js
@@ -77,7 +77,10 @@ const ExpressCheckout = () => {
 			<CardBody size={ 0 }>
 				<ul className="express-checkouts-list">
 					{ isPlatformCheckoutFeatureFlagEnabled && (
-						<li className="express-checkout">
+						<li
+							className="express-checkout"
+							id="express-checkout-woopay"
+						>
 							<div className="express-checkout__checkbox">
 								{ isStripeLinkEnabled ? (
 									<Tooltip
@@ -193,7 +196,10 @@ const ExpressCheckout = () => {
 							</div>
 						</li>
 					) }
-					<li className="express-checkout">
+					<li
+						className="express-checkout"
+						id="express-checkout-apple-google-pay"
+					>
 						<div className="express-checkout__checkbox">
 							<CheckboxControl
 								label={ __(
@@ -320,7 +326,10 @@ const ExpressCheckout = () => {
 						</div>
 					</li>
 					{ displayLinkPaymentMethod && (
-						<li className="express-checkout">
+						<li
+							className="express-checkout"
+							id="express-checkout-link"
+						>
 							<div className="express-checkout__checkbox">
 								{ isPlatformCheckoutEnabled ? (
 									<Tooltip

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { ExternalLink } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -22,7 +22,7 @@ import WCPaySettingsContext from '../wcpay-settings-context';
 import LoadableSettingsSection from '../loadable-settings-section';
 import WcPayUpeContextProvider from '../wcpay-upe-toggle/provider';
 import ErrorBoundary from '../../components/error-boundary';
-import { useDepositDelayDays } from '../../data';
+import { useDepositDelayDays, useSettings } from '../../data';
 import FraudProtection from '../fraud-protection';
 
 const PaymentMethodsDescription = () => (
@@ -140,6 +140,36 @@ const SettingsManager = () => {
 	const [ isTransactionInputsValid, setTransactionInputsValid ] = useState(
 		true
 	);
+	const { isLoading } = useSettings();
+
+	// Simulate scroll to hash on React component.
+	useEffect( () => {
+		if ( isLoading ) {
+			return;
+		}
+
+		const { hash } = window.location;
+
+		if ( ! hash ) {
+			return;
+		}
+
+		const element = document.querySelector( hash );
+
+		if ( ! element ) {
+			return;
+		}
+
+		const headerOffset = 110; // header size + margin
+		const elementPosition = element.getBoundingClientRect().top;
+		const offsetPosition =
+			elementPosition + window.pageYOffset - headerOffset;
+
+		window.scrollTo( {
+			top: offsetPosition,
+			behavior: 'smooth',
+		} );
+	}, [ isLoading ] );
 
 	return (
 		<SettingsLayout>
@@ -164,7 +194,10 @@ const SettingsManager = () => {
 					</LoadableSettingsSection>
 				</SettingsSection>
 			) }
-			<SettingsSection description={ ExpressCheckoutDescription }>
+			<SettingsSection
+				id="express-checkout"
+				description={ ExpressCheckoutDescription }
+			>
 				<LoadableSettingsSection numLines={ 20 }>
 					<ErrorBoundary>
 						<ExpressCheckout />

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -160,7 +160,11 @@ const SettingsManager = () => {
 			return;
 		}
 
-		const headerOffset = 110; // header size + margin
+		const headerElement = document.querySelector(
+			'.woocommerce-layout__header'
+		);
+		const headerSize = headerElement ? headerElement.clientHeight : 60;
+		const headerOffset = headerSize + 50; // header size + margin
 		const elementPosition = element.getBoundingClientRect().top;
 		const offsetPosition =
 			elementPosition + window.pageYOffset - headerOffset;

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -195,7 +195,7 @@ const SettingsManager = () => {
 				</SettingsSection>
 			) }
 			<SettingsSection
-				id="express-checkout"
+				id="express-checkouts"
 				description={ ExpressCheckoutDescription }
 			>
 				<LoadableSettingsSection numLines={ 20 }>

--- a/client/settings/settings-section.tsx
+++ b/client/settings/settings-section.tsx
@@ -15,8 +15,14 @@ const SettingsSection: React.FunctionComponent< {
 	className?: string;
 	description?: React.FunctionComponent;
 	title?: string;
-} > = ( { description: Description = () => null, children, className } ) => (
-	<div className={ classNames( 'settings-section', className ) }>
+	id?: string;
+} > = ( {
+	description: Description = () => null,
+	children,
+	className,
+	id,
+} ) => (
+	<div className={ classNames( 'settings-section', className ) } id={ id }>
 		<div className="settings-section__details">
 			<Description />
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR makes `window.location.hash` scroll directly into the views after the React components load on Settings page, also add IDs/hashes to the express checkouts section, allowing scrolling directly into it.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access WCPay settings page.
* Add `#express-checkouts` to the end of the URL and reload the page or [click here](http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments#express-checkouts) if you it on port `8082`.
* The page should scroll automatically to the `Express Checkouts` section.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
