### PR TITLE
Subscriptions core update to 5.7.2

### DIFF
--- a/changelog/subscriptions-core-5.7.2
+++ b/changelog/subscriptions-core-5.7.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved an issue that resulted in customers being incorrectly redirected to an invalid Pay for Order URL after login.

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
       "automattic/jetpack-autoloader": "2.11.18",
       "automattic/jetpack-identity-crisis": "0.8.43",
       "automattic/jetpack-sync": "1.47.7",
-      "woocommerce/subscriptions-core": "5.7.1"
+      "woocommerce/subscriptions-core": "5.7.2"
     },
     "require-dev": {
       "composer/installers": "1.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89b4b68a03f740d9e6834cde32ee71d9",
+    "content-hash": "0571fbd3f848f7e75919fe06199e4a90",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -940,16 +940,16 @@
         },
         {
             "name": "woocommerce/subscriptions-core",
-            "version": "5.7.1",
+            "version": "5.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-subscriptions-core.git",
-                "reference": "12402c886760d71a67f89ccea1d6d70279456098"
+                "reference": "c9f95d9d675cf0a05d1dcb4f68d125bb7e5ccc98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/12402c886760d71a67f89ccea1d6d70279456098",
-                "reference": "12402c886760d71a67f89ccea1d6d70279456098",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-subscriptions-core/zipball/c9f95d9d675cf0a05d1dcb4f68d125bb7e5ccc98",
+                "reference": "c9f95d9d675cf0a05d1dcb4f68d125bb7e5ccc98",
                 "shasum": ""
             },
             "require": {
@@ -990,10 +990,10 @@
             "description": "Sell products and services with recurring payments in your WooCommerce Store.",
             "homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/5.7.1",
+                "source": "https://github.com/Automattic/woocommerce-subscriptions-core/tree/5.7.2",
                 "issues": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
             },
-            "time": "2023-05-11T04:36:46+00:00"
+            "time": "2023-05-24T06:39:40+00:00"
         }
     ],
     "packages-dev": [
@@ -6464,5 +6464,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
This PR updates our subscriptions-core library version from 5.7.1 to 5.7.2

There's only a single change between these versions so I've copied over the changelog entry.

To test:

1. Run `composer update woocommerce/subscriptions-core`.
2. Check that `vendor/woocommerce/subscriptions-core` has pulled the latest version (simplest way it to check the changelog.txt file)

