### PR TITLE
Add cart item count to fraud metadata

### DIFF
--- a/changelog/add-cart-items-count-to-fraud-metadata
+++ b/changelog/add-cart-items-count-to-fraud-metadata
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This is adding some fixes to the fraud prevention UI. Also adding a new fraud metadata to contain order items.
+
+

--- a/client/data/fraud-outcomes/hooks.ts
+++ b/client/data/fraud-outcomes/hooks.ts
@@ -9,7 +9,6 @@ import { useSelect } from '@wordpress/data';
  */
 import { STORE_NAME } from '../constants';
 import { LatestFraudOutcomeResponse } from './types';
-import { FraudOutcome } from '../../types/fraud-outcome';
 
 export const useLatestFraudOutcome = (
 	id: string
@@ -18,13 +17,14 @@ export const useLatestFraudOutcome = (
 		( select ) => {
 			const {
 				isResolving,
+				hasFinishedResolution,
 				getLatestFraudOutcome,
 				getLatestFraudOutcomeError,
 			} = select( STORE_NAME );
 
 			if ( ! id || ! wcpaySettings.isFraudProtectionSettingsEnabled ) {
 				return {
-					data: {} as FraudOutcome,
+					data: undefined,
 					error: undefined,
 					isLoading: false,
 				};
@@ -33,7 +33,9 @@ export const useLatestFraudOutcome = (
 			return {
 				data: getLatestFraudOutcome( id ),
 				error: getLatestFraudOutcomeError( id ),
-				isLoading: isResolving( 'getLatestFraudOutcome', [ id ] ),
+				isLoading:
+					isResolving( 'getLatestFraudOutcome', [ id ] ) ||
+					! hasFinishedResolution( 'getLatestFraudOutcome', [ id ] ),
 			};
 		},
 		[ id ]

--- a/client/data/fraud-outcomes/reducer.ts
+++ b/client/data/fraud-outcomes/reducer.ts
@@ -29,6 +29,7 @@ const receiveFraudOutcomes = (
 					[ id ]: {
 						...state.latestFraudOutcome[ id ],
 						data: ( action as UpdateLatestFraudOutcomeAction ).data,
+						error: undefined,
 					},
 				},
 			};
@@ -38,6 +39,7 @@ const receiveFraudOutcomes = (
 				latestFraudOutcome: {
 					[ id ]: {
 						...state.latestFraudOutcome[ id ],
+						data: undefined,
 						error: ( action as UpdateErrorForLatestFraudOutcomeAction )
 							.error,
 					},

--- a/client/data/fraud-outcomes/selectors.ts
+++ b/client/data/fraud-outcomes/selectors.ts
@@ -18,11 +18,9 @@ const getLatestFraudOutcomeState = ( { fraudOutcomes }: State, id: string ) => {
 export const getLatestFraudOutcome = (
 	state: State,
 	id: string
-): FraudOutcome =>
-	getLatestFraudOutcomeState( state, id )?.data || ( {} as FraudOutcome );
+): FraudOutcome | undefined => getLatestFraudOutcomeState( state, id )?.data;
 
 export const getLatestFraudOutcomeError = (
 	state: State,
 	id: string
-): ApiError =>
-	getLatestFraudOutcomeState( state, id )?.error || ( {} as ApiError );
+): ApiError | undefined => getLatestFraudOutcomeState( state, id )?.error;

--- a/client/data/fraud-outcomes/test/hooks.ts
+++ b/client/data/fraud-outcomes/test/hooks.ts
@@ -56,6 +56,7 @@ describe( 'Fraud outcomes hooks', () => {
 					.fn()
 					.mockReturnValue( undefined ),
 				isResolving: jest.fn().mockReturnValue( false ),
+				hasFinishedResolution: jest.fn().mockReturnValue( true ),
 			};
 
 			const result = useLatestFraudOutcome( paymentIntentId );
@@ -74,12 +75,13 @@ describe( 'Fraud outcomes hooks', () => {
 					.fn()
 					.mockReturnValue( undefined ),
 				isResolving: jest.fn().mockReturnValue( false ),
+				hasFinishedResolution: jest.fn().mockReturnValue( true ),
 			};
 
 			const result = useLatestFraudOutcome( paymentIntentId );
 
 			expect( result ).toEqual( {
-				data: {},
+				data: undefined,
 				error: undefined,
 				isLoading: false,
 			} );

--- a/client/data/fraud-outcomes/test/selectors.ts
+++ b/client/data/fraud-outcomes/test/selectors.ts
@@ -31,7 +31,7 @@ describe( 'Fraud Outcomes selectors', () => {
 
 		it( 'should return an empty object if the id is not present in the state', () => {
 			const result = getLatestFraudOutcome( stateMock, 'not-found' );
-			expect( result ).toEqual( {} );
+			expect( result ).toEqual( undefined );
 		} );
 	} );
 
@@ -46,7 +46,7 @@ describe( 'Fraud Outcomes selectors', () => {
 
 		it( 'should return an empty object if the id is not present in the state', () => {
 			const result = getLatestFraudOutcomeError( stateMock, 'not-found' );
-			expect( result ).toEqual( {} );
+			expect( result ).toEqual( undefined );
 		} );
 	} );
 } );

--- a/client/data/fraud-outcomes/types.d.ts
+++ b/client/data/fraud-outcomes/types.d.ts
@@ -33,7 +33,7 @@ export type FraudOutcomesActions =
 	| UpdateErrorForLatestFraudOutcomeAction;
 
 export interface LatestFraudOutcomeResponse {
-	data: FraudOutcome;
+	data?: FraudOutcome;
 	error?: ApiError;
 	isLoading: boolean;
 }

--- a/client/data/payment-intents/hooks.ts
+++ b/client/data/payment-intents/hooks.ts
@@ -37,6 +37,7 @@ export const usePaymentIntentWithChargeFallback = (
 				getPaymentIntent,
 				getPaymentIntentError,
 				isResolving,
+				hasFinishedResolution,
 			} = selectors;
 
 			const paymentIntent: PaymentIntent = getPaymentIntent( id );
@@ -44,7 +45,9 @@ export const usePaymentIntentWithChargeFallback = (
 			return {
 				data: paymentIntent || ( {} as PaymentIntent ),
 				error: getPaymentIntentError( id ),
-				isLoading: isResolving( 'getPaymentIntent', [ id ] ),
+				isLoading:
+					isResolving( 'getPaymentIntent', [ id ] ) ||
+					! hasFinishedResolution( 'getPaymentIntent', [ id ] ),
 			};
 		},
 		[ id ]

--- a/client/data/payment-intents/test/hooks.ts
+++ b/client/data/payment-intents/test/hooks.ts
@@ -132,6 +132,7 @@ describe( 'Payment Intent hooks', () => {
 					.fn()
 					.mockReturnValue( paymentIntentMock ),
 				getPaymentIntentError: jest.fn().mockReturnValue( {} ),
+				hasFinishedResolution: jest.fn().mockReturnValue( true ),
 			};
 
 			const result = usePaymentIntentWithChargeFallback(

--- a/client/payment-details/index.tsx
+++ b/client/payment-details/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import { Card, CardBody } from '@wordpress/components';
 import { getAdminUrl } from 'wcpay/utils';
@@ -55,10 +55,22 @@ const PaymentChargeDetails: React.FC< PaymentChargeDetailsProps > = ( {
 	} = useLatestFraudOutcome( orderId );
 
 	// Additional loading state prevent flashing while the data is not available.
-	const isLoadingFraudOutcome =
-		isLoadingLatestFraudOutcome ||
-		( ! Object.keys( latestFraudOutcome || {} ).length &&
-			'undefined' !== typeof latestFraudOutcomeError );
+	const [ isLoadingFraudOutcome, setIsLoadingFraudOutcome ] = useState(
+		true
+	);
+
+	useEffect( () => {
+		if (
+			! isLoadingLatestFraudOutcome &&
+			! Object.keys( latestFraudOutcome || {} ).length &&
+			'undefined' !== typeof latestFraudOutcomeError
+		)
+			setIsLoadingFraudOutcome( false );
+	}, [
+		isLoadingLatestFraudOutcome,
+		latestFraudOutcome,
+		latestFraudOutcomeError,
+	] );
 
 	const isChargeId = getIsChargeId( id );
 	const isLoading = isChargeId || isLoadingData || isLoadingFraudOutcome;

--- a/client/payment-details/index.tsx
+++ b/client/payment-details/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { __ } from '@wordpress/i18n';
 import { Card, CardBody } from '@wordpress/components';
 import { getAdminUrl } from 'wcpay/utils';
@@ -49,28 +49,9 @@ const PaymentChargeDetails: React.FC< PaymentChargeDetailsProps > = ( {
 	const orderId = paymentIntent?.metadata?.order_id;
 
 	const {
-		data: latestFraudOutcome,
-		error: latestFraudOutcomeError,
-		isLoading: isLoadingLatestFraudOutcome,
+		data: fraudOutcome,
+		isLoading: isLoadingFraudOutcome,
 	} = useLatestFraudOutcome( orderId );
-
-	// Additional loading state prevent flashing while the data is not available.
-	const [ isLoadingFraudOutcome, setIsLoadingFraudOutcome ] = useState(
-		true
-	);
-
-	useEffect( () => {
-		if (
-			! isLoadingLatestFraudOutcome &&
-			! Object.keys( latestFraudOutcome || {} ).length &&
-			'undefined' !== typeof latestFraudOutcomeError
-		)
-			setIsLoadingFraudOutcome( false );
-	}, [
-		isLoadingLatestFraudOutcome,
-		latestFraudOutcome,
-		latestFraudOutcomeError,
-	] );
 
 	const isChargeId = getIsChargeId( id );
 	const isLoading = isChargeId || isLoadingData || isLoadingFraudOutcome;
@@ -124,7 +105,7 @@ const PaymentChargeDetails: React.FC< PaymentChargeDetailsProps > = ( {
 					charge={ charge }
 					metadata={ metadata }
 					isLoading={ isLoading }
-					fraudOutcome={ latestFraudOutcome }
+					fraudOutcome={ fraudOutcome }
 					paymentIntent={ paymentIntent }
 				/>
 			</ErrorBoundary>

--- a/client/payment-details/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/test/__snapshots__/index.test.tsx.snap
@@ -412,16 +412,11 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
             <p
               class="payment-details-summary__amount"
             >
-              $1,500.00
               <span
-                class="payment-details-summary__amount-currency"
+                aria-busy="true"
+                class="is-loadable-placeholder"
               >
-                usd
-              </span>
-              <span
-                class="chip chip-light"
-              >
-                Paid
+                Amount placeholder
               </span>
             </p>
             <div
@@ -429,13 +424,21 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
             >
               
               <p>
-                Fee: 
-                -$74.00
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder"
+                >
+                  Fee amount
+                </span>
               </p>
               
               <p>
-                Net: 
-                $1,426.00
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder"
+                >
+                  Net amount
+                </span>
               </p>
             </div>
           </div>
@@ -445,8 +448,12 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
             <div
               class="payment-details-summary__id"
             >
-              Payment ID: 
-              pi_mock
+              <span
+                aria-busy="true"
+                class="is-loadable-placeholder"
+              >
+                Payment ID: pi_xxxxxxxxxxxxxxxxxxxxxxxx
+              </span>
             </div>
           </div>
         </div>
@@ -458,160 +465,16 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
       <div
         class="components-card__body is-size-medium css-xmjzce-BodyUI e1q7k77g3"
       >
-        <ul
-          class="woocommerce-list woocommerce-list--horizontal"
-          role="menu"
+        <span
+          aria-busy="true"
+          class="is-loadable-placeholder is-block"
         >
-          <li
-            class="woocommerce-list__item"
+          <p
+            style="line-height: 4;"
           >
-            <div
-              class="woocommerce-list__item-inner"
-            >
-              <div
-                class="woocommerce-list__item-text"
-              >
-                <span
-                  class="woocommerce-list__item-title"
-                >
-                  Date
-                </span>
-                <span
-                  class="woocommerce-list__item-content"
-                >
-                  Jun 22, 2022, 2:16pm
-                </span>
-              </div>
-            </div>
-          </li>
-          <li
-            class="woocommerce-list__item"
-          >
-            <div
-              class="woocommerce-list__item-inner"
-            >
-              <div
-                class="woocommerce-list__item-text"
-              >
-                <span
-                  class="woocommerce-list__item-title"
-                >
-                  Channel
-                </span>
-                <span
-                  class="woocommerce-list__item-content"
-                >
-                  <span>
-                    Online
-                  </span>
-                </span>
-              </div>
-            </div>
-          </li>
-          <li
-            class="woocommerce-list__item"
-          >
-            <div
-              class="woocommerce-list__item-inner"
-            >
-              <div
-                class="woocommerce-list__item-text"
-              >
-                <span
-                  class="woocommerce-list__item-title"
-                >
-                  Customer
-                </span>
-                <span
-                  class="woocommerce-list__item-content"
-                >
-                  <a
-                    data-link-type="wc-admin"
-                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&search%5B0%5D=First%20Name%20(email%40example.com)"
-                  >
-                    First Name
-                  </a>
-                </span>
-              </div>
-            </div>
-          </li>
-          <li
-            class="woocommerce-list__item"
-          >
-            <div
-              class="woocommerce-list__item-inner"
-            >
-              <div
-                class="woocommerce-list__item-text"
-              >
-                <span
-                  class="woocommerce-list__item-title"
-                >
-                  Order
-                </span>
-                <span
-                  class="woocommerce-list__item-content"
-                >
-                  <span>
-                    –
-                  </span>
-                </span>
-              </div>
-            </div>
-          </li>
-          <li
-            class="woocommerce-list__item"
-          >
-            <div
-              class="woocommerce-list__item-inner"
-            >
-              <div
-                class="woocommerce-list__item-text"
-              >
-                <span
-                  class="woocommerce-list__item-title"
-                >
-                  Payment method
-                </span>
-                <span
-                  class="woocommerce-list__item-content"
-                >
-                  <span
-                    class="payment-method-details"
-                  >
-                    <span
-                      class="payment-method__brand payment-method__brand--visa"
-                    />
-                     •••• 
-                    4242
-                  </span>
-                </span>
-              </div>
-            </div>
-          </li>
-          <li
-            class="woocommerce-list__item"
-          >
-            <div
-              class="woocommerce-list__item-inner"
-            >
-              <div
-                class="woocommerce-list__item-text"
-              >
-                <span
-                  class="woocommerce-list__item-title"
-                >
-                  Risk evaluation
-                </span>
-                <span
-                  class="woocommerce-list__item-content"
-                >
-                  –
-                </span>
-              </div>
-            </div>
-          </li>
-        </ul>
+            Block placeholder
+          </p>
+        </span>
       </div>
     </div>
     <div
@@ -642,7 +505,12 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
       <div
         class="components-flex components-card__header is-size-large e1q7k77g1 css-1ufeymn-Flex-HeaderUI eboqfv50"
       >
-        Payment method
+        <span
+          aria-busy="true"
+          class="is-loadable-placeholder"
+        >
+          Payment method
+        </span>
       </div>
       <div
         class="components-card__body is-size-large css-xmjzce-BodyUI e1q7k77g3"
@@ -659,13 +527,23 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                Number
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder is-block"
+                >
+                  Number
+                </span>
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                •••• 
-                4242
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder"
+                >
+                  •••• 
+                  4242
+                </span>
               </p>
             </div>
             <div
@@ -674,12 +552,22 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                Expires
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder is-block"
+                >
+                  Expires
+                </span>
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                12 / 2099
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder"
+                >
+                  12 / 2099
+                </span>
               </p>
             </div>
             <div
@@ -688,12 +576,22 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                Type
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder is-block"
+                >
+                  Type
+                </span>
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                Visa credit card
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder"
+                >
+                  Visa credit card
+                </span>
               </p>
             </div>
             <div
@@ -702,12 +600,22 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                ID
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder is-block"
+                >
+                  ID
+                </span>
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                pm_mock
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder"
+                >
+                  pm_mock
+                </span>
               </p>
             </div>
           </div>
@@ -720,45 +628,21 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                Owner
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder is-block"
+                >
+                  Owner
+                </span>
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                First Name
-              </p>
-            </div>
-            <div
-              class="payment-method-detail"
-            >
-              <h4
-                class="payment-method-detail__label"
-              >
-                Owner email
-              </h4>
-              <p
-                class="payment-method-detail__value"
-              >
-                email@example.com
-              </p>
-            </div>
-            <div
-              class="payment-method-detail"
-            >
-              <h4
-                class="payment-method-detail__label"
-              >
-                Address
-              </h4>
-              <p
-                class="payment-method-detail__value"
-              >
-                <span>
-                  Line 1 Street
-                  <br />
-                  Line 2
-                  <br />
-                  City, CA 99999
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder"
+                >
+                  First Name
                 </span>
               </p>
             </div>
@@ -768,12 +652,22 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                Origin
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder is-block"
+                >
+                  Owner email
+                </span>
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                United States of America
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder"
+                >
+                  email@example.com
+                </span>
               </p>
             </div>
             <div
@@ -782,12 +676,28 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                CVC check
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder is-block"
+                >
+                  Address
+                </span>
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                Passed
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder"
+                >
+                  <span>
+                    Line 1 Street
+                    <br />
+                    Line 2
+                    <br />
+                    City, CA 99999
+                  </span>
+                </span>
               </p>
             </div>
             <div
@@ -796,12 +706,22 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                Street check
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder is-block"
+                >
+                  Origin
+                </span>
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                Passed
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder"
+                >
+                  United States of America
+                </span>
               </p>
             </div>
             <div
@@ -810,12 +730,70 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                Zip check
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder is-block"
+                >
+                  CVC check
+                </span>
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                Passed
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder"
+                >
+                  Passed
+                </span>
+              </p>
+            </div>
+            <div
+              class="payment-method-detail"
+            >
+              <h4
+                class="payment-method-detail__label"
+              >
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder is-block"
+                >
+                  Street check
+                </span>
+              </h4>
+              <p
+                class="payment-method-detail__value"
+              >
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder"
+                >
+                  Passed
+                </span>
+              </p>
+            </div>
+            <div
+              class="payment-method-detail"
+            >
+              <h4
+                class="payment-method-detail__label"
+              >
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder is-block"
+                >
+                  Zip check
+                </span>
+              </h4>
+              <p
+                class="payment-method-detail__value"
+              >
+                <span
+                  aria-busy="true"
+                  class="is-loadable-placeholder"
+                >
+                  Passed
+                </span>
               </p>
             </div>
           </div>

--- a/client/payment-details/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/test/__snapshots__/index.test.tsx.snap
@@ -412,11 +412,16 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
             <p
               class="payment-details-summary__amount"
             >
+              $1,500.00
               <span
-                aria-busy="true"
-                class="is-loadable-placeholder"
+                class="payment-details-summary__amount-currency"
               >
-                Amount placeholder
+                usd
+              </span>
+              <span
+                class="chip chip-light"
+              >
+                Paid
               </span>
             </p>
             <div
@@ -424,21 +429,13 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
             >
               
               <p>
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder"
-                >
-                  Fee amount
-                </span>
+                Fee: 
+                -$74.00
               </p>
               
               <p>
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder"
-                >
-                  Net amount
-                </span>
+                Net: 
+                $1,426.00
               </p>
             </div>
           </div>
@@ -448,12 +445,8 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
             <div
               class="payment-details-summary__id"
             >
-              <span
-                aria-busy="true"
-                class="is-loadable-placeholder"
-              >
-                Payment ID: pi_xxxxxxxxxxxxxxxxxxxxxxxx
-              </span>
+              Payment ID: 
+              pi_mock
             </div>
           </div>
         </div>
@@ -465,16 +458,160 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
       <div
         class="components-card__body is-size-medium css-xmjzce-BodyUI e1q7k77g3"
       >
-        <span
-          aria-busy="true"
-          class="is-loadable-placeholder is-block"
+        <ul
+          class="woocommerce-list woocommerce-list--horizontal"
+          role="menu"
         >
-          <p
-            style="line-height: 4;"
+          <li
+            class="woocommerce-list__item"
           >
-            Block placeholder
-          </p>
-        </span>
+            <div
+              class="woocommerce-list__item-inner"
+            >
+              <div
+                class="woocommerce-list__item-text"
+              >
+                <span
+                  class="woocommerce-list__item-title"
+                >
+                  Date
+                </span>
+                <span
+                  class="woocommerce-list__item-content"
+                >
+                  Jun 22, 2022, 2:16pm
+                </span>
+              </div>
+            </div>
+          </li>
+          <li
+            class="woocommerce-list__item"
+          >
+            <div
+              class="woocommerce-list__item-inner"
+            >
+              <div
+                class="woocommerce-list__item-text"
+              >
+                <span
+                  class="woocommerce-list__item-title"
+                >
+                  Channel
+                </span>
+                <span
+                  class="woocommerce-list__item-content"
+                >
+                  <span>
+                    Online
+                  </span>
+                </span>
+              </div>
+            </div>
+          </li>
+          <li
+            class="woocommerce-list__item"
+          >
+            <div
+              class="woocommerce-list__item-inner"
+            >
+              <div
+                class="woocommerce-list__item-text"
+              >
+                <span
+                  class="woocommerce-list__item-title"
+                >
+                  Customer
+                </span>
+                <span
+                  class="woocommerce-list__item-content"
+                >
+                  <a
+                    data-link-type="wc-admin"
+                    href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&search%5B0%5D=First%20Name%20(email%40example.com)"
+                  >
+                    First Name
+                  </a>
+                </span>
+              </div>
+            </div>
+          </li>
+          <li
+            class="woocommerce-list__item"
+          >
+            <div
+              class="woocommerce-list__item-inner"
+            >
+              <div
+                class="woocommerce-list__item-text"
+              >
+                <span
+                  class="woocommerce-list__item-title"
+                >
+                  Order
+                </span>
+                <span
+                  class="woocommerce-list__item-content"
+                >
+                  <span>
+                    –
+                  </span>
+                </span>
+              </div>
+            </div>
+          </li>
+          <li
+            class="woocommerce-list__item"
+          >
+            <div
+              class="woocommerce-list__item-inner"
+            >
+              <div
+                class="woocommerce-list__item-text"
+              >
+                <span
+                  class="woocommerce-list__item-title"
+                >
+                  Payment method
+                </span>
+                <span
+                  class="woocommerce-list__item-content"
+                >
+                  <span
+                    class="payment-method-details"
+                  >
+                    <span
+                      class="payment-method__brand payment-method__brand--visa"
+                    />
+                     •••• 
+                    4242
+                  </span>
+                </span>
+              </div>
+            </div>
+          </li>
+          <li
+            class="woocommerce-list__item"
+          >
+            <div
+              class="woocommerce-list__item-inner"
+            >
+              <div
+                class="woocommerce-list__item-text"
+              >
+                <span
+                  class="woocommerce-list__item-title"
+                >
+                  Risk evaluation
+                </span>
+                <span
+                  class="woocommerce-list__item-content"
+                >
+                  –
+                </span>
+              </div>
+            </div>
+          </li>
+        </ul>
       </div>
     </div>
     <div
@@ -505,12 +642,7 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
       <div
         class="components-flex components-card__header is-size-large e1q7k77g1 css-1ufeymn-Flex-HeaderUI eboqfv50"
       >
-        <span
-          aria-busy="true"
-          class="is-loadable-placeholder"
-        >
-          Payment method
-        </span>
+        Payment method
       </div>
       <div
         class="components-card__body is-size-large css-xmjzce-BodyUI e1q7k77g3"
@@ -527,23 +659,13 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder is-block"
-                >
-                  Number
-                </span>
+                Number
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder"
-                >
-                  •••• 
-                  4242
-                </span>
+                •••• 
+                4242
               </p>
             </div>
             <div
@@ -552,22 +674,12 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder is-block"
-                >
-                  Expires
-                </span>
+                Expires
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder"
-                >
-                  12 / 2099
-                </span>
+                12 / 2099
               </p>
             </div>
             <div
@@ -576,22 +688,12 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder is-block"
-                >
-                  Type
-                </span>
+                Type
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder"
-                >
-                  Visa credit card
-                </span>
+                Visa credit card
               </p>
             </div>
             <div
@@ -600,22 +702,12 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder is-block"
-                >
-                  ID
-                </span>
+                ID
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder"
-                >
-                  pm_mock
-                </span>
+                pm_mock
               </p>
             </div>
           </div>
@@ -628,21 +720,45 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder is-block"
-                >
-                  Owner
-                </span>
+                Owner
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder"
-                >
-                  First Name
+                First Name
+              </p>
+            </div>
+            <div
+              class="payment-method-detail"
+            >
+              <h4
+                class="payment-method-detail__label"
+              >
+                Owner email
+              </h4>
+              <p
+                class="payment-method-detail__value"
+              >
+                email@example.com
+              </p>
+            </div>
+            <div
+              class="payment-method-detail"
+            >
+              <h4
+                class="payment-method-detail__label"
+              >
+                Address
+              </h4>
+              <p
+                class="payment-method-detail__value"
+              >
+                <span>
+                  Line 1 Street
+                  <br />
+                  Line 2
+                  <br />
+                  City, CA 99999
                 </span>
               </p>
             </div>
@@ -652,22 +768,12 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder is-block"
-                >
-                  Owner email
-                </span>
+                Origin
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder"
-                >
-                  email@example.com
-                </span>
+                United States of America
               </p>
             </div>
             <div
@@ -676,28 +782,12 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder is-block"
-                >
-                  Address
-                </span>
+                CVC check
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder"
-                >
-                  <span>
-                    Line 1 Street
-                    <br />
-                    Line 2
-                    <br />
-                    City, CA 99999
-                  </span>
-                </span>
+                Passed
               </p>
             </div>
             <div
@@ -706,22 +796,12 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder is-block"
-                >
-                  Origin
-                </span>
+                Street check
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder"
-                >
-                  United States of America
-                </span>
+                Passed
               </p>
             </div>
             <div
@@ -730,70 +810,12 @@ exports[`Payment details page should match the snapshot - Payment Intent query p
               <h4
                 class="payment-method-detail__label"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder is-block"
-                >
-                  CVC check
-                </span>
+                Zip check
               </h4>
               <p
                 class="payment-method-detail__value"
               >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder"
-                >
-                  Passed
-                </span>
-              </p>
-            </div>
-            <div
-              class="payment-method-detail"
-            >
-              <h4
-                class="payment-method-detail__label"
-              >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder is-block"
-                >
-                  Street check
-                </span>
-              </h4>
-              <p
-                class="payment-method-detail__value"
-              >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder"
-                >
-                  Passed
-                </span>
-              </p>
-            </div>
-            <div
-              class="payment-method-detail"
-            >
-              <h4
-                class="payment-method-detail__label"
-              >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder is-block"
-                >
-                  Zip check
-                </span>
-              </h4>
-              <p
-                class="payment-method-detail__value"
-              >
-                <span
-                  aria-busy="true"
-                  class="is-loadable-placeholder"
-                >
-                  Passed
-                </span>
+                Passed
               </p>
             </div>
           </div>

--- a/client/payment-details/test/index.test.tsx
+++ b/client/payment-details/test/index.test.tsx
@@ -6,6 +6,7 @@
 import { render } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
 import React from 'react';
+import { useLatestFraudOutcome } from '../../data/fraud-outcomes';
 
 /**
  * Internal dependencies
@@ -35,6 +36,10 @@ jest.mock( '@wordpress/data', () => ( {
 	withDispatch: jest.fn( () => jest.fn() ),
 	withSelect: jest.fn( () => jest.fn() ),
 	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '../../data/fraud-outcomes', () => ( {
+	useLatestFraudOutcome: jest.fn(),
 } ) );
 
 const chargeMock = {
@@ -116,6 +121,16 @@ const chargeMock = {
 		} )
 	)
 );
+
+( useLatestFraudOutcome as jest.Mock ).mockImplementation( () => {
+	return {
+		data: {
+			status: 'allow',
+		},
+		error: '',
+		isLoading: false,
+	};
+} );
 
 global.wcSettings = {
 	countries: {

--- a/client/payment-details/test/index.test.tsx
+++ b/client/payment-details/test/index.test.tsx
@@ -6,7 +6,6 @@
 import { render } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
 import React from 'react';
-import { useLatestFraudOutcome } from '../../data/fraud-outcomes';
 
 /**
  * Internal dependencies
@@ -36,10 +35,6 @@ jest.mock( '@wordpress/data', () => ( {
 	withDispatch: jest.fn( () => jest.fn() ),
 	withSelect: jest.fn( () => jest.fn() ),
 	useSelect: jest.fn(),
-} ) );
-
-jest.mock( '../../data/fraud-outcomes', () => ( {
-	useLatestFraudOutcome: jest.fn(),
 } ) );
 
 const chargeMock = {
@@ -102,6 +97,7 @@ const chargeMock = {
 		jest.fn().mockReturnValue( {
 			getCharge: jest.fn().mockReturnValue( chargeMock ),
 			isResolving: jest.fn().mockReturnValue( false ),
+			hasFinishedResolution: jest.fn().mockReturnValue( true ),
 			getChargeError: jest.fn().mockReturnValue( null ),
 			getPaymentIntent: jest.fn().mockReturnValue( {
 				id: 'pi_mock',
@@ -121,16 +117,6 @@ const chargeMock = {
 		} )
 	)
 );
-
-( useLatestFraudOutcome as jest.Mock ).mockImplementation( () => {
-	return {
-		data: {
-			status: 'allow',
-		},
-		error: '',
-		isLoading: false,
-	};
-} );
 
 global.wcSettings = {
 	countries: {

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -551,11 +551,13 @@ const getManualFraudOutcomeTimelineItem = ( event, status ) => {
 const buildAutomaticFraudOutcomeRuleset = ( event ) => {
 	const rulesetResults = Object.entries( event.ruleset_results || {} );
 
-	return rulesetResults.map( ( [ rule, status ] ) => (
-		<p key={ rule } className="fraud-outcome-ruleset-item">
-			{ fraudOutcomeRulesetMapping[ status ][ rule ] }
-		</p>
-	) );
+	return rulesetResults
+		.filter( ( [ , status ] ) => 'allow' !== status )
+		.map( ( [ rule, status ] ) => (
+			<p key={ rule } className="fraud-outcome-ruleset-item">
+				{ fraudOutcomeRulesetMapping[ status ][ rule ] }
+			</p>
+		) );
 };
 
 const getAutomaticFraudOutcomeTimelineItem = ( event, status ) => {

--- a/client/payment-details/timeline/mappings.ts
+++ b/client/payment-details/timeline/mappings.ts
@@ -14,23 +14,23 @@ import {
 export const fraudOutcomeRulesetMapping = {
 	[ Outcomes.REVIEW ]: {
 		[ Rules.RULE_ADDRESS_MISMATCH ]: __(
-			'Place in review if the shipping address differs from the billing address',
+			'Place in review if the shipping address country differs from the billing address country',
 			'woocommerce-payments'
 		),
 		[ Rules.RULE_INTERNATIONAL_IP_ADDRESS ]: __(
-			'Place in review if the billing address is outside your supported countries',
+			'Place in review if the country resolved from customer IP is not listed in your selling countries',
 			'woocommerce-payments'
 		),
 		[ Rules.RULE_INTERNATIONAL_BILLING_ADDRESS ]: __(
-			'Place in review if the shipping address differs from the billing address',
+			'Place in review if the billing address is not listed in your selling countries',
 			'woocommerce-payments'
 		),
 		[ Rules.RULE_ORDER_ITEMS_THRESHOLD ]: __(
-			'Place in review if the shipping address differs from the billing address',
+			'Place in review if the items count is not in your defined range',
 			'woocommerce-payments'
 		),
 		[ Rules.RULE_PURCHASE_PRICE_THRESHOLD ]: __(
-			'Place in review if the shipping address differs from the billing address',
+			'Place in review if the purchase price is not in your defined range',
 			'woocommerce-payments'
 		),
 	},
@@ -40,19 +40,19 @@ export const fraudOutcomeRulesetMapping = {
 			'woocommerce-payments'
 		),
 		[ Rules.RULE_INTERNATIONAL_IP_ADDRESS ]: __(
-			'Block if the billing address is outside your supported countries',
+			'Block if the country resolved from customer IP is not listed in your selling countries',
 			'woocommerce-payments'
 		),
 		[ Rules.RULE_INTERNATIONAL_BILLING_ADDRESS ]: __(
-			'Block if the shipping address differs from the billing address',
+			'Block if the billing address is not listed in your selling countries',
 			'woocommerce-payments'
 		),
 		[ Rules.RULE_ORDER_ITEMS_THRESHOLD ]: __(
-			'Block if the shipping address differs from the billing address',
+			'Block if the items count is not in your defined range',
 			'woocommerce-payments'
 		),
 		[ Rules.RULE_PURCHASE_PRICE_THRESHOLD ]: __(
-			'Block if the shipping address differs from the billing address',
+			'Block if the purchase price is not in your defined range',
 			'woocommerce-payments'
 		),
 	},

--- a/client/settings/fraud-protection/advanced-settings/test/index.test.js
+++ b/client/settings/fraud-protection/advanced-settings/test/index.test.js
@@ -121,8 +121,12 @@ describe( 'Advanced fraud protection settings', () => {
 			check: {
 				operator: 'or',
 				checks: [
-					{ key: 'order_total', operator: 'less_than', value: 10 },
-					{ key: 'order_total', operator: 'greater_than', value: 1 },
+					{ key: 'order_total', operator: 'less_than', value: 1000 },
+					{
+						key: 'order_total',
+						operator: 'greater_than',
+						value: 100,
+					},
 				],
 			},
 		} );
@@ -164,8 +168,12 @@ describe( 'Advanced fraud protection settings', () => {
 			check: {
 				operator: 'or',
 				checks: [
-					{ key: 'order_total', operator: 'less_than', value: 1 },
-					{ key: 'order_total', operator: 'greater_than', value: 10 },
+					{ key: 'order_total', operator: 'less_than', value: 100 },
+					{
+						key: 'order_total',
+						operator: 'greater_than',
+						value: 1000,
+					},
 				],
 			},
 		} );
@@ -218,8 +226,12 @@ describe( 'Advanced fraud protection settings', () => {
 			check: {
 				operator: 'or',
 				checks: [
-					{ key: 'order_total', operator: 'less_than', value: 1 },
-					{ key: 'order_total', operator: 'greater_than', value: 10 },
+					{ key: 'order_total', operator: 'less_than', value: 100 },
+					{
+						key: 'order_total',
+						operator: 'greater_than',
+						value: 1000,
+					},
 				],
 			},
 		} );
@@ -276,8 +288,12 @@ describe( 'Advanced fraud protection settings', () => {
 			check: {
 				operator: 'or',
 				checks: [
-					{ key: 'order_total', operator: 'less_than', value: 1 },
-					{ key: 'order_total', operator: 'greater_than', value: 10 },
+					{ key: 'order_total', operator: 'less_than', value: 100 },
+					{
+						key: 'order_total',
+						operator: 'greater_than',
+						value: 1000,
+					},
 				],
 			},
 		} );

--- a/client/settings/fraud-protection/advanced-settings/test/utils.test.js
+++ b/client/settings/fraud-protection/advanced-settings/test/utils.test.js
@@ -147,12 +147,12 @@ describe( 'Ruleset adapter utilities test', () => {
 						{
 							key: Checks.CHECK_ORDER_TOTAL,
 							operator: CheckOperators.OPERATOR_LT,
-							value: 1,
+							value: 100,
 						},
 						{
 							key: Checks.CHECK_ORDER_TOTAL,
 							operator: CheckOperators.OPERATOR_GT,
-							value: 10,
+							value: 1000,
 						},
 					],
 				},
@@ -180,7 +180,7 @@ describe( 'Ruleset adapter utilities test', () => {
 						{
 							key: Checks.CHECK_ORDER_TOTAL,
 							operator: CheckOperators.OPERATOR_LT,
-							value: 1,
+							value: 100,
 						},
 					],
 				},
@@ -221,7 +221,7 @@ describe( 'Ruleset adapter utilities test', () => {
 				check: {
 					key: Checks.CHECK_ORDER_TOTAL,
 					operator: CheckOperators.OPERATOR_LT,
-					value: 1,
+					value: 100,
 				},
 			},
 		];
@@ -267,7 +267,7 @@ describe( 'Ruleset adapter utilities test', () => {
 				check: {
 					key: Checks.CHECK_ORDER_TOTAL,
 					operator: 'exp',
-					value: 1,
+					value: 100,
 				},
 			},
 		];
@@ -289,7 +289,7 @@ describe( 'Ruleset adapter utilities test', () => {
 				check: {
 					key: Checks.CHECK_ORDER_TOTAL,
 					operator: CheckOperators.OPERATOR_LT,
-					value: 1,
+					value: 100,
 				},
 			},
 		];
@@ -312,7 +312,7 @@ describe( 'Ruleset adapter utilities test', () => {
 			[ Rules.RULE_PURCHASE_PRICE_THRESHOLD ]: {
 				enabled: true,
 				block: false,
-				min_amount: 1,
+				min_amount: 0.01,
 				max_amount: '',
 			},
 		} );
@@ -456,7 +456,7 @@ describe( 'Ruleset adapter utilities test', () => {
 					check: {
 						key: Checks.CHECK_BILLING_COUNTRY,
 						operator: checkOperator,
-						value: checkValue,
+						value: checkValue.toLowerCase(),
 					},
 				},
 			];
@@ -499,7 +499,7 @@ describe( 'Ruleset adapter utilities test', () => {
 					check: {
 						key: Checks.CHECK_IP_COUNTRY,
 						operator: checkOperator,
-						value: checkValue,
+						value: checkValue.toLowerCase(),
 					},
 				},
 			];
@@ -601,12 +601,12 @@ describe( 'Ruleset adapter utilities test', () => {
 							{
 								key: Checks.CHECK_ORDER_TOTAL,
 								operator: CheckOperators.OPERATOR_LT,
-								value: minAmount,
+								value: minAmount * 100,
 							},
 							{
 								key: Checks.CHECK_ORDER_TOTAL,
 								operator: CheckOperators.OPERATOR_GT,
-								value: maxAmount,
+								value: maxAmount * 100,
 							},
 						],
 					},
@@ -621,7 +621,10 @@ describe( 'Ruleset adapter utilities test', () => {
 							'' !== maxAmount
 								? CheckOperators.OPERATOR_GT
 								: CheckOperators.OPERATOR_LT,
-						value: '' !== maxAmount ? maxAmount : minAmount,
+						value:
+							'' !== maxAmount
+								? maxAmount * 100
+								: minAmount * 100,
 					},
 				} );
 			} else {

--- a/client/settings/fraud-protection/advanced-settings/utils.js
+++ b/client/settings/fraud-protection/advanced-settings/utils.js
@@ -50,7 +50,7 @@ const buildRuleset = ( ruleKey, shouldBlock, ruleConfiguration = {} ) => {
 					'specific' === getSupportedCountriesType()
 						? CheckOperators.OPERATOR_NOT_IN
 						: CheckOperators.OPERATOR_IN,
-				value: getSettingCountries().join( '|' ),
+				value: getSettingCountries().join( '|' ).toLowerCase(),
 			};
 			break;
 		case Rules.RULE_INTERNATIONAL_BILLING_ADDRESS:
@@ -62,7 +62,7 @@ const buildRuleset = ( ruleKey, shouldBlock, ruleConfiguration = {} ) => {
 					'specific' === getSupportedCountriesType()
 						? CheckOperators.OPERATOR_NOT_IN
 						: CheckOperators.OPERATOR_IN,
-				value: getSettingCountries().join( '|' ),
+				value: getSettingCountries().join( '|' ).toLowerCase(),
 			};
 			break;
 		case Rules.RULE_ORDER_ITEMS_THRESHOLD:
@@ -121,12 +121,16 @@ const buildRuleset = ( ruleKey, shouldBlock, ruleConfiguration = {} ) => {
 						{
 							key: Checks.CHECK_ORDER_TOTAL,
 							operator: CheckOperators.OPERATOR_LT,
-							value: parseFloat( ruleConfiguration.min_amount ),
+							value:
+								parseFloat( ruleConfiguration.min_amount ) *
+								100,
 						},
 						{
 							key: Checks.CHECK_ORDER_TOTAL,
 							operator: CheckOperators.OPERATOR_GT,
-							value: parseFloat( ruleConfiguration.max_amount ),
+							value:
+								parseFloat( ruleConfiguration.max_amount ) *
+								100,
 						},
 					],
 				};
@@ -138,12 +142,16 @@ const buildRuleset = ( ruleKey, shouldBlock, ruleConfiguration = {} ) => {
 					? {
 							key: Checks.CHECK_ORDER_TOTAL,
 							operator: CheckOperators.OPERATOR_LT,
-							value: parseFloat( ruleConfiguration.min_amount ),
+							value:
+								parseFloat( ruleConfiguration.min_amount ) *
+								100,
 					  }
 					: {
 							key: Checks.CHECK_ORDER_TOTAL,
 							operator: CheckOperators.OPERATOR_GT,
-							value: parseFloat( ruleConfiguration.max_amount ),
+							value:
+								parseFloat( ruleConfiguration.max_amount ) *
+								100,
 					  };
 			}
 			break;
@@ -259,8 +267,8 @@ export const readRuleset = ( rulesetConfig ) => {
 				parsedUIConfig[ rule.key ] = {
 					enabled: true,
 					block: rule.outcome === Outcomes.BLOCK,
-					min_amount: minAmount.value ?? '',
-					max_amount: maxAmount.value ?? '',
+					min_amount: minAmount.value ? minAmount.value / 100 : '',
+					max_amount: maxAmount.value ? maxAmount.value / 100 : '',
 				};
 				break;
 		}

--- a/client/settings/fraud-protection/advanced-settings/utils.js
+++ b/client/settings/fraud-protection/advanced-settings/utils.js
@@ -146,16 +146,20 @@ const buildRuleset = ( ruleKey, shouldBlock, ruleConfiguration = {} ) => {
 					? {
 							key: Checks.CHECK_ORDER_TOTAL,
 							operator: CheckOperators.OPERATOR_LT,
-							value:
+							value: parseInt(
 								parseFloat( ruleConfiguration.min_amount ) *
-								100,
+									100,
+								10
+							),
 					  }
 					: {
 							key: Checks.CHECK_ORDER_TOTAL,
 							operator: CheckOperators.OPERATOR_GT,
-							value:
+							value: parseInt(
 								parseFloat( ruleConfiguration.max_amount ) *
-								100,
+									100,
+								10
+							),
 					  };
 			}
 			break;

--- a/client/settings/fraud-protection/advanced-settings/utils.js
+++ b/client/settings/fraud-protection/advanced-settings/utils.js
@@ -121,16 +121,20 @@ const buildRuleset = ( ruleKey, shouldBlock, ruleConfiguration = {} ) => {
 						{
 							key: Checks.CHECK_ORDER_TOTAL,
 							operator: CheckOperators.OPERATOR_LT,
-							value:
+							value: parseInt(
 								parseFloat( ruleConfiguration.min_amount ) *
-								100,
+									100,
+								10
+							),
 						},
 						{
 							key: Checks.CHECK_ORDER_TOTAL,
 							operator: CheckOperators.OPERATOR_GT,
-							value:
+							value: parseInt(
 								parseFloat( ruleConfiguration.max_amount ) *
-								100,
+									100,
+								10
+							),
 						},
 					],
 				};

--- a/includes/fraud-prevention/class-buyer-fingerprinting-service.php
+++ b/includes/fraud-prevention/class-buyer-fingerprinting-service.php
@@ -62,10 +62,13 @@ class Buyer_Fingerprinting_Service {
 	 * @return string[] An array of hashed data for an order.
 	 */
 	public function get_hashed_data_for_customer( $fingerprint ): array {
-		return [
-			'fraud_prevention_data_shopper_ip_hash' => $this->hash_data_for_fraud_prevention( WC_Geolocation::get_ip_address() ),
-			'fraud_prevention_data_shopper_ua_hash' => $fingerprint,
-			'fraud_prevention_data_ip_country'      => WC_Geolocation::geolocate_ip( '', true )['country'],
-		];
+		return array_filter(
+			[
+				'fraud_prevention_data_shopper_ip_hash' => $this->hash_data_for_fraud_prevention( WC_Geolocation::get_ip_address() ),
+				'fraud_prevention_data_shopper_ua_hash' => $fingerprint,
+				'fraud_prevention_data_ip_country'      => WC_Geolocation::geolocate_ip( '', true )['country'],
+				'fraud_prevention_data_cart_contents'   => WC()->cart ? intval( WC()->cart->get_cart_contents_count() ) : null,
+			]
+		);
 	}
 }

--- a/includes/fraud-prevention/class-buyer-fingerprinting-service.php
+++ b/includes/fraud-prevention/class-buyer-fingerprinting-service.php
@@ -59,7 +59,7 @@ class Buyer_Fingerprinting_Service {
 	 *
 	 * @param string $fingerprint User fingerprint.
 	 *
-	 * @return string[] An array of hashed data for an order.
+	 * @return array An array of hashed data for an order.
 	 */
 	public function get_hashed_data_for_customer( $fingerprint ): array {
 		return array_filter(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the cart item count to fraud metadata, to let the server use the value instead of level 3 line items array, because it is only available for US merchants. This way we won't have a dependency to Level 3 data existence, and this fix will apply to all our merchants. 

Other than the main goal of this PR, this fixes several things on the frontend:

- Filters out "allow" outcomes from the block/review timeline items, so they don't cause an exception because the text mappings doesn't exist for them.
- Improves the strings used for each rule failure a bit. May need review and improvements.
- The UI was accepting amount inputs as floats, but the rule engine checks the amounts in cents, so this adds a multiplication of 100 when building the ruleset, and division of 100 when reading from a ruleset to display in the UI.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Tests should pass, and the changes should make sense. 
* The tests were already written for the use cases, so I modified them to match the modifications.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
