### PR TITLE
Update InlineNotice styles to match WC Admin design library 

### DIFF
--- a/client/components/inline-notice/index.tsx
+++ b/client/components/inline-notice/index.tsx
@@ -10,7 +10,14 @@ import classNames from 'classnames';
  */
 import './style.scss';
 
-const InlineNotice = ( { className, ...restProps } ) => (
+interface InlineNoticeProps extends Notice.Props {
+	className?: string;
+}
+
+const InlineNotice: React.FC< InlineNoticeProps > = ( {
+	className,
+	...restProps
+} ) => (
 	<Notice
 		className={ classNames( 'wcpay-inline-notice', className ) }
 		{ ...restProps }

--- a/client/components/inline-notice/index.tsx
+++ b/client/components/inline-notice/index.tsx
@@ -10,11 +10,7 @@ import classNames from 'classnames';
  */
 import './style.scss';
 
-interface InlineNoticeProps extends Notice.Props {
-	className?: string;
-}
-
-const InlineNotice: React.FC< InlineNoticeProps > = ( {
+const InlineNotice: React.FC< Notice.Props > = ( {
 	className,
 	...restProps
 } ) => (

--- a/client/components/inline-notice/style.scss
+++ b/client/components/inline-notice/style.scss
@@ -1,11 +1,68 @@
-.wcpay-inline-notice {
+.components-notice.wcpay-inline-notice {
 	// increasing the specificity of the styles to override the Gutenberg ones
 	&#{&} {
+		color: $gray-900;
+		border-left: none;
+		padding: 12px 16px;
 		margin: 0;
 		margin-bottom: $grid-unit-30;
 	}
 
+	.components-button.is-secondary:not( :disabled ) {
+		box-shadow: none;
+		transition: background-color 0.2s;
+		margin: 16px 0 0;
+	}
+
+	&,
 	&.is-info {
-		background: #def1f7;
+		background-color: $studio-blue-0;
+
+		.components-button.is-secondary:not( :disabled ) {
+			box-shadow: none;
+			transition: background-color 0.2s;
+
+			border: 1px solid $studio-blue-40;
+			color: $studio-blue-40;
+
+			&:active,
+			&:hover {
+				background-color: darken( $studio-blue-0, 5% );
+			}
+		}
+	}
+
+	&.is-warning {
+		background-color: $studio-yellow-0;
+
+		.components-button.is-secondary:not( :disabled ) {
+			box-shadow: none;
+			transition: background-color 0.2s;
+
+			border: 1px solid $studio-yellow-40;
+			color: $studio-yellow-40;
+
+			&:active,
+			&:hover {
+				background-color: darken( $studio-yellow-0, 5% );
+			}
+		}
+	}
+
+	&.is-error {
+		background-color: $studio-red-0;
+
+		.components-button.is-secondary:not( :disabled ) {
+			box-shadow: none;
+			transition: background-color 0.2s;
+
+			border: 1px solid $studio-red-40;
+			color: $studio-red-40;
+
+			&:active,
+			&:hover {
+				background-color: darken( $studio-red-0, 5% );
+			}
+		}
 	}
 }


### PR DESCRIPTION
**Update:** this PR is no longer requires, as the component we're looking to utilise for this design (#6373) has already been implemented as `BannerNotice` in #5814. See screenshot using `BannerNotice` for the Order Dispute Notice:

![image](https://github.com/Automattic/woocommerce-payments/assets/3147296/6b4e87f9-b349-46ee-867f-1d8c9d66d7d8)

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

As part of #6354, we will be using the latest (proposed) WooCommerce Design Library `InlineNotice` component. Proposed in figma here: Kofpo8jj4zDWXDsVdlSz0f-fi-4172_49449.

This PR also migrates the `InlineNotice` component to TypeScript to improve code quality.


**TODO**


- [ ] Match colours with design library. We've used color-studio colours but these don't match the WC figma. There may be a newer or different colour library we need.
- [ ] Padding
- [ ] Check issues reported that might be related (#6424).
- [ ] Test with action button and icon (#6373)


<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This `InlineNotice` component is used in various places in our UI, and these need to be tested.

* [client/components/currency-information-for-methods/index.js](https://github.com/Automattic/woocommerce-payments/blob/acad044f0e299e069173c964af7ce3ee072f0865/client/components/currency-information-for-methods/index.js#L93)
	* Ensure the currency **Polish złoty (zł)** is not enabled on your store.
	* Go the the URL `/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fadditional-payment-methods`. Enable the payment method `Przelewy24` to see the notice.
	* Before:
		<img width="400" alt="Screenshot 2023-06-15 at 14 46 51" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/bf84668d-994d-4d20-870a-f39abe0453c1">

* [client/components/error-boundary/index.js](https://github.com/Automattic/woocommerce-payments/blob/acad044f0e299e069173c964af7ce3ee072f0865/client/components/error-boundary/index.js#L33)
	* Edit this components state to `error: 'test'` in [`client/components/error-boundary/index.js`](https://github.com/Automattic/woocommerce-payments/blob/ff27f046cfa50032d1ce47369f82a37680f17a8e/client/components/error-boundary/index.js#L13) to mock an error thrown.
	* Visit **Payments → Overview** to see the notice.
	* Before:
		<img width="400" alt="Screenshot 2023-06-15 at 14 46 51" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/e37ed0fa-3ced-4006-a096-99260d7339da">

* [client/settings/disable-upe-modal/index.js](https://github.com/Automattic/woocommerce-payments/blob/acad044f0e299e069173c964af7ce3ee072f0865/client/settings/disable-upe-modal/index.js#L23)
	* With UPE enabled, navigate to **Payments → Settings → Payment Methods** to click **Disable** from the dropdown menu.
	* Before:
		<img width="400" alt="Screenshot 2023-06-15 at 14 39 50" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/5a00f68f-c42b-4721-b456-c97c02806fec">


* [client/settings/survey-modal/index.js](https://github.com/Automattic/woocommerce-payments/blob/acad044f0e299e069173c964af7ce3ee072f0865/client/settings/survey-modal/index.js#L29)
	* With UPE enabled, navigate to **Payments → Settings → Payment Methods** to click **Disable** from the dropdown menu.
	* On the modal that appears, click **Disable**. You will see the success notice in the following modal.
	* Before:
		<img width="400" alt="Screenshot 2023-06-15 at 15 14 20" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/66ffd2b6-6c76-458d-8ded-68724211be53">

* [client/settings/express-checkout-settings/payment-request-button-preview.js](https://github.com/Automattic/woocommerce-payments/blob/acad044f0e299e069173c964af7ce3ee072f0865/client/settings/express-checkout-settings/payment-request-button-preview.js#L155)
	* In WCPay devtools, force the `platform_checkout_eligible` flag to `true`
	* Navigate to **Payments → Settings → Express checkouts → WooPay → Customise**
	* Ensure no WooPay button options are enabled. View the notice at the bottom of this settings page
	* Before:
		<img width="400" alt="Screenshot 2023-06-15 at 15 04 51" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/a6a1471d-4966-4314-bc9d-cc1b06b6dcef">

* [client/settings/fraud-protection/components/protection-levels/index.tsx](https://github.com/Automattic/woocommerce-payments/blob/acad044f0e299e069173c964af7ce3ee072f0865/client/settings/fraud-protection/components/protection-levels/index.tsx#L59)
	* Force this notice to appear by returning `true` on line 58 of [client/settings/fraud-protection/components/protection-levels/index.tsx](https://github.com/Automattic/woocommerce-payments/blob/ff27f046cfa50032d1ce47369f82a37680f17a8e/client/settings/fraud-protection/components/protection-levels/index.tsx#L58)
	* Navigate to **Payments → Settings → Fraud protection** to see the error notice
	* Before:
		<img width="400" alt="Screenshot 2023-06-15 at 15 08 06" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/8c45369e-70b6-44f6-85b8-b975f27105e2">

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
