### PR TITLE
Affirm&Afterpay: messaging element shall not appear for subscription products.

### DIFF
--- a/changelog/update-messaging-element-hide-for-subscriptions
+++ b/changelog/update-messaging-element-hide-for-subscriptions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Affirm&Afterpay: do not show messaging element for subscription products

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1644,9 +1644,21 @@ class WC_Payments {
 	 */
 	public static function load_stripe_bnpl_site_messaging() {
 		if ( WC_Payments_Features::is_bnpl_affirm_afterpay_enabled() ) {
-			require_once __DIR__ . '/class-wc-payments-payment-method-messaging-element.php';
-			$stripe_site_messaging = new WC_Payments_Payment_Method_Messaging_Element( self::$account, self::$card_gateway );
-			echo wp_kses( $stripe_site_messaging->init(), 'post' );
+			// The messaging element shall not be shown for subscription products.
+			// As we are not too deep into subscriptions API, we follow simplistic approach for now.
+			$is_subscription           = false;
+			$are_subscriptions_enabled = class_exists( 'WC_Subscriptions' ) || class_exists( 'WC_Subscriptions_Core_Plugin' );
+			if ( $are_subscriptions_enabled ) {
+					// The subscription identification shall be aligned with WC_Subscriptions_Product::is_subscription.
+					global $product;
+					$is_subscription = $product && $product->is_type( [ 'subscription', 'subscription_variation', 'variable-subscription' ] );
+			}
+
+			if ( ! $is_subscription ) {
+				require_once __DIR__ . '/class-wc-payments-payment-method-messaging-element.php';
+				$stripe_site_messaging = new WC_Payments_Payment_Method_Messaging_Element( self::$account, self::$card_gateway );
+				echo wp_kses( $stripe_site_messaging->init(), 'post' );
+			}
 		}
 	}
 


### PR DESCRIPTION
Followup on the project demo last Friday.

#### Changes proposed in this Pull Request

* Adds conditionals for rendering the element as per subject

#### Testing instructions

* Ensure the messaging element appears on the regular product page
* Ensure the messaging element doesn't appear on a subscription product page.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
