### PR TITLE
SEPA: remove declaration of subscriptions support

### DIFF
--- a/changelog/update-3776-disable-sepa-for-subscriptions
+++ b/changelog/update-3776-disable-sepa-for-subscriptions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Disable subscriptions purchase with SEPA payment method.

--- a/includes/payment-methods/class-sepa-payment-method.php
+++ b/includes/payment-methods/class-sepa-payment-method.php
@@ -25,7 +25,7 @@ class Sepa_Payment_Method extends UPE_Payment_Method {
 		parent::__construct( $token_service );
 		$this->stripe_id   = self::PAYMENT_METHOD_STRIPE_ID;
 		$this->title       = 'SEPA Direct Debit';
-		$this->is_reusable = true;
+		$this->is_reusable = false;
 		$this->currencies  = [ 'EUR' ];
 		$this->icon_url    = plugins_url( 'assets/images/payment-methods/sepa-debit.svg', WCPAY_PLUGIN_FILE );
 	}


### PR DESCRIPTION
Fixes #3776

#### Changes proposed in this Pull Request

- Remove subscriptions support declaration for SEPA payment method.
- Note the saved token will reveal, and we keep the underlying SEPA+subs integrations which need more work. Hence our changes are kinda cosmetic.

#### Testing instructions

* Enable SEPA in WooCommerce Payments settings
* Create a subscription product
* Add a subscription to cart and proceed to checkout
* Ensure SEPA is NOT available as payment method there
* Clear cart, add a regular product in there and proceed to checkout
* Ensure SEPA is available there
* Complete the purchase and ensure transaction details are available

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
