### PR TITLE
Add Cart to WooPay enabled check

### DIFF
--- a/changelog/fix-6181-woopay-button-on-cart
+++ b/changelog/fix-6181-woopay-button-on-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay express checkout button display issue on Cart blocks.

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -117,7 +117,7 @@ class WC_Payments_Checkout {
 			'isUPEEnabled'                   => WC_Payments_Features::is_upe_enabled(),
 			'isUPESplitEnabled'              => WC_Payments_Features::is_upe_split_enabled(),
 			'isSavedCardsEnabled'            => $this->gateway->is_saved_cards_enabled(),
-			'isPlatformCheckoutEnabled'      => $this->platform_checkout_util->should_enable_platform_checkout( $this->gateway ) && $this->platform_checkout_util->should_enable_woopay_on_checkout(),
+			'isPlatformCheckoutEnabled'      => $this->platform_checkout_util->should_enable_platform_checkout( $this->gateway ) && $this->platform_checkout_util->should_enable_woopay_on_cart_or_checkout(),
 			'isWoopayExpressCheckoutEnabled' => $this->platform_checkout_util->is_woopay_express_checkout_enabled(),
 			'isClientEncryptionEnabled'      => WC_Payments_Features::is_client_secret_encryption_enabled(),
 			'platformCheckoutHost'           => defined( 'PLATFORM_CHECKOUT_FRONTEND_HOST' ) ? PLATFORM_CHECKOUT_FRONTEND_HOST : 'https://pay.woo.com',

--- a/includes/platform-checkout/class-platform-checkout-utilities.php
+++ b/includes/platform-checkout/class-platform-checkout-utilities.php
@@ -39,14 +39,14 @@ class Platform_Checkout_Utilities {
 	/**
 	 * Checks various conditions to determine if WooPay should be enabled on the checkout page.
 	 *
-	 * This function should only be called when evaluating something for the checkout page. The
+	 * This function should only be called when evaluating something for the checkout or cart page. The
 	 * function will return false if you're on any other page.
 	 *
 	 * @return bool  True if WooPay should be enabled, false otherwise.
 	 */
 	public function should_enable_woopay_on_checkout(): bool {
-		if ( ! is_checkout() && ! has_block( 'woocommerce/checkout' ) ) {
-			// Wrong usage, this should only be called for the checkout page.
+		if ( ! is_checkout() && ! has_block( 'woocommerce/checkout' ) && ! is_cart() && ! has_block( 'woocommerce/cart' ) ) {
+			// Wrong usage, this should only be called for the checkout or cart page.
 			return false;
 		}
 

--- a/includes/platform-checkout/class-platform-checkout-utilities.php
+++ b/includes/platform-checkout/class-platform-checkout-utilities.php
@@ -44,7 +44,7 @@ class Platform_Checkout_Utilities {
 	 *
 	 * @return bool  True if WooPay should be enabled, false otherwise.
 	 */
-	public function should_enable_woopay_on_checkout(): bool {
+	public function should_enable_woopay_on_cart_or_checkout(): bool {
 		if ( ! is_checkout() && ! has_block( 'woocommerce/checkout' ) && ! is_cart() && ! has_block( 'woocommerce/cart' ) ) {
 			// Wrong usage, this should only be called for the checkout or cart page.
 			return false;

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2135,7 +2135,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->wcpay_gateway->update_option( 'platform_checkout', 'yes' );
 		$this->assertTrue( $this->platform_checkout_utilities->should_enable_platform_checkout( $this->wcpay_gateway ) );
 
-		// This will return false because platform_checkout_utilities->should_enable_woopay_on_checkout() will return false.
+		// This will return false because platform_checkout_utilities->should_enable_woopay_on_cart_or_checkout() will return false.
 		$this->assertFalse( $this->payments_checkout->get_payment_fields_js_config()['isPlatformCheckoutEnabled'] );
 	}
 


### PR DESCRIPTION
Fixes #6181 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
This PR is to fix the issue where the WooPay express checkout button was not displaying on the blocks cart page. This was due to a check that was limiting the button to the checkout page. This PR extends that check to also include the cart page. The product page and cart shortcode were unaffected due to how they are rendered on the page using HTML as opposed to rendering payment methods through the blocks API.

This maintains all the existing checks to be sure WooPay is not offered to shoppers that should not receive it. In the testing instructions I included an outline of scenarios to test and the expected results.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. With a merchant store set up with WooPay enabled and eligible.
2. Make sure that WooPay is enabled on product, cart, checkout page.
3. If not already created, [create a blocks Cart page](https://woocommerce.com/document/using-the-new-block-based-checkout/).
4. As a shopper visit the merchant store.
5. Visit the product cart and confirm button IS displayed.
6. Add product to cart and visit the blocks cart page.
7. Confirm express checkout button IS displayed.
8. Click on checkout and confirm express checkout button IS displayed.

This flow just checks the basic functionality. To test the full flow you will need to have a subscription product available and know how to disable guest checkout on the store (WooCommerce > Accounts & Privacy > `Allow customers to place orders without an account` option).

Subscription + Logged out = NO WooPay
Guest checkout disabled + Logged out = NO WooPay
All other scenarios = YES WooPay

1. Guest Checkout disabled
	1.  Simple product, logged out            NO
	2. Simple product, logged in               YES
	3. Subscription product, logged out   NO
	4. Subscription product, logged in     YES
2. Guest Checkout enabled
	1. Simple product, logged out             YES
	2. Simple product, logged in               YES
	3. Subscription product, logged out   NO
	4. Subscription product, logged in     YES
3. All of the above scenarios should be checked on the blocks and shortcode cart.
5. Confirm checkout is still working as expected for blocks and shortcode just for additional regression testing. In addition to the button on the checkout page, also confirm that the email field does not trigger the OTP modal when the button is not present.
6. Confirm product button is still working as expected for additional regression testing.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
