### PR TITLE
Add express checkout button abstract class

### DIFF
--- a/includes/class-wc-payments-express-checkout-button.php
+++ b/includes/class-wc-payments-express-checkout-button.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * Abstract Express Checkout Button class
+ *
+ * Handles general functionality express checkout buttons
+ *
+ * @package WooCommerce\Payments
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Abstract class for Express Checkout Buttons
+ */
+abstract class WC_Payments_Express_Checkout_Button {
+
+	/**
+	 * Name of the option that stores the available button locations
+	 *
+	 * Override this in child classes to change the option name
+	 *
+	 * @var string
+	 */
+	const BUTTON_LOCATIONS_OPTION_NAME = '';
+
+	/**
+	 * WC_Payments_Account instance to get information about the account
+	 *
+	 * @var WC_Payments_Account
+	 */
+	protected $account;
+
+	/**
+	 * WC_Payment_Gateway_WCPay instance.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	protected $gateway;
+
+	/**
+	 * Initialize class actions.
+	 *
+	 * @param WC_Payments_Account      $account Account information.
+	 * @param WC_Payment_Gateway_WCPay $gateway WCPay gateway.
+	 */
+	public function __construct( WC_Payments_Account $account, WC_Payment_Gateway_WCPay $gateway ) {
+		$this->account = $account;
+		$this->gateway = $gateway;
+	}
+
+	/**
+	 * Initialize hooks.
+	 *
+	 * @return  void
+	 */
+	abstract public function init();
+
+	/**
+	 * Load public scripts and styles.
+	 */
+	abstract public function scripts();
+
+	/**
+	 * Adds the current product to the cart. Used on product detail page.
+	 */
+	abstract public function ajax_add_to_cart();
+
+	/**
+	 * Builds the line items to pass to Payment Request
+	 *
+	 * @param boolean $itemized_display_items Indicates whether to show subtotals or itemized views.
+	 */
+	protected function build_display_items( $itemized_display_items = false ) {
+		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
+			define( 'WOOCOMMERCE_CART', true );
+		}
+
+		$items     = [];
+		$subtotal  = 0;
+		$discounts = 0;
+		$currency  = get_woocommerce_currency();
+
+		// Default show only subtotal instead of itemization.
+		if ( ! apply_filters( 'wcpay_payment_request_hide_itemization', true ) || $itemized_display_items ) {
+			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+				$amount         = $cart_item['line_subtotal'];
+				$subtotal      += $cart_item['line_subtotal'];
+				$quantity_label = 1 < $cart_item['quantity'] ? ' (x' . $cart_item['quantity'] . ')' : '';
+
+				$product_name = $cart_item['data']->get_name();
+
+				$item_tax = $this->prices_exclude_tax() ? 0 : ( $cart_item['line_subtotal_tax'] ?? 0 );
+
+				$item = [
+					'label'  => $product_name . $quantity_label,
+					'amount' => WC_Payments_Utils::prepare_amount( $amount + $item_tax, $currency ),
+				];
+
+				$items[] = $item;
+			}
+		}
+
+		if ( version_compare( WC_VERSION, '3.2', '<' ) ) {
+			$discounts = wc_format_decimal( WC()->cart->get_cart_discount_total(), WC()->cart->dp );
+		} else {
+			$applied_coupons = array_values( WC()->cart->get_coupon_discount_totals() );
+
+			foreach ( $applied_coupons as $amount ) {
+				$discounts += (float) $amount;
+			}
+		}
+
+		$discounts   = wc_format_decimal( $discounts, WC()->cart->dp );
+		$tax         = wc_format_decimal( WC()->cart->tax_total + WC()->cart->shipping_tax_total, WC()->cart->dp );
+		$shipping    = wc_format_decimal( WC()->cart->shipping_total, WC()->cart->dp );
+		$items_total = wc_format_decimal( WC()->cart->cart_contents_total, WC()->cart->dp ) + $discounts;
+		$order_total = version_compare( WC_VERSION, '3.2', '<' ) ? wc_format_decimal( $items_total + $tax + $shipping - $discounts, WC()->cart->dp ) : WC()->cart->get_total( '' );
+
+		if ( $this->prices_exclude_tax() ) {
+			$items[] = [
+				'label'  => esc_html( __( 'Tax', 'woocommerce-payments' ) ),
+				'amount' => WC_Payments_Utils::prepare_amount( $tax, $currency ),
+			];
+		}
+
+		if ( WC()->cart->needs_shipping() ) {
+			$shipping_tax = $this->prices_exclude_tax() ? 0 : WC()->cart->shipping_tax_total;
+			$items[]      = [
+				'label'  => esc_html( __( 'Shipping', 'woocommerce-payments' ) ),
+				'amount' => WC_Payments_Utils::prepare_amount( $shipping + $shipping_tax, $currency ),
+			];
+		}
+
+		if ( WC()->cart->has_discount() ) {
+			$items[] = [
+				'label'  => esc_html( __( 'Discount', 'woocommerce-payments' ) ),
+				'amount' => WC_Payments_Utils::prepare_amount( $discounts, $currency ),
+			];
+		}
+
+		if ( version_compare( WC_VERSION, '3.2', '<' ) ) {
+			$cart_fees = WC()->cart->fees;
+		} else {
+			$cart_fees = WC()->cart->get_fees();
+		}
+
+		// Include fees and taxes as display items.
+		foreach ( $cart_fees as $key => $fee ) {
+			$items[] = [
+				'label'  => $fee->name,
+				'amount' => WC_Payments_Utils::prepare_amount( $fee->amount, $currency ),
+			];
+		}
+
+		return [
+			'displayItems' => $items,
+			'total'        => [
+				'label'   => $this->get_total_label(),
+				'amount'  => max( 0, apply_filters( 'wcpay_calculated_total', WC_Payments_Utils::prepare_amount( $order_total, $currency ), $order_total, WC()->cart ) ),
+				'pending' => false,
+			],
+		];
+	}
+
+	/**
+	 * Whether tax should be displayed on seperate line.
+	 * returns true if tax is enabled & display of tax in checkout is set to exclusive.
+	 *
+	 * @return boolean
+	 */
+	public function prices_exclude_tax() {
+		return wc_tax_enabled() && 'incl' !== get_option( 'woocommerce_tax_display_cart' );
+	}
+
+	/**
+	 * Gets total label.
+	 *
+	 * @return string
+	 */
+	public function get_total_label() {
+		// Get statement descriptor from API/cached account data.
+		$statement_descriptor = $this->account->get_statement_descriptor();
+		return str_replace( "'", '', $statement_descriptor ) . apply_filters( 'wcpay_payment_request_total_label_suffix', ' (via WooCommerce)' );
+	}
+
+	/**
+	 * Checks if this is a product page or content contains a product_page shortcode.
+	 *
+	 * @return boolean
+	 */
+	public function is_product() {
+		return is_product() || wc_post_content_has_shortcode( 'product_page' );
+	}
+
+	/**
+	 * Checks if this is the Pay for Order page.
+	 *
+	 * @return boolean
+	 */
+	public function is_pay_for_order_page() {
+		return is_checkout() && isset( $_GET['pay_for_order'] ); // phpcs:ignore WordPress.Security.NonceVerification
+	}
+
+	/**
+	 * Checks if this is the cart page or content contains a cart block.
+	 *
+	 * @return boolean
+	 */
+	public function is_cart() {
+		return is_cart() || has_block( 'woocommerce/cart' );
+	}
+
+	/**
+	 * Checks if this is the checkout page or content contains a cart block.
+	 *
+	 * @return boolean
+	 */
+	public function is_checkout() {
+		$something = static::BUTTON_LOCATIONS_OPTION_NAME;
+		$hey       = false;
+		return is_checkout() || has_block( 'woocommerce/checkout' );
+	}
+
+	/**
+	 * Checks if payment request is available at a given location.
+	 *
+	 * @param string $location Location.
+	 * @return boolean
+	 */
+	public function is_available_at( $location ) {
+		$available_locations = $this->gateway->get_option( static::BUTTON_LOCATIONS_OPTION_NAME );
+		if ( $available_locations && is_array( $available_locations ) ) {
+			return in_array( $location, $available_locations, true );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get product from product page or product_page shortcode.
+	 *
+	 * @return WC_Product|false|null Product object.
+	 */
+	protected function get_product() {
+		global $post;
+
+		if ( is_product() ) {
+			return wc_get_product( $post->ID );
+		} elseif ( wc_post_content_has_shortcode( 'product_page' ) ) {
+			// Get id from product_page shortcode.
+			preg_match( '/\[product_page id="(?<id>\d+)"\]/', $post->post_content, $shortcode_match );
+			if ( isset( $shortcode_match['id'] ) ) {
+				return wc_get_product( $shortcode_match['id'] );
+			}
+		}
+
+		return false;
+	}
+}

--- a/includes/class-wc-payments-payment-request-button-handler.php
+++ b/includes/class-wc-payments-payment-request-button-handler.php
@@ -13,38 +13,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use WCPay\Exceptions\Invalid_Price_Exception;
 use WCPay\Logger;
-use WCPay\Payment_Information;
+use WCPay\Exceptions\Invalid_Price_Exception;
 
 /**
  * WC_Payments_Payment_Request_Button_Handler class.
  */
-class WC_Payments_Payment_Request_Button_Handler {
-	/**
-	 * WC_Payments_Account instance to get information about the account
-	 *
-	 * @var WC_Payments_Account
-	 */
-	private $account;
+class WC_Payments_Payment_Request_Button_Handler extends WC_Payments_Express_Checkout_Button {
 
-	/**
-	 * WC_Payment_Gateway_WCPay instance.
-	 *
-	 * @var WC_Payment_Gateway_WCPay
-	 */
-	private $gateway;
-
-	/**
-	 * Initialize class actions.
-	 *
-	 * @param WC_Payments_Account      $account Account information.
-	 * @param WC_Payment_Gateway_WCPay $gateway WCPay gateway.
-	 */
-	public function __construct( WC_Payments_Account $account, WC_Payment_Gateway_WCPay $gateway ) {
-		$this->account = $account;
-		$this->gateway = $gateway;
-	}
+	const BUTTON_LOCATIONS_OPTION_NAME = 'payment_request_button_locations';
 
 	/**
 	 * Initialize hooks.
@@ -124,17 +101,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 			'yes' === get_option( 'woocommerce_registration_generate_username', 'yes' ) &&
 			'yes' === get_option( 'woocommerce_registration_generate_password', 'yes' )
 		);
-	}
-
-	/**
-	 * Gets total label.
-	 *
-	 * @return string
-	 */
-	public function get_total_label() {
-		// Get statement descriptor from API/cached account data.
-		$statement_descriptor = $this->account->get_statement_descriptor();
-		return str_replace( "'", '', $statement_descriptor ) . apply_filters( 'wcpay_payment_request_total_label_suffix', ' (via WooCommerce)' );
 	}
 
 	/**
@@ -610,78 +576,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 				if ( WC_Subscriptions_Product::is_subscription( $_product ) ) {
 					return true;
 				}
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Checks if this is a product page or content contains a product_page shortcode.
-	 *
-	 * @return boolean
-	 */
-	public function is_product() {
-		return is_product() || wc_post_content_has_shortcode( 'product_page' );
-	}
-
-	/**
-	 * Checks if this is the Pay for Order page.
-	 *
-	 * @return boolean
-	 */
-	public function is_pay_for_order_page() {
-		return is_checkout() && isset( $_GET['pay_for_order'] ); // phpcs:ignore WordPress.Security.NonceVerification
-	}
-
-	/**
-	 * Checks if this is the cart page or content contains a cart block.
-	 *
-	 * @return boolean
-	 */
-	public function is_cart() {
-		return is_cart() || has_block( 'woocommerce/cart' );
-	}
-
-	/**
-	 * Checks if this is the checkout page or content contains a cart block.
-	 *
-	 * @return boolean
-	 */
-	public function is_checkout() {
-		return is_checkout() || has_block( 'woocommerce/checkout' );
-	}
-
-	/**
-	 * Checks if payment request is available at a given location.
-	 *
-	 * @param string $location Location.
-	 * @return boolean
-	 */
-	public function is_available_at( $location ) {
-		$available_locations = $this->gateway->get_option( 'payment_request_button_locations' );
-		if ( $available_locations && is_array( $available_locations ) ) {
-			return in_array( $location, $available_locations, true );
-		}
-
-		return false;
-	}
-
-	/**
-	 * Get product from product page or product_page shortcode.
-	 *
-	 * @return WC_Product|false|null Product object.
-	 */
-	public function get_product() {
-		global $post;
-
-		if ( is_product() ) {
-			return wc_get_product( $post->ID );
-		} elseif ( wc_post_content_has_shortcode( 'product_page' ) ) {
-			// Get id from product_page shortcode.
-			preg_match( '/\[product_page id="(?<id>\d+)"\]/', $post->post_content, $shortcode_match );
-			if ( isset( $shortcode_match['id'] ) ) {
-				return wc_get_product( $shortcode_match['id'] );
 			}
 		}
 
@@ -1449,16 +1343,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 	}
 
 	/**
-	 * Whether tax should be displayed on seperate line.
-	 * returns true if tax is enabled & display of tax in checkout is set to exclusive.
-	 *
-	 * @return boolean
-	 */
-	private function prices_exclude_tax() {
-		return wc_tax_enabled() && 'incl' !== get_option( 'woocommerce_tax_display_cart' );
-	}
-
-	/**
 	 * Builds the shipping methods to pass to Payment Request
 	 *
 	 * @param array $shipping_methods Shipping methods.
@@ -1480,103 +1364,6 @@ class WC_Payments_Payment_Request_Button_Handler {
 		}
 
 		return $shipping;
-	}
-
-	/**
-	 * Builds the line items to pass to Payment Request
-	 *
-	 * @param boolean $itemized_display_items Indicates whether to show subtotals or itemized views.
-	 */
-	protected function build_display_items( $itemized_display_items = false ) {
-		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
-			define( 'WOOCOMMERCE_CART', true );
-		}
-
-		$items     = [];
-		$subtotal  = 0;
-		$discounts = 0;
-		$currency  = get_woocommerce_currency();
-
-		// Default show only subtotal instead of itemization.
-		if ( ! apply_filters( 'wcpay_payment_request_hide_itemization', true ) || $itemized_display_items ) {
-			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-				$amount         = $cart_item['line_subtotal'];
-				$subtotal      += $cart_item['line_subtotal'];
-				$quantity_label = 1 < $cart_item['quantity'] ? ' (x' . $cart_item['quantity'] . ')' : '';
-
-				$product_name = $cart_item['data']->get_name();
-
-				$item_tax = $this->prices_exclude_tax() ? 0 : ( $cart_item['line_subtotal_tax'] ?? 0 );
-
-				$item = [
-					'label'  => $product_name . $quantity_label,
-					'amount' => WC_Payments_Utils::prepare_amount( $amount + $item_tax, $currency ),
-				];
-
-				$items[] = $item;
-			}
-		}
-
-		if ( version_compare( WC_VERSION, '3.2', '<' ) ) {
-			$discounts = wc_format_decimal( WC()->cart->get_cart_discount_total(), WC()->cart->dp );
-		} else {
-			$applied_coupons = array_values( WC()->cart->get_coupon_discount_totals() );
-
-			foreach ( $applied_coupons as $amount ) {
-				$discounts += (float) $amount;
-			}
-		}
-
-		$discounts   = wc_format_decimal( $discounts, WC()->cart->dp );
-		$tax         = wc_format_decimal( WC()->cart->tax_total + WC()->cart->shipping_tax_total, WC()->cart->dp );
-		$shipping    = wc_format_decimal( WC()->cart->shipping_total, WC()->cart->dp );
-		$items_total = wc_format_decimal( WC()->cart->cart_contents_total, WC()->cart->dp ) + $discounts;
-		$order_total = version_compare( WC_VERSION, '3.2', '<' ) ? wc_format_decimal( $items_total + $tax + $shipping - $discounts, WC()->cart->dp ) : WC()->cart->get_total( '' );
-
-		if ( $this->prices_exclude_tax() ) {
-			$items[] = [
-				'label'  => esc_html( __( 'Tax', 'woocommerce-payments' ) ),
-				'amount' => WC_Payments_Utils::prepare_amount( $tax, $currency ),
-			];
-		}
-
-		if ( WC()->cart->needs_shipping() ) {
-			$shipping_tax = $this->prices_exclude_tax() ? 0 : WC()->cart->shipping_tax_total;
-			$items[]      = [
-				'label'  => esc_html( __( 'Shipping', 'woocommerce-payments' ) ),
-				'amount' => WC_Payments_Utils::prepare_amount( $shipping + $shipping_tax, $currency ),
-			];
-		}
-
-		if ( WC()->cart->has_discount() ) {
-			$items[] = [
-				'label'  => esc_html( __( 'Discount', 'woocommerce-payments' ) ),
-				'amount' => WC_Payments_Utils::prepare_amount( $discounts, $currency ),
-			];
-		}
-
-		if ( version_compare( WC_VERSION, '3.2', '<' ) ) {
-			$cart_fees = WC()->cart->fees;
-		} else {
-			$cart_fees = WC()->cart->get_fees();
-		}
-
-		// Include fees and taxes as display items.
-		foreach ( $cart_fees as $key => $fee ) {
-			$items[] = [
-				'label'  => $fee->name,
-				'amount' => WC_Payments_Utils::prepare_amount( $fee->amount, $currency ),
-			];
-		}
-
-		return [
-			'displayItems' => $items,
-			'total'        => [
-				'label'   => $this->get_total_label(),
-				'amount'  => max( 0, apply_filters( 'wcpay_calculated_total', WC_Payments_Utils::prepare_amount( $order_total, $currency ), $order_total, WC()->cart ) ),
-				'pending' => false,
-			],
-		];
 	}
 
 	/**

--- a/includes/class-wc-payments-platform-checkout-button-handler.php
+++ b/includes/class-wc-payments-platform-checkout-button-handler.php
@@ -3,8 +3,6 @@
  * Class WC_Payments_Platform_Checkout_Button_Handler
  * Adds support for the WooPay express checkout button.
  *
- * Borrowed heavily from the WC_Payments_Payment_Request_Button_Handler class.
- *
  * @package WooCommerce\Payments
  */
 
@@ -12,29 +10,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// TODO: Not sure which of these are needed yet.
-use WCPay\Exceptions\Invalid_Price_Exception;
 use WCPay\Logger;
-use WCPay\Payment_Information;
 use WCPay\Platform_Checkout\Platform_Checkout_Utilities;
 
 /**
  * WC_Payments_Platform_Checkout_Button_Handler class.
  */
-class WC_Payments_Platform_Checkout_Button_Handler {
+class WC_Payments_Platform_Checkout_Button_Handler extends WC_Payments_Express_Checkout_Button {
+
+	const BUTTON_LOCATIONS_OPTION_NAME = 'platform_checkout_button_locations';
+
 	/**
 	 * WC_Payments_Account instance to get information about the account
 	 *
 	 * @var WC_Payments_Account
 	 */
-	private $account;
+	protected $account;
 
 	/**
 	 * WC_Payment_Gateway_WCPay instance.
 	 *
 	 * @var WC_Payment_Gateway_WCPay
 	 */
-	private $gateway;
+	protected $gateway;
 
 	/**
 	 * Platform_Checkout_Utilities instance.
@@ -51,6 +49,7 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 	 * @param Platform_Checkout_Utilities $platform_checkout_utilities WCPay gateway.
 	 */
 	public function __construct( WC_Payments_Account $account, WC_Payment_Gateway_WCPay $gateway, Platform_Checkout_Utilities $platform_checkout_utilities ) {
+		parent::__construct( $account, $gateway );
 		$this->account                     = $account;
 		$this->gateway                     = $gateway;
 		$this->platform_checkout_utilities = $platform_checkout_utilities;
@@ -239,175 +238,6 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 		$data['result'] = 'success';
 
 		wp_send_json( $data );
-	}
-
-	/**
-	 * Builds the line items to pass to Payment Request
-	 *
-	 * @param boolean $itemized_display_items Indicates whether to show subtotals or itemized views.
-	 */
-	protected function build_display_items( $itemized_display_items = false ) {
-		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
-			define( 'WOOCOMMERCE_CART', true );
-		}
-
-		$items     = [];
-		$subtotal  = 0;
-		$discounts = 0;
-		$currency  = get_woocommerce_currency();
-
-		// Default show only subtotal instead of itemization.
-		if ( ! apply_filters( 'wcpay_payment_request_hide_itemization', true ) || $itemized_display_items ) {
-			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-				$amount         = $cart_item['line_subtotal'];
-				$subtotal      += $cart_item['line_subtotal'];
-				$quantity_label = 1 < $cart_item['quantity'] ? ' (x' . $cart_item['quantity'] . ')' : '';
-
-				$product_name = $cart_item['data']->get_name();
-
-				$item_tax = $this->prices_exclude_tax() ? 0 : ( $cart_item['line_subtotal_tax'] ?? 0 );
-
-				$item = [
-					'label'  => $product_name . $quantity_label,
-					'amount' => WC_Payments_Utils::prepare_amount( $amount + $item_tax, $currency ),
-				];
-
-				$items[] = $item;
-			}
-		}
-
-		if ( version_compare( WC_VERSION, '3.2', '<' ) ) {
-			$discounts = wc_format_decimal( WC()->cart->get_cart_discount_total(), WC()->cart->dp );
-		} else {
-			$applied_coupons = array_values( WC()->cart->get_coupon_discount_totals() );
-
-			foreach ( $applied_coupons as $amount ) {
-				$discounts += (float) $amount;
-			}
-		}
-
-		$discounts   = wc_format_decimal( $discounts, WC()->cart->dp );
-		$tax         = wc_format_decimal( WC()->cart->tax_total + WC()->cart->shipping_tax_total, WC()->cart->dp );
-		$shipping    = wc_format_decimal( WC()->cart->shipping_total, WC()->cart->dp );
-		$items_total = wc_format_decimal( WC()->cart->cart_contents_total, WC()->cart->dp ) + $discounts;
-		$order_total = version_compare( WC_VERSION, '3.2', '<' ) ? wc_format_decimal( $items_total + $tax + $shipping - $discounts, WC()->cart->dp ) : WC()->cart->get_total( '' );
-
-		if ( $this->prices_exclude_tax() ) {
-			$items[] = [
-				'label'  => esc_html( __( 'Tax', 'woocommerce-payments' ) ),
-				'amount' => WC_Payments_Utils::prepare_amount( $tax, $currency ),
-			];
-		}
-
-		if ( WC()->cart->needs_shipping() ) {
-			$shipping_tax = $this->prices_exclude_tax() ? 0 : WC()->cart->shipping_tax_total;
-			$items[]      = [
-				'label'  => esc_html( __( 'Shipping', 'woocommerce-payments' ) ),
-				'amount' => WC_Payments_Utils::prepare_amount( $shipping + $shipping_tax, $currency ),
-			];
-		}
-
-		if ( WC()->cart->has_discount() ) {
-			$items[] = [
-				'label'  => esc_html( __( 'Discount', 'woocommerce-payments' ) ),
-				'amount' => WC_Payments_Utils::prepare_amount( $discounts, $currency ),
-			];
-		}
-
-		if ( version_compare( WC_VERSION, '3.2', '<' ) ) {
-			$cart_fees = WC()->cart->fees;
-		} else {
-			$cart_fees = WC()->cart->get_fees();
-		}
-
-		// Include fees and taxes as display items.
-		foreach ( $cart_fees as $key => $fee ) {
-			$items[] = [
-				'label'  => $fee->name,
-				'amount' => WC_Payments_Utils::prepare_amount( $fee->amount, $currency ),
-			];
-		}
-
-		return [
-			'displayItems' => $items,
-			'total'        => [
-				'label'   => $this->get_total_label(),
-				'amount'  => max( 0, apply_filters( 'wcpay_calculated_total', WC_Payments_Utils::prepare_amount( $order_total, $currency ), $order_total, WC()->cart ) ),
-				'pending' => false,
-			],
-		];
-	}
-
-	/**
-	 * Whether tax should be displayed on seperate line.
-	 * returns true if tax is enabled & display of tax in checkout is set to exclusive.
-	 *
-	 * @return boolean
-	 */
-	private function prices_exclude_tax() {
-		return wc_tax_enabled() && 'incl' !== get_option( 'woocommerce_tax_display_cart' );
-	}
-
-	/**
-	 * Gets total label.
-	 *
-	 * @return string
-	 */
-	public function get_total_label() {
-		// Get statement descriptor from API/cached account data.
-		$statement_descriptor = $this->account->get_statement_descriptor();
-		return str_replace( "'", '', $statement_descriptor ) . apply_filters( 'wcpay_payment_request_total_label_suffix', ' (via WooCommerce)' );
-	}
-
-	/**
-	 * Checks if this is a product page or content contains a product_page shortcode.
-	 *
-	 * @return boolean
-	 */
-	public function is_product() {
-		return is_product() || wc_post_content_has_shortcode( 'product_page' );
-	}
-
-	/**
-	 * Checks if this is the Pay for Order page.
-	 *
-	 * @return boolean
-	 */
-	public function is_pay_for_order_page() {
-		return is_checkout() && isset( $_GET['pay_for_order'] ); // phpcs:ignore WordPress.Security.NonceVerification
-	}
-
-	/**
-	 * Checks if this is the cart page or content contains a cart block.
-	 *
-	 * @return boolean
-	 */
-	public function is_cart() {
-		return is_cart() || has_block( 'woocommerce/cart' );
-	}
-
-	/**
-	 * Checks if this is the checkout page or content contains a cart block.
-	 *
-	 * @return boolean
-	 */
-	public function is_checkout() {
-		return is_checkout() || has_block( 'woocommerce/checkout' );
-	}
-
-	/**
-	 * Checks if payment request is available at a given location.
-	 *
-	 * @param string $location Location.
-	 * @return boolean
-	 */
-	public function is_available_at( $location ) {
-		$available_locations = $this->gateway->get_option( 'platform_checkout_button_locations' );
-		if ( $available_locations && is_array( $available_locations ) ) {
-			return in_array( $location, $available_locations, true );
-		}
-
-		return false;
 	}
 
 	/**
@@ -618,29 +448,6 @@ class WC_Payments_Platform_Checkout_Button_Handler {
 		}
 
 		return apply_filters( 'wcpay_platform_checkout_button_are_cart_items_supported', $is_supported );
-	}
-
-	/**
-	 * Get product from product page or product_page shortcode.
-	 *
-	 * @todo Abstract this. This is a copy of the same method in the `WC_Payments_Payment_Request_Button_Handler` class.
-	 *
-	 * @return WC_Product|false|null Product object.
-	 */
-	private function get_product() {
-		global $post;
-
-		if ( is_product() ) {
-			return wc_get_product( $post->ID );
-		} elseif ( wc_post_content_has_shortcode( 'product_page' ) ) {
-			// Get id from product_page shortcode.
-			preg_match( '/\[product_page id="(?<id>\d+)"\]/', $post->post_content, $shortcode_match );
-			if ( isset( $shortcode_match['id'] ) ) {
-				return wc_get_product( $shortcode_match['id'] );
-			}
-		}
-
-		return false;
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -369,6 +369,7 @@ class WC_Payments {
 		include_once __DIR__ . '/class-wc-payment-token-wcpay-sepa.php';
 		include_once __DIR__ . '/class-wc-payments-status.php';
 		include_once __DIR__ . '/class-wc-payments-token-service.php';
+		include_once __DIR__ . '/class-wc-payments-express-checkout-button.php';
 		include_once __DIR__ . '/class-wc-payments-express-checkout-button-display-handler.php';
 		include_once __DIR__ . '/class-wc-payments-payment-request-button-handler.php';
 		include_once __DIR__ . '/class-wc-payments-platform-checkout-button-handler.php';


### PR DESCRIPTION
Fixes 1545-gh-Automattic/woopay

#### Changes proposed in this Pull Request

Initially, the only express checkout button included in WooCommerce Payments was the Stripe Payment Request button, which included Google Pay and Apple Pay. Then, with WooPay, came the WooPay express checkout button. This new class duplicated a lot the functionality and logic from the `WC_Payments_Payment_Request_Button_Handler` class. This PR serves to add a new abstract class that express checkout methods can extend to make use of any common or required functionality.

<!--
Title: A descriptive, yet concise, title.
-->

#### Testing instructions

1. Enable Payment Requests and WooPay buttons.
2. Verify that the buttons appear on the Cart, Checkout, and Product pages.
3. Verify that each buttons location settings can be customized, i.e. disabled on Cart, enabled on Checkout, etc.
4. Verify that payments are working with each button.

------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.