### PR TITLE
Improve validation when `Enter` key is pressed

### DIFF
--- a/changelog/6547-validation-po-form
+++ b/changelog/6547-validation-po-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improved user experience on onboarding form when validating fields if Enter key is pressed.

--- a/client/components/phone-number-control/index.tsx
+++ b/client/components/phone-number-control/index.tsx
@@ -27,6 +27,7 @@ interface Props {
 	value: string;
 	onChange: ( value: string, country: string ) => void;
 	onBlur?: () => void;
+	onKeyDown?: ( event: React.KeyboardEvent< HTMLInputElement > ) => void;
 	country?: string;
 	className?: string;
 	label?: string;
@@ -38,6 +39,7 @@ const PhoneNumberControl: React.FC< Props > = ( {
 	country,
 	onChange,
 	onBlur,
+	onKeyDown,
 	...rest
 } ) => {
 	const [ focused, setFocused ] = useState( false );
@@ -113,6 +115,9 @@ const PhoneNumberControl: React.FC< Props > = ( {
 						setFocused( false );
 						onBlur?.();
 					} }
+					onKeyDown={ (
+						event: React.KeyboardEvent< HTMLInputElement >
+					) => onKeyDown?.( event ) }
 					style={ {
 						paddingLeft: spanWidth + 8,
 						marginLeft: -spanWidth,

--- a/client/components/phone-number-control/test/index.test.tsx
+++ b/client/components/phone-number-control/test/index.test.tsx
@@ -12,6 +12,7 @@ import PhoneNumberControl from '../';
 
 describe( 'Phone Number Control', () => {
 	const onChange = jest.fn();
+	const onKeyDown = jest.fn();
 
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -83,6 +84,27 @@ describe( 'Phone Number Control', () => {
 		userEvent.selectOptions( select, 'CA' );
 
 		expect( input ).toHaveFocus();
+	} );
+
+	it( 'calls onKeyDown when input is focused and key is pressed', () => {
+		render(
+			<PhoneNumberControl
+				value=""
+				onChange={ onChange }
+				onKeyDown={ onKeyDown }
+			/>
+		);
+
+		const input = screen.getByRole( 'textbox' );
+		userEvent.type( input, '1234567890' );
+		fireEvent.keyDown( input, {
+			key: 'Enter',
+			code: 'Enter',
+			charCode: 13,
+		} );
+
+		// Will be called 10 times by the input, then once more by the 'Enter' keydown.
+		expect( onKeyDown ).toHaveBeenCalledTimes( 11 );
 	} );
 
 	it( 'toggles focused class as expected', () => {

--- a/client/onboarding-prototype/form.tsx
+++ b/client/onboarding-prototype/form.tsx
@@ -74,6 +74,9 @@ export const OnboardingTextField: React.FC< OnboardingTextFieldProps > = ( {
 				if ( touched[ name ] ) validate( value );
 			} }
 			onBlur={ () => validate() }
+			onKeyDown={ ( event: React.KeyboardEvent< HTMLInputElement > ) => {
+				if ( event.key === 'Enter' ) validate( data[ name ] );
+			} }
 			error={ error() }
 			{ ...rest }
 		/>
@@ -104,6 +107,9 @@ export const OnboardingPhoneNumberField: React.FC< OnboardingPhoneNumberFieldPro
 			} }
 			onBlur={ () => validate() }
 			error={ error() }
+			onKeyDown={ ( event: React.KeyboardEvent< HTMLInputElement > ) => {
+				if ( event.key === 'Enter' ) validate( data[ name ] );
+			} }
 			{ ...rest }
 		/>
 	);

--- a/client/onboarding-prototype/form.tsx
+++ b/client/onboarding-prototype/form.tsx
@@ -75,7 +75,7 @@ export const OnboardingTextField: React.FC< OnboardingTextFieldProps > = ( {
 			} }
 			onBlur={ () => validate() }
 			onKeyDown={ ( event: React.KeyboardEvent< HTMLInputElement > ) => {
-				if ( event.key === 'Enter' ) validate( data[ name ] );
+				if ( event.key === 'Enter' ) validate();
 			} }
 			error={ error() }
 			{ ...rest }
@@ -108,7 +108,7 @@ export const OnboardingPhoneNumberField: React.FC< OnboardingPhoneNumberFieldPro
 			onBlur={ () => validate() }
 			error={ error() }
 			onKeyDown={ ( event: React.KeyboardEvent< HTMLInputElement > ) => {
-				if ( event.key === 'Enter' ) validate( data[ name ] );
+				if ( event.key === 'Enter' ) validate();
 			} }
 			{ ...rest }
 		/>


### PR DESCRIPTION
Fixes #6547 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

* Improve the validation behaviour when `Enter` key is pressed while focusing an input field.
* Fixes a bug where the phone number field is incorrectly validated if Enter is pressed while focussing.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Checkout `develop` and run `npm run watch`
* Open the PO form, type valid inputs for each field on the first form step. You can use `2015553210` for the phone number field.
* Focus the phone number field, then press `Enter`. You should see a validation error appear even though the input is valid.

* Checkout this branch and run `npm run watch`
* Refresh the page, repeat the steps above.
* This time, the validation error should not appear when you press enter.
* Try inputting both valid/non-valid input in the `First Name`, `Last Name`, `Email` and `Phone Number` fields and then pressing enter.
* The form should be correctly validated in all cases. If all fields are valid, `Enter` will continue to the next step of the form.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
