### PR TITLE
Add settings page section anchors

### DIFF
--- a/changelog/add-add-settings-page-section-anchors
+++ b/changelog/add-add-settings-page-section-anchors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add settings page section anchors

--- a/client/settings/express-checkout/index.js
+++ b/client/settings/express-checkout/index.js
@@ -77,7 +77,10 @@ const ExpressCheckout = () => {
 			<CardBody size={ 0 }>
 				<ul className="express-checkouts-list">
 					{ isPlatformCheckoutFeatureFlagEnabled && (
-						<li className="express-checkout">
+						<li
+							className="express-checkout"
+							id="express-checkouts-woopay"
+						>
 							<div className="express-checkout__checkbox">
 								{ isStripeLinkEnabled ? (
 									<HoverTooltip
@@ -193,7 +196,10 @@ const ExpressCheckout = () => {
 							</div>
 						</li>
 					) }
-					<li className="express-checkout">
+					<li
+						className="express-checkout"
+						id="express-checkouts-apple-google-pay"
+					>
 						<div className="express-checkout__checkbox">
 							<CheckboxControl
 								label={ __(
@@ -320,7 +326,10 @@ const ExpressCheckout = () => {
 						</div>
 					</li>
 					{ displayLinkPaymentMethod && (
-						<li className="express-checkout">
+						<li
+							className="express-checkout"
+							id="express-checkouts-link"
+						>
 							<div className="express-checkout__checkbox">
 								{ isPlatformCheckoutEnabled ? (
 									<HoverTooltip

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -113,9 +113,7 @@ const DepositsDescription = () => {
 const FraudProtectionDescription = () => {
 	return (
 		<>
-			<h2 id="fp-settings">
-				{ __( 'Fraud protection', 'woocommerce-payments' ) }
-			</h2>
+			<h2>{ __( 'Fraud protection', 'woocommerce-payments' ) }</h2>
 			<p>
 				{ __(
 					'Help avoid chargebacks by setting your security and fraud protection risk level.',
@@ -148,17 +146,38 @@ const SettingsManager = () => {
 
 	useLayoutEffect( () => {
 		const { anchor } = getQuery();
+		const { hash } = window.location;
+		const scrollTo = anchor || hash;
 
-		if ( ! isLoading && anchor ) {
-			document
-				.querySelector( decodeURIComponent( anchor ) )
-				?.scrollIntoView( { behavior: 'smooth' } );
+		if ( ! isLoading && scrollTo ) {
+			const element = document.querySelector( scrollTo );
+
+			if ( ! scrollTo ) {
+				return;
+			}
+
+			const headerElement = document.querySelector(
+				'.woocommerce-layout__header'
+			);
+			const headerSize = headerElement ? headerElement.clientHeight : 60;
+			const headerOffset = headerSize + 50; // header size + margin
+			const elementPosition = element.getBoundingClientRect().top;
+			const offsetPosition =
+				elementPosition + window.pageYOffset - headerOffset;
+
+			window.scrollTo( {
+				top: offsetPosition,
+				behavior: 'smooth',
+			} );
 		}
 	}, [ isLoading ] );
 
 	return (
 		<SettingsLayout>
-			<SettingsSection description={ GeneralSettingsDescription }>
+			<SettingsSection
+				description={ GeneralSettingsDescription }
+				id="general"
+			>
 				<LoadableSettingsSection numLines={ 20 }>
 					<ErrorBoundary>
 						<GeneralSettings />
@@ -166,7 +185,10 @@ const SettingsManager = () => {
 				</LoadableSettingsSection>
 			</SettingsSection>
 			{ isUPESettingsPreviewEnabled && (
-				<SettingsSection description={ PaymentMethodsDescription }>
+				<SettingsSection
+					description={ PaymentMethodsDescription }
+					id="payment-methods"
+				>
 					<LoadableSettingsSection numLines={ 60 }>
 						<ErrorBoundary>
 							<WcPayUpeContextProvider
@@ -179,14 +201,20 @@ const SettingsManager = () => {
 					</LoadableSettingsSection>
 				</SettingsSection>
 			) }
-			<SettingsSection description={ ExpressCheckoutDescription }>
+			<SettingsSection
+				id="express-checkouts"
+				description={ ExpressCheckoutDescription }
+			>
 				<LoadableSettingsSection numLines={ 20 }>
 					<ErrorBoundary>
 						<ExpressCheckout />
 					</ErrorBoundary>
 				</LoadableSettingsSection>
 			</SettingsSection>
-			<SettingsSection description={ TransactionsDescription }>
+			<SettingsSection
+				description={ TransactionsDescription }
+				id="transactions"
+			>
 				<LoadableSettingsSection numLines={ 20 }>
 					<ErrorBoundary>
 						<WcPayUpeContextProvider
@@ -201,7 +229,7 @@ const SettingsManager = () => {
 					</ErrorBoundary>
 				</LoadableSettingsSection>
 			</SettingsSection>
-			<SettingsSection description={ DepositsDescription }>
+			<SettingsSection description={ DepositsDescription } id="deposits">
 				<div id={ 'deposit-schedule' }>
 					<LoadableSettingsSection numLines={ 20 }>
 						<ErrorBoundary>
@@ -211,7 +239,10 @@ const SettingsManager = () => {
 				</div>
 			</SettingsSection>
 			{ wcpaySettings.isFraudProtectionSettingsEnabled && (
-				<SettingsSection description={ FraudProtectionDescription }>
+				<SettingsSection
+					description={ FraudProtectionDescription }
+					id="fp-settings"
+				>
 					<LoadableSettingsSection numLines={ 20 }>
 						<ErrorBoundary>
 							<FraudProtection />

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -152,7 +152,7 @@ const SettingsManager = () => {
 		if ( ! isLoading && scrollTo ) {
 			const element = document.querySelector( scrollTo );
 
-			if ( ! scrollTo ) {
+			if ( ! element ) {
 				return;
 			}
 

--- a/client/settings/settings-section.tsx
+++ b/client/settings/settings-section.tsx
@@ -15,8 +15,14 @@ const SettingsSection: React.FunctionComponent< {
 	className?: string;
 	description?: React.FunctionComponent;
 	title?: string;
-} > = ( { description: Description = () => null, children, className } ) => (
-	<div className={ classNames( 'settings-section', className ) }>
+	id?: string;
+} > = ( {
+	description: Description = () => null,
+	children,
+	className,
+	id,
+} ) => (
+	<div className={ classNames( 'settings-section', className ) } id={ id }>
 		<div className="settings-section__details">
 			<Description />
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR is related to #5848 that needed to be reverted.

This PR makes `window.location.hash` scroll directly into the views after the React components load on Settings page, also add IDs/hashes to all settings page sections, allowing scrolling directly into it.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access WCPay settings page.
* Add `#express-checkouts` to the end of the URL and reload the page or [click here](http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments#express-checkouts) if you it on port `8082`.
* The page should scroll automatically to the `Express Checkouts` section.
* You can also test with `#general`, `#payment-methods`, `#transactions`, `#deposits` and `#fp-settings`.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
