### PR TITLE
Remove fraud and risk tools feature flag

### DIFF
--- a/changelog/remove-3026-fraud-and-risk-tools-feature-flag
+++ b/changelog/remove-3026-fraud-and-risk-tools-feature-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove fraud and risk tools feature flag checks and tests

--- a/client/components/fraud-risk-tools-banner/test/index.test.js
+++ b/client/components/fraud-risk-tools-banner/test/index.test.js
@@ -13,13 +13,8 @@ jest.mock( '@wordpress/data', () => ( {
 } ) );
 
 describe( 'FRTDiscoverabilityBanner', () => {
-	beforeEach( () => {
-		global.wcpaySettings = {
-			isFraudProtectionSettingsEnabled: true,
-		};
-	} );
-
 	it( 'renders', () => {
+		global.wcpaySettings = {};
 		const { container: frtBanner } = render( <FRTDiscoverabilityBanner /> );
 
 		expect( frtBanner ).toMatchSnapshot();
@@ -27,7 +22,6 @@ describe( 'FRTDiscoverabilityBanner', () => {
 
 	it( 'renders with dont show again button if remindMeCount greater than or equal to 3', () => {
 		global.wcpaySettings = {
-			...global.wcpaySettings,
 			frtDiscoverBannerSettings: JSON.stringify( {
 				remindMeCount: 3,
 				remindMeAt: null,
@@ -42,7 +36,6 @@ describe( 'FRTDiscoverabilityBanner', () => {
 
 	it( 'renders without dont show again button if remindMeCount greater than 0 but less than 3', () => {
 		global.wcpaySettings = {
-			...global.wcpaySettings,
 			frtDiscoverBannerSettings: JSON.stringify( {
 				remindMeCount: 2,
 				remindMeAt: null,
@@ -63,7 +56,6 @@ describe( 'FRTDiscoverabilityBanner', () => {
 		const remindMeAt = new Date( '2023-03-11T11:33:37.000Z' ).getTime();
 
 		global.wcpaySettings = {
-			...global.wcpaySettings,
 			frtDiscoverBannerSettings: JSON.stringify( {
 				remindMeCount: 1,
 				remindMeAt: remindMeAt,
@@ -84,7 +76,6 @@ describe( 'FRTDiscoverabilityBanner', () => {
 		const remindMeAt = new Date( '2023-03-15T12:33:37.000Z' ).getTime();
 
 		global.wcpaySettings = {
-			...global.wcpaySettings,
 			frtDiscoverBannerSettings: JSON.stringify( {
 				remindMeCount: 1,
 				remindMeAt: remindMeAt,
@@ -101,7 +92,6 @@ describe( 'FRTDiscoverabilityBanner', () => {
 		const remindMeAt = new Date( '2023-03-14T12:33:37.000Z' ).getTime();
 
 		global.wcpaySettings = {
-			...global.wcpaySettings,
 			frtDiscoverBannerSettings: JSON.stringify( {
 				remindMeCount: 3,
 				remindMeAt: remindMeAt,

--- a/client/data/fraud-outcomes/hooks.ts
+++ b/client/data/fraud-outcomes/hooks.ts
@@ -22,7 +22,7 @@ export const useLatestFraudOutcome = (
 				getLatestFraudOutcomeError,
 			} = select( STORE_NAME );
 
-			if ( ! id || ! wcpaySettings.isFraudProtectionSettingsEnabled ) {
+			if ( ! id ) {
 				return {
 					data: undefined,
 					error: undefined,

--- a/client/data/fraud-outcomes/test/hooks.ts
+++ b/client/data/fraud-outcomes/test/hooks.ts
@@ -20,20 +20,11 @@ export const latestFraudOutcomeMock: FraudOutcome = {
 	status: 'review',
 };
 
-declare const global: {
-	wcpaySettings: {
-		isFraudProtectionSettingsEnabled: boolean;
-	};
-};
-
 describe( 'Fraud outcomes hooks', () => {
 	let selectors: Record< string, () => any >;
 
 	beforeEach( () => {
 		selectors = {};
-		global.wcpaySettings = {
-			isFraudProtectionSettingsEnabled: false,
-		};
 
 		const selectMock = jest.fn( ( storeName ) =>
 			STORE_NAME === storeName ? selectors : {}
@@ -45,9 +36,7 @@ describe( 'Fraud outcomes hooks', () => {
 	} );
 
 	describe( 'useLatestFraudOutcome', () => {
-		it( 'should return the correct data with the feature flag enabled', async () => {
-			global.wcpaySettings.isFraudProtectionSettingsEnabled = true;
-
+		it( 'should return the correct data', async () => {
 			selectors = {
 				getLatestFraudOutcome: jest
 					.fn()
@@ -63,25 +52,6 @@ describe( 'Fraud outcomes hooks', () => {
 
 			expect( result ).toEqual( {
 				data: latestFraudOutcomeMock,
-				error: undefined,
-				isLoading: false,
-			} );
-		} );
-
-		it( 'should return the correct data with the feature flag disabled', async () => {
-			selectors = {
-				getLatestFraudOutcome: jest.fn().mockReturnValue( {} ),
-				getLatestFraudOutcomeError: jest
-					.fn()
-					.mockReturnValue( undefined ),
-				isResolving: jest.fn().mockReturnValue( false ),
-				hasFinishedResolution: jest.fn().mockReturnValue( true ),
-			};
-
-			const result = useLatestFraudOutcome( paymentIntentId );
-
-			expect( result ).toEqual( {
-				data: undefined,
 				error: undefined,
 				isLoading: false,
 			} );

--- a/client/data/transactions/resolvers.js
+++ b/client/data/transactions/resolvers.js
@@ -148,9 +148,6 @@ export function* getFraudOutcomeTransactions( status, query ) {
  * @param { string } query Data on which to parameterize the selection.
  */
 export function* getFraudOutcomeTransactionsSummary( status, query ) {
-	// @todo Remove feature flag
-	if ( ! wcpaySettings.isFraudProtectionSettingsEnabled ) return;
-
 	const path = addQueryArgs(
 		`${ NAMESPACE }/transactions/fraud-outcomes/summary`,
 		{

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -59,7 +59,6 @@ declare const wcpaySettings: {
 		isWelcomeTourDismissed?: boolean;
 	};
 	accountDefaultCurrency: string;
-	isFraudProtectionSettingsEnabled: boolean;
 };
 
 declare const wcTracks: any;

--- a/client/index.js
+++ b/client/index.js
@@ -255,7 +255,7 @@ addFilter(
 				capability: 'manage_woocommerce',
 			} );
 		}
-		if ( wcpaySettings && wcpaySettings.isFraudProtectionSettingsEnabled ) {
+		if ( wcpaySettings ) {
 			pages.push( {
 				container: FraudProtectionAdvancedSettingsPage,
 				path: '/payments/fraud-protection',

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -119,11 +119,9 @@ const OverviewPage = () => {
 
 			<TestModeNotice topic={ topics.overview } />
 
-			{ wcpaySettings.isFraudProtectionSettingsEnabled && (
-				<ErrorBoundary>
-					<FRTDiscoverabilityBanner />
-				</ErrorBoundary>
-			) }
+			<ErrorBoundary>
+				<FRTDiscoverabilityBanner />
+			</ErrorBoundary>
 
 			{ showConnectionSuccess && <ConnectionSuccessNotice /> }
 

--- a/client/overview/test/index.js
+++ b/client/overview/test/index.js
@@ -111,6 +111,19 @@ describe( 'Overview page', () => {
 		).toBeNull();
 	} );
 
+	it( 'Skips rendering task list when accountOverviewTaskList feature flag is off', () => {
+		global.wcpaySettings = {
+			...global.wcpaySettings,
+			featureFlags: {},
+		};
+
+		const { container } = render( <OverviewPage /> );
+
+		expect(
+			container.querySelector( '.woocommerce-experimental-list' )
+		).toBeNull();
+	} );
+
 	it( 'Displays the login error for query param wcpay-login-error=1', () => {
 		getQuery.mockReturnValue( { 'wcpay-login-error': '1' } );
 

--- a/client/overview/test/index.js
+++ b/client/overview/test/index.js
@@ -93,7 +93,6 @@ describe( 'Overview page', () => {
 				accountOverviewTaskList: true,
 			},
 			accountLoans: {},
-			isFraudProtectionSettingsEnabled: true,
 			frtDiscoverBannerSettings: JSON.stringify( {
 				remindMeCount: 0,
 				remindMeAt: null,
@@ -105,19 +104,6 @@ describe( 'Overview page', () => {
 	} );
 
 	it( 'Skips rendering task list when there are no tasks', () => {
-		const { container } = render( <OverviewPage /> );
-
-		expect(
-			container.querySelector( '.woocommerce-experimental-list' )
-		).toBeNull();
-	} );
-
-	it( 'Skips rendering task list when accountOverviewTaskList feature flag is off', () => {
-		global.wcpaySettings = {
-			...global.wcpaySettings,
-			featureFlags: {},
-		};
-
 		const { container } = render( <OverviewPage /> );
 
 		expect(
@@ -293,20 +279,7 @@ describe( 'Overview page', () => {
 		} );
 	} );
 
-	it( 'does not render FRTDiscoverabilityBanner if feature flag option is false', () => {
-		global.wcpaySettings = {
-			...global.wcpaySettings,
-			isFraudProtectionSettingsEnabled: false,
-		};
-
-		render( <OverviewPage /> );
-
-		expect(
-			screen.queryByText( 'Enhanced fraud protection for your store' )
-		).not.toBeInTheDocument();
-	} );
-
-	it( 'renders FRTDiscoverabilityBanner if feature flag option is true', () => {
+	it( 'renders FRTDiscoverabilityBanner', () => {
 		render( <OverviewPage /> );
 
 		expect(

--- a/client/payment-details/order-details/test/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/order-details/test/__snapshots__/index.test.tsx.snap
@@ -28,9 +28,9 @@ exports[`Order details page should match the snapshot - Charge without payment i
                 USD
               </span>
               <span
-                class="chip chip-light"
+                class="chip chip-alert"
               >
-                Pending
+                Payment blocked
               </span>
             </p>
             <div
@@ -239,11 +239,67 @@ exports[`Order details page should match the snapshot - Charge without payment i
         <div
           class="woocommerce-timeline"
         >
-          <p
-            class="timeline_no_events"
-          >
-            No data to display
-          </p>
+          <ul>
+            <li
+              class="woocommerce-timeline-group"
+            >
+              <p
+                class="woocommerce-timeline-group__title"
+              >
+                March 27, 2023
+              </p>
+              <ul>
+                <li
+                  class="woocommerce-timeline-item"
+                >
+                  <div
+                    class="woocommerce-timeline-item__top-border"
+                  />
+                  <div
+                    class="woocommerce-timeline-item__title"
+                  >
+                    <div
+                      class="woocommerce-timeline-item__headline"
+                    >
+                      <svg
+                        class="gridicon gridicons-cross is-error"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <g>
+                          <path
+                            d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z"
+                          />
+                        </g>
+                      </svg>
+                      <span>
+                        Payment was screened by your fraud filters and blocked.
+                      </span>
+                    </div>
+                    <span
+                      class="woocommerce-timeline-item__timestamp"
+                    >
+                      6:09am
+                    </span>
+                  </div>
+                  <div
+                    class="woocommerce-timeline-item__body"
+                  >
+                    <span>
+                      <p
+                        class="fraud-outcome-ruleset-item"
+                      >
+                        Block if the purchase price is not in your defined range
+                      </p>
+                    </span>
+                  </div>
+                </li>
+              </ul>
+              <hr />
+            </li>
+          </ul>
         </div>
       </div>
     </div>

--- a/client/payment-details/summary/test/index.tsx
+++ b/client/payment-details/summary/test/index.tsx
@@ -25,7 +25,6 @@ declare const global: {
 		featureFlags: {
 			isAuthAndCaptureEnabled: boolean;
 		};
-		isFraudProtectionSettingsEnabled: boolean;
 	};
 };
 
@@ -127,7 +126,6 @@ describe( 'PaymentDetailsSummary', () => {
 					precision: 2,
 				},
 			},
-			isFraudProtectionSettingsEnabled: false,
 		};
 	} );
 
@@ -246,8 +244,6 @@ describe( 'PaymentDetailsSummary', () => {
 	} );
 
 	test( 'renders the fraud outcome buttons', () => {
-		global.wcpaySettings.isFraudProtectionSettingsEnabled = true;
-
 		mockUseAuthorization.mockReturnValueOnce( {
 			authorization: {
 				captured: false,

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -510,8 +510,6 @@ export const composeFeeBreakdown = ( event ) => {
 };
 
 const getManualFraudOutcomeTimelineItem = ( event, status ) => {
-	if ( ! wcpaySettings.isFraudProtectionSettingsEnabled ) return [];
-
 	const isBlock = 'block' === status;
 
 	const headline = isBlock
@@ -561,8 +559,6 @@ const buildAutomaticFraudOutcomeRuleset = ( event ) => {
 };
 
 const getAutomaticFraudOutcomeTimelineItem = ( event, status ) => {
-	if ( ! wcpaySettings.isFraudProtectionSettingsEnabled ) return [];
-
 	const isBlock = 'block' === status;
 
 	const headline = isBlock

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -578,9 +578,12 @@ const getAutomaticFraudOutcomeTimelineItem = ( event, status ) => {
 	);
 
 	return [
-		getMainTimelineItem( event, headline, icon, [
-			buildAutomaticFraudOutcomeRuleset( event ),
-		] ),
+		getMainTimelineItem(
+			event,
+			headline,
+			icon,
+			buildAutomaticFraudOutcomeRuleset( event )
+		),
 	];
 };
 

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -210,15 +210,13 @@ const SettingsManager = () => {
 					</LoadableSettingsSection>
 				</div>
 			</SettingsSection>
-			{ wcpaySettings.isFraudProtectionSettingsEnabled && (
-				<SettingsSection description={ FraudProtectionDescription }>
-					<LoadableSettingsSection numLines={ 20 }>
-						<ErrorBoundary>
-							<FraudProtection />
-						</ErrorBoundary>
-					</LoadableSettingsSection>
-				</SettingsSection>
-			) }
+			<SettingsSection description={ FraudProtectionDescription }>
+				<LoadableSettingsSection numLines={ 20 }>
+					<ErrorBoundary>
+						<FraudProtection />
+					</ErrorBoundary>
+				</LoadableSettingsSection>
+			</SettingsSection>
 			<AdvancedSettings />
 			<SaveSettingsSection disabled={ ! isTransactionInputsValid } />
 		</SettingsLayout>

--- a/client/settings/settings-manager/test/index.test.js
+++ b/client/settings/settings-manager/test/index.test.js
@@ -40,12 +40,9 @@ describe( 'SettingsManager', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	it( 'renders the Fraud Protection settings section if the option flag is enabled', () => {
+	it( 'renders the Fraud Protection settings section', () => {
 		const context = { featureFlags: {} };
-		global.wcpaySettings = {
-			isFraudProtectionSettingsEnabled: true,
-		};
-
+		global.wcpaySettings = {};
 		render(
 			<WCPaySettingsContext.Provider value={ context }>
 				<SettingsManager />
@@ -53,22 +50,5 @@ describe( 'SettingsManager', () => {
 		);
 
 		expect( screen.queryByText( 'Fraud protection' ) ).toBeInTheDocument();
-	} );
-
-	it( 'does not render the Fraud Protection settings section if the option flag is disabled', () => {
-		const context = { featureFlags: {} };
-		global.wcpaySettings = {
-			isFraudProtectionSettingsEnabled: false,
-		};
-
-		render(
-			<WCPaySettingsContext.Provider value={ context }>
-				<SettingsManager />
-			</WCPaySettingsContext.Provider>
-		);
-
-		expect(
-			screen.queryByText( 'Fraud protection' )
-		).not.toBeInTheDocument();
 	} );
 } );

--- a/client/transactions/index.tsx
+++ b/client/transactions/index.tsx
@@ -158,17 +158,10 @@ export const TransactionsPage: React.FC = () => {
 			className: 'blocked-list',
 		},
 	].filter( ( item ) => {
-		if ( [ 'review-page', 'blocked-page' ].includes( item.name ) ) {
-			return false;
-		}
-
 		if ( 'uncaptured-page' !== item.name ) return true;
 
 		return isAuthAndCaptureEnabled && shouldShowUncapturedTab;
 	} );
-
-	if ( typeof shouldShowUncapturedTab === 'undefined' )
-		return tabsComponentMap[ 'transactions-page' ];
 
 	return (
 		<Page>

--- a/client/transactions/index.tsx
+++ b/client/transactions/index.tsx
@@ -38,7 +38,6 @@ declare const window: any;
 export const TransactionsPage: React.FC = () => {
 	const currentQuery = getQuery();
 	const initialTab = currentQuery.tab ?? null;
-	const { isFraudProtectionSettingsEnabled } = wcpaySettings;
 
 	const onTabSelected = ( tab: string ) => {
 		// When switching tabs, make sure to revert the query strings to default values
@@ -159,11 +158,7 @@ export const TransactionsPage: React.FC = () => {
 			className: 'blocked-list',
 		},
 	].filter( ( item ) => {
-		// @todo Remove feature flag
-		if (
-			! isFraudProtectionSettingsEnabled &&
-			[ 'review-page', 'blocked-page' ].includes( item.name )
-		) {
+		if ( [ 'review-page', 'blocked-page' ].includes( item.name ) ) {
 			return false;
 		}
 
@@ -172,11 +167,7 @@ export const TransactionsPage: React.FC = () => {
 		return isAuthAndCaptureEnabled && shouldShowUncapturedTab;
 	} );
 
-	// @todo Remove feature flag
-	if (
-		! isFraudProtectionSettingsEnabled &&
-		typeof shouldShowUncapturedTab === 'undefined'
-	)
+	if ( typeof shouldShowUncapturedTab === 'undefined' )
 		return tabsComponentMap[ 'transactions-page' ];
 
 	return (

--- a/client/transactions/test/index.tsx
+++ b/client/transactions/test/index.tsx
@@ -80,7 +80,6 @@ declare const global: {
 		accountStatus: {
 			status: boolean;
 		};
-		isFraudProtectionSettingsEnabled: boolean;
 	};
 };
 
@@ -128,7 +127,6 @@ describe( 'TransactionsPage', () => {
 			accountStatus: {
 				status: true,
 			},
-			isFraudProtectionSettingsEnabled: true,
 		};
 	} );
 
@@ -194,7 +192,7 @@ describe( 'TransactionsPage', () => {
 		expect( screen.queryByText( /uncaptured/i ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'renders fraud outcome tabs if the feature flag is enabled', async () => {
+	test( 'renders fraud outcome tabs', async () => {
 		mockUseManualCapture.mockReturnValue( [ false ] );
 		mockUseAuthorizationsSummary.mockReturnValue( {
 			authorizationsSummary: {
@@ -206,21 +204,5 @@ describe( 'TransactionsPage', () => {
 		await renderTransactionsPage();
 		expect( screen.queryByText( /blocked/i ) ).toBeInTheDocument();
 		expect( screen.queryByText( /risk review/i ) ).toBeInTheDocument();
-	} );
-
-	test( 'do not render fraud outcome tabs if the feature flag is disabled', async () => {
-		global.wcpaySettings.isFraudProtectionSettingsEnabled = false;
-
-		mockUseManualCapture.mockReturnValue( [ false ] );
-		mockUseAuthorizationsSummary.mockReturnValue( {
-			authorizationsSummary: {
-				total: 0,
-			},
-			isLoading: false,
-		} );
-
-		await renderTransactionsPage();
-		expect( screen.queryByText( /blocked/i ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( /risk review/i ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/utils/charge/index.ts
+++ b/client/utils/charge/index.ts
@@ -59,7 +59,6 @@ export const isOnHoldByFraudTools = (
 	paymentIntent?: PaymentIntent
 ): boolean => {
 	return (
-		wcpaySettings.isFraudProtectionSettingsEnabled &&
 		paymentIntent?.status === 'requires_capture' &&
 		fraudOutcome?.status === 'review'
 	);
@@ -71,7 +70,6 @@ export const isBlockedByFraudTools = (
 	paymentIntent?: PaymentIntent
 ): boolean => {
 	return (
-		wcpaySettings.isFraudProtectionSettingsEnabled &&
 		( paymentIntent?.status === 'canceled' || ! charge?.payment_intent ) &&
 		!! fraudOutcome
 	);

--- a/client/utils/charge/test/index.js
+++ b/client/utils/charge/test/index.js
@@ -38,12 +38,6 @@ const partiallyRefundedCharge = {
 };
 
 describe( 'Charge utilities', () => {
-	beforeEach( () => {
-		global.wcpaySettings = {
-			isFraudProtectionSettingsEnabled: false,
-		};
-	} );
-
 	describe( 'isCharge methods', () => {
 		test( 'should identify a captured successful charge as successful', () => {
 			expect( utils.isChargeSuccessful( paidCharge ) ).toEqual( true );

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -486,55 +486,54 @@ class WC_Payments_Admin {
 		$account_status_data = $this->account->get_account_status_data();
 
 		$wcpay_settings = [
-			'connectUrl'                       => WC_Payments_Account::get_connect_url(),
-			'connect'                          => [
+			'connectUrl'                 => WC_Payments_Account::get_connect_url(),
+			'connect'                    => [
 				'country'            => WC()->countries->get_base_country(),
 				'availableCountries' => WC_Payments_Utils::supported_countries(),
 				'availableStates'    => WC()->countries->get_states(),
 			],
-			'testMode'                         => WC_Payments::mode()->is_test(),
+			'testMode'                   => WC_Payments::mode()->is_test(),
 			// set this flag for use in the front-end to alter messages and notices if on-boarding has been disabled.
-			'onBoardingDisabled'               => WC_Payments_Account::is_on_boarding_disabled(),
-			'errorMessage'                     => $error_message,
-			'featureFlags'                     => $this->get_frontend_feature_flags(),
-			'isSubscriptionsActive'            => class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '2.2.0', '>=' ),
+			'onBoardingDisabled'         => WC_Payments_Account::is_on_boarding_disabled(),
+			'errorMessage'               => $error_message,
+			'featureFlags'               => $this->get_frontend_feature_flags(),
+			'isSubscriptionsActive'      => class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '2.2.0', '>=' ),
 			// used in the settings page by the AccountFees component.
-			'zeroDecimalCurrencies'            => WC_Payments_Utils::zero_decimal_currencies(),
-			'fraudServices'                    => $this->account->get_fraud_services_config(),
-			'isJetpackConnected'               => $this->payments_api_client->is_server_connected(),
-			'isJetpackIdcActive'               => Jetpack_Identity_Crisis::has_identity_crisis(),
-			'accountStatus'                    => $account_status_data,
-			'accountFees'                      => $this->account->get_fees(),
-			'accountLoans'                     => $this->account->get_capital(),
-			'accountEmail'                     => $this->account->get_account_email(),
-			'showUpdateDetailsTask'            => $this->get_should_show_update_business_details_task( $account_status_data ),
-			'wpcomReconnectUrl'                => $this->payments_api_client->is_server_connected() && ! $this->payments_api_client->has_server_connection_owner() ? WC_Payments_Account::get_wpcom_reconnect_url() : null,
-			'additionalMethodsSetup'           => [
+			'zeroDecimalCurrencies'      => WC_Payments_Utils::zero_decimal_currencies(),
+			'fraudServices'              => $this->account->get_fraud_services_config(),
+			'isJetpackConnected'         => $this->payments_api_client->is_server_connected(),
+			'isJetpackIdcActive'         => Jetpack_Identity_Crisis::has_identity_crisis(),
+			'accountStatus'              => $account_status_data,
+			'accountFees'                => $this->account->get_fees(),
+			'accountLoans'               => $this->account->get_capital(),
+			'accountEmail'               => $this->account->get_account_email(),
+			'showUpdateDetailsTask'      => $this->get_should_show_update_business_details_task( $account_status_data ),
+			'wpcomReconnectUrl'          => $this->payments_api_client->is_server_connected() && ! $this->payments_api_client->has_server_connection_owner() ? WC_Payments_Account::get_wpcom_reconnect_url() : null,
+			'additionalMethodsSetup'     => [
 				'isUpeEnabled' => WC_Payments_Features::is_upe_enabled(),
 				'upeType'      => WC_Payments_Features::get_enabled_upe_type(),
 			],
-			'multiCurrencySetup'               => [
+			'multiCurrencySetup'         => [
 				'isSetupCompleted' => get_option( 'wcpay_multi_currency_setup_completed' ),
 			],
-			'isMultiCurrencyEnabled'           => WC_Payments_Features::is_customer_multi_currency_enabled(),
-			'isClientEncryptionEligible'       => WC_Payments_Features::is_client_secret_encryption_eligible(),
-			'shouldUseExplicitPrice'           => WC_Payments_Explicit_Price_Formatter::should_output_explicit_price(),
-			'overviewTasksVisibility'          => [
+			'isMultiCurrencyEnabled'     => WC_Payments_Features::is_customer_multi_currency_enabled(),
+			'isClientEncryptionEligible' => WC_Payments_Features::is_client_secret_encryption_eligible(),
+			'shouldUseExplicitPrice'     => WC_Payments_Explicit_Price_Formatter::should_output_explicit_price(),
+			'overviewTasksVisibility'    => [
 				'dismissedTodoTasks'     => get_option( 'woocommerce_dismissed_todo_tasks', [] ),
 				'deletedTodoTasks'       => get_option( 'woocommerce_deleted_todo_tasks', [] ),
 				'remindMeLaterTodoTasks' => get_option( 'woocommerce_remind_me_later_todo_tasks', [] ),
 			],
-			'currentUserEmail'                 => $current_user_email,
-			'currencyData'                     => $currency_data,
-			'restUrl'                          => get_rest_url( null, '' ), // rest url to concatenate when merchant use Plain permalinks.
-			'numDisputesNeedingResponse'       => $this->get_disputes_awaiting_response_count(),
-			'isFraudProtectionSettingsEnabled' => WC_Payments_Features::is_fraud_protection_settings_enabled(),
-			'fraudProtection'                  => [
+			'currentUserEmail'           => $current_user_email,
+			'currencyData'               => $currency_data,
+			'restUrl'                    => get_rest_url( null, '' ), // rest url to concatenate when merchant use Plain permalinks.
+			'numDisputesNeedingResponse' => $this->get_disputes_awaiting_response_count(),
+			'fraudProtection'            => [
 				'isWelcomeTourDismissed' => WC_Payments_Features::is_fraud_protection_welcome_tour_dismissed(),
 			],
-			'accountDefaultCurrency'           => $this->account->get_account_default_currency(),
-			'frtDiscoverBannerSettings'        => get_option( 'wcpay_frt_discover_banner_settings', '' ),
-			'storeCurrency'                    => get_option( 'woocommerce_currency' ),
+			'accountDefaultCurrency'     => $this->account->get_account_default_currency(),
+			'frtDiscoverBannerSettings'  => get_option( 'wcpay_frt_discover_banner_settings', '' ),
+			'storeCurrency'              => get_option( 'woocommerce_currency' ),
 		];
 
 		wp_localize_script(

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -773,10 +773,6 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	 * @param WP_REST_Request $request Request object.
 	 */
 	private function update_fraud_protection_settings( WP_REST_Request $request ) {
-		if ( ! WC_Payments_Features::is_fraud_protection_settings_enabled() ) {
-			return;
-		}
-
 		if ( ! $request->has_param( 'current_protection_level' ) || ! $request->has_param( 'advanced_fraud_protection_settings' ) ) {
 			return;
 		}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2237,11 +2237,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @return  string The current fraud protection level.
 	 */
 	protected function get_current_protection_level() {
-		// If fraud and risk tools feature is not enabled, do not expose the settings.
-		if ( ! WC_Payments_Features::is_fraud_protection_settings_enabled() ) {
-			return '';
-		}
-
 		$this->maybe_refresh_fraud_protection_settings();
 		return get_option( 'current_protection_level', 'basic' );
 	}
@@ -2253,11 +2248,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 *                       If there's a fetch error, it returns "error".
 	 */
 	protected function get_advanced_fraud_protection_settings() {
-		// If fraud and risk tools feature is not enabled, do not expose the settings.
-		if ( ! WC_Payments_Features::is_fraud_protection_settings_enabled() ) {
-			return [];
-		}
-
 		// Check if Stripe is connected.
 		if ( ! $this->is_connected() ) {
 			return [];

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -240,15 +240,6 @@ class WC_Payments_Features {
 	}
 
 	/**
-	 * Checks whether the Fraud and Risk Tools feature flag is enabled.
-	 *
-	 * @return  bool
-	 */
-	public static function is_fraud_protection_settings_enabled(): bool {
-		return '1' === get_option( 'wcpay_fraud_protection_settings_active', '0' );
-	}
-
-	/**
 	 * Checks whether the Fraud and Risk Tools welcome tour was dismissed.
 	 *
 	 * @return bool

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -543,9 +543,7 @@ class WC_Payments {
 
 			new WC_Payments_Status( self::get_wc_payments_http(), self::get_account_service() );
 
-			if ( WC_Payments_Features::is_fraud_protection_settings_enabled() ) {
-				new WCPay\Fraud_Prevention\Order_Fraud_And_Risk_Meta_Box( self::$order_service );
-			}
+			new WCPay\Fraud_Prevention\Order_Fraud_And_Risk_Meta_Box( self::$order_service );
 		}
 
 		// Load WCPay Subscriptions.

--- a/includes/fraud-prevention/class-fraud-risk-tools.php
+++ b/includes/fraud-prevention/class-fraud-risk-tools.php
@@ -69,22 +69,6 @@ class Fraud_Risk_Tools {
 		if ( is_admin() && current_user_can( 'manage_woocommerce' ) ) {
 			add_action( 'admin_menu', [ $this, 'init_advanced_settings_page' ] );
 		}
-
-		// Adds the required parameter on server.
-		if ( WC_Payments_Features::is_fraud_protection_settings_enabled() ) {
-			add_filter(
-				'wcpay_api_request_params',
-				function( $params, $api, $method ) {
-					if ( false !== strpos( $api, WC_Payments_API_Client::INTENTIONS_API ) && WC_Payments_API_Client::POST === $method ) {
-						$params['fraud_settings_enabled'] = 'true';
-					}
-
-					return $params;
-				},
-				10,
-				3
-			);
-		}
 	}
 
 	/**
@@ -99,11 +83,6 @@ class Fraud_Risk_Tools {
 		}
 
 		if ( ! $this->payments_account->is_stripe_connected() ) {
-			return;
-		}
-
-		// Skip registering the page if the fraud and risk tools feature is not enabled.
-		if ( ! WC_Payments_Features::is_fraud_protection_settings_enabled() ) {
 			return;
 		}
 

--- a/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
+++ b/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
@@ -38,8 +38,8 @@ class Order_Fraud_And_Risk_Meta_Box {
 	 * Maybe add the meta box.
 	 */
 	public function maybe_add_meta_box() {
-		// If fraud settings are off, or if we cannot get the screen ID, exit.
-		if ( ! WC_Payments_Features::is_fraud_protection_settings_enabled() || ! function_exists( '\wc_get_page_screen_id' ) ) {
+		// If we cannot get the screen ID, exit.
+		if ( ! function_exists( '\wc_get_page_screen_id' ) ) {
 			return;
 		}
 

--- a/tests/e2e/specs/wcpay/merchant/merchant-payment-settings-manual-capture.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-payment-settings-manual-capture.spec.js
@@ -25,6 +25,7 @@ describe( 'As a merchant, I should be prompted a confirmation modal when I try t
 	it( 'should show the confirmation dialog when enabling the manual capture while UPE is activated', async () => {
 		await merchantWCP.activateUpe();
 		await merchantWCP.openWCPSettings();
+		await merchantWCP.skipFraudProtectionTour();
 		await merchantWCP.setCheckboxByTestId( checkboxCaptureLaterOption );
 		const confirmationModal = await expect( page ).toMatchElement(
 			confirmationModalClass
@@ -37,6 +38,7 @@ describe( 'As a merchant, I should be prompted a confirmation modal when I try t
 	it( 'should not show the confirmation dialog when disabling the manual capture while UPE is activated', async () => {
 		await merchantWCP.activateUpe();
 		await merchantWCP.openWCPSettings();
+		await merchantWCP.skipFraudProtectionTour();
 		await merchantWCP.setCheckboxByTestId( checkboxCaptureLaterOption );
 		const confirmationModal = await expect( page ).toMatchElement(
 			confirmationModalClass
@@ -51,7 +53,7 @@ describe( 'As a merchant, I should be prompted a confirmation modal when I try t
 
 	it( 'should not show the confirmation dialog when enabling the manual capture while UPE is disabled', async () => {
 		await merchantWCP.openWCPSettings();
-
+		await merchantWCP.skipFraudProtectionTour();
 		await merchantWCP.setCheckboxByTestId( checkboxCaptureLaterOption );
 		await expect( page ).not.toMatchElement( '.wcpay-confirmation-modal' );
 	} );
@@ -59,6 +61,7 @@ describe( 'As a merchant, I should be prompted a confirmation modal when I try t
 	it( 'should show the UPE methods disabled when manual capture is enabled', async () => {
 		await merchantWCP.activateUpe();
 		await merchantWCP.openWCPSettings();
+		await merchantWCP.skipFraudProtectionTour();
 		await merchantWCP.setCheckboxByTestId( checkboxCaptureLaterOption );
 		const confirmationModal = await expect( page ).toMatchElement(
 			confirmationModalClass

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -537,6 +537,15 @@ export const merchantWCP = {
 		await merchant.openSettings( 'checkout', 'woocommerce_payments' );
 	},
 
+	skipFraudProtectionTour: async () => {
+		const tourKitDismissButton = await page.$(
+			`.woocommerce-tour-kit button`
+		);
+		if ( tourKitDismissButton ) {
+			await tourKitDismissButton.click();
+		}
+	},
+
 	wcpSettingsSaveChanges: async () => {
 		const snackbarSettingsSaved = '.components-snackbar';
 

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -399,6 +399,14 @@ export const merchantWCP = {
 			waitUntil: 'networkidle0',
 		} );
 
+		// Skip fraud protection tools tour.
+		const tourKitDismissButton = await page.$(
+			`.woocommerce-tour-kit button`
+		);
+		if ( tourKitDismissButton ) {
+			await tourKitDismissButton.click();
+		}
+
 		await page.$eval( paymentMethod, ( method ) => method.click() );
 		await new Promise( ( resolve ) => setTimeout( resolve, 2000 ) );
 		await expect( page ).toClick( 'button', {
@@ -410,6 +418,14 @@ export const merchantWCP = {
 		await page.goto( WCPAY_PAYMENT_SETTINGS, {
 			waitUntil: 'networkidle0',
 		} );
+
+		// Skip fraud protection tools tour.
+		const tourKitDismissButton = await page.$(
+			`.woocommerce-tour-kit button`
+		);
+		if ( tourKitDismissButton ) {
+			await tourKitDismissButton.click();
+		}
 
 		await page.$eval( paymentMethod, ( method ) => method.click() );
 		await expect( page ).toClick( 'button', {

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -298,34 +298,6 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		$this->assertTrue( WC_Payments_Features::is_upe_deferred_intent_enabled() );
 	}
 
-	public function test_is_fraud_protection_settings_enabled_returns_true() {
-		add_filter(
-			'pre_option_wcpay_fraud_protection_settings_active',
-			function ( $pre_option, $option, $default ) {
-				return '1';
-			},
-			10,
-			3
-		);
-		$this->assertTrue( WC_Payments_Features::is_fraud_protection_settings_enabled() );
-	}
-
-	public function test_is_fraud_protection_settings_enabled_returns_false_when_flag_is_false() {
-		add_filter(
-			'pre_option_wcpay_fraud_protection_settings_active',
-			function ( $pre_option, $option, $default ) {
-				return '0';
-			},
-			10,
-			3
-		);
-		$this->assertFalse( WC_Payments_Features::is_fraud_protection_settings_enabled() );
-	}
-
-	public function test_is_fraud_protection_settings_enabled_returns_false_when_flag_is_not_set() {
-		$this->assertFalse( WC_Payments_Features::is_fraud_protection_settings_enabled() );
-	}
-
 	private function setup_enabled_flags( array $enabled_flags ) {
 		foreach ( array_keys( self::FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING ) as $flag ) {
 			add_filter(


### PR DESCRIPTION
Fixes Automattic/woocommerce-payments-server#3026

#### Changes proposed in this Pull Request

This PR removes all fraud and risk tools feature flags, it's checks, and tests related to it.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Remove all the fraud protection related options with:
```
npm run cli wp option delete wcpay_fraud_protection_settings_active
npm run cli wp option delete wcpay_frt_discover_banner_settings
npm run cli wp option delete wcpay_fraud_protection_welcome_tour_dismissed
npm run cli wp option delete _transient_timeout_wcpay_fraud_protection_settings
npm run cli wp option delete _transient_wcpay_fraud_protection_settings
```
* Run `npm run build:client` to build the new assets.
* Run `npm run listen` on your server to listen to webhooks.
* Open _Payments > Overview_, you should see the fraud and risk tools discoverability banner.
* Open _Payments > Settings_, you should see the welcome tour of fraud and risk tools.
* On the same page, you should see the fraud protection settings section, Basic protection level should be selected as default. 
* Select "High" protection level. Save changes.
* Refresh the page, you should see the high protection settings active.
* Click "Advanced" radio button, and then click the "Configure" button. You should see the  protection settings with the right filters enabled (the settings should be the defaults for high protection level).
* Change something and click "save changes". When you refresh the page, the setting you saved should be there.
* Go to your store, sell one item with a different billing country than the country you're in. 
* The order should be blocked.
* Again, change the country to your residence country, and try to sell it again. 
* The order should pass, but fall into review.
* Go to the last order in _WooCommerce > Orders_ page, you should see the order notes and the review meta box.
* Click on the "View more details" link on one of the order notes, or "Review payment" link on the fraud meta box. You should be redirected to the transaction details page in a new tab.
* Check the timeline contains the block and the review details.
* Check the header contains Approve and Block transaction buttons.
* When you click the approva button, you should get the correct response, and the timeline should update with the approval details.
* Try another order that'll fall into review, now click the block button, you should see the correct details on the timeline. 
* Navigate to _Payments > Transactions_ page, you should see the blocked and review tabs. 
* When you click them, you should see the correct transactions. 
* When you click the blocked ones, you should see the correct transaction details.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
