### PR TITLE
Ensuring rest_pre_dispatch used in test returns a WP_REST_Response

### DIFF
--- a/changelog/fix-pre_http_dispatch_test
+++ b/changelog/fix-pre_http_dispatch_test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix tests by ensuring the rest_pre_dispatch filter returns a WP_REST_Response

--- a/tests/unit/test-class-wc-payments.php
+++ b/tests/unit/test-class-wc-payments.php
@@ -125,7 +125,7 @@ class WC_Payments_Test extends WCPAY_UnitTestCase {
 
 		$pre_http_dispatch = function ( $result, $server, $request ) {
 			if ( in_array( $request->get_route(), [ '/wc/store/v1/checkout', '/wc/store/v1/cart' ], true ) ) {
-				return [ 'body' => wp_json_encode( [] ) ];
+				return new WP_REST_Response( [ 'body' => wp_json_encode( [] ) ], 200 );
 			}
 
 			return $result;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes compatibility tests (broken in #6751) by ensuring the rest_pre_dispatch filter returns a WP_REST_Response. This is needed because before WordPress 6.2.2 the result of this filter is not normalized to a WP_REST_Response: https://github.com/WordPress/WordPress/commit/42b25d58eae6ee169a76ff0982151865f0ed2482

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
