### PR TITLE
Bring back the rest-user-exists-controller file

### DIFF
--- a/changelog/fix-plugin-upgrade
+++ b/changelog/fix-plugin-upgrade
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Temporary fix to hide an error notice that's printed during the plugin upgrade
+
+

--- a/changelog/fix-plugin-upgrade
+++ b/changelog/fix-plugin-upgrade
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Missing file during plugin upgrade

--- a/changelog/fix-plugin-upgrade
+++ b/changelog/fix-plugin-upgrade
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Missing file during plugin upgrade

--- a/includes/admin/class-wc-rest-user-exists-controller.php
+++ b/includes/admin/class-wc-rest-user-exists-controller.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Class WC_REST_User_Exists_Controller
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST controller to check if a user exists.
+ */
+class WC_REST_User_Exists_Controller extends WP_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Endpoint path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'users/exists';
+
+	/**
+	 * Configure REST API routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'user_exists' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
+					'email' => [
+						'required'    => true,
+						'description' => __( 'Email address.', 'woocommerce-payments' ),
+						'type'        => 'string',
+						'format'      => 'email',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Retrieve if a user exists by email address.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function user_exists( WP_REST_Request $request ): WP_REST_Response {
+		$email        = $request->get_param( 'email' );
+		$email_exists = ! empty( email_exists( $email ) );
+		$message      = null;
+
+		if ( $email_exists ) {
+			// Use this function to show the core error message.
+			$error   = wc_create_new_customer( $email );
+			$message = $error->get_error_message();
+		}
+
+		return new WP_REST_Response(
+			[
+				'user-exists' => $email_exists,
+				'message'     => $message,
+			]
+		);
+	}
+}
+


### PR DESCRIPTION
This fixes an error that happens during the plugin upgrade process. 

`class-wc-rest-user-exists-controller.php` and its references were removed in https://github.com/Automattic/woocommerce-payments/pull/6174

During the plugin upgrade process, `init_rest_api` of the current WCPay version is invoked. This results in printing an error during the upgrade. This PR adds the file back to silence the error until we find a more robust solution.


#### Changes proposed in this Pull Request
- Reintroduce `class-wc-rest-user-exists-controller.php` file removed in #6174 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install WCPay 5.8.1.
* Go through onboarding.
* Update to 5.9.0.
* With base branch, expect a fatal error below. With PR branch, expect no error.

```
Failed opening '/srv/users/user217f0884/apps/user217f0884/public/wp-content/plugins/woocommerce-payments/includes/admin/class-wc-rest-user-exists-controller.php' for inclusion (include_path='.:/opt/sp/php7.4/lib/php') in /srv/users/user217f0884/apps/user217f0884/public/wp-content/plugins/woocommerce-payments/includes/class-wc-payments.php on line 954

Fatal error: Uncaught Error: Class 'WC_REST_User_Exists_Controller' not found in /srv/users/user217f0884/apps/user217f0884/public/wp-content/plugins/woocommerce-payments/includes/class-wc-payments.php:955 Stack trace: #0 /srv/users/user217f0884/apps/user217f0884/public/wp-includes/class-wp-hook.php(308): WC_Payments::init_rest_api(Object(WP_REST_Server)) #1 /srv/users/user217f0884/apps/user217f0884/public/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters(NULL, Array) #2 /srv/users/user217f0884/apps/user217f0884/public/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #3 /srv/users/user217f0884/apps/user217f0884/public/wp-includes/rest-api.php(577): do_action('rest_api_init', Object(WP_REST_Server)) #4 /srv/users/user217f0884/apps/user217f0884/public/wp-includes/rest-api.php(535): rest_get_server() #5 /srv/users/user217f0884/apps/user217f0884/public/wp-includes/rest-api.php(2889): rest_do_request(Object(WP_REST_Request)) #6 [internal function]: rest_preload_api_request(Array, '/wc-analytics/r...') #7 /srv/use in /srv/users/user217f0884/apps/user217f0884/public/wp-content/plugins/woocommerce-payments/includes/class-wc-payments.php on line 955
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
