### PR TITLE
Fix outdated documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We adopt the L-2 version support policy for WordPress core strictly, and a loose
 
 ### Install dependencies & build
 
--   `npm install` 
+-   `npm install`
 -   `composer install`
 -   `npm run build:client`, or if you're developing the client you can have it auto-update when changes are made: `npm start`
 
@@ -55,7 +55,7 @@ We currently support the following variables:
 
 ## Test account setup
 
-For setting up a test account follow [these instructions](https://woocommerce.com/document/payments/testing/dev-mode/).
+For setting up a test account follow [these instructions](https://woocommerce.com/document/woocommerce-payments/testing-and-troubleshooting/dev-mode/).
 
 You will need a externally accessible URL to set up the plugin. You can use ngrok for this.
 

--- a/changelog/fix-outdated-documentation-links
+++ b/changelog/fix-outdated-documentation-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix outdated documentation links.

--- a/client/additional-methods-setup/upe-preview-methods-selector/add-payment-methods-task.js
+++ b/client/additional-methods-setup/upe-preview-methods-selector/add-payment-methods-task.js
@@ -252,7 +252,7 @@ const AddPaymentMethodsTask = () => {
 						components: {
 							learnMoreLink: (
 								// eslint-disable-next-line max-len
-								<ExternalLink href="https://woocommerce.com/document/payments/additional-payment-methods/#available-methods" />
+								<ExternalLink href="https://woocommerce.com/document/woocommerce-payments/payment-methods/additional-payment-methods/" />
 							),
 						},
 					} ) }

