### PR TITLE
Adds toggled legal mandate to all WooPay settings pages

### DIFF
--- a/changelog/add-woopay-settings-legal-mandate-toggle
+++ b/changelog/add-woopay-settings-legal-mandate-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Updates legal mandate displayed prior to enabling WooPay.

--- a/client/settings/express-checkout-settings/platform-checkout-settings.js
+++ b/client/settings/express-checkout-settings/platform-checkout-settings.js
@@ -71,13 +71,13 @@ const PlatformCheckoutSettings = ( { section } ) => {
 							/* eslint-disable jsx-a11y/anchor-has-content */
 							isPlatformCheckoutEnabled
 								? __(
-										'Boost conversion and customer loyalty by offering a single click, secure way to pay.',
+										'When enabled, customers will be able to checkout using WooPay.',
 										'woocommerce-payments'
 								  )
 								: interpolateComponents( {
 										mixedString: __(
 											/* eslint-disable-next-line max-len */
-											'Boost conversion and customer loyalty by offering a single click, secure way to pay. ' +
+											'When enabled, customers will be able to checkout using WooPay. ' +
 												'In order to use {{wooPayLink}}WooPay{{/wooPayLink}}, you must agree to our ' +
 												'{{tosLink}}WooCommerce Terms of Service{{/tosLink}} ' +
 												'and {{privacyLink}}Privacy Policy{{/privacyLink}}. ' +

--- a/client/settings/express-checkout-settings/platform-checkout-settings.js
+++ b/client/settings/express-checkout-settings/platform-checkout-settings.js
@@ -78,10 +78,9 @@ const PlatformCheckoutSettings = ( { section } ) => {
 										mixedString: __(
 											/* eslint-disable-next-line max-len */
 											'When enabled, customers will be able to checkout using WooPay. ' +
-												'By using {{wooPayLink}}WooPay{{/wooPayLink}}, you agree to our ' +
+												'In order to use {{wooPayLink}}WooPay{{/wooPayLink}}, you must agree to our ' +
 												'{{tosLink}}WooCommerce Terms of Service{{/tosLink}} ' +
-												'and and {{privacyLink}}Privacy Policy{{/privacyLink}}. ' +
-												'You understand you will be sharing data with us. ' +
+												'and {{privacyLink}}Privacy Policy{{/privacyLink}}. ' +
 												'{{trackingLink}}Click here{{/trackingLink}} to learn more about the ' +
 												'data you will be sharing and opt-out options.',
 											'woocommerce-payments'

--- a/client/settings/express-checkout-settings/platform-checkout-settings.js
+++ b/client/settings/express-checkout-settings/platform-checkout-settings.js
@@ -71,13 +71,13 @@ const PlatformCheckoutSettings = ( { section } ) => {
 							/* eslint-disable jsx-a11y/anchor-has-content */
 							isPlatformCheckoutEnabled
 								? __(
-										'When enabled, customers will be able to checkout using WooPay.',
+										'Boost conversion and customer loyalty by offering a single click, secure way to pay.',
 										'woocommerce-payments'
 								  )
 								: interpolateComponents( {
 										mixedString: __(
 											/* eslint-disable-next-line max-len */
-											'When enabled, customers will be able to checkout using WooPay. ' +
+											'Boost conversion and customer loyalty by offering a single click, secure way to pay. ' +
 												'In order to use {{wooPayLink}}WooPay{{/wooPayLink}}, you must agree to our ' +
 												'{{tosLink}}WooCommerce Terms of Service{{/tosLink}} ' +
 												'and {{privacyLink}}Privacy Policy{{/privacyLink}}. ' +

--- a/client/settings/express-checkout-settings/platform-checkout-settings.js
+++ b/client/settings/express-checkout-settings/platform-checkout-settings.js
@@ -5,6 +5,7 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Card, CheckboxControl, TextControl } from '@wordpress/components';
+import interpolateComponents from '@automattic/interpolate-components';
 
 /**
  * Internal dependencies
@@ -66,10 +67,58 @@ const PlatformCheckoutSettings = ( { section } ) => {
 						checked={ isPlatformCheckoutEnabled }
 						onChange={ updateIsPlatformCheckoutEnabled }
 						label={ __( 'Enable WooPay', 'woocommerce-payments' ) }
-						help={ __(
-							'When enabled, customers will be able to checkout using WooPay',
-							'woocommerce-payments'
-						) }
+						help={
+							/* eslint-disable jsx-a11y/anchor-has-content */
+							isPlatformCheckoutEnabled
+								? __(
+										'When enabled, customers will be able to checkout using WooPay.',
+										'woocommerce-payments'
+								  )
+								: interpolateComponents( {
+										mixedString: __(
+											/* eslint-disable-next-line max-len */
+											'When enabled, customers will be able to checkout using WooPay. ' +
+												'By using {{wooPayLink}}WooPay{{/wooPayLink}}, you agree to our ' +
+												'{{tosLink}}WooCommerce Terms of Service{{/tosLink}} ' +
+												'and and {{privacyLink}}Privacy Policy{{/privacyLink}}. ' +
+												'You understand you will be sharing data with us. ' +
+												'{{trackingLink}}Click here{{/trackingLink}} to learn more about the ' +
+												'data you will be sharing and opt-out options.',
+											'woocommerce-payments'
+										),
+										components: {
+											wooPayLink: (
+												<a
+													target="_blank"
+													rel="noreferrer"
+													href="https://woocommerce.com/document/woopay-merchant-documentation/"
+												/>
+											),
+											tosLink: (
+												<a
+													target="_blank"
+													rel="noreferrer"
+													href="https://wordpress.com/tos/"
+												/>
+											),
+											privacyLink: (
+												<a
+													target="_blank"
+													rel="noreferrer"
+													href="https://automattic.com/privacy/"
+												/>
+											),
+											trackingLink: (
+												<a
+													target="_blank"
+													rel="noreferrer"
+													href="https://woocommerce.com/usage-tracking/"
+												/>
+											),
+										},
+								  } )
+							/* eslint-enable jsx-a11y/anchor-has-content */
+						}
 					/>
 					<h4>
 						{ __(

--- a/client/settings/express-checkout/index.js
+++ b/client/settings/express-checkout/index.js
@@ -139,10 +139,9 @@ const ExpressCheckout = () => {
 													mixedString: __(
 														/* eslint-disable-next-line max-len */
 														'Boost conversion and customer loyalty by offering a single click, secure way to pay. ' +
-															'By using {{wooPayLink}}WooPay{{/wooPayLink}}, you agree to our ' +
+															'In order to use {{wooPayLink}}WooPay{{/wooPayLink}}, you must agree to our ' +
 															'{{tosLink}}WooCommerce Terms of Service{{/tosLink}} ' +
-															'and and {{privacyLink}}Privacy Policy{{/privacyLink}}. ' +
-															'You understand you will be sharing data with us. ' +
+															'and {{privacyLink}}Privacy Policy{{/privacyLink}}. ' +
 															'{{trackingLink}}Click here{{/trackingLink}} to learn more about the ' +
 															'data you will be sharing and opt-out options.',
 														'woocommerce-payments'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
Updates legal mandate displayed alongside the checkbox to enable WooPay inside WCPay settings, ensures that this mandate is presented in both places where WooPay is enabled, and toggles mandate depending on WooPay status.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
Here is the copy for this legal mandate.

>In order to use WooPay, you must agree to our [WooCommerce Terms of Service](https://wordpress.com/tos/) and [Privacy Policy](https://automattic.com/privacy/). [Click here](https://href.li/?https://woocommerce.com/usage-tracking/) to learn more about the data you will be sharing and opt-out options.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
1. Pull the changes in this PR.
2. Go to WCPay settings (Payments > Settings). When checkbox to enable WooPay is not selected, above mandate should be present on page. When checkbox is selected, mandate should disappear.
3. Go to Customize WooPay settings (Payments > Settings > Customize WooPay). When checkbox to enable WooPay is not selected, above mandate should be present on page. When checkbox is selected, mandate should disappear.
4. Copy and hyperlinks should match as above.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
