### PR TITLE
Hotfix: additional filters on deposits

### DIFF
--- a/changelog/hotfix-fix-deposits-adv-filters
+++ b/changelog/hotfix-fix-deposits-adv-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix for syntax error on the advanced filters logic (deposits).

--- a/client/deposits/filters/config.js
+++ b/client/deposits/filters/config.js
@@ -135,7 +135,7 @@ export const advancedFilters = {
 				),
 				/* translators: A sentence describing a deposit status filter. See screen shot for context: https://d.pr/i/NcGpwL */
 				title:
-					7.8 >= wooCommerceVersion
+					7.8 > wooCommerceVersion
 						? __(
 								'{{title}}Status{{/title}} {{rule /}} {{filter /}}',
 								'woocommerce-payments'

--- a/client/deposits/filters/config.js
+++ b/client/deposits/filters/config.js
@@ -93,13 +93,13 @@ export const advancedFilters = {
 				),
 				/* translators: A sentence describing a deposit date filter. See screen shot for context: https://d.pr/i/NcGpwL */
 				title:
-					7.8 >= wooCommerceVersion
+					7.8 > wooCommerceVersion
 						? __(
-								'<title>Date</title> <rule /> <filter />',
+								'{{title}}Date{{/title}} {{rule /}} {{filter /}}',
 								'woocommerce-payments'
 						  )
 						: __(
-								'{{title}}Date{{/title}} {{rule /}} {{filter /}}',
+								'<title>Date</title> <rule /> <filter />',
 								'woocommerce-payments'
 						  ),
 				filter: __( 'Select a deposit date', 'woocommerce-payments' ),
@@ -137,11 +137,11 @@ export const advancedFilters = {
 				title:
 					7.8 >= wooCommerceVersion
 						? __(
-								'<title>Status</title> <rule /> <filter />',
+								'{{title}}Status{{/title}} {{rule /}} {{filter /}}',
 								'woocommerce-payments'
 						  )
 						: __(
-								'{{title}}Status{{/title}} {{rule /}} {{filter /}}',
+								'<title>Status</title> <rule /> <filter />',
 								'woocommerce-payments'
 						  ),
 				filter: __( 'Select a deposit status', 'woocommerce-payments' ),

--- a/client/deposits/filters/config.js
+++ b/client/deposits/filters/config.js
@@ -73,12 +73,12 @@ const wooCommerceVersion = parseFloat( wooCommerceVersionString ); // This will 
 export const advancedFilters = {
 	/** translators: A sentence describing filters for deposits. See screen shot for context: https://d.pr/i/NcGpwL */
 	title:
-		7.8 >= wooCommerceVersion
-			? __( 'Deposits match <select /> filters', 'woocommerce-payments' )
-			: __(
+		7.8 > wooCommerceVersion
+			? __(
 					'Deposits match {{select /}} filters',
 					'woocommerce-payments'
-			  ),
+			  )
+			: __( 'Deposits match <select /> filters', 'woocommerce-payments' ),
 	filters: {
 		date: {
 			labels: {

--- a/client/deposits/filters/test/index.js
+++ b/client/deposits/filters/test/index.js
@@ -12,6 +12,12 @@ import { getQuery, updateQueryString } from '@woocommerce/navigation';
  */
 import { DepositsFilters } from '../';
 
+// TODO: this is a bit of a hack as we're mocking an old version of WC, we should relook at this.
+jest.mock( '@woocommerce/settings', () => ( {
+	...jest.requireActual( '@woocommerce/settings' ),
+	getSetting: jest.fn( ( key ) => ( 'wcVersion' === key ? 7.7 : '' ) ),
+} ) );
+
 describe( 'Deposits filters', () => {
 	beforeEach( () => {
 		// the query string is preserved across tests, so we need to reset it
@@ -180,12 +186,6 @@ describe( 'Deposits filters', () => {
 			expect( getQuery().status_is ).toEqual( 'estimated' );
 		} );
 	} );
-
-	// TODO: this is a bit of a hack as we're mocking an old version of WC, we should relook at this.
-	jest.mock( '@woocommerce/settings', () => ( {
-		...jest.requireActual( '@woocommerce/settings' ),
-		getSetting: jest.fn( ( key ) => ( 'wcVersion' === key ? 7.7 : '' ) ),
-	} ) );
 
 	function addAdvancedFilter( filter ) {
 		user.click( screen.getByRole( 'button', { name: /Add a Filter/i } ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes an error affecting the ordering of the conditional statement implemented in #6617. Follows up #6625.

#### Testing instructions

* Follow the testing instructions in #6617, checking the Transactions, Disputes, Documents and Deposits pages.
* All should look correct in both WooCommerce 7.8 and an earlier version of WooCommerce.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
