### PR TITLE
Fix process changelog composite action

### DIFF
--- a/.github/actions/process-changelog/action.yml
+++ b/.github/actions/process-changelog/action.yml
@@ -39,15 +39,13 @@ runs:
         if [ "$(ls -A changelog | wc -l)" -eq 1 ] && [[ "$FINAL_RELEASE_VERSION" == "$CURRENT_RELEASE_VERSION" ]]; then
           echo "ACTION_TYPE=amend-version" >> $GITHUB_OUTPUT
           echo "CURRENT_VERSION=$CURRENT_RELEASE_VERSION" >> $GITHUB_OUTPUT
-        else
-          echo "ACTION_TYPE=$ACTION_TYPE" >> $GITHUB_OUTPUT
         fi
 
     - name: "Process changelog for changelog.txt"
       id: process_changelog
       shell: bash
       env:
-        ACTION_TYPE: ${{ steps.verify_action_type.outputs.ACTION_TYPE }}
+        ACTION_TYPE: ${{ steps.verify_action_type.outputs.ACTION_TYPE || inputs.action-type }}
         CURRENT_VERSION: ${{ steps.verify_action_type.outputs.CURRENT_VERSION }}
         RELEASE_VERSION: ${{ inputs.release-version }}
         RELEASE_DATE: ${{ inputs.release-date }}
@@ -81,7 +79,7 @@ runs:
     - name: "Process changelog for readme.txt"
       shell: bash
       env:
-        ACTION_TYPE: ${{ steps.verify_action_type.outputs.ACTION_TYPE }}
+        ACTION_TYPE: ${{ steps.verify_action_type.outputs.ACTION_TYPE || inputs.action-type }}
         CURRENT_VERSION: ${{ steps.verify_action_type.outputs.CURRENT_VERSION }}
         RELEASE_VERSION: ${{ inputs.release-version }}
         RELEASE_DATE: ${{ inputs.release-date }}

--- a/changelog/fix-process-changelog-composite-action
+++ b/changelog/fix-process-changelog-composite-action
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix to process-changelog action
+
+


### PR DESCRIPTION
Fixes #6627 

#### Changes proposed in this Pull Request

- Fallback to the initial `action-type` input value in case the first step is skipped (i.e. when the action type is initially `generate`)

This fixes the `amend` workflow

#### Testing instructions

- Create a branch based on that one so we can test the workflow safely without polluting this PR
- On that new test branch, run the Release - Changelog workflow with "amend" action type and "6.1.1" release version (i.e. the last version that appears in the changelog)
- Confirm it adds the changelog entries into the existing changelog block `6.1.1`

Test branch: [test-release-changelog-workflow-amend](https://github.com/Automattic/woocommerce-payments/tree/test-release-changelog-workflow-amend) 
Example run: https://github.com/Automattic/woocommerce-payments/actions/runs/5442822498
Result: https://github.com/Automattic/woocommerce-payments/commit/09eb1dceb800d57bafc5f4aeb458e8b5714be3d4

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
