### PR TITLE
Update Dependabot to tag team Harmony for reviews

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       directory: '/'
       # Check the npm registry for updates every day (weekdays)
       schedule:
-          interval: 'daily'
+        interval: 'weekly'
       # Reviewers for issues created
       reviewers:
           - 'Automattic/harmony'
@@ -17,7 +17,7 @@ updates:
       directory: '/'
       # Check the npm registry for updates every day (weekdays)
       schedule:
-          interval: 'daily'
+        interval: 'weekly'
       # Reviewers for issues created
       reviewers:
           - 'Automattic/harmony'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
           interval: 'daily'
       # Reviewers for issues created
       reviewers:
-          - 'jessepearson'
+          - 'Automattic/harmony'
 
     # Enable version updates for composer
     - package-ecosystem: 'composer'
@@ -20,7 +20,7 @@ updates:
           interval: 'daily'
       # Reviewers for issues created
       reviewers:
-          - 'jessepearson'
+          - 'Automattic/harmony'
 
     # Enable version updates for Docker
     - package-ecosystem: 'docker'
@@ -31,4 +31,4 @@ updates:
           interval: 'weekly'
       # Reviewers for issues created
       reviewers:
-          - 'jessepearson'
+          - 'Automattic/harmony'

--- a/changelog/dev-update-depenabot-reviewers
+++ b/changelog/dev-update-depenabot-reviewers
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Dev update, no change to client functionality.
+
+


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Removes myself as the reviewer for Dependabot PRs and adds team @Automattic/harmony  as the reviewers.

@Automattic/harmony you may want to change the interval from daily to weekly, as well.