### PR TITLE
[POC] Add a Multi Currency comaptibility layer for WooCommerce Blocks

### DIFF
--- a/includes/multi-currency/Compatibility.php
+++ b/includes/multi-currency/Compatibility.php
@@ -12,6 +12,7 @@ use WC_Deposits_Product_Manager;
 use WC_Order;
 use WC_Order_Refund;
 use WCPay\MultiCurrency\Compatibility\BaseCompatibility;
+use WCPay\MultiCurrency\Compatibility\WooCommerceBlocks;
 use WCPay\MultiCurrency\Compatibility\WooCommerceBookings;
 use WCPay\MultiCurrency\Compatibility\WooCommerceFedEx;
 use WCPay\MultiCurrency\Compatibility\WooCommerceNameYourPrice;
@@ -56,6 +57,7 @@ class Compatibility extends BaseCompatibility {
 	 */
 	public function init_compatibility_classes() {
 		if ( 1 < count( $this->multi_currency->get_enabled_currencies() ) ) {
+			$this->compatibility_classes[] = new WooCommerceBlocks( $this->multi_currency, $this->utils );
 			$this->compatibility_classes[] = new WooCommerceBookings( $this->multi_currency, $this->utils, $this->multi_currency->get_frontend_currencies() );
 			$this->compatibility_classes[] = new WooCommerceFedEx( $this->multi_currency, $this->utils );
 			$this->compatibility_classes[] = new WooCommerceNameYourPrice( $this->multi_currency, $this->utils );

--- a/includes/multi-currency/Compatibility/WooCommerceBlocks.php
+++ b/includes/multi-currency/Compatibility/WooCommerceBlocks.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Class WooCommerceBlocks
+ *
+ * @package WCPay\MultiCurrency\Compatibility
+ */
+
+namespace WCPay\MultiCurrency\Compatibility;
+
+use WCPay\MultiCurrency\MultiCurrency;
+use WCPay\MultiCurrency\Utils;
+
+/**
+ * Class that controls Multi Currency Compatibility with WooCommerce Blocks Plugin.
+ */
+class WooCommerceBlocks extends BaseCompatibility {
+
+	/**
+	 * Init the class.
+	 *
+	 * @return  void
+	 */
+	protected function init() {
+        add_filter( 'woocommerce_blocks_min_price', [ $this, 'convert_price_to_user_currency' ] );
+        add_filter( 'woocommerce_blocks_max_price', [ $this, 'convert_price_to_user_currency' ] );
+	}
+
+	public function convert_price_to_user_currency( $price ): float {
+		return $this->multi_currency->get_price( $price, 'product' );
+	}
+
+    public function convert_price_to_default_currency( $price ): float {
+		/**
+		 * We would like this function to return the price in the default currency.
+		 */
+	}
+}

--- a/includes/multi-currency/Compatibility/WooCommerceBlocks.php
+++ b/includes/multi-currency/Compatibility/WooCommerceBlocks.php
@@ -22,8 +22,8 @@ class WooCommerceBlocks extends BaseCompatibility {
 	 */
 	protected function init() {
 		// Convert the min and max price to be displayed on the frontend.
-        add_filter( 'woocommerce_get_min_price', [ $this, 'convert_price_to_user_currency' ] );
-        add_filter( 'woocommerce_get_max_price', [ $this, 'convert_price_to_user_currency' ] );
+        add_filter( 'woocommerce_blocks_get_min_price', [ $this, 'convert_price_to_user_currency' ] );
+        add_filter( 'woocommerce_blocks_get_max_price', [ $this, 'convert_price_to_user_currency' ] );
 
 		// Convert the min and max price choosen by user on the frontend.
 		add_filter( 'woocommerce_blocks_set_min_price', [ $this, 'convert_price_to_default_currency' ] );

--- a/includes/multi-currency/Compatibility/WooCommerceBlocks.php
+++ b/includes/multi-currency/Compatibility/WooCommerceBlocks.php
@@ -21,8 +21,13 @@ class WooCommerceBlocks extends BaseCompatibility {
 	 * @return  void
 	 */
 	protected function init() {
-        add_filter( 'woocommerce_blocks_min_price', [ $this, 'convert_price_to_user_currency' ] );
-        add_filter( 'woocommerce_blocks_max_price', [ $this, 'convert_price_to_user_currency' ] );
+		// Convert the min and max price to be displayed on the frontend.
+        add_filter( 'woocommerce_get_min_price', [ $this, 'convert_price_to_user_currency' ] );
+        add_filter( 'woocommerce_get_max_price', [ $this, 'convert_price_to_user_currency' ] );
+
+		// Convert the min and max price choosen by user on the frontend.
+		add_filter( 'woocommerce_blocks_set_min_price', [ $this, 'convert_price_to_default_currency' ] );
+        add_filter( 'woocommerce_blocks_set_max_price', [ $this, 'convert_price_to_default_currency' ] );
 	}
 
 	public function convert_price_to_user_currency( $price ): float {


### PR DESCRIPTION
Most of the blocks from WooCommerce Blocks work fine with Multi-Currency feature, except for the Filter by Price block.

### Filter by Price - short intro
<img width="305" alt="image" src="https://user-images.githubusercontent.com/20098064/230152676-8b99efa1-9d64-408a-9878-9deda1fdeb67.png">

Filter by Price block allows users to filter products based on price. It's frontend rendered and It fetches the min and max price from the Store API. However it gets the data directly from the DB, so it always uses default currency.

### Suggestion
In order to make the block support the Multi-Currency, we're suggesting adding a Compatibility layer with two filters:
- `convert_price_to_user_currency` - this one's needed to convert the values we get in the default currency. We managed to achieve expected result by calling `$this->multi_currency->get_price`
- `convert_price_to_default_currency` - when user chooses some price range, we send the value back to the backend. In order to make the filtering correct, we need to convert it back to the default currency. We couldn't find the method (or set of methods) that would allow for that conversion, so we're looking for help here.

cc: @gigitux 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
