### PR TITLE
Add Android option in Device type advanced filter on Transactions page

### DIFF
--- a/changelog/add-6748-android-option-device-filters
+++ b/changelog/add-6748-android-option-device-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add Android option in Device type advanced filter

--- a/client/transactions/filters/test/__snapshots__/index.tsx.snap
+++ b/client/transactions/filters/test/__snapshots__/index.tsx.snap
@@ -23,6 +23,11 @@ HTMLOptionsCollection [
 exports[`Transactions filters when filtering by source device should render all types 1`] = `
 HTMLOptionsCollection [
   <option
+    value="android"
+  >
+    Android
+  </option>,
+  <option
     value="ios"
   >
     iPhone

--- a/client/transactions/filters/test/index.tsx
+++ b/client/transactions/filters/test/index.tsx
@@ -246,5 +246,20 @@ describe( 'Transactions filters', () => {
 
 			expect( getQuery().source_device_is ).toEqual( 'ios' );
 		} );
+
+		test( 'should filter by is_not', () => {
+			user.selectOptions( ruleSelector, 'is_not' );
+
+			// need to include $ in name, otherwise "Select a transaction type filter" is also matched.
+			user.selectOptions(
+				screen.getByRole( 'combobox', {
+					name: /transaction device type$/i,
+				} ),
+				'android'
+			);
+			user.click( screen.getByRole( 'link', { name: /Filter/ } ) );
+
+			expect( getQuery().source_device_is_not ).toEqual( 'android' );
+		} );
 	} );
 } );

--- a/client/transactions/strings.ts
+++ b/client/transactions/strings.ts
@@ -25,5 +25,6 @@ export const displayType = {
 
 // Mapping of transaction device type string.
 export const sourceDevice = {
+	android: __( 'Android', 'woocommerce-payments' ),
 	ios: __( 'iPhone', 'woocommerce-payments' ),
 };


### PR DESCRIPTION
Fixes #6748

#### Changes proposed in this Pull Request
Added a new option `Android` to the Device type advanced filter on the Transaction list page in order to filter the Tap to Pay transactions done on Android.

<img width="797" alt="Screenshot 2023-07-12 at 15 53 25" src="https://github.com/Automattic/woocommerce-payments/assets/8667118/06278721-6854-43ab-b016-6c6a3bff938a">

#### Testing instructions
- Navigate to `Payments` -> `Transactions`
- Add a new `Device type` advanced filter from the `Add a Filter` button
- Verify both the `Android` and `iPhone` options are available.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
