### PR TITLE
Show PO eligibility modal without checking account status

### DIFF
--- a/changelog/fix-6412-eligibility-modal-peding-status
+++ b/changelog/fix-6412-eligibility-modal-peding-status
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix behind PO feature flag
+
+

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -83,8 +83,7 @@ const OverviewPage = () => {
 	const showProgressiveOnboardingEligibilityModal =
 		showConnectionSuccess &&
 		accountStatus.progressiveOnboarding.isEnabled &&
-		! accountStatus.progressiveOnboarding.isComplete &&
-		'pending_verification' !== accountStatus.status;
+		! accountStatus.progressiveOnboarding.isComplete;
 	const accountRejected =
 		accountStatus.status && accountStatus.status.startsWith( 'rejected' );
 


### PR DESCRIPTION
Fixes #6412

#### Changes proposed in this Pull Request
Remove account status check from PO eligibility modal show conditions, we need to show it without checking the account status, otherwise, it can be missed in some cases.

#### Testing instructions
- Create a new JN site using [the comment below](https://github.com/Automattic/woocommerce-payments/pull/6414#issuecomment-1571746663).
- Enable PO feature flag.
- Onboard a new PO account.
- After being redirected to **Payments → Overview** you should see the eligibility modal. Even if the account status is pending.
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
