### PR TITLE
Fix condition to enable WooPay in the checkout page

### DIFF
--- a/changelog/as-fix-subs-woopay
+++ b/changelog/as-fix-subs-woopay
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Restore removed condition after naming convention.

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -183,7 +183,7 @@ class WC_Payments_Checkout {
 			'isUPESplitEnabled'              => WC_Payments_Features::is_upe_split_enabled(),
 			'isUPEDeferredEnabled'           => WC_Payments_Features::is_upe_deferred_intent_enabled(),
 			'isSavedCardsEnabled'            => $this->gateway->is_saved_cards_enabled(),
-			'isWooPayEnabled'                => $this->woopay_util->should_enable_woopay( $this->gateway ),
+			'isWooPayEnabled'                => $this->woopay_util->should_enable_woopay( $this->gateway ) && $this->woopay_util->should_enable_woopay_on_cart_or_checkout(),
 			'isWoopayExpressCheckoutEnabled' => $this->woopay_util->is_woopay_express_checkout_enabled(),
 			'isClientEncryptionEnabled'      => WC_Payments_Features::is_client_secret_encryption_enabled(),
 			'woopayHost'                     => WooPay_Utilities::get_woopay_url(),

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2145,8 +2145,8 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->wcpay_gateway->update_option( 'platform_checkout', 'yes' );
 		$this->assertTrue( $this->woopay_utilities->should_enable_woopay( $this->wcpay_gateway ) );
 
-		// This will return TRUE because woopay_utilities->should_enable_woopay() will return true.
-		$this->assertTrue( $this->payments_checkout->get_payment_fields_js_config()['isWooPayEnabled'] );
+		// This will return false because woopay_utilities->should_enable_woopay_on_cart_or_checkout() will return false.
+		$this->assertFalse( $this->payments_checkout->get_payment_fields_js_config()['isWooPayEnabled'] );
 	}
 
 	public function test_should_use_stripe_platform_on_checkout_page_not_woopay_eligible() {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -80,13 +80,6 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	private $mock_wcpay_account;
 
 	/**
-	 * WooPay_Utilities instance
-	 *
-	 * @var WooPay_Utilities
-	 */
-	private $woopay_utilities;
-
-	/**
 	 * Session_Rate_Limiter instance.
 	 *
 	 * @var Session_Rate_Limiter|PHPUnit_Framework_MockObject_MockObject
@@ -99,6 +92,13 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	 * @var WC_Payments_Order_Service
 	 */
 	private $order_service;
+
+	/**
+	 * WooPay_Utilities instance.
+	 *
+	 * @var WooPay_Utilities
+	 */
+	private $woopay_utilities;
 
 	/**
 	 * WC_Payments_Checkout instance.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -80,6 +80,14 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	private $mock_wcpay_account;
 
 	/**
+	 * WooPay_Utilities instance
+	 *
+	 * @var WooPay_Utilities|PHPUnit_Framework_MockObject_MockObject
+	 *
+	 */
+	private $mock_woopay_utilities;
+
+	/**
 	 * Session_Rate_Limiter instance.
 	 *
 	 * @var Session_Rate_Limiter|PHPUnit_Framework_MockObject_MockObject
@@ -92,13 +100,6 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	 * @var WC_Payments_Order_Service
 	 */
 	private $order_service;
-
-	/**
-	 * WooPay_Utilities instance.
-	 *
-	 * @var WooPay_Utilities
-	 */
-	private $woopay_utilities;
 
 	/**
 	 * WC_Payments_Checkout instance.
@@ -178,11 +179,11 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			$this->mock_dpps
 		);
 
-		$this->woopay_utilities = new WooPay_Utilities();
+		$this->mock_woopay_utilities = $this->createMock( WooPay_Utilities::class );
 
 		$this->payments_checkout = new WC_Payments_Checkout(
 			$this->wcpay_gateway,
-			$this->woopay_utilities,
+			$this->mock_woopay_utilities,
 			$this->mock_wcpay_account,
 			$this->mock_customer_service
 		);
@@ -2141,26 +2142,18 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_woopay_enabled_returns_true() {
-		$mock_woopay_utilities = $this->createMock( WooPay_Utilities::class );
-		$mock_woopay_utilities
+		$this->mock_woopay_utilities
 			->method( 'should_enable_woopay_on_cart_or_checkout' )
 			->willReturn( true );
-		$mock_woopay_utilities
+		$this->mock_woopay_utilities
 			->method( 'should_enable_woopay' )
 			->willReturn( true );
 
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
 		$this->wcpay_gateway->update_option( 'platform_checkout', 'yes' );
 
-		$payments_checkout = new WC_Payments_Checkout(
-			$this->wcpay_gateway,
-			$mock_woopay_utilities,
-			$this->mock_wcpay_account,
-			$this->mock_customer_service
-		);
-
-		$this->assertTrue( $this->woopay_utilities->should_enable_woopay( $this->wcpay_gateway ) );
-		$this->assertTrue( $payments_checkout->get_payment_fields_js_config()['isWooPayEnabled'] );
+		$this->assertTrue( $this->mock_woopay_utilities->should_enable_woopay( $this->wcpay_gateway ) );
+		$this->assertTrue( $this->payments_checkout->get_payment_fields_js_config()['isWooPayEnabled'] );
 	}
 
 	public function test_should_use_stripe_platform_on_checkout_page_not_woopay_eligible() {
@@ -2185,7 +2178,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$payments_checkout = new WC_Payments_Checkout(
 			$mock_wcpay_gateway,
-			$this->woopay_utilities,
+			$this->mock_woopay_utilities,
 			$this->mock_wcpay_account,
 			$this->mock_customer_service
 		);
@@ -2330,7 +2323,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$this->payments_checkout = new WC_Payments_Checkout(
 			$this->wcpay_gateway,
-			$this->woopay_utilities,
+			$this->mock_woopay_utilities,
 			$this->mock_wcpay_account,
 			$this->mock_customer_service
 		);

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2141,12 +2141,26 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_woopay_enabled_returns_true() {
+		$mock_woopay_utilities = $this->createMock( WooPay_Utilities::class );
+		$mock_woopay_utilities
+			->method( 'should_enable_woopay_on_cart_or_checkout' )
+			->willReturn( true );
+		$mock_woopay_utilities
+			->method( 'should_enable_woopay' )
+			->willReturn( true );
+
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
 		$this->wcpay_gateway->update_option( 'platform_checkout', 'yes' );
-		$this->assertTrue( $this->woopay_utilities->should_enable_woopay( $this->wcpay_gateway ) );
 
-		// This will return false because woopay_utilities->should_enable_woopay_on_cart_or_checkout() will return false.
-		$this->assertFalse( $this->payments_checkout->get_payment_fields_js_config()['isWooPayEnabled'] );
+		$payments_checkout = new WC_Payments_Checkout(
+			$this->wcpay_gateway,
+			$mock_woopay_utilities,
+			$this->mock_wcpay_account,
+			$this->mock_customer_service
+		);
+
+		$this->assertTrue( $this->woopay_utilities->should_enable_woopay( $this->wcpay_gateway ) );
+		$this->assertTrue( $payments_checkout->get_payment_fields_js_config()['isWooPayEnabled'] );
 	}
 
 	public function test_should_use_stripe_platform_on_checkout_page_not_woopay_eligible() {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -82,10 +82,9 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	/**
 	 * WooPay_Utilities instance
 	 *
-	 * @var WooPay_Utilities|PHPUnit_Framework_MockObject_MockObject
-	 *
+	 * @var WooPay_Utilities
 	 */
-	private $mock_woopay_utilities;
+	private $woopay_utilities;
 
 	/**
 	 * Session_Rate_Limiter instance.
@@ -179,11 +178,11 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			$this->mock_dpps
 		);
 
-		$this->mock_woopay_utilities = $this->createMock( WooPay_Utilities::class );
+		$this->woopay_utilities = new WooPay_Utilities();
 
 		$this->payments_checkout = new WC_Payments_Checkout(
 			$this->wcpay_gateway,
-			$this->mock_woopay_utilities,
+			$this->woopay_utilities,
 			$this->mock_wcpay_account,
 			$this->mock_customer_service
 		);
@@ -2142,18 +2141,15 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_woopay_enabled_returns_true() {
-		$this->mock_woopay_utilities
-			->method( 'should_enable_woopay_on_cart_or_checkout' )
-			->willReturn( true );
-		$this->mock_woopay_utilities
-			->method( 'should_enable_woopay' )
-			->willReturn( true );
-
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
 		$this->wcpay_gateway->update_option( 'platform_checkout', 'yes' );
+		wp_set_current_user( 1 );
+		add_filter( 'woocommerce_is_checkout', '__return_true' );
 
-		$this->assertTrue( $this->mock_woopay_utilities->should_enable_woopay( $this->wcpay_gateway ) );
+		$this->assertTrue( $this->woopay_utilities->should_enable_woopay( $this->wcpay_gateway ) );
 		$this->assertTrue( $this->payments_checkout->get_payment_fields_js_config()['isWooPayEnabled'] );
+
+		remove_filter( 'woocommerce_is_checkout', '__return_true' );
 	}
 
 	public function test_should_use_stripe_platform_on_checkout_page_not_woopay_eligible() {
@@ -2178,7 +2174,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$payments_checkout = new WC_Payments_Checkout(
 			$mock_wcpay_gateway,
-			$this->mock_woopay_utilities,
+			$this->woopay_utilities,
 			$this->mock_wcpay_account,
 			$this->mock_customer_service
 		);
@@ -2323,7 +2319,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$this->payments_checkout = new WC_Payments_Checkout(
 			$this->wcpay_gateway,
-			$this->mock_woopay_utilities,
+			$this->woopay_utilities,
 			$this->mock_wcpay_account,
 			$this->mock_customer_service
 		);


### PR DESCRIPTION
Restores a missing condition required to enable WooPay in the checkout page. Spotted by @bborman22.

It was removed by mistake in https://github.com/Automattic/woocommerce-payments/pull/6061 as part of the naming convention update.


#### Testing instructions
- Make sure you are logged out from the merchant store.
- Login to WooPay.
- Go to the merchant store and add a simple subscription to the cart.
- Go to the checkout page.
- Enter the user's WooPay email
- WooPay popup **should not** be displayed.
- Remove the subscription and add another product.
- Go to the checkout page.
- Enter the user's WooPay email.
- WooPay popup should be displayed.