### PR TITLE
Remove redundant unused variable `isButtonDisabled` in instant deposits test to fix JS linter warning

### DIFF
--- a/changelog/dev-6314-fix-instant-deposits-unused-var
+++ b/changelog/dev-6314-fix-instant-deposits-unused-var
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: No changelog required, a very minor fix for a linting issue, not user-facing
+
+

--- a/client/deposits/instant-deposits/test/index.tsx
+++ b/client/deposits/instant-deposits/test/index.tsx
@@ -22,12 +22,6 @@ mockUseInstantDeposit.mockReturnValue( {
 	submit: () => null,
 } );
 
-// eslint-disable-next-line no-unused-vars
-const isButtonDisabled = jest
-	.fn()
-	.mockReturnValue( false ) // Default response to show enabled button.
-	.mockReturnValueOnce( true ); // Response for first test that should have button disabled.
-
 const mockInstantBalance = {
 	amount: 12345,
 	fee: 123.45,


### PR DESCRIPTION
Fixes #6314

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR removes the redundant variable `isButtonDisabled` from [`client/deposits/instant-deposits/test/index.tsx`](https://github.com/Automattic/woocommerce-payments/blob/7689451f39aaa019642c4a1440bd9a0ef6f05de4/client/deposits/instant-deposits/test/index.tsx) to fix the JS linter warning that appears when reviewing PRs via the GitHub interface ([example PR with this warning](https://github.com/Automattic/woocommerce-payments/pull/6307/files)).

![Screenshot 2023-05-15 at 01 41 28](https://github.com/Automattic/woocommerce-payments/assets/73803630/0e80bcb4-1541-4a8f-830b-26929b336c1a)

This variable is no longer of use and the tests within this file pass without it. 

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure all JS linter GH checks pass.
* Ensure the JS linter warning does not display in the GitHub PR "Files changed" view

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
