### PR TITLE
Remove all actions on preflight check

### DIFF
--- a/changelog/fix-prevent-preflight-checkout-actions
+++ b/changelog/fix-prevent-preflight-checkout-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove all actions on preflight check

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -446,6 +446,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			add_filter( 'rest_request_before_callbacks', [ $this, 'remove_all_actions_on_preflight_check' ], 10, 3 );
 		}
+
+		$this->maybe_init_subscriptions_hooks();
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -443,9 +443,48 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			add_action( 'template_redirect', [ $this, 'clear_session_processing_order_after_landing_order_received_page' ], 21 );
 
 			add_action( 'woocommerce_update_order', [ $this, 'schedule_order_tracking' ], 10, 2 );
+
+			add_filter( 'rest_request_before_callbacks', [ $this, 'remove_all_actions_on_preflight_check' ], 10, 3 );
+		}
+	}
+
+	/**
+	 * If we're in a WooPay preflight check, remove all the checkout order processed
+	 * actions to prevent reduce available resources quantity.
+	 *
+	 * @param mixed           $response The response object.
+	 * @param mixed           $handler The handler used for the response.
+	 * @param WP_REST_Request $request The request used to generate the response.
+	 *
+	 * @return mixed
+	 */
+	public function remove_all_actions_on_preflight_check( $response, $handler, $request ) {
+		$payment_data = $this->get_request_payment_data( $request );
+		if ( ! empty( $payment_data['is-woopay-preflight-check'] ) ) {
+			remove_all_actions( 'woocommerce_store_api_checkout_order_processed' );
 		}
 
-		$this->maybe_init_subscriptions_hooks();
+		return $response;
+	}
+
+	/**
+	 * Gets and formats payment request data.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return array
+	 */
+	private function get_request_payment_data( \WP_REST_Request $request ) {
+		static $payment_data = [];
+		if ( ! empty( $payment_data ) ) {
+			return $payment_data;
+		}
+		if ( ! empty( $request['payment_data'] ) ) {
+			foreach ( $request['payment_data'] as $data ) {
+				$payment_data[ sanitize_key( $data['key'] ) ] = wc_clean( $data['value'] );
+			}
+		}
+
+		return $payment_data;
 	}
 
 	/**


### PR DESCRIPTION
The issue on Slack p1685041380475779-slack-C022WMN88KG

#### Changes proposed in this Pull Request
This PR removes all actions on the preflight check.  This is a quick and simple fix.  I believe creating a new preflight check endpoint would be the correct way to do this, but it would be a lot more work and might break backwards compatibility.

<!--
Questions for PR author:
- How can this code break?  - If plugins that use `woocommerce_store_api_checkout_order_processed` and update the argument order to something else, it will break.
-->


#### Testing instructions
1. Create a bookable product with time slots/blocks.
2. Make sure that the product has only 1 resource quantity per time slot.
3. Checkout and ensure this error `Merchant store order creation failed with the following error: Sorry, the selected block is no longer available for [YOUR PRODUCT]. Please choose another block.` doesn't show.
4. Go back to the product page and make sure the time slot you just checkout with doesn't show up.

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
