### PR TITLE
Update `@wordpress/url` to v3.7.1

### DIFF
--- a/changelog/update-wordpress-date-dependency
+++ b/changelog/update-wordpress-date-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update @wordpress/url to v3.7.1

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -43,6 +43,7 @@ to catalog our packages and provide guidance to a developer who wants to test an
 | [husky](https://www.npmjs.com/package/husky) |  Used to run hooks pre/post commit, like automatically running PHPCS. | Check out another branch `composer install` should run automatically. |  |
 | [lodash](https://www.npmjs.com/package/lodash) | Lodash makes JavaScript easier by taking the hassle out of working with arrays, numbers, objects, strings, etc. | JS tests should pass. |  |
 | [node](https://www.npmjs.com/package/node) | Not a package, but we declare the supported version of node in our `.nvmrc` file. We use node to build the JavaScript for the plugin and run the JavaScript unit tests. | Ensure you're running the new version of node by running the `nvm use` command or manually setting up the correct version. For minor and patch upgrades testing that the build runs is sufficient. For major versions, smoke testing the running plugin would be advised. | |
+| [@wordpress/url](https://www.npmjs.com/package/@wordpress/url) | A collection of utilities to manipulate URLs.| JS unit tests are passing| |
 
 ### PHP Runtime Dependencies
 | Package Name | Usage Summary | Testing | Notes |

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "@wordpress/jest-preset-default": "4.0.0",
         "@wordpress/plugins": "4.0.6",
         "@wordpress/scripts": "12.6.0",
-        "@wordpress/url": "3.30.0",
+        "@wordpress/url": "3.7.1",
         "archiver": "5.2.0",
         "babel-loader": "8.2.2",
         "chalk": "4.1.2",
@@ -12989,6 +12989,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wordpress/e2e-test-utils/node_modules/@wordpress/url": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.32.0.tgz",
+      "integrity": "sha512-dbz4KjcwYxkd2GsJwNVXD6Do39W13jlGmsLgWkSe/4dEw4SnaJQVYJv3yBpykmYqbfwilPrSM/KmpybKeghPFA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "remove-accents": "^0.4.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@wordpress/e2e-test-utils/node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -16804,13 +16817,13 @@
       }
     },
     "node_modules/@wordpress/url": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.30.0.tgz",
-      "integrity": "sha512-RtvReNo2TRuorS4JdgVeV53mgDJeMrWokCiE4LV2oTdguGuBrlQ3YcywEApfZMkoAY7MSwxexy1WAfyBdee/qg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.7.1.tgz",
+      "integrity": "sha512-wX/Uck/If+/b8nLhB3UazLMlG7s6jjHv7isG/+/QCaJ01cf/VXXg8x6bRWnoB84ObhwBbBiM4rDTperge7+elg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "remove-accents": "^0.4.2"
+        "lodash": "^4.17.21"
       },
       "engines": {
         "node": ">=12"
@@ -36099,9 +36112,9 @@
       "dev": true
     },
     "node_modules/remove-accents": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.3.tgz",
-      "integrity": "sha512-bwzzFccF6RgWWt+KrcEpCDMw9uCwz5GCdyo+r4p2hu6PhqtlEMOXEO0uPAw6XmVYAnODxHaqLanhUY1lqmsNFw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+      "integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
       "dev": true
     },
     "node_modules/remove-trailing-separator": {
@@ -53157,6 +53170,16 @@
             "lodash": "^4.17.21"
           }
         },
+        "@wordpress/url": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.32.0.tgz",
+          "integrity": "sha512-dbz4KjcwYxkd2GsJwNVXD6Do39W13jlGmsLgWkSe/4dEw4SnaJQVYJv3yBpykmYqbfwilPrSM/KmpybKeghPFA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "remove-accents": "^0.4.2"
+          }
+        },
         "form-data": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -56175,13 +56198,13 @@
       }
     },
     "@wordpress/url": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.30.0.tgz",
-      "integrity": "sha512-RtvReNo2TRuorS4JdgVeV53mgDJeMrWokCiE4LV2oTdguGuBrlQ3YcywEApfZMkoAY7MSwxexy1WAfyBdee/qg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.7.1.tgz",
+      "integrity": "sha512-wX/Uck/If+/b8nLhB3UazLMlG7s6jjHv7isG/+/QCaJ01cf/VXXg8x6bRWnoB84ObhwBbBiM4rDTperge7+elg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "remove-accents": "^0.4.2"
+        "lodash": "^4.17.21"
       }
     },
     "@wordpress/viewport": {
@@ -71337,9 +71360,9 @@
       "dev": true
     },
     "remove-accents": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.3.tgz",
-      "integrity": "sha512-bwzzFccF6RgWWt+KrcEpCDMw9uCwz5GCdyo+r4p2hu6PhqtlEMOXEO0uPAw6XmVYAnODxHaqLanhUY1lqmsNFw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.4.tgz",
+      "integrity": "sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==",
       "dev": true
     },
     "remove-trailing-separator": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@wordpress/jest-preset-default": "4.0.0",
     "@wordpress/plugins": "4.0.6",
     "@wordpress/scripts": "12.6.0",
-    "@wordpress/url": "3.30.0",
+    "@wordpress/url": "3.7.1",
     "archiver": "5.2.0",
     "babel-loader": "8.2.2",
     "chalk": "4.1.2",


### PR DESCRIPTION
Fixes #6077

#### Changes proposed in this Pull Request

- Update the version of `@wordpress/url` to 3.7.1
- Add an entry in the dependencies doc

This is a downgrade to match what [WP L-2](https://github.com/WordPress/wordpress-develop/blob/6.0.3/package.json#L129) is using

#### Testing instructions

- JS tests are passing

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
