### PR TITLE
Fix the ACTION_TYPE variable for the default case of the pre-release workflow

### DIFF
--- a/.github/actions/process-changelog/action.yml
+++ b/.github/actions/process-changelog/action.yml
@@ -29,6 +29,7 @@ runs:
       env:
         RELEASE_VERSION: ${{ inputs.release-version }}
         RELEASE_DATE: ${{ inputs.release-date }}
+        ACTION_TYPE: ${{ inputs.action-type }}
       run: |
         FINAL_RELEASE_VERSION=$(echo "$RELEASE_VERSION" | grep -Po '\d.\d.\d(.*?)') # Keep only x.y.z from x.y.z(-test-n)
         CURRENT_RELEASE_VERSION=$(jq '.version' package.json -r)
@@ -38,6 +39,8 @@ runs:
         if [ "$(ls -A changelog | wc -l)" -eq 1 ] && [[ "$FINAL_RELEASE_VERSION" == "$CURRENT_RELEASE_VERSION" ]]; then
           echo "ACTION_TYPE=amend-version" >> $GITHUB_OUTPUT
           echo "CURRENT_VERSION=$CURRENT_RELEASE_VERSION" >> $GITHUB_OUTPUT
+        else
+          echo "ACTION_TYPE=$ACTION_TYPE" >> $GITHUB_OUTPUT
         fi
 
     - name: "Process changelog for changelog.txt"

--- a/changelog/fix-pre-release-workflow
+++ b/changelog/fix-pre-release-workflow
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix for pre-release workflow
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I noticed a regression following #6462 

The changelog would not be appropriately generated for the default use case of the pre-release workflow.
Instead of generating new entries, it would amend the previous one.

#### Testing instructions

* Create a test branch from that branch 
* Run the [Create a GH pre-release](https://github.com/Automattic/woocommerce-payments/actions/workflows/create-pre-release.yml) workflow from this branch with a dummy package version number
* Confirm the changelog is generated correctly by looking at the last commits fro the new `testing/x.y.z-test-n` branch that was created
* Clean up the side effects of the workflow (GitHub release, tag and branch)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
