### PR TITLE
Add support of complete_kyc_link in wcpay-link-handler route

### DIFF
--- a/changelog/add-server-3268-support-complete-kyc-link
+++ b/changelog/add-server-3268-support-complete-kyc-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add support for complete_kyc_link wcpay-link-handler

--- a/client/onboarding-prototype/steps/loading.tsx
+++ b/client/onboarding-prototype/steps/loading.tsx
@@ -37,7 +37,7 @@ const LoadingStep: React.FC< Props > = () => {
 			business: {
 				country: data.country,
 				type: data.business_type,
-				mcc: 'computers_peripherals_and_software', // TODO GH-4853 add MCC from onboarding form
+				mcc: 'software_services', // TODO GH-4853 add MCC from onboarding form
 				annual_revenue: data.annual_revenue,
 				go_live_timeframe: data.go_live_timeframe,
 			},

--- a/client/onboarding-prototype/steps/test/loading.tsx
+++ b/client/onboarding-prototype/steps/test/loading.tsx
@@ -75,7 +75,7 @@ describe( 'Loading', () => {
 		data = {
 			country: 'US',
 			business_type: 'individual',
-			mcc: 'computers_peripherals_and_software',
+			mcc: 'software_services',
 			annual_revenue: 'less_than_250k',
 			go_live_timeframe: 'within_1month',
 		};
@@ -93,7 +93,7 @@ describe( 'Loading', () => {
 					business: {
 						country: 'US',
 						type: 'individual',
-						mcc: 'computers_peripherals_and_software',
+						mcc: 'software_services',
 						annual_revenue: 'less_than_250k',
 						go_live_timeframe: 'within_1month',
 					},
@@ -110,7 +110,7 @@ describe( 'Loading', () => {
 		data = {
 			country: 'GB',
 			business_type: 'individual',
-			mcc: 'computers_peripherals_and_software',
+			mcc: 'software_services',
 			annual_revenue: 'less_than_250k',
 			go_live_timeframe: 'within_1month',
 		};
@@ -128,7 +128,7 @@ describe( 'Loading', () => {
 					business: {
 						country: 'GB',
 						type: 'individual',
-						mcc: 'computers_peripherals_and_software',
+						mcc: 'software_services',
 						annual_revenue: 'less_than_250k',
 						go_live_timeframe: 'within_1month',
 					},

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -570,6 +570,9 @@ class WC_Payments_Account {
 
 		try {
 			$link = $this->payments_api_client->get_link( $args );
+			if ( isset( $args['type'] ) && 'complete_kyc_link' === $args['type'] && isset( $link['state'] ) ) {
+				set_transient( 'wcpay_stripe_onboarding_state', $link['state'], DAY_IN_SECONDS );
+			}
 
 			$this->redirect_to( $link['url'] );
 		} catch ( API_Exception $e ) {

--- a/tests/unit/admin/test-class-wc-rest-payments-onboarding-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-onboarding-controller.php
@@ -133,7 +133,7 @@ class WC_REST_Payments_Onboarding_Controller_Test extends WCPAY_UnitTestCase {
 				'business' => [
 					'country'           => 'US',
 					'type'              => 'company',
-					'mcc'               => 'computers_peripherals_and_software',
+					'mcc'               => 'software_services',
 					'annual_revenue'    => 'less_than_250k',
 					'go_live_timeframe' => 'within_1month',
 				],
@@ -168,7 +168,7 @@ class WC_REST_Payments_Onboarding_Controller_Test extends WCPAY_UnitTestCase {
 				'business' => [
 					'country'           => 'US',
 					'type'              => 'company',
-					'mcc'               => 'computers_peripherals_and_software',
+					'mcc'               => 'software_services',
 					'annual_revenue'    => 'from_1m_to_20m',
 					'go_live_timeframe' => 'from_1_to_3months',
 				],

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -909,7 +909,7 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 				'business' => [
 					'country'           => 'US',
 					'type'              => 'company',
-					'mcc'               => 'computers_peripherals_and_software',
+					'mcc'               => 'software_services',
 					'annual_revenue'    => 'less_than_250k',
 					'go_live_timeframe' => 'within_1month',
 				],


### PR DESCRIPTION
Related to server issue 3341

#### Changes proposed in this Pull Request

- Support `complete_kyc_link` type in `?wcpay-link-handler` route
- Tweak PO eligible logic with valid MCC

#### Testing instructions

* Should be tested with server issue

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
