### PR TITLE
Fix Tracks prop to use the correct header

### DIFF
--- a/changelog/fix-place-order-usage-tracking
+++ b/changelog/fix-place-order-usage-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Usage tracking props when placing WooPay orders

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -286,7 +286,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		$this->maybe_record_event(
 			'order_checkout_complete',
 			[
-				'source' => isset( $_SERVER['HTTP_X_WCPAY_WOOPAY_USER'] ) ? 'platform' : 'standard',
+				'source' => ( isset( $_SERVER['HTTP_USER_AGENT'] ) && 'WooPay' === $_SERVER['HTTP_USER_AGENT'] ) ? 'platform' : 'standard',
 			]
 		);
 	}


### PR DESCRIPTION


Fixes #6264 

#### Changes proposed in this Pull Request

`HTTP_X_WCPAY_PLATFORM_CHECKOUT_USER` header is now defunct, This PR updates the Tracks event to check the user agent header instead in order to determine whether the order is placed using WooPay or using standard checkout.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Place an order using WooPay
* In ~5 minutes, check Tracks Live View for the relevant `woocommerceanalytics_order_checkout_complete` entry.
* This entry should have the `source` prop set to `platform`
* Now place an order using the WCPay checkout.
* In ~5 minutes, check Tracks Live View for the relevant `woocommerceanalytics_order_checkout_complete` entry.
* This entry should have the `source` prop set to `standard`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
