### PR TITLE
Override currency formatter with multicurrency support, add query conversion for min_price and max_price

### DIFF
--- a/changelog/fix-5996-price-filter-multicurrency-support
+++ b/changelog/fix-5996-price-filter-multicurrency-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add compatibility for price filter widget when used with multicurrency

--- a/includes/multi-currency/Compatibility.php
+++ b/includes/multi-currency/Compatibility.php
@@ -12,6 +12,7 @@ use WC_Deposits_Product_Manager;
 use WC_Order;
 use WC_Order_Refund;
 use WCPay\MultiCurrency\Compatibility\BaseCompatibility;
+use WCPay\MultiCurrency\Compatibility\StoreAPICompatibility;
 use WCPay\MultiCurrency\Compatibility\WooCommerceBookings;
 use WCPay\MultiCurrency\Compatibility\WooCommerceFedEx;
 use WCPay\MultiCurrency\Compatibility\WooCommerceNameYourPrice;
@@ -65,6 +66,7 @@ class Compatibility extends BaseCompatibility {
 			$this->compatibility_classes[] = new WooCommerceUPS( $this->multi_currency, $this->utils );
 			$this->compatibility_classes[] = new WooCommerceDeposits( $this->multi_currency, $this->utils );
 			$this->compatibility_classes[] = new WooCommercePointsAndRewards( $this->multi_currency, $this->utils );
+			$this->compatibility_classes[] = new StoreAPICompatibility( $this->multi_currency, $this->utils );
 		}
 	}
 

--- a/includes/multi-currency/Compatibility/Helpers/MultiCurrencyFormatter.php
+++ b/includes/multi-currency/Compatibility/Helpers/MultiCurrencyFormatter.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Class MultiCurrencyFormatter
+ *
+ * @package WCPay\MultiCurrency\Compatibility\Helpers
+ */
+
+namespace WCPay\MultiCurrency\Compatibility\Helpers;
+
+use Automattic\WooCommerce\StoreApi\Formatters\CurrencyFormatter;
+use WCPay\MultiCurrency\MultiCurrency;
+
+/**
+ * Class that controls currency conversion in StoreAPI.
+ */
+class MultiCurrencyFormatter {
+	/**
+	 * Format a given value and return the result.
+	 *
+	 * @param array $value Value to format.
+	 * @param array $options Options that influence the formatting.
+	 * @return array
+	 */
+	public function format( $value, array $options = [] ) {
+		$original_formatter = new CurrencyFormatter();
+		if ( is_array( $value ) ) {
+			foreach ( $value as $key => $original ) {
+				if ( is_string( $original ) ) {
+					$value[ $key ] = (string) MultiCurrency::instance()->get_price( $original, 'product' );
+				}
+			}
+		}
+		return $original_formatter->format( $value, $options );
+	}
+}

--- a/includes/multi-currency/Compatibility/Helpers/MultiCurrencyFormatter.php
+++ b/includes/multi-currency/Compatibility/Helpers/MultiCurrencyFormatter.php
@@ -9,11 +9,29 @@ namespace WCPay\MultiCurrency\Compatibility\Helpers;
 
 use Automattic\WooCommerce\StoreApi\Formatters\CurrencyFormatter;
 use WCPay\MultiCurrency\MultiCurrency;
