### PR TITLE
Update test mode notice for uncaptured authorizations tab

### DIFF
--- a/changelog/update-5181-uncaptured-tab-test-mode-notice
+++ b/changelog/update-5181-uncaptured-tab-test-mode-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update test mode notice for Authorizations tab

--- a/client/components/test-mode-notice/index.js
+++ b/client/components/test-mode-notice/index.js
@@ -40,7 +40,7 @@ export const topics = {
 		'woocommerce-payments'
 	),
 	authorizations: __(
-		'Viewing test uncaptured transactions. To view live uncaptured transactions, disable test mode in WooCommerce Payments settings.',
+		'Viewing test authorizations. To view live authorizations, disable test mode in WooCommerce Payments settings.',
 		'woocommerce-payments'
 	),
 	riskReviewTransactions: __(


### PR DESCRIPTION
Fixes #5181 

#### Changes proposed in this Pull Request

Tweak the notice text for Uncaptured Authorizations tab within `Payments > Transactions> Uncaptured tab`

#### Testing instructions

* Checkout to this branch and open the client. ( test mode ) 
* Within `Payments > Settings > Transactions` section, please enable `Issue an authorization on checkout, and capture later` option, and click the save button at the bottom
* Do a test transaction from the site frontend and come back to WP Admin within `Payments > Settings > Transactions`. Click the `Uncaptured` tab. 
* You should see a notice with the text - 

```
Viewing test authorizations. To view live authorizations, disable test mode in WooCommerce Payments settings.
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) - Not needed
- [x] Tested on mobile (or does not apply) - Not needed.

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
