### PR TITLE
Wrap logos to not overlap the container

### DIFF
--- a/changelog/fix-6590-wrap-logos-on-confirmation-screen
+++ b/changelog/fix-6590-wrap-logos-on-confirmation-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+

--- a/changelog/fix-6590-wrap-logos-on-confirmation-screen
+++ b/changelog/fix-6590-wrap-logos-on-confirmation-screen
@@ -1,4 +1,5 @@
 Significance: patch
 Type: fix
 
+Wrap list of payment method logos on next line
 

--- a/client/additional-methods-setup/upe-preview-methods-selector/setup-complete-task.scss
+++ b/client/additional-methods-setup/upe-preview-methods-selector/setup-complete-task.scss
@@ -10,6 +10,7 @@
 	&__enabled-methods-list {
 		display: flex;
 		align-items: center;
+		flex-wrap: wrap;
 
 		> *:not( :last-child ) {
 			margin-right: $grid-unit-10;


### PR DESCRIPTION
Fixes #6590 

#### Changes proposed in this Pull Request

Add CSS wrapping for logos on the payment method confirmation screen so they wouldn't overlap the container if all PMs are selected. 

With the addition of Affirm & Affterpay the number of possible PMs have reached the critical limit where we need this wrap to force them to be displayed in second line.

**Before**
<img width="730" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/24650518/d34f8516-5e5d-4f7b-b3a2-162ed3539c05">


**After** 
<img width="711" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/24650518/bc8d5448-b343-4ec8-9da9-0078a1c98d8d">


#### Testing instructions

- Go to Payments -> settings and disable "Payment Methods"
- Re-enable them
- Select all possible payment methods and click "continue"
- Observe that logos are properly displayed 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
