### PR TITLE
Fix failing dispute e2e test `merchant-disputes-submit-winning`

### DIFF
--- a/changelog/fix-6771-dispute-won-e2e-test
+++ b/changelog/fix-6771-dispute-won-e2e-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix for failing e2e test – no need for changelog entry since this is not user-facing.
+
+

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js
@@ -161,10 +161,10 @@ describe( 'Disputes > Submit winning dispute', () => {
 
 		// Confirm dispute status is Won.
 		await page.waitForSelector(
-			'div.wcpay-dispute-details .header-dispute-overview span.chip-light'
+			'div.wcpay-dispute-details .header-dispute-overview span.chip'
 		);
 		await expect( page ).toMatchElement(
-			'div.wcpay-dispute-details .header-dispute-overview span.chip-light',
+			'div.wcpay-dispute-details .header-dispute-overview span.chip',
 			{
 				text: 'Won',
 			}


### PR DESCRIPTION
Fixes #6771

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR fixes the e2e test `tests/e2e/specs/wcpay/merchant/merchant-disputes-submit-winning.spec.js` which has been failing since #6723.

Since the "Won" chip type has changed from `light` to `success`, the selector `div.wcpay-dispute-details .header-dispute-overview span.chip-light` did not exist.

This PR changes this selector to use `span.chip` to reduce unnecessary reliance on the colour of the chip, which is not relevant for this e2e test.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure e2e test GH checks succeed on this PR.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
