### PR TITLE
Disable WooPay when customer is logged out and trying to buy a subscription or guest checkout is disabled

### DIFF
--- a/changelog/add-disable-woopay-when-unsupported-products-in-cart
+++ b/changelog/add-disable-woopay-when-unsupported-products-in-cart
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Disable the WooPay auto-redirect and SMS OTP modal in unsupported contexts.

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -117,7 +117,7 @@ class WC_Payments_Checkout {
 			'isUPEEnabled'                   => WC_Payments_Features::is_upe_enabled(),
 			'isUPESplitEnabled'              => WC_Payments_Features::is_upe_split_enabled(),
 			'isSavedCardsEnabled'            => $this->gateway->is_saved_cards_enabled(),
-			'isPlatformCheckoutEnabled'      => $this->platform_checkout_util->should_enable_platform_checkout( $this->gateway ),
+			'isPlatformCheckoutEnabled'      => $this->platform_checkout_util->should_enable_platform_checkout( $this->gateway ) && $this->platform_checkout_util->should_enable_woopay_on_checkout(),
 			'isWoopayExpressCheckoutEnabled' => $this->platform_checkout_util->is_woopay_express_checkout_enabled(),
 			'isClientEncryptionEnabled'      => WC_Payments_Features::is_client_secret_encryption_enabled(),
 			'platformCheckoutHost'           => defined( 'PLATFORM_CHECKOUT_FRONTEND_HOST' ) ? PLATFORM_CHECKOUT_FRONTEND_HOST : 'https://pay.woo.com',

--- a/includes/class-wc-payments-platform-checkout-button-handler.php
+++ b/includes/class-wc-payments-platform-checkout-button-handler.php
@@ -548,7 +548,7 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 			}
 
 			// If guest checkout is not allowed, and customer is not logged in, disable the WooPay button.
-			if ( ! $this->is_guest_checkout_enabled() ) {
+			if ( ! $this->platform_checkout_utilities->is_guest_checkout_enabled() ) {
 				return false;
 			}
 		}
@@ -657,14 +657,5 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 		return 'subscription' === $product->get_type()
 			|| 'subscription_variation' === $product->get_type()
 			|| 'variable-subscription' === $product->get_type();
-	}
-
-	/**
-	 * Returns true if guest checkout is enabled, false otherwise.
-	 *
-	 * @return bool  True if guest checkout is enabled, false otherwise.
-	 */
-	private function is_guest_checkout_enabled(): bool {
-		return 'yes' === get_option( 'woocommerce_enable_guest_checkout', 'no' );
 	}
 }

--- a/includes/platform-checkout/class-platform-checkout-utilities.php
+++ b/includes/platform-checkout/class-platform-checkout-utilities.php
@@ -33,6 +33,22 @@ class Platform_Checkout_Utilities {
 		$is_platform_checkout_eligible = WC_Payments_Features::is_platform_checkout_eligible(); // Feature flag.
 		$is_platform_checkout_enabled  = 'yes' === $gateway->get_option( 'platform_checkout', 'no' );
 
+		if ( ! is_user_logged_in() ) {
+			// If there's a subscription product in the cart and the customer isn't logged in we
+			// should not enable WooPay since that situation is currently not supported.
+			// Note that this is mirrored in the WC_Payments_Platform_Checkout_Button_Handler class.
+			if ( class_exists( 'WC_Subscriptions_Cart' ) && \WC_Subscriptions_Cart::cart_contains_subscription() ) {
+				return false;
+			}
+
+			// If guest checkout is disabled and the customer isn't logged in we should not enable
+			// WooPay scripts since that situations is currently not supported.
+			// Note that this is mirrored in the WC_Payments_Platform_Checkout_Button_Handler class.
+			if ( ! $this->is_guest_checkout_enabled() ) {
+				return false;
+			}
+		}
+
 		return $is_platform_checkout_eligible && $is_platform_checkout_enabled;
 	}
 
@@ -207,5 +223,14 @@ class Platform_Checkout_Utilities {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Returns true if guest checkout is enabled, false otherwise.
+	 *
+	 * @return bool  True if guest checkout is enabled, false otherwise.
+	 */
+	public function is_guest_checkout_enabled(): bool {
+		return 'yes' === get_option( 'woocommerce_enable_guest_checkout', 'no' );
 	}
 }

