### PR TITLE
Affirm&Afterpay: respect supported payment ranges.

### DIFF
--- a/changelog/fix-affirm-afterpay-respect-cart-total
+++ b/changelog/fix-affirm-afterpay-respect-cart-total
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Ensure Affirm and Afterpay available on checkout only when the payment is in expected range.

--- a/includes/payment-methods/class-affirm-payment-method.php
+++ b/includes/payment-methods/class-affirm-payment-method.php
@@ -17,18 +17,6 @@ class Affirm_Payment_Method extends UPE_Payment_Method {
 
 	const PAYMENT_METHOD_STRIPE_ID = 'affirm';
 
-	const PAYMENT_METHOD_TOTAL_LIMIT = [
-		// See https://stripe.com/docs/payments/buy-now-pay-later#product-support.
-		'CAD' => [
-			'min' => 5000,
-			'max' => 3000000,
-		], // Represents CAD 50 - 30,000 CAD.
-		'USD' => [
-			'min' => 5000,
-			'max' => 3000000,
-		], // Represents USD 50 - 30,000 USD.
-	];
-
 	/**
 	 * Constructor for link payment method
 	 *
@@ -36,29 +24,21 @@ class Affirm_Payment_Method extends UPE_Payment_Method {
 	 */
 	public function __construct( $token_service ) {
 		parent::__construct( $token_service );
-		$this->stripe_id   = self::PAYMENT_METHOD_STRIPE_ID;
-		$this->title       = __( 'Affirm', 'woocommerce-payments' );
-		$this->is_reusable = false;
-		$this->currencies  = [ 'USD', 'CAD' ];
-		$this->icon_url    = plugins_url( 'assets/images/payment-methods/woo.svg', WCPAY_PLUGIN_FILE );
-	}
-
-	/**
-	 * Returns boolean dependent on whether payment method can be used at checkout.
-	 *
-	 * @return bool
-	 */
-	public function is_enabled_at_checkout() {
-		$is_enabled = parent::is_enabled_at_checkout();
-		if ( $is_enabled && isset( WC()->cart ) ) {
-			$currency = get_woocommerce_currency();
-			$amount   = WC_Payments_Utils::prepare_amount( WC()->cart->get_total( '' ), $currency );
-			if ( $amount > 0 ) {
-				$range = self::PAYMENT_METHOD_TOTAL_LIMIT[ $currency ];
-				return $amount >= $range['min'] && $amount <= $range['max'];
-			}
-		}
-		return $is_enabled;
+		$this->stripe_id           = self::PAYMENT_METHOD_STRIPE_ID;
+		$this->title               = __( 'Affirm', 'woocommerce-payments' );
+		$this->is_reusable         = false;
+		$this->icon_url            = plugins_url( 'assets/images/payment-methods/woo.svg', WCPAY_PLUGIN_FILE );
+		$this->currencies          = [ 'USD', 'CAD' ];
+		$this->limits_per_currency = [
+			'CAD' => [
+				'min' => 5000,
+				'max' => 3000000,
+			], // Represents CAD 50 - 30,000 CAD.
+			'USD' => [
+				'min' => 5000,
+				'max' => 3000000,
+			], // Represents USD 50 - 30,000 USD.
+		];
 	}
 
 	/**

--- a/includes/payment-methods/class-afterpay-payment-method.php
+++ b/includes/payment-methods/class-afterpay-payment-method.php
@@ -17,34 +17,6 @@ class Afterpay_Payment_Method extends UPE_Payment_Method {
 
 	const PAYMENT_METHOD_STRIPE_ID = 'afterpay_clearpay';
 
-	const PAYMENT_METHOD_TOTAL_LIMIT = [
-		// See https://stripe.com/docs/payments/afterpay-clearpay#collection-schedule.
-		'AUD' => [
-			'min' => 100,
-			'max' => 200000,
-		], // Represents AUD 1 - 2,000 AUD.
-		'CAD' => [
-			'min' => 100,
-			'max' => 200000,
-		], // Represents CAD 1 - 2,000 CAD.
-		'NZD' => [
-			'min' => 100,
-			'max' => 200000,
-		], // Represents NZD 1 - 2,000 NZD.
-		'GBP' => [
-			'min' => 100,
-			'max' => 100000,
-		], // Represents GBP 1 - 1,000 GBP.
-		'USD' => [
-			'min' => 100,
-			'max' => 400000,
-		], // Represents USD 1 - 4,000 USD.
-		'EUR' => [
-			'min' => 100,
-			'max' => 100000,
-		], // Represents EUR 1 - 1,000 EUR.
-	];
-
 	/**
 	 * Constructor for link payment method
 	 *
@@ -52,29 +24,37 @@ class Afterpay_Payment_Method extends UPE_Payment_Method {
 	 */
 	public function __construct( $token_service ) {
 		parent::__construct( $token_service );
-		$this->stripe_id   = self::PAYMENT_METHOD_STRIPE_ID;
-		$this->title       = __( 'Afterpay', 'woocommerce-payments' );
-		$this->is_reusable = false;
-		$this->currencies  = [ 'USD', 'CAD', 'AUD', 'NZD', 'GBP', 'EUR' ];
-		$this->icon_url    = plugins_url( 'assets/images/payment-methods/afterpay.svg', WCPAY_PLUGIN_FILE );
-	}
-
-	/**
-	 * Returns boolean dependent on whether payment method can be used at checkout.
-	 *
-	 * @return bool
-	 */
-	public function is_enabled_at_checkout() {
-		$is_enabled = parent::is_enabled_at_checkout();
-		if ( $is_enabled && isset( WC()->cart ) ) {
-			$currency = get_woocommerce_currency();
-			$amount   = WC_Payments_Utils::prepare_amount( WC()->cart->get_total( '' ), $currency );
-			if ( $amount > 0 ) {
-				$range = self::PAYMENT_METHOD_TOTAL_LIMIT[ $currency ];
-				return $amount >= $range['min'] && $amount <= $range['max'];
-			}
-		}
-		return $is_enabled;
+		$this->stripe_id           = self::PAYMENT_METHOD_STRIPE_ID;
+		$this->title               = __( 'Afterpay', 'woocommerce-payments' );
+		$this->is_reusable         = false;
+		$this->icon_url            = plugins_url( 'assets/images/payment-methods/afterpay.svg', WCPAY_PLUGIN_FILE );
+		$this->currencies          = [ 'USD', 'CAD', 'AUD', 'NZD', 'GBP', 'EUR' ];
+		$this->limits_per_currency = [
+			'AUD' => [
+				'min' => 100,
+				'max' => 200000,
+			], // Represents AUD 1 - 2,000 AUD.
+			'CAD' => [
+				'min' => 100,
+				'max' => 200000,
+			], // Represents CAD 1 - 2,000 CAD.
+			'NZD' => [
+				'min' => 100,
+				'max' => 200000,
+			], // Represents NZD 1 - 2,000 NZD.
+			'GBP' => [
+				'min' => 100,
+				'max' => 100000,
+			], // Represents GBP 1 - 1,000 GBP.
+			'USD' => [
+				'min' => 100,
+				'max' => 400000,
+			], // Represents USD 1 - 4,000 USD.
+			'EUR' => [
+				'min' => 100,
+				'max' => 100000,
+			], // Represents EUR 1 - 1,000 EUR.
+		];
 	}
 
 	/**

--- a/includes/payment-methods/class-afterpay-payment-method.php
+++ b/includes/payment-methods/class-afterpay-payment-method.php
@@ -8,6 +8,7 @@
 namespace WCPay\Payment_Methods;
 
 use WC_Payments_Token_Service;
+use WC_Payments_Utils;
 
 /**
  * Afterpay Payment Method class extending UPE base class
@@ -15,6 +16,34 @@ use WC_Payments_Token_Service;
 class Afterpay_Payment_Method extends UPE_Payment_Method {
 
 	const PAYMENT_METHOD_STRIPE_ID = 'afterpay_clearpay';
+
+	const PAYMENT_METHOD_TOTAL_LIMIT = [
+		// See https://stripe.com/docs/payments/afterpay-clearpay#collection-schedule.
+		'AUD' => [
+			'min' => 100,
+			'max' => 200000,
+		], // Represents AUD 1 - 2,000 AUD.
+		'CAD' => [
+			'min' => 100,
+			'max' => 200000,
+		], // Represents CAD 1 - 2,000 CAD.
+		'NZD' => [
+			'min' => 100,
+			'max' => 200000,
+		], // Represents NZD 1 - 2,000 NZD.
+		'GBP' => [
+			'min' => 100,
+			'max' => 100000,
+		], // Represents GBP 1 - 1,000 GBP.
+		'USD' => [
+			'min' => 100,
+			'max' => 400000,
+		], // Represents USD 1 - 4,000 USD.
+		'EUR' => [
+			'min' => 100,
+			'max' => 100000,
+		], // Represents EUR 1 - 1,000 EUR.
+	];
 
 	/**
 	 * Constructor for link payment method
@@ -28,6 +57,24 @@ class Afterpay_Payment_Method extends UPE_Payment_Method {
 		$this->is_reusable = false;
 		$this->currencies  = [ 'USD', 'CAD', 'AUD', 'NZD', 'GBP', 'EUR' ];
 		$this->icon_url    = plugins_url( 'assets/images/payment-methods/afterpay.svg', WCPAY_PLUGIN_FILE );
+	}
+
+	/**
+	 * Returns boolean dependent on whether payment method can be used at checkout.
+	 *
+	 * @return bool
+	 */
+	public function is_enabled_at_checkout() {
+		$is_enabled = parent::is_enabled_at_checkout();
+		if ( $is_enabled && isset( WC()->cart ) ) {
+			$currency = get_woocommerce_currency();
+			$amount   = WC_Payments_Utils::prepare_amount( WC()->cart->get_total( '' ), $currency );
+			if ( $amount > 0 ) {
+				$range = self::PAYMENT_METHOD_TOTAL_LIMIT[ $currency ];
+				return $amount >= $range['min'] && $amount <= $range['max'];
+			}
+		}
+		return $is_enabled;
 	}
 
 	/**

--- a/includes/payment-methods/class-upe-payment-method.php
+++ b/includes/payment-methods/class-upe-payment-method.php
@@ -9,6 +9,7 @@
 
 namespace WCPay\Payment_Methods;
 
+use WC_Payments_Utils;
 use WP_User;
 use WC_Payments_Token_Service;
 use WC_Payment_Token_CC;
@@ -55,9 +56,16 @@ abstract class UPE_Payment_Method {
 	 * Supported presentment currencies for which charges for a payment method can be processed
 	 * Empty if all currencies are supported
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	protected $currencies;
+
+	/**
+	 * Represent payment total limitations for the payment method (per-currency).
+	 *
+	 * @var array<string,array<string,int>>
+	 */
+	protected $limits_per_currency = [];
 
 	/**
 	 * Payment method icon URL
@@ -114,6 +122,21 @@ abstract class UPE_Payment_Method {
 		if ( $this->is_subscription_item_in_cart() || $this->is_changing_payment_method_for_subscription() ) {
 			return $this->is_reusable();
 		}
+
+		// This part ensures that when payment limits for the currency declared, those will be respected (e.g. BNPLs).
+		if ( [] !== $this->limits_per_currency ) {
+			$currency = get_woocommerce_currency();
+			// If the currency limits are not defined, we allow the PM for now (gateway has similar validation for limits).
+			// Additionally, we don't engage with limits verification in no-checkout context (cart is not available or empty).
+			if ( isset( $this->limits_per_currency[ $currency ], WC()->cart ) ) {
+				$amount = WC_Payments_Utils::prepare_amount( WC()->cart->get_total( '' ), $currency );
+				if ( $amount > 0 ) {
+					$range = $this->limits_per_currency[ $currency ];
+					return $amount >= $range['min'] && $amount <= $range['max'];
+				}
+			}
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Adds checking cart total to be in the supported range, when checking PM accessibility at checkout 

#### Testing instructions

* Ensure the cart is below $50 - checkout shall show only Afterpay in PMs on checkout
* Ensure the cart is above $50 - checkout shall show only Affirm and Afterpay in PMs on checkout

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
