### PR TITLE
Post-onboarding test mode UX

### DIFF
--- a/changelog/add-5481-builder-post-onboarding-ux
+++ b/changelog/add-5481-builder-post-onboarding-ux
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Post-onboarding test mode UX behind PO feature flag.
+
+

--- a/client/components/icons/block-embed.tsx
+++ b/client/components/icons/block-embed.tsx
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default (
+	<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm.5 16c0 .3-.2.5-.5.5H5c-.3 0-.5-.2-.5-.5V9.8l4.7-5.3H19c.3 0 .5.2.5.5v14zm-6-9.5L16 12l-2.5 2.8 1.1 1L18 12l-3.5-3.5-1 1zm-3 0l-1-1L6 12l3.5 3.8 1.1-1L8 12l2.5-2.5z" />
+	</svg>
+);

--- a/client/components/icons/block-post-author.tsx
+++ b/client/components/icons/block-post-author.tsx
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default (
+	<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<path
+			d="M10 4.5a1 1 0 11-2 0 1 1 0 012 0zm1.5 0a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0zm2.25 7.5v-1A2.75 2.75 0 0011 8.25H7A2.75 2.75 0 004.25 11v1h1.5v-1c0-.69.56-1.25 1.25-1.25h4c.69 0 1.25.56 1.25 1.25v1h1.5zM4 20h9v-1.5H4V20zm16-4H4v-1.5h16V16z"
+			fillRule="evenodd"
+			clipRule="evenodd"
+		/>
+	</svg>
+);

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -67,6 +67,7 @@ declare const wcpaySettings: {
 	};
 	accountDefaultCurrency: string;
 	isFraudProtectionSettingsEnabled: boolean;
+	onboardingTestMode: boolean;
 };
 
 declare const wcTracks: any;

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -22,9 +22,10 @@ import TaskList from './task-list';
 import { getTasks, taskSort } from './task-list/tasks';
 import InboxNotifications from './inbox-notifications';
 import ConnectionSuccessNotice from './connection-sucess-notice';
+import SetupRealPayments from './setup-real-payments';
 import JetpackIdcNotice from 'components/jetpack-idc-notice';
 import AccountBalances from 'components/account-balances';
-import FRTDiscoverabilityBanner from 'wcpay/components/fraud-risk-tools-banner';
+import FRTDiscoverabilityBanner from 'components/fraud-risk-tools-banner';
 import { useSettings } from 'wcpay/data';
 import './style.scss';
 
