### PR TITLE
Fixed php8.1 errors on /wp-admin

### DIFF
--- a/changelog/fix-5985-php8.1-errors
+++ b/changelog/fix-5985-php8.1-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fixed php 8.1 wp-admin errors

--- a/includes/core/server/class-response.php
+++ b/includes/core/server/class-response.php
@@ -46,7 +46,8 @@ class Response implements ArrayAccess {
 	 * @param mixed $offset The key to retrieve.
 	 * @return mixed
 	 */
-	public function offsetGet( $offset ): mixed {
+	#[\ReturnTypeWillChange]
+	public function offsetGet( $offset ) {
 		return $this->data[ $offset ];
 	}
 

--- a/includes/core/server/class-response.php
+++ b/includes/core/server/class-response.php
@@ -46,7 +46,7 @@ class Response implements ArrayAccess {
 	 * @param mixed $offset The key to retrieve.
 	 * @return mixed
 	 */
-	public function offsetGet( $offset ) {
+	public function offsetGet( $offset ): mixed {
 		return $this->data[ $offset ];
 	}
 
@@ -57,7 +57,7 @@ class Response implements ArrayAccess {
 	 * @param mixed $value               The value.
 	 * @throws Server_Response_Exception It is not possible.
 	 */
-	public function offsetSet( $offset, $value ) {
+	public function offsetSet( $offset, $value ): void {
 		throw new Server_Response_Exception( 'Server responses cannot be mutated.', 'wcpay_core_server_response_malformed' );
 	}
 
@@ -67,7 +67,7 @@ class Response implements ArrayAccess {
 	 * @param mixed $offset                The offset to remove.
 	 * @throws Server_Response_Exception   It is not possible.
 	 */
-	public function offsetUnset( $offset ) {
+	public function offsetUnset( $offset ): void {
 		throw new Server_Response_Exception( 'Server responses cannot be mutated.', 'wcpay_core_server_response_malformed' );
 	}
 


### PR DESCRIPTION
Fixes #5985 

#### Changes proposed in this Pull Request
This PR fixes errors that would show up on /wp-admin when using php 8.1. I tested this down to 7.4 and the [documentation](https://www.php.net/manual/en/language.types.declarations.php) states that return types were introduced in 7.0 and void and null as return types were introduced in 7.1. 

Mixed was only introduced in php 8.0 that's why I added #[\ReturnTypeWillChange] for the function that would require mixed as the return type.

#### Testing instructions
- Using php 8.1
- Checkout to this branch
- Go to /wp-admin
- Make sure no errors/warnings show up or are logged to the log files
- A warning for the subscriptions core might show up. It's being fixed at https://github.com/Automattic/woocommerce-subscriptions-core/pull/428
- Test again with php 7.2 if possible as that is the oldest version we officially support

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 