### PR TITLE
Add additional validation in VAT controller

### DIFF
--- a/changelog/add-add-validation-vat-controller
+++ b/changelog/add-add-validation-vat-controller
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add additional validation in VAT controller.

--- a/includes/admin/class-wc-rest-payments-vat-controller.php
+++ b/includes/admin/class-wc-rest-payments-vat-controller.php
@@ -42,14 +42,17 @@ class WC_REST_Payments_VAT_Controller extends WC_Payments_REST_Controller {
 				'args'                => [
 					'vat_number' => [
 						'type'     => 'string',
+						'format'   => 'text-field',
 						'required' => false,
 					],
 					'name'       => [
 						'type'     => 'string',
+						'format'   => 'text-field',
 						'required' => true,
 					],
 					'address'    => [
 						'type'     => 'string',
+						'format'   => 'textarea-field',
 						'required' => true,
 					],
 				],
@@ -65,7 +68,7 @@ class WC_REST_Payments_VAT_Controller extends WC_Payments_REST_Controller {
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	public function validate_vat( $request ) {
-		$vat_number = $request->get_param( 'vat_number' );
+		$vat_number = sanitize_text_field( $request->get_param( 'vat_number' ) );
 		return $this->forward_request( 'validate_vat', [ $vat_number ] );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds additional validation of fields passed to the VAT controller. 

#### Testing instructions

* Tests should pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
