### PR TITLE
Remove the "Reserve" funds balance block

### DIFF
--- a/changelog/issue-5865-remove-reserved-funds-section
+++ b/changelog/issue-5865-remove-reserved-funds-section
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: NA. This section of the UI was never released publically and is being removed as part of this PR.
+
+

--- a/client/components/account-balances/balance-block.tsx
+++ b/client/components/account-balances/balance-block.tsx
@@ -13,7 +13,7 @@ import { fundLabelStrings } from './strings';
 /**
  * balanceType
  */
-type balanceType = 'pending' | 'available' | 'reserved';
+type balanceType = 'pending' | 'available';
 
 /**
  * BalanceBlockProps

--- a/client/components/account-balances/balances-tab-panel.tsx
+++ b/client/components/account-balances/balances-tab-panel.tsx
@@ -29,7 +29,6 @@ type BalanceTab = {
 	currencyCode: string;
 	availableFunds: number;
 	pendingFunds: number;
-	reservedFunds: number;
 };
 
 /**
@@ -51,7 +50,6 @@ const AccountBalancesTabPanel: React.FC = () => {
 			currencyCode: wcpaySettings.accountDefaultCurrency,
 			availableFunds: 0,
 			pendingFunds: 0,
-			reservedFunds: 0,
 		},
 	];
 
@@ -65,7 +63,6 @@ const AccountBalancesTabPanel: React.FC = () => {
 				currencyCode: overview.currency,
 				availableFunds: overview.available.amount,
 				pendingFunds: overview.pending.amount,
-				reservedFunds: 0, // TODO: Add reserve funds to the overview object.
 			} )
 		);
 	}
@@ -83,12 +80,6 @@ const AccountBalancesTabPanel: React.FC = () => {
 					<BalanceBlock
 						type="pending"
 						amount={ tab.pendingFunds }
-						currencyCode={ tab.currencyCode }
-						isLoading={ isLoading }
-					/>
-					<BalanceBlock
-						type="reserved"
-						amount={ tab.reservedFunds }
 						currencyCode={ tab.currencyCode }
 						isLoading={ isLoading }
 					/>

--- a/client/components/account-balances/balances-tab-panel.tsx
+++ b/client/components/account-balances/balances-tab-panel.tsx
@@ -21,7 +21,6 @@ import BalanceBlock from './balance-block';
  * @param {string} currencyCode   Currency code of the tab.
  * @param {number} availableFunds Available funds of the tab.
  * @param {number} pendingFunds   Pending funds of the tab.
- * @param {number} reservedFunds  Reserved funds of the tab.
  */
 type BalanceTab = {
 	name: string;

--- a/client/components/account-balances/strings.ts
+++ b/client/components/account-balances/strings.ts
@@ -22,7 +22,6 @@ export const greetingStrings = {
 export const fundLabelStrings = {
 	available: __( 'Available funds', 'woocommerce-payments' ),
 	pending: __( 'Pending funds', 'woocommerce-payments' ),
-	reserved: __( 'Reserved funds', 'woocommerce-payments' ),
 };
 
 /** translators: %s is the currency code, e.g. USD. */

--- a/client/components/account-balances/style.scss
+++ b/client/components/account-balances/style.scss
@@ -43,7 +43,7 @@
 	flex-direction: column;
 	align-items: flex-start;
 	padding: 24px;
-	flex-grow: 1;
+	flex: 1;
 
 	&__title {
 		font-size: 12px;

--- a/client/components/account-balances/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/account-balances/test/__snapshots__/index.test.tsx.snap
@@ -86,22 +86,6 @@ exports[`AccountBalances renders 1`] = `
               $1.00
             </p>
           </div>
-          <div
-            class="wcpay-account-balances__balances__item"
-          >
-            <p
-              class="wcpay-account-balances__balances__item__title"
-              id="wcpay-account-balances-usd-reserved-title"
-            >
-              Reserved funds
-            </p>
-            <p
-              aria-labelledby="wcpay-account-balances-usd-reserved-title"
-              class="wcpay-account-balances__balances__item__amount"
-            >
-              $0.00
-            </p>
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #5865 

#### Changes proposed in this Pull Request

This PR removes the "Reserved funds" balance from the Account balances card. 

<p align="center">

<img width="709" alt="Screenshot 2023-03-27 at 5 46 53 pm" src="https://user-images.githubusercontent.com/8490476/227875051-33e46ee6-a91c-430d-9e59-dc51a057e5eb.png">
</p>

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable the deposits overview updates by flipping on the feature flag.
   - `update_option( '_wcpay_feature_simplify_deposits_ui', 1 );`
2. Go to the **Payments > Overview** admin page. You should see the new balances card.
3. The reserved funds section should be removed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