@@ -157,6 +158,12 @@ const OverviewPage = () => {
 					accountFees={ activeAccountFees }
 				/>
 			</ErrorBoundary>
+
+			{ wcpaySettings.onboardingTestMode && (
+				<ErrorBoundary>
+					<SetupRealPayments />
+				</ErrorBoundary>
+			) }
 
 			{ wcpaySettings.accountLoans.has_active_loan && (
 				<ErrorBoundary>

--- a/client/overview/setup-real-payments.tsx
+++ b/client/overview/setup-real-payments.tsx
@@ -3,6 +3,7 @@
  */
 import React, { useState } from 'react';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import {
 	Button,
 	Card,
@@ -22,6 +23,12 @@ import BlockPostAuthorIcon from 'components/icons/block-post-author';
 
 const SetupRealPayments: React.FC = () => {
 	const [ modalVisible, setModalVisible ] = useState( false );
+
+	const handleContinue = () => {
+		window.location.href = addQueryArgs( wcpaySettings.connectUrl, {
+			'wcpay-disable-onboarding-test-mode': true,
+		} );
+	};
 
 	return (
 		<>
@@ -101,10 +108,13 @@ const SetupRealPayments: React.FC = () => {
 						) }
 					</div>
 					<div className="wcpay-setup-real-payments-modal__footer">
-						<Button isTertiary>
+						<Button
+							isTertiary
+							onClick={ () => setModalVisible( false ) }
+						>
 							{ __( 'Go back', 'woocommerce-payments' ) }
 						</Button>
-						<Button isPrimary>
+						<Button isPrimary onClick={ handleContinue }>
 							{ __( 'Continue setup', 'woocommerce-payments' ) }
 						</Button>
 					</div>

--- a/client/overview/setup-real-payments.tsx
+++ b/client/overview/setup-real-payments.tsx
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import React, { useState } from 'react';
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardFooter,
+	CardHeader,
+	Modal,
+} from '@wordpress/components';
+import { Icon, payment, globe, currencyDollar } from '@wordpress/icons';
+import ScheduledIcon from 'gridicons/dist/scheduled';
+
+/**
+ * Internal dependencies
+ */
+import BlockEmbedIcon from 'components/icons/block-embed';
+import BlockPostAuthorIcon from 'components/icons/block-post-author';
+
+const SetupRealPayments: React.FC = () => {
+	const [ modalVisible, setModalVisible ] = useState( false );
+
+	return (
+		<>
+			<Card className="wcpay-setup-real-payments">
+				<CardHeader>
+					{ __(
+						'Ready to setup real payments on your store?',
+						'woocommerce-payments'
+					) }
+				</CardHeader>
+				<CardBody className="wcpay-setup-real-payments__body">
+					<div>
+						<Icon icon={ payment } size={ 32 } />
+						{ __(
+							'Offer a wide range of card payments',
+							'woocommerce-payments'
+						) }
+					</div>
+					<div>
+						<Icon icon={ globe } size={ 32 } />
+						{ __(
+							'135 different currencies and local payment methods',
+							'woocommerce-payments'
+						) }
+					</div>
+					<div>
+						<ScheduledIcon size={ 32 } />
+						{ __(
+							'Enjoy direct deposits into your bank account',
+							'woocommerce-payments'
+						) }
+					</div>
+				</CardBody>
+				<CardFooter className="wcpay-setup-real-payments__footer">
+					<Button isPrimary onClick={ () => setModalVisible( true ) }>
+						{ __( 'Set up payments', 'woocommerce-payments' ) }
+					</Button>
+				</CardFooter>
+			</Card>
+			{ modalVisible && (
+				<Modal
+					title={ __(
+						'Setup live payments on your store',
+						'woocommerce-payments'
+					) }
+					className="wcpay-setup-real-payments-modal"
+					isDismissible={ false }
+					onRequestClose={ () => setModalVisible( false ) }
+				>
+					<h2 className="wcpay-setup-real-payments-modal__title">
+						{ __(
+							'Setup live payments on your store',
+							'woocommerce-payments'
+						) }
+					</h2>
+					<p className="wcpay-setup-real-payments-modal__headline">
+						{ __(
+							'Before proceeding, please take note of the following information:',
+							'woocommerce-payments'
+						) }
+					</p>
+					<div className="wcpay-setup-real-payments-modal__content">
+						<Icon icon={ BlockEmbedIcon } />
+						{ __(
+							'Your test account will be deactivated and your transaction records will be preserved for future reference.',
+							'woocommerce-payments'
+						) }
+						<Icon icon={ BlockPostAuthorIcon } />
+						{ __(
+							'The owner, business and contact information will be required.',
+							'woocommerce-payments'
+						) }
+						<Icon icon={ currencyDollar } />
+						{ __(
+							'We will need your banking details in order to process any payouts to you.',
+							'woocommerce-payments'
+						) }
+					</div>
+					<div className="wcpay-setup-real-payments-modal__footer">
+						<Button isTertiary>
+							{ __( 'Go back', 'woocommerce-payments' ) }
+						</Button>
+						<Button isPrimary>
+							{ __( 'Continue setup', 'woocommerce-payments' ) }
+						</Button>
+					</div>
+				</Modal>
+			) }
+		</>
+	);
+};
+
+export default SetupRealPayments;

--- a/client/overview/setup-real-payments.tsx
+++ b/client/overview/setup-real-payments.tsx
@@ -78,12 +78,6 @@ const SetupRealPayments: React.FC = () => {
 					isDismissible={ false }
 					onRequestClose={ () => setModalVisible( false ) }
 				>
-					<h2 className="wcpay-setup-real-payments-modal__title">
-						{ __(
-							'Setup live payments on your store',
-							'woocommerce-payments'
-						) }
-					</h2>
 					<p className="wcpay-setup-real-payments-modal__headline">
 						{ __(
 							'Before proceeding, please take note of the following information:',

--- a/client/overview/style.scss
+++ b/client/overview/style.scss
@@ -73,4 +73,65 @@
 		width: 1px;
 		word-wrap: normal;
 	}
+
+	.wcpay-setup-real-payments {
+		&__body {
+			display: grid;
+			grid-template-columns: repeat( 3, 1fr );
+			grid-column-gap: $gap-largest;
+			margin: $gap $gap-small;
+			text-align: center;
+			fill: $studio-woocommerce-purple-50;
+
+			@media ( max-width: 783px ) {
+				grid-template-columns: 1fr;
+			}
+
+			svg {
+				display: block;
+				margin: 0 auto $gap-smaller;
+			}
+		}
+
+		&__footer {
+			justify-content: end;
+		}
+	}
+}
+
+.wcpay-setup-real-payments-modal {
+	color: $gray-900;
+	fill: $studio-woocommerce-purple-50;
+
+	.components-modal__content {
+		box-sizing: border-box;
+		max-width: 600px;
+		margin: auto;
+		padding: $gap-smaller $gap-larger $gap-larger;
+	}
+
+	.components-modal__header {
+		display: none;
+	}
+
+	&__title {
+		@include title-small;
+	}
+
+	&__headline {
+		font-weight: 600;
+	}
+
+	&__content {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		gap: $gap;
+		padding: $gap-smallest;
+		align-items: center;
+		margin-bottom: $gap-large;
+	}
+
+	&__footer {
+		@include modal-footer-buttons;
+	}
 }

--- a/client/overview/style.scss
+++ b/client/overview/style.scss
@@ -111,7 +111,15 @@
 	}
 
 	.components-modal__header {
-		display: none;
+		position: initial;
+		height: initial;
+		padding: 0;
+		border: 0;
+
+		h1 {
+			@include title-small;
+			margin-bottom: $gap-smaller;
+		}
 	}
 
 	&__title {

--- a/client/overview/test/index.js
+++ b/client/overview/test/index.js
@@ -313,4 +313,30 @@ describe( 'Overview page', () => {
 			screen.queryByText( 'Enhanced fraud protection for your store' )
 		).toBeInTheDocument();
 	} );
+
+	it( 'displays SetupRealPayments if onboardingTestMode is true', () => {
+		global.wcpaySettings = {
+			...global.wcpaySettings,
+			onboardingTestMode: true,
+		};
+
+		render( <OverviewPage /> );
+
+		expect(
+			screen.getByText( 'Ready to setup real payments on your store?' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'does not displays SetupRealPayments if onboardingTestMode is false', () => {
+		global.wcpaySettings = {
+			...global.wcpaySettings,
+			onboardingTestMode: false,
+		};
+
+		render( <OverviewPage /> );
+
+		expect(
+			screen.queryByText( 'Ready to setup real payments on your store?' )
+		).not.toBeInTheDocument();
+	} );
 } );

--- a/client/overview/test/setup-real-payments.test.tsx
+++ b/client/overview/test/setup-real-payments.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import user from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import SetupRealPayments from '../setup-real-payments';
+
+declare const global: {
+	wcpaySettings: {
+		connectUrl: string;
+	};
+};
+
+describe( 'Setup Real Payments', () => {
+	it( 'opens modal when set up payments button is clicked', () => {
+		render( <SetupRealPayments /> );
+
+		const queryHeading = () =>
+			screen.queryByRole( 'heading', {
+				name: 'Setup live payments on your store',
+			} );
+
+		expect( queryHeading() ).not.toBeInTheDocument();
+
+		user.click( screen.getByRole( 'button' ) );
+
+		expect( queryHeading() ).toBeInTheDocument();
+	} );
+
+	it( 'closes modal when go back button is clicked', () => {
+		render( <SetupRealPayments /> );
+
+		user.click( screen.getByRole( 'button' ) );
+		user.click(
+			screen.getByRole( 'button', {
+				name: 'Go back',
+			} )
+		);
+
+		expect(
+			screen.queryByRole( 'heading', {
+				name: 'Setup live payments on your store',
+			} )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'calls handleContinue when continue setup button is clicked', () => {
+		global.wcpaySettings = {
+			connectUrl: 'https://wcpay.test/connect',
+		};
+
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			enumerable: true,
+			value: new URL( window.location.href ),
+		} );
+
+		render( <SetupRealPayments /> );
+
+		user.click( screen.getByRole( 'button' ) );
+		user.click(
+			screen.getByRole( 'button', {
+				name: 'Continue setup',
+			} )
+		);
+
+		expect( window.location.href ).toBe(
+			`https://wcpay.test/connect?wcpay-disable-onboarding-test-mode=true`
+		);
+	} );
+} );

--- a/client/stylesheets/abstracts/_mixins.scss
+++ b/client/stylesheets/abstracts/_mixins.scss
@@ -42,3 +42,10 @@
 		}
 	}
 }
+
+// WordPress/Title Small
+@mixin title-small {
+	font-size: 20px;
+	line-height: 28px;
+	font-weight: 400;
+}

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -494,6 +494,7 @@ class WC_Payments_Admin {
 				'availableStates'    => WC()->countries->get_states(),
 			],
 			'testMode'                         => WC_Payments::mode()->is_test(),
+			'onboardingTestMode'               => WC_Payments_Onboarding_Service::is_test_mode_enabled(),
 			// set this flag for use in the front-end to alter messages and notices if on-boarding has been disabled.
 			'onBoardingDisabled'               => WC_Payments_Account::is_on_boarding_disabled(),
 			'errorMessage'                     => $error_message,

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -765,6 +765,12 @@ class WC_Payments_Account {
 				$this->redirect_to_prototype_onboarding_page();
 			}
 
+			if ( isset( $_GET['wcpay-disable-onboarding-test-mode'] ) ) {
+				WC_Payments_Onboarding_Service::set_test_mode( false );
+				$this->redirect_to_onboarding_page();
+				return;
+			}
+
 			// Hide menu notification badge upon starting setup.
 			update_option( 'wcpay_menu_badge_hidden', 'yes' );
 
@@ -1004,7 +1010,7 @@ class WC_Payments_Account {
 		// Enable dev mode if the test_mode query param is set.
 		$test_mode = isset( $_GET['test_mode'] ) ? boolval( wc_clean( wp_unslash( $_GET['test_mode'] ) ) ) : false;
 		if ( $test_mode ) {
-			WC_Payments_Onboarding_Service::enable_test_mode();
+			WC_Payments_Onboarding_Service::set_test_mode( true );
 		}
 
 		$current_user = wp_get_current_user();

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -145,7 +145,6 @@ class WC_Payments_Onboarding_Service {
 		// Ensure WC_Payments mode is switched immediately.
 		if ( $test_mode ) {
 			WC_Payments::mode()->dev();
-
 		} else {
 			WC_Payments::mode()->live();
 		}

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -128,18 +128,27 @@ class WC_Payments_Onboarding_Service {
 	 *
 	 * @return bool
 	 */
-	public function maybe_enable_dev_mode( $dev_mode ) {
-		return get_option( self::TEST_MODE_OPTION, $dev_mode );
+	public function maybe_enable_dev_mode( bool $dev_mode ): bool {
+		return self::is_test_mode_enabled() || $dev_mode;
 	}
 
 	/**
-	 * Enable onboarding test mode.
-	 * This will enable WCPay dev mode immediately.
+	 * Set onboarding test mode.
+	 * Will also switch WC_Payments mode immediately.
+	 *
+	 * @param boolean $test_mode Whether to enable test mode.
+	 * @return void
 	 */
-	public static function enable_test_mode(): void {
-		add_option( self::TEST_MODE_OPTION, true );
-		// Ensure dev mode is enabled immediately.
-		WC_Payments::mode()->dev();
+	public static function set_test_mode( bool $test_mode ): void {
+		update_option( self::TEST_MODE_OPTION, $test_mode ? 'yes' : 'no' );
+
+		// Ensure WC_Payments mode is switched immediately.
+		if ( $test_mode ) {
+			WC_Payments::mode()->dev();
+
+		} else {
+			WC_Payments::mode()->live();
+		}
 	}
 
 	/**
@@ -148,6 +157,6 @@ class WC_Payments_Onboarding_Service {
 	 * @return bool
 	 */
 	public static function is_test_mode_enabled(): bool {
-		return get_option( self::TEST_MODE_OPTION, false );
+		return get_option( self::TEST_MODE_OPTION ) === 'yes';
 	}
 }

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -140,7 +140,7 @@ class WC_Payments_Onboarding_Service {
 	 * @return void
 	 */
 	public static function set_test_mode( bool $test_mode ): void {
-		update_option( self::TEST_MODE_OPTION, $test_mode ? 'yes' : 'no' );
+		update_option( self::TEST_MODE_OPTION, $test_mode );
 
 		// Ensure WC_Payments mode is switched immediately.
 		if ( $test_mode ) {
@@ -157,6 +157,6 @@ class WC_Payments_Onboarding_Service {
 	 * @return bool
 	 */
 	public static function is_test_mode_enabled(): bool {
-		return get_option( self::TEST_MODE_OPTION ) === 'yes';
+		return get_option( self::TEST_MODE_OPTION );
 	}
 }

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -134,11 +134,20 @@ class WC_Payments_Onboarding_Service {
 
 	/**
 	 * Enable onboarding test mode.
-	 * This will enable WCPay dev mode.
+	 * This will enable WCPay dev mode immediately.
 	 */
-	public static function enable_test_mode() {
+	public static function enable_test_mode(): void {
 		add_option( self::TEST_MODE_OPTION, true );
 		// Ensure dev mode is enabled immediately.
 		WC_Payments::mode()->dev();
+	}
+
+	/**
+	 * Returns whether onboarding test mode is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_test_mode_enabled(): bool {
+		return get_option( self::TEST_MODE_OPTION, false );
 	}
 }

--- a/tests/unit/test-class-wc-payments-onboarding-service.php
+++ b/tests/unit/test-class-wc-payments-onboarding-service.php
@@ -192,4 +192,18 @@ class WC_Payments_Onboarding_Service_Test extends WCPAY_UnitTestCase {
 
 		$this->assertFalse( $this->onboarding_service->get_cached_business_types() );
 	}
+
+	public function test_set_test_mode() {
+		$this->onboarding_service->set_test_mode( true );
+
+		$this->assertTrue( get_option( 'wcpay_onboarding_test_mode' ) );
+		$this->assertTrue( WC_Payments::mode()->is_dev() );
+
+		$this->onboarding_service->set_test_mode( false );
+
+		$this->assertFalse( get_option( 'wcpay_onboarding_test_mode' ) );
+		$this->assertFalse( WC_Payments::mode()->is_dev() );
+
+		delete_option( 'wcpay_onboarding_test_mode' );
+	}
 }


### PR DESCRIPTION
Fixes #5481
Closes #2459

#### Changes proposed in this Pull Request
- Add `block-embed` and `block-post-author` icons.
- Add `title-small` mixin to match WordPress/Title small style.
- Replace `Onboarding_Service` `enable_test_mode` by `set_test_mode` and add `is_test_mode_enabled`.
- Add `onboardingTestMode` under `wcpaySettings` JS global var.
- Create `SetupRealPayments` card plus modal, and add it to `Overview`.
- Disable onboarding test mode by adding `wcpay-disable-onboarding-test-mode` to connect URL and redirecting there after clicking on `Continue setup`.

#### Testing instructions
- As we need to filter `dev_mode` we need to disable `Dev mode enabled` under **WCPay Dev** or use a JN site.
- Enable PO feature flag, you can edit this file directly in a JN site. (`wp-admin/plugin-editor.php?file=woocommerce-payments-dev/includes/class-wc-payments-features.php&plugin=woocommerce-payments-dev/woocommerce-payments.php`)
- Onboard a new account choosing `I’d like to set up test payments`.
- Stripe onboarding should be in test mode.
- After finishing it you'll be redirected to **Payments → Overview**.
- The new `Ready to setup real payments on your store?` card should be visible.
- Clicking on `Set up payments` should display the modal.
- Clicking on `Go back` should close the modal.
- Clicking on `Continue setup` should redirect to **Payments** connect page.
- Onboarding a new account but choosing `I’d like to set up payments for my store` this time. (Remember choose answer that redirects to full onboarding if you're using a JN site)
- Stripe onboarding should be in live mode.

#### Screenshots
> **Note**: Due to our outdated @wordpress/components dependency, I've added two missing icons, and the `globe` one is slighly different.

<img width="691" alt="Screenshot 2023-04-12 at 15 15 36" src="https://user-images.githubusercontent.com/7670276/231469141-42abff8a-fa6c-4977-ba2d-6b28ad5b32a4.png">
<img width="611" alt="Screenshot 2023-04-12 at 15 15 45" src="https://user-images.githubusercontent.com/7670276/231469146-aa1f7ad0-944f-4784-ba45-d45a4dfccbb2.png">



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
