### PR TITLE
Hide WooPay button when logged out and subscriptions involved

### DIFF
--- a/changelog/add-woopay-unavailable-for-subscriptions-when-logged-out
+++ b/changelog/add-woopay-unavailable-for-subscriptions-when-logged-out
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Hide WooPay button in unsupported contexts

--- a/includes/class-wc-payments-platform-checkout-button-handler.php
+++ b/includes/class-wc-payments-platform-checkout-button-handler.php
@@ -531,6 +531,23 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 			return false;
 		}
 
+		if ( ! is_user_logged_in() ) {
+			// On product page for a subscription product, but not logged in, making WooPay unavailable.
+			if ( $this->is_product() ) {
+				$current_product = wc_get_product();
+
+				if ( $current_product && $this->is_product_subscription( $current_product ) ) {
+					return false;
+				}
+			}
+
+			// On cart or checkout page with a subscription product in cart, but not logged in, making WooPay unavailable.
+			if ( ( $this->is_checkout() || $this->is_cart() ) && class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) {
+				// Check cart for subscription products.
+				return false;
+			}
+		}
+
 		/**
 		 * TODO: We need to do some research here and see if there are any product types that we
 		 * absolutely cannot support with WooPay at this time. There are some examples in the
@@ -622,5 +639,16 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Returns true if the provided WC_Product is a subscription, false otherwise.
+	 *
+	 * @param WC_Product $product The product to check.
+	 *
+	 * @return bool  True if product is subscription, false otherwise.
+	 */
+	private function is_product_subscription( WC_Product $product ): bool {
+		return 'subscription' === $product->get_type() || 'subscription_variation' === $product->get_type();
 	}
 }

--- a/includes/class-wc-payments-platform-checkout-button-handler.php
+++ b/includes/class-wc-payments-platform-checkout-button-handler.php
@@ -654,7 +654,9 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 	 * @return bool  True if product is subscription, false otherwise.
 	 */
 	private function is_product_subscription( WC_Product $product ): bool {
-		return 'subscription' === $product->get_type() || 'subscription_variation' === $product->get_type();
+		return 'subscription' === $product->get_type()
+			|| 'subscription_variation' === $product->get_type()
+			|| 'variable-subscription' === $product->get_type();
 	}
 
 	/**

--- a/includes/class-wc-payments-platform-checkout-button-handler.php
+++ b/includes/class-wc-payments-platform-checkout-button-handler.php
@@ -546,6 +546,11 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 				// Check cart for subscription products.
 				return false;
 			}
+
+			// If guest checkout is not allowed, and customer is not logged in, disable the WooPay button.
+			if ( ! $this->is_guest_checkout_enabled() ) {
+				return false;
+			}
 		}
 
 		/**
@@ -650,5 +655,14 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 	 */
 	private function is_product_subscription( WC_Product $product ): bool {
 		return 'subscription' === $product->get_type() || 'subscription_variation' === $product->get_type();
+	}
+
+	/**
+	 * Returns true if guest checkout is enabled, false otherwise.
+	 *
+	 * @return bool  True if guest checkout is enabled, false otherwise.
+	 */
+	private function is_guest_checkout_enabled(): bool {
+		return 'yes' === get_option( 'woocommerce_enable_guest_checkout', 'no' );
 	}
 }


### PR DESCRIPTION
Fixes #6131 

## Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

> **Note**
> "Subscription product" here refers to both WC Subscriptions products and WCPay Subscriptions products.

Do not show WooPay button when:

- The customer is not logged into the merchant store and a subscription product is in the cart.
- The customer is not logged into the merchant store and is looking at a subscription product page.
- The customer is not logged into the merchant store and the **WooCommerce → Accounts & Privacy → Allow customers to place orders without an account** setting is disabled.


| \ | Logged In | Logged Out |
|:---:|:---:|:---:|
| Product | <img width="843" alt="image" src="https://user-images.githubusercontent.com/13835680/233756374-2c3b5e6e-877c-472b-8255-80cc7b36e703.png"> | <img width="843" alt="image" src="https://user-images.githubusercontent.com/13835680/233756440-e0912e7c-a476-4ac0-b4ad-ec9f1b1750df.png"> |
| Cart | <img width="843" alt="image" src="https://user-images.githubusercontent.com/13835680/233756396-26878ee1-0c28-4ced-9454-f02afb7cfb31.png"> | <img width="843" alt="image" src="https://user-images.githubusercontent.com/13835680/233756455-4ab75c9e-9a7d-4edb-977e-8553a806cef9.png"> |
| Checkout | <img width="843" alt="image" src="https://user-images.githubusercontent.com/13835680/233756418-0d7bc347-1cd4-416d-82f5-7f90b6fbea77.png"> | <img width="843" alt="image" src="https://user-images.githubusercontent.com/13835680/233756471-cc15fce6-3b95-43d5-b3bb-570540091106.png"> |

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> **Warning**
> The following testing instructions assume you have the WooPay button enabled everywhere it can possibly be:
>
> <img width="481" alt="image" src="https://user-images.githubusercontent.com/13835680/233755952-936ae028-98ca-4668-b96d-4f36b968b3e9.png">


