### PR TITLE
Bump WC and WP and PHP versions

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -4,8 +4,8 @@ on:
   pull_request
 
 env:
-  WC_L2_VERSION: '7.3.0'
-  WP_L2_VERSION: '5.9'
+  WC_L2_VERSION: '7.5.0'
+  WP_L2_VERSION: '6.0'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -23,7 +23,7 @@ env:
   E2E_SLACK_TOKEN:       ${{ secrets.E2E_SLACK_TOKEN }}
   E2E_USE_LOCAL_SERVER:  false
   E2E_RESULT_FILEPATH:   'tests/e2e/results.json'
-  WC_L2_VERSION: '7.3.0'
+  WC_L2_VERSION: '7.5.0'
   NODE_ENV: 'test'
 
 jobs:

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   WP_VERSION:        latest
-  WC_L2_VERSION: '7.3.0'  # the min supported version as per L-2 policy
+  WC_L2_VERSION: '7.5.0'  # the min supported version as per L-2 policy
   GUTENBERG_VERSION: latest
 
 concurrency:

--- a/phpcs-compat.xml.dist
+++ b/phpcs-compat.xml.dist
@@ -15,8 +15,8 @@
 	<exclude-pattern>tests/</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="5.6" />
-	<config name="testVersion" value="7.0-" />
+	<config name="minimum_supported_wp_version" value="6.0" />
+	<config name="testVersion" value="8.0-" />
 
 	<rule ref="PHPCompatibility">
 		<!-- WP has sodium compatibility since https://wordpress.org/support/wordpress-version/version-5-2/ -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,8 +15,8 @@
 	<exclude-pattern>./vendor-dist/*</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="5.9" />
-	<config name="testVersion" value="7.0-" />
+	<config name="minimum_supported_wp_version" value="6.0" />
+	<config name="testVersion" value="8.0-" />
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" >

--- a/readme.txt
+++ b/readme.txt
@@ -40,7 +40,7 @@ Our global support team is available to answer questions you may have about WooC
 
 * WordPress 5.9 or newer.
 * WooCommerce 7.3 or newer.
-* PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
+* PHP 7.2 or newer is recommended.
 
 = Try it now =
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === WooCommerce Payments - Fully Integrated Solution Built and Supported by Woo ===
 Contributors: woocommerce, automattic
 Tags: payment gateway, payment, apple pay, credit card, google pay
-Requires at least: 5.9
-Tested up to: 6.1
-Requires PHP: 7.0
+Requires at least: 6.0
+Tested up to: 6.2
+Requires PHP: 8.0
 Stable tag: 5.6.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -38,9 +38,9 @@ Our global support team is available to answer questions you may have about WooC
 
 = Requirements =
 
-* WordPress 5.9 or newer.
-* WooCommerce 7.3 or newer.
-* PHP 7.2 or newer is recommended.
+* WordPress 6.0 or newer.
+* WooCommerce 7.5 or newer.
+* PHP 8.0 or newer is recommended.
 
 = Try it now =
 

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,10 +8,10 @@
  * Woo: 5278104:bf3cf30871604e15eec560c962593c1f
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
- * WC requires at least: 7.3
- * WC tested up to: 7.5.1
- * Requires at least: 5.9
- * Requires PHP: 7.0
+ * WC requires at least: 7.5
+ * WC tested up to: 7.7.0
+ * Requires at least: 6.0
+ * Requires PHP: 8.0
  * Version: 5.6.2
  *
  * @package WooCommerce\Payments


### PR DESCRIPTION
Bump versions according to the L-2 policy - Bump WC 'tested up to' version to 7.7 and minimum version to 7.5.<br />- Bump WP 'tested up to' version to 6.2 and minimum version to 6.0.<br />- Bump PHP minimum version to 8.0.

- ff
- 