### PR TITLE
Transactions - Increase the size of the Capture action button on the Authorizations list

### DIFF
--- a/changelog/fix-increase-capture-button-size
+++ b/changelog/fix-increase-capture-button-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Bump up the size of Capture action button on the Authorizations list page.

--- a/client/transactions/uncaptured/index.tsx
+++ b/client/transactions/uncaptured/index.tsx
@@ -191,6 +191,7 @@ export const AuthorizationsList = (): JSX.Element => {
 					<CaptureAuthorizationButton
 						orderId={ auth.order_id }
 						paymentIntentId={ auth.payment_intent_id }
+						buttonIsSmall={ false }
 						onClick={ () => {
 							wcpayTracks.recordEvent(
 								'payments_transactions_uncaptured_list_capture_charge_button_click',

--- a/client/transactions/uncaptured/test/__snapshots__/index.test.tsx.snap
+++ b/client/transactions/uncaptured/test/__snapshots__/index.test.tsx.snap
@@ -330,7 +330,7 @@ exports[`Authorizations list renders correctly 1`] = `
                   class="woocommerce-table__item"
                 >
                   <button
-                    class="components-button is-secondary is-small"
+                    class="components-button is-secondary"
                     type="button"
                   >
                     Capture
@@ -407,7 +407,7 @@ exports[`Authorizations list renders correctly 1`] = `
                   class="woocommerce-table__item"
                 >
                   <button
-                    class="components-button is-secondary is-small"
+                    class="components-button is-secondary"
                     type="button"
                   >
                     Capture


### PR DESCRIPTION
Fixes #6044 

#### Changes proposed in this Pull Request

Bump up the size of the Capture button on the Authorizations list page. 

Before:

![image](https://user-images.githubusercontent.com/4162931/232007946-369e0171-4f59-4bcf-85af-0c2bfeb53004.png)

After: 

![image](https://user-images.githubusercontent.com/4162931/232008103-52f5dade-10d8-443f-8e40-fd5cfc2305ce.png)


#### Testing instructions

* Make sure the setting - `Issue an authorization on checkout, and capture later` is checked and do a few test orders to make them show up in the `Payments > Transactions > Uncaptured tab` 
* Make sure the buttons resemble the `After` screenshot above. They should be slightly larger.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
