### PR TITLE
Automatically update the local WCPay Dev Tools clone to use the latest on trunk

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -6,22 +6,3 @@ npx --no-install yarnhook
 
 # make sure composer packages are installed and the autoload files are regenerated
 composer install
-
-DEV_TOOLS_PATH="docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools"
-if [[ "$(cd $DEV_TOOLS_PATH && git rev-parse --show-toplevel 2>/dev/null)" = "$(cd $DEV_TOOLS_PATH && pwd)" ]]; then
-	echo
-	echo "\033[32mDetermining if there is an update for the WCPay Dev Tools plugin...\033[0m"
-
-	DEV_TOOLS_BRANCH=$(cd $DEV_TOOLS_PATH && git branch --show-current)
-	if [[ $DEV_TOOLS_BRANCH = "trunk" ]]; then
-		echo "  \033[32mThe current branch is trunk. Check if we are safe to pull from origin/trunk...\033[0m"
-		if [[ `cd $DEV_TOOLS_PATH && git status --porcelain` ]]; then
-			echo "  There are uncommitted local changes on the WCPay Dev Tools repo. Skipping any attempt to update it."
-		else
-			echo "  \033[32mPulling the latest changes from origin/trunk, if any...\033[0m"
-			cd $DEV_TOOLS_PATH && git pull
-		fi
-	else
-		echo "  The WCPay Dev Tools local clone is not on the trunk branch. Skipping any attempt to update it."
-	fi
-fi

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -14,14 +14,14 @@ if [[ "$(cd $DEV_TOOLS_PATH && git rev-parse --show-toplevel 2>/dev/null)" = "$(
 
 	DEV_TOOLS_BRANCH=$(cd $DEV_TOOLS_PATH && git branch --show-current)
 	if [[ $DEV_TOOLS_BRANCH = "trunk" ]]; then
-		echo "\033[32mThe current branch is trunk. Check if we are safe to pull from origin/trunk...\033[0m"
+		echo "  \033[32mThe current branch is trunk. Check if we are safe to pull from origin/trunk...\033[0m"
 		if [[ `cd $DEV_TOOLS_PATH && git status --porcelain` ]]; then
-			echo "There are uncommitted local changes on the WCPay Dev Tools repo. Skipping any attempt to update it."
+			echo "  There are uncommitted local changes on the WCPay Dev Tools repo. Skipping any attempt to update it."
 		else
-			echo "\033[32mPulling the latest changes from origin/trunk, if any...\033[0m"
+			echo "  \033[32mPulling the latest changes from origin/trunk, if any...\033[0m"
 			cd $DEV_TOOLS_PATH && git pull
 		fi
 	else
-		echo "The WCPay Dev Tools local clone is not on the trunk branch. Skipping any attempt to update it."
+		echo "  The WCPay Dev Tools local clone is not on the trunk branch. Skipping any attempt to update it."
 	fi
 fi

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -6,3 +6,22 @@ npx --no-install yarnhook
 
 # make sure composer packages are installed and the autoload files are regenerated
 composer install
+
+DEV_TOOLS_PATH="docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools"
+if [[ "$(cd $DEV_TOOLS_PATH && git rev-parse --show-toplevel 2>/dev/null)" = "$(cd $DEV_TOOLS_PATH && pwd)" ]]; then
+	echo
+	echo "\033[32mDetermining if there is an update for the WCPay Dev Tools plugin...\033[0m"
+
+	DEV_TOOLS_BRANCH=$(cd $DEV_TOOLS_PATH && git branch --show-current)
+	if [[ $DEV_TOOLS_BRANCH = "trunk" ]]; then
+		echo "\033[32mThe current branch is trunk. Check if we are safe to pull from origin/trunk...\033[0m"
+		if [[ `cd $DEV_TOOLS_PATH && git status --porcelain` ]]; then
+			echo "There are uncommitted local changes on the WCPay Dev Tools repo. Skipping any attempt to update it."
+		else
+			echo "\033[32mPulling the latest changes from origin/trunk, if any...\033[0m"
+			cd $DEV_TOOLS_PATH && git pull
+		fi
+	else
+		echo "The WCPay Dev Tools local clone is not on the trunk branch. Skipping any attempt to update it."
+	fi
+fi

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -14,14 +14,14 @@ if [[ "$(cd $DEV_TOOLS_PATH && git rev-parse --show-toplevel 2>/dev/null)" = "$(
 
 	DEV_TOOLS_BRANCH=$(cd $DEV_TOOLS_PATH && git branch --show-current)
 	if [[ $DEV_TOOLS_BRANCH = "trunk" ]]; then
-		echo "\033[32mThe current branch is trunk. Check if we are safe to pull from origin/trunk...\033[0m"
+		echo "  \033[32mThe current branch is trunk. Check if we are safe to pull from origin/trunk...\033[0m"
 		if [[ `cd $DEV_TOOLS_PATH && git status --porcelain` ]]; then
-			echo "There are uncommitted local changes on the WCPay Dev Tools repo. Skipping any attempt to update it."
+			echo "  There are uncommitted local changes on the WCPay Dev Tools repo. Skipping any attempt to update it."
 		else
-			echo "\033[32mPulling the latest changes from origin/trunk, if any...\033[0m"
+			echo "  \033[32mPulling the latest changes from origin/trunk, if any...\033[0m"
 			cd $DEV_TOOLS_PATH && git pull
 		fi
 	else
-		echo "The WCPay Dev Tools local clone is not on the trunk branch. Skipping any attempt to update it."
+		echo "  The WCPay Dev Tools local clone is not on the trunk branch. Skipping any attempt to update it."
 	fi
 fi

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,5 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env sh
 . "$(dirname "$0")/_/husky.sh"
+
+# Load local env variables if present.
+if [[ -f "$(pwd)/local.env" ]]; then
+	. "$(pwd)/local.env"
+fi
 
 # using `--no-install` just in case it's the first time a person is checking out the repo and doesn't have yarnhook installed
 npx --no-install yarnhook
@@ -7,21 +12,26 @@ npx --no-install yarnhook
 # make sure composer packages are installed and the autoload files are regenerated
 composer install
 
-DEV_TOOLS_PATH="docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools"
-if [[ "$(cd $DEV_TOOLS_PATH && git rev-parse --show-toplevel 2>/dev/null)" = "$(cd $DEV_TOOLS_PATH && pwd)" ]]; then
+DEV_TOOLS_PLUGIN_PATH=${LOCAL_WCPAY_DEV_TOOLS_PLUGIN_REPO_PATH:-"docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools"}
+if [ ! -d $DEV_TOOLS_PLUGIN_PATH ]; then
 	echo
-	echo "\033[32mDetermining if there is an update for the WCPay Dev Tools plugin...\033[0m"
+    echo "\033[33mCouldn't find the '$DEV_TOOLS_PLUGIN_PATH' directory. Skipping the auto-update for the WCPay Dev Tools plugin...\033[0m"
+else
+	if [[ "$(cd $DEV_TOOLS_PLUGIN_PATH && git rev-parse --show-toplevel 2>/dev/null)" = "$(cd $DEV_TOOLS_PLUGIN_PATH && pwd)" ]]; then
+		echo
+		echo "\033[32mDetermining if there is an update for the WCPay Dev Tools plugin...\033[0m"
 
-	DEV_TOOLS_BRANCH=$(cd $DEV_TOOLS_PATH && git branch --show-current)
-	if [[ $DEV_TOOLS_BRANCH = "trunk" ]]; then
-		echo "  \033[32mThe current branch is trunk. Check if we are safe to pull from origin/trunk...\033[0m"
-		if [[ `cd $DEV_TOOLS_PATH && git status --porcelain` ]]; then
-			echo "  There are uncommitted local changes on the WCPay Dev Tools repo. Skipping any attempt to update it."
+		DEV_TOOLS_BRANCH=$(cd $DEV_TOOLS_PLUGIN_PATH && git branch --show-current)
+		if [[ $DEV_TOOLS_BRANCH = "trunk" ]]; then
+			echo "  \033[32mThe current branch is trunk. Check if we are safe to pull from origin/trunk...\033[0m"
+			if [[ `cd $DEV_TOOLS_PLUGIN_PATH && git status --porcelain` ]]; then
+				echo "\033[33m  There are uncommitted local changes on the WCPay Dev Tools repo. Skipping any attempt to update it.\033[0m"
+			else
+				echo "  \033[32mPulling the latest changes from origin/trunk, if any...\033[0m"
+				cd $DEV_TOOLS_PLUGIN_PATH && git pull
+			fi
 		else
-			echo "  \033[32mPulling the latest changes from origin/trunk, if any...\033[0m"
-			cd $DEV_TOOLS_PATH && git pull
+			echo "\033[33m  The WCPay Dev Tools local clone is not on the trunk branch. Skipping any attempt to update it.\033[0m"
 		fi
-	else
-		echo "  The WCPay Dev Tools local clone is not on the trunk branch. Skipping any attempt to update it."
 	fi
 fi

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -6,3 +6,22 @@ npx --no-install yarnhook
 
 # make sure composer packages are installed and the autoload files are regenerated
 composer install
+
+DEV_TOOLS_PATH="docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools"
+if [[ "$(cd $DEV_TOOLS_PATH && git rev-parse --show-toplevel 2>/dev/null)" = "$(cd $DEV_TOOLS_PATH && pwd)" ]]; then
+	echo
+	echo "\033[32mDetermining if there is an update for the WCPay Dev Tools plugin...\033[0m"
+
+	DEV_TOOLS_BRANCH=$(cd $DEV_TOOLS_PATH && git branch --show-current)
+	if [[ $DEV_TOOLS_BRANCH = "trunk" ]]; then
+		echo "\033[32mThe current branch is trunk. Check if we are safe to pull from origin/trunk...\033[0m"
+		if [[ `cd $DEV_TOOLS_PATH && git status --porcelain` ]]; then
+			echo "There are uncommitted local changes on the WCPay Dev Tools repo. Skipping any attempt to update it."
+		else
+			echo "\033[32mPulling the latest changes from origin/trunk, if any...\033[0m"
+			cd $DEV_TOOLS_PATH && git pull
+		fi
+	else
+		echo "The WCPay Dev Tools local clone is not on the trunk branch. Skipping any attempt to update it."
+	fi
+fi

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ https://github.com/Automattic/woocommerce-payments/blob/trunk/docker/README.md
 Install the following plugins:
 
 -   WooCommerce
+-   WCPay Dev Tools (clone or download [the GitHub repo](https://github.com/Automattic/woocommerce-payments-dev-tools))
+
+### Optional local.env file
+
+If you are using a custom local development setup (as opposed to the Docker-based one), you can create a `local.env` file to provide environment variables for our development scripts.
+
+We currently support the following variables:
+
+-   `LOCAL_WCPAY_DEV_TOOLS_PLUGIN_REPO_PATH`: The path to your local WCPay Dev Tools plugin directory for auto-updates; it defaults to `docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools`.
 
 ## Test account setup
 

--- a/changelog/dev-6311-automatically-update-wcpay-dev-tools
+++ b/changelog/dev-6311-automatically-update-wcpay-dev-tools
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: We auto-update the local dev clone of WCPay Dev Tools.
+
+


### PR DESCRIPTION
Fixes #6311 

#### Changes proposed in this Pull Request

We upgrade the [Husky](https://typicode.github.io/husky/) `post-merge` and `post-checkout` hooks to automatically pull the latest trunk changes on the local WCPay Dev Tools clone. 

To keep the behavior safe, this will only happen if:
- the local clone is on the `trunk` branch
- there are no WCPay Dev Tools uncommitted changes

Here are some screenshots of the command line messaging when doing a `git checkout` on the local WCPay client:
![Screenshot 2023-05-16 at 15 20 30](https://github.com/Automattic/woocommerce-payments/assets/8830539/bc53ca52-7a69-4305-978c-0b0b5a453ec5)
![Screenshot 2023-05-16 at 15 19 54](https://github.com/Automattic/woocommerce-payments/assets/8830539/ba784892-a767-4e90-a91d-563f33336e89)

#### Testing instructions

* On your local WCPay client, checkout the PR branch with `git fetch && git checkout dev/6311-automatically-update-wcpay-dev-tools`
* On your local WCPay Dev Tools, make sure you are using the latest trunk by running `cd docker/wordpress/wp-content/plugins/woocommerce-payments-dev-tools && git checkout trunk && git pull`
* In the root of your WCPay Client, run `git checkout`; after the composer messaging, you should see messaging around attempting to update for the WCPay Dev Tools plugin; the final line should say "Already up to date."
* Edit some file in your local WCPay Dev Tools clone so there are some uncommitted changes
* In the root of your WCPay Client, run `git checkout`; after the composer messaging, you should see messaging around attempting to update for the WCPay Dev Tools plugin; the final line should say: "There are uncommitted local changes on the WCPay Dev Tools repo. Skipping any attempt to update it.";
* Check that the changes you've made on your local WCPay Dev Tools clone are still there; undo the changes;
* In the root of your local WCPay Dev Tools, check out a different branch than `trunk` (for example `update/reorganize-cleanup-document-dev-tools-options`)
* In the root of your WCPay Client, run `git checkout`; after the composer messaging, you should see messaging around attempting to update for the WCPay Dev Tools plugin; the final line should say: "The WCPay Dev Tools local clone is not on the trunk branch. Skipping any attempt to update it.";
* In the root of your local WCPay Dev Tools, reset to a previous commit so there are changes to be pulled from origin/trunk (for example, `git reset --hard 700b195cad544bdbf52f5139dd427aada05a9bdd`)
* In the root of your WCPay Client, run `git checkout`; after the composer messaging, you should see messaging around attempting to update for the WCPay Dev Tools plugin; the final lines should be git's messaging around updating and fast-forwarding;
* Check that your local WCPay Dev Tools clone is up-to-date with the origin.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
