### PR TITLE
Update @wordpress/api-fetch dependency to version 6.3.1

### DIFF
--- a/changelog/update-dependency-wordpress-api-fetch
+++ b/changelog/update-dependency-wordpress-api-fetch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update @wordpress/api-fetch to v6.3.1

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -47,7 +47,7 @@ to catalog our packages and provide guidance to a developer who wants to test an
 | [@wordpress/url](https://www.npmjs.com/package/@wordpress/url) | A collection of utilities to manipulate URLs.| JS unit tests are passing| |
 | [@wordpress/data](https://www.npmjs.com/package/@wordpress/data) | It serves as a hub to manage application state for both plugins and WordPress itself, providing tools to manage data within and between distinct modules.| JS unit tests are passing| |
 | [@wordpress/i18n](https://www.npmjs.com/package/@wordpress/i18n) | Internationalization utilities for client-side localization.| JS unit tests are passing. | The `wpi18n` used in `postbuild:client` script comes from `node-wp-i18n` and is thus separate from this. |
-| [@wordpress/api-fetch](https://www.npmjs.com/package/@wordpress/api-fetch) | Utility to make WordPress REST API requests. | JS tests should pass. | |
+| [@wordpress/api-fetch](https://www.npmjs.com/package/@wordpress/api-fetch) | Utility to make WordPress REST API requests. | JS unit tests are passing. | |
 
 ### PHP Runtime Dependencies
 | Package Name | Usage Summary | Testing | Notes |

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -45,7 +45,7 @@ to catalog our packages and provide guidance to a developer who wants to test an
 | [node](https://www.npmjs.com/package/node) | Not a package, but we declare the supported version of node in our `.nvmrc` file. We use node to build the JavaScript for the plugin and run the JavaScript unit tests. | Ensure you're running the new version of node by running the `nvm use` command or manually setting up the correct version. For minor and patch upgrades testing that the build runs is sufficient. For major versions, smoke testing the running plugin would be advised. | |
 | [@woocommerce/currency](https://www.npmjs.com/package/@woocommerce/currency) | A collection of utilities to display and work with currency values. | JS tests should pass.	 | |
 | [@wordpress/url](https://www.npmjs.com/package/@wordpress/url) | A collection of utilities to manipulate URLs.| JS unit tests are passing| |
-
+| [@wordpress/api-fetch](https://www.npmjs.com/package/@wordpress/api-fetch) | Utility to make WordPress REST API requests. | JS tests should pass. | |
 ### PHP Runtime Dependencies
 | Package Name | Usage Summary | Testing | Notes |
 | ------------ | ------------- | ------- | ----- |

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@woocommerce/e2e-utils": "0.2.0",
         "@woocommerce/eslint-plugin": "1.1.0",
         "@woocommerce/experimental": "2.1.0",
-        "@wordpress/api-fetch": "5.1.1",
+        "@wordpress/api-fetch": "6.3.1",
         "@wordpress/babel-plugin-makepot": "4.2.0",
         "@wordpress/babel-preset-default": "7.4.0",
         "@wordpress/base-styles": "3.5.4",
@@ -10807,14 +10807,46 @@
       }
     },
     "node_modules/@wordpress/api-fetch": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-5.1.1.tgz",
-      "integrity": "sha512-pThYQhoKiePeGgb5aZnc4A9YT5WktfZkejSk4JIfFxdzXF7YXunyMoA9Aib2YvY94IkItLzBeTl/jDk9yYL2hw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.3.1.tgz",
+      "integrity": "sha512-jfa5c+sffADJCz36oYr5xY5IihNUJPg0II+rZ6SyJfHQyA3NuUJfRk63hS2GF2vaD8Zgp2p5s7uD1h9ZMi+5iA==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@wordpress/i18n": "^4.1.1",
-        "@wordpress/url": "^3.1.1"
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/i18n": "^4.6.1",
+        "@wordpress/url": "^3.7.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/api-fetch/node_modules/@wordpress/hooks": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.31.0.tgz",
+      "integrity": "sha512-dtXTk6miFaqAQmtjuO1Ox11sdkJNMl/Wv402VlPI8Z3QBUyEAH+FMGoHbAwpy3AGHJJb5pFYSRQBNAgZMGZLIw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/api-fetch/node_modules/@wordpress/i18n": {
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.31.0.tgz",
+      "integrity": "sha512-MRPnym60ZUqZv4AZkXK3HPdZBRUEUD+zU11sB+5ydBPYMQXLSSxOGmt3NlEiPxynYPNkjBtW/52DCQz99rsDzw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/hooks": "^3.31.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^1.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
       },
       "engines": {
         "node": ">=12"
@@ -12260,6 +12292,20 @@
       "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
       "dev": true
     },
+    "node_modules/@wordpress/core-data/node_modules/@wordpress/api-fetch": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-5.2.7.tgz",
+      "integrity": "sha512-r8dxJ8ScyKJ9yqHqwybJe2ANAyEZTKcjalp8bdMIZc7lJXgRa5f9kTvulE6hItkSVgBe38u6rx0T7UrlXNrUTw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/i18n": "^4.2.4",
+        "@wordpress/url": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/blocks": {
       "version": "9.1.8",
       "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-9.1.8.tgz",
@@ -12288,51 +12334,6 @@
         "simple-html-tokenizer": "^0.5.7",
         "tinycolor2": "^1.4.2",
         "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/blocks/node_modules/@wordpress/i18n": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.2.4.tgz",
-      "integrity": "sha512-36PnV7wTaLKCb+JZoapR3AtfrLTluhO5bIR6cUTG+QBBJ+g3gjRAdNFihnV8kz66FANu8PqDMI0T1jow/mrbYw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.2.2",
-        "gettext-parser": "^1.3.1",
-        "lodash": "^4.17.21",
-        "memize": "^1.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/blocks/node_modules/@wordpress/i18n/node_modules/@babel/runtime": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
-      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
-      "dev": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/blocks/node_modules/@wordpress/i18n/node_modules/@wordpress/hooks": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.2.tgz",
-      "integrity": "sha512-MlFWyu2ttJhmzDFBVWPRwZwIMqQdHFZTjFWFWm50NlzUzIJ3gEtNA95mHNtav1Fone24N+I2YkaYMNb6PEPTyA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
       },
       "engines": {
         "node": ">=12"
@@ -12411,20 +12412,6 @@
       "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw==",
       "dev": true
     },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/data-controls/node_modules/@wordpress/api-fetch": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-5.2.6.tgz",
-      "integrity": "sha512-AG8KdCHwtYJWR38AAU7nEI+UbumUSqSBthQj3rShLUVyFbYGkQdpwXJJG6vFj7FjIp41zljiyj3K1Fh3cqdaAw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.2.4",
-        "@wordpress/url": "^3.3.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/data-controls/node_modules/@wordpress/compose": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.6.tgz",
@@ -12495,39 +12482,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/data-controls/node_modules/@wordpress/hooks": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.2.tgz",
-      "integrity": "sha512-MlFWyu2ttJhmzDFBVWPRwZwIMqQdHFZTjFWFWm50NlzUzIJ3gEtNA95mHNtav1Fone24N+I2YkaYMNb6PEPTyA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/data-controls/node_modules/@wordpress/i18n": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.2.4.tgz",
-      "integrity": "sha512-36PnV7wTaLKCb+JZoapR3AtfrLTluhO5bIR6cUTG+QBBJ+g3gjRAdNFihnV8kz66FANu8PqDMI0T1jow/mrbYw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.2.2",
-        "gettext-parser": "^1.3.1",
-        "lodash": "^4.17.21",
-        "memize": "^1.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/deprecated": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.2.3.tgz",
@@ -12536,18 +12490,6 @@
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@wordpress/hooks": "^3.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/deprecated/node_modules/@wordpress/hooks": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.2.tgz",
-      "integrity": "sha512-MlFWyu2ttJhmzDFBVWPRwZwIMqQdHFZTjFWFWm50NlzUzIJ3gEtNA95mHNtav1Fone24N+I2YkaYMNb6PEPTyA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
       },
       "engines": {
         "node": ">=12"
@@ -12620,6 +12562,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@wordpress/core-data/node_modules/@wordpress/hooks": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.31.0.tgz",
+      "integrity": "sha512-dtXTk6miFaqAQmtjuO1Ox11sdkJNMl/Wv402VlPI8Z3QBUyEAH+FMGoHbAwpy3AGHJJb5pFYSRQBNAgZMGZLIw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/html-entities": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.2.3.tgz",
@@ -12642,6 +12596,26 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@wordpress/core-data/node_modules/@wordpress/i18n": {
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.31.0.tgz",
+      "integrity": "sha512-MRPnym60ZUqZv4AZkXK3HPdZBRUEUD+zU11sB+5ydBPYMQXLSSxOGmt3NlEiPxynYPNkjBtW/52DCQz99rsDzw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/hooks": "^3.31.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^1.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/icons": {
@@ -12706,39 +12680,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/keycodes/node_modules/@wordpress/hooks": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.2.tgz",
-      "integrity": "sha512-MlFWyu2ttJhmzDFBVWPRwZwIMqQdHFZTjFWFWm50NlzUzIJ3gEtNA95mHNtav1Fone24N+I2YkaYMNb6PEPTyA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.2.4.tgz",
-      "integrity": "sha512-36PnV7wTaLKCb+JZoapR3AtfrLTluhO5bIR6cUTG+QBBJ+g3gjRAdNFihnV8kz66FANu8PqDMI0T1jow/mrbYw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.2.2",
-        "gettext-parser": "^1.3.1",
-        "lodash": "^4.17.21",
-        "memize": "^1.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@wordpress/core-data/node_modules/@wordpress/primitives": {
@@ -51485,14 +51426,39 @@
       }
     },
     "@wordpress/api-fetch": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-5.1.1.tgz",
-      "integrity": "sha512-pThYQhoKiePeGgb5aZnc4A9YT5WktfZkejSk4JIfFxdzXF7YXunyMoA9Aib2YvY94IkItLzBeTl/jDk9yYL2hw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.3.1.tgz",
+      "integrity": "sha512-jfa5c+sffADJCz36oYr5xY5IihNUJPg0II+rZ6SyJfHQyA3NuUJfRk63hS2GF2vaD8Zgp2p5s7uD1h9ZMi+5iA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@wordpress/i18n": "^4.1.1",
-        "@wordpress/url": "^3.1.1"
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/i18n": "^4.6.1",
+        "@wordpress/url": "^3.7.1"
+      },
+      "dependencies": {
+        "@wordpress/hooks": {
+          "version": "3.31.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.31.0.tgz",
+          "integrity": "sha512-dtXTk6miFaqAQmtjuO1Ox11sdkJNMl/Wv402VlPI8Z3QBUyEAH+FMGoHbAwpy3AGHJJb5pFYSRQBNAgZMGZLIw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0"
+          }
+        },
+        "@wordpress/i18n": {
+          "version": "4.31.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.31.0.tgz",
+          "integrity": "sha512-MRPnym60ZUqZv4AZkXK3HPdZBRUEUD+zU11sB+5ydBPYMQXLSSxOGmt3NlEiPxynYPNkjBtW/52DCQz99rsDzw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/hooks": "^3.31.0",
+            "gettext-parser": "^1.3.1",
+            "memize": "^1.1.0",
+            "sprintf-js": "^1.1.1",
+            "tannin": "^1.2.0"
+          }
+        }
       }
     },
     "@wordpress/autop": {
@@ -52682,6 +52648,17 @@
           "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
           "dev": true
         },
+        "@wordpress/api-fetch": {
+          "version": "5.2.7",
+          "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-5.2.7.tgz",
+          "integrity": "sha512-r8dxJ8ScyKJ9yqHqwybJe2ANAyEZTKcjalp8bdMIZc7lJXgRa5f9kTvulE6hItkSVgBe38u6rx0T7UrlXNrUTw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/i18n": "^4.2.4",
+            "@wordpress/url": "^3.3.2"
+          }
+        },
         "@wordpress/blocks": {
           "version": "9.1.8",
           "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-9.1.8.tgz",
@@ -52710,43 +52687,6 @@
             "simple-html-tokenizer": "^0.5.7",
             "tinycolor2": "^1.4.2",
             "uuid": "^8.3.0"
-          },
-          "dependencies": {
-            "@wordpress/i18n": {
-              "version": "4.2.4",
-              "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.2.4.tgz",
-              "integrity": "sha512-36PnV7wTaLKCb+JZoapR3AtfrLTluhO5bIR6cUTG+QBBJ+g3gjRAdNFihnV8kz66FANu8PqDMI0T1jow/mrbYw==",
-              "dev": true,
-              "requires": {
-                "@babel/runtime": "^7.16.0",
-                "@wordpress/hooks": "^3.2.2",
-                "gettext-parser": "^1.3.1",
-                "lodash": "^4.17.21",
-                "memize": "^1.1.0",
-                "sprintf-js": "^1.1.1",
-                "tannin": "^1.2.0"
-              },
-              "dependencies": {
-                "@babel/runtime": {
-                  "version": "7.16.3",
-                  "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
-                  "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
-                  "dev": true,
-                  "requires": {
-                    "regenerator-runtime": "^0.13.4"
-                  }
-                },
-                "@wordpress/hooks": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.2.tgz",
-                  "integrity": "sha512-MlFWyu2ttJhmzDFBVWPRwZwIMqQdHFZTjFWFWm50NlzUzIJ3gEtNA95mHNtav1Fone24N+I2YkaYMNb6PEPTyA==",
-                  "dev": true,
-                  "requires": {
-                    "@babel/runtime": "^7.16.0"
-                  }
-                }
-              }
-            }
           }
         },
         "@wordpress/compose": {
@@ -52810,17 +52750,6 @@
               "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw==",
               "dev": true
             },