### Logged-out customer


#### Doesn't see WooPay button on subscription product page

1. Create a **Simple Subscription** product if you haven't already.
2. Navigate to that product's page.
3. Make sure the WooPay button isn't visible.

Repeat the test with a **Variable Subscription** product.


#### Does see WooPay button on a non-subscription product page

1. Create a product that **is not** a Simple or Variable Subscription if you haven't already.
2. Navigate to that product's page.
3. Make sure the WooPay button is visible.

Repeat the test with all non-subscription type products.


#### Doesn't see WooPay button on cart page when a subscription product is in the cart

1. Create a **Simple Subscription** product and a product that **is not** a Simple or Variable Subscription if you haven't already.
2. Add that product to the cart.
3. Navigate to the **Cart** page.
4. Make sure the WooPay button isn't visible.
5. Add another non-subscription product to the cart and navigate back to the **Cart** page.
6. Make sure the WooPay button isn't visible.

Repeat the test with a **Variable Subscription** product and 2-3 different sets and amounts of subscription and non-subscription products.

Check with a mix of subscription and non-subscription products as well.


#### Does see WooPay button on cart page when all products in the cart are non-subscription products

1. Create a product that **is not** a Simple or Variable Subscription if you haven't already.
2. Add any number of non-subscription products to the cart.
3. Navigate to the **Cart** page.
4. Make sure the WooPay button is visible.


#### Doesn't see WooPay button on checkout page when a subscription product is in the cart

1. Create a **Simple Subscription** product and a product that **is not** a Simple or Variable Subscription if you haven't already.
2. Add that product to the cart.
3. Navigate to the **Checkout** page.
4. Make sure the WooPay button isn't visible.
5. Add another non-subscription product to the cart and navigate back to the **Checkout** page.
6. Make sure the WooPay button isn't visible.

Repeat the test with a **Variable Subscription** product and 2-3 different sets and amounts of subscription and non-subscription products.

Check with a mix of subscription and non-subscription products as well.


#### Does see WooPay button on checkout page when all products in the cart are non-subscription products

1. Create a product that **is not** a Simple or Variable Subscription if you haven't already.
2. Add any number of non-subscription products to the cart.
3. Navigate to the **Checkout** page.
4. Make sure the WooPay button is visible.


#### Doesn't see WooPay button anywhere when the **WooCommerce → Accounts & Privacy → Allow customers to place orders without an account** setting is disabled

1. Go to **WooCommerce → Accounts & Privacy** and make sure the **Allow customers to place orders without an account** is disabled.
2. Navigate to any product page and make sure the WooPay button is not visible.
3. Add the product to the cart.
4. Navigate to the **Cart** page and make sure the WooPay button is not visible.
5. Navigate to the **Checkout** page and make sure the WooPay button is not visible.

Repeat steps 1-5 with different types of products, e.g. try with a simple product, simple subscription, and a variable product.


### Logged-in customer

#### Does see WooPay button on a subscription product page

1. Create a **Simple Subscription** product if you haven't already.
7. Navigate to that product's page.
8. Make sure the WooPay button is visible.

Repeat the test with a **Variable Subscription** product.


#### Does see WooPay button on cart page when a subscription product is in the cart

1. Create a **Simple Subscription** product and a product that **is not** a Simple or Variable Subscription if you haven't already.
2. Add that product to the cart.
3. Navigate to the **Cart** page.
9. Make sure the WooPay button isn't visible.
10. Add another non-subscription product to the cart and navigate back to the **Cart** page.
11. Make sure the WooPay button is visible.

Repeat the test with a **Variable Subscription** product and 2-3 different sets and amounts of subscription and non-subscription products.

Check with a mix of subscription and non-subscription products as well.


#### Does see WooPay button on checkout page when a subscription product is in the cart

1. Create a **Simple Subscription** product and a product that **is not** a Simple or Variable Subscription if you haven't already.
2. Add that product to the cart.
3. Navigate to the **Checkout** page.
4. Make sure the WooPay button isn't visible.
6. Add another non-subscription product to the cart and navigate back to the **Checkout** page.
7. Make sure the WooPay button is visible.

Repeat the test with a **Variable Subscription** product and 2-3 different sets and amounts of subscription and non-subscription products.

Check with a mix of subscription and non-subscription products as well.


#### Does see WooPay button everywhere when the **WooCommerce → Accounts & Privacy → Allow customers to place orders without an account** setting is disabled

1. Go to **WooCommerce → Accounts & Privacy** and make sure the **Allow customers to place orders without an account** is disabled.
2. Navigate to any product page and make sure the WooPay button is visible.
3. Add the product to the cart.
4. Navigate to the **Cart** page and make sure the WooPay button is visible.
5. Navigate to the **Checkout** page and make sure the WooPay button is visible.

Repeat steps 1-5 with different types of products, e.g. try with a simple product, simple subscription, and a variable product.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
