### PR TITLE
Affirm&Afterpay: added logo for transactions listing and transaction details

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -130,6 +130,16 @@
 	background-size: contain;
 }
 
+.payment-method__brand--afterpay_clearpay {
+	background: no-repeat url( '../images/payment-methods/afterpay.svg' );
+	background-size: contain;
+}
+
+.payment-method__brand--affirm {
+	background: no-repeat url( '../images/payment-methods/affirm.svg' );
+	background-size: contain;
+}
+
 .wc_gateways tr[data-gateway_id='woocommerce_payments'] .payment-method__icon {
 	border: 1px solid #ddd;
 	border-radius: 2px;

--- a/changelog/add-6123-affirm-afterpay-logo
+++ b/changelog/add-6123-affirm-afterpay-logo
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Affirm and Afterpay logo support in transactions listing and transaction details


### PR DESCRIPTION
Fixes #6123

#### Changes proposed in this Pull Request

- added logos

#### Testing instructions

* Given you already have transactions of each type, ensure the logo is displayed

![Screenshot from 2023-06-15 15-17-04](https://github.com/Automattic/woocommerce-payments/assets/1577185/3d9e7ad3-4f1b-4995-800c-dbe50e60dbec)
![Screenshot from 2023-06-15 15-16-53](https://github.com/Automattic/woocommerce-payments/assets/1577185/3cd20a6a-3958-48a0-9938-63f95de25c6b)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
