### PR TITLE
Update subscriptions-core to 5.6.0

### DIFF
--- a/changelog/subscriptions-core-5.6.0
+++ b/changelog/subscriptions-core-5.6.0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update subscriptions-core to 5.6.0.

--- a/changelog/subscriptions-core-5.6.0-1
+++ b/changelog/subscriptions-core-5.6.0-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correctly determine subscription free shipping eligibility when the initial payment cart isn't eligible. Fixes erroneous "Invalid recurring shipping method" errors on checkout.

--- a/changelog/subscriptions-core-5.6.0-2
+++ b/changelog/subscriptions-core-5.6.0-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fixed precision loss notice that occurs when running PHP 8.1.

--- a/changelog/subscriptions-core-5.6.0-3
+++ b/changelog/subscriptions-core-5.6.0-3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix phpcs and semgrep warnings to improve code quality.

--- a/changelog/subscriptions-core-5.6.0-4
+++ b/changelog/subscriptions-core-5.6.0-4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Use `wp_safe_redirect()` when processing a payment method change request.

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
       "automattic/jetpack-autoloader": "2.11.18",
       "automattic/jetpack-identity-crisis": "0.8.43",
       "automattic/jetpack-sync": "1.47.7",
-      "woocommerce/subscriptions-core": "5.5.0"
+      "woocommerce/subscriptions-core": "5.6.0"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce62d17e19b9c2e9e2d60147e1685590",
+    "content-hash": "783aa9cf01d47443baa8a3c61bc68a9d",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -940,16 +940,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "5.5.0",
+            "version": "5.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "5f114e1fad79196a24f189236c9e7fb04482b8a2"
+                "reference": "a923da64ef4e5c4b7747fa81f4b496ca4dfb6298"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/5f114e1fad79196a24f189236c9e7fb04482b8a2",
-                "reference": "5f114e1fad79196a24f189236c9e7fb04482b8a2",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/a923da64ef4e5c4b7747fa81f4b496ca4dfb6298",
+                "reference": "a923da64ef4e5c4b7747fa81f4b496ca4dfb6298",
                 "shasum": ""
             },
             "require": {
@@ -990,10 +990,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/5.5.0",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/5.6.0",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2023-03-10T02:33:18+00:00"
+            "time": "2023-04-19T23:37:10+00:00"
         }
     ],
     "packages-dev": [
@@ -6464,5 +6464,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
This PR updates the subscriptions-core library version from 5.5.0 to [5.6.0](https://github.com/Automattic/woocommerce-subscriptions-core/releases/tag/5.6.0).

5.6.0 includes the following changes, for which a WCPay changelog entry has been created via `npm run changelog`:

```
* Fix - Correctly determine subscription free shipping eligibility when the initial payment cart isn't eligible. Fixes erroneous "Invalid recurring shipping method" errors on checkout. #409
* Dev - Fixed precision loss notice that occurs when running PHP 8.1. #428
* Dev - Fix phpcs and semgrep warnings to improve code quality. #429
* Dev - Use `wp_safe_redirect()` when processing a payment method change request. #429
```