### PR TITLE
Fix incorrectly labelled card gateway for the enabled deferred intent creation UPE

### DIFF
--- a/changelog/fix-incorrectly-labelled-gateway-deferred-intent-upe
+++ b/changelog/fix-incorrectly-labelled-gateway-deferred-intent-upe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix incorrectly labelled card gateway for the enabled deferred intent creation UPE

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -1053,7 +1053,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	 * @return string Filtered gateway title.
 	 */
 	public function maybe_filter_gateway_title( $title, $id ) {
-		if ( ! WC_Payments_Features::is_upe_split_enabled() && self::GATEWAY_ID === $id && $this->title === $title ) {
+		if ( ! ( WC_Payments_Features::is_upe_split_enabled() || WC_Payments_Features::is_upe_deferred_intent_enabled() ) && self::GATEWAY_ID === $id && $this->title === $title ) {
 			$title                   = $this->checkout_title;
 			$enabled_payment_methods = $this->get_payment_method_ids_enabled_at_checkout();
 

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -1854,10 +1854,73 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 	/**
 	 * @dataProvider maybe_filter_gateway_title_data_provider
 	 */
-	public function test_maybe_filter_gateway_title( $data ) {
+	public function test_maybe_filter_gateway_title_with_no_additional_feature_flags_enabled( $data ) {
 		$data           = $data[0];
 		$default_option = $this->mock_upe_gateway->get_option( 'upe_enabled_payment_method_ids' );
 		$this->mock_upe_gateway->update_option( 'upe_enabled_payment_method_ids', $data['methods'] );
+		WC_Helper_Site_Currency::$mock_site_currency = $data['currency'];
+		$this->set_get_upe_enabled_payment_method_statuses_return_value( $data['statuses'] );
+		$this->assertSame( $data['expected'], $this->mock_upe_gateway->maybe_filter_gateway_title( $data['title'], $data['id'] ) );
+		$this->mock_upe_gateway->update_option( 'upe_enabled_payment_method_ids', $default_option );
+	}
+
+	public function test_maybe_filter_gateway_title_skips_update_due_to_enabled_split_upe() {
+		update_option( '_wcpay_feature_upe_split', '1' );
+		update_option( '_wcpay_feature_upe_deferred_intent', '0' );
+
+		$data = [
+			'methods'  => [
+				'card',
+				'bancontact',
+			],
+			'statuses' => [
+				'card_payments'       => [
+					'status' => 'active',
+				],
+				'bancontact_payments' => [
+					'status' => 'active',
+				],
+			],
+			'currency' => 'EUR',
+			'title'    => 'WooCommerce Payments',
+			'id'       => UPE_Payment_Gateway::GATEWAY_ID,
+			'expected' => 'WooCommerce Payments',
+		];
+
+		$default_option = $this->mock_upe_gateway->get_option( 'upe_enabled_payment_method_ids' );
+		$this->mock_upe_gateway->update_option( 'upe_enabled_payment_method_ids', $data['methods'] );
+
+		WC_Helper_Site_Currency::$mock_site_currency = $data['currency'];
+		$this->set_get_upe_enabled_payment_method_statuses_return_value( $data['statuses'] );
+		$this->assertSame( $data['expected'], $this->mock_upe_gateway->maybe_filter_gateway_title( $data['title'], $data['id'] ) );
+		$this->mock_upe_gateway->update_option( 'upe_enabled_payment_method_ids', $default_option );
+	}
+
+	public function test_maybe_filter_gateway_title_skips_update_due_to_enabled_upe_with_deferred_intent_creation() {
+		update_option( '_wcpay_feature_upe_split', '0' );
+		update_option( '_wcpay_feature_upe_deferred_intent', '1' );
+		$data = [
+			'methods'  => [
+				'card',
+				'bancontact',
+			],
+			'statuses' => [
+				'card_payments'       => [
+					'status' => 'active',
+				],
+				'bancontact_payments' => [
+					'status' => 'active',
+				],
+			],
+			'currency' => 'EUR',
+			'title'    => 'WooCommerce Payments',
+			'id'       => UPE_Payment_Gateway::GATEWAY_ID,
+			'expected' => 'WooCommerce Payments',
+		];
+
+		$default_option = $this->mock_upe_gateway->get_option( 'upe_enabled_payment_method_ids' );
+		$this->mock_upe_gateway->update_option( 'upe_enabled_payment_method_ids', $data['methods'] );
+
 		WC_Helper_Site_Currency::$mock_site_currency = $data['currency'];
 		$this->set_get_upe_enabled_payment_method_statuses_return_value( $data['statuses'] );
 		$this->assertSame( $data['expected'], $this->mock_upe_gateway->maybe_filter_gateway_title( $data['title'], $data['id'] ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/6227

#### Changes proposed in this Pull Request
This PR enhances the logic responsible for the payment gateway title filtering. Previously, the `maybe_filter_gateway_title` method in `class-upe-payment-gateway.php` skipped the split UPE filtering thus allowing the system to render the proper title. Deferred intent creation UPE wasn't taken into consideration in this flow, and thus it wasn't skipped, effectively leading to the title being updated to the wrong **_Popular payment methods_** value. This PR adds the check to ensure that the enabled deferred intent creation UPE should be handled like the split UPE.


<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
1. Ensure **_Enable Split UPE checkout with deferred intent creation_** is checked in your WCPay Dev Tools and ensure WooPay is deselected in your WCPay settings, so that the CC gateway uses the UPE instead of the legacy card element.
2. Enable CC and a few additional LPMs in settings (e.g. Sofort, giropay, etc.). At currency you will need to use a supported currency that will allow these additional payment gateways to appear (e.g. EUR).
3. Add item to cart and proceed to checkout.
4. Confirm that the title of CC payment gateway is **_Credit card / debit card_** and not **_Popular payment methods_**
5. To double-check, you can checkout to develop, refresh the checkout page right after and see, that the gateway title is **_Popular payment methods_**.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
