### PR TITLE
Sort uncaptured transactions to show older first

### DIFF
--- a/changelog/fix-5183-sort-uncaptured-transactions
+++ b/changelog/fix-5183-sort-uncaptured-transactions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Sort uncaptured transactions with oldest first.

--- a/client/data/authorizations/hooks.ts
+++ b/client/data/authorizations/hooks.ts
@@ -37,7 +37,7 @@ export const useAuthorizations = ( {
 				paged: pagedQuery ? '1' : paged,
 				per_page: perPageQuery ? '25' : per_page,
 				orderby: orderby || 'created',
-				order: order || 'desc',
+				order: order || 'asc',
 			};
 
 			return {

--- a/client/data/authorizations/resolvers.ts
+++ b/client/data/authorizations/resolvers.ts
@@ -31,7 +31,7 @@ export function* getAuthorizations( query: Query ): Generator< unknown > {
 		paged = 1,
 		per_page: perPage = 25,
 		orderby = 'created',
-		order = 'desc',
+		order = 'asc',
 	} = query;
 
 	if ( orderby === 'capture_by' ) {
@@ -119,6 +119,6 @@ export function* getAuthorizationsSummary( query: Query ): any {
 				'woocommerce-payments'
 			)
 		);
-		yield updateErrorForAuthorizationsSummary( query, e );
+		yield updateErrorForAuthorizationsSummary( query, e as Error );
 	}
 }

--- a/client/transactions/uncaptured/index.tsx
+++ b/client/transactions/uncaptured/index.tsx
@@ -44,7 +44,7 @@ const getColumns = (): Column[] =>
 			screenReaderLabel: __( 'Authorized on', 'woocommerce-payments' ),
 			required: true,
 			isLeftAligned: true,
-			defaultOrder: 'desc',
+			defaultOrder: 'asc',
 			cellClassName: 'date-time',
 			isSortable: true,
 			defaultSort: true,

--- a/client/transactions/uncaptured/test/__snapshots__/index.test.tsx.snap
+++ b/client/transactions/uncaptured/test/__snapshots__/index.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`Authorizations list renders correctly 1`] = `
             <tbody>
               <tr>
                 <th
-                  aria-sort="descending"
+                  aria-sort="ascending"
                   class="woocommerce-table__header date-time is-left-aligned is-sortable is-sorted"
                   role="columnheader"
                   scope="col"
@@ -106,7 +106,7 @@ exports[`Authorizations list renders correctly 1`] = `
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
+                        d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z"
                       />
                     </svg>
                     <span
@@ -124,7 +124,7 @@ exports[`Authorizations list renders correctly 1`] = `
                     class="screen-reader-text"
                     id="header-0-0"
                   >
-                    Sort by Authorized on in ascending order
+                    Sort by Authorized on in descending order
                   </span>
                 </th>
                 <th

--- a/client/transactions/uncaptured/test/index.test.tsx
+++ b/client/transactions/uncaptured/test/index.test.tsx
@@ -188,10 +188,10 @@ describe( 'Authorizations list', () => {
 
 		test( 'sorts by authorized on field', () => {
 			sortBy( 'Authorized on' );
-			expectSortingToBe( 'created', 'asc' );
+			expectSortingToBe( 'created', 'desc' );
 
 			sortBy( 'Authorized on' );
-			expectSortingToBe( 'created', 'desc' );
+			expectSortingToBe( 'created', 'asc' );
 		} );
 
 		test( 'sorts by capture by field', () => {


### PR DESCRIPTION
Fixes #5183 

#### Changes proposed in this Pull Request

Sort uncaptured transaction to show older ones first and in increasing order of time ( chronological ). This will help merchants to see transactions that would expire first, on top. 

#### Testing instructions

* Within `Payments > Settings > Transactions` make sure to enable `Issue an authorization on checkout, and capture later` , and click the blue `Save Changes` button
* From the front end, create at least three to four orders 
* Browse to `Payments > Transactions > Uncaptured tab`
* The list of transactions should be in ascending order of time. i.e. oldest first 

#### Screenshots

<details><summary>Before</summary>
<p>

![image](https://user-images.githubusercontent.com/4162931/228149223-f53cb635-14a2-4ae4-b7f6-73dffae29c0d.png)

</p>
</details> 

<details><summary>After</summary>
<p>

![image](https://user-images.githubusercontent.com/4162931/228148956-626ce004-8b5a-49ab-971a-a17eac40d74a.png)

</p>
</details> 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️) - Not needed
- [x] Tested on mobile (or does not apply) - Not applicable

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
