### PR TITLE
[BNPL site messaging] Fix Country informed as empty for logged-out user

### DIFF
--- a/changelog/fix-6630-bnpl-site-messaging-country-informed-as-empty-for-logged-out-user
+++ b/changelog/fix-6630-bnpl-site-messaging-country-informed-as-empty-for-logged-out-user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Country informed as empty for logged-out user in the BNPL site messaging configuration.

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -50,11 +50,8 @@ class WC_Payments_Payment_Method_Messaging_Element {
 		global $product;
 		$price           = $product->get_price();
 		$currency_code   = get_woocommerce_currency();
-		$billing_country = WC()->countries->get_base_country();
-
-		if ( WC()->customer ) {
-			$billing_country = WC()->customer->get_billing_country(); // Use the customer's billing country if available.
-		}
+		$base_country    = WC()->countries->get_base_country();
+		$billing_country = WC()->customer->get_billing_country();
 
 		$enabled_upe_payment_methods = $this->gateway->get_payment_method_ids_enabled_at_checkout();
 		// Filter non BNPL out of the list of payment methods.
@@ -70,7 +67,7 @@ class WC_Payments_Payment_Method_Messaging_Element {
 			[
 				'price'          => WC_Payments_Utils::prepare_amount( $price, $currency_code ),
 				'currency'       => $currency_code,
-				'country'        => $billing_country,
+				'country'        => empty( $billing_country ) ? $base_country : $billing_country,
 				'publishableKey' => $this->account->get_publishable_key( WC_Payments::mode()->is_test() ),
 				'paymentMethods' => array_values( $bnpl_payment_methods ),
 			]

--- a/includes/class-wc-payments-payment-method-messaging-element.php
+++ b/includes/class-wc-payments-payment-method-messaging-element.php
@@ -50,7 +50,7 @@ class WC_Payments_Payment_Method_Messaging_Element {
 		global $product;
 		$price           = $product->get_price();
 		$currency_code   = get_woocommerce_currency();
-		$base_country    = WC()->countries->get_base_country();
+		$store_country   = WC()->countries->get_base_country();
 		$billing_country = WC()->customer->get_billing_country();
 
 		$enabled_upe_payment_methods = $this->gateway->get_payment_method_ids_enabled_at_checkout();
@@ -67,7 +67,7 @@ class WC_Payments_Payment_Method_Messaging_Element {
 			[
 				'price'          => WC_Payments_Utils::prepare_amount( $price, $currency_code ),
 				'currency'       => $currency_code,
-				'country'        => empty( $billing_country ) ? $base_country : $billing_country,
+				'country'        => empty( $billing_country ) ? $store_country : $billing_country,
 				'publishableKey' => $this->account->get_publishable_key( WC_Payments::mode()->is_test() ),
 				'paymentMethods' => array_values( $bnpl_payment_methods ),
 			]


### PR DESCRIPTION
Fixes #6630 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
Refactor the country fallback to avoid country set as empty when the customer billing address is not set.
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
1. Make sure that Affirm or Afterpay are available in your test site.
2. As a non-logged-in user, visit the product details page
3. Check that the BNPL site messaging block is displayed
4. Check that the country field in `wcpayStripeSiteMessaging` configuration object is set to the store's country.
5. This error is not shown in browser console
<img width="1692" alt="Screenshot 2023-06-29 at 17 29 47" src="https://github.com/Automattic/woocommerce-payments/assets/1553182/1ac532bf-f4d2-403e-be69-ad35683a42f9">

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
