### PR TITLE
Bump PHP versions

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -51,8 +51,6 @@ jobs:
           php-version: ${{ matrix.php }}
           tools:       composer
           coverage:    none
-      # No longer needed. Early version of PHPUnit is already part of repository.
-      # run: if [[ "${{ matrix.php }}" == '7.0' ]]; then wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar; fi;
       # run CI checks
       - run: bash bin/run-ci-tests.bash
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,5 +36,4 @@ jobs:
           tools:       composer
           coverage:    xdebug2
       # run CI checks
-      - run: if [[ "${{ matrix.php }}" == '7.0' ]]; then wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar; fi;
       - run: bash bin/run-ci-tests-check-coverage.bash

--- a/phpcs-compat.xml.dist
+++ b/phpcs-compat.xml.dist
@@ -16,7 +16,7 @@
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="5.6" />
-	<config name="testVersion" value="7.0-" />
+	<config name="testVersion" value="7.2-" />
 
 	<rule ref="PHPCompatibility">
 		<!-- WP has sodium compatibility since https://wordpress.org/support/wordpress-version/version-5-2/ -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,7 +16,7 @@
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="5.9" />
-	<config name="testVersion" value="7.0-" />
+	<config name="testVersion" value="7.2-" />
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" >

--- a/readme.txt
+++ b/readme.txt
@@ -40,7 +40,7 @@ Our global support team is available to answer questions you may have about WooC
 
 * WordPress 5.9 or newer.
 * WooCommerce 7.3 or newer.
-* PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
+* PHP 7.2 or newer is recommended.
 
 = Try it now =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: woocommerce, automattic
 Tags: payment gateway, payment, apple pay, credit card, google pay
 Requires at least: 5.9
 Tested up to: 6.1
-Requires PHP: 7.0
+Requires PHP: 7.2
 Stable tag: 5.6.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -11,7 +11,7 @@
  * WC requires at least: 7.3
  * WC tested up to: 7.5.1
  * Requires at least: 5.9
- * Requires PHP: 7.0
+ * Requires PHP: 7.2
  * Version: 5.6.2
  *
  * @package WooCommerce\Payments


### PR DESCRIPTION
The changes and this PR were made via the [wcpay:bump-versions](https://github.com/woocommerce/woorelease-extensions/blob/trunk/class-woocommerce-payments-bump-versions.php) command<br /><br />- Bump PHP minimum version to `7.2`.