-            "@wordpress/api-fetch": {
-              "version": "5.2.6",
-              "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-5.2.6.tgz",
-              "integrity": "sha512-AG8KdCHwtYJWR38AAU7nEI+UbumUSqSBthQj3rShLUVyFbYGkQdpwXJJG6vFj7FjIp41zljiyj3K1Fh3cqdaAw==",
-              "dev": true,
-              "requires": {
-                "@babel/runtime": "^7.16.0",
-                "@wordpress/i18n": "^4.2.4",
-                "@wordpress/url": "^3.3.1"
-              }
-            },
             "@wordpress/compose": {
               "version": "5.0.6",
               "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.6.tgz",
@@ -52878,30 +52807,6 @@
                 "react": "^17.0.1",
                 "react-dom": "^17.0.1"
               }
-            },
-            "@wordpress/hooks": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.2.tgz",
-              "integrity": "sha512-MlFWyu2ttJhmzDFBVWPRwZwIMqQdHFZTjFWFWm50NlzUzIJ3gEtNA95mHNtav1Fone24N+I2YkaYMNb6PEPTyA==",
-              "dev": true,
-              "requires": {
-                "@babel/runtime": "^7.16.0"
-              }
-            },
-            "@wordpress/i18n": {
-              "version": "4.2.4",
-              "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.2.4.tgz",
-              "integrity": "sha512-36PnV7wTaLKCb+JZoapR3AtfrLTluhO5bIR6cUTG+QBBJ+g3gjRAdNFihnV8kz66FANu8PqDMI0T1jow/mrbYw==",
-              "dev": true,
-              "requires": {
-                "@babel/runtime": "^7.16.0",
-                "@wordpress/hooks": "^3.2.2",
-                "gettext-parser": "^1.3.1",
-                "lodash": "^4.17.21",
-                "memize": "^1.1.0",
-                "sprintf-js": "^1.1.1",
-                "tannin": "^1.2.0"
-              }
             }
           }
         },
