### PR TITLE
Allow skipping the build zip job when running the "Release - Create a PR" workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -35,6 +35,11 @@ on:
         required: false
         default: "next wednesday"
         type: string
+      skip-build-zip:
+        type: boolean
+        required: false
+        default: true
+        description: "Skip building the zip file"
       skip-smoke-tests:
         type: boolean
         required: false
@@ -136,6 +141,7 @@ jobs:
   build-zip-and-run-smoke-tests:
     name: "Build zip & Run smoke tests"
     needs: prepare-release
+    if: ${{ ! inputs.skip-build-zip }}
     uses: ./.github/workflows/build-zip-and-run-smoke-tests.yml
     with:
       skip-smoke-tests: ${{ inputs.skip-smoke-tests }}

--- a/changelog/update-release-pr-workflow
+++ b/changelog/update-release-pr-workflow
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Minor update to the release-pr workflow
+
+


### PR DESCRIPTION
Fixes #6618 

#### Changes proposed in this Pull Request

- Introduce a new boolean "Skip building the zip file" for the "Release - Create a PR" workflow

The DRI can now skip that part for patch releases as it is useless in this context. Instead of doing it automatically, the choice is left to the user because sometimes this workflow is also used during scheduled releases when the Code Freeze workflow fails unexpectedly.

#### Testing instructions

* Running the workflow manually skips the "build zip file" part if the checkbox "Skip building the zip file" is ticked
  * See run: https://github.com/Automattic/woocommerce-payments/actions/runs/5410439598
* Running the workflow manually does NOT skip the "build zip file" part if the checkbox "Skip building the zip file" is NOT ticked
  * See run: https://github.com/Automattic/woocommerce-payments/actions/runs/5410893249
* The code freeze workflow does NOT skip the "build zip file" part
  * See run: https://github.com/Automattic/woocommerce-payments/actions/runs/5410812570  I cancelled it manually when I confirmed it started to run)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