--- a/client/checkout/blocks/fields.js
+++ b/client/checkout/blocks/fields.js
@@ -36,7 +36,7 @@ const WCPayFields = ( {
 		<p>
 			<strong>Test mode:</strong> use the test VISA card 4242424242424242
 			with any expiry date and CVC, or any test card numbers listed{ ' ' }
-			<a href="https://woocommerce.com/document/payments/testing/#test-cards">
+			<a href="https://woocommerce.com/document/woocommerce-payments/testing-and-troubleshooting/testing/#test-cards">
 				here
 			</a>
 			.

--- a/client/components/deposits-overview/suspended-deposit-notice.tsx
+++ b/client/components/deposits-overview/suspended-deposit-notice.tsx
@@ -36,7 +36,7 @@ function SuspendedDepositNotice(): JSX.Element {
 					suspendLink: (
 						<Link
 							href={
-								'https://woocommerce.com/document/payments/faq/deposits-suspended/'
+								'https://woocommerce.com/document/woocommerce-payments/deposits/why-deposits-suspended/'
 							}
 						/>
 					),

--- a/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
+++ b/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
@@ -178,7 +178,7 @@ exports[`Deposits Overview information Component Renders 1`] = `
           <span
             class="wcpay-deposits-overview__heading__description__text"
           >
-            Your deposits are dispatched 
+            Your deposits are dispatched
             <strong>
               automatically every Monday
             </strong>
@@ -452,14 +452,14 @@ exports[`Suspended Deposit Notice Renders Component Renders 1`] = `
           data-wp-c16t="true"
           data-wp-component="FlexItem"
         >
-          Your deposits are 
+          Your deposits are
           <strong>
             temporarily suspended
           </strong>
-          . 
+          .
           <a
             data-link-type="wc-admin"
-            href="https://woocommerce.com/document/payments/faq/deposits-suspended/"
+            href="https://woocommerce.com/document/woocommerce-payments/deposits/why-deposits-suspended/"
           >
             Learn more
           </a>

--- a/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
+++ b/client/components/deposits-overview/test/__snapshots__/index.tsx.snap
@@ -178,7 +178,7 @@ exports[`Deposits Overview information Component Renders 1`] = `
           <span
             class="wcpay-deposits-overview__heading__description__text"
           >
-            Your deposits are dispatched
+            Your deposits are dispatched 
             <strong>
               automatically every Monday
             </strong>
@@ -452,11 +452,11 @@ exports[`Suspended Deposit Notice Renders Component Renders 1`] = `
           data-wp-c16t="true"
           data-wp-component="FlexItem"
         >
-          Your deposits are
+          Your deposits are 
           <strong>
             temporarily suspended
           </strong>
-          .
+          . 
           <a
             data-link-type="wc-admin"
             href="https://woocommerce.com/document/woocommerce-payments/deposits/why-deposits-suspended/"

--- a/client/components/deposits-status/index.tsx
+++ b/client/components/deposits-status/index.tsx
@@ -61,7 +61,7 @@ const DepositsStatus: React.FC< Props > = ( {
 		icon = <GridiconNotice size={ iconSize } />;
 	} else if ( showSuspendedNotice ) {
 		const learnMoreHref =
-			'https://woocommerce.com/document/payments/faq/deposits-suspended/';
+			'https://woocommerce.com/document/woocommerce-payments/deposits/why-deposits-suspended/';
 		description = createInterpolateElement(
 			/* translators: <a> - suspended accounts FAQ URL */
 			__(

--- a/client/components/deposits-status/test/__snapshots__/index.js.snap
+++ b/client/components/deposits-status/test/__snapshots__/index.js.snap
@@ -20,7 +20,7 @@ exports[`DepositsStatus renders blocked status 1`] = `
     </svg>
     Temporarily suspended (
     <a
-      href="https://woocommerce.com/document/payments/faq/deposits-suspended/"
+      href="https://woocommerce.com/document/woocommerce-payments/deposits/why-deposits-suspended/"
       rel="noopener noreferrer"
       target="_blank"
     >
@@ -51,7 +51,7 @@ exports[`DepositsStatus renders blocked status 2`] = `
     </svg>
     Temporarily suspended (
     <a
-      href="https://woocommerce.com/document/payments/faq/deposits-suspended/"
+      href="https://woocommerce.com/document/woocommerce-payments/deposits/why-deposits-suspended/"
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/client/connect-account-page/modal/index.js
+++ b/client/connect-account-page/modal/index.js
@@ -15,7 +15,7 @@ import './style.scss';
 const LearnMoreLink = ( props ) => (
 	<Link
 		{ ...props }
-		href="https://woocommerce.com/document/payments/countries/"
+		href="https://woocommerce.com/document/woocommerce-payments/compatibility/countries/"
 		target="_blank"
 		rel="noopener noreferrer"
 		type="external"

--- a/client/connect-account-page/modal/test/__snapshots__/index.js.snap
+++ b/client/connect-account-page/modal/test/__snapshots__/index.js.snap
@@ -51,7 +51,7 @@ exports[`Onboarding: location check dialog renders correctly when continue butto
       <div
         class="woocommerce-payments__onboarding_location_check-modal-message"
       >
-        It appears you're attempting to set up WooPayments from an unsupported country. In order to complete the set up of WooPayments, your store is required to have a business entity in one of the following countries: 
+        It appears you're attempting to set up WooPayments from an unsupported country. In order to complete the set up of WooPayments, your store is required to have a business entity in one of the following countries:
         <ul
           class="woocommerce-list"
           role="menu"
@@ -91,10 +91,10 @@ exports[`Onboarding: location check dialog renders correctly when continue butto
             </div>
           </li>
         </ul>
-         
+
         <a
           data-link-type="external"
-          href="https://woocommerce.com/document/payments/countries/"
+          href="https://woocommerce.com/document/woocommerce-payments/compatibility/countries/"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -173,7 +173,7 @@ exports[`Onboarding: location check dialog renders correctly when opened 1`] = `
       <div
         class="woocommerce-payments__onboarding_location_check-modal-message"
       >
-        It appears you're attempting to set up WooPayments from an unsupported country. In order to complete the set up of WooPayments, your store is required to have a business entity in one of the following countries: 
+        It appears you're attempting to set up WooPayments from an unsupported country. In order to complete the set up of WooPayments, your store is required to have a business entity in one of the following countries:
         <ul
           class="woocommerce-list"
           role="menu"
@@ -213,10 +213,10 @@ exports[`Onboarding: location check dialog renders correctly when opened 1`] = `
             </div>
           </li>
         </ul>
-         
+
         <a
           data-link-type="external"
-          href="https://woocommerce.com/document/payments/countries/"
+          href="https://woocommerce.com/document/woocommerce-payments/compatibility/countries/"
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/client/connect-account-page/modal/test/__snapshots__/index.js.snap
+++ b/client/connect-account-page/modal/test/__snapshots__/index.js.snap
@@ -51,7 +51,7 @@ exports[`Onboarding: location check dialog renders correctly when continue butto
       <div
         class="woocommerce-payments__onboarding_location_check-modal-message"
       >
-        It appears you're attempting to set up WooPayments from an unsupported country. In order to complete the set up of WooPayments, your store is required to have a business entity in one of the following countries:
+        It appears you're attempting to set up WooPayments from an unsupported country. In order to complete the set up of WooPayments, your store is required to have a business entity in one of the following countries: 
         <ul
           class="woocommerce-list"
           role="menu"
@@ -91,7 +91,7 @@ exports[`Onboarding: location check dialog renders correctly when continue butto
             </div>
           </li>
         </ul>
-
+         
         <a
           data-link-type="external"
           href="https://woocommerce.com/document/woocommerce-payments/compatibility/countries/"
@@ -173,7 +173,7 @@ exports[`Onboarding: location check dialog renders correctly when opened 1`] = `
       <div
         class="woocommerce-payments__onboarding_location_check-modal-message"
       >
-        It appears you're attempting to set up WooPayments from an unsupported country. In order to complete the set up of WooPayments, your store is required to have a business entity in one of the following countries:
+        It appears you're attempting to set up WooPayments from an unsupported country. In order to complete the set up of WooPayments, your store is required to have a business entity in one of the following countries: 
         <ul
           class="woocommerce-list"
           role="menu"
@@ -213,7 +213,7 @@ exports[`Onboarding: location check dialog renders correctly when opened 1`] = `
             </div>
           </li>
         </ul>
-
+         
         <a
           data-link-type="external"
           href="https://woocommerce.com/document/woocommerce-payments/compatibility/countries/"

--- a/client/deposits/instant-deposits/modal.tsx
+++ b/client/deposits/instant-deposits/modal.tsx
@@ -28,7 +28,7 @@ const InstantDepositModal: React.FC< InstantDepositModalProps > = ( {
 	inProgress,
 } ) => {
 	const learnMoreHref =
-		'https://woocommerce.com/document/payments/instant-deposits/';
+		'https://woocommerce.com/document/woocommerce-payments/deposits/instant-deposits/';
 	const feePercentage = `${ percentage }%`;
 	const description = createInterpolateElement(
 		/* translators: %s: amount representing the fee percentage, <a>: instant payout doc URL */

--- a/client/deposits/instant-deposits/test/__snapshots__/index.tsx.snap
+++ b/client/deposits/instant-deposits/test/__snapshots__/index.tsx.snap
@@ -67,9 +67,9 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
       </button>
     </div>
     <p>
-      Need cash in a hurry? Instant deposits are available within 30 minutes for a nominal 1.5% service fee. 
+      Need cash in a hurry? Instant deposits are available within 30 minutes for a nominal 1.5% service fee.
       <a
-        href="https://woocommerce.com/document/payments/instant-deposits/"
+        href="https://woocommerce.com/document/woocommerce-payments/deposits/instant-deposits/"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -80,7 +80,7 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
       <li
         class="wcpay-instant-deposits-modal__balance"
       >
-        Balance available for instant deposit: 
+        Balance available for instant deposit:
         <span>
           $123.45
         </span>
@@ -88,7 +88,7 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
       <li
         class="wcpay-instant-deposits-modal__fee"
       >
-        1.5% service fee: 
+        1.5% service fee:
         <span>
           -
           $1.23
@@ -97,7 +97,7 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
       <li
         class="wcpay-instant-deposits-modal__net"
       >
-        Net deposit amount: 
+        Net deposit amount:
         <span>
           $122.22
         </span>

--- a/client/deposits/instant-deposits/test/__snapshots__/index.tsx.snap
+++ b/client/deposits/instant-deposits/test/__snapshots__/index.tsx.snap
@@ -67,7 +67,7 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
       </button>
     </div>
     <p>
-      Need cash in a hurry? Instant deposits are available within 30 minutes for a nominal 1.5% service fee.
+      Need cash in a hurry? Instant deposits are available within 30 minutes for a nominal 1.5% service fee. 
       <a
         href="https://woocommerce.com/document/woocommerce-payments/deposits/instant-deposits/"
         rel="noopener noreferrer"
@@ -80,7 +80,7 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
       <li
         class="wcpay-instant-deposits-modal__balance"
       >
-        Balance available for instant deposit:
+        Balance available for instant deposit: 
         <span>
           $123.45
         </span>
@@ -88,7 +88,7 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
       <li
         class="wcpay-instant-deposits-modal__fee"
       >
-        1.5% service fee:
+        1.5% service fee: 
         <span>
           -
           $1.23
@@ -97,7 +97,7 @@ exports[`Instant deposit button and modal modal renders correctly 1`] = `
       <li
         class="wcpay-instant-deposits-modal__net"
       >
-        Net deposit amount:
+        Net deposit amount: 
         <span>
           $122.22
         </span>

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/index.js
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/index.js
@@ -25,7 +25,7 @@ import SettingsSection from 'wcpay/settings/settings-section';
 
 const EnabledCurrenciesSettingsDescription = () => {
 	const LEARN_MORE_URL =
-		'https://woocommerce.com/document/payments/currencies/multi-currency-setup/';
+		'https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/';
 
 	return (
 		<>

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/test/__snapshots__/index.js.snap
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/test/__snapshots__/index.js.snap
@@ -12,7 +12,7 @@ exports[`Multi-Currency enabled currencies list Enabled currencies list renders 
         Enabled currencies
       </h2>
       <p>
-        Accept payments in multiple currencies. Prices are converted based on exchange rates and rounding rules.
+        Accept payments in multiple currencies. Prices are converted based on exchange rates and rounding rules. 
         <a
           href="https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/"
           rel="noreferrer"
@@ -363,7 +363,7 @@ exports[`Multi-Currency enabled currencies list Remove currency modal renders co
       </div>
     </div>
     <p>
-      Are you sure you want to remove
+      Are you sure you want to remove 
       <strong>
         Euro (EUR €)
       </strong>

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/test/__snapshots__/index.js.snap
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/test/__snapshots__/index.js.snap
@@ -12,9 +12,9 @@ exports[`Multi-Currency enabled currencies list Enabled currencies list renders 
         Enabled currencies
       </h2>
       <p>
-        Accept payments in multiple currencies. Prices are converted based on exchange rates and rounding rules. 
+        Accept payments in multiple currencies. Prices are converted based on exchange rates and rounding rules.
         <a
-          href="https://woocommerce.com/document/payments/currencies/multi-currency-setup/"
+          href="https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/"
           rel="noreferrer"
           target="_blank"
         >
@@ -363,7 +363,7 @@ exports[`Multi-Currency enabled currencies list Remove currency modal renders co
       </div>
     </div>
     <p>
-      Are you sure you want to remove 
+      Are you sure you want to remove
       <strong>
         Euro (EUR €)
       </strong>

--- a/client/multi-currency/multi-currency-settings/store-settings/index.js
+++ b/client/multi-currency/multi-currency-settings/store-settings/index.js
@@ -18,7 +18,7 @@ import PreviewModal from 'wcpay/multi-currency/preview-modal';
 
 const StoreSettingsDescription = () => {
 	const LEARN_MORE_URL =
-		'https://woocommerce.com/document/payments/currencies/multi-currency-setup/';
+		'https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/';
 
 	return (
 		<>

--- a/client/multi-currency/multi-currency-settings/store-settings/test/__snapshots__/index.test.js.snap
+++ b/client/multi-currency/multi-currency-settings/store-settings/test/__snapshots__/index.test.js.snap
@@ -12,9 +12,9 @@ exports[`Multi-Currency store settings store settings task renders correctly: sn
         Store settings
       </h2>
       <p>
-        Store settings allow your customers to choose which currency they would like to use when shopping at your store. 
+        Store settings allow your customers to choose which currency they would like to use when shopping at your store.
         <a
-          href="https://woocommerce.com/document/payments/currencies/multi-currency-setup/"
+          href="https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/"
           rel="noreferrer"
           target="_blank"
         >
@@ -66,7 +66,7 @@ exports[`Multi-Currency store settings store settings task renders correctly: sn
             <div
               class="multi-currency-settings__description"
             >
-              Customers will be notified via store alert banner. 
+              Customers will be notified via store alert banner.
               <button
                 class="components-button is-link"
                 type="button"
@@ -102,7 +102,7 @@ exports[`Multi-Currency store settings store settings task renders correctly: sn
             <div
               class="multi-currency-settings__description"
             >
-              A currency switcher is also available in your widgets. 
+              A currency switcher is also available in your widgets.
               <a
                 href="widgets.php"
               >

--- a/client/multi-currency/multi-currency-settings/store-settings/test/__snapshots__/index.test.js.snap
+++ b/client/multi-currency/multi-currency-settings/store-settings/test/__snapshots__/index.test.js.snap
@@ -12,7 +12,7 @@ exports[`Multi-Currency store settings store settings task renders correctly: sn
         Store settings
       </h2>
       <p>
-        Store settings allow your customers to choose which currency they would like to use when shopping at your store.
+        Store settings allow your customers to choose which currency they would like to use when shopping at your store. 
         <a
           href="https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/"
           rel="noreferrer"
@@ -66,7 +66,7 @@ exports[`Multi-Currency store settings store settings task renders correctly: sn
             <div
               class="multi-currency-settings__description"
             >
-              Customers will be notified via store alert banner.
+              Customers will be notified via store alert banner. 
               <button
                 class="components-button is-link"
                 type="button"
@@ -102,7 +102,7 @@ exports[`Multi-Currency store settings store settings task renders correctly: sn
             <div
               class="multi-currency-settings__description"
             >
-              A currency switcher is also available in your widgets.
+              A currency switcher is also available in your widgets. 
               <a
                 href="widgets.php"
               >

--- a/client/multi-currency/single-currency-settings/index.js
+++ b/client/multi-currency/single-currency-settings/index.js
@@ -411,8 +411,7 @@ const SingleCurrencySettings = () => {
 													isLink
 													onClick={ () => {
 														open(
-															'http://woocommerce.com/document/payments/' +
-																'currencies/multi-currency-setup/#price-rounding',
+															'https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/#price-rounding',
 															'_blank'
 														);
 													} }
@@ -476,8 +475,7 @@ const SingleCurrencySettings = () => {
 													isLink
 													onClick={ () => {
 														open(
-															'http://woocommerce.com/document/payments/' +
-																'currencies/multi-currency-setup/#price-charm',
+															'https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/#charm-pricing',
 															'_blank'
 														);
 													} }

--- a/client/multi-currency/single-currency-settings/index.js
+++ b/client/multi-currency/single-currency-settings/index.js
@@ -411,6 +411,7 @@ const SingleCurrencySettings = () => {
 													isLink
 													onClick={ () => {
 														open(
+															/* eslint-disable-next-line max-len */
 															'https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/#price-rounding',
 															'_blank'
 														);
@@ -475,6 +476,7 @@ const SingleCurrencySettings = () => {
 													isLink
 													onClick={ () => {
 														open(
+															/* eslint-disable-next-line max-len */
 															'https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/#charm-pricing',
 															'_blank'
 														);

--- a/client/payment-gateways/disable-confirmation-modal.js
+++ b/client/payment-gateways/disable-confirmation-modal.js
@@ -113,7 +113,7 @@ const DisableConfirmationModal = ( { onClose, onConfirm } ) => {
 						strong: <strong />,
 						wooCommercePaymentsLink: (
 							// eslint-disable-next-line jsx-a11y/anchor-has-content
-							<a href="https://woocommerce.com/document/payments/" />
+							<a href="https://woocommerce.com/document/woocommerce-payments/" />
 						),
 						contactSupportLink: (
 							// eslint-disable-next-line jsx-a11y/anchor-has-content

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -109,7 +109,7 @@ const UpeSetupBanner = () => {
 							) }
 						</Button>
 					</span>
-					<ExternalLink href="https://woocommerce.com/document/payments/additional-payment-methods/">
+					<ExternalLink href="https://woocommerce.com/document/woocommerce-payments/payment-methods/additional-payment-methods/">
 						{ __( 'Learn more', 'woocommerce-payments' ) }
 					</ExternalLink>
 				</div>

--- a/client/settings/advanced-settings/multi-currency-toggle.js
+++ b/client/settings/advanced-settings/multi-currency-toggle.js
@@ -40,7 +40,7 @@ const MultiCurrencyToggle = () => {
 				components: {
 					learnMoreLink: (
 						// eslint-disable-next-line max-len
-						<ExternalLink href="https://woocommerce.com/document/payments/currencies/multi-currency-setup" />
+						<ExternalLink href="https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/" />
 					),
 				},
 			} ) }

--- a/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
+++ b/client/settings/advanced-settings/wcpay-subscriptions-toggle.js
@@ -51,7 +51,7 @@ const WCPaySubscriptionsToggle = () => {
 				components: {
 					learnMoreLink: (
 						// eslint-disable-next-line max-len
-						<ExternalLink href="https://woocommerce.com/document/payments/subscriptions/" />
+						<ExternalLink href="https://woocommerce.com/document/woocommerce-payments/built-in-subscriptions/" />
 					),
 				},
 			} ) }

--- a/client/settings/deposits/index.js
+++ b/client/settings/deposits/index.js
@@ -165,7 +165,7 @@ const DepositsSchedule = () => {
 						'Learn more about deposit scheduling.',
 						'woocommerce-payments'
 					) }
-					href="https://woocommerce.com/document/payments/faq/deposit-schedule/"
+					href="https://woocommerce.com/document/woocommerce-payments/deposits/deposit-schedule/"
 					target="_blank"
 					rel="external noreferrer noopener"
 				>
@@ -192,7 +192,7 @@ const DepositsSchedule = () => {
 						'Learn more about deposit scheduling.',
 						'woocommerce-payments'
 					) }
-					href="https://woocommerce.com/document/payments/faq/deposit-schedule/"
+					href="https://woocommerce.com/document/woocommerce-payments/deposits/deposit-schedule/"
 					target="_blank"
 					rel="external noreferrer noopener"
 				>

--- a/client/settings/disable-upe-modal/index.js
+++ b/client/settings/disable-upe-modal/index.js
@@ -29,7 +29,7 @@ const NeedHelpBarSection = () => {
 				components: {
 					docsLink: (
 						// eslint-disable-next-line max-len
-						<ExternalLink href="https://woocommerce.com/document/payments/additional-payment-methods/#introduction">
+						<ExternalLink href="https://woocommerce.com/document/woocommerce-payments/payment-methods/additional-payment-methods/">
 							{ sprintf(
 								/* translators: %s: WooPayments */
 								__( '%s docs', 'woocommerce-payments' ),

--- a/client/settings/express-checkout/link-item.js
+++ b/client/settings/express-checkout/link-item.js
@@ -153,7 +153,7 @@ const LinkExpressCheckoutItem = () => {
 												target="_blank"
 												rel="noreferrer"
 												/* eslint-disable-next-line max-len */
-												href="https://woocommerce.com/document/payments/woocommerce-payments-stripe-link/"
+												href="https://woocommerce.com/document/woocommerce-payments/payment-methods/link-by-stripe/"
 											/>
 										),
 									},

--- a/client/settings/general-settings/index.js
+++ b/client/settings/general-settings/index.js
@@ -63,6 +63,7 @@ const GeneralSettings = () => {
 								<a
 									target="_blank"
 									rel="noreferrer"
+									/* eslint-disable-next-line max-len */
 									href="https://woocommerce.com/document/woocommerce-payments/testing-and-troubleshooting/testing/#test-cards"
 								/>
 							),

--- a/client/settings/general-settings/index.js
+++ b/client/settings/general-settings/index.js
@@ -63,7 +63,7 @@ const GeneralSettings = () => {
 								<a
 									target="_blank"
 									rel="noreferrer"
-									href="https://woocommerce.com/document/payments/testing/#test-cards"
+									href="https://woocommerce.com/document/woocommerce-payments/testing-and-troubleshooting/testing/#test-cards"
 								/>
 							),
 							learnMoreLink: (
@@ -71,7 +71,7 @@ const GeneralSettings = () => {
 								<a
 									target="_blank"
 									rel="noreferrer"
-									href="https://woocommerce.com/document/payments/testing/"
+									href="https://woocommerce.com/document/woocommerce-payments/testing-and-troubleshooting/testing/"
 								/>
 							),
 						},

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -83,8 +83,8 @@ const TransactionsDescription = () => (
 				'woocommerce-payments'
 			) }
 		</p>
-		<ExternalLink href="https://woocommerce.com/document/payments/faq/">
-			{ __( 'View frequently asked questions', 'woocommerce-payments' ) }
+		<ExternalLink href="https://woocommerce.com/document/woocommerce-payments/">
+			{ __( 'View our documentation', 'woocommerce-payments' ) }
 		</ExternalLink>
 	</>
 );
@@ -104,7 +104,7 @@ const DepositsDescription = () => {
 					depositDelayDays
 				) }
 			</p>
-			<ExternalLink href="https://woocommerce.com/document/payments/faq/deposit-schedule/#section-2">
+			<ExternalLink href="https://woocommerce.com/document/woocommerce-payments/deposits/deposit-schedule/">
 				{ __(
 					'Learn more about pending schedules',
 					'woocommerce-payments'

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -18,9 +18,9 @@ import { PaymentMethod } from 'wcpay/types/payment-methods';
 import { createInterpolateElement } from '@wordpress/element';
 
 const countryFeeStripeDocsBaseLink =
-	'https://woocommerce.com/document/payments/faq/fees/#';
+	'https://woocommerce.com/document/woocommerce-payments/fees-and-debits/fees/#';
 const countryFeeStripeDocsBaseLinkNoCountry =
-	'https://woocommerce.com/document/payments/faq/fees';
+	'https://woocommerce.com/document/woocommerce-payments/fees-and-debits/fees/';
 const countryFeeStripeDocsSectionNumbers: Record< string, string > = {
 	AU: 'australia',
 	AT: 'austria',

--- a/client/utils/test/__snapshots__/account-fees.tsx.snap
+++ b/client/utils/test/__snapshots__/account-fees.tsx.snap
@@ -44,7 +44,7 @@ exports[`Account fees utility functions formatMethodFeesTooltip() displays base 
     >
       <span>
         <a
-          href="https://woocommerce.com/document/payments/faq/fees/#united-states"
+          href="https://woocommerce.com/document/woocommerce-payments/fees-and-debits/fees/#united-states"
           rel="noreferrer"
           target="_blank"
         >
@@ -101,7 +101,7 @@ exports[`Account fees utility functions formatMethodFeesTooltip() displays base 
     >
       <span>
         <a
-          href="https://woocommerce.com/document/payments/faq/fees/#united-states"
+          href="https://woocommerce.com/document/woocommerce-payments/fees-and-debits/fees/#united-states"
           rel="noreferrer"
           target="_blank"
         >
@@ -158,7 +158,7 @@ exports[`Account fees utility functions formatMethodFeesTooltip() displays custo
     >
       <span>
         <a
-          href="https://woocommerce.com/document/payments/faq/fees/#united-states"
+          href="https://woocommerce.com/document/woocommerce-payments/fees-and-debits/fees/#united-states"
           rel="noreferrer"
           target="_blank"
         >

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -246,7 +246,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				'title'       => __( 'Customer bank statement', 'woocommerce-payments' ),
 				'description' => WC_Payments_Utils::esc_interpolated_html(
 					__( 'Edit the way your store name appears on your customers’ bank statements (read more about requirements <a>here</a>).', 'woocommerce-payments' ),
-					[ 'a' => '<a href="https://woocommerce.com/document/payments/bank-statement-descriptor/" target="_blank" rel="noopener noreferrer">' ]
+					[ 'a' => '<a href="https://woocommerce.com/document/woocommerce-payments/customization-and-translation/bank-statement-descriptor/" target="_blank" rel="noopener noreferrer">' ]
 				),
 			],
 			'manual_capture'                   => [

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -240,7 +240,7 @@ class WC_Payments_Checkout {
 						__( '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC, or any test card numbers listed <a>here</a>.', 'woocommerce-payments' ),
 						[
 							'strong' => '<strong>',
-							'a'      => '<a href="https://woocommerce.com/document/payments/testing/#test-cards" target="_blank">',
+							'a'      => '<a href="https://woocommerce.com/document/woocommerce-payments/testing-and-troubleshooting/testing/#test-cards" target="_blank">',
 						]
 					);
 					?>

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -258,7 +258,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 					$payment_method->get_testing_instructions(),
 					[
 						'strong' => '<strong>',
-						'a'      => '<a href="https://woocommerce.com/document/payments/testing/#test-cards" target="_blank">',
+						'a'      => '<a href="https://woocommerce.com/document/woocommerce-payments/testing-and-troubleshooting/testing/#test-cards" target="_blank">',
 					]
 				);
 			}
@@ -332,7 +332,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 							$testing_instructions,
 							[
 								'strong' => '<strong>',
-								'a'      => '<a href="https://woocommerce.com/document/payments/testing/#test-cards" target="_blank">',
+								'a'      => '<a href="https://woocommerce.com/document/woocommerce-payments/testing-and-troubleshooting/testing/#test-cards" target="_blank">',
 							]
 						);
 					}

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -212,8 +212,8 @@ class WC_Payments_Utils {
 	}
 
 	/**
-	 * List of countries enabled for Stripe platform account. See also
-	 * https://woocommerce.com/document/payments/countries/ for the most actual status.
+	 * List of countries enabled for Stripe platform account. See also this URL:
+	 * https://woocommerce.com/document/woocommerce-payments/compatibility/countries/#supported-countries
 	 *
 	 * @return string[]
 	 */

--- a/includes/core/class-mode.php
+++ b/includes/core/class-mode.php
@@ -89,7 +89,7 @@ class Mode {
 		/**
 		 * Allows WooCommerce to enter dev mode.
 		 *
-		 * @see https://woocommerce.com/document/payments/testing/dev-mode/
+		 * @see https://woocommerce.com/document/woocommerce-payments/testing-and-troubleshooting/dev-mode/
 		 * @param bool $dev_mode The pre-determined dev mode.
 		 */
 		$this->dev_mode = (bool) apply_filters( 'wcpay_dev_mode', $dev_mode );
@@ -100,7 +100,7 @@ class Mode {
 		/**
 		 * Allows WooCommerce to enter test mode.
 		 *
-		 * @see https://woocommerce.com/document/payments/testing/
+		 * @see https://woocommerce.com/document/woocommerce-payments/testing-and-troubleshooting/testing/#enabling-test-mode
 		 * @param bool $test_mode The pre-determined test mode.
 		 */
 		$this->test_mode = (bool) apply_filters( 'wcpay_test_mode', $test_mode );

--- a/includes/multi-currency/SettingsOnboardCta.php
+++ b/includes/multi-currency/SettingsOnboardCta.php
@@ -18,7 +18,7 @@ class SettingsOnboardCta extends \WC_Settings_Page {
 	 *
 	 * @var string
 	 */
-	const LEARN_MORE_URL = 'https://woocommerce.com/document/payments/currencies/multi-currency-setup/';
+	const LEARN_MORE_URL = 'https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/';
 
 	/**
 	 * MultiCurrency instance.

--- a/includes/notes/class-wc-payments-notes-additional-payment-methods.php
+++ b/includes/notes/class-wc-payments-notes-additional-payment-methods.php
@@ -71,7 +71,7 @@ class WC_Payments_Notes_Additional_Payment_Methods {
 					'WooPayments'
 				),
 				[
-					'a' => '<a href="https://woocommerce.com/document/payments/additional-payment-methods/" target="wcpay_upe_learn_more">',
+					'a' => '<a href="https://woocommerce.com/document/woocommerce-payments/payment-methods/additional-payment-methods/" target="wcpay_upe_learn_more">',
 				]
 			)
 		);

--- a/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
+++ b/includes/notes/class-wc-payments-notes-instant-deposits-eligible.php
@@ -41,7 +41,7 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 					__( "Get immediate access to your funds when you need them – including nights, weekends, and holidays. With %s' <a>Instant Deposits feature</a>, you're able to transfer your earnings to a debit card within minutes.", 'woocommerce-payments' ),
 					'WooPayments'
 				),
-				[ 'a' => '<a href="https://woocommerce.com/document/payments/instant-deposits/">' ]
+				[ 'a' => '<a href="https://woocommerce.com/document/woocommerce-payments/deposits/instant-deposits/">' ]
 			)
 		);
 		$note->set_content_data( (object) [] );
@@ -51,7 +51,7 @@ class WC_Payments_Notes_Instant_Deposits_Eligible {
 		$note->add_action(
 			self::NOTE_NAME,
 			__( 'Request an instant deposit', 'woocommerce-payments' ),
-			'https://woocommerce.com/document/payments/instant-deposits/#section-2',
+			'https://woocommerce.com/document/woocommerce-payments/deposits/instant-deposits/#request-an-instant-deposit',
 			'unactioned',
 			true
 		);

--- a/includes/notes/class-wc-payments-notes-set-up-stripelink.php
+++ b/includes/notes/class-wc-payments-notes-set-up-stripelink.php
@@ -27,7 +27,7 @@ class WC_Payments_Notes_Set_Up_StripeLink {
 	/**
 	 * CTA button link
 	 */
-	const NOTE_DOCUMENTATION_URL = 'https://woocommerce.com/document/payments/woocommerce-payments-stripe-link/';
+	const NOTE_DOCUMENTATION_URL = 'https://woocommerce.com/document/woocommerce-payments/payment-methods/link-by-stripe/';
 
 	/**
 	 * The account service instance.

--- a/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
+++ b/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
@@ -38,7 +38,7 @@
 								esc_html__( 'Existing subscribers will need to pay for their next renewal manually, after which automatic payments will resume. You will also no longer have access to the %1$s%3$sadvanced features%4$s%2$s of WooCommerce Subscriptions.', 'woocommerce-payments' ),
 								'<strong>',
 								'</strong>',
-								'<a href="https://woocommerce.com/document/payments/subscriptions-basics/comparison/" target="_blank" rel="noopener noreferrer">',
+								'<a href="https://woocommerce.com/document/woocommerce-payments/built-in-subscriptions/comparison/" target="_blank" rel="noopener noreferrer">',
 								'</a>'
 							);
 							?>

--- a/includes/subscriptions/templates/html-wcpay-deactivate-warning.php
+++ b/includes/subscriptions/templates/html-wcpay-deactivate-warning.php
@@ -22,7 +22,7 @@
 							printf(
 							// translators: $1 $2 $3 placeholders are opening and closing HTML link tags, linking to documentation. $4 $5 placeholders are opening and closing strong HTML tags. $6 is WooPayments.
 								esc_html__( 'Your store has active subscriptions using the built-in %6$s functionality. Due to the %1$soff-site billing engine%3$s these subscriptions use, %4$sthey will continue to renew even after you deactivate %6$s%5$s. %2$sLearn more%3$s.', 'woocommerce-payments' ),
-								'<a href="https://woocommerce.com/document/payments/subscriptions/comparison/#billing-engine">',
+								'<a href="https://woocommerce.com/document/woocommerce-payments/built-in-subscriptions/comparison/#billing-engine">',
 								'<a href="https://woocommerce.com/document/woocommerce-payments/built-in-subscriptions/deactivate/#existing-subscriptions">',
 								'</a>',
 								'<strong>',

--- a/readme.txt
+++ b/readme.txt
@@ -22,13 +22,13 @@ See payments, track cash flow into your bank account, manage refunds, and stay o
 
 Features previously only available on your payment provider’s website are now part of your store’s **integrated payments dashboard**. This enables you to:
 
-- View the details of [payments, refunds, and other transactions](https://woocommerce.com/document/payments/#section-4).
-- View and respond to [disputes and chargebacks](https://woocommerce.com/document/payments/disputes/).
-- [Track deposits](https://woocommerce.com/document/payments/#section-5) into your bank account or debit card.
+- View the details of [payments, refunds, and other transactions](https://woocommerce.com/document/woocommerce-payments/managing-money/).
+- View and respond to [disputes and chargebacks](https://woocommerce.com/document/woocommerce-payments/fraud-and-disputes/managing-disputes-with-woocommerce-payments/).
+- [Track deposits](https://woocommerce.com/document/woocommerce-payments/deposits/) into your bank account or debit card.
 
 **Pay as you go**
 
-WooCommerce Payments is **free to install**, with **no setup fees or monthly fees**. Pay-as-you-go fees start at 2.9% + $0.30 per transaction for U.S.-issued cards. [Read more about transaction fees](https://woocommerce.com/document/payments/faq/fees/).
+WooCommerce Payments is **free to install**, with **no setup fees or monthly fees**. Pay-as-you-go fees start at 2.9% + $0.30 per transaction for U.S.-issued cards. [Read more about transaction fees](https://woocommerce.com/document/woocommerce-payments/fees-and-debits/fees/).
 
 **Supported by the WooCommerce team**
 
@@ -56,7 +56,7 @@ Install and activate the WooCommerce and WooCommerce Payments plugins, if you ha
 
 = What countries and currencies are supported? =
 
-If you are an individual or business based in [one of these countries](https://woocommerce.com/document/payments/countries/#section-1), you can sign-up with WooCommerce Payments. After completing sign up, you can accept payments from customers anywhere in the world.
+If you are an individual or business based in [one of these countries](https://woocommerce.com/document/woocommerce-payments/compatibility/countries/#supported-countries), you can sign-up with WooCommerce Payments. After completing sign up, you can accept payments from customers anywhere in the world.
 
 We are actively planning to expand into additional countries based on your interest. Let us know where you would like to [see WooCommerce Payments launch next](https://woocommerce.com/payments/#request-invite).
 

--- a/tests/unit/notes/test-class-wc-payments-notes-additional-payment-methods.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-additional-payment-methods.php
@@ -28,7 +28,7 @@ class WC_Payments_Notes_Additional_Payment_Methods_Test extends WCPAY_UnitTestCa
 		$note = WC_Payments_Notes_Additional_Payment_Methods::get_note();
 
 		$this->assertSame( 'Boost your sales by accepting new payment methods', $note->get_title() );
-		$this->assertSame( 'Get early access to additional payment methods and an improved checkout experience, coming soon to WooPayments. <a href="https://woocommerce.com/document/payments/additional-payment-methods/" target="wcpay_upe_learn_more">Learn more</a>', $note->get_content() );
+		$this->assertSame( 'Get early access to additional payment methods and an improved checkout experience, coming soon to WooPayments. <a href="https://woocommerce.com/document/woocommerce-payments/payment-methods/additional-payment-methods/" target="wcpay_upe_learn_more">Learn more</a>', $note->get_content() );
 		$this->assertSame( 'info', $note->get_type() );
 		$this->assertSame( 'wc-payments-notes-additional-payment-methods', $note->get_name() );
 		$this->assertSame( 'woocommerce-payments', $note->get_source() );

--- a/tests/unit/notes/test-class-wc-payments-notes-set-up-stripelink.php
+++ b/tests/unit/notes/test-class-wc-payments-notes-set-up-stripelink.php
@@ -52,7 +52,7 @@ class WC_Payments_Notes_Set_Up_StripeLink_Test extends WCPAY_UnitTestCase {
 		list( $set_up_action ) = $note->get_actions();
 		$this->assertSame( 'wc-payments-notes-set-up-stripe-link', $set_up_action->name );
 		$this->assertSame( 'Set up now', $set_up_action->label );
-		$this->assertStringStartsWith( 'https://woocommerce.com/document/payments/woocommerce-payments-stripe-link/', $set_up_action->query );
+		$this->assertStringStartsWith( 'https://woocommerce.com/document/woocommerce-payments/payment-methods/link-by-stripe/', $set_up_action->query );
 	}
 
 	public function test_stripelink_setup_note_null_when_upe_disabled() {

--- a/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
@@ -2070,7 +2070,7 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 					'countries'            => [],
 					'upePaymentIntentData' => null,
 					'upeSetupIntentData'   => null,
-					'testingInstructions'  => '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a href="https://woocommerce.com/document/payments/testing/#test-cards" target="_blank">here</a>.',
+					'testingInstructions'  => '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a href="https://woocommerce.com/document/woocommerce-payments/testing-and-troubleshooting/testing/#test-cards" target="_blank">here</a>.',
 				],
 				'link' => [
 					'isReusable'           => true,

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -302,7 +302,7 @@ function wcpay_get_jetpack_idc_custom_content(): array {
 			__( 'We’ve detected that you have duplicate sites connected to %s. When Safe Mode is active, payments will not be interrupted. However, some features may not be available until you’ve resolved this issue below. Safe Mode is most frequently activated when you’re transferring your site from one domain to another, or creating a staging site for testing. A site adminstrator can resolve this issue. <safeModeLink>Learn more</safeModeLink>', 'woocommerce-payments' ),
 			'WooPayments'
 		),
-		'supportURL'                => 'https://woocommerce.com/document/payments/faq/safe-mode/',
+		'supportURL'                => 'https://woocommerce.com/document/woocommerce-payments/testing-and-troubleshooting/safe-mode/',
 		'adminBarSafeModeLabel'     => sprintf(
 			/* translators: %s: WooPayments. */
 			__( '%s Safe Mode', 'woocommerce-payments' ),
@@ -313,7 +313,7 @@ function wcpay_get_jetpack_idc_custom_content(): array {
 			__( "<strong>Notice:</strong> It appears that your 'wp-config.php' file might be using dynamic site URL values. Dynamic site URLs could cause %s to enter Safe Mode. <dynamicSiteUrlSupportLink>Learn how to set a static site URL.</dynamicSiteUrlSupportLink>", 'woocommerce-payments' ),
 			'WooPayments'
 		),
-		'dynamicSiteUrlSupportLink' => 'https://woocommerce.com/document/payments/faq/safe-mode/#dynamic-site-urls',
+		'dynamicSiteUrlSupportLink' => 'https://woocommerce.com/document/woocommerce-payments/testing-and-troubleshooting/safe-mode/#dynamic-site-urls',
 	];
 
 	$urls = Automattic\Jetpack\Identity_Crisis::get_mismatched_urls();


### PR DESCRIPTION
Fixes many outdated documentation links through WooCommerce Payments code.

Many links to our documentation were still beginning with:

`https://woocommerce.com/document/payments/`

... despite this no longer being the correct link structure for our docs. All WooCommerce Payments docs now start with the following:

`https://woocommerce.com/document/woocommerce-payments/`

This means that any merchant or shopper who clicks one of these docs links was hitting at least one redirect, maybe more.

This PR is intended to fix all those links to point to the correct URLs, nothing more. (Although I see some minor whitespace changes crept in.)

A dev should probably spot-check `client/multi-currency/single-currency-settings/index.js`, since in that file links were previously being concatenated together, but I just replaced them with whole links.

Otherwise, this PR should not break anything or cause other problems. 🤞 (Famous last words!)