### PR TITLE
Remove feature flag for simplify deposits ui that was re-added due to merge conflict

### DIFF
--- a/changelog/fix-recover-simplify-deposits-ui-feature-flag
+++ b/changelog/fix-recover-simplify-deposits-ui-feature-flag
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fixing incorrect merge conflict
+
+

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -11,6 +11,7 @@ declare global {
 			customSearch: boolean;
 			isAuthAndCaptureEnabled: boolean;
 			paymentTimeline: boolean;
+			simplifyDepositsUi?: boolean;
 		};
 		fraudServices: unknown[];
 		isJetpackConnected: boolean;

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -11,7 +11,6 @@ declare global {
 			customSearch: boolean;
 			isAuthAndCaptureEnabled: boolean;
 			paymentTimeline: boolean;
-			simplifyDepositsUi?: boolean;
 		};
 		fraudServices: unknown[];
 		isJetpackConnected: boolean;

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -20,7 +20,6 @@ class WC_Payments_Features {
 	const WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME = '_wcpay_feature_woopay_express_checkout';
 	const AUTH_AND_CAPTURE_FLAG_NAME        = '_wcpay_feature_auth_and_capture';
 	const PROGRESSIVE_ONBOARDING_FLAG_NAME  = '_wcpay_feature_progressive_onboarding';
-	const SIMPLIFY_DEPOSITS_UI_FLAG_NAME    = '_wcpay_feature_simplify_deposits_ui';
 
 	/**
 	 * Checks whether any UPE gateway is enabled.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -278,16 +278,6 @@ class WC_Payments_Features {
 	}
 
 	/**
-
-	 * Checks whether Simplify Deposits UI is enabled. Enabled by default.
-	 *
-	 * @return bool
-	 */
-	public static function is_simplify_deposits_ui_enabled(): bool {
-		return '1' === get_option( self::SIMPLIFY_DEPOSITS_UI_FLAG_NAME, '1' );
-	}
-
-	/**
 	 * Checks whether the BNPL Affirm Afterpay is enabled.
 	 */
 	public static function is_bnpl_affirm_afterpay_enabled(): bool {
@@ -296,7 +286,6 @@ class WC_Payments_Features {
 	}
 
 	/**
-
 	 * Returns feature flags as an array suitable for display on the front-end.
 	 *
 	 * @return bool[]
@@ -316,7 +305,6 @@ class WC_Payments_Features {
 				'woopayExpressCheckout'   => self::is_woopay_express_checkout_enabled(),
 				'isAuthAndCaptureEnabled' => self::is_auth_and_capture_enabled(),
 				'progressiveOnboarding'   => self::is_progressive_onboarding_enabled(),
-				'simplifyDepositsUi'      => self::is_simplify_deposits_ui_enabled(),
 			]
 		);
 	}

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -20,6 +20,7 @@ class WC_Payments_Features {
 	const WOOPAY_EXPRESS_CHECKOUT_FLAG_NAME = '_wcpay_feature_woopay_express_checkout';
 	const AUTH_AND_CAPTURE_FLAG_NAME        = '_wcpay_feature_auth_and_capture';
 	const PROGRESSIVE_ONBOARDING_FLAG_NAME  = '_wcpay_feature_progressive_onboarding';
+	const SIMPLIFY_DEPOSITS_UI_FLAG_NAME    = '_wcpay_feature_simplify_deposits_ui';
 
 	/**
 	 * Checks whether any UPE gateway is enabled.
@@ -315,6 +316,7 @@ class WC_Payments_Features {
 				'woopayExpressCheckout'   => self::is_woopay_express_checkout_enabled(),
 				'isAuthAndCaptureEnabled' => self::is_auth_and_capture_enabled(),
 				'progressiveOnboarding'   => self::is_progressive_onboarding_enabled(),
+				'simplifyDepositsUi'      => self::is_simplify_deposits_ui_enabled(),
 			]
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

~~The code introduced in #5763  was most likely partially lost during incorrect merge conflict resolving upon merging #6288. This PR addressed the issue by adding code back in.~~

[#6280](https://github.com/Automattic/woocommerce-payments/pull/6280) removed the simplify deposits UI feature flag but incorrect merge conflict resolving in #6288 left one method in the codebase.

This PR addressed the issue by removing the method from the codebase as it's expected to not be there.


-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
