### PR TITLE
Fixed the currency switcher on widgets admin page

### DIFF
--- a/changelog/fix-6010-currency-switcher-widget
+++ b/changelog/fix-6010-currency-switcher-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fixed blocks currency switcher widget

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -623,8 +623,8 @@ class WC_Payments_Admin {
 		}
 
 		// TODO: Try to enqueue the JS and CSS bundles lazily (will require changes on WC-Admin).
-		$current_screen = get_current_screen();
-		if ( wc_admin_is_registered_page() || 'widgets' === $current_screen->base ) {
+		$current_screen = get_current_screen() ? get_current_screen()->base : null;
+		if ( wc_admin_is_registered_page() || 'widgets' === $current_screen ) {
 			wp_enqueue_script( 'WCPAY_DASH_APP' );
 			wp_enqueue_style( 'WCPAY_DASH_APP' );
 		}

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -447,10 +447,6 @@ class WC_Payments_Admin {
 	public function register_payments_scripts() {
 		WC_Payments::register_script_with_dependencies( 'WCPAY_DASH_APP', 'dist/index' );
 
-		// Has on-boarding been disabled? Set the flag for use in the front-end so messages and notices can be altered
-		// as appropriate.
-		$on_boarding_disabled = WC_Payments_Account::is_on_boarding_disabled();
-
 		$error_message = get_transient( WC_Payments_Account::ERROR_MESSAGE_TRANSIENT );
 		delete_transient( WC_Payments_Account::ERROR_MESSAGE_TRANSIENT );
 
@@ -627,7 +623,8 @@ class WC_Payments_Admin {
 		}
 
 		// TODO: Try to enqueue the JS and CSS bundles lazily (will require changes on WC-Admin).
-		if ( wc_admin_is_registered_page() ) {
+		$current_screen = get_current_screen();
+		if ( wc_admin_is_registered_page() || 'widgets' === $current_screen->base ) {
 			wp_enqueue_script( 'WCPAY_DASH_APP' );
 			wp_enqueue_style( 'WCPAY_DASH_APP' );
 		}


### PR DESCRIPTION
Fixes #6010

#### Changes proposed in this Pull Request
This PR fixes the blocks currency switcher in the widgets admin

#### Testing instructions
- In WP Admin, click on Appearance > Widgets page.
- Add a new block to the sidebar by clicking the plus icon at the bottom of the existing sidebar widgets.
- Search Currency Switcher Block Widget and select it.
- Make sure the block loaded instead of showing "This block has encountered an error and cannot be previewed." message
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
