### PR TITLE
Allow `card_` prefix when validating payment method IDs to fix failing subscription renewals

### DIFF
--- a/changelog/fix-6490-allow-payment-method-card-prefix
+++ b/changelog/fix-6490-allow-payment-method-card-prefix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow `card_` prefix when validating payment method IDs to fix failing subscription renewals

--- a/includes/core/server/request/class-create-and-confirm-setup-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-setup-intention.php
@@ -79,6 +79,7 @@ class Create_And_Confirm_Setup_Intention extends Request {
 	 * @throws Invalid_Request_Parameter_Exception
 	 */
 	public function set_payment_method( string $payment_method_id ) {
+		// Including the 'card' prefix to support subscription renewals using legacy payment method IDs.
 		$this->validate_stripe_id( $payment_method_id, [ 'pm', 'src', 'card' ] );
 		$this->set_param( 'payment_method', $payment_method_id );
 	}

--- a/includes/core/server/request/class-create-and-confirm-setup-intention.php
+++ b/includes/core/server/request/class-create-and-confirm-setup-intention.php
@@ -79,7 +79,7 @@ class Create_And_Confirm_Setup_Intention extends Request {
 	 * @throws Invalid_Request_Parameter_Exception
 	 */
 	public function set_payment_method( string $payment_method_id ) {
-		$this->validate_stripe_id( $payment_method_id, [ 'pm', 'src' ] );
+		$this->validate_stripe_id( $payment_method_id, [ 'pm', 'src', 'card' ] );
 		$this->set_param( 'payment_method', $payment_method_id );
 	}
 }

--- a/includes/core/server/request/class-create-intention.php
+++ b/includes/core/server/request/class-create-intention.php
@@ -47,7 +47,7 @@ class Create_Intention extends Request {
 	 * @throws Invalid_Request_Parameter_Exception
 	 */
 	public function set_payment_method( string $payment_method_id ) {
-		$this->validate_stripe_id( $payment_method_id, [ 'pm', 'src' ] );
+		$this->validate_stripe_id( $payment_method_id, [ 'pm', 'src', 'card' ] );
 		$this->set_param( 'payment_method', $payment_method_id );
 	}
 

--- a/includes/core/server/request/class-create-intention.php
+++ b/includes/core/server/request/class-create-intention.php
@@ -47,6 +47,7 @@ class Create_Intention extends Request {
 	 * @throws Invalid_Request_Parameter_Exception
 	 */
 	public function set_payment_method( string $payment_method_id ) {
+		// Including the 'card' prefix to support subscription renewals using legacy payment method IDs.
 		$this->validate_stripe_id( $payment_method_id, [ 'pm', 'src', 'card' ] );
 		$this->set_param( 'payment_method', $payment_method_id );
 	}

--- a/tests/unit/core/server/request/test-class-core-create-and-confirm-intention-request.php
+++ b/tests/unit/core/server/request/test-class-core-create-and-confirm-intention-request.php
@@ -166,18 +166,27 @@ class Create_And_Confirm_Intention_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( WC_Payments_API_Client::INTENTIONS_API, $request->get_api() );
 	}
 
-	public function test_woopay_create_intent_request_will_be_created() {
+	public function create_intent_request_provider() {
+		return [
+			[ 'pm_1', 'cus_1' ],
+			[ 'src_2', 'cus_3' ],
+			[ 'card_1', 'cus_1' ],
+		];
+	}
+
+	/**
+	 *   * @dataProvider create_intent_request_provider
+	 */
+	public function test_woopay_create_intent_request_will_be_created( $payment_method, $customer_id ) {
 		$amount     = 1;
 		$currency   = 'usd';
-		$pm         = 'pm_1';
-		$cs         = 'cus_1';
 		$cvc        = 'cvc';
 		$return_url = 'localhost/order-received/';
 		$request    = new WooPay_Create_And_Confirm_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$request->set_amount( 1 );
 		$request->set_currency_code( 'usd' );
-		$request->set_payment_method( 'pm_1' );
-		$request->set_customer( 'cus_1' );
+		$request->set_payment_method( $payment_method );
+		$request->set_customer( $customer_id );
 		$request->set_capture_method( true );
 		$request->setup_future_usage();
 		$request->set_metadata( [ 'order_number' => 1 ] );
@@ -193,8 +202,8 @@ class Create_And_Confirm_Intention_Test extends WCPAY_UnitTestCase {
 		$this->assertIsArray( $params );
 		$this->assertSame( $amount, $params['amount'] );
 		$this->assertSame( $currency, $params['currency'] );
-		$this->assertSame( $pm, $params['payment_method'] );
-		$this->assertSame( $cs, $params['customer'] );
+		$this->assertSame( $payment_method, $params['payment_method'] );
+		$this->assertSame( $customer_id, $params['customer'] );
 		$this->assertSame( 'manual', $params['capture_method'] );
 		$this->assertSame( 'off_session', $params['setup_future_usage'] );
 		$this->assertArrayHasKey( 'description', $params );

--- a/tests/unit/core/server/request/test-class-core-create-and-confirm-setup-intention-request.php
+++ b/tests/unit/core/server/request/test-class-core-create-and-confirm-setup-intention-request.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Class Create_And_Confirm_Setup_Intention_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Core\Exceptions\Server\Request\Immutable_Parameter_Exception;
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
+use WCPay\Core\Server\Request\Create_And_Confirm_Setup_Intention;
+use WCPay\Core\Server\Request\WooPay_Create_And_Confirm_Setup_Intention;
+
+/**
+ * WCPay\Core\Server\Create_And_Confirm_Setup_Intention_Test unit tests.
+ */
+class Create_And_Confirm_Setup_Intention_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_API_Client|MockObject
+	 */
+	private $mock_api_client;
+	/**
+	 * Mock WC_Payments_API_Client.
+	 *
+	 * @var WC_Payments_Http_Interface|MockObject
+	 */
+	private $mock_wc_payments_http_client;
+
+
+	/**
+	 * Set up the unit tests objects.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->mock_api_client              = $this->createMock( WC_Payments_API_Client::class );
+		$this->mock_wc_payments_http_client = $this->createMock( WC_Payments_Http_Interface::class );
+	}
+
+	public function test_exception_will_throw_if_payment_method_is_invalid() {
+		$request = new Create_And_Confirm_Setup_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request->set_payment_method( '1' );
+	}
+
+	public function test_exception_will_throw_if_customer_is_not_set() {
+		$request = new Create_And_Confirm_Setup_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request->set_payment_method( 'pm_1' );
+		$request->set_metadata( [ 'order_number' => 1 ] );
+		$request->get_params();
+	}
+	public function test_exception_will_throw_if_customer_is_invalid() {
+		$request = new Create_And_Confirm_Setup_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request->set_customer( '1' );
+	}
+
+
+	public function create_intent_request_provider() {
+		return [
+			[ 'pm_1', 'cus_1' ],
+			[ 'src_2', 'cus_3' ],
+			[ 'card_1', 'cus_1' ],
+		];
+	}
+
+	/**
+	 *   * @dataProvider create_intent_request_provider
+	 */
+	public function test_create_intent_request_will_be_created( $payment_method, $customer_id ) {
+
+		$request = new Create_And_Confirm_Setup_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request->set_payment_method( $payment_method );
+		$request->set_customer( $customer_id );
+		$this->assertInstanceOf( Create_And_Confirm_Setup_Intention::class, $request );
+		$params = $request->get_params();
+
+		$this->assertIsArray( $params );
+		$this->assertSame( $payment_method, $params['payment_method'] );
+		$this->assertSame( $customer_id, $params['customer'] );
+		$this->assertArrayHasKey( 'metadata', $params );
+		$this->assertSame( 'POST', $request->get_method() );
+		$this->assertSame( WC_Payments_API_Client::SETUP_INTENTS_API, $request->get_api() );
+	}
+
+	public function test_woopay_create_intent_request_will_be_created() {
+
+		$pm      = 'pm_1';
+		$cs      = 'cus_1';
+		$request = new WooPay_Create_And_Confirm_Setup_Intention( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request->set_payment_method( 'pm_1' );
+		$request->set_customer( 'cus_1' );
+		$request->set_metadata( [ 'order_number' => 1 ] );
+		$params = $request->get_params();
+
+		$this->assertIsArray( $params );
+		$this->assertSame( $pm, $params['payment_method'] );
+		$this->assertSame( $cs, $params['customer'] );
+		$this->assertArrayHasKey( 'metadata', $params );
+		$this->assertSame( 1, $params['metadata']['order_number'] );
+		$this->assertSame( 'POST', $request->get_method() );
+		$this->assertSame( WC_Payments_API_Client::SETUP_INTENTS_API, $request->get_api() );
+	}
+}


### PR DESCRIPTION
Fixes #6490

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR allows the `card_` prefix when validating payment method IDs. This fixes failing subscription renewals for stores that have stored legacy `card_` payment method IDs: namely WCCOM.


2 calls to `validate_stripe_response()` that enforce `'pm', 'src'` now allow the prefix `'card'`:
* [`WCPay\Core\Server\Request\Create_Intention::set_payment_method`](https://github.com/Automattic/woocommerce-payments/blob/1356f2f6101e49497f06eb9e0eff1eafb37236d5/includes/core/server/request/class-create-intention.php#L50)
* [`WCPay\Core\Server\Request\Create_Setup_Intention::set_payment_method`](https://github.com/Automattic/woocommerce-payments/blob/1356f2f6101e49497f06eb9e0eff1eafb37236d5/includes/core/server/request/class-create-and-confirm-setup-intention.php#L81)

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Note:** This original issue described in #6490 is not straightforward to reproduce, since Stripe no longer issues `card_` payment method IDs.

**Regression testing**
1. Install WooCommerce Subscriptions alongside WCPay.
1. Purchase a subscription product. Note the subscription ID as shopper.
2. Navigate to this subscription via **WC→ Subscriptions** as merchant.
3. Process a WC Subscription renewal using the Actions dropdown. You may have to run the scheduled action `woocommerce_scheduled_subscription_payment` in WC → Status → Scheduled Actions.
4. Confirm the renewal order is processed successfully.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) **N/A**

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