--- a/includes/platform-checkout/class-platform-checkout-utilities.php
+++ b/includes/platform-checkout/class-platform-checkout-utilities.php
@@ -33,6 +33,15 @@ class Platform_Checkout_Utilities {
 		$is_platform_checkout_eligible = WC_Payments_Features::is_platform_checkout_eligible(); // Feature flag.
 		$is_platform_checkout_enabled  = 'yes' === $gateway->get_option( 'platform_checkout', 'no' );
 
+		return $is_platform_checkout_eligible && $is_platform_checkout_enabled;
+	}
+
+	/**
+	 * Checks various conditions to determine if WooPay should be enabled on the checkout page.
+	 *
+	 * @return bool  True if WooPay should be enabled, false otherwise.
+	 */
+	public function should_enable_woopay_on_checkout(): bool {
 		if ( ! is_user_logged_in() ) {
 			// If there's a subscription product in the cart and the customer isn't logged in we
 			// should not enable WooPay since that situation is currently not supported.
@@ -49,7 +58,7 @@ class Platform_Checkout_Utilities {
 			}
 		}
 
-		return $is_platform_checkout_eligible && $is_platform_checkout_enabled;
+		return true;
 	}
 
 	/**

--- a/includes/platform-checkout/class-platform-checkout-utilities.php
+++ b/includes/platform-checkout/class-platform-checkout-utilities.php
@@ -39,9 +39,17 @@ class Platform_Checkout_Utilities {
 	/**
 	 * Checks various conditions to determine if WooPay should be enabled on the checkout page.
 	 *
+	 * This function should only be called when evaluating something for the checkout page. The
+	 * function will return false if you're on any other page.
+	 *
 	 * @return bool  True if WooPay should be enabled, false otherwise.
 	 */
 	public function should_enable_woopay_on_checkout(): bool {
+		if ( ! is_checkout() && ! has_block( 'woocommerce/checkout' ) ) {
+			// Wrong usage, this should only be called for the checkout page.
+			return false;
+		}
+
 		if ( ! is_user_logged_in() ) {
 			// If there's a subscription product in the cart and the customer isn't logged in we
 			// should not enable WooPay since that situation is currently not supported.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2133,7 +2133,10 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	public function test_is_platform_checkout_enabled_returns_true() {
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
 		$this->wcpay_gateway->update_option( 'platform_checkout', 'yes' );
-		$this->assertTrue( $this->payments_checkout->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
+		$this->assertTrue( $this->platform_checkout_utilities->should_enable_platform_checkout( $this->wcpay_gateway ) );
+
+		// This will return false because platform_checkout_utilities->should_enable_woopay_on_checkout() will return false.
+		$this->assertFalse( $this->payments_checkout->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
 	}
 
 	public function test_should_use_stripe_platform_on_checkout_page_not_platform_checkout_eligible() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

We want to disable WooPay when any of the following is true:

- Customer is logged out and has a subscription product in the cart.
- Customer is logged out and guest checkout is disabled via the **WooCommerce → Accounts & Privacy → Allow customers to place orders without an account** setting.

This PR adds a condition when loading the JS parameters making `isPlatformCheckoutEnabled` `false` when the conditions above are true. This makes it so the WooPay SMS OTP modal is not automatically opened when the conditions above are true, and the customer isn't automatically redirected even if a WooPay session exists in their browser when any of the above conditions are true.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have an active WooPay session, log out of your test store, add a subscription product to the cart, and make sure you're not redirected to WooPay automatically from the **Checkout** page.
2. Log out of WooPay, log out of your test store, add a subscription product to the cart, and make sure the SMS OTP modal doesn't pop up on the **Checkout** page.
3. Have an active WooPay session, log out of your test store, add a non-subscription product to the cart, and make sure you're automatically redirected to WooPay from the **Checkout** page.
4. Log out of WooPay, log out of your test store, add a non-subscription product to the cart, and make sure the SMS OTP modal pops up on the **Checkout** page.

Repeat steps (1)-(4) while logged into the store and make sure you're either redirected to WooPay or the SMS OTP modal shows up — depending on the testing step.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
