### PR TITLE
Fix syntax for advanced filters in WC 7.8 and over

### DIFF
--- a/changelog/hotfix-6533-advanced-filters-error
+++ b/changelog/hotfix-6533-advanced-filters-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix syntax for advanced filters in WC 7.8 and over

--- a/client/deposits/filters/config.js
+++ b/client/deposits/filters/config.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __, _x } from '@wordpress/i18n';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -64,10 +65,20 @@ export const filters = [
 	// Declare advanced filters here.
 ];
 
+// TODO: Remove this and all the checks once we drop support of WooCommerce 7.7 and below.
+const wooCommerceVersionString = getSetting( 'wcVersion' );
+const wooCommerceVersion = parseFloat( wooCommerceVersionString ); // This will parse 7.7.1 to 7.7, but it's fine for this purpose
+
 /*eslint-disable max-len*/
 export const advancedFilters = {
 	/** translators: A sentence describing filters for deposits. See screen shot for context: https://d.pr/i/NcGpwL */
-	title: __( 'Deposits match {{select /}} filters', 'woocommerce-payments' ),
+	title:
+		7.8 < wooCommerceVersion
+			? __( 'Deposits match <select /> filters', 'woocommerce-payments' )
+			: __(
+					'Deposits match {{select /}} filters',
+					'woocommerce-payments'
+			  ),
 	filters: {
 		date: {
 			labels: {
@@ -81,10 +92,16 @@ export const advancedFilters = {
 					'woocommerce-payments'
 				),
 				/* translators: A sentence describing a deposit date filter. See screen shot for context: https://d.pr/i/NcGpwL */
-				title: __(
-					'{{title}}Date{{/title}} {{rule /}} {{filter /}}',
-					'woocommerce-payments'
-				),
+				title:
+					7.8 < wooCommerceVersion
+						? __(
+								'<title>Date</title> <rule /> <filter />',
+								'woocommerce-payments'
+						  )
+						: __(
+								'{{title}}Date{{/title}} {{rule /}} {{filter /}}',
+								'woocommerce-payments'
+						  ),
 				filter: __( 'Select a deposit date', 'woocommerce-payments' ),
 			},
 			rules: [
@@ -117,10 +134,16 @@ export const advancedFilters = {
 					'woocommerce-payments'
 				),
 				/* translators: A sentence describing a deposit status filter. See screen shot for context: https://d.pr/i/NcGpwL */
-				title: __(
-					'{{title}}Status{{/title}} {{rule /}} {{filter /}}',
-					'woocommerce-payments'
-				),
+				title:
+					7.8 < wooCommerceVersion
+						? __(
+								'<title>Status</title> <rule /> <filter />',
+								'woocommerce-payments'
+						  )
+						: __(
+								'{{title}}Status{{/title}} {{rule /}} {{filter /}}',
+								'woocommerce-payments'
+						  ),
 				filter: __( 'Select a deposit status', 'woocommerce-payments' ),
 			},
 			rules: [

--- a/client/deposits/filters/test/index.js
+++ b/client/deposits/filters/test/index.js
@@ -181,6 +181,12 @@ describe( 'Deposits filters', () => {
 		} );
 	} );
 
+	// TODO: this is a bit of a hack as we're mocking an old version of WC, we should relook at this.
+	jest.mock( '@woocommerce/settings', () => ( {
+		...jest.requireActual( '@woocommerce/settings' ),
+		getSetting: jest.fn( ( key ) => ( 'wcVersion' === key ? 7.7 : '' ) ),
+	} ) );
+
 	function addAdvancedFilter( filter ) {
 		user.click( screen.getByRole( 'button', { name: /Add a Filter/i } ) );
 		user.click( screen.getByRole( 'button', { name: filter } ) );

--- a/client/disputes/filters/config.ts
+++ b/client/disputes/filters/config.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __, _x } from '@wordpress/i18n';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -91,10 +92,20 @@ export const filters: [ DisputesFilterType, DisputesFilterType ] = [
 	},
 ];
 
+// TODO: Remove this and all the checks once we drop support of WooCommerce 7.7 and below.
+const wooCommerceVersionString = getSetting( 'wcVersion' );
+const wooCommerceVersion = parseFloat( wooCommerceVersionString ); // This will parse 7.7.1 to 7.7, but it's fine for this purpose
+
 /*eslint-disable max-len*/
 export const advancedFilters = {
 	/** translators: A sentence describing filters for Disputes. */
-	title: __( 'Disputes match {{select /}} filters', 'woocommerce-payments' ),
+	title:
+		wooCommerceVersion > 7.8
+			? __( 'Disputes match <select /> filters', 'woocommerce-payments' )
+			: __(
+					'Disputes match {{select /}} filters',
+					'woocommerce-payments'
+			  ),
 	filters: {
 		date: {
 			labels: {
@@ -108,10 +119,16 @@ export const advancedFilters = {
 					'woocommerce-payments'
 				),
 				/* translators: A sentence describing a Dispute date filter. */
-				title: __(
-					'{{title}}Date{{/title}} {{rule /}} {{filter /}}',
-					'woocommerce-payments'
-				),
+				title:
+					wooCommerceVersion > 7.8
+						? __(
+								'<title>Date</title> <rule /> <filter />',
+								'woocommerce-payments'
+						  )
+						: __(
+								'{{title}}Date{{/title}} {{rule /}} {{filter /}}',
+								'woocommerce-payments'
+						  ),
 				filter: __( 'Select a dispute date', 'woocommerce-payments' ),
 			},
 			rules: [
@@ -144,10 +161,16 @@ export const advancedFilters = {
 					'woocommerce-payments'
 				),
 				/* translators: A sentence describing a Dispute status filter. */
-				title: __(
-					'{{title}}Status{{/title}} {{rule /}} {{filter /}}',
-					'woocommerce-payments'
-				),
+				title:
+					wooCommerceVersion > 7.8
+						? __(
+								'<title>Status</title> <rule /> <filter />',
+								'woocommerce-payments'
+						  )
+						: __(
+								'{{title}}Status{{/title}} {{rule /}} {{filter /}}',
+								'woocommerce-payments'
+						  ),
 				filter: __( 'Select a dispute status', 'woocommerce-payments' ),
 			},
 			rules: [

--- a/client/disputes/filters/test/index.tsx
+++ b/client/disputes/filters/test/index.tsx
@@ -14,6 +14,12 @@ import { getQuery, updateQueryString } from '@woocommerce/navigation';
 import { DisputesFilters } from '../';
 import { formatCurrencyName } from '../../../utils/currency';
 
+// TODO: this is a bit of a hack as we're mocking an old version of WC, we should relook at this.
+jest.mock( '@woocommerce/settings', () => ( {
+	...jest.requireActual( '@woocommerce/settings' ),
+	getSetting: jest.fn( ( key ) => ( key === 'wcVersion' ? 7.7 : '' ) ),
+} ) );
+
 function addAdvancedFilter( filter: string ) {
 	user.click( screen.getByRole( 'button', { name: /Add a Filter/i } ) );
 	user.click( screen.getByRole( 'button', { name: filter } ) );

--- a/client/documents/filters/config.ts
+++ b/client/documents/filters/config.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __, _x } from '@wordpress/i18n';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -49,10 +50,20 @@ export const filters: [ DocumentsFilterType ] = [
 	},
 ];
 
+// TODO: Remove this and all the checks once we drop support of WooCommerce 7.7 and below.
+const wooCommerceVersionString = getSetting( 'wcVersion' );
+const wooCommerceVersion = parseFloat( wooCommerceVersionString ); // This will parse 7.7.1 to 7.7, but it's fine for this purpose
+
 /*eslint-disable max-len*/
 export const advancedFilters = {
 	/** translators: A sentence describing filters for Documents. */
-	title: __( 'Documents match {{select /}} filters', 'woocommerce-payments' ),
+	title:
+		wooCommerceVersion > 7.8
+			? __( 'Documents match <select /> filters', 'woocommerce-payments' )
+			: __(
+					'Documents match {{select /}} filters',
+					'woocommerce-payments'
+			  ),
 	filters: {
 		date: {
 			labels: {
@@ -66,10 +77,16 @@ export const advancedFilters = {
 					'woocommerce-payments'
 				),
 				/* translators: A sentence describing a Document date filter. */
-				title: __(
-					'{{title}}Date{{/title}} {{rule /}} {{filter /}}',
-					'woocommerce-payments'
-				),
+				title:
+					wooCommerceVersion > 7.8
+						? __(
+								'<title>Date</title> <rule /> <filter />',
+								'woocommerce-payments'
+						  )
+						: __(
+								'{{title}}Date{{/title}} {{rule /}} {{filter /}}',
+								'woocommerce-payments'
+						  ),
 				filter: __( 'Select a document date', 'woocommerce-payments' ),
 			},
 			rules: [
@@ -102,10 +119,16 @@ export const advancedFilters = {
 					'woocommerce-payments'
 				),
 				/* translators: A sentence describing a Document type filter. */
-				title: __(
-					'{{title}}Type{{/title}} {{rule /}} {{filter /}}',
-					'woocommerce-payments'
-				),
+				title:
+					wooCommerceVersion > 7.8
+						? __(
+								'<title>Type</title> <rule /> <filter />',
+								'woocommerce-payments'
+						  )
+						: __(
+								'{{title}}Type{{/title}} {{rule /}} {{filter /}}',
+								'woocommerce-payments'
+						  ),
 				filter: __( 'Select a document type', 'woocommerce-payments' ),
 			},
 			rules: [

--- a/client/documents/filters/test/index.tsx
+++ b/client/documents/filters/test/index.tsx
@@ -13,6 +13,12 @@ import { getQuery, updateQueryString } from '@woocommerce/navigation';
  */
 import { DocumentsFilters } from '../';
 
+// TODO: this is a bit of a hack as we're mocking an old version of WC, we should relook at this.
+jest.mock( '@woocommerce/settings', () => ( {
+	...jest.requireActual( '@woocommerce/settings' ),
+	getSetting: jest.fn( ( key ) => ( key === 'wcVersion' ? 7.7 : '' ) ),
+} ) );
+
 function addAdvancedFilter( filter: string ) {
 	user.click( screen.getByRole( 'button', { name: /Add a Filter/i } ) );
 	user.click( screen.getByRole( 'button', { name: filter } ) );

--- a/client/external-declarations.d.ts
+++ b/client/external-declarations.d.ts
@@ -21,3 +21,7 @@ declare module 'dompurify' {
 	): string;
 	/* eslint-enable @typescript-eslint/naming-convention */
 }
+
+declare module '@woocommerce/settings' {
+	const getSetting: ( key: string ) => string;
+}

--- a/client/transactions/declarations.d.ts
+++ b/client/transactions/declarations.d.ts
@@ -168,3 +168,7 @@ declare module '@woocommerce/csv-export' {
 		params: Record< string, any >
 	) => string;
 }
+
+declare module '@woocommerce/settings' {
+	const getSetting: ( key: string ) => string;
+}

--- a/client/transactions/declarations.d.ts
+++ b/client/transactions/declarations.d.ts
@@ -168,7 +168,3 @@ declare module '@woocommerce/csv-export' {
 		params: Record< string, any >
 	) => string;
 }
-
-declare module '@woocommerce/settings' {
-	const getSetting: ( key: string ) => string;
-}

--- a/client/transactions/filters/config.ts
+++ b/client/transactions/filters/config.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -125,12 +126,22 @@ export const getFilters = (
 export const getAdvancedFilters = (
 	customerCurrencyOptions?: TransactionsFilterEntryType[]
 ): any => {
+	// TODO: Remove this and all the checks once we drop support of WooCommerce 7.7 and below.
+	const wooCommerceVersionString = getSetting( 'wcVersion' );
+	const wooCommerceVersion = parseFloat( wooCommerceVersionString ); // This will parse 7.7.1 to 7.7, but it's fine for this purpose
+
 	return {
 		/** translators: A sentence describing filters for Transactions. */
-		title: __(
-			'Transactions match {{select /}} filters',
-			'woocommerce-payments'
-		),
+		title:
+			wooCommerceVersion < 7.8
+				? __(
+						'Transactions match {{select /}} filters',
+						'woocommerce-payments'
+				  )
+				: __(
+						'Transactions match <select /> filters',
+						'woocommerce-payments'
+				  ),
 		filters: {
 			date: {
 				labels: {
@@ -144,10 +155,16 @@ export const getAdvancedFilters = (
 						'woocommerce-payments'
 					),
 					/* translators: A sentence describing a Transaction date filter. */
-					title: __(
-						'{{title}}Date{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-payments'
-					),
+					title:
+						wooCommerceVersion < 7.8
+							? __(
+									'{{title}}Date{{/title}} {{rule /}} {{filter /}}',
+									'woocommerce-payments'
+							  )
+							: __(
+									'<title>Date</title> <rule /> <filter />',
+									'woocommerce-payments'
+							  ),
 					filter: __(
 						'Select a transaction date',
 						'woocommerce-payments'
@@ -183,10 +200,16 @@ export const getAdvancedFilters = (
 						'woocommerce-payments'
 					),
 					/* translators: A sentence describing a Transaction customer currency filter. */
-					title: __(
-						'{{title}}Customer currency{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-payments'
-					),
+					title:
+						wooCommerceVersion < 7.8
+							? __(
+									'{{title}}Customer currency{{/title}} {{rule /}} {{filter /}}',
+									'woocommerce-payments'
+							  )
+							: __(
+									'<title>Customer currency</title> <rule /> <filter />',
+									'woocommerce-payments'
+							  ),
 					filter: __(
 						'Select a customer currency',
 						'woocommerce-payments'
@@ -229,10 +252,16 @@ export const getAdvancedFilters = (
 						'woocommerce-payments'
 					),
 					/* translators: A sentence describing a Transaction type filter. */
-					title: __(
-						'{{title}}Type{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-payments'
-					),
+					title:
+						wooCommerceVersion < 7.8
+							? __(
+									'{{title}}Type{{/title}} {{rule /}} {{filter /}}',
+									'woocommerce-payments'
+							  )
+							: __(
+									'<title>Type</title> <rule /> <filter />',
+									'woocommerce-payments'
+							  ),
 					filter: __(
 						'Select a transaction type',
 						'woocommerce-payments'
@@ -269,10 +298,16 @@ export const getAdvancedFilters = (
 					remove: __( 'Remove loan filter', 'woocommerce-payments' ),
 					rule: __( 'Select a loan', 'woocommerce-payments' ),
 					/* translators: A sentence describing a Loan ID filter. */
-					title: __(
-						'{{title}}Loan{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-payments'
-					),
+					title:
+						wooCommerceVersion < 7.8
+							? __(
+									'{{title}}Loan{{/title}} {{rule /}} {{filter /}}',
+									'woocommerce-payments'
+							  )
+							: __(
+									'<title>Loan</title> <rule /> <filter />',
+									'woocommerce-payments'
+							  ),
 					filter: __( 'Select a loan', 'woocommerce-payments' ),
 				},
 				input: {
@@ -293,10 +328,16 @@ export const getAdvancedFilters = (
 						'woocommerce-payments'
 					),
 					/* translators: A sentence describing a Transaction Device Type filter. */
-					title: __(
-						'{{title}}Device type{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-payments'
-					),
+					title:
+						wooCommerceVersion < 7.8
+							? __(
+									'{{title}}Device type{{/title}} {{rule /}} {{filter /}}',
+									'woocommerce-payments'
+							  )
+							: __(
+									'<title>Device type</title> <rule /> <filter />',
+									'woocommerce-payments'
+							  ),
 					filter: __(
 						'Select a transaction device type',
 						'woocommerce-payments'

--- a/client/transactions/filters/test/index.tsx
+++ b/client/transactions/filters/test/index.tsx
@@ -13,6 +13,11 @@ import { getQuery, updateQueryString } from '@woocommerce/navigation';
  */
 import { TransactionsFilters } from '../';
 
+jest.mock( '@woocommerce/settings', () => ( {
+	...jest.requireActual( '@woocommerce/settings' ),
+	getSetting: jest.fn( ( key ) => ( key === 'wcVersion' ? 7.7 : '' ) ),
+} ) );
+
 function addAdvancedFilter( filter: string ) {
 	user.click( screen.getByRole( 'button', { name: /Add a Filter/i } ) );
 	user.click( screen.getByRole( 'button', { name: filter } ) );

--- a/client/transactions/filters/test/index.tsx
+++ b/client/transactions/filters/test/index.tsx
@@ -13,6 +13,7 @@ import { getQuery, updateQueryString } from '@woocommerce/navigation';
  */
 import { TransactionsFilters } from '../';
 
+// TODO: this is a bit of a hack as we're mocking an old version of WC, we should relook at this.
 jest.mock( '@woocommerce/settings', () => ( {
 	...jest.requireActual( '@woocommerce/settings' ),
 	getSetting: jest.fn( ( key ) => ( key === 'wcVersion' ? 7.7 : '' ) ),


### PR DESCRIPTION
Fixes #6533 

#### Changes proposed in this Pull Request
This change allows Advanced Filters to be compatible with the newly introduced syntax in WC 7.8 https://github.com/woocommerce/woocommerce/pull/37967

It introduces a check for the WC version and picks the right format depending if WC is less than 7.8 or not, in order to make it backward compatible.

Because the string is part of the translation function, it needs to be literal, so more elegant approaches with string concatenation were not available for this.

**### Testing instructions**
- Install WooCommerce 7.8 or bigger
- Go to Transactions
- All the advanced filters should be functional and displayed without any error
- Go to Deposits
- All the advanced filters should be functional and displayed without any error
- Go to Disputes
- All the advanced filters should be functional and displayed without any error
- Go to Documents (enable it in Dev tools if not appearing)
- All the advanced filters should be functional and displayed without any error

- Install [WP Rollback](https://wordpress.org/plugins/wp-rollback/)
- Rollback WooCommerce to any version under 7.8 (7.7, for example)
- Go to Transactions
- All the advanced filters should be functional and displayed without any error
- Go to Deposits
- All the advanced filters should be functional and displayed without any error
- Go to Disputes
- All the advanced filters should be functional and displayed without any error
- Go to Documents (enable it in Dev tools if not appearing)
- All the advanced filters should be functional and displayed without any error


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
