### PR TITLE
Clear account cache on update plugin

### DIFF
--- a/changelog/add-clear-cache-on-update-plugin
+++ b/changelog/add-clear-cache-on-update-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Clear account cache on update plugin

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -73,6 +73,7 @@ class WC_Payments_Account {
 		add_filter( 'allowed_redirect_hosts', [ $this, 'allowed_redirect_hosts' ] );
 		add_action( 'jetpack_site_registered', [ $this, 'clear_cache' ] );
 		add_action( 'updated_option', [ $this, 'possibly_update_wcpay_account_locale' ], 10, 3 );
+		add_action( 'woocommerce_woocommerce_payments_updated', [ $this, 'clear_cache' ] );
 
 		// Add capital offer redirection.
 		add_action( 'admin_init', [ $this, 'maybe_redirect_to_capital_offer' ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Forced-feature-flag refresh on WCPay update so merchants can enable WooPay immediately.

Slack: p1681860640595309-slack-C043JN7AJHY


#### Testing instructions
1. Go to WCPay Dev
2. Search `'platform_checkout_eligible' => false` in settings
3. Go to WCPay Server's Mission Control and enable WooPay for your blog
4. Go back to WCPay Dev and make sure `platform_checkout_eligible` is still `false`
5. Update WCPay to a higher version by changing the version to `5.7.1-woopay`.  If you need to re-run this, you can delete `woocommerce_woocommerce_payments_version` in the `wp_options` table.
6. Go back to WCPay Dev and check `platform_checkout_eligible` has been updated to `true`

-------------------

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.