### PR TITLE
Fix tour copy to remove review mentions

### DIFF
--- a/changelog/fix-3379-remove-review-from-frt-tour-copy
+++ b/changelog/fix-3379-remove-review-from-frt-tour-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix fraud and risk tools welcome tour copy to remove mentions of risk review.

--- a/client/settings/fraud-protection/tour/steps.tsx
+++ b/client/settings/fraud-protection/tour/steps.tsx
@@ -58,12 +58,12 @@ const readyForReviewStep = {
 		desktop: '#toplevel_page_wc-admin-path--payments-overview',
 	},
 	meta: {
-		name: 'ready-for-review',
-		heading: __( 'Ready for review 📥️' ),
+		name: 'review-blocked-transactions',
+		heading: __( 'Review blocked transactions 📥️' ),
 		descriptions: {
 			desktop: interpolateComponents( {
 				mixedString: __(
-					"Payments that have been blocked by a risk filter will appear in the blocked column in {{strong}}Payments > Transactions{{/strong}}. We'll let you know why each payment was blocked so you can determine if you need to adjust your risk filters."
+					"Payments that have been blocked by a risk filter will appear under the blocked tab in {{strong}}Payments > Transactions{{/strong}}. We'll let you know why each payment was blocked so you can determine if you need to adjust your risk filters."
 				),
 				components: { strong: <strong /> },
 			} ),

--- a/client/settings/fraud-protection/tour/steps.tsx
+++ b/client/settings/fraud-protection/tour/steps.tsx
@@ -11,14 +11,18 @@ const enhancedFraudProtectionStep = {
 	},
 	meta: {
 		name: 'enhanced-fraud-protection',
-		heading: __( 'Enhanced fraud protection is here 🔒' ),
+		heading: __(
+			'Enhanced fraud protection is here 🔒',
+			'woocommerce-payments'
+		),
 		descriptions: {
 			desktop: __(
-				'You can now choose a level of protection for screening incoming transactions. Screened transactions are automatically blocked.'
+				'You can now choose a level of protection for screening incoming transactions. Screened transactions will be automatically blocked by your customized fraud filters.',
+				'woocommerce-payments'
 			),
 		},
 		primaryButton: {
-			text: __( "See what's new" ),
+			text: __( "See what's new", 'woocommerce-payments' ),
 		},
 	},
 };
@@ -29,10 +33,11 @@ const chooseYourFilterLevelStep = {
 	},
 	meta: {
 		name: 'choose-your-filter-level',
-		heading: __( 'Choose your filter level 🚦' ),
+		heading: __( 'Choose your filter level 🚦', 'woocommerce-payments' ),
 		descriptions: {
 			desktop: __(
-				"Choose how you'd like to screen incoming transactions using our Basic or Advanced options."
+				"Choose how you'd like to screen incoming transactions using our Basic or Advanced options.",
+				'woocommerce-payments'
 			),
 		},
 	},
@@ -44,10 +49,11 @@ const takeMoreControlStep = {
 	},
 	meta: {
 		name: 'take-more-control',
-		heading: __( 'Take more control 🎚️' ),
+		heading: __( 'Take more control 🎚️', 'woocommerce-payments' ),
 		descriptions: {
 			desktop: __(
-				'Choose Advanced settings for full control over each filter. You can enable and configure filters to block risky transactions.'
+				'Choose Advanced settings for full control over each filter. You can enable and configure filters to block risky transactions.',
+				'woocommerce-payments'
 			),
 		},
 	},
@@ -59,17 +65,21 @@ const readyForReviewStep = {
 	},
 	meta: {
 		name: 'review-blocked-transactions',
-		heading: __( 'Review blocked transactions 📥️' ),
+		heading: __(
+			'Review blocked transactions 📥️',
+			'woocommerce-payments'
+		),
 		descriptions: {
 			desktop: interpolateComponents( {
 				mixedString: __(
-					"Payments that have been blocked by a risk filter will appear under the blocked tab in {{strong}}Payments > Transactions{{/strong}}. We'll let you know why each payment was blocked so you can determine if you need to adjust your risk filters."
+					"Payments that have been blocked by a risk filter will appear under the blocked tab in {{strong}}Payments > Transactions{{/strong}}. We'll let you know why each payment was blocked so you can determine if you need to adjust your risk filters.",
+					'woocommerce-payments'
 				),
 				components: { strong: <strong /> },
 			} ),
 		},
 		primaryButton: {
-			text: __( 'Got it' ),
+			text: __( 'Got it', 'woocommerce-payments' ),
 		},
 	},
 };

--- a/client/settings/fraud-protection/tour/steps.tsx
+++ b/client/settings/fraud-protection/tour/steps.tsx
@@ -14,7 +14,7 @@ const enhancedFraudProtectionStep = {
 		heading: __( 'Enhanced fraud protection is here 🔒' ),
 		descriptions: {
 			desktop: __(
-				'You can now choose a level of protection for screening incoming transactions. You can then review any flagged transactions and decide to approve or block them.'
+				'You can now choose a level of protection for screening incoming transactions. Screened transactions are automatically blocked.'
 			),
 		},
 		primaryButton: {
@@ -32,7 +32,7 @@ const chooseYourFilterLevelStep = {
 		heading: __( 'Choose your filter level 🚦' ),
 		descriptions: {
 			desktop: __(
-				"Choose how you'd like to filter suspicious transactions, from Basic to Advanced."
+				"Choose how you'd like to screen incoming transactions using our Basic or Advanced options."
 			),
 		},
 	},
@@ -47,7 +47,7 @@ const takeMoreControlStep = {
 		heading: __( 'Take more control 🎚️' ),
 		descriptions: {
 			desktop: __(
-				'Choose Advanced settings for full control over each filter. You can enable and configure filters and choose an action between risk review or block.'
+				'Choose Advanced settings for full control over each filter. You can enable and configure filters to block risky transactions.'
 			),
 		},
 	},
@@ -63,7 +63,7 @@ const readyForReviewStep = {
 		descriptions: {
 			desktop: interpolateComponents( {
 				mixedString: __(
-					"Payments that have been caught by a risk filter will appear in {{strong}}Payments > Transactions{{/strong}}. We'll let you know why each payment was flagged so you can determine whether to approve or block it."
+					"Payments that have been blocked by a risk filter will appear in the blocked column in {{strong}}Payments > Transactions{{/strong}}. We'll let you know why each payment was blocked so you can determine if you need to adjust your risk filters."
 				),
 				components: { strong: <strong /> },
 			} ),


### PR DESCRIPTION
Fixes [#3379 on the server](https://github.com/Automattic/woocommerce-payments-server/issues/3379)

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

Fix fraud protection feature tour copy to remove 'review' mentions

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR updates the text copy of each tour step to remove risk review related wording and replacing it with clear wording that transactions are only blocked.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR branch.
* All tests should pass.
* Run the following command to ensure that the welcome tour shows up for you: `npm run wp option delete wcpay_fraud_protection_welcome_tour_dismissed`
* Visit the WCPay settings page in your local client.
* Click through each of the four tour cards and compare with the screenshots below.

![frt-tour-step-1](https://github.com/Automattic/woocommerce-payments/assets/60988591/af8c9096-55cb-41e5-9375-886ca2973702)

![frt-tour-step-2](https://github.com/Automattic/woocommerce-payments/assets/60988591/3306ab91-39a3-455e-895d-71ea2e40bc51)

![frt-tour-step-3](https://github.com/Automattic/woocommerce-payments/assets/60988591/6019a1db-32cc-4749-bdff-47ee2d45b768)

![frt-tour-step-4](https://github.com/Automattic/woocommerce-payments/assets/60988591/b4d48ec9-bcc8-46c1-be1b-e5de51e2df6a)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
