### PR TITLE
Allow webhooks without livemode to be processed.

### DIFF
--- a/changelog/fix-3131-notification-webhooks-not-working
+++ b/changelog/fix-3131-notification-webhooks-not-working
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Allow webhoks without livemode to be received.
+Allow webhooks without livemode to be received.

--- a/changelog/fix-3131-notification-webhooks-not-working
+++ b/changelog/fix-3131-notification-webhooks-not-working
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow webhoks without livemode to be received.

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -213,6 +213,10 @@ class WC_Payments_Webhook_Processing_Service {
 	 * @throws Invalid_Webhook_Data_Exception Event mode does not match the gateway mode.
 	 */
 	private function is_webhook_mode_mismatch( array $event_body ): bool {
+		if ( ! $this->has_webhook_property( $event_body, 'livemode' ) ) {
+			return false;
+		}
+
 		$is_gateway_live_mode = WC_Payments::mode()->is_live();
 		$is_event_live_mode   = $this->read_webhook_property( $event_body, 'livemode' );
 
@@ -687,6 +691,18 @@ class WC_Payments_Webhook_Processing_Service {
 			);
 		}
 		return $array[ $key ];
+	}
+
+	/**
+	 * Safely check whether a webhook contains a property.
+	 *
+	 * @param array  $array Array to read from.
+	 * @param string $key   ID to fetch on.
+	 *
+	 * @return bool
+	 */
+	private function has_webhook_property( $array, $key ) {
+		return isset( $array[ $key ] );
 	}
 
 	/**

--- a/includes/core/server/request/class-paginated.php
+++ b/includes/core/server/request/class-paginated.php
@@ -95,7 +95,6 @@ abstract class Paginated extends Request {
 		$this->set_param( 'page', $page );
 	}
 
-
 	/**
 	 * Set page size.
 	 *


### PR DESCRIPTION
Fixes #3131 (server)

#### Changes proposed in this Pull Request

Allow webhooks without a `livemode` parameter to be processed.

As described in the issue, once we started verifying whether the `livemode` parameter is matched between the local settings and the webhook, we started ignoring all webhooks that do not have a `livemove` parameter. However, some webhooks are `livemode`-independent, and those should be processed as well.

This PR checks whether there is a `livemode` parameter at all, before rejecting a webhook.

#### Testing instructions

1. Figure out how to simulate a webhook without `livemode`. Suggestion below.
2. Without this PR, trigger the webhook, and check whether it's processed. Adding a debug point within the webhook processing service is helpful here. **The webhook will be rejected.**
3. Check out this PR, and try again. The webhook should be successfully processed.

Simulating a webhook:

1. On your local server, run `npm run cli` to enter the shell.
2. Change some account meta to trigger a webhook:

```sh
wp wcpay set_account_meta acct_XYZ --key=platform_checkout_eligible --value=0
```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)