### PR TITLE
Add setup intent to order for zero-amount order processing

### DIFF
--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -572,6 +572,9 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 					// UPE method gives us the error of the previous payment attempt, so we use that for the Rate Limiter.
 					$this->failed_transaction_rate_limiter->bump();
 				}
+			} else {
+				$setup_intent = $this->payments_api_client->get_setup_intent( $payment_intent_id );
+				$this->order_service->attach_intent_info_to_order( $order, $payment_intent_id, $setup_intent['status'], $setup_intent['payment_method'], $customer_id, null, $currency );
 			}
 		} else {
 			return $this->parent_process_payment( $order_id );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/6576

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable legacy UPE
* Add a free trial subscription to the cart
* Buy a subscription using a default credit card
* Navigate to _WooCommerce -> Orders_ and ensure the order status is _Processing_
* Navigate to _WooCommerce -> Subscriptions_ and start a renewal for this subscription
* Confirm that a new renewal order was placed successfully and also has the status _Processing_
* Set a debugger point [here](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/payment-methods/class-upe-payment-gateway.php#L702), buy a free trial subscription with a default card, and when debugger stopped at this point, check that `$this->order_service->get_intent_id_for_order( $order );` returns non-empty and valid setup intent id.
* Enable split UPE and perform all the above steps for the split UPE

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
