### PR TITLE
Adds remote inbox notification for WooPay and amends WooPay legal mandate

### DIFF
--- a/client/settings/express-checkout-settings/platform-checkout-settings.js
+++ b/client/settings/express-checkout-settings/platform-checkout-settings.js
@@ -78,10 +78,9 @@ const PlatformCheckoutSettings = ( { section } ) => {
 										mixedString: __(
 											/* eslint-disable-next-line max-len */
 											'When enabled, customers will be able to checkout using WooPay. ' +
-												'By using {{wooPayLink}}WooPay{{/wooPayLink}}, you agree to our ' +
+												'In order to use {{wooPayLink}}WooPay{{/wooPayLink}}, you must agree to our ' +
 												'{{tosLink}}WooCommerce Terms of Service{{/tosLink}} ' +
-												'and and {{privacyLink}}Privacy Policy{{/privacyLink}}. ' +
-												'You understand you will be sharing data with us. ' +
+												'and {{privacyLink}}Privacy Policy{{/privacyLink}}. ' +
 												'{{trackingLink}}Click here{{/trackingLink}} to learn more about the ' +
 												'data you will be sharing and opt-out options.',
 											'woocommerce-payments'

--- a/client/settings/express-checkout-settings/platform-checkout-settings.js
+++ b/client/settings/express-checkout-settings/platform-checkout-settings.js
@@ -5,6 +5,7 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Card, CheckboxControl, TextControl } from '@wordpress/components';
+import interpolateComponents from '@automattic/interpolate-components';
 
 /**
  * Internal dependencies
@@ -66,10 +67,58 @@ const PlatformCheckoutSettings = ( { section } ) => {
 						checked={ isPlatformCheckoutEnabled }
 						onChange={ updateIsPlatformCheckoutEnabled }
 						label={ __( 'Enable WooPay', 'woocommerce-payments' ) }
-						help={ __(
-							'When enabled, customers will be able to checkout using WooPay',
-							'woocommerce-payments'
-						) }
+						help={
+							/* eslint-disable jsx-a11y/anchor-has-content */
+							isPlatformCheckoutEnabled
+								? __(
+										'When enabled, customers will be able to checkout using WooPay.',
+										'woocommerce-payments'
+								  )
+								: interpolateComponents( {
+										mixedString: __(
+											/* eslint-disable-next-line max-len */
+											'When enabled, customers will be able to checkout using WooPay. ' +
+												'By using {{wooPayLink}}WooPay{{/wooPayLink}}, you agree to our ' +
+												'{{tosLink}}WooCommerce Terms of Service{{/tosLink}} ' +
+												'and and {{privacyLink}}Privacy Policy{{/privacyLink}}. ' +
+												'You understand you will be sharing data with us. ' +
+												'{{trackingLink}}Click here{{/trackingLink}} to learn more about the ' +
+												'data you will be sharing and opt-out options.',
+											'woocommerce-payments'
+										),
+										components: {
+											wooPayLink: (
+												<a
+													target="_blank"
+													rel="noreferrer"
+													href="https://woocommerce.com/document/woopay-merchant-documentation/"
+												/>
+											),
+											tosLink: (
+												<a
+													target="_blank"
+													rel="noreferrer"
+													href="https://wordpress.com/tos/"
+												/>
+											),
+											privacyLink: (
+												<a
+													target="_blank"
+													rel="noreferrer"
+													href="https://automattic.com/privacy/"
+												/>
+											),
+											trackingLink: (
+												<a
+													target="_blank"
+													rel="noreferrer"
+													href="https://woocommerce.com/usage-tracking/"
+												/>
+											),
+										},
+								  } )
+							/* eslint-enable jsx-a11y/anchor-has-content */
+						}
 					/>
 					<h4>
 						{ __(

--- a/client/settings/express-checkout/index.js
+++ b/client/settings/express-checkout/index.js
@@ -139,10 +139,9 @@ const ExpressCheckout = () => {
 													mixedString: __(
 														/* eslint-disable-next-line max-len */
 														'Boost conversion and customer loyalty by offering a single click, secure way to pay. ' +
-															'By using {{wooPayLink}}WooPay{{/wooPayLink}}, you agree to our ' +
+															'In order to use {{wooPayLink}}WooPay{{/wooPayLink}}, you must agree to our ' +
 															'{{tosLink}}WooCommerce Terms of Service{{/tosLink}} ' +
-															'and and {{privacyLink}}Privacy Policy{{/privacyLink}}. ' +
-															'You understand you will be sharing data with us. ' +
+															'and {{privacyLink}}Privacy Policy{{/privacyLink}}. ' +
 															'{{trackingLink}}Click here{{/trackingLink}} to learn more about the ' +
 															'data you will be sharing and opt-out options.',
 														'woocommerce-payments'

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1252,6 +1252,10 @@ class WC_Payments {
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-set-up-stripelink.php';
 			WC_Payments_Notes_Set_Up_StripeLink::set_gateway( self::get_gateway() );
 			WC_Payments_Notes_Set_Up_StripeLink::possibly_add_note();
+
+			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-woopay-beta-recruitment.php';
+			WC_Payments_Notes_WooPay_Beta_Recruitment::set_platform_checkout_button_handler( self::$platform_checkout_button_handler );
+			WC_Payments_Notes_WooPay_Beta_Recruitment::possibly_add_note();
 		}
 
 		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '7.5', '<' ) && get_woocommerce_currency() === 'NOK' ) {

--- a/includes/notes/class-wc-payments-notes-woopay-beta-recruitment.php
+++ b/includes/notes/class-wc-payments-notes-woopay-beta-recruitment.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Display a notice to merchants explaining that WooPay is now available.
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+
+defined( 'ABSPATH' ) || exit;
+
+
+
+/**
+ * Class WC_Payments_Notes_WooPay_Beta_Recruitment
+ */
+class WC_Payments_Notes_WooPay_Beta_Recruitment {
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-payments-notes-woopay-beta-recruitment';
+
+	/**
+	 * Nonce action name
+	 */
+	const NOTE_ACTION = 'woopay-beta-recruitment';
+
+	/**
+	 * Minimum WCPay version to enable WooPay
+	 */
+	const MINIMUM_WCPAY_VERSION = '5.7.1';
+
+	/**
+	 * Platform checkout button handler
+	 *
+	 * @var WC_Payments_Platform_Checkout_Button_Handler
+	 */
+	private static $platform_checkout_button_handler;
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		$note = new Note();
+
+		$note->set_title( self::get_title() );
+		$note->set_content( self::get_content() );
+		$note->set_content_data( (object) [] );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-payments' );
+
+		if ( ! self::has_minimum_wcpay_version() ) {
+			$note->add_action(
+				self::NOTE_NAME,
+				__( 'Update WooCommerce Payments', 'woocommerce-payments' ),
+				admin_url( 'plugins.php' ),
+				Note::E_WC_ADMIN_NOTE_UNACTIONED,
+				true
+			);
+		} elseif ( ! self::is_woopay_enabled() ) {
+			$note->add_action(
+				self::NOTE_NAME,
+				__( 'Get started in seconds.', 'woocommerce-payments' ),
+				admin_url( 'admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments&method=platform_checkout' ),
+				Note::E_WC_ADMIN_NOTE_UNACTIONED,
+				true
+			);
+		}
+
+		return $note;
+	}
+
+	/**
+	 * Sets the platform checkout button handler on the class.
+	 *
+	 * @param WC_Payments_Platform_Checkout_Button_Handler $platform_checkout_button_handler Platform checkout button handler instance.
+	 * @return void
+	 */
+	public static function set_platform_checkout_button_handler( $platform_checkout_button_handler ) {
+		self::$platform_checkout_button_handler = $platform_checkout_button_handler;
+	}
+
+	/**
+	 * Returns title for note, depending on certain conditions.
+	 *
+	 * @return string
+	 */
+	private static function get_title() {
+		return self::is_woopay_enabled() ?
+			__( 'WooPay is back!', 'woocommerce-payments' ) :
+			__( 'Increase conversions with WooPay - our fastest checkout yet', 'woocommerce-payments' );
+	}
+
+	/**
+	 * Returns content for note, depending on certain conditions.
+	 *
+	 * @return string
+	 */
+	private static function get_content() {
+		if ( self::is_woopay_enabled() ) {
+			if ( self::has_minimum_wcpay_version() ) {
+				return __( 'Thank you for previously trying WooPay—a new express checkout feature built into WooCommerce Payments. We’re excited to announce that WooPay availability has resumed. No action is required on your part. You can now continue boosting conversions by offering your customers a simple, secure way to pay with a single click.', 'woocommerce-payments' );
+			} else {
+				return __( 'Thank you for previously trying WooPay—a new express checkout feature built into WooCommerce Payments. We’re excited to announce that WooPay availability has resumed. Update WooCommerce Payments to continue boosting conversions by offering your customers a simple, secure way to pay with a single click.', 'woocommerce-payments' );
+			}
+		} else {
+			if ( self::has_minimum_wcpay_version() ) {
+				return __( 'WooPay, a new express checkout feature built into WooCommerce Payments, is now available—and you’re invited to be one of the first to try it. Boost conversions by offering your customers a simple, secure way to pay with a single click.', 'woocommerce-payments' );
+			} else {
+				return __( 'WooPay, a new express checkout feature built into WooCommerce Payments, is now available—and you’re invited to try it. Boost conversions by offering customers a simple, secure way to pay with a single click. Update WooCommerce Payments to get started.', 'woocommerce-payments' );
+			}
+		}
+	}
+
+	/**
+	 * Checks whether store has minimum WCPay version.
+	 *
+	 * @return boolean
+	 */
+	private static function has_minimum_wcpay_version() {
+		return version_compare( self::MINIMUM_WCPAY_VERSION, get_option( 'woocommerce_woocommerce_payments_version' ), '>=' );
+	}
+
+	/**
+	 * Checks whether merchant has enabled WooPay.
+	 *
+	 * @return boolean
+	 */
+	private static function is_woopay_enabled() {
+		return self::$platform_checkout_button_handler->is_woopay_enabled();
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
This PR ensures that the legal mandate for WooPay is shown on all WooPay settings pages (**Payments > Settings > Express checkouts** & **Payments > Settings > Customize WooPay**) before WooPay is enabled. While WooPay is disabled, this mandate should be presented to the store owner; however, it should disappear when the enable WooPay checkbox is selected.

We also add a new remote inbox notification for WooPay recruitment that will be displayed on the WooCommerce dashboard. You can refer to [this document](https://docs.google.com/document/d/1k4nfuuDnvnaG5Q3jtHynFderXnpTXacssvOGoV0A3oI/edit#heading=h.fkp3ze9csydw) for the conditional details and actions for this RIN, but allow me to summarise below.

### Merchant has enabled WooPay AND required WCPay version (5.7.1) is installed

*Notification content:*

>WooPay is back!
>
>Thank you for previously trying WooPay — a new express checkout feature built into WooCommerce Payments. We’re excited to announce that WooPay availability has resumed. No action is required on your part.
>
>You can now continue boosting conversions by offering your customers a simple, secure way to pay with a single click.

*Notification action:* No action

### Merchant has enabled WooPay AND required WCPay version (5.7.1) is not installed

*Notification content:*

>WooPay is back!
>
>Thank you for previously trying WooPay — a new express checkout feature built into WooCommerce Payments. We’re excited to announce that WooPay availability has resumed.
>
>Update WooCommerce Payments to continue boosting conversions by offering your customers a simple, secure way to pay with a single click.

*Notification action:* Redirect to plugins page to update plugin.

### Merchant has not enabled WooPay AND required WCPay version (5.7.1) is installed

*Notification content:*

>Increase conversions with WooPay — our fastest checkout yet
>
>Boost conversions by offering your customers a simple, secure way to pay with a single click.
>
>Get started in seconds.

*Notification action:* Redirect to WooPay settings to enable WooPay

### Merchant has not enabled WooPay AND required WCPay version (5.7.1) is not installed

*Notification content:*

>Increase conversions with WooPay — our fastest checkout yet
>
>Boost conversions by offering your customers a simple, secure way to pay with a single click.
>
>Update WooCommerce Payments to get started.

*Notification action:* Redirect to plugins page to update plugin.
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Pull this PR and ensure site is eligible for WooPay.
2. Go to WooCommerce dashboard and there should be one of the above notices in your inbox. Confirm notification message and action are correct and appropriate.
3. To restart this to receive a new notification, delete the row in your `wp_wc_admin_notes` table with `name` value of "wc-payments-notes-woopay-beta-recruitment".
4. Retry with WooPay enabled and disabled in your WCPay settings. 
5. Retry with different values for your current WCPay version (you can fake this using a snippet or by editing the row in your `wp_options` with `option_name` of `woocommerce_woocommerce_payments_version`).

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
