### PR TITLE
Validate PO text fields on change only after blur

### DIFF
--- a/changelog/update-6407-po-form-validation-on-blur
+++ b/changelog/update-6407-po-form-validation-on-blur
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Minor update behind PO feature flag
+
+

--- a/client/components/phone-number-control/index.tsx
+++ b/client/components/phone-number-control/index.tsx
@@ -26,6 +26,7 @@ const countryCodes = window.intlTelInputGlobals
 interface Props {
 	value: string;
 	onChange: ( value: string, country: string ) => void;
+	onBlur?: () => void;
 	country?: string;
 	className?: string;
 	label?: string;
@@ -36,6 +37,7 @@ const PhoneNumberControl: React.FC< Props > = ( {
 	value,
 	country,
 	onChange,
+	onBlur,
 	...rest
 } ) => {
 	const [ focused, setFocused ] = useState( false );
@@ -107,7 +109,10 @@ const PhoneNumberControl: React.FC< Props > = ( {
 					value={ phoneNumber }
 					onChange={ handleInput }
 					onFocus={ () => setFocused( true ) }
-					onBlur={ () => setFocused( false ) }
+					onBlur={ () => {
+						setFocused( false );
+						onBlur?.();
+					} }
 					style={ {
 						paddingLeft: spanWidth + 8,
 						marginLeft: -spanWidth,

--- a/client/onboarding-prototype/form.tsx
+++ b/client/onboarding-prototype/form.tsx
@@ -62,7 +62,7 @@ export const OnboardingTextField: React.FC< OnboardingTextFieldProps > = ( {
 	name,
 	...rest
 } ) => {
-	const { data, setData } = useOnboardingContext();
+	const { data, setData, touched } = useOnboardingContext();
 	const { validate, error } = useValidation( name );
 
 	return (
@@ -71,8 +71,9 @@ export const OnboardingTextField: React.FC< OnboardingTextFieldProps > = ( {
 			value={ data[ name ] || '' }
 			onChange={ ( value: string ) => {
 				setData( { [ name ]: value } );
-				validate( value );
+				if ( touched[ name ] ) validate( value );
 			} }
+			onBlur={ () => validate() }
 			error={ error() }
 			{ ...rest }
 		/>
@@ -88,7 +89,7 @@ export const OnboardingPhoneNumberField: React.FC< OnboardingPhoneNumberFieldPro
 	name,
 	...rest
 } ) => {
-	const { data, setData, temp, setTemp } = useOnboardingContext();
+	const { data, setData, temp, setTemp, touched } = useOnboardingContext();
 	const { validate, error } = useValidation( name );
 
 	return (
@@ -99,8 +100,9 @@ export const OnboardingPhoneNumberField: React.FC< OnboardingPhoneNumberFieldPro
 			onChange={ ( value: string, phoneCountryCode: string ) => {
 				setTemp( { phoneCountryCode } );
 				setData( { [ name ]: value } );
-				validate( value );
+				if ( touched[ name ] ) validate( value );
 			} }
+			onBlur={ () => validate() }
 			error={ error() }
 			{ ...rest }
 		/>


### PR DESCRIPTION
Fixes #6407

#### Changes proposed in this Pull Request
Update `OnboardingTextField` and `OnboardingPhoneNumberField` to only call `validate` inside `onChange` when they are already touched. Add it to `onBlur` so it gets validated after loosing focus.

With those changes, it will not show any validation error until they are blurred for the first time, hiding them while the user writes on the first focus.

#### Testing instructions
- With Progressive onboarding feature flag enabled.
- Go **Payments → Finish setup → Continue**.
- Write an invalid email.
- It **should not** display any validation error while the input has focus.
- Focus out, by clicking somewhere else or pressing `Tab`, the validation error should be visible now.
- Write a valid email.
- The validation error should go away.
- Write an invalid email again.
- This time, while you edit it and keep the focus, the validation error should be visible.

#### Recorded demo

https://github.com/Automattic/woocommerce-payments/assets/7670276/19b9ac4c-eaeb-46d5-9283-2975db5edfe0

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : __QA Testing Not Applicable__
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
