### PR TITLE
Revalidate incompatible extensions when an extension is activated or deactivate

### DIFF
--- a/changelog/add-check_newly_activated_extension
+++ b/changelog/add-check_newly_activated_extension
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Check for invalid extensions when one is activated or deactivated.

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -386,7 +386,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 				'is_saved_cards_enabled'              => $this->wcpay_gateway->is_saved_cards_enabled(),
 				'is_card_present_eligible'            => $this->wcpay_gateway->is_card_present_eligible(),
 				'is_woopay_enabled'                   => 'yes' === $this->wcpay_gateway->get_option( 'platform_checkout' ),
-				'show_woopay_incompatibility_notice'  => get_option( 'woopay_disabled_invalid_extensions', false ),
+				'show_woopay_incompatibility_notice'  => get_option( 'woopay_invalid_extension_found', false ),
 				'woopay_custom_message'               => $this->wcpay_gateway->get_option( 'platform_checkout_custom_message' ),
 				'woopay_store_logo'                   => $this->wcpay_gateway->get_option( 'platform_checkout_store_logo' ),
 				'woopay_enabled_locations'            => $this->wcpay_gateway->get_option( 'platform_checkout_button_locations', [] ),

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -476,7 +476,7 @@ class WC_Payments {
 		self::$woopay_tracker                      = new WooPay_Tracker( self::get_wc_payments_http() );
 		self::$incentives_service                  = new WC_Payments_Incentives_Service( self::$database_cache );
 
-		( new WooPay_Scheduler() )->init();
+		( new WooPay_Scheduler( self::$api_client ) )->init();
 
 		self::$legacy_card_gateway = new CC_Payment_Gateway( self::$api_client, self::$account, self::$customer_service, self::$token_service, self::$action_scheduler_service, self::$failed_transaction_rate_limiter, self::$order_service );
 

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -38,7 +38,8 @@ class WC_Payments_API_Client {
 
 	const ACCOUNTS_API                 = 'accounts';
 	const CAPABILITIES_API             = 'accounts/capabilities';
-	const WOOPAY_API                   = 'accounts/platform_checkout';
+	const WOOPAY_ACCOUNTS_API          = 'accounts/platform_checkout';
+	const WOOPAY_EXTENSIONS_API        = 'woopay/extensions';
 	const APPLE_PAY_API                = 'apple_pay';
 	const CHARGES_API                  = 'charges';
 	const CONN_TOKENS_API              = 'terminal/connection_tokens';
@@ -838,7 +839,7 @@ class WC_Payments_API_Client {
 			[
 				'test_mode' => WC_Payments::mode()->is_dev(), // only send a test mode request if in dev mode.
 			],
-			self::WOOPAY_API,
+			self::WOOPAY_ACCOUNTS_API,
 			self::GET
 		);
 	}
@@ -858,7 +859,7 @@ class WC_Payments_API_Client {
 				[ 'test_mode' => WC_Payments::mode()->is_dev() ],
 				$data
 			),
-			self::WOOPAY_API,
+			self::WOOPAY_ACCOUNTS_API,
 			self::POST
 		);
 	}
