### PR TITLE
Show setup deposits task for PO accounts without sales and right after account creation

### DIFF
--- a/changelog/fix-show-connect-deposits-for-po-accounts-without-sales-before-14-days
+++ b/changelog/fix-show-connect-deposits-for-po-accounts-without-sales-before-14-days
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show setup deposits task for PO accounts without sales and right after acount creation

--- a/client/overview/task-list/po-tasks.tsx
+++ b/client/overview/task-list/po-tasks.tsx
@@ -39,7 +39,7 @@ export const getVerifyBankAccountTask = (): any => {
 			.format( 'MMMM D, YYYY' );
 		const daysFromAccountCreation = moment().diff( createdDate, 'days' );
 
-		// when account is created less than 14 days ago, no need to show any notice
+		// when account is created less than 14 days ago, we also show a notice but it's just info
 		if ( 14 > daysFromAccountCreation ) {
 			title = strings.po_tasks.after_payment.title;
 			level = 3;

--- a/client/overview/task-list/po-tasks.tsx
+++ b/client/overview/task-list/po-tasks.tsx
@@ -41,7 +41,12 @@ export const getVerifyBankAccountTask = (): any => {
 
 		// when account is created less than 14 days ago, no need to show any notice
 		if ( 14 > daysFromAccountCreation ) {
-			return null;
+			title = strings.po_tasks.after_payment.title;
+			level = 3;
+			description = strings.po_tasks.after_payment.description(
+				verifyDetailsDueDate
+			);
+			actionLabelText = strings.po_tasks.after_payment.action_label;
 		}
 
 		if ( 14 <= daysFromAccountCreation ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show setup deposits task for PO accounts without sales and right after acount creation

#### Testing instructions

* Checkout `fix/show-connect-deposits-for-po-accounts-without-sales-before-14-days`
* Onboard new PO account
* Check that you see the connect deposits task
    ![image](https://github.com/Automattic/woocommerce-payments/assets/79862886/95cedfe1-42ad-4ee1-a1b6-8148b93543a4)
* Click on Start Receiving Deposits, complete the remaining steps of the PO
* Check that account is complete now (may be in pending verification for a min)
    ![image](https://github.com/Automattic/woocommerce-payments/assets/79862886/47593ef5-4db4-4d32-90b7-855a6077ac15)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
