### PR TITLE
Increase the size of PO elegibility modal to avoid vertical scroll

### DIFF
--- a/changelog/fix-6560-elegibility-modal-scroll
+++ b/changelog/fix-6560-elegibility-modal-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+

--- a/client/overview/modal/progressive-onboarding-eligibility/style.scss
+++ b/client/overview/modal/progressive-onboarding-eligibility/style.scss
@@ -1,7 +1,7 @@
 .wcpay-progressive-onboarding-eligibility-modal {
 	// fix for the modal being too short on smaller screens
 	@media ( max-height: 880px ) {
-		max-height: calc( 100% - 120px ) !important;
+		max-height: calc( 100% ) !important;
 	}
 	.components-modal__content {
 		box-sizing: border-box;

--- a/client/overview/modal/progressive-onboarding-eligibility/style.scss
+++ b/client/overview/modal/progressive-onboarding-eligibility/style.scss
@@ -1,7 +1,7 @@
 .wcpay-progressive-onboarding-eligibility-modal {
 	// fix for the modal being too short on smaller screens
 	@media ( max-height: 880px ) {
-		max-height: calc( 100% ) !important;
+		max-height: 100% !important;
 	}
 	.components-modal__content {
 		box-sizing: border-box;


### PR DESCRIPTION
Fixes #6560 

#### Changes proposed in this Pull Request
Adjustment to a CSS `max-height` value that was causing to display the PO eligibility modal with a vertical scroll.

**Before**
<img width="787" alt="Screenshot 2023-06-20 at 15 40 52" src="https://github.com/Automattic/woocommerce-payments/assets/2612426/5841ad32-2b8f-4942-910f-7ec1578dbcaa">


**After**
<img width="799" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/2612426/ad04b8d9-d795-4960-904b-1027f29429e1">

The change doesn't affect mobile or small screens, but this is an example of how it shows up
<img width="756" alt="Screenshot 2023-06-20 at 14 03 30" src="https://github.com/Automattic/woocommerce-payments/assets/2612426/2977dae1-a57e-4216-8bfc-4f699743f6e5">
<img width="756" alt="Screenshot 2023-06-20 at 14 03 34" src="https://github.com/Automattic/woocommerce-payments/assets/2612426/6362bbb6-fdf9-4468-a176-d72ab9830184">

#### Testing instructions
**Creation of PO account**

- Enable Progressive Onboarding in the dev tools settings, and ensure you don't have an active connected account on your client.
- Go through the onboarding using the values necessary to onboard a PO account (US, Individual, Less than 250k, Ready to start selling).
-  Go through Stripe KYC
- You should see the referred eligibility modal after being redirected from Stripe

If you already have a PO account, you can see the modal without having to onboard a new account by going to http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Foverview&wcpay-connection-success=1

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) :  'QA Testing Not Applicable'
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable: Not applicable taking into account this is still not a publicly available feature.
