### PR TITLE
Dev - Add tests to cover using user tokens for some recently added WCPay core request classes. 

### DIFF
--- a/changelog/update-add-tests-using-user-token-for-account-releated-requests
+++ b/changelog/update-add-tests-using-user-token-for-account-releated-requests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Just add tests to cover using user tokens for some recently added WCPay core request classes.
+
+

--- a/tests/unit/core/server/request/test-class-add-account-tos-agreement.php
+++ b/tests/unit/core/server/request/test-class-add-account-tos-agreement.php
@@ -53,6 +53,7 @@ class Add_Account_Tos_Agreement_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( $admin_username, $params['user_name'] );
 		$this->assertSame( 'accounts/tos_agreements', $request->get_api() );
 		$this->assertSame( 'POST', $request->get_method() );
+		$this->assertTrue( $request->should_use_user_token() );
 	}
 
 	public function test_add_account_tos_agreement_with_invalid_user_name_param_will_throw_exception() {

--- a/tests/unit/core/server/request/test-class-core-get-account-capital-link.php
+++ b/tests/unit/core/server/request/test-class-core-get-account-capital-link.php
@@ -56,6 +56,7 @@ class Get_Account_Capital_Link_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( $valid_refresh_url, $params['refresh_url'] );
 		$this->assertSame( 'accounts/capital_links', $request->get_api() );
 		$this->assertSame( 'POST', $request->get_method() );
+		$this->assertTrue( $request->should_use_user_token() );
 	}
 
 	public function test_get_account_login_data_with_invalid_return_url_param_will_throw_exception() {

--- a/tests/unit/core/server/request/test-class-core-get-account-login-data.php
+++ b/tests/unit/core/server/request/test-class-core-get-account-login-data.php
@@ -52,6 +52,7 @@ class Get_Account_Login_Data_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( $params['test_mode'] );
 		$this->assertSame( 'accounts/login_links', $request->get_api() );
 		$this->assertSame( 'POST', $request->get_method() );
+		$this->assertTrue( $request->should_use_user_token() );
 	}
 	public function test_get_account_will_be_requested_as_test_mode_only_in_dev_mode() {
 		// enable test mode.

--- a/tests/unit/core/server/request/test-class-core-update-account-request.php
+++ b/tests/unit/core/server/request/test-class-core-update-account-request.php
@@ -56,6 +56,9 @@ class Update_Account_Test extends WCPAY_UnitTestCase {
 		// Assert method and endpoint.
 		$this->assertSame( 'POST', $request->get_method() );
 		$this->assertSame( 'accounts', $request->get_api() );
+
+		// Assert using user token.
+		$this->assertTrue( $request->should_use_user_token() );
 	}
 
 	public function test_from_account_settings_with_empty_input_will_throw_exception() {


### PR DESCRIPTION
Fixes # 

I've just noticed p3btAN-2aU-p2#comment-18360 and paJDYF-1DU-p2 and thought that we would check against using the user token for these endpoints too. 

#### Changes proposed in this Pull Request

Just add tests to cover using user tokens for some recently added WCPay core request classes in #5959 and #5948. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

Confirm that all new tests are passed. 

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.