### PR TITLE
Reverse change made to the plugin name.

### DIFF
--- a/changelog/fix-wcpay-display-string
+++ b/changelog/fix-wcpay-display-string
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Reverting change to the plugin name because of compatibility with iOS app.

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: WooPayments
+ * Plugin Name: WooCommerce Payments
  * Plugin URI: https://woocommerce.com/payments/
  * Description: Accept payments via credit card. Manage transactions within WordPress.
  * Author: Automattic


### PR DESCRIPTION
Fixes #6807 

Fix for issue noticed in WCPay testing for next release.

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

The iOS application checks for the plugin name, expecting it to be `WooCommerce Payments`. Until we can implement a more generic solution to finding the plugin, it is necessary to rollback a change to make the name `WooPayments`.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Before checking out this branch, an API call to `/wp/v2/plugins` on the REST API of the WP Site should return `WooPayments`. ([ref](https://developer.wordpress.org/rest-api/reference/plugins/))
* After checking out this branch, the same request should return `WooCommerce Payments`.

Sample command:

`curl https://example.com/wp-json/wp/v2/plugins`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
