### PR TITLE
Cooldown – Prevent `moment` bundling

### DIFF
--- a/changelog/dev-prevent-moment-bundling
+++ b/changelog/dev-prevent-moment-bundling
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: It only affects bundle size without affecting functionality
+
+

--- a/client/overview/modal/update-business-details/index.tsx
+++ b/client/overview/modal/update-business-details/index.tsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { Button, Modal, Notice } from '@wordpress/components';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -12,7 +13,6 @@ import strings from './strings';
 import { useState } from '@wordpress/element';
 import { dateI18n } from '@wordpress/date';
 import { sprintf } from '@wordpress/i18n';
-import moment from 'moment/moment';
 
 interface Props {
 	errorMessages: Array< string >;

--- a/client/overview/modal/update-business-details/index.tsx
+++ b/client/overview/modal/update-business-details/index.tsx
@@ -1,18 +1,17 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { Button, Modal, Notice } from '@wordpress/components';
+import { dateI18n } from '@wordpress/date';
+import { sprintf } from '@wordpress/i18n';
 import moment from 'moment';
 
 /**
  * Internal dependencies
  */
-import './index.scss';
 import strings from './strings';
-import { useState } from '@wordpress/element';
-import { dateI18n } from '@wordpress/date';
-import { sprintf } from '@wordpress/i18n';
+import './index.scss';
 
 interface Props {
 	errorMessages: Array< string >;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
We rely on WP/WC `dependency-extraction-webpack-plugin` to reuse existing libraries and avoid bundling them. But due to a malformed import, we are including `moment` in our bundle. As it was imported as `moment/moment`, the plugin wasn't able to externalize it.

#### Testing instructions
Code change makes sense. There is no functional difference.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
