### PR TITLE
Affirm&Afterpay: add new test cases.

### DIFF
--- a/changelog/add-tests-affirm-afterpay-methods-availability
+++ b/changelog/add-tests-affirm-afterpay-methods-availability
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Affirm&Afterpay: add new test cases to ensure the method availability on checkout

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -207,6 +207,8 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 			Sepa_Payment_Method::class,
 			Becs_Payment_Method::class,
 			Link_Payment_Method::class,
+			Affirm_Payment_Method::class,
+			Afterpay_Payment_Method::class,
 		];
 
 		$this->mock_rate_limiter = $this->createMock( Session_Rate_Limiter::class );
@@ -1542,6 +1544,12 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$mock_becs_details       = [
 			'type' => 'au_becs_debit',
 		];
+		$mock_affirm_details     = [
+			'type' => 'affirm',
+		];
+		$mock_afterpay_details   = [
+			'type' => 'afterpay_clearpay',
+		];
 
 		$this->set_cart_contains_subscription_items( false );
 		$card_method       = $this->mock_payment_methods['card'];
@@ -1553,6 +1561,8 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$sepa_method       = $this->mock_payment_methods['sepa_debit'];
 		$ideal_method      = $this->mock_payment_methods['ideal'];
 		$becs_method       = $this->mock_payment_methods['au_becs_debit'];
+		$affirm_method     = $this->mock_payment_methods['affirm'];
+		$afterpay_method   = $this->mock_payment_methods['afterpay_clearpay'];
 
 		$this->assertEquals( 'card', $card_method->get_id() );
 		$this->assertEquals( 'Credit card / debit card', $card_method->get_title() );
@@ -1609,6 +1619,18 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( 'BECS Direct Debit', $becs_method->get_title( $mock_becs_details ) );
 		$this->assertTrue( $becs_method->is_enabled_at_checkout() );
 		$this->assertFalse( $becs_method->is_reusable() );
+
+		$this->assertSame( 'affirm', $affirm_method->get_id() );
+		$this->assertSame( 'Affirm', $affirm_method->get_title() );
+		$this->assertSame( 'Affirm', $affirm_method->get_title( $mock_affirm_details ) );
+		$this->assertTrue( $affirm_method->is_enabled_at_checkout() );
+		$this->assertFalse( $affirm_method->is_reusable() );
+
+		$this->assertSame( 'afterpay_clearpay', $afterpay_method->get_id() );
+		$this->assertSame( 'Afterpay', $afterpay_method->get_title() );
+		$this->assertSame( 'Afterpay', $afterpay_method->get_title( $mock_afterpay_details ) );
+		$this->assertTrue( $afterpay_method->is_enabled_at_checkout() );
+		$this->assertFalse( $afterpay_method->is_reusable() );
 	}
 
 	public function test_only_reusabled_payment_methods_enabled_with_subscription_item_present() {
@@ -1623,6 +1645,8 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$p24_method        = $this->mock_payment_methods['p24'];
 		$ideal_method      = $this->mock_payment_methods['ideal'];
 		$becs_method       = $this->mock_payment_methods['au_becs_debit'];
+		$affirm_method     = $this->mock_payment_methods['affirm'];
+		$afterpay_method   = $this->mock_payment_methods['afterpay_clearpay'];
 
 		$this->assertTrue( $card_method->is_enabled_at_checkout() );
 		$this->assertFalse( $giropay_method->is_enabled_at_checkout() );
@@ -1633,6 +1657,8 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( $p24_method->is_enabled_at_checkout() );
 		$this->assertFalse( $ideal_method->is_enabled_at_checkout() );
 		$this->assertFalse( $becs_method->is_enabled_at_checkout() );
+		$this->assertFalse( $affirm_method->is_enabled_at_checkout() );
+		$this->assertFalse( $afterpay_method->is_enabled_at_checkout() );
 	}
 
 	public function test_only_valid_payment_methods_returned_for_currency() {
@@ -1645,6 +1671,8 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$p24_method        = $this->mock_payment_methods['p24'];
 		$ideal_method      = $this->mock_payment_methods['ideal'];
 		$becs_method       = $this->mock_payment_methods['au_becs_debit'];
+		$affirm_method     = $this->mock_payment_methods['affirm'];
+		$afterpay_method   = $this->mock_payment_methods['afterpay_clearpay'];
 
 		WC_Helper_Site_Currency::$mock_site_currency = 'EUR';
 
@@ -1657,6 +1685,8 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$this->assertTrue( $p24_method->is_currency_valid() );
 		$this->assertTrue( $ideal_method->is_currency_valid() );
 		$this->assertFalse( $becs_method->is_currency_valid() );
+		$this->assertFalse( $affirm_method->is_currency_valid() );
+		$this->assertTrue( $afterpay_method->is_currency_valid() );
 
 		WC_Helper_Site_Currency::$mock_site_currency = 'USD';
 
@@ -1669,6 +1699,8 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( $p24_method->is_currency_valid() );
 		$this->assertFalse( $ideal_method->is_currency_valid() );
 		$this->assertFalse( $becs_method->is_currency_valid() );
+		$this->assertTrue( $affirm_method->is_currency_valid() );
+		$this->assertTrue( $afterpay_method->is_currency_valid() );
 
 		WC_Helper_Site_Currency::$mock_site_currency = 'AUD';
 		$this->assertTrue( $becs_method->is_currency_valid() );
@@ -1686,6 +1718,8 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$p24_method        = $this->mock_payment_methods['p24'];
 		$ideal_method      = $this->mock_payment_methods['ideal'];
 		$becs_method       = $this->mock_payment_methods['au_becs_debit'];
+		$affirm_method     = $this->mock_payment_methods['affirm'];
+		$afterpay_method   = $this->mock_payment_methods['afterpay_clearpay'];
 
 		WC_Helper_Site_Currency::$mock_site_currency = 'EUR';
 
@@ -1714,6 +1748,8 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( $p24_method->is_currency_valid() );
 		$this->assertFalse( $ideal_method->is_currency_valid() );
 		$this->assertFalse( $becs_method->is_currency_valid() );
+		$this->assertTrue( $affirm_method->is_currency_valid() );
+		$this->assertTrue( $afterpay_method->is_currency_valid() );
 
 		$wp->query_vars = [];
 	}


### PR DESCRIPTION
Follows up on https://github.com/Automattic/woocommerce-payments/pull/6545

#### Changes proposed in this Pull Request

* Extends tests cases to ensure the PMs payment range verification engages properly in regards to context, currency and cart context.

#### Testing instructions

* CI checks shall pass

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
