### PR TITLE
Only attach subscription integration hooks if subscriptions is enabled

### DIFF
--- a/changelog/fix-checkout-fatal-non-US
+++ b/changelog/fix-checkout-fatal-non-US
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: The changes that lead to a fatal on checkout were unreleased and so no changelog is necessary.
+
+

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -156,7 +156,7 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 		 * If new payment method IDs (eg 'sepa_debit') are added to this condition in the future, care should be taken to ensure duplication,
 		 * including double renewal charging, isn't introduced.
 		 */
-		if ( self::$has_attached_integration_hooks || 'woocommerce_payments' !== $this->id ) {
+		if ( self::$has_attached_integration_hooks || 'woocommerce_payments' !== $this->id || ! $this->is_subscriptions_enabled() ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes fatal errors on checkout introduced in #6326 for users who don't have subscriptions functionality enabled. 

#### Changes proposed in this Pull Request

In #6326 we updated the way hooks are attached for subscriptions functionality to prevent attaching them multiple times. Previously they were attached as part of `maybe_init_subscriptions()` which runs for every payment gateway instance (eg all the UPE payment methods) and that led to duplication and the potential for double renewal charges. 

This duplicate was patched as part of #6326 the hooks were moved to this new function which doesn't include a `is_subscriptions_enabled()` check. This leads to subscription related callbacks being attached when they aren't needed.

This PR fixes that by adding an check to make sure we only attach these hooks when Subscriptions functionality (via the plugin or feature) is enabled. 
 
#### Testing instructions

* Make sure the WC Subscriptions plugin is inactive. 
* Disable WCPay Subscriptions functionality via the **Payments > Advanced** settings or disable it via the code in `WC_Payments_Features::is_wcpay_subscriptions_enabled()` function.
* Place a standard simple product in your cart and go to checkout. 
    * On `develop` you will be presented this fatal.
    * On this branch there should be no issue. 

```
PHP Fatal error:  Uncaught Error: Class "WC_Subscriptions_Cart" not found in /wp-content/plugins/woocommerce-payments/includes/compat/subscriptions/trait-wc-payments-subscriptions-utilities.php:72
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
