### PR TITLE
Add the WooPay Express button to the Pay for order page

### DIFF
--- a/changelog/add-pay-for-order
+++ b/changelog/add-pay-for-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add the express button on the pay for order page

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -6,7 +6,11 @@ import { getConfig } from 'wcpay/utils/checkout';
 import wcpayTracks from 'tracks';
 import request from '../utils/request';
 import { buildAjaxURL } from '../../payment-request/utils';
-import { getTargetElement, validateEmail } from './utils';
+import {
+	getTargetElement,
+	validateEmail,
+	appendRedirectionParams,
+} from './utils';
 
 export const handleWooPayEmailInput = async (
 	field,
@@ -534,7 +538,9 @@ export const handleWooPayEmailInput = async (
 					true
 				);
 				if ( e.data.redirectUrl ) {
-					window.location = e.data.redirectUrl;
+					window.location = appendRedirectionParams(
+						e.data.redirectUrl
+					);
 				}
 				break;
 			case 'redirect_to_platform_checkout':

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -5,7 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { getConfig } from 'utils/checkout';
 import request from 'wcpay/checkout/utils/request';
 import { buildAjaxURL } from 'wcpay/payment-request/utils';
-import { getTargetElement, validateEmail } from '../utils';
+import {
+	getTargetElement,
+	validateEmail,
+	appendRedirectionParams,
+} from '../utils';
 import wcpayTracks from 'tracks';
 
 export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
@@ -168,23 +172,6 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 		}
 	};
 
-	const appendParamsToWooPayUrl = ( woopayUrl ) => {
-		const isPayForOrder = window.wcpayConfig.pay_for_order;
-		const orderId = window.wcpayConfig.order_id;
-		const key = window.wcpayConfig.key;
-
-		if ( ! isPayForOrder || ! orderId || ! key ) {
-			return woopayUrl;
-		}
-
-		const url = new URL( woopayUrl );
-		url.searchParams.append( 'pay_for_order', isPayForOrder );
-		url.searchParams.append( 'order_id', orderId );
-		url.searchParams.append( 'key', key );
-
-		return url.href;
-	};
-
 	const closeIframe = () => {
 		window.removeEventListener( 'resize', getWindowSize );
 		window.removeEventListener( 'resize', setPopoverPosition );
@@ -267,7 +254,9 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 					true
 				);
 				if ( e.data.redirectUrl ) {
-					window.location = e.data.redirectUrl;
+					window.location = appendRedirectionParams(
+						e.data.redirectUrl
+					);
 				}
 				break;
 			case 'redirect_to_platform_checkout':
@@ -286,7 +275,7 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 						return;
 					}
 					if ( response.result === 'success' ) {
-						window.location = appendParamsToWooPayUrl(
+						window.location = appendRedirectionParams(
 							response.url
 						);
 					} else {

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -168,6 +168,23 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 		}
 	};
 
