### PR TITLE
Bump WP and PHP versions

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -51,8 +51,6 @@ jobs:
           php-version: ${{ matrix.php }}
           tools:       composer
           coverage:    none
-      # No longer needed. Early version of PHPUnit is already part of repository.
-      # run: if [[ "${{ matrix.php }}" == '7.0' ]]; then wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar; fi;
       # run CI checks
       - run: bash bin/run-ci-tests.bash
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,5 +36,4 @@ jobs:
           tools:       composer
           coverage:    xdebug2
       # run CI checks
-      - run: if [[ "${{ matrix.php }}" == '7.0' ]]; then wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar; fi;
       - run: bash bin/run-ci-tests-check-coverage.bash

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
-          tools:       composer:2.5.0
-          coverage:    none
+          tools: composer
+          coverage: none
       - run: bash bin/phpcs-compat.sh

--- a/readme.txt
+++ b/readme.txt
@@ -40,7 +40,7 @@ Our global support team is available to answer questions you may have about WooC
 
 * WordPress 5.9 or newer.
 * WooCommerce 7.3 or newer.
-* PHP version 7.0 or newer. PHP 7.2 or newer is recommended.
+* PHP 7.2 or newer is recommended.
 
 = Try it now =
 


### PR DESCRIPTION
The changes and this PR were made via the [wcpay:bump-versions](https://github.com/woocommerce/woorelease-extensions/blob/trunk/class-woocommerce-payments-bump-versions.php) command.<br /><br />- Bump WP 'tested up to' version to `6.2` and minimum version to `6.0`.<br />- Bump PHP minimum version to `7.2`.