### PR TITLE
Add WooCommerce Subscriptions support to WooPay

### DIFF
--- a/changelog/as-store-api-w-subs
+++ b/changelog/as-store-api-w-subs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add WooCommerce Subscriptions support to WooPay

--- a/includes/woopay/class-woopay-store-api-session-handler.php
+++ b/includes/woopay/class-woopay-store-api-session-handler.php
@@ -49,10 +49,20 @@ final class SessionHandler extends WC_Session {
 	}
 
 	/**
-	 * Note: This method was added to the original class for compatibility with WooPay.
+	 * Note: Init session cookie.
 	 */
 	public function init_session_cookie() {
-		$this->init();
+		if ( is_user_logged_in() && strval( get_current_user_id() ) !== $this->_customer_id ) {
+			$old_data           = (array) $this->get_session( $this->_customer_id, [] );
+			$this->_customer_id = strval( get_current_user_id() );
+			$this->_data        = $old_data;
+
+			$customer                = maybe_unserialize( $this->_data['customer'] );
+			$customer['id']          = strval( $this->_customer_id );
+			$this->_data['customer'] = maybe_serialize( $customer );
+
+			$this->save_data();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Apart from the changes introduced in this PR, to allow subscriptions purchases on WooPay, we need a few additional tweaks:


#### 1. Comment out [this line in class-woocommerce.php](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-woocommerce.php#L861) in WooCommerce.

```php
// add_action( 'shutdown', array( $this->customer, 'save' ), 10 );
```
**The scenario:** 

- A subscription is in the cart.
- The user is not logged in to the merchant store.
- Users click "Places Order" which fires the request to the `/checkout` endpoint using the Store API.

**On the merchant store:** 

WC Core hooks to the `shutdown` action ([ref](https://github.com/woocommerce/woocommerce/blob/0f8d274d7f049a27bc6cc7b534efc4a03f64e9ab/plugins/woocommerce/includes/class-woocommerce.php#L861)). And uses the data of a non-logged in user.

Given that we are buying a subscription, later in the same request, we create a new user and save it in `SessionHandler::save_data` (`class-woopay-store-api-session-handler.php`). The customer object in the session is updated with the newly created user.

The problem starts at the end of the request when the `shutdown` action is performed. WC core replaces the customer object with the non-logged-in user. We end up saving the session data with the wrong customer data.

The subsequent request to the `/checkout` endpoint, which will process the payment, assumes the request comes from a non-logged-in user and tries to create the user again, then throws the error saying there's an account already with the same email.

#### 2. Disable nonce verification

```php
add_filter('woocommerce_store_api_disable_nonce_check', '__return_true');
```
I left a comment explaining the issue with nonces [here](pdFofs-WX-p2#comment-1084) so I'm just going to copy and paste it here:

> A [unique WP session token](https://github.com/WordPress/WordPress/blob/6064478fa75cef6e85965d1041e26ec4f0ddcac3/wp-includes/pluggable.php#L1028-L1029) is [create](https://github.com/WordPress/WordPress/blob/6064478fa75cef6e85965d1041e26ec4f0ddcac3/wp-includes/pluggable.php#L2362)d every time the WP auth cookie is set. To create and [verify](https://github.com/WordPress/WordPress/blob/6064478fa75cef6e85965d1041e26ec4f0ddcac3/wp-includes/pluggable.php#L2311) the Nonce, this WP session token is used.
> 
> Although, in the second `/checkout` request, we are login-in the correct user (using `wc_set_customer_auth_cookie($cart_token_user_id))`. A new WP auth cookie is set, and a new WP session token is also created. Which will be different from the one the store API used to create the previous `wc_store_api` nonce making it impossible to validate the nonce.
> 
> Passing the WP auth cookie would fix this issue. But we want to solve this issue without cookies which leaves us with a few options:
> 
> - Pass the WP session token using the StoreAPI via header and somehow put it on the nonce validator (I don’t think this is feasible. Maybe we could hijack the `$_COOKIE` superglobal).
> - Implement a new cookieless nonce creation/verification system.
> - Any other ideas?