### PR TITLE
Add Progressive Onboarding Express Explat experiment

### DIFF
--- a/changelog/add-5928-po-express-explat-experiment
+++ b/changelog/add-5928-po-express-explat-experiment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Show Progressive Onboarding Express using Explat experiment

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -335,7 +335,7 @@ class WC_Payments_Admin {
 				);
 				remove_submenu_page( 'wc-admin&path=/payments/connect', 'wc-admin&path=/payments/onboarding' );
 			}
-			if ( WC_Payments_Utils::is_in_progressive_onboarding_treatment_mode() ) {
+			if ( WC_Payments_Utils::is_in_progressive_onboarding_treatment_mode() || WC_Payments_Features::is_progressive_onboarding_enabled() ) {
 				wc_admin_register_page(
 					[
 						'id'         => 'wc-payments-onboarding-prototype',

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -335,7 +335,7 @@ class WC_Payments_Admin {
 				);
 				remove_submenu_page( 'wc-admin&path=/payments/connect', 'wc-admin&path=/payments/onboarding' );
 			}
-			if ( WC_Payments_Features::is_progressive_onboarding_enabled() ) {
+			if ( WC_Payments_Utils::is_in_progressive_onboarding_treatment_mode() ) {
 				wc_admin_register_page(
 					[
 						'id'         => 'wc-payments-onboarding-prototype',

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1592,13 +1592,13 @@ class WC_Payments_Account {
 	}
 
 	/**
-	 * Redirects to the onboarding prototype page if the feature flag is enabled.
+	 * Redirects to the onboarding prototype page if the experiment is enabled.
 	 * Also checks if the server is connect and try to connect it otherwise.
 	 *
 	 * @return void
 	 */
 	private function redirect_to_prototype_onboarding_page() {
-		if ( ! WC_Payments_Features::is_progressive_onboarding_enabled() ) {
+		if ( ! WC_Payments_Utils::is_in_progressive_onboarding_treatment_mode() ) {
 			return;
 		}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1592,7 +1592,7 @@ class WC_Payments_Account {
 	}
 
 	/**
-	 * Redirects to the onboarding prototype page if the experiment is enabled.
+	 * Redirects to the onboarding prototype page if the experiment or PO feature flag is enabled.
 	 * Also checks if the server is connect and try to connect it otherwise.
 	 *
 	 * @return void

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1598,7 +1598,7 @@ class WC_Payments_Account {
 	 * @return void
 	 */
 	private function redirect_to_prototype_onboarding_page() {
-		if ( ! WC_Payments_Utils::is_in_progressive_onboarding_treatment_mode() || WC_Payments_Features::is_progressive_onboarding_enabled() ) {
+		if ( ! WC_Payments_Utils::is_in_progressive_onboarding_treatment_mode() && ! WC_Payments_Features::is_progressive_onboarding_enabled() ) {
 			return;
 		}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1598,7 +1598,7 @@ class WC_Payments_Account {
 	 * @return void
 	 */
 	private function redirect_to_prototype_onboarding_page() {
-		if ( ! WC_Payments_Utils::is_in_progressive_onboarding_treatment_mode() ) {
+		if ( ! WC_Payments_Utils::is_in_progressive_onboarding_treatment_mode() || WC_Payments_Features::is_progressive_onboarding_enabled() ) {
 			return;
 		}
 

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -699,6 +699,26 @@ class WC_Payments_Utils {
 	}
 
 	/**
+	 * Check to see if the current user is in progressive onboarding experiment treatment mode.
+	 *
+	 * @return bool
+	 */
+	public static function is_in_progressive_onboarding_treatment_mode(): bool {
+		if ( ! isset( $_COOKIE['tk_ai'] ) ) {
+			return false;
+		}
+
+		$abtest = new \WCPay\Experimental_Abtest(
+			sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ),
+			'woocommerce',
+			'yes' === get_option( 'woocommerce_allow_tracking' )
+		);
+
+		return 'treatment' === $abtest->get_variation( 'woocommerce_payments_onboarding_progressive_express_2023_v1' )
+			|| 'treatment' === $abtest->get_variation( 'woocommerce_payments_onboarding_progressive_express_2023_v2' );
+	}
+
+	/**
 	 * Return the currency format based on the symbol position.
 	 * Similar to get_woocommerce_price_format but with an input.
 	 *


### PR DESCRIPTION
Fixes #5928 

### Changes proposed in this Pull Request

- Redirect to the TOFU UX only those merchants who have `treatment` experiment group in addition to those that have feature branch enabled

### Testing instructions

#### Pre-requisites
* Checkout `add/5928-po-express-explat-experiment`
* Make sure your WPCom sandbox is up-to-date (needed to run experiment locally)

#### Testing control
* Delete the account (if you have one) locally using server database, refresh cache
* Disable `Progressive Onboarding` feature flag in the dev tools if it's enabled, save changes
* Try onboarding new account from `Payments` connect page `/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect`, you **should not** be able to see new TOFU UX
* Finish onboarding, check that the account is complete.

#### Testing feature flag still works
* Delete the account locally using server database, refresh cache
* Enable `Progressive Onboarding` feature flag in the dev tools, save changes
* Try onboarding new account from `Payments` connect page, you **should** be able to see new TOFU UX
* Finish PO onboarding, then add necessary data for payouts and check that account is complete. PO onboarding conditions:
    * Country: United States
    * MCC: Software
    * Estimated Store revenue: Less than $250k
    * Estimated time to store readiness: My store is already live

#### Testing treatment
* Delete the account (if you have one) locally using server database, refresh cache
* Disable `Progressive Onboarding` feature flag in the dev tools, save changes
* Enable tracking in WooCommerce -> Settings -> Advanced -> WooCommerce.com
* Use experiment bookmarklet 21240-explat-experiment to manually set treatment mode.
* Try onboarding new account from `Payments` connect page, you **should** be able to see new TOFU UX
* Finish PO onboarding, then add necessary data for payouts and check that account is complete.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.