### PR TITLE
Update fraud protection discoverability banner action buttons

### DIFF
--- a/changelog/update-6064-update-fraud-protection-banner-buttons
+++ b/changelog/update-6064-update-fraud-protection-banner-buttons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Updates the display of the remind me later button and changes the text of the dismiss button to 'dismiss' on the fraud and risk tools discoverability banner.

--- a/client/components/fraud-risk-tools-banner/components/banner-actions/index.tsx
+++ b/client/components/fraud-risk-tools-banner/components/banner-actions/index.tsx
@@ -38,12 +38,14 @@ const BannerActions: React.FC< BannerActionsProps > = ( {
 			>
 				{ __( 'Learn more', 'woocommerce-payments' ) }
 			</Button>
-			<Button isTertiary onClick={ handleRemindOnClick }>
-				{ __( 'Remind me later', 'woocommerce-payments' ) }
-			</Button>
+			{ 3 > remindMeCount && (
+				<Button isTertiary onClick={ handleRemindOnClick }>
+					{ __( 'Remind me later', 'woocommerce-payments' ) }
+				</Button>
+			) }
 			{ 3 <= remindMeCount && (
 				<Button isTertiary onClick={ handleDontShowAgainOnClick }>
-					{ __( "Don't show me this again", 'woocommerce-payments' ) }
+					{ __( 'Dismiss', 'woocommerce-payments' ) }
 				</Button>
 			) }
 		</div>

--- a/client/components/fraud-risk-tools-banner/components/banner-actions/index.tsx
+++ b/client/components/fraud-risk-tools-banner/components/banner-actions/index.tsx
@@ -38,12 +38,11 @@ const BannerActions: React.FC< BannerActionsProps > = ( {
 			>
 				{ __( 'Learn more', 'woocommerce-payments' ) }
 			</Button>
-			{ 3 > remindMeCount && (
+			{ 3 > remindMeCount ? (
 				<Button isTertiary onClick={ handleRemindOnClick }>
 					{ __( 'Remind me later', 'woocommerce-payments' ) }
 				</Button>
-			) }
-			{ 3 <= remindMeCount && (
+			) : (
 				<Button isTertiary onClick={ handleDontShowAgainOnClick }>
 					{ __( 'Dismiss', 'woocommerce-payments' ) }
 				</Button>

--- a/client/components/fraud-risk-tools-banner/components/banner-actions/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/fraud-risk-tools-banner/components/banner-actions/test/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BannerActions renders with dont show again button when remindMeCount greater than or equal to 3 1`] = `
+exports[`BannerActions renders with dismiss button when remindMeCount greater than or equal to 3 1`] = `
 <div>
   <div
     class="discoverability-card__actions"
@@ -16,19 +16,13 @@ exports[`BannerActions renders with dont show again button when remindMeCount gr
       class="components-button is-tertiary"
       type="button"
     >
-      Remind me later
-    </button>
-    <button
-      class="components-button is-tertiary"
-      type="button"
-    >
-      Don't show me this again
+      Dismiss
     </button>
   </div>
 </div>
 `;
 
-exports[`BannerActions renders without dont show again button when remindMeCount less than 3 1`] = `
+exports[`BannerActions renders without dismiss button when remindMeCount less than 3 1`] = `
 <div>
   <div
     class="discoverability-card__actions"

--- a/client/components/fraud-risk-tools-banner/components/banner-actions/test/index.test.tsx
+++ b/client/components/fraud-risk-tools-banner/components/banner-actions/test/index.test.tsx
@@ -13,7 +13,7 @@ const mockHandleRemindOnClick = jest.fn();
 const mockHandleDontShowAgainOnClick = jest.fn();
 
 describe( 'BannerActions', () => {
-	it( 'renders without dont show again button when remindMeCount less than 3', () => {
+	it( 'renders without dismiss button when remindMeCount less than 3', () => {
 		const { container: bannerActionsComponent } = render(
 			<BannerActions
 				remindMeCount={ 0 }
@@ -25,7 +25,7 @@ describe( 'BannerActions', () => {
 		expect( bannerActionsComponent ).toMatchSnapshot();
 	} );
 
-	it( 'renders with dont show again button when remindMeCount greater than or equal to 3', () => {
+	it( 'renders with dismiss button when remindMeCount greater than or equal to 3', () => {
 		const { container: bannerActionsComponent } = render(
 			<BannerActions
 				remindMeCount={ 3 }

--- a/client/components/fraud-risk-tools-banner/test/__snapshots__/index.test.tsx.snap
+++ b/client/components/fraud-risk-tools-banner/test/__snapshots__/index.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`FRTDiscoverabilityBanner renders when remindMeAt timestamp is in the pa
 </div>
 `;
 
-exports[`FRTDiscoverabilityBanner renders with dont show again button if remindMeCount greater than or equal to 3 1`] = `
+exports[`FRTDiscoverabilityBanner renders with dismiss button if remindMeCount greater than or equal to 3 1`] = `
 <div>
   <div
     class="components-card is-size-medium css-1xs3c37-CardUI e1q7k77g0"
@@ -143,13 +143,7 @@ exports[`FRTDiscoverabilityBanner renders with dont show again button if remindM
           class="components-button is-tertiary"
           type="button"
         >
-          Remind me later
-        </button>
-        <button
-          class="components-button is-tertiary"
-          type="button"
-        >
-          Don't show me this again
+          Dismiss
         </button>
       </div>
     </div>
@@ -157,7 +151,7 @@ exports[`FRTDiscoverabilityBanner renders with dont show again button if remindM
 </div>
 `;
 
-exports[`FRTDiscoverabilityBanner renders without dont show again button if remindMeCount greater than 0 but less than 3 1`] = `
+exports[`FRTDiscoverabilityBanner renders without dismiss button if remindMeCount greater than 0 but less than 3 1`] = `
 <div>
   <div
     class="components-card is-size-medium css-1xs3c37-CardUI e1q7k77g0"

--- a/client/components/fraud-risk-tools-banner/test/index.test.tsx
+++ b/client/components/fraud-risk-tools-banner/test/index.test.tsx
@@ -43,7 +43,7 @@ describe( 'FRTDiscoverabilityBanner', () => {
 		expect( frtBanner ).toMatchSnapshot();
 	} );
 
-	it( 'renders with dont show again button if remindMeCount greater than or equal to 3', () => {
+	it( 'renders with dismiss button if remindMeCount greater than or equal to 3', () => {
 		global.wcpaySettings = {
 			...global.wcpaySettings,
 			frtDiscoverBannerSettings: JSON.stringify( {
@@ -58,7 +58,7 @@ describe( 'FRTDiscoverabilityBanner', () => {
 		expect( frtBanner ).toMatchSnapshot();
 	} );
 
-	it( 'renders without dont show again button if remindMeCount greater than 0 but less than 3', () => {
+	it( 'renders without dismiss button if remindMeCount greater than 0 but less than 3', () => {
 		global.wcpaySettings = {
 			...global.wcpaySettings,
 			frtDiscoverBannerSettings: JSON.stringify( {

--- a/client/overview/test/index.js
+++ b/client/overview/test/index.js
@@ -268,7 +268,7 @@ describe( 'Overview page', () => {
 		} );
 	} );
 
-	it( 'dismisses the FRTDiscoverabilityBanner when dont show again button is clicked', async () => {
+	it( 'dismisses the FRTDiscoverabilityBanner when dismiss button is clicked', async () => {
 		global.wcpaySettings = {
 			...global.wcpaySettings,
 			frtDiscoverBannerSettings: JSON.stringify( {
@@ -286,7 +286,7 @@ describe( 'Overview page', () => {
 
 		expect( bannerHeader ).toBeInTheDocument();
 
-		userEvent.click( screen.getByText( "Don't show me this again" ) );
+		userEvent.click( screen.getByText( 'Dismiss' ) );
 
 		await waitFor( () => {
 			expect( bannerHeader ).not.toBeInTheDocument();


### PR DESCRIPTION
Fixes #6064

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

This PR makes the following changes to the fraud protection discoverability banner action buttons:

- Once the 'Remind me later' button has been clicked three times, the button will no longer show up when the banner re-appears.
- Changes the text of the dismiss button from 'Don't show this again' to 'Dismiss'.
- The dismiss button now renders where the 'Remind me later' button was, beside the primary 'Learn more' button.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch.
* All tests should pass.
* Apply the following patch:

<details>
<summary><strong>Patch</strong></summary>

```patch
diff --git a/client/components/fraud-risk-tools-banner/index.tsx b/client/components/fraud-risk-tools-banner/index.tsx
index 231d6fa6c..19cc110eb 100644
--- a/client/components/fraud-risk-tools-banner/index.tsx
+++ b/client/components/fraud-risk-tools-banner/index.tsx
@@ -41,7 +41,7 @@ const FRTDiscoverabilityBanner: React.FC = () => {
 			return {
 				...prevSettings,
 				remindMeCount: prevSettings.remindMeCount + 1,
-				remindMeAt: nowTimestamp + 3 * TIME.DAY_IN_MS,
+				remindMeAt: nowTimestamp + TIME.MIN_IN_MS,
 			};
 		} );
 	};
diff --git a/client/constants.ts b/client/constants.ts
index ccd0d4892..097e33718 100644
--- a/client/constants.ts
+++ b/client/constants.ts
@@ -1,3 +1,4 @@
 export enum TIME {
 	DAY_IN_MS = 24 * 60 * 60 * 1000,
+	MIN_IN_MS = 60 * 1000,
 }
diff --git a/woocommerce-payments.php b/woocommerce-payments.php
index cad6944d9..06a394761 100644
--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -12,7 +12,7 @@
  * WC tested up to: 7.5.1
  * Requires at least: 6.0
  * Requires PHP: 7.2
- * Version: 5.7.0
+ * Version: 5.8.0
  *
  * @package WooCommerce\Payments
  */
```

</details>

#### Test steps:

1. Make sure the feature flag option is enabled: `npm run wp option update wcpay_fraud_protection_settings_active 1`.
2. Make sure the banner settings option is deleted: `npm run wp option delete wcpay_frt_discover_banner_settings`.
3.  Visit the WC Pay overview page. You should see the banner with the 'Learn more' and 'Remind me later' buttons visible at the bottom of the banner. Click the 'Remind me later' button. 
4. Visit the WCPay deposits page. Then go back to the Overview page in less than one minute. The banner should still be hidden. 
5. Go back to the deposits page and wait one minute.
6. Go to the Overview page. The banner should be visible.
7. Now repeat steps 3 through 6, two more times.
8. After you have followed the steps above you should have clicked the 'Remind me later' button three times. When the banner re-appears after the third remind button click the 'Remind me later' button will now be hidden and replaced with a 'Dismiss' button. The banner should look like this: 

![frt-discover-banner-update-actions](https://user-images.githubusercontent.com/60988591/232892320-e7ec8d90-7490-4564-860d-898146840081.png)

9. Click the 'Dismiss' button. 
10. Click around to different pages and back to the Overview page for the next minute or two. The banner should not re-appear.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
