### PR TITLE
Adjust style of deposits icon and text in account details for progressive accounts

### DIFF
--- a/changelog/fix-account-status-deposits-disabled-to-not-connected
+++ b/changelog/fix-account-status-deposits-disabled-to-not-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adjust style of deposits icon and text in account details for progressive accounts

--- a/client/components/account-status/index.js
+++ b/client/components/account-status/index.js
@@ -96,6 +96,10 @@ const AccountStatusDetails = ( props ) => {
 					status={ accountStatus.deposits?.status }
 					interval={ accountStatus.deposits?.interval }
 					accountStatus={ accountStatus.status }
+					poEnabled={ accountStatus.progressiveOnboarding.isEnabled }
+					poComplete={
+						accountStatus.progressiveOnboarding.isComplete
+					}
 				/>
 			</AccountStatusItem>
 			{ 0 < accountFees.length && (

--- a/client/components/deposits-status/index.tsx
+++ b/client/components/deposits-status/index.tsx
@@ -22,6 +22,8 @@ interface Props {
 	status: DepositsStatus;
 	interval: DepositsIntervals;
 	accountStatus: AccountStatus;
+	poEnabled: boolean;
+	poComplete: boolean;
 	iconSize: number;
 }
 
@@ -29,6 +31,8 @@ const DepositsStatus: React.FC< Props > = ( {
 	status,
 	interval,
 	accountStatus,
+	poEnabled,
+	poComplete,
 	iconSize,
 } ) => {
 	let className = 'account-status__info__green';
@@ -46,8 +50,14 @@ const DepositsStatus: React.FC< Props > = ( {
 		className = 'account-status__info__gray';
 		icon = <GridiconNotice size={ iconSize } />;
 	} else if ( 'disabled' === status ) {
-		description = __( 'Disabled', 'woocommerce-payments' );
-		className = 'account-status__info__red';
+		description =
+			poEnabled && ! poComplete
+				? __( 'Not connected', 'woocommerce-payments' )
+				: __( 'Disabled', 'woocommerce-payments' );
+		className =
+			poEnabled && ! poComplete
+				? 'account-status__info__gray'
+				: 'account-status__info__red';
 		icon = <GridiconNotice size={ iconSize } />;
 	} else if ( showSuspendedNotice ) {
 		const learnMoreHref =

--- a/client/components/deposits-status/test/index.js
+++ b/client/components/deposits-status/test/index.js
@@ -108,6 +108,8 @@ describe( 'DepositsStatus', () => {
 		status,
 		interval,
 		accountStatus,
+		poEnabled = false,
+		poComplete = false,
 		iconSize,
 	} ) {
 		return render(
@@ -115,6 +117,8 @@ describe( 'DepositsStatus', () => {
 				status={ status }
 				accountStatus={ accountStatus }
 				interval={ interval }
+				poEnabled={ poEnabled }
+				poComplete={ poComplete }
 				iconSize={ iconSize }
 			/>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the styling according to the design 

#### Testing instructions

* Checkout to `fix/account-status-deposits-disabled-to-not-connected`
* Onboard new PO account
* Check that the account details is following the design

![image](https://github.com/Automattic/woocommerce-payments/assets/79862886/a06deb67-a8fc-4849-adc9-58947fb42060)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