+	const appendParamsToWooPayUrl = ( woopayUrl ) => {
+		const isPayForOrder = window.wcpayConfig.pay_for_order;
+		const orderId = window.wcpayConfig.order_id;
+		const key = window.wcpayConfig.key;
+
+		if ( ! isPayForOrder || ! orderId || ! key ) {
+			return woopayUrl;
+		}
+
+		const url = new URL( woopayUrl );
+		url.searchParams.append( 'pay_for_order', isPayForOrder );
+		url.searchParams.append( 'order_id', orderId );
+		url.searchParams.append( 'key', key );
+
+		return url.href;
+	};
+
 	const closeIframe = () => {
 		window.removeEventListener( 'resize', getWindowSize );
 		window.removeEventListener( 'resize', setPopoverPosition );
@@ -269,7 +286,9 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 						return;
 					}
 					if ( response.result === 'success' ) {
-						window.location = response.url;
+						window.location = appendParamsToWooPayUrl(
+							response.url
+						);
 					} else {
 						showErrorMessage();
 						closeIframe( false );

--- a/client/checkout/woopay/utils.js
+++ b/client/checkout/woopay/utils.js
@@ -39,3 +39,20 @@ export const validateEmail = ( value ) => {
 	/* eslint-enable */
 	return pattern.test( value );
 };
+
+export const appendRedirectionParams = ( woopayUrl ) => {
+	const isPayForOrder = window.wcpayConfig.pay_for_order;
+	const orderId = window.wcpayConfig.order_id;
+	const key = window.wcpayConfig.key;
+
+	if ( ! isPayForOrder || ! orderId || ! key ) {
+		return woopayUrl;
+	}
+
+	const url = new URL( woopayUrl );
+	url.searchParams.append( 'pay_for_order', isPayForOrder );
+	url.searchParams.append( 'order_id', orderId );
+	url.searchParams.append( 'key', key );
+
+	return url.href;
+};

--- a/client/checkout/woopay/utils.js
+++ b/client/checkout/woopay/utils.js
@@ -44,6 +44,7 @@ export const appendRedirectionParams = ( woopayUrl ) => {
 	const isPayForOrder = window.wcpayConfig.pay_for_order;
 	const orderId = window.wcpayConfig.order_id;
 	const key = window.wcpayConfig.key;
+	const billingEmail = window.wcpayConfig.billing_email;
 
 	if ( ! isPayForOrder || ! orderId || ! key ) {
 		return woopayUrl;
@@ -53,6 +54,7 @@ export const appendRedirectionParams = ( woopayUrl ) => {
 	url.searchParams.append( 'pay_for_order', isPayForOrder );
 	url.searchParams.append( 'order_id', orderId );
 	url.searchParams.append( 'key', key );
+	url.searchParams.append( 'billing_email', billingEmail );
 
 	return url.href;
 };

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -212,12 +212,13 @@ class WC_Payments_Checkout {
 	 */
 	public function add_pay_for_order_params_to_js_config( $order ) {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['pay_for_order'] ) ) {
+		if ( isset( $_GET['pay_for_order'] ) && isset( $_GET['key'] ) ) {
 			add_filter(
 				'wcpay_payment_fields_js_config',
 				function( $js_config ) use ( $order ) {
 					$js_config['order_id']      = $order->get_id();
 					$js_config['pay_for_order'] = sanitize_text_field( wp_unslash( $_GET['pay_for_order'] ) );
+					$js_config['key']           = sanitize_text_field( wp_unslash( $_GET['key'] ) );
 
 					return $js_config;
 				}

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -206,6 +206,27 @@ class WC_Payments_Checkout {
 	}
 
 	/**
+	 * Add the Pay for order params to the JS config.
+	 *
+	 * @param WC_Order $order The pay-for-order order.
+	 */
+	public function add_pay_for_order_params_to_js_config( $order ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['pay_for_order'] ) ) {
+			add_filter(
+				'wcpay_payment_fields_js_config',
+				function( $js_config ) use ( $order ) {
+					$js_config['order_id']      = $order->get_id();
+					$js_config['pay_for_order'] = sanitize_text_field( wp_unslash( $_GET['pay_for_order'] ) );
+
+					return $js_config;
+				}
+			);
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
 	 * Renders the credit card input fields needed to get the user's payment information on the checkout page.
 	 *
 	 * We also add the JavaScript which drives the UI.

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -206,28 +206,6 @@ class WC_Payments_Checkout {
 	}
 
 	/**
-	 * Add the Pay for order params to the JS config.
-	 *
-	 * @param WC_Order $order The pay-for-order order.
-	 */
-	public function add_pay_for_order_params_to_js_config( $order ) {
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['pay_for_order'] ) && isset( $_GET['key'] ) ) {
-			add_filter(
-				'wcpay_payment_fields_js_config',
-				function( $js_config ) use ( $order ) {
-					$js_config['order_id']      = $order->get_id();
-					$js_config['pay_for_order'] = sanitize_text_field( wp_unslash( $_GET['pay_for_order'] ) );
-					$js_config['key']           = sanitize_text_field( wp_unslash( $_GET['key'] ) );
-
-					return $js_config;
-				}
-			);
-		}
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended
-	}
-
-	/**
 	 * Renders the credit card input fields needed to get the user's payment information on the checkout page.
 	 *
 	 * We also add the JavaScript which drives the UI.

--- a/includes/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/class-wc-payments-express-checkout-button-display-handler.php
@@ -57,10 +57,11 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 			add_action( 'woocommerce_after_add_to_cart_form', [ $this, 'display_express_checkout_buttons' ], 1 );
 			add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_express_checkout_buttons' ], 21 );
 			add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_express_checkout_buttons' ], 1 );
+			add_action( 'before_woocommerce_pay_form', [ $this, 'add_pay_for_order_params_to_js_config' ] );
 
 			if ( $is_payment_request_enabled ) {
 				// Load separator on the Pay for Order page.
-				add_action( 'before_woocommerce_pay_form', [ $this, 'display_express_checkout_buttons' ], 1 );
+				add_action( 'woocommerce_pay_order_before_payment', [ $this, 'display_express_checkout_buttons' ], 1 );
 			}
 		}
 	}
@@ -110,5 +111,27 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 	 */
 	public function is_woopay_enabled() {
 		return $this->platform_checkout_button_handler->is_woopay_enabled();
+	}
+
+	/**
+	 * Add the Pay for order params to the JS config.
+	 *
+	 * @param WC_Order $order The pay-for-order order.
+	 */
+	public function add_pay_for_order_params_to_js_config( $order ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['pay_for_order'] ) && isset( $_GET['key'] ) ) {
+			add_filter(
+				'wcpay_payment_fields_js_config',
+				function( $js_config ) use ( $order ) {
+					$js_config['order_id']      = $order->get_id();
+					$js_config['pay_for_order'] = sanitize_text_field( wp_unslash( $_GET['pay_for_order'] ) );
+					$js_config['key']           = sanitize_text_field( wp_unslash( $_GET['key'] ) );
+
+					return $js_config;
+				}
+			);
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 	}
 }

--- a/includes/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/class-wc-payments-express-checkout-button-display-handler.php
@@ -123,6 +123,7 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 					$js_config['order_id']      = $order->get_id();
 					$js_config['pay_for_order'] = sanitize_text_field( wp_unslash( $_GET['pay_for_order'] ) );
 					$js_config['key']           = sanitize_text_field( wp_unslash( $_GET['key'] ) );
+					$js_config['billing_email'] = $order->get_billing_email();
 
 					return $js_config;
 				}

--- a/includes/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/class-wc-payments-express-checkout-button-display-handler.php
@@ -58,11 +58,7 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 			add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_express_checkout_buttons' ], 21 );
 			add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_express_checkout_buttons' ], 1 );
 			add_action( 'before_woocommerce_pay_form', [ $this, 'add_pay_for_order_params_to_js_config' ] );
-
-			if ( $is_woopay_enabled ) {
-				// Load separator on the Pay for Order page.
-				add_action( 'woocommerce_pay_order_before_payment', [ $this, 'display_express_checkout_buttons' ], 1 );
-			}
+			add_action( 'woocommerce_pay_order_before_payment', [ $this, 'display_express_checkout_buttons' ], 1 );
 		}
 	}
 

