### PR TITLE
Add a way to allow us to define if WooPay should be enabled or disabled by default for new merchants

### DIFF
--- a/changelog/add-enable-woopay-by-default-flag
+++ b/changelog/add-enable-woopay-by-default-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added flag to allow us to remotely set if WooPay should be enabled or not for new merchants.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -80,6 +80,7 @@ class WC_Payments_Account {
 
 		// Add server links handler.
 		add_action( 'admin_init', [ $this, 'maybe_redirect_to_server_link' ] );
+		add_action( 'admin_init', [ $this, 'maybe_activate_woopay' ] );
 	}
 
 	/**
@@ -1129,10 +1130,25 @@ class WC_Payments_Account {
 			exit;
 		}
 
+		set_transient( 'woopay_enabled_by_default', $onboarding_data['woopay_enabled_by_default'], DAY_IN_SECONDS );
 		set_transient( 'wcpay_stripe_onboarding_state', $onboarding_data['state'], DAY_IN_SECONDS );
 
 		wp_safe_redirect( $onboarding_data['url'] );
 		exit;
+	}
+
+	/**
+	 * Activates WooPay when visiting the KYC success page and woopay_enabled_by_default transient is set to true.
+	 */
+	public function maybe_activate_woopay() {
+		if ( ! isset( $_GET['wcpay-connection-success'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return;
+		}
+
+		if ( get_transient( 'woopay_enabled_by_default' ) ) {
+			WC_Payments::get_gateway()->update_is_woopay_enabled( true );
+			delete_transient( 'woopay_enabled_by_default' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #6494

#### Changes proposed in this Pull Request
This PR adds a check to enable WooPay if a flag is set in the WC Payments server.

WooPay will only be activated if it's the first onboarding of the merchant and if the server flag is set to true. 
Merchants already onboarded won't have WooPay automatically enabled or disabled

#### Testing instructions
**Server setup**
- Checkout your server to https://github.com/Automattic/woocommerce-payments-server/pull/3512
- Execute `npm run sync -- --mc`
- Execute `npm run sync -- --live`
- Sync the server changes to your sandbox and make your merchant site use the sandbox server
- Set up your host file to point `dev-mc.a8c.com` to your sandbox

**Merchant site**
- Checkout to this PR branch in your merchant site
- Go to /wp-admin > Payments > Settings and Disable WooPay 
- Save the changes
- Go to /wp-admin > WCPay Dev > click Re-onboard with WCPay
- Go through the KYC
- Make sure WooPay is **not** enabled (This will test what happens when `woopay_enabled_by_default` meta is not set)
- Now go to https://dev-mc.a8c.com/woopay/index.php
- Check the option `Enable WooPay automatically for new merchants.`
- Save
- Make sure it stays checked after the page finishes reloading
- Go to your merchant site > /wp-admin > WCPay Dev > click Re-onboard with WCPay
- Go through the KYC
- Make sure WooPay is **enabled** by default
- Disable WooPay again
- Go to https://dev-mc.a8c.com/woopay/index.php
- Uncheck the option `Enable WooPay automatically for new merchants.`
- Save
- Make sure it stays unchecked after the page finishes reloading
- Go to your merchant site > /wp-admin > WCPay Dev > click Re-onboard with WCPay
- Go through the KYC
- Make sure WooPay is **not** enabled by default


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
