### PR TITLE
Links in subscription deactiavtion modal now open in a new tab

### DIFF
--- a/changelog/add-target-blank-in-sub-deactivation-modal
+++ b/changelog/add-target-blank-in-sub-deactivation-modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Links in subscription deactivation modal open in a new tab

--- a/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
+++ b/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
@@ -24,7 +24,7 @@
 								esc_html__( 'By deactivating the %1$sWooCommerce Subscriptions%2$s plugin, your store will switch to using the subscriptions functionality %1$sbuilt into WooCommerce Payments%2$s. %1$s%3$sLearn more.%4$s%2$s', 'woocommerce-payments' ),
 								'<strong>',
 								'</strong>',
-								'<a href="https://woocommerce.com/document/subscriptions/renewal-process/#section-4">',
+								'<a href="https://woocommerce.com/document/subscriptions/renewal-process/#section-4" target="_blank" rel="noopener noreferrer">',
 								'</a>'
 							);
 							?>
@@ -36,7 +36,7 @@
 								esc_html__( 'Existing subscribers will need to pay for their next renewal manually, after which automatic payments will resume. You will also no longer have access to the %1$s%3$sadvanced features%4$s%2$s of WooCommerce Subscriptions.', 'woocommerce-payments' ),
 								'<strong>',
 								'</strong>',
-								'<a href="https://woocommerce.com/document/payments/subscriptions-basics/comparison/">',
+								'<a href="https://woocommerce.com/document/payments/subscriptions-basics/comparison/" target="_blank" rel="noopener noreferrer">',
 								'</a>'
 							);
 							?>


### PR DESCRIPTION
Fixes #6532 
Extension of https://github.com/Automattic/woocommerce-payments/pull/6499

#### Changes proposed in this Pull Request

- Added target `blank` for links to open in a new tab for subscription deactivation modal for better User experience.
- Added `rel="noopener noreferrer"` to make it more secure.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
* Make sure you have [WooCommerce Subscriptions](https://github.com/woocommerce/woocommerce-subscriptions) plugin installed.
* Try to deactivate the plugin and verify if the links are opening in a new tab
<img width="335" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/15019298/f37a51cb-f8f7-4bb2-b75b-e4a33ef02d8e">

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