--- a/includes/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/class-wc-payments-express-checkout-button-display-handler.php
@@ -59,7 +59,7 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 			add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_express_checkout_buttons' ], 1 );
 			add_action( 'before_woocommerce_pay_form', [ $this, 'add_pay_for_order_params_to_js_config' ] );
 
-			if ( $is_payment_request_enabled ) {
+			if ( $is_woopay_enabled ) {
 				// Load separator on the Pay for Order page.
 				add_action( 'woocommerce_pay_order_before_payment', [ $this, 'display_express_checkout_buttons' ], 1 );
 			}

--- a/includes/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/class-wc-payments-express-checkout-button-display-handler.php
@@ -57,6 +57,9 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 			add_action( 'woocommerce_after_add_to_cart_form', [ $this, 'display_express_checkout_buttons' ], 1 );
 			add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_express_checkout_buttons' ], 21 );
 			add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_express_checkout_buttons' ], 1 );
+		}
+
+		if ( class_exists( '\Automattic\WooCommerce\Blocks\Package' ) && version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '10.8.0', '>=' ) ) {
 			add_action( 'before_woocommerce_pay_form', [ $this, 'add_pay_for_order_params_to_js_config' ] );
 			add_action( 'woocommerce_pay_order_before_payment', [ $this, 'display_express_checkout_buttons' ], 1 );
 		}

--- a/includes/class-wc-payments-woopay-button-handler.php
+++ b/includes/class-wc-payments-woopay-button-handler.php
@@ -529,10 +529,6 @@ class WC_Payments_WooPay_Button_Handler {
 			return false;
 		}
 
-		if ( $this->is_pay_for_order_page() ) {
-			return false;
-		}
-
 		if ( ! is_user_logged_in() ) {
 			// On product page for a subscription product, but not logged in, making WooPay unavailable.
 			if ( $this->is_product() ) {


### PR DESCRIPTION
Fixes #5901 

**Note: This PR ~~still needs design and~~ won't be merged until [WooPay](2104-gh-Automattic/woopay) and [WC](https://github.com/woocommerce/woocommerce/pull/37588) PRs are merged.**

#### Changes proposed in this Pull Request
1. Add the WooPay Express button to the pay-for-order page
2. Pass the pay-for-order params `order_id`, `pay_for_order`, `key`, and `billing_email` to WooPay redirect URL.

#### Screenshot ( ~~Needs design~~ )

Before             |  After
:-------------------------:|:-------------------------:
<img width="565" alt="Screen Shot 2023-03-29 at 5 15 03 PM" src="https://user-images.githubusercontent.com/56378160/228696174-0167d08d-366a-4f5b-a514-5994c1d9261d.png">  | <img width="559" alt="Screen Shot 2023-04-05 at 5 19 10 PM" src="https://user-images.githubusercontent.com/56378160/230241779-19b5c108-6282-4655-ab21-e7912a22d63d.png">



#### Testing instructions
<img width="446" alt="Screen Shot 2023-04-05 at 5 21 07 PM" src="https://user-images.githubusercontent.com/56378160/230242121-0880e42a-a848-4052-b1c4-58b2bf0993f8.png">

1. Test with [WC](https://github.com/woocommerce/woocommerce/pull/37588) PR
2. Install and activate a plugin with pay-for-order flow. ex WooCommerce-Bookings
1. Purchase the product with pay-for-order flow
1. Go to WooCommerce -> Orders
1. Find the order you just replaced and order_data metabox
1. Click on the `Customer payment page →` link next to the order status
1. Check if the WooPay Express button is append on the pay for order page shown in the above picture
1. Copy the `order_id` and the `key` from the URL
1. Click on the WooPay Express button
1. It should redirect to the WooPay checkout page
1. Confirm and compare the URL containing the params `&pay_for_order=true&order_id=YOUR_ORDER_ID&key=wc_order_YOUR_KEY&billing_email=YOUR_BILLING_EMAIL`

*

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.