### PR TITLE
Add `strlen` as a callback to metadata filter

### DIFF
--- a/changelog/fix-6598-qit-warning-in-class-buyer-fingerprinting-service
+++ b/changelog/fix-6598-qit-warning-in-class-buyer-fingerprinting-service
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add array_filter callback method

--- a/includes/fraud-prevention/class-buyer-fingerprinting-service.php
+++ b/includes/fraud-prevention/class-buyer-fingerprinting-service.php
@@ -77,13 +77,16 @@ class Buyer_Fingerprinting_Service {
 			}
 		}
 
+		// According to https://www.php.net/manual/en/function.array-filter.php#111091
+		// Applying "strlen" as the callback function will remove `false`, `null` and empty strings, but not "0" values.
 		return array_filter(
 			[
 				'fraud_prevention_data_shopper_ip_hash' => $this->hash_data_for_fraud_prevention( WC_Geolocation::get_ip_address() ),
 				'fraud_prevention_data_shopper_ua_hash' => $fingerprint,
 				'fraud_prevention_data_ip_country'      => WC_Geolocation::geolocate_ip( '', true )['country'],
 				'fraud_prevention_data_cart_contents'   => $order_items_count,
-			]
+			],
+			'strlen'
 		);
 	}
 }

--- a/tests/unit/fraud-prevention/test-class-buyer-fingerprinting-service.php
+++ b/tests/unit/fraud-prevention/test-class-buyer-fingerprinting-service.php
@@ -58,6 +58,7 @@ class Buyer_Fingerprinting_Service_Test extends WCPAY_UnitTestCase {
 			'fraud_prevention_data_shopper_ip_hash' => hash( 'sha512', '127.0.0.1', false ),
 			'fraud_prevention_data_shopper_ua_hash' => $fingerprint,
 			'fraud_prevention_data_ip_country'      => $ip_country,
+			'fraud_prevention_data_cart_contents'   => 0,
 		];
 
 		$this->assertSame( $order_hashes, $expected_hashed_array );


### PR DESCRIPTION
Fixes #6598

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

This adds a callback function for the `array_filter` method used in `includes/fraud-prevention/class-buyer-fingerprinting-service.php` file for filtering the metadata, changing the approach slightly to keep `0` values, which will hopefully also solve the `item_count` errors on the rule engine. 

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The automated tests should pass. There is no change in the approach of building the metadata array.
* cc @ricardo to run the QIT again on this branch to see if the warning disappears.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
