### PR TITLE
Update dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,23 @@ updates:
     - package-ecosystem: 'npm'
       # Look for `package.json` and `lock` files in the `root` directory
       directory: '/'
-      # Check the npm registry for updates every day (weekdays)
+      # Check for updates once a week
       schedule:
         interval: 'weekly'
+      ignore:
+        # For @wordpress dependencies, ignore all updates as most of them need to be synced to the min WP version
+        - dependency-name: "@wordpress/*"
+        # For @woocommerce dependencies, ignore all updates as most of them need to be synced to the min WC version
+        - dependency-name: "@woocommerce/*"
       # Reviewers for issues created
       reviewers:
-          - 'Automattic/harmony'
+        - 'Automattic/harmony'
 
     # Enable version updates for composer
     - package-ecosystem: 'composer'
       # Look for `package.json` and `lock` files in the `root` directory
       directory: '/'
-      # Check the npm registry for updates every day (weekdays)
+      # Check for updates once a week
       schedule:
         interval: 'weekly'
       # Reviewers for issues created

--- a/changelog/dev-ignore-deps-dependabot-config
+++ b/changelog/dev-ignore-deps-dependabot-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update dependabot config file to ignore wordpress and woocommerce dependencies
+
+


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

- Make dependabot ignore all `@wordpress/*` and `@woocommerce/*` dependencies update

We generally need to have them synced to the minimum supported versions of WordPress/WooCommerce so we don't need to have Dependabot generate PRs for those all the time. We'll probably do those updates in batch, from time to time, when we bump the minimum versions

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
