### PR TITLE
Fix class `AbstractCartRoute` not found

### DIFF
--- a/changelog/fix-fatal-undefined-class-abstract-cart-route
+++ b/changelog/fix-fatal-undefined-class-abstract-cart-route
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Check for the `AbstractCartRoute` class before making WooPay available.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -186,6 +186,11 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_platform_checkout_eligible() {
+		// Checks for the dependency on Store API AbstractCartRoute.
+		if ( ! class_exists( 'Automattic\WooCommerce\StoreApi\Routes\V1\AbstractCartRoute' ) ) {
+			return false;
+		}
+
 		// read directly from cache, ignore cache expiration check.
 		$account = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
 		return is_array( $account ) && ( $account['platform_checkout_eligible'] ?? false );

--- a/includes/platform-checkout/class-platform-checkout-store-api-token.php
+++ b/includes/platform-checkout/class-platform-checkout-store-api-token.php
@@ -9,51 +9,53 @@ namespace WCPay\Platform_Checkout;
 
 use Automattic\WooCommerce\StoreApi\Routes\V1\AbstractCartRoute;
 
-/**
- * This class is used to get the cart token from the cart route.
- */
-class Platform_Checkout_Store_Api_Token extends AbstractCartRoute {
-
+if ( class_exists( AbstractCartRoute::class ) ) {
 	/**
-	 * Helper method to get the instance of the class.
-	 *
-	 * @return Platform_Checkout_Store_Api_Token The instance of the class.
-	 *
-	 * @psalm-suppress InvalidArgument Psalm thinks namespace is incorrect.
+	 * This class is used to get the cart token from the cart route.
 	 */
-	public static function init() {
-		$formatters        = new \Automattic\WooCommerce\StoreApi\Formatters();
-		$extend_schema     = new \Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema( $formatters );
-		$schema_controller = new \Automattic\WooCommerce\StoreApi\SchemaController( $extend_schema );
-		return new self( $schema_controller, $schema_controller->get( 'cart' ) );
-	}
+	class Platform_Checkout_Store_Api_Token extends AbstractCartRoute {
 
-	/**
-	 * Get the path of this REST route.
-	 *
-	 * @throws \Exception Throws exception because this method is not meant to be implemented in this utility class.
-	 */
-	public function get_path() {
-		throw new \Exception( 'Not implemented' );
-	}
+		/**
+		 * Helper method to get the instance of the class.
+		 *
+		 * @return Platform_Checkout_Store_Api_Token The instance of the class.
+		 *
+		 * @psalm-suppress InvalidArgument Psalm thinks namespace is incorrect.
+		 */
+		public static function init() {
+			$formatters        = new \Automattic\WooCommerce\StoreApi\Formatters();
+			$extend_schema     = new \Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema( $formatters );
+			$schema_controller = new \Automattic\WooCommerce\StoreApi\SchemaController( $extend_schema );
+			return new self( $schema_controller, $schema_controller->get( 'cart' ) );
+		}
 
-	/**
-	 * Get arguments for this REST route.
-	 *
-	 * @throws \Exception Throws exception because this method is not meant to be implemented in this utility class.
-	 */
-	public function get_args() {
-		throw new \Exception( 'Not implemented' );
-	}
+		/**
+		 * Get the path of this REST route.
+		 *
+		 * @throws \Exception Throws exception because this method is not meant to be implemented in this utility class.
+		 */
+		public function get_path() {
+			throw new \Exception( 'Not implemented' );
+		}
 
-    //phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod
-	/**
-	 * This function is used to get the cart token from the cart route.
-	 *
-	 * @return string The cart token.
-	 * @psalm-suppress UndefinedMethod
-	 */
-	public function get_cart_token() {
-		return parent::get_cart_token();
+		/**
+		 * Get arguments for this REST route.
+		 *
+		 * @throws \Exception Throws exception because this method is not meant to be implemented in this utility class.
+		 */
+		public function get_args() {
+			throw new \Exception( 'Not implemented' );
+		}
+
+		//phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod
+		/**
+		 * This function is used to get the cart token from the cart route.
+		 *
+		 * @return string The cart token.
+		 * @psalm-suppress UndefinedMethod
+		 */
+		public function get_cart_token() {
+			return parent::get_cart_token();
+		}
 	}
 }


### PR DESCRIPTION
Context: p1682423318365569-slack-CGGCLBN58

#### Changes proposed in this Pull Request

- Wrap new class `Platform_Checkout_Store_Api_Token` around `class_exists` check.
- Add dependency check to `is_platform_checkout_eligible` – This is probably not the best place to handle this, but it's where we need the least amount of changes.

#### Testing instructions

* Install an old version of WooCommerce. E.g [6.0.0](https://github.com/woocommerce/woocommerce/releases/tag/6.0.0). (TBD: Check the latest version where this problem appears).
* Ensure the error doesn't happen on this branch.
* Ensure WooPay is not available in settings.
* Ensure WooPay is not available at checkout.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.