### PR TITLE
Prototype: Add in-line dispute notice to order page

### DIFF
--- a/client/order/index.js
+++ b/client/order/index.js
@@ -16,7 +16,7 @@ import BannerNotice from 'wcpay/components/banner-notice';
 jQuery( function ( $ ) {
 	const disableManualRefunds = getConfig( 'disableManualRefunds' ) ?? false;
 	const manualRefundsTip = getConfig( 'manualRefundsTip' ) ?? '';
-	const hasDispute = getConfig( 'hasDispute' ) ?? true; // hardcoded as true for example
+	const hasDispute = getConfig( 'hasDispute' ) ?? false;
 
 	$( '#woocommerce-order-items' ).on(
 		'click',

--- a/client/order/index.js
+++ b/client/order/index.js
@@ -3,16 +3,20 @@
 import { __ } from '@wordpress/i18n';
 import ReactDOM from 'react-dom';
 import { dispatch } from '@wordpress/data';
+import { Button } from '@wordpress/components';
+
 /**
  * Internal dependencies
  */
 import { getConfig } from 'utils/order';
 import RefundConfirmationModal from './refund-confirm-modal';
 import CancelConfirmationModal from './cancel-confirm-modal';
+import BannerNotice from 'wcpay/components/banner-notice';
 
 jQuery( function ( $ ) {
 	const disableManualRefunds = getConfig( 'disableManualRefunds' ) ?? false;
 	const manualRefundsTip = getConfig( 'manualRefundsTip' ) ?? '';
+	const hasDispute = getConfig( 'hasDispute' ) ?? true; // hardcoded as true for example
 
 	$( '#woocommerce-order-items' ).on(
 		'click',
@@ -96,5 +100,29 @@ jQuery( function ( $ ) {
 		container.id = 'wcpay-orderstatus-confirm-container';
 		document.body.appendChild( container );
 		ReactDOM.render( modalToRender, container );
+	}
+
+	function renderDisputeNotice() {
+		const Notice = () => (
+			<BannerNotice status="info" isDismissible={ false }>
+				<div style={ { marginBottom: 10 } }>
+					This order has a chargeback dispute of $123 for the reason
+					of &quot;product damaged&quot;. Please respond to this
+					dispute before May 29, 2023.
+				</div>
+				<Button isSecondary>See dispute details</Button>
+			</BannerNotice>
+		);
+
+		const noticeWrapper = document.createElement( 'div' );
+		document
+			.querySelector( '.woocommerce-order-data__meta ' )
+			.insertAdjacentElement( 'afterend', noticeWrapper );
+
+		ReactDOM.render( <Notice />, noticeWrapper );
+	}
+
+	if ( hasDispute ) {
+		renderDisputeNotice();
 	}
 } );

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -671,6 +671,7 @@ class WC_Payments_Admin {
 						'formattedRefundAmount' => wp_strip_all_tags( wc_price( $refund_amount, [ 'currency' => $order->get_currency() ] ) ),
 						'refundedAmount'        => $order->get_total_refunded(),
 						'canRefund'             => $this->wcpay_gateway->can_refund_order( $order ),
+						'hasDispute'            => true,
 					]
 				);
 


### PR DESCRIPTION
> **Warning**
> This is a prototype, not intended for production

As part of the WCPay project "Improving Merchant Response Rate to Disputes: Phase 1" (pdjTHR-2F9-p2), we are adding a notice to the order details admin page when the order has a dispute that needs a response.

This PR demonstrates adding this in-line notice to the WC order page by injecting a React component.

Design for in-line order dispute notice:
![image](https://github.com/Automattic/woocommerce-payments/assets/3147296/5e89d5f1-58bc-4ac8-a0e5-272568e0d058)


### How
This PR conditionally renders the notice as a React component after the [“order data meta” element (.woocommerce-order-data__meta)](https://github.com/woocommerce/woocommerce/blob/6d4014042b3c7fbbdc1b77f1a1d9b71cc1b54543/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php#L253) using the existing [client/order/index.js script](https://github.com/Automattic/woocommerce-payments/blob/3209bec75aba75ad09c0257b53f4d759a953d009/client/order/index.js#L105).

### Additional details
Proposal P2 for this method: pdjTHR-2Gk-p2
Project exploration P2: pdjTHR-2F9-p2
