### PR TITLE
Apply latest rule defaults and fix modals

### DIFF
--- a/changelog/fix-adapt-latest-fraud-tools-defaults-and-modals
+++ b/changelog/fix-adapt-latest-fraud-tools-defaults-and-modals
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Adds basic protection level modal and fixes standard and high level protection modal rules

--- a/client/settings/fraud-protection/components/fp-modal/index.js
+++ b/client/settings/fraud-protection/components/fp-modal/index.js
@@ -236,3 +236,80 @@ export const StandardFraudProtectionModal = ( {
 		</>
 	);
 };
+
+export const BasicFraudProtectionModal = ( {
+	level,
+	isBasicModalOpen,
+	setBasicModalOpen,
+} ) => {
+	const { declineOnAVSFailure, declineOnCVCFailure } = window.wcpaySettings
+		?.accountStatus?.fraudProtection ?? {
+		declineOnAVSFailure: true,
+		declineOnCVCFailure: true,
+	};
+
+	const hasActivePlatformChecks = declineOnAVSFailure || declineOnCVCFailure;
+	return (
+		<>
+			{ isBasicModalOpen && (
+				<Modal
+					title={ __(
+						'Standard filter level',
+						'woocommerce-payments'
+					) }
+					isDismissible={ true }
+					shouldCloseOnClickOutside={ true }
+					shouldCloseOnEsc={ true }
+					onRequestClose={ () => setBasicModalOpen( false ) }
+					className="fraud-protection-level-modal"
+				>
+					<div className="components-modal__body--fraud-protection">
+						<ProtectionLevelModalNotice level={ level } />
+						{ hasActivePlatformChecks && (
+							<>
+								<p>
+									{ interpolateComponents( {
+										mixedString: __(
+											'Payments will be {{blocked}}blocked{{/blocked}} if:',
+											'woocommerce-payments'
+										),
+										components: {
+											blocked: (
+												<span className="component-modal__text--blocked" />
+											),
+										},
+									} ) }
+								</p>
+								<ul>
+									{ declineOnAVSFailure && (
+										<li>
+											{ __(
+												'The billing address does not match what is on file with the card issuer.',
+												'woocommerce-payments'
+											) }
+										</li>
+									) }
+									{ declineOnCVCFailure && (
+										<li>
+											{ __(
+												"The card's issuing bank cannot verify the CVV.",
+												'woocommerce-payments'
+											) }
+										</li>
+									) }
+								</ul>
+							</>
+						) }
+						<Button
+							className="component-modal__button--confirm"
+							onClick={ () => setBasicModalOpen( false ) }
+							isTertiary
+						>
+							{ __( 'Got it', 'woocommerce-payments' ) }
+						</Button>
+					</div>
+				</Modal>
+			) }
+		</>
+	);
+};

