### PR TITLE
E2E - Fix failing shopper test on WC Beta

### DIFF
--- a/changelog/e2e-fix-wc-beta-shopper-test
+++ b/changelog/e2e-fix-wc-beta-shopper-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix failing e2e shopper test - WC Beta

--- a/tests/e2e/specs/wcpay/shopper/shopper-pay-for-order.spec.js
+++ b/tests/e2e/specs/wcpay/shopper/shopper-pay-for-order.spec.js
@@ -36,9 +36,7 @@ describe( 'Shopper > Pay for Order', () => {
 		// after the card has been declined, go to the order page and pay with a basic card
 		await shopperWCP.goToOrders();
 
-		const payButtons = await page.$$(
-			'.woocommerce-button.wp-element-button.button.pay'
-		);
+		const payButtons = await page.$$( '.woocommerce-button.button.pay' );
 		const payButton = payButtons.find(
 			async ( button ) =>
 				'Pay' ===


### PR DESCRIPTION
Fixes #6410 

#### Changes proposed in this Pull Request

Since WooCommerce 7.8.0-beta.1, the pay for order button My Account page, doesn't have the class `wp-element-button`, which we used with the failing shopper test. This PR updates the element classes to remove `wp-element-button`.

#### Testing instructions

* Trigger a new `E2E Tests - All` test against this branch from the Actions page. (Reference job - https://github.com/Automattic/woocommerce-payments/actions/runs/5136397105)
* Tests should be successful, especially `WC - beta | wcpay - shopper`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
