### PR TITLE
Ignore semgrep errors where safe

### DIFF
--- a/changelog/fix-ignore-semgrep-safe-warnings
+++ b/changelog/fix-ignore-semgrep-safe-warnings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Ignore the semgrep errors when the code is safe

--- a/changelog/fix-ignore-semgrep-safe-warnings
+++ b/changelog/fix-ignore-semgrep-safe-warnings
@@ -1,5 +1,5 @@
 Significance: patch
 Type: dev
-Comment: AIgnore false positives flagged by semgrep audit
+Comment: Ignore false positives flagged by semgrep audit
 
 

--- a/changelog/fix-ignore-semgrep-safe-warnings
+++ b/changelog/fix-ignore-semgrep-safe-warnings
@@ -1,4 +1,5 @@
-Significance: minor
-Type: add
+Significance: patch
+Type: dev
+Comment: AIgnore false positives flagged by semgrep audit
 
-Ignore the semgrep errors when the code is safe
+

--- a/includes/admin/class-wc-payments-admin-sections-overwrite.php
+++ b/includes/admin/class-wc-payments-admin-sections-overwrite.php
@@ -135,7 +135,7 @@ class WC_Payments_Admin_Sections_Overwrite {
 	 */
 	public function overwrite_payments_tab_url( $url, $path ): string {
 		if ( 'admin.php?page=wc-settings&tab=checkout' === $path ) {
-			return add_query_arg( [ 'section' => 'woocommerce_payments' ], $url );
+			return add_query_arg( [ 'section' => 'woocommerce_payments' ], $url ); // nosemgrep: audit.php.wp.security.xss.query-arg -- Admin area URL is passed in.
 		}
 
 		return $url;

--- a/includes/admin/class-wc-payments-admin-settings.php
+++ b/includes/admin/class-wc-payments-admin-settings.php
@@ -86,6 +86,6 @@ class WC_Payments_Admin_Settings {
 	 * @return string URL of the configuration screen for this gateway
 	 */
 	public static function get_settings_url() {
-		return admin_url( add_query_arg( self::$settings_url_params, 'admin.php' ) );
+		return admin_url( add_query_arg( self::$settings_url_params, 'admin.php' ) ); // nosemgrep: audit.php.wp.security.xss.query-arg -- constant string is passed in.
 	}
 }

--- a/includes/class-experimental-abtest.php
+++ b/includes/class-experimental-abtest.php
@@ -159,7 +159,7 @@ final class Experimental_Abtest {
 
 		$url = add_query_arg(
 			$args,
-			sprintf(
+			sprintf( // nosemgrep: audit.php.wp.security.xss.query-arg -- constant value is passed in to add_query_arg.
 				'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/%s',
 				$this->platform
 			)

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2000,7 +2000,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		$return_url = $this->get_return_url( $order );
 		$return_url = add_query_arg( self::FLAG_PREVIOUS_SUCCESSFUL_INTENT, 'yes', $return_url );
-		return [
+		return [ // nosemgrep: audit.php.wp.security.xss.query-arg -- https://woocommerce.github.io/code-reference/classes/WC-Payment-Gateway.html#method_get_return_url is passed in.
 			'result'                               => 'success',
 			'redirect'                             => $return_url,
 			'wcpay_upe_previous_successful_intent' => 'yes', // This flag is needed for UPE flow.
@@ -2047,7 +2047,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$return_url = $this->get_return_url( $session_order );
 		$return_url = add_query_arg( self::FLAG_PREVIOUS_ORDER_PAID, 'yes', $return_url );
 
-		return [
+		return [ // nosemgrep: audit.php.wp.security.xss.query-arg -- https://woocommerce.github.io/code-reference/classes/WC-Payment-Gateway.html#method_get_return_url is passed in.
 			'result'                            => 'success',
 			'redirect'                          => $return_url,
 			'wcpay_upe_paid_for_previous_order' => 'yes', // This flag is needed for UPE flow.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -829,7 +829,7 @@ class WC_Payments_Account {
 	 * @return string Stripe account login url.
 	 */
 	private function get_login_url() {
-		return add_query_arg(
+		return add_query_arg( // nosemgrep: audit.php.wp.security.xss.query-arg -- no user input data used.
 			[
 				'wcpay-login' => '1',
 				'_wpnonce'    => wp_create_nonce( 'wcpay-login' ),
@@ -985,7 +985,7 @@ class WC_Payments_Account {
 		);
 
 		if ( 1 === $is_from_subscription_product_publish ) {
-			return add_query_arg(
+			return add_query_arg( // nosemgrep: audit.php.wp.security.xss.query-arg -- specific admin url passed in.
 				[ 'wcpay-subscriptions-onboarded' => '1' ],
 				get_edit_post_link( $matches[1], 'url' )
 			);

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1100,7 +1100,7 @@ class WC_Payments_Account {
 				'site_locale'   => get_locale(),
 			],
 			$this->get_actioned_notes(),
-			array_filter( $account_data ),
+			array_filter( $account_data ), // nosemgrep: audit.php.lang.misc.array-filter-no-callback -- output of array_filter is escaped.
 			$progressive,
 			$collect_payout_requirements
 		);

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -1647,7 +1647,7 @@ class WC_Payments_Payment_Request_Button_Handler {
 			home_url()
 		);
 
-		return [
+		return [ // nosemgrep: audit.php.wp.security.xss.query-arg -- home_url passed in to add_query_arg.
 			'message'      => $message,
 			'redirect_url' => $redirect_url,
 		];

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -137,7 +137,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 						$payment_fields['newTokenFormId'] = '#wc-' . $token->get_gateway_id() . '-payment-token-' . $token->get_id();
 					}
 				}
-				return $payment_fields;
+				return $payment_fields; // nosemgrep: audit.php.wp.security.xss.query-arg -- server generated url is passed in.
 			}
 
 			$payment_fields['isOrderPay'] = true;
@@ -158,7 +158,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 				);
 			}
 		}
-		return $payment_fields;
+		return $payment_fields; // nosemgrep: audit.php.wp.security.xss.query-arg -- server generated url is passed in.
 	}
 
 	/**

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -638,7 +638,7 @@ class WC_Payments_Utils {
 			return '';
 		}
 
-		return add_query_arg(
+		return add_query_arg( // nosemgrep: audit.php.wp.security.xss.query-arg -- server generated url is passed in.
 			array_merge(
 				[
 					'page' => 'wc-admin',

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1010,7 +1010,7 @@ class WC_Payments {
 		$script_file                  = $script . '.js';
 		$script_src_url               = plugins_url( $script_file, WCPAY_PLUGIN_FILE );
 		$script_asset_path            = WCPAY_ABSPATH . $script . '.asset.php';
-		$script_asset                 = file_exists( $script_asset_path ) ? require $script_asset_path : [ 'dependencies' => [] ];
+		$script_asset                 = file_exists( $script_asset_path ) ? require $script_asset_path : [ 'dependencies' => [] ]; // nosemgrep: audit.php.lang.security.file.inclusion-arg -- server generated path is used.
 		$script_asset['dependencies'] = array_merge( $script_asset['dependencies'], $dependencies );
 		wp_register_script(
 			$handler,

--- a/includes/compat/subscriptions/class-wc-payments-email-failed-renewal-authentication.php
+++ b/includes/compat/subscriptions/class-wc-payments-email-failed-renewal-authentication.php
@@ -101,7 +101,7 @@ class WC_Payments_Email_Failed_Renewal_Authentication extends WC_Email {
 	 * @return string
 	 */
 	public function get_authorization_url( $order ) {
-		return add_query_arg( 'wcpay-confirmation', 1, $order->get_checkout_payment_url( false ) );
+		return add_query_arg( 'wcpay-confirmation', 1, $order->get_checkout_payment_url( false ) ); // nosemgrep: audit.php.wp.security.xss.query-arg -- server generated url is passed in.
 	}
 
 	/**

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -591,7 +591,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 			return $this->parent_process_payment( $order_id );
 		}
 
-		return [
+		return [ // nosemgrep: audit.php.wp.security.xss.query-arg  -- The output of add_query_arg is being escaped.
 			'result'         => 'success',
 			'payment_needed' => $payment_needed,
 			'redirect_url'   => wp_sanitize_redirect(

--- a/includes/subscriptions/class-wc-payments-subscription-change-payment-method-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscription-change-payment-method-handler.php
@@ -189,7 +189,7 @@ class WC_Payments_Subscription_Change_Payment_Method_Handler {
 	 * @return string The update payment method
 	 */
 	private function get_subscription_update_payment_url( $subscription ) {
-		return add_query_arg(
+		return add_query_arg( // nosemgrep: audit.php.wp.security.xss.query-arg -- no user input is used in this URL.
 			[
 				'change_payment_method' => $subscription->get_id(),
 				'_wpnonce'              => wp_create_nonce(),

--- a/includes/subscriptions/class-wc-payments-subscriptions-onboarding-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-onboarding-handler.php
@@ -86,7 +86,7 @@ class WC_Payments_Subscriptions_Onboarding_Handler {
 		add_filter(
 			'redirect_post_location',
 			function() use ( $product ) {
-				return add_query_arg(
+				return add_query_arg( // nosemgrep: audit.php.wp.security.xss.query-arg -- server generated url is passed in.
 					[
 						'message' => 10, // Post saved as draft message.
 						'wcpay-subscription-saved-as-draft' => 1,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

1) Ignore `audit.php.wp.security.xss.query-arg` where the usage is safe
2) Ignore `audit.php.lang.misc.array-filter-no-callback` as the output of the array is already escaped where used. Ref:  Similar issue discussed at p1681737008050159-slack-C6JKZ8MLK
3) Ignore `audit.php.lang.security.file.inclusion-arg` as no user input is involved in generating the file path. Ref: Similar issue discussed at p1681831069935119-slack-C6JKZ8MLK

#### Testing instructions
Ensure that the usages are indeed safe and not prone to any vulnerability and hence safe to ignore

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.