### PR TITLE
Allows 3DS payment methods to be reusable with deferred intent UPE

### DIFF
--- a/changelog/fix-5025-3ds-auth-checkout
+++ b/changelog/fix-5025-3ds-auth-checkout
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Ensures 3DS authenticated payment methods can be saved and reused.
+Ensures 3DS authenticated payment methods can be saved and reused with deferred intent UPE.

--- a/changelog/fix-5025-3ds-auth-checkout
+++ b/changelog/fix-5025-3ds-auth-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensures 3DS authenticated payment methods can be saved and reused.

--- a/client/checkout/classic/upe-deferred-intent-creation/3ds-flow-handling.js
+++ b/client/checkout/classic/upe-deferred-intent-creation/3ds-flow-handling.js
@@ -1,15 +1,8 @@
 /**
  * Internal dependencies
  */
-import { isWCPayChosen } from 'wcpay/checkout/utils/upe';
 import { getConfig } from 'wcpay/utils/checkout';
 import showErrorCheckout from 'wcpay/checkout/utils/show-error-checkout';
-
-const getPaymentMethodId = () => {
-	return isWCPayChosen()
-		? document.querySelector( '#wcpay-payment-method-sepa' )?.value ?? ''
-		: document.querySelector( '#wcpay-payment-method' )?.value ?? '';
-};
 
 export const shouldSavePaymentPaymentMethod = () => {
 	return (
@@ -30,7 +23,8 @@ const cleanupURL = () => {
 
 export const showAuthenticationModalIfRequired = ( api ) => {
 	const url = window.location.href;
-	const paymentMethodId = getPaymentMethodId();
+	const paymentMethodId = document.querySelector( '#wcpay-payment-method' )
+		?.value;
 
 	const confirmation = api.confirmIntent(
 		url,

--- a/client/checkout/utils/upe.js
+++ b/client/checkout/utils/upe.js
@@ -176,7 +176,7 @@ export const generateCheckoutEventNames = () => {
 
 export const appendPaymentMethodIdToForm = ( form, paymentMethodId ) => {
 	form.append(
-		`<input type="hidden" name="wcpay-payment-method" value="${ paymentMethodId }" />`
+		`<input type="hidden" id="wcpay-payment-method" name="wcpay-payment-method" value="${ paymentMethodId }" />`
 	);
 };
 


### PR DESCRIPTION
Fixes #5025

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
# Fixes 3DS authenticated payment methods with the deferred intent UPE
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
Previously in the deferred intent UPE MVP, customers were able to successfully checkout using payment methods that require 3DS authentication, but they were unable to save these cards and reuse them. In this flow, a payment method is created and [injected into the checkout form](https://github.com/Automattic/woocommerce-payments/blob/develop/client/checkout/classic/upe-deferred-intent-creation/stripe-checkout.js#L208). When the intent confirmation requires further actio,n the user remains in the checkout to authenticate via Stripe's modal. Once this is complete [we resend this payment method to the backend](https://github.com/Automattic/woocommerce-payments/blob/develop/client/checkout/classic/upe-deferred-intent-creation/3ds-flow-handling.js#L33-L38) to confirm and finalise the transaction. 

However, after injecting this payment method ID into the form, we were not extracting it correctly. This PR makes a small amend to ensure that we send the PM ID correctly to the backend.
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
Please enable the UPE with deferred intent creation via the dev tools, pull this PR, and test the following scenarios.
- Checkout with non-3DS payment method.
- Checkout with [3DS payment method](https://stripe.com/docs/testing#regulatory-cards) without saving payment method.
- Checkout with 3DS payment method for subscription product.
- Checkout using saved 3DS payment method.
- Subscription renewal using saved 3DS payment method.

After successfully completing a checkout using a payment method requiring 3DS authentication and electing to save the payment method or checking out for a subscription product (where the payment method is automatically saved), the 3DS payment method should now appear both at checkout and in the My Account section amongs the list of saved payment methods. 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
