### PR TITLE
Add support for Sweden

### DIFF
--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -48,6 +48,7 @@ const countryFeeStripeDocsSectionNumbers: Record< string, string > = {
 	SG: 'singapore',
 	SI: 'slovenia',
 	SK: 'slovakia',
+	SW: 'sweden',
 	ES: 'spain',
 	CH: 'switzerland',
 	UK: 'united-kingdom',

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -245,6 +245,7 @@ class WC_Payments_Utils {
 			'NZ' => __( 'New Zealand', 'woocommerce-payments' ),
 			'PL' => __( 'Poland', 'woocommerce-payments' ),
 			'PT' => __( 'Portugal', 'woocommerce-payments' ),
+			'SE' => __( 'Sweden', 'woocommerce-payments' ),
 			'SI' => __( 'Slovenia', 'woocommerce-payments' ),
 			'SK' => __( 'Slovakia', 'woocommerce-payments' ),
 			'SG' => __( 'Singapore', 'woocommerce-payments' ),


### PR DESCRIPTION
Fixes #5975 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This adds support for Sweden and should be tested with server PR `3253`
#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You can use Stripe account id in the server PR for testing

### Testing Card, INTL, and FX fees
* Please pick a card from [Stripe's testing cards](https://stripe.com/docs/testing?testing-method=card-numbers#international-cards)
* A card from `EU` should only have base fees. Other cards should have INTL and FX fees

### Testing iDEAL, Bancontact...
This needs the `EUR` currency to show up in the Stripe checkout.
* Add a new currency to your store via Woo Settings.
* Turn on iDEAL, Bancontact... from Payments settings
* Go to the shop and add `?currency=eur` to the URL of the store
* Shop for something
* Go to checkout and double check iDEAL and other payment methods are showing
* Pay with one
* Double check the fees


## My own testing results

EU card (only base fee applied)
<img width="512" alt="Screenshot 2023-04-19 at 13 00 46" src="https://user-images.githubusercontent.com/12542046/233082824-9a2c6bab-8144-4285-bfe2-f5f3a883292a.png">

Giropay
<img width="538" alt="Screenshot 2023-04-19 at 13 01 09" src="https://user-images.githubusercontent.com/12542046/233082837-62142bb6-de01-4e25-9747-1a18ad733793.png">

iDEAL
<img width="493" alt="Screenshot 2023-04-19 at 13 01 16" src="https://user-images.githubusercontent.com/12542046/233082845-84c97030-6452-4e79-8976-5efec3e21207.png">

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