+use WCPay\MultiCurrency\Utils;
 
 /**
  * Class that controls currency conversion in StoreAPI.
  */
 class MultiCurrencyFormatter {
+
+	/**
+	 * Multicurrency Utility class.
+	 *
+	 * @var WCPay\MultiCurrency\Utils
+	 */
+	protected $utils;
+
+	/**
+	 * Constructor.
+	 *
+	 * @return  void
+	 */
+	public function __construct() {
+		$this->utils = new Utils();
+	}
+
 	/**
 	 * Format a given value and return the result.
 	 *
@@ -22,11 +40,14 @@ class MultiCurrencyFormatter {
 	 * @return array
 	 */
 	public function format( $value, array $options = [] ) {
-		$original_formatter = new CurrencyFormatter();
-		if ( is_array( $value ) ) {
-			foreach ( $value as $key => $original ) {
-				if ( is_string( $original ) ) {
-					$value[ $key ] = (string) MultiCurrency::instance()->get_price( $original, 'product' );
+		$is_call_for_price_filter = $this->utils->is_call_in_backtrace( [ 'Automattic\WooCommerce\StoreApi\Schemas\V1\ProductCollectionDataSchema->get_item_response' ] );
+		$original_formatter       = new CurrencyFormatter();
+		if ( $is_call_for_price_filter ) {
+			if ( is_array( $value ) ) {
+				foreach ( $value as $key => $original ) {
+					if ( is_string( $original ) ) {
+						$value[ $key ] = (string) MultiCurrency::instance()->get_price( $original, 'product' );
+					}
 				}
 			}
 		}

--- a/includes/multi-currency/Compatibility/StoreAPICompatibility.php
+++ b/includes/multi-currency/Compatibility/StoreAPICompatibility.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Class StoreAPICompatibility
+ *
+ * @package WCPay\MultiCurrency\Compatibility
+ */
+
+namespace WCPay\MultiCurrency\Compatibility;
+
+use Automattic\WooCommerce\StoreApi\Formatters;
+use Automattic\WooCommerce\StoreApi\StoreApi;
+use WP_Query;
+
+/**
+ * Class that controls Multi Currency Compatibility with StoreAPI currency formatter.
+ */
+class StoreAPICompatibility extends BaseCompatibility {
+
+	/**
+	 * Init the class.
+	 *
+	 * @return void
+	 */
+	protected function init() {
+		// Override existing currency formatter to get converted prices.
+		$container  = StoreApi::container();
+		$formatters = $container->get( Formatters::class );
+		$formatters->register( 'currency', Helpers\MultiCurrencyFormatter::class );
+		add_action( 'posts_clauses', [ $this, 'convert_prices_if_min_max_price' ], 9, 2 );
+	}
+
+	/**
+	 * Converts the min_price and max_price filters back to the store currency.
+	 *
+	 * @param   array    $args      Arguments array.
+	 * @param   WP_Query $wp_query  The query object to modify args.
+	 *
+	 * @return  array
+	 */
+	public function convert_prices_if_min_max_price( $args, $wp_query ) {
+		// Check first if it has min_price or max_price.
+		if ( ! $wp_query->get( 'min_price', false ) && ! $wp_query->get( 'max_price', false ) ) {
+			return $args;
+		}
+		$currency_rate = $this->multi_currency->get_selected_currency()->get_rate();
+		if ( $wp_query->get( 'min_price' ) && ! $wp_query->get( 'is_min_price_converted', false ) ) {
+			$converted_price   = $wp_query->get( 'min_price' ) / $currency_rate;
+			$_GET['min_price'] = $converted_price;
+			$wp_query->set( 'is_min_price_converted', true );
+		}
+		if ( $wp_query->get( 'max_price' ) && ! $wp_query->get( 'is_max_price_converted', false ) ) {
+			$converted_price   = $wp_query->get( 'max_price' ) / $currency_rate;
+			$_GET['max_price'] = $converted_price;
+			$wp_query->set( 'is_max_price_converted', true );
+		}
+		return $args;
+	}
+}

--- a/includes/multi-currency/Compatibility/StoreAPICompatibility.php
+++ b/includes/multi-currency/Compatibility/StoreAPICompatibility.php
@@ -27,33 +27,27 @@ class StoreAPICompatibility extends BaseCompatibility {
 		$formatters = $container->get( Formatters::class );
 		$formatters->register( 'currency', Helpers\MultiCurrencyFormatter::class );
 		// Convert GET parameter prices before it is applied to posts query.
-		add_filter( 'posts_clauses', [ $this, 'convert_prices_if_min_max_price' ], 9, 2 );
+		add_filter( 'pre_get_posts', [ $this, 'modify_query_vars_currency_for_price_filter' ] );
 	}
 
 	/**
 	 * Converts the min_price and max_price filters back to the store currency.
 	 *
-	 * @param   array    $args      Arguments array.
-	 * @param   WP_Query $wp_query  The query object to modify args.
+	 * @param   WP_Query $wp_query  The WP query vars to modify.
 	 *
 	 * @return  array
 	 */
-	public function convert_prices_if_min_max_price( $args, $wp_query ) {
-		/**
-		 * Context:
-		 * The `price_filter_post_clauses` method checks the $_GET['min_price'] or $_GET['max_price'] and limits the
-		 * product display to those limits by directly applying the parameters to the DB query, which is always saved
-		 * in the store currency, and when MC is involved, the prices on the querystring are sent as the customer currency.
-		 * To match the price limits on the querystring to the saved values on the DB, the filters need to be converted
-		 * back to the store currency.
-		 *
-		 * Permalink: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-query.php#L670-L673
-		 */
-
+	public function modify_query_vars_currency_for_price_filter( $wp_query ) {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( ! $wp_query->is_main_query() || isset( $_GET['are_prices_converted'] ) || ( ! isset( $_GET['max_price'] ) && ! isset( $_GET['min_price'] ) ) ) {
-			return $args;
+		if (
+			! isset( $wp_query->query_vars['wc_query'] )
+			|| 'product_query' !== $wp_query->query_vars['wc_query']
+			|| isset( $_GET['are_prices_converted'] )
+			|| ( ! isset( $_GET['max_price'] ) && ! isset( $_GET['min_price'] ) )
+		) {
+			return $wp_query;
 		}
+
 		$currency_rate = $this->multi_currency->get_selected_currency()->get_rate();
 		if ( isset( $_GET['min_price'] ) ) {
 			$_GET['min_price'] = floatval( wp_unslash( $_GET['min_price'] ) ) / $currency_rate;
@@ -63,7 +57,6 @@ class StoreAPICompatibility extends BaseCompatibility {
 		}
 		$_GET['are_prices_converted'] = true;
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
-
-		return $args;
+		return $wp_query;
 	}
 }

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -916,6 +916,13 @@ class MultiCurrency {
 		WC()->initialize_session();
 		$currency_code = WC()->session->get( self::CURRENCY_SESSION_KEY );
 
+		// If the user does not have a session cookie yet and uses geolocation.
+		if (
+			! $currency_code
+			&& $this->is_using_auto_currency_switching() ) {
+			$currency_code = $this->geolocation->get_currency_by_customer_location();
+		}
+
 		return is_string( $currency_code ) ? $currency_code : null;
 	}
 

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -916,10 +916,9 @@ class MultiCurrency {
 		WC()->initialize_session();
 		$currency_code = WC()->session->get( self::CURRENCY_SESSION_KEY );
 
-		// If the user does not have a session cookie yet and uses geolocation.
-		if (
-			! $currency_code
-			&& $this->is_using_auto_currency_switching() ) {
+		// If the user does not have a session cookie yet and enabled auto-currency selection from geolocation.
+		if ( ! $currency_code && $this->is_using_auto_currency_switching() ) {
+			// Refetch the currency from geolocation.
 			$currency_code = $this->geolocation->get_currency_by_customer_location();
 		}
 


### PR DESCRIPTION
Fixes #5996

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

Context: https://woofseengineering.wordpress.com/2023/04/07/filter-by-price-and-multi-currency-feature-problems/

This PR aims to fix the compatibility with WC Blocks Price Filter and WCPay Multi-Currency, by adding an override Currency formatter, to send FX converted prices to the frontend coming from StoreAPI requests, and modifying the $_GET parameters that `post_clauses` filter uses to query products within a specific price range. To limit the execution, this compatibility layer will take place when only a `max_price` or `min_price` filter is set in the request query string.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.cv
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Don't checkout this PR yet.
* Open your WCPay multicurrency settings, add some currencies if not added before, including your local currency.
* Enable the "Automatically switch customers to their local currency if it has been enabled"
* Go to your Shop page, click "Customize"
* Change the page layout to have a sidebar, 
<img width="427" alt="image" src="https://user-images.githubusercontent.com/3295/232536341-ccd560da-977b-44f2-be7e-41fef289fb61.png">

* And to that sidebar add the "Filter by Price" widget 
<img width="423" alt="image" src="https://user-images.githubusercontent.com/3295/232536537-be7a6628-34e4-498c-bfc1-ea7785c8de4b.png">

* Go to your store, see if you see the local currency on your store and a banner telling you that the site switched to your currency automatically.
* Go to the shop page, see if the price filter on the sidebar shows the correct min/max amounts and the correct currency. Check if you move the sliders the correct price filters are applied.
* Checkout this branch
* Refresh the page and check if the price filter works correctly now. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
