### PR TITLE
Moved WooPay pre-flight check response to utility class

### DIFF
--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -741,15 +741,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			// The request is a preflight check from WooPay.
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing
 			if ( ! empty( $_POST['is-woopay-preflight-check'] ) ) {
-				// Set the order status to "pending payment".
-				$order->update_status( 'pending' );
-
-				// Bail out with success so we don't process the payment now,
-				// but still let WooPay continue with the payment processing.
-				return [
-					'result'   => 'success',
-					'redirect' => '',
-				];
+				return $this->woopay_util->preflight_response( $order );
 			}
 
 			UPE_Payment_Gateway::remove_upe_payment_intent_from_session();

--- a/includes/woopay/class-woopay-utilities.php
+++ b/includes/woopay/class-woopay-utilities.php
@@ -12,6 +12,7 @@ use WC_Payments_Subscriptions_Utilities;
 use WooPay_Extension;
 use WCPay\Logger;
 use WC_Geolocation;
+use WC_Order;
 use WC_Payments;
 
 /**
@@ -266,4 +267,25 @@ class WooPay_Utilities {
 	public function is_guest_checkout_enabled(): bool {
 		return 'yes' === get_option( 'woocommerce_enable_guest_checkout', 'no' );
 	}
+
+
+	/**
+	 * Respond to a WooPay pre-flight request, updates order status and returns response.
+	 *
+	 * @param WC_Order $order The order for which the request is made.
+	 *
+	 * @return array
+	 */
+	public function preflight_response( WC_Order $order ): array {
+		// Set the order status to "pending payment".
+		$order->update_status( 'pending' );
+
+		// Bail out with success so we don't process the payment now,
+		// but still let WooPay continue with the payment processing.
+		return [
+			'result'   => 'success',
+			'redirect' => '',
+		];
+	}
+
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Moved the code related to sending a response to WooPay pre-flight check into the utilities class.

#### Testing instructions

* Tests pass
* Able to checkout
* WooPay preflight response is correct.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
