### PR TITLE
Improve subscription deactivation copy

### DIFF
--- a/changelog/imp-5365-improve-subscription-deactivation-copy
+++ b/changelog/imp-5365-improve-subscription-deactivation-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Improve copy in Subscriptions deactivation modal

--- a/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
+++ b/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
@@ -21,7 +21,7 @@
 						<?php
 							printf(
 								// Translators: placeholders are opening and closing strong HTML tags.
-								esc_html__( 'By deactivating the %1$sWooCommerce Subscriptions%2$s plugin, your store will switch to using the subscriptions functionality %1$sbuilt into WooCommerce Payments%2$s.%1$s%3$sLearn more.%4$s%2$s', 'woocommerce-payments' ),
+								esc_html__( 'By deactivating the %1$sWooCommerce Subscriptions%2$s plugin, your store will switch to using the subscriptions functionality %1$sbuilt into WooCommerce Payments%2$s. %1$s%3$sLearn more.%4$s%2$s', 'woocommerce-payments' ),
 								'<strong>',
 								'</strong>',
 								'<a href="https://woocommerce.com/document/subscriptions/renewal-process/#section-4">',

--- a/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
+++ b/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
@@ -21,7 +21,7 @@
 						<?php
 							printf(
 								// Translators: placeholders are opening and closing strong HTML tags.
-								esc_html__( 'By deactivating the %1$sWooCommerce Subscriptions%2$s plugin, your store will switch to using the subscriptions functionality %1$sbuilt into WooCommerce Payments%2$s.%3$sLearn more.%4$s', 'woocommerce-payments' ),
+								esc_html__( 'By deactivating the %1$sWooCommerce Subscriptions%2$s plugin, your store will switch to using the subscriptions functionality %1$sbuilt into WooCommerce Payments%2$s.%1$s%3$sLearn more.%4$s%2$s', 'woocommerce-payments' ),
 								'<strong>',
 								'</strong>',
 								'<a href="https://woocommerce.com/document/subscriptions/renewal-process/#section-4">',

--- a/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
+++ b/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
@@ -21,21 +21,23 @@
 						<?php
 							printf(
 								// Translators: placeholders are opening and closing strong HTML tags.
-								esc_html__( 'By deactivating the %1$sWooCommerce Subscriptions%2$s plugin, your store will switch to using the subscriptions functionality %1$sbuilt into WooCommerce Payments%2$s.', 'woocommerce-payments' ),
-								'<strong>',
-								'</strong>'
-							);
-							?>
-						</br>
-						<?php
-							printf(
-								// Translators: $1 and $2 placeholders are opening and closing strong HTML tags. $3 and $4 are opening and closing link HTML tags. $5 is an opening link HTML tag.
-								esc_html__( 'Existing subscriptions will %1$s%3$srenew manually%4$s%2$s, meaning that subscribers will need to log in to pay for renewal. Access to the advanced features of the Subscriptions extension will be removed. %5$sLearn more.%4$s', 'woocommerce-payments' ),
+								esc_html__( 'By deactivating the %1$sWooCommerce Subscriptions%2$s plugin, your store will switch to using the subscriptions functionality %1$sbuilt into WooCommerce Payments%2$s.%3$sLearn more.%4$s', 'woocommerce-payments' ),
 								'<strong>',
 								'</strong>',
 								'<a href="https://woocommerce.com/document/subscriptions/renewal-process/#section-4">',
-								'</a>',
-								'<a href="https://woocommerce.com/document/subscriptions/deactivation/">'
+								'</a>'
+							);
+							?>
+						</br>
+						</br>
+						<?php
+							printf(
+								// Translators: $1 and $2 placeholders are opening and closing strong HTML tags. $3 and $4 are opening and closing link HTML tags.
+								esc_html__( 'Existing subscribers will need to pay for their next renewal manually, after which automatic payments will resume. You will also no longer have access to the %1$s%3$sadvanced features%4$s%2$s of WooCommerce Subscriptions.', 'woocommerce-payments' ),
+								'<strong>',
+								'</strong>',
+								'<a href="https://woocommerce.com/document/payments/subscriptions-basics/comparison/">',
+								'</a>'
 							);
 							?>
 					</p>


### PR DESCRIPTION
Fixes #5365 

#### Changes proposed in this Pull Request
Modified the copy of modal as mentioned in the description of the issue
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
![image](https://github.com/Automattic/woocommerce-payments/assets/15019298/247ea15e-ac2d-467e-8989-af3a2ff2ee15)


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you have [WooCommerce Subscriptions](https://github.com/woocommerce/woocommerce-subscriptions) plugin installed.
* Try to deactivate the plugin and verify the modal text that pops up with what is mentioned in the issue.
<img width="335" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/15019298/f37a51cb-f8f7-4bb2-b75b-e4a33ef02d8e">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
