### PR TITLE
Fix the changelog entries generation in readme.txt

### DIFF
--- a/.github/actions/process-changelog/action.yml
+++ b/.github/actions/process-changelog/action.yml
@@ -22,7 +22,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: "Process changelog"
+    - name: "Process changelog for changelog.txt"
       id: process_changelog
       shell: bash
       env:
@@ -40,13 +40,29 @@ runs:
           CHANGELOG_FLAG="--amend"
           echo "Amending the changelog entries." >> $GITHUB_STEP_SUMMARY
         fi
-          
+        
         ~/.composer/vendor/bin/changelogger write --use-version="$RELEASE_VERSION" --release-date="$RELEASE_DATE" $CHANGELOG_FLAG --no-interaction
         
         echo "Picking up changelog for version '$RELEASE_VERSION'..."
         CHANGELOG=$(awk '/^= / { if (p) { exit }; p=1; next } p && NF' changelog.txt)
         echo "$CHANGELOG"
         
-        # New line characters need to be escaped because set-output doesn't support multi-line strings out of the box
-        CHANGELOG="${CHANGELOG//$'\n'/\\n}"  
+        # Escape backslash, new line and ampersand characters. The order is important.
+        CHANGELOG=${CHANGELOG//\\/\\\\}
+        CHANGELOG=${CHANGELOG//$'\n'/\\n} 
+        CHANGELOG=${CHANGELOG//&/\\&}
         echo "CHANGELOG=$CHANGELOG" >> $GITHUB_OUTPUT
+
+    - name: "Process changelog for readme.txt"
+      shell: bash
+      env:
+        ACTION_TYPE: ${{ inputs.action-type }}
+        RELEASE_VERSION: ${{ inputs.release-version }}
+        RELEASE_DATE: ${{ inputs.release-date }}
+        CHANGELOG: ${{ steps.process_changelog.outputs.CHANGELOG }}
+      run: |
+        if ${{ env.ACTION_TYPE == 'amend' }}; then
+          perl -i -p0e "s/= $RELEASE_VERSION.*?(\n){2}//s" readme.txt # Delete the existing changelog for the release version first
+        fi
+        
+        sed -ri "s|(== Changelog ==)|\1\n\n= $RELEASE_VERSION - $RELEASE_DATE =\n$CHANGELOG|" readme.txt

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -51,17 +51,6 @@ jobs:
           release-version: ${{ env.RELEASE_VERSION }}
           release-date: ${{ steps.format_date.outputs.RELEASE_DATE }}
           action-type: ${{ env.CHANGELOG_ACTION }}
-        
-      - name: "Update readme.txt"
-        env:
-          RELEASE_DATE: ${{ steps.format_date.outputs.RELEASE_DATE }}
-          CHANGELOG: ${{ steps.process_changelog.outputs.changelog }}
-        run: |
-          if ${{ env.CHANGELOG_ACTION == 'amend' }}; then
-            perl -i -p0e "s/= $RELEASE_VERSION.*?(\n){2}//s" readme.txt # Delete the existing changelog for the release version
-          fi
-            
-          sed -ri "s|(== Changelog ==)|\1\n\n= $RELEASE_VERSION - $RELEASE_DATE =\n$CHANGELOG|" readme.txt
                     
       - name: "Commit and push the changes"
         run: |

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -100,9 +100,6 @@ jobs:
           # 'Stable tag' header in readme.txt;
           sed -i "s/^Stable tag: .*$/Stable tag: $RELEASE_VERSION/" readme.txt
 
-          # Duplicate the generated changelog into the Changelog section from the readme.txt
-          sed -ri "s|(== Changelog ==)|\1\n\n= $RELEASE_VERSION - $RELEASE_DATE =\n$CHANGELOG|" readme.txt
-
       - name: "Commit and push changes"
         env:
           RELEASE_VERSION: ${{ steps.create_branch.outputs.trimmed-version }}

--- a/changelog/fix-5647-changelog-entries-format-in-readme
+++ b/changelog/fix-5647-changelog-entries-format-in-readme
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix some edge cases in the changelog part of the GitHub workflows
+
+


### PR DESCRIPTION
Fixes #5647 

#### Changes proposed in this Pull Request

- Fix a problem with the `&` character which would result in the matched text being inserted in place of this character
  - Note: `&` is a special character and needs to be escaped. Otherwise it means “the whole part of the input that was matched by the pattern”
- Fix a problem with the `\` character which was removed from the changelog entries when inserted in `readme.txt` via the sed command
  -  Note: `\` is also a special character and needs to be escaped
- Refactored a bit the `process-changelog` action to also include the entries in the `readme.txt`, instead of having the parent actions doing it (which increased code duplication)

#### Testing instructions

- Run the [Release - Changelog](https://github.com/Automattic/woocommerce-payments/actions/workflows/release-changelog.yml) workflow from a branch with this code and some changelog entries using the special characters mentioned above. Confirm that both the `changelog.txt` and `readme.txt` files have the expected format when you first generate the entries, and then you amend it later.

Note: I ran some tests with this workflow and it worked well.

- Ideally, retest the [Release - Create PR to trunk](https://github.com/Automattic/woocommerce-payments/actions/workflows/release-pr.yml) workflow to ensure everything's fine with the changelog generation.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
