### PR TITLE
Address progressive onboarding feedback

### DIFF
--- a/changelog/add-6158-progressive-onboarding-feedback
+++ b/changelog/add-6158-progressive-onboarding-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Progressive onboarding design fixes

--- a/client/onboarding-prototype/style.scss
+++ b/client/onboarding-prototype/style.scss
@@ -93,11 +93,12 @@ body.wcpay-onboarding-prototype__body {
 			}
 		}
 
-		// TODO fix css on loading screen
-
 		.loading-step {
 			max-width: 520px;
-			margin: 50% auto 0;
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			transform: translate( -50%, -50% );
 		}
 
 		.onboarding-mode__note {

--- a/client/onboarding-prototype/style.scss
+++ b/client/onboarding-prototype/style.scss
@@ -93,6 +93,8 @@ body.wcpay-onboarding-prototype__body {
 			}
 		}
 
+		// TODO fix css on loading screen
+
 		.loading-step {
 			max-width: 520px;
 			margin: 50% auto 0;

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -110,9 +110,6 @@ const OverviewPage = () => {
 		} )
 		.filter( ( e ) => e && e.fee !== undefined );
 
-	// TODO SetupRealPayments should be placed above the account card.
-	// TODO SetupRealPayments should be dismissable.
-
 	return (
 		<Page isNarrow className="wcpay-overview">
 			<OverviewPageError />
@@ -171,18 +168,18 @@ const OverviewPage = () => {
 					</ErrorBoundary>
 				) }
 
+			{ wcpaySettings.onboardingTestMode && (
+				<ErrorBoundary>
+					<SetupRealPayments />
+				</ErrorBoundary>
+			) }
+
 			<ErrorBoundary>
 				<AccountStatus
 					accountStatus={ wcpaySettings.accountStatus }
 					accountFees={ activeAccountFees }
 				/>
 			</ErrorBoundary>
-
-			{ wcpaySettings.onboardingTestMode && (
-				<ErrorBoundary>
-					<SetupRealPayments />
-				</ErrorBoundary>
-			) }
 
 			{ wcpaySettings.accountLoans.has_active_loan && (
 				<ErrorBoundary>

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -110,6 +110,9 @@ const OverviewPage = () => {
 		} )
 		.filter( ( e ) => e && e.fee !== undefined );
 
+	// TODO SetupRealPayments should be placed above the account card.
+	// TODO SetupRealPayments should be dismissable.
+
 	return (
 		<Page isNarrow className="wcpay-overview">
 			<OverviewPageError />

--- a/client/overview/modal/progressive-onboarding-eligibility/style.scss
+++ b/client/overview/modal/progressive-onboarding-eligibility/style.scss
@@ -1,5 +1,8 @@
 .wcpay-progressive-onboarding-eligibility-modal {
-	// TODO fix padding on the bottom buttons
+	// fix for the modal being too short on smaller screens
+	@media ( max-height: 880px ) {
+		max-height: calc( 100% - 120px ) !important;
+	}
 	.components-modal__content {
 		box-sizing: border-box;
 		max-width: 700px;

--- a/client/overview/modal/progressive-onboarding-eligibility/style.scss
+++ b/client/overview/modal/progressive-onboarding-eligibility/style.scss
@@ -1,4 +1,5 @@
 .wcpay-progressive-onboarding-eligibility-modal {
+	// TODO fix padding on the bottom buttons
 	.components-modal__content {
 		box-sizing: border-box;
 		max-width: 700px;

--- a/client/overview/setup-real-payments.tsx
+++ b/client/overview/setup-real-payments.tsx
@@ -25,6 +25,7 @@ const SetupRealPayments: React.FC = () => {
 	const [ modalVisible, setModalVisible ] = useState( false );
 
 	const handleContinue = () => {
+		// TODO continue setup should redirect to the new onboarding flow directly, skipping payments connect screen.
 		window.location.href = addQueryArgs( wcpaySettings.connectUrl, {
 			'wcpay-disable-onboarding-test-mode': true,
 		} );

--- a/client/overview/setup-real-payments.tsx
+++ b/client/overview/setup-real-payments.tsx
@@ -25,7 +25,6 @@ const SetupRealPayments: React.FC = () => {
 	const [ modalVisible, setModalVisible ] = useState( false );
 
 	const handleContinue = () => {
-		// TODO continue setup should redirect to the new onboarding flow directly, skipping payments connect screen.
 		window.location.href = addQueryArgs( wcpaySettings.connectUrl, {
 			'wcpay-disable-onboarding-test-mode': true,
 		} );
@@ -76,7 +75,7 @@ const SetupRealPayments: React.FC = () => {
 						'woocommerce-payments'
 					) }
 					className="wcpay-setup-real-payments-modal"
-					isDismissible={ false }
+					isDismissible={ true }
 					onRequestClose={ () => setModalVisible( false ) }
 				>
 					<p className="wcpay-setup-real-payments-modal__headline">

--- a/client/overview/style.scss
+++ b/client/overview/style.scss
@@ -134,7 +134,6 @@
 
 	.components-modal__header {
 		position: initial;
-		height: initial;
 		padding: 0;
 		border: 0;
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -780,7 +780,7 @@ class WC_Payments_Account {
 
 			if ( isset( $_GET['wcpay-disable-onboarding-test-mode'] ) ) {
 				WC_Payments_Onboarding_Service::set_test_mode( false );
-				$this->redirect_to_onboarding_page();
+				$this->redirect_to_prototype_onboarding_page();
 				return;
 			}
 


### PR DESCRIPTION
Fixes #6158 

### Changes proposed in this Pull Request

* fix styling of eligibility modal
* fix styling of the loading screen
* change the placing of SetupRealPayments and make it dismissable
* change the link of Continue setup on Setup live payments on your store

### Testing instructions

#### Testing eligibility modal and loading screen UI fixes
* Checkout this branch, run `npm build:client`
* Onboard new PO account. Please make sure that the loading screen looks good (it's centered).
* Check that eligibility modal styling looks good (lower buttons are not cut)

#### Setup real payments testing
* Delete the prev account and clear the cache
* As we need to filter `dev_mode` we need to disable `Dev mode enabled` under WCPay Dev
* Onboard a new account choosing `I’m building a store for someone else and would like to test payments`.
* After completing the KYC and being redirected to the overview page, check the placement of the `SetupRealPayments` card according to the issue (before the account status).
* Check that `SetupRealPayments` is dismissible.
* Check that `Continue setup` on `Setup live payments on your store` redirects to the new onboarding flow directly, skipping the payments connect screen. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _ 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
