### PR TITLE
Fix account status chip for progressively onboarded accounts

### DIFF
--- a/changelog/fix-6375-account-status-for-po
+++ b/changelog/fix-6375-account-status-for-po
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix account status chip from restricted to pending for PO accounts

--- a/client/account-status-settings/index.js
+++ b/client/account-status-settings/index.js
@@ -123,7 +123,13 @@ const AccountStatus = ( props ) => {
 	return (
 		<div>
 			<div>
-				<StatusChip accountStatus={ accountStatus.status } />
+				<StatusChip
+					accountStatus={ accountStatus.status }
+					poEnabled={ accountStatus.progressiveOnboarding.isEnabled }
+					poComplete={
+						accountStatus.progressiveOnboarding.isComplete
+					}
+				/>
 				{ renderPaymentsStatus( accountStatus.paymentsEnabled ) }
 				{ renderDepositsStatus( { deposits: accountStatus.deposits } ) }
 			</div>

--- a/client/account-status-settings/test/index.js
+++ b/client/account-status-settings/test/index.js
@@ -22,6 +22,10 @@ describe( 'AccountStatus', () => {
 				status: 'enabled',
 				interval: 'daily',
 			},
+			progressiveOnboarding: {
+				isEnabled: false,
+				isComplete: false,
+			},
 			currentDeadline: 0,
 			accountLink: '',
 		} );
@@ -35,6 +39,10 @@ describe( 'AccountStatus', () => {
 			deposits: {
 				status: 'enabled',
 				interval: 'daily',
+			},
+			progressiveOnboarding: {
+				isEnabled: false,
+				isComplete: false,
 			},
 			currentDeadline: 1583844589,
 			accountLink:
@@ -50,6 +58,10 @@ describe( 'AccountStatus', () => {
 			deposits: {
 				status: 'disabled',
 				interval: '',
+			},
+			progressiveOnboarding: {
+				isEnabled: false,
+				isComplete: false,
 			},
 			currentDeadline: 1583844589,
 			pastDue: true,
@@ -67,6 +79,10 @@ describe( 'AccountStatus', () => {
 				status: 'disabled',
 				interval: 'daily',
 			},
+			progressiveOnboarding: {
+				isEnabled: false,
+				isComplete: false,
+			},
 			currentDeadline: 1583844589,
 			pastDue: false,
 			accountLink: '',
@@ -81,6 +97,10 @@ describe( 'AccountStatus', () => {
 			deposits: {
 				status: 'disabled',
 				interval: 'daily',
+			},
+			progressiveOnboarding: {
+				isEnabled: false,
+				isComplete: false,
 			},
 			currentDeadline: 1583844589,
 			pastDue: false,
@@ -97,6 +117,10 @@ describe( 'AccountStatus', () => {
 				status: 'disabled',
 				interval: 'monthly',
 			},
+			progressiveOnboarding: {
+				isEnabled: false,
+				isComplete: false,
+			},
 			currentDeadline: 0,
 			accountLink: '',
 		} );
@@ -110,6 +134,10 @@ describe( 'AccountStatus', () => {
 			deposits: {
 				status: 'disabled',
 				interval: 'daily',
+			},
+			progressiveOnboarding: {
+				isEnabled: false,
+				isComplete: false,
 			},
 			currentDeadline: 0,
 			accountLink: '',
@@ -125,6 +153,10 @@ describe( 'AccountStatus', () => {
 				status: 'disabled',
 				interval: 'daily',
 			},
+			progressiveOnboarding: {
+				isEnabled: false,
+				isComplete: false,
+			},
 			currentDeadline: 0,
 			accountLink: '',
 		} );
@@ -138,6 +170,10 @@ describe( 'AccountStatus', () => {
 			deposits: {
 				status: 'enabled',
 				interval: 'manual',
+			},
+			progressiveOnboarding: {
+				isEnabled: false,
+				isComplete: false,
 			},
 			currentDeadline: 0,
 			accountLink: '',

--- a/client/components/account-status/index.js
+++ b/client/components/account-status/index.js
@@ -57,14 +57,19 @@ const AccountStatusError = () => {
 
 const AccountStatusDetails = ( props ) => {
 	const { accountStatus, accountFees } = props;
-
 	const cardTitle = (
 		<>
 			<FlexItem className={ 'account-details' }>
 				{ __( 'Account details', 'woocommerce-payments' ) }
 			</FlexItem>
 			<FlexBlock className={ 'account-status' }>
-				<StatusChip accountStatus={ accountStatus.status } />
+				<StatusChip
+					accountStatus={ accountStatus.status }
+					poEnabled={ accountStatus.progressiveOnboarding.isEnabled }
+					poComplete={
+						accountStatus.progressiveOnboarding.isComplete
+					}
+				/>
 			</FlexBlock>
 			<FlexItem className={ 'edit-details' }>
 				<Button isLink href={ accountStatus.accountLink }>

--- a/client/components/account-status/status-chip.js
+++ b/client/components/account-status/status-chip.js
@@ -17,6 +17,7 @@ const StatusChip = ( props ) => {
 	let description = __( 'Unknown', 'woocommerce-payments' );
 	let type = 'light';
 	let tooltip = '';
+	// TODO support Pending for PO accounts.
 	if ( 'complete' === accountStatus ) {
 		description = __( 'Complete', 'woocommerce-payments' );
 		type = 'primary';

--- a/client/components/account-status/status-chip.js
+++ b/client/components/account-status/status-chip.js
@@ -12,19 +12,22 @@ import Chip from 'components/chip';
 import './style.scss';
 
 const StatusChip = ( props ) => {
-	const { accountStatus } = props;
+	const { accountStatus, poEnabled, poComplete } = props;
 
 	let description = __( 'Unknown', 'woocommerce-payments' );
 	let type = 'light';
 	let tooltip = '';
-	// TODO support Pending for PO accounts.
+	// Pending status is also shown when the account is PO enabled but not complete and in that case status is restricted.
 	if ( 'complete' === accountStatus ) {
 		description = __( 'Complete', 'woocommerce-payments' );
 		type = 'primary';
 	} else if ( 'restricted_soon' === accountStatus ) {
 		description = __( 'Restricted soon', 'woocommerce-payments' );
 		type = 'warning';
-	} else if ( 'pending_verification' === accountStatus ) {
+	} else if (
+		'pending_verification' === accountStatus ||
+		( poEnabled && ! poComplete && 'restricted' === accountStatus )
+	) {
 		description = __( 'Pending', 'woocommerce-payments' );
 		type = 'light';
 		tooltip = __(

--- a/client/components/account-status/test/__snapshots__/index.js.snap
+++ b/client/components/account-status/test/__snapshots__/index.js.snap
@@ -245,6 +245,25 @@ exports[`StatusChip renders pending verification status 1`] = `
 </div>
 `;
 
+exports[`StatusChip renders pending verification status for po 1`] = `
+<div>
+  <button
+    class="wcpay-tooltip__content-wrapper"
+    type="button"
+  >
+    <div
+      class="wcpay-tooltip__content-wrapper"
+    >
+      <span
+        class="chip chip-light is-compact"
+      >
+        Pending
+      </span>
+    </div>
+  </button>
+</div>
+`;
+
 exports[`StatusChip renders rejected status 1`] = `
 <div>
   <span

--- a/client/components/account-status/test/index.js
+++ b/client/components/account-status/test/index.js
@@ -47,6 +47,10 @@ describe( 'AccountStatus', () => {
 					status: 'enabled',
 					interval: 'weekly',
 				},
+				progressiveOnboarding: {
+					isEnabled: false,
+					isComplete: false,
+				},
 			},
 			[
 				{

--- a/client/components/account-status/test/index.js
+++ b/client/components/account-status/test/index.js
@@ -119,12 +119,31 @@ describe( 'StatusChip', () => {
 		expect( statusChip ).toMatchSnapshot();
 	} );
 
+	test( 'renders pending verification status for po', () => {
+		const { container: statusChip } = renderStatusChip(
+			'pending_verification',
+			true,
+			false
+		);
+		expect( statusChip ).toMatchSnapshot();
+	} );
+
 	test( 'renders unknown status', () => {
 		const { container: statusChip } = renderStatusChip( 'foobar' );
 		expect( statusChip ).toMatchSnapshot();
 	} );
 
-	function renderStatusChip( accountStatus ) {
-		return render( <StatusChip accountStatus={ accountStatus } /> );
+	function renderStatusChip(
+		accountStatus,
+		poEnabled = false,
+		poComplete = false
+	) {
+		return render(
+			<StatusChip
+				accountStatus={ accountStatus }
+				poEnabled={ poEnabled }
+				poComplete={ poComplete }
+			/>
+		);
 	}
 } );


### PR DESCRIPTION
Fixes #6375 

#### Changes proposed in this Pull Request

Fix account chip status for PO accounts: `Restricted` -> `Pending`.

#### Testing instructions

* Checkout the branch `fix/6375-account-status-for-po`
* Delete the old account if it exists (using server DB) + clear the cache. Force onboarding also may work.
* Ensure `Progressive Onboarding` feature flag is enabled.
* Onboard the new PO account and check its status. It should be _Pending_.

<img width="716" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/79862886/ec9a3a21-7eb9-4d44-bec3-823491b655c3">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _ 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