--- a/client/settings/fraud-protection/components/fp-modal/index.js
+++ b/client/settings/fraud-protection/components/fp-modal/index.js
@@ -253,10 +253,7 @@ export const BasicFraudProtectionModal = ( {
 		<>
 			{ isBasicModalOpen && (
 				<Modal
-					title={ __(
-						'Standard filter level',
-						'woocommerce-payments'
-					) }
+					title={ __( 'Basic filter level', 'woocommerce-payments' ) }
 					isDismissible={ true }
 					shouldCloseOnClickOutside={ true }
 					shouldCloseOnEsc={ true }

--- a/client/settings/fraud-protection/components/fp-modal/index.js
+++ b/client/settings/fraud-protection/components/fp-modal/index.js
@@ -109,7 +109,7 @@ export const HighFraudProtectionModal = ( {
 							</li>
 							<li>
 								{ __(
-									'The billing address is a non-domestic address.',
+									"The billing address country doesn't match the country resolved from the IP address.",
 									'woocommerce-payments'
 								) }
 							</li>
@@ -209,6 +209,12 @@ export const StandardFraudProtectionModal = ( {
 							<li>
 								{ __(
 									'An order originates from an IP address outside your country.',
+									'woocommerce-payments'
+								) }
+							</li>
+							<li>
+								{ __(
+									"The billing address country doesn't match the country resolved from the IP address.",
 									'woocommerce-payments'
 								) }
 							</li>

--- a/client/settings/fraud-protection/components/fp-modal/test/__snapshots__/index.test.js.snap
+++ b/client/settings/fraud-protection/components/fp-modal/test/__snapshots__/index.test.js.snap
@@ -119,7 +119,7 @@ exports[`HighFraudProtectionModal renders the high protection level content with
         The shipping and billing addresses don't match.
       </li>
       <li>
-        The billing address is a non-domestic address.
+        The billing address country doesn't match the country resolved from the IP address.
       </li>
     </ul>
     <button
@@ -251,7 +251,7 @@ exports[`HighFraudProtectionModal renders the high protection level content with
         The shipping and billing addresses don't match.
       </li>
       <li>
-        The billing address is a non-domestic address.
+        The billing address country doesn't match the country resolved from the IP address.
       </li>
     </ul>
     <button
@@ -361,6 +361,9 @@ exports[`StandardFraudProtectionModal renders the standard protection level cont
     <ul>
       <li>
         An order originates from an IP address outside your country.
+      </li>
+      <li>
+        The billing address country doesn't match the country resolved from the IP address.
       </li>
       <li>
         An order exceeds 
@@ -480,6 +483,9 @@ exports[`StandardFraudProtectionModal renders the standard protection level cont
     <ul>
       <li>
         An order originates from an IP address outside your country.
+      </li>
+      <li>
+        The billing address country doesn't match the country resolved from the IP address.
       </li>
       <li>
         An order exceeds the equivalent of 

--- a/client/settings/fraud-protection/components/index.js
+++ b/client/settings/fraud-protection/components/index.js
@@ -6,6 +6,7 @@ import ProtectionLevelModalNotice from './protection-level-modal-notice';
 import FraudProtectionHelpText from './fp-help-text';
 import ProtectionLevels from './protection-levels';
 import {
+	BasicFraudProtectionModal,
 	HighFraudProtectionModal,
 	StandardFraudProtectionModal,
 } from './fp-modal';
@@ -17,4 +18,5 @@ export {
 	ProtectionLevels,
 	HighFraudProtectionModal,
 	StandardFraudProtectionModal,
+	BasicFraudProtectionModal,
 };

--- a/client/settings/fraud-protection/components/protection-level-modal-notice/index.js
+++ b/client/settings/fraud-protection/components/protection-level-modal-notice/index.js
@@ -12,7 +12,20 @@ import { TipIcon } from 'wcpay/icons';
 import { ProtectionLevel } from '../../advanced-settings/constants';
 
 const ProtectionLevelModalNotice = ( { level } ) => {
-	const isHighProtectionLevel = ProtectionLevel.HIGH === level;
+	const modalTexts = {
+		[ ProtectionLevel.BASIC ]: __(
+			'Provides basic anti-fraud protection only.',
+			'woocommerce-payments'
+		),
+		[ ProtectionLevel.STANDARD ]: __(
+			"Provides a standard level of filtering that's suitable for most business.",
+			'woocommerce-payments'
+		),
+		[ ProtectionLevel.HIGH ]: __(
+			'Offers the highest level of filtering for stores, but may catch some legitimate transactions.',
+			'woocommerce-payments'
+		),
+	};
 
 	return (
 		<Notice
@@ -22,17 +35,7 @@ const ProtectionLevelModalNotice = ( { level } ) => {
 		>
 			<div className="component-notice__content--flex">
 				<TipIcon className="component-notice__icon" />
-				<p>
-					{ isHighProtectionLevel
-						? __(
-								'Offers the highest level of filtering for stores, but may catch some legitimate transactions.',
-								'woocommerce-payments'
-						  )
-						: __(
-								"Provides a standard level of filtering that's suitable for most business.",
-								'woocommerce-payments'
-						  ) }
-				</p>
+				<p>{ modalTexts[ level ] }</p>
 			</div>
 		</Notice>
 	);

--- a/client/settings/fraud-protection/components/protection-levels/index.js
+++ b/client/settings/fraud-protection/components/protection-levels/index.js
@@ -18,6 +18,7 @@ import {
 	FraudProtectionHelpText,
 	HighFraudProtectionModal,
 	StandardFraudProtectionModal,
+	BasicFraudProtectionModal,
 } from '../index';
 import interpolateComponents from '@automattic/interpolate-components';
 import { Button } from '@wordpress/components';
@@ -87,10 +88,10 @@ const ProtectionLevels = () => {
 								className="fraud-protection__help-icon"
 								onClick={ () => setBasicModalOpen( true ) }
 							/>
-							<StandardFraudProtectionModal
+							<BasicFraudProtectionModal
 								level={ ProtectionLevel.BASIC }
-								isStandardModalOpen={ isBasicModalOpen }
-								setStandardModalOpen={ setBasicModalOpen }
+								isBasicModalOpen={ isBasicModalOpen }
+								setBasicModalOpen={ setBasicModalOpen }
 							/>
 						</div>
 						<FraudProtectionHelpText

--- a/client/settings/fraud-protection/components/protection-levels/index.js
+++ b/client/settings/fraud-protection/components/protection-levels/index.js
@@ -26,6 +26,7 @@ import { ProtectionLevel } from '../../advanced-settings/constants';
 import InlineNotice from '../../../../components/inline-notice';
 
 const ProtectionLevels = () => {
+	const [ isBasicModalOpen, setBasicModalOpen ] = useState( false );
 	const [ isStandardModalOpen, setStandardModalOpen ] = useState( false );
 	const [ isHighModalOpen, setHighModalOpen ] = useState( false );
 	const { currencies } = useCurrencies();
@@ -80,6 +81,17 @@ const ProtectionLevels = () => {
 							>
 								{ __( 'Basic', 'woocommerce-payments' ) }
 							</label>
+							<HelpOutlineIcon
+								size={ 18 }
+								title="Basic level help icon"
+								className="fraud-protection__help-icon"
+								onClick={ () => setBasicModalOpen( true ) }
+							/>
+							<StandardFraudProtectionModal
+								level={ ProtectionLevel.BASIC }
+								isStandardModalOpen={ isBasicModalOpen }
+								setStandardModalOpen={ setBasicModalOpen }
+							/>
 						</div>
 						<FraudProtectionHelpText
 							level={ ProtectionLevel.BASIC }

--- a/client/settings/fraud-protection/components/protection-levels/test/__snapshots__/index.test.js.snap
+++ b/client/settings/fraud-protection/components/protection-levels/test/__snapshots__/index.test.js.snap
@@ -22,6 +22,20 @@ exports[`ProtectionLevels renders 1`] = `
           >
             Basic
           </label>
+          <svg
+            class="gridicon gridicons-help-outline fraud-protection__help-icon needs-offset"
+            height="18"
+            title="Basic level help icon"
+            viewBox="0 0 24 24"
+            width="18"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z"
+              />
+            </g>
+          </svg>
         </div>
         <p
           class="fraud-protection__text--help-text"
@@ -186,6 +200,20 @@ exports[`ProtectionLevels renders an error message when settings can not be fetc
           >
             Basic
           </label>
+          <svg
+            class="gridicon gridicons-help-outline fraud-protection__help-icon needs-offset"
+            height="18"
+            title="Basic level help icon"
+            viewBox="0 0 24 24"
+            width="18"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z"
+              />
+            </g>
+          </svg>
         </div>
         <p
           class="fraud-protection__text--help-text"

--- a/client/settings/fraud-protection/test/__snapshots__/index.test.js.snap
+++ b/client/settings/fraud-protection/test/__snapshots__/index.test.js.snap
@@ -34,6 +34,20 @@ exports[`FraudProtection should render correctly 1`] = `
               >
                 Basic
               </label>
+              <svg
+                class="gridicon gridicons-help-outline fraud-protection__help-icon needs-offset"
+                height="18"
+                title="Basic level help icon"
+                viewBox="0 0 24 24"
+                width="18"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g>
+                  <path
+                    d="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z"
+                  />
+                </g>
+              </svg>
             </div>
             <p
               class="fraud-protection__text--help-text"
@@ -204,6 +218,20 @@ exports[`FraudProtection should render with the welcome tour dismissed 1`] = `
               >
                 Basic
               </label>
+              <svg
+                class="gridicon gridicons-help-outline fraud-protection__help-icon needs-offset"
+                height="18"
+                title="Basic level help icon"
+                viewBox="0 0 24 24"
+                width="18"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g>
+                  <path
+                    d="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm4 8c0-2.21-1.79-4-4-4s-4 1.79-4 4h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2c-.552 0-1 .448-1 1v2h2v-1.14c1.722-.447 3-1.998 3-3.86zm-3 6h-2v2h2v-2z"
+                  />
+                </g>
+              </svg>
             </div>
             <p
               class="fraud-protection__text--help-text"

--- a/includes/fraud-prevention/class-fraud-risk-tools.php
+++ b/includes/fraud-prevention/class-fraud-risk-tools.php
@@ -164,6 +164,7 @@ class Fraud_Risk_Tools {
 					10
 				)
 			),
+			// REVIEW An order exceeds $1,000.00 or 10 items.
 			new Rule(
 				self::RULE_PURCHASE_PRICE_THRESHOLD,
 				Rule::FRAUD_OUTCOME_REVIEW,
@@ -171,6 +172,16 @@ class Fraud_Risk_Tools {
 					'order_total',
 					Check::OPERATOR_GT,
 					1000 * 100
+				)
+			),
+			// REVIEW An order is originated from a different country than the shipping country.
+			new Rule(
+				self::RULE_IP_ADDRESS_MISMATCH,
+				Rule::FRAUD_OUTCOME_REVIEW,
+				Check::check(
+					'ip_billing_country_same',
+					Check::OPERATOR_EQUALS,
+					false
 				)
 			),
 		];

--- a/tests/unit/fraud-prevention/test-class-fraud-risk-tools.php
+++ b/tests/unit/fraud-prevention/test-class-fraud-risk-tools.php
@@ -66,6 +66,15 @@ class Fraud_Risk_Tools_Test extends WCPAY_UnitTestCase {
 				'value'    => 100000,
 			],
 		],
+		[
+			'key'     => 'ip_address_mismatch',
+			'outcome' => 'review',
+			'check'   => [
+				'key'      => 'ip_billing_country_same',
+				'operator' => 'equals',
+				'value'    => false,
+			],
+		],
 	];
 
 	/**
@@ -101,6 +110,15 @@ class Fraud_Risk_Tools_Test extends WCPAY_UnitTestCase {
 				'value'    => 100000,
 			],
 		],
+		[
+			'key'     => 'ip_address_mismatch',
+			'outcome' => 'review',
+			'check'   => [
+				'key'      => 'ip_billing_country_same',
+				'operator' => 'equals',
+				'value'    => false,
+			],
+		],
 	];
 
 	/**
@@ -134,6 +152,15 @@ class Fraud_Risk_Tools_Test extends WCPAY_UnitTestCase {
 				'key'      => 'order_total',
 				'operator' => 'greater_than',
 				'value'    => 100000,
+			],
+		],
+		[
+			'key'     => 'ip_address_mismatch',
+			'outcome' => 'review',
+			'check'   => [
+				'key'      => 'ip_billing_country_same',
+				'operator' => 'equals',
+				'value'    => false,
 			],
 		],
 	];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the "IP country mismatch" rule to both standard and default protection rules, and adds the respective texts to the modals according to pcqRLn-1wY-p2#comment-2073. Also adds a basic protection modal according to paJDYF-6pl-p2#comment-17230

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Unit tests should pass
* Enable the fraud protection feature flag
  * If this is the first time, run `npm run wp option add wcpay_fraud_protection_settings_active 1`
  * If you already have it set, run `npm run wp option update wcpay_fraud_protection_settings_active 1`
* Build the client `npm run start`
* Go to **Payments > Settings**
* Check if the basic protection level modal is clickable and shows the AVS and CVV checks.
* Check if both standard and high level modals contain the IP country mismatch filter text, which is: `The billing address country doesn't match the country resolved from the IP address.` in the review group for both protection levels.
* Activate standard protection level, save changes.
* Click "advanced" and then "configure"
* You should see the "IP country mismatch" filter activated and the block checkbox not checked.
* Go back and activate the high protection level, save changes.
* Click "advanced" and then "configure"
* You should see the "IP country mismatch" filter activated and the block checkbox not checked.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.