### PR TITLE
Fixed typo in businessInfo strings in strings.tsx file

### DIFF
--- a/changelog/6368-fix-typo-business-info
+++ b/changelog/6368-fix-typo-business-info
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed typo in businessInfo strings in strings.tsx file

--- a/client/connect-account-page/strings.tsx
+++ b/client/connect-account-page/strings.tsx
@@ -167,7 +167,7 @@ export default {
 					'Country where your business is based',
 					'woocommerce-payments '
 				),
-				__( 'Type of businesss', 'woocommerce-payments ' ),
+				__( 'Type of business', 'woocommerce-payments ' ),
 				__( 'Industry', 'woocommerce-payments ' ),
 				__( 'Company address', 'woocommerce-payments ' ),
 				__( 'Company phone number', 'woocommerce-payments ' ),

--- a/client/connect-account-page/test/__snapshots__/info-notice-modal.test.tsx.snap
+++ b/client/connect-account-page/test/__snapshots__/info-notice-modal.test.tsx.snap
@@ -141,7 +141,7 @@ exports[`Connect Account Page – Info Notice Modal renders correctly when opene
             Country where your business is based
           </li>
           <li>
-            Type of businesss
+            Type of business
           </li>
           <li>
             Industry


### PR DESCRIPTION
Fixes #6368 

#### Changes proposed in this Pull Request
Fixed typo in `Learn more about how to receive deposits`, an extra S in the word business:

![image](https://github.com/Automattic/woocommerce-payments/assets/15019298/99663a28-8e55-46e4-8733-9ea949cc7fc9)

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions
- Force WCPay account to be disconnected using dev plugin
- Click on Learn more... as mentioned in the screenshot below

![image](https://github.com/Automattic/woocommerce-payments/assets/15019298/bdc8b0f6-5f2f-4aab-82ee-4fb216268bfb)
![image](https://github.com/Automattic/woocommerce-payments/assets/15019298/cd442443-b441-4daf-a3bb-8315e0b3ebe4)

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
