### PR TITLE
Add descriptive validation to first and last names and business name fields in PO flow

### DIFF
--- a/changelog/fix-6783-specific-validation-text-po
+++ b/changelog/fix-6783-specific-validation-text-po
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adding more descriptive error messages in gradual signup

--- a/client/onboarding/strings.tsx
+++ b/client/onboarding/strings.tsx
@@ -140,6 +140,15 @@ export default {
 			'Please provide a business name',
 			'woocommerce-payments'
 		),
+		country: __( 'Please provide a country', 'woocommerce-payments' ),
+		business_type: __(
+			'Please provide a business type',
+			'woocommerce-payments'
+		),
+		mcc: __(
+			'Please provide a type of goods or services',
+			'woocommerce-payments'
+		),
 	},
 	placeholders: {
 		country: __(

--- a/client/onboarding/strings.tsx
+++ b/client/onboarding/strings.tsx
@@ -122,12 +122,24 @@ export default {
 	},
 	errors: {
 		generic: __( 'Please provide a response', 'woocommerce-payments' ),
+		'individual.first_name': __(
+			'Please provide a first name',
+			'woocommerce-payments'
+		),
+		'individual.last_name': __(
+			'Please provide a last name',
+			'woocommerce-payments'
+		),
 		email: __( 'Please provide a valid email', 'woocommerce-payments' ),
 		phone: __(
 			'Please provide a valid phone number',
 			'woocommerce-payments'
 		),
 		url: __( 'Please provide a valid website', 'woocommerce-payments' ),
+		business_name: __(
+			'Please provide a business name',
+			'woocommerce-payments'
+		),
 	},
 	placeholders: {
 		country: __(

--- a/client/onboarding/test/validation.ts
+++ b/client/onboarding/test/validation.ts
@@ -33,9 +33,12 @@ describe( 'useValidation', () => {
 	} );
 
 	it( 'uses a generic string for a non existing error', () => {
-		const { result } = renderHook( () => useValidation( 'country' ), {
-			wrapper: OnboardingContextProvider,
-		} );
+		const { result } = renderHook(
+			() => useValidation( 'annual_revenue' ),
+			{
+				wrapper: OnboardingContextProvider,
+			}
+		);
 
 		act( () => result.current.validate() );
 


### PR DESCRIPTION
Fixes #6783

#### Changes proposed in this Pull Request

This issue adds a descriptive error messages to the empty first name, last name and business name fields.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
<img width="683" alt="Screenshot 2023-07-18 at 13 03 27" src="https://github.com/Automattic/woocommerce-payments/assets/2612426/78592ebd-ccfe-403f-9ad2-4e6ff51087bd">

<img width="683" alt="Screenshot 2023-07-18 at 13 04 46" src="https://github.com/Automattic/woocommerce-payments/assets/2612426/454f08b7-ad77-40d5-899a-9be834c2c2ea">


#### Testing instructions
- Set your currently onboarded account as deleted in the database
- Go Dev Tools and enable Progressive Onboarding
- Select "live account" in the selection mode
- Don't fill "First name" and "Last name" and see the updated messages
- Fill them and go to the next screen
- Don't fill "Business name" and see the updated message
- Make sure the generic message is not there anymore

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