@@ -52913,17 +52818,6 @@
           "requires": {
             "@babel/runtime": "^7.16.0",
             "@wordpress/hooks": "^3.2.2"
-          },
-          "dependencies": {
-            "@wordpress/hooks": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.2.tgz",
-              "integrity": "sha512-MlFWyu2ttJhmzDFBVWPRwZwIMqQdHFZTjFWFWm50NlzUzIJ3gEtNA95mHNtav1Fone24N+I2YkaYMNb6PEPTyA==",
-              "dev": true,
-              "requires": {
-                "@babel/runtime": "^7.16.0"
-              }
-            }
           }
         },
         "@wordpress/dom": {
@@ -52982,6 +52876,15 @@
             }
           }
         },
+        "@wordpress/hooks": {
+          "version": "3.31.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.31.0.tgz",
+          "integrity": "sha512-dtXTk6miFaqAQmtjuO1Ox11sdkJNMl/Wv402VlPI8Z3QBUyEAH+FMGoHbAwpy3AGHJJb5pFYSRQBNAgZMGZLIw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0"
+          }
+        },
         "@wordpress/html-entities": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.2.3.tgz",
@@ -53000,6 +52903,20 @@
                 "regenerator-runtime": "^0.13.4"
               }
             }
+          }
+        },
+        "@wordpress/i18n": {
+          "version": "4.31.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.31.0.tgz",
+          "integrity": "sha512-MRPnym60ZUqZv4AZkXK3HPdZBRUEUD+zU11sB+5ydBPYMQXLSSxOGmt3NlEiPxynYPNkjBtW/52DCQz99rsDzw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "@wordpress/hooks": "^3.31.0",
+            "gettext-parser": "^1.3.1",
+            "memize": "^1.1.0",
+            "sprintf-js": "^1.1.1",
+            "tannin": "^1.2.0"
           }
         },
         "@wordpress/icons": {
@@ -53051,30 +52968,6 @@
               "dev": true,
               "requires": {
                 "regenerator-runtime": "^0.13.4"
-              }
-            },
-            "@wordpress/hooks": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.2.tgz",
-              "integrity": "sha512-MlFWyu2ttJhmzDFBVWPRwZwIMqQdHFZTjFWFWm50NlzUzIJ3gEtNA95mHNtav1Fone24N+I2YkaYMNb6PEPTyA==",
-              "dev": true,
-              "requires": {
-                "@babel/runtime": "^7.16.0"
-              }
-            },
-            "@wordpress/i18n": {
-              "version": "4.2.4",
-              "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.2.4.tgz",
-              "integrity": "sha512-36PnV7wTaLKCb+JZoapR3AtfrLTluhO5bIR6cUTG+QBBJ+g3gjRAdNFihnV8kz66FANu8PqDMI0T1jow/mrbYw==",
-              "dev": true,
-              "requires": {
-                "@babel/runtime": "^7.16.0",
-                "@wordpress/hooks": "^3.2.2",
-                "gettext-parser": "^1.3.1",
-                "lodash": "^4.17.21",
-                "memize": "^1.1.0",
-                "sprintf-js": "^1.1.1",
-                "tannin": "^1.2.0"
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@woocommerce/e2e-utils": "0.2.0",
     "@woocommerce/eslint-plugin": "1.1.0",
     "@woocommerce/experimental": "2.1.0",
-    "@wordpress/api-fetch": "5.1.1",
+    "@wordpress/api-fetch": "6.3.1",
     "@wordpress/babel-plugin-makepot": "4.2.0",
     "@wordpress/babel-preset-default": "7.4.0",
     "@wordpress/base-styles": "3.5.4",


### PR DESCRIPTION
Fixes #6076 

#### Changes proposed in this Pull Request

- Update the version of `@wordpress/api-fetch` to 6.3.1
- Add an entry in the dependencies doc

#### Testing instructions

- JS tests are passing

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
