### PR TITLE
When dispute details page is rendered, add CSS class 'current' to the Payments > Disputes menu item

### DIFF
--- a/client/disputes/details/index.tsx
+++ b/client/disputes/details/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { Card, CardBody, CardFooter, CardHeader } from '@wordpress/components';
 
@@ -49,6 +49,18 @@ const DisputeDetails = ( {
 
 	const mapping = reasons[ disputeObject.reason ] || {};
 	const testModeNotice = <TestModeNotice topic={ topics.disputeDetails } />;
+
+	// Hack to make "Payments > Disputes" the active selected menu item.
+	useEffect( () => {
+		const disputesMenuItem = document.querySelector(
+			`#toplevel_page_wc-admin-path--payments-overview a[href^="admin.php?page=wc-admin&path=${ encodeURIComponent(
+				'/payments/disputes'
+			) }"]`
+		);
+		if ( disputesMenuItem ) {
+			disputesMenuItem.parentElement?.classList.add( 'current' );
+		}
+	}, [] );
 
 	if ( ! isLoading && ! disputeIsAvailable ) {
 		return (


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/6394.

#### Changes proposed in this Pull Request

Inspired by https://github.com/Automattic/woocommerce-payments/blob/317d8270a355f2db79d43a5ab5d10cecab698a3c/client/settings/fraud-protection/advanced-settings/index.tsx#L188-L198, I try to highlight Payments > Disputes menu item when dispute details page is rendered.

However, I found that [wpNavMenuClassChange() will remove `current` CSS class from all the menu items](https://github.com/woocommerce/woocommerce/blob/96c686c4d987469e95e3681c10109ffd1a322155/plugins/woocommerce-admin/client/layout/controller.js#L467-L471) when route changes.

I need to either add the `current` CSS class in later time or find a better solution.

#### Testing instructions

TBD.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