@@ -2389,5 +2390,20 @@ class WC_Payments_API_Client {
 	 */
 	public function get_authorization( string $payment_intent_id ) {
 		return $this->request( [], self::AUTHORIZATIONS_API . '/' . $payment_intent_id, self::GET );
+	}
+
+	/**
+	 * Gets the list of extensions that are incompatible with WooPay.
+	 *
+	 * @return array of extensions.
+	 * @throws API_Exception When request fails.
+	 */
+	public function get_woopay_incompatible_extensions() {
+		return $this->request(
+			[],
+			self::WOOPAY_EXTENSIONS_API . '/incompatible',
+			self::GET,
+			false
+		);
 	}
 }

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -39,7 +39,7 @@ class WC_Payments_API_Client {
 	const ACCOUNTS_API                 = 'accounts';
 	const CAPABILITIES_API             = 'accounts/capabilities';
 	const WOOPAY_ACCOUNTS_API          = 'accounts/platform_checkout';
-	const WOOPAY_EXTENSIONS_API        = 'woopay/extensions';
+	const WOOPAY_COMPATIBILITY_API     = 'woopay/compatibility';
 	const APPLE_PAY_API                = 'apple_pay';
 	const CHARGES_API                  = 'charges';
 	const CONN_TOKENS_API              = 'terminal/connection_tokens';
@@ -2401,7 +2401,7 @@ class WC_Payments_API_Client {
 	public function get_woopay_incompatible_extensions() {
 		return $this->request(
 			[],
-			self::WOOPAY_EXTENSIONS_API . '/incompatible',
+			self::WOOPAY_COMPATIBILITY_API,
 			self::GET,
 			false
 		);

--- a/includes/woopay/class-woopay-scheduler.php
+++ b/includes/woopay/class-woopay-scheduler.php
@@ -70,7 +70,7 @@ class WooPay_Scheduler {
 	public function update_incompatible_extensions_list_and_maybe_show_warning() {
 		try {
 			$incompatible_extensions = $this->get_incompatible_extensions();
-			$active_plugins          = get_option( 'active_plugins' );
+			$active_plugins          = get_option( 'active_plugins', [] );
 
 			update_option( self::INCOMPATIBLE_EXTENSIONS_LIST_OPTION_NAME, $incompatible_extensions );
 			delete_option( self::INVALID_EXTENSIONS_FOUND_OPTION_NAME );
@@ -91,7 +91,7 @@ class WooPay_Scheduler {
 	 * @param string $plugin The plugin being enabled.
 	 */
 	public function show_warning_when_incompatible_extension_is_enabled( $plugin ) {
-		$incompatible_extensions = get_option( self::INCOMPATIBLE_EXTENSIONS_LIST_OPTION_NAME );
+		$incompatible_extensions = get_option( self::INCOMPATIBLE_EXTENSIONS_LIST_OPTION_NAME, [] );
 		$plugin                  = $this->format_extension_name( $plugin );
 
 		if ( $this->contains_incompatible_extension( [ $plugin ], $incompatible_extensions ) ) {
@@ -105,8 +105,8 @@ class WooPay_Scheduler {
 	 * @param string $plugin_being_deactivated The plugin name.
 	 */
 	public function hide_warning_when_incompatible_extension_is_disabled( $plugin_being_deactivated ) {
-		$incompatible_extensions = get_option( self::INCOMPATIBLE_EXTENSIONS_LIST_OPTION_NAME );
-		$active_plugins          = get_option( 'active_plugins' );
+		$incompatible_extensions = get_option( self::INCOMPATIBLE_EXTENSIONS_LIST_OPTION_NAME, [] );
+		$active_plugins          = get_option( 'active_plugins', [] );
 
 		// Needs to remove the plugin being deactivated because WordPress only updates the list after this hook runs.
 		$active_plugins = array_diff( $active_plugins, [ $plugin_being_deactivated ] );

--- a/tests/unit/woopay/class-woopay-scheduler-test.php
+++ b/tests/unit/woopay/class-woopay-scheduler-test.php
@@ -13,6 +13,12 @@ use WCPay\WooPay\WooPay_Scheduler;
 class WooPay_Scheduler_Test extends WP_UnitTestCase {
 
 	/**
+	 * Mocked WC_Payments_API_Client.
+	 * @var WC_Payments_API_Client
+	 */
+	private $mock_api;
+
+	/**
 	 * WooPay_Scheduler instance.
 	 * @var WooPay_Scheduler
 	 */
@@ -21,23 +27,14 @@ class WooPay_Scheduler_Test extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->scheduler = new WooPay_Scheduler();
+		$this->mock_api = $this->createMock( WC_Payments_API_Client::class );
+
+		$this->scheduler = new WooPay_Scheduler( $this->mock_api );
 	}
 
-	public function test_get_incompatible_extensions() {
-
-		$incompatible_extensions = [
-			'test-extension',
-			'test-extension-2',
-		];
-
-		$this->mock_api( $incompatible_extensions );
-
-		$returned_incompatible_extensions = $this->scheduler->get_incompatible_extensions();
-
-		$this->assertEquals( $incompatible_extensions, $returned_incompatible_extensions );
-	}
-
+	/**
+	 * Checks if the warning will show up when and incompatible extension is active.
+	 */
 	public function test_disable_woopay_when_incompatible_extension_active() {
 
 		$incompatible_extensions = [
@@ -45,21 +42,24 @@ class WooPay_Scheduler_Test extends WP_UnitTestCase {
 			'test-extension-2',
 		];
 
-		$this->mock_api( $incompatible_extensions );
+		$this->mock_api_response( $incompatible_extensions );
 
-		$pre_http_request = function () {
+		$active_plugins_mock = function () {
 			return [ 'test-extension/test-extension.php' ];
 		};
 
-		add_filter( 'pre_option_active_plugins', $pre_http_request, 10, 3 );
+		add_filter( 'pre_option_active_plugins', $active_plugins_mock, 10, 3 );
 
-		delete_option( 'woopay_disabled_invalid_extensions' );
+		delete_option( WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME );
 
-		$this->scheduler->disable_woopay_if_incompatible_extension_active();
+		$this->scheduler->update_incompatible_extensions_list_and_maybe_show_warning();
 
-		$this->assertTrue( get_option( 'woopay_disabled_invalid_extensions', null ) );
+		$this->assertTrue( get_option( WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME, null ) );
 	}
 
+	/**
+	 * Checks if the warning will not show up when and no incompatible extension are active.
+	 */
 	public function test_disable_woopay_when_no_incompatible_extension_active() {
 
 		$incompatible_extensions = [
@@ -67,38 +67,133 @@ class WooPay_Scheduler_Test extends WP_UnitTestCase {
 			'test-extension-2',
 		];
 
-		$this->mock_api( $incompatible_extensions );
+		$this->mock_api_response( $incompatible_extensions );
 
-		$pre_http_request = function () {
+		$active_plugins_mock = function () {
 			return [ 'test-extension/test-extension-3.php' ];
 		};
 
-		update_option( 'woopay_disabled_invalid_extensions', true );
+		update_option( WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME, true );
 
-		add_filter( 'pre_option_active_plugins', $pre_http_request, 10, 3 );
+		add_filter( 'pre_option_active_plugins', $active_plugins_mock, 10, 3 );
 
-		$this->scheduler->disable_woopay_if_incompatible_extension_active();
+		$this->scheduler->update_incompatible_extensions_list_and_maybe_show_warning();
 
-		$this->assertNull( get_option( 'woopay_disabled_invalid_extensions', null ) );
+		$this->assertNull( get_option( WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME, null ) );
 	}
 
-	private function mock_api( $incompatible_extensions ) {
-		// Mocks the remote server response.
-		$pre_http_request = function ( $preempt, $parsed_args, $url ) use ( $incompatible_extensions ) {
-			return [ 'body' => wp_json_encode( [ 'incompatible_extensions' => $incompatible_extensions ] ) ];
+	/**
+	 * Checks if the warning will show up after activating an incompatible extension.
+	 */
+	public function test_show_warning_when_incompatible_extension_is_enabled() {
+		update_option( WooPay_Scheduler::INCOMPATIBLE_EXTENSIONS_LIST_OPTION_NAME, [ 'test-extension' ] );
+		delete_option( WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME );
+
+		$this->scheduler->show_warning_when_incompatible_extension_is_enabled( 'test-extension/test-extension.php' );
+
+		$this->assertTrue( get_option( WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME, null ) );
+	}
+
+	/**
+	 * Checks if the warning will not show up after activating a compatible extension.
+	 */
+	public function test_will_not_show_warning_when_compatible_extension_is_enabled() {
+		update_option( WooPay_Scheduler::INCOMPATIBLE_EXTENSIONS_LIST_OPTION_NAME, [ 'test-extension' ] );
+		delete_option( WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME );
+
+		$this->scheduler->show_warning_when_incompatible_extension_is_enabled( 'test-extension/test-extension-2.php' );
+
+		$this->assertNull( get_option( WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME, null ) );
+	}
+
+	/**
+	 * Checks if the warning will not show up after deactivating the last incompatible extension.
+	 */
+	public function test_will_stop_showing_warning_when_incompatible_extension_is_removed() {
+		update_option( WooPay_Scheduler::INCOMPATIBLE_EXTENSIONS_LIST_OPTION_NAME, [ 'test-extension' ] );
+
+		$active_plugins_mock = function () {
+			return [
+				'test-extension/test-extension-3.php',
+				'test-extension/test-extension.php',
+			];
 		};
+		add_filter( 'pre_option_active_plugins', $active_plugins_mock, 10, 3 );
 
-		add_filter( 'pre_http_request', $pre_http_request, 10, 3 );
+		update_option( WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME, true );
 
-		// Mocks the jetpack token.
-		$jetpack_token = function ( $value, $name ) {
-			if ( 'blog_token' === $name ) {
-				return 'moked.token';
-			}
+		$this->scheduler->hide_warning_when_incompatible_extension_is_disabled( 'test-extension/test-extension.php' );
 
-			return $value;
+		$this->assertNull( get_option( WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME, null ) );
+	}
+
+	/**
+	 * Checks if the warning will still show up after deactivating only one incompatible extension.
+	 */
+	public function test_will_keep_showing_warning_when_only_one_incompatible_extension_is_removed() {
+		update_option(
+			WooPay_Scheduler::INCOMPATIBLE_EXTENSIONS_LIST_OPTION_NAME,
+			[
+				'test-extension',
+				'test-extension-3',
+			]
+		);
+
+		$active_plugins_mock = function () {
+			return [
+				'test-extension/test-extension-3.php',
+				'test-extension/test-extension.php',
+			];
 		};
+		add_filter( 'pre_option_active_plugins', $active_plugins_mock, 10, 3 );
 
-		add_filter( 'jetpack_options', $jetpack_token, 10, 2 );
+		update_option( WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME, true );
+
+		$this->scheduler->hide_warning_when_incompatible_extension_is_disabled( 'test-extension/test-extension.php' );
+
+		$this->assertTrue( get_option( WooPay_Scheduler::INVALID_EXTENSIONS_FOUND_OPTION_NAME, null ) );
+	}
+
+	/**
+	 * Will check if the incompatible extension is found.
+	 */
+	public function test_contains_invalid_extension() {
+		$active_plugins_mock = [
+			'test-extension/test-extension-3.php',
+			'test-extension/test-extension.php',
+		];
+
+		$incompatible_extensions = [
+			'test-extension-3',
+			'test-extension-2',
+		];
+
+		$found = $this->scheduler->contains_incompatible_extension( $active_plugins_mock, $incompatible_extensions );
+
+		$this->assertTrue( $found );
+	}
+
+	/**
+	 * Will check if no incompatible extension is found.
+	 */
+	public function test_does_not_contains_invalid_extension() {
+		$active_plugins_mock = [
+			'test-extension/test-extension-3.php',
+			'test-extension/test-extension.php',
+		];
+
+		$incompatible_extensions = [ 'test-extension-2' ];
+
+		$found = $this->scheduler->contains_incompatible_extension( $active_plugins_mock, $incompatible_extensions );
+		$this->assertFalse( $found );
+	}
+
+	/**
+	 * Mocks the return of WC_Payments_API_Client::get_woopay_incompatible_extensions.
+	 *
+	 * @param array $incompatible_extensions
+	 */
+	private function mock_api_response( $incompatible_extensions ) {
+		$this->mock_api->method( 'get_woopay_incompatible_extensions' )->willReturn( [ 'incompatible_extensions' => $incompatible_extensions ] );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a check for invalid extensions when extensions are activated or deactivated instead of waiting for the daily cron to run.

#### Testing instructions
- Checkout payments server to the latest version
- Change [this line](https://github.com/Automattic/woocommerce-payments-server/pull/3522/files#diff-5bb125880899ef7de4311905c5552402c73c1d7640a6c6e9d8bca2447ec86c0fR57) to look like this:
`'incompatible_extensions' => ['test-extension', 'test-extension-2'],` 
- On your merchant site
- Execute the `validate_incompatible_extensions` cron
- Install and activate this extension
[test-extension.zip](https://github.com/Automattic/woocommerce-payments/files/11791369/test-extension.zip)
- Go to /wp-admin > Payments > Scroll to Express checkout
- Make sure there is a warning about incompatible extensions showing up
- Disable the extension and make sure the warning is gone
- Re-enable the extension and make sure the warning is back
- Install and activate this extension
[test-extension.zip](https://github.com/Automattic/woocommerce-payments/files/11791379/test-extension.zip)
- Disable one of the installed extensions
- Make sure the warning still shows up
- Disable the other extension 
- Make sure the warning is now gone



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
