### PR TITLE
Add setup_mode to the account data.

### DIFF
--- a/changelog/dev-pass-setup-mode
+++ b/changelog/dev-pass-setup-mode
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Pass the setup mode selected during Progressive Onboarding to the server onboarding init.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1043,6 +1043,7 @@ class WC_Payments_Account {
 		if ( $self_assessment_data ) {
 			$business_type = $self_assessment_data['business_type'] ?? null;
 			$account_data  = [
+				'setup_mode'    => 'live',  // If there is self assessment data, the user chose the 'live' setup mode.
 				'country'       => $self_assessment_data['country'] ?? null,
 				'email'         => $self_assessment_data['email'] ?? null,
 				'business_name' => $self_assessment_data['business_name'] ?? null,
@@ -1072,6 +1073,7 @@ class WC_Payments_Account {
 				$url = $default_url;
 			}
 			$account_data = [
+				'setup_mode'    => 'test',
 				'country'       => 'US',
 				'business_type' => 'individual',
 				'individual'    => [


### PR DESCRIPTION
Fixes server/3459 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

* Pass the `setup_mode` parameter to the server.
* The value will be `live` if there is self assessment data (this means the user chose the live setup)
* It will be `test` if there's no self assessment data and test mode is enabled (this means they user chose test setup)
* It will be unset if the new UX onboarding was not used (the server will fall back to using either `test`/`live` depending on if dev mode is enabled).

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Please follow the instructions in the corresponding server PR.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
