### PR TITLE
Fix WC requires header to omit the patch version

### DIFF
--- a/changelog/fix-wc-header-version
+++ b/changelog/fix-wc-header-version
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Minor fix for the WC header version
+
+

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ Our global support team is available to answer questions you may have about WooC
 = Requirements =
 
 * WordPress 6.0 or newer.
-* WooCommerce 7.4.1 or newer.
+* WooCommerce 7.4 or newer.
 * PHP 7.2 or newer is recommended.
 
 = Try it now =

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Woo: 5278104:bf3cf30871604e15eec560c962593c1f
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
- * WC requires at least: 7.4.1
+ * WC requires at least: 7.4
  * WC tested up to: 7.6.0
  * Requires at least: 6.0
  * Requires PHP: 7.2


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

- We should stick to `x.y` format for the WC "requires at least" header, otherwise the woorelease `wcpay"bump-versions` command will not be able to parse it