### PR TITLE
Comment on the unused user exists controller

### DIFF
--- a/changelog/add-comment-on-unused-user-exists-file
+++ b/changelog/add-comment-on-unused-user-exists-file
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Adds a code comment on why we are keeping an unused file
+
+

--- a/includes/admin/class-wc-rest-user-exists-controller.php
+++ b/includes/admin/class-wc-rest-user-exists-controller.php
@@ -3,6 +3,13 @@
  * Class WC_REST_User_Exists_Controller
  *
  * @package WooCommerce\Payments\Admin
+ *
+ *
+ * NOTE: This API endpoint is never registered and not available for use.
+ * It is only available here as a temporary workaround for the issue described in
+ * https://github.com/Automattic/woocommerce-payments/issues/6304
+ *
+ * This file can be removed once the issue is resolved.
  */
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
`class-wc-rest-user-exists-controller.php` was re-introduced in https://github.com/Automattic/woocommerce-payments/pull/6303 although the API defined in the file is not registered. This PR adds a comment to clarify this.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

No tests needed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
