### PR TITLE
Introduce code ownership file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Each line is a file pattern followed by one or more owners.
+
+# Harmony owns any files in the .github directory at the root of the repository and any of its subdirectories.
+/.github/ @Automattic/harmony

--- a/changelog/add-define-code-owners
+++ b/changelog/add-define-code-owners
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Code ownership file for GitHub repo
+
+


### PR DESCRIPTION
Fixes #6467 

#### Changes proposed in this Pull Request

- Introduce a new `CODEOWNERS` file under the `.github` folder

For now, the only owner mentioned is Harmony for any files under `.github`

Note: I also enabled in the branch protection settings for `develop` a setting to require the approval of code owners too, to ensure we don't miss anything

#### Testing instructions

Not sure it is truly active until it gets merged on `develop`, so probably can't be tested right now

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
