### PR TITLE
Migrate remaining classes to use init_hooks

### DIFF
--- a/changelog/add-init-hooks-1
+++ b/changelog/add-init-hooks-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Refactor the way hooks are initialized for non-admin classes

--- a/dev/phpcs/Sniffs/DisallowHooksInConstructorSniff.php
+++ b/dev/phpcs/Sniffs/DisallowHooksInConstructorSniff.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This sniff prohibits the use of add_action and add_filter in __construct.
+ */
+
+namespace WCPay\CodingStandards\Sniffs;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class DisallowHooksInConstructorSniff implements Sniff {
+	private $forbiddenFunctions = [
+		'add_action',
+		'add_filter',
+	];
+
+	/**
+	 * Returns the token types that this sniff is interested in.
+	 *
+	 * @return array<int>
+	 */
+	public function register() {
+		return [ \T_FUNCTION ];
+	}
+
+	/**
+	 * Processes the sniff if one of its tokens is encountered.
+	 *
+	 * @param File $phpcsFile The current file being checked.
+	 * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		// Check that we're looking at the __construct function.
+		$namePtr = $phpcsFile->findNext( T_STRING, $stackPtr + 1 );
+		$nameToken = $tokens[ $namePtr ];
+		if ( $nameToken['content'] !== '__construct' ) {
+			return;
+		}
+
+		// Retrieve the current token.
+		$token = $tokens[ $stackPtr ];
+
+		// Check the current token's scope.
+		$scopeOpener = $token['scope_opener'];
+		$scopeCloser = $token['scope_closer'];
+
+		// For every string token in the scope...
+		for ( $i = $scopeOpener; $i < $scopeCloser; $i++ ) {
+			if ( $tokens[ $i ]['type'] !== 'T_STRING' ) {
+				continue;
+			}
+			// ...check if it's one of the forbidden functions.
+			$currentToken        = $tokens[ $i ];
+			$currentTokenContent = $currentToken['content'];
+			if ( in_array( $currentTokenContent, $this->forbiddenFunctions ) ) {
+				$phpcsFile->addError(
+					"Usage of $currentTokenContent in __construct() is not allowed",
+					$i,
+					'WCPay.CodingStandards.DisallowHooksInConstructor',
+					$token['content']
+				);
+			}
+		}
+	}
+}

--- a/dev/phpcs/ruleset.xml
+++ b/dev/phpcs/ruleset.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset name="WCPay" namespace="WCPay\CodingStandards">
+	<description>WCPay custom coding standards.</description>
+
+	<exclude-pattern>*/includes/multi-currency/*</exclude-pattern>
+	<exclude-pattern>*/includes/subscriptions/*</exclude-pattern>
+	<exclude-pattern>*/includes/compat/subscriptions/*</exclude-pattern>
+	<exclude-pattern>*/includes/emails/*</exclude-pattern>
+</ruleset>

--- a/includes/admin/class-wc-payments-admin-sections-overwrite.php
+++ b/includes/admin/class-wc-payments-admin-sections-overwrite.php
@@ -25,7 +25,14 @@ class WC_Payments_Admin_Sections_Overwrite {
 	 */
 	public function __construct( WC_Payments_Account $account ) {
 		$this->account = $account;
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_filter( 'woocommerce_get_sections_checkout', [ $this, 'add_checkout_sections' ] );
 	}
 

--- a/includes/admin/class-wc-payments-admin-settings.php
+++ b/includes/admin/class-wc-payments-admin-settings.php
@@ -35,7 +35,14 @@ class WC_Payments_Admin_Settings {
 	 */
 	public function __construct( WC_Payment_Gateway_WCPay $gateway ) {
 		$this->gateway = $gateway;
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_action( 'woocommerce_woocommerce_payments_admin_notices', [ $this, 'display_test_mode_notice' ] );
 		add_filter( 'plugin_action_links_' . plugin_basename( WCPAY_PLUGIN_FILE ), [ $this, 'add_plugin_links' ] );
 	}

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -134,21 +134,6 @@ class WC_Payments_Admin {
 		$this->incentives_service  = $incentives_service;
 		$this->database_cache      = $database_cache;
 
-		add_action( 'admin_notices', [ $this, 'display_not_supported_currency_notice' ], 9999 );
-		add_action( 'admin_notices', [ $this, 'display_isk_decimal_notice' ] );
-
-		add_action( 'woocommerce_admin_order_data_after_payment_info', [ $this, 'render_order_edit_payment_details_container' ] );
-
-		// Add menu items.
-		add_action( 'admin_menu', [ $this, 'add_payments_menu' ], 0 );
-		add_action( 'admin_init', [ $this, 'maybe_redirect_to_onboarding' ], 11 ); // Run this after the WC setup wizard and onboarding redirection logic.
-		add_action( 'admin_enqueue_scripts', [ $this, 'maybe_redirect_overview_to_connect' ], 1 ); // Run this late (after `admin_init`) but before any scripts are actually enqueued.
-		add_action( 'admin_enqueue_scripts', [ $this, 'register_payments_scripts' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_payments_scripts' ], 12 );
-		add_action( 'woocommerce_admin_field_payment_gateways', [ $this, 'payment_gateways_container' ] );
-		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'show_woopay_payment_method_name_admin' ] );
-		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'display_wcpay_transaction_fee' ] );
-
 		$this->admin_child_pages = [
 			'wc-payments-overview'     => [
 				'id'       => 'wc-payments-overview',
@@ -191,6 +176,28 @@ class WC_Payments_Admin {
 				],
 			],
 		];
+	}
+
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
+		add_action( 'admin_notices', [ $this, 'display_not_supported_currency_notice' ], 9999 );
+		add_action( 'admin_notices', [ $this, 'display_isk_decimal_notice' ] );
+
+		add_action( 'woocommerce_admin_order_data_after_payment_info', [ $this, 'render_order_edit_payment_details_container' ] );
+
+		// Add menu items.
+		add_action( 'admin_menu', [ $this, 'add_payments_menu' ], 0 );
+		add_action( 'admin_init', [ $this, 'maybe_redirect_to_onboarding' ], 11 ); // Run this after the WC setup wizard and onboarding redirection logic.
+		add_action( 'admin_enqueue_scripts', [ $this, 'maybe_redirect_overview_to_connect' ], 1 ); // Run this late (after `admin_init`) but before any scripts are actually enqueued.
+		add_action( 'admin_enqueue_scripts', [ $this, 'register_payments_scripts' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_payments_scripts' ], 12 );
+		add_action( 'woocommerce_admin_field_payment_gateways', [ $this, 'payment_gateways_container' ] );
+		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'show_woopay_payment_method_name_admin' ] );
+		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'display_wcpay_transaction_fee' ] );
 	}
 
 	/**

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -69,7 +69,14 @@ class Database_Cache {
 	 */
 	public function __construct() {
 		$this->refresh_disabled = false;
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_action( 'action_scheduler_before_execute', [ $this, 'disable_refresh' ] );
 	}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -63,7 +63,14 @@ class WC_Payments_Account {
 		$this->payments_api_client      = $payments_api_client;
 		$this->database_cache           = $database_cache;
 		$this->action_scheduler_service = $action_scheduler_service;
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_action( 'admin_init', [ $this, 'maybe_handle_onboarding' ] );
 		add_action( 'admin_init', [ $this, 'maybe_redirect_to_onboarding' ], 11 ); // Run this after the WC setup wizard and onboarding redirection logic.
 		add_action( 'admin_init', [ $this, 'maybe_redirect_to_wcpay_connect' ], 12 ); // Run this after the redirect to onboarding logic.

--- a/includes/class-wc-payments-action-scheduler-service.php
+++ b/includes/class-wc-payments-action-scheduler-service.php
@@ -40,8 +40,6 @@ class WC_Payments_Action_Scheduler_Service {
 	) {
 		$this->payments_api_client = $payments_api_client;
 		$this->order_service       = $order_service;
-
-		$this->add_action_scheduler_hooks();
 	}
 
 	/**
@@ -49,7 +47,7 @@ class WC_Payments_Action_Scheduler_Service {
 	 *
 	 * @return void
 	 */
-	public function add_action_scheduler_hooks() {
+	public function init_hooks() {
 		add_action( 'wcpay_track_new_order', [ $this, 'track_new_order_action' ] );
 		add_action( 'wcpay_track_update_order', [ $this, 'track_update_order_action' ] );
 		add_action( WC_Payments_Order_Service::ADD_FEE_BREAKDOWN_TO_ORDER_NOTES, [ $this->order_service, 'add_fee_breakdown_to_order_notes' ], 10, 3 );

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -71,7 +71,14 @@ class WC_Payments_Apple_Pay_Registration {
 		$this->payments_api_client     = $payments_api_client;
 		$this->account                 = $account;
 		$this->gateway                 = $gateway;
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_action( 'init', [ $this, 'add_domain_association_rewrite_rule' ], 5 );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ $this, 'verify_domain_on_update' ] );
 		add_action( 'init', [ $this, 'init' ] );

--- a/includes/class-wc-payments-customer-service.php
+++ b/includes/class-wc-payments-customer-service.php
@@ -75,7 +75,14 @@ class WC_Payments_Customer_Service {
 		$this->payments_api_client = $payments_api_client;
 		$this->account             = $account;
 		$this->database_cache      = $database_cache;
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		/*
 		 * Adds the WooCommerce Payments customer ID found in the user session
 		 * to the WordPress user as metadata.

--- a/includes/class-wc-payments-dependency-service.php
+++ b/includes/class-wc-payments-dependency-service.php
@@ -25,10 +25,11 @@ class WC_Payments_Dependency_Service {
 	const DEV_ASSETS_NOT_BUILT  = 'dev_assets_not_built';
 
 	/**
-	 * Constructor.
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
 	 */
-	public function __construct() {
-
+	public function init_hooks() {
 		add_filter( 'admin_notices', [ $this, 'display_admin_notices' ] );
 	}
 

--- a/includes/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/class-wc-payments-express-checkout-button-display-handler.php
@@ -52,7 +52,14 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 
 		$is_woopay_enabled          = WC_Payments_Features::is_woopay_enabled();
 		$is_payment_request_enabled = 'yes' === $this->gateway->get_option( 'payment_request' );
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		if ( $is_woopay_enabled || $is_payment_request_enabled ) {
 			add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_express_checkout_buttons' ], 1 );
 			add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_express_checkout_buttons' ], 1 );

--- a/includes/class-wc-payments-express-checkout-button-display-handler.php
+++ b/includes/class-wc-payments-express-checkout-button-display-handler.php
@@ -46,12 +46,6 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 		$this->gateway                          = $gateway;
 		$this->payment_request_button_handler   = $payment_request_button_handler;
 		$this->platform_checkout_button_handler = $platform_checkout_button_handler;
-
-		$this->platform_checkout_button_handler->init();
-		$this->payment_request_button_handler->init();
-
-		$is_woopay_enabled          = WC_Payments_Features::is_woopay_enabled();
-		$is_payment_request_enabled = 'yes' === $this->gateway->get_option( 'payment_request' );
 	}
 
 	/**
@@ -59,7 +53,11 @@ class WC_Payments_Express_Checkout_Button_Display_Handler {
 	 *
 	 * @return void
 	 */
-	public function init_hooks() {
+	public function init() {
+		$this->platform_checkout_button_handler->init();
+		$this->payment_request_button_handler->init();
+		$is_woopay_enabled          = WC_Payments_Features::is_woopay_enabled();
+		$is_payment_request_enabled = 'yes' === $this->gateway->get_option( 'payment_request' );
 		if ( $is_woopay_enabled || $is_payment_request_enabled ) {
 			add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_express_checkout_buttons' ], 1 );
 			add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_express_checkout_buttons' ], 1 );

--- a/includes/class-wc-payments-fraud-service.php
+++ b/includes/class-wc-payments-fraud-service.php
@@ -50,7 +50,14 @@ class WC_Payments_Fraud_Service {
 		$this->payments_api_client = $payments_api_client;
 		$this->customer_service    = $customer_service;
 		$this->account             = $account;
+	}
 
+	/**
+	 * Initializes this class' WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_filter( 'wcpay_prepare_fraud_config', [ $this, 'prepare_fraud_config' ], 10, 2 );
 		add_action( 'init', [ $this, 'link_session_if_user_just_logged_in' ] );
 		add_action( 'admin_print_footer_scripts', [ $this, 'add_sift_js_tracker' ] );

--- a/includes/class-wc-payments-incentives-service.php
+++ b/includes/class-wc-payments-incentives-service.php
@@ -30,7 +30,14 @@ class WC_Payments_Incentives_Service {
 	 */
 	public function __construct( Database_Cache $database_cache ) {
 		$this->database_cache = $database_cache;
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_action( 'admin_menu', [ $this, 'add_payments_menu_badge' ] );
 		add_filter( 'woocommerce_admin_allowed_promo_notes', [ $this, 'allowed_promo_notes' ] );
 	}

--- a/includes/class-wc-payments-localization-service.php
+++ b/includes/class-wc-payments-localization-service.php
@@ -29,13 +29,6 @@ class WC_Payments_Localization_Service {
 	protected $locale_info = [];
 
 	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$this->load_locale_data();
-	}
-
-	/**
 	 * Retrieves the currency's format from mapped data.
 	 *
 	 * @param string $currency_code The currency code.
@@ -100,7 +93,7 @@ class WC_Payments_Localization_Service {
 	 *
 	 * @return void
 	 */
-	private function load_locale_data() {
+	public function load_locale_data() {
 		$transient_currency_format_data = get_transient( self::WCPAY_CURRENCY_FORMAT_TRANSIENT );
 		$transient_locale_info_data     = get_transient( self::WCPAY_LOCALE_INFO_TRANSIENT );
 

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -42,7 +42,14 @@ class WC_Payments_Onboarding_Service {
 	public function __construct( WC_Payments_API_Client $payments_api_client, Database_Cache $database_cache ) {
 		$this->payments_api_client = $payments_api_client;
 		$this->database_cache      = $database_cache;
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_filter( 'wcpay_dev_mode', [ $this, 'maybe_enable_dev_mode' ], 100 );
 		add_filter( 'admin_body_class', [ $this, 'add_admin_body_classes' ] );
 	}

--- a/includes/class-wc-payments-order-success-page.php
+++ b/includes/class-wc-payments-order-success-page.php
@@ -11,11 +11,12 @@ use WCPay\Duplicate_Payment_Prevention_Service;
  * Class handling order success page.
  */
 class WC_Payments_Order_Success_Page {
-
 	/**
-	 * Constructor.
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
 	 */
-	public function __construct() {
+	public function init_hooks() {
 		add_action( 'woocommerce_before_thankyou', [ $this, 'register_payment_method_override' ] );
 		add_action( 'woocommerce_order_details_before_order_table', [ $this, 'unregister_payment_method_override' ] );
 		add_filter( 'woocommerce_thankyou_order_received_text', [ $this, 'add_notice_previous_paid_order' ], 11 );

--- a/includes/class-wc-payments-status.php
+++ b/includes/class-wc-payments-status.php
@@ -36,7 +36,14 @@ class WC_Payments_Status {
 	public function __construct( $http, $account ) {
 		$this->http    = $http;
 		$this->account = $account;
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_action( 'woocommerce_system_status_report', [ $this, 'render_status_report_section' ] );
 		add_filter( 'woocommerce_debug_tools', [ $this, 'debug_tools' ] );
 	}

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -47,7 +47,14 @@ class WC_Payments_Token_Service {
 	public function __construct( WC_Payments_API_Client $payments_api_client, WC_Payments_Customer_Service $customer_service ) {
 		$this->payments_api_client = $payments_api_client;
 		$this->customer_service    = $customer_service;
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_action( 'woocommerce_payment_token_deleted', [ $this, 'woocommerce_payment_token_deleted' ], 10, 2 );
 		add_action( 'woocommerce_payment_token_set_default', [ $this, 'woocommerce_payment_token_set_default' ], 10, 2 );
 		add_filter( 'woocommerce_get_customer_payment_tokens', [ $this, 'woocommerce_get_customer_payment_tokens' ], 10, 3 );

--- a/includes/class-wc-payments-webhook-reliability-service.php
+++ b/includes/class-wc-payments-webhook-reliability-service.php
@@ -59,7 +59,14 @@ class WC_Payments_Webhook_Reliability_Service {
 		$this->payments_api_client        = $payments_api_client;
 		$this->action_scheduler_service   = $action_scheduler_service;
 		$this->webhook_processing_service = $webhook_processing_service;
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_action( 'woocommerce_payments_account_refreshed', [ $this, 'maybe_schedule_fetch_events' ] );
 		add_action( self::WEBHOOK_FETCH_EVENTS_ACTION, [ $this, 'fetch_events_and_schedule_processing_jobs' ] );
 		add_action( self::WEBHOOK_PROCESS_EVENT_ACTION, [ $this, 'process_event' ] );

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -299,10 +299,12 @@ class WC_Payments {
 
 		include_once __DIR__ . '/class-database-cache.php';
 		self::$database_cache = new Database_Cache();
+		self::$database_cache->init_hooks();
 
 		include_once __DIR__ . '/class-wc-payments-dependency-service.php';
 
 		self::$dependency_service = new WC_Payments_Dependency_Service();
+		self::$dependency_service->init_hooks();
 
 		if ( false === self::$dependency_service->has_valid_dependencies() ) {
 			return;
@@ -963,6 +965,7 @@ class WC_Payments {
 
 		if ( ! $http_class instanceof WC_Payments_Http_Interface ) {
 			$http_class = new WC_Payments_Http( new Automattic\Jetpack\Connection\Manager( 'woocommerce-payments' ) );
+			$http_class->init_hooks();
 		}
 
 		return $http_class;
@@ -1471,7 +1474,8 @@ class WC_Payments {
 				add_action( 'admin_init', [ $draft_orders, 'install' ] );
 			}
 
-			new WooPay_Order_Status_Sync( self::$api_client );
+			$woopay_order_status_sync = new WooPay_Order_Status_Sync( self::$api_client );
+			$woopay_order_status_sync->init_hooks();
 		}
 	}
 
@@ -1482,9 +1486,11 @@ class WC_Payments {
 	 */
 	public static function maybe_display_express_checkout_buttons() {
 		if ( WC_Payments_Features::are_payments_enabled() ) {
-			$payment_request_button_handler          = new WC_Payments_Payment_Request_Button_Handler( self::$account, self::get_gateway() );
-			$woopay_button_handler                   = new WC_Payments_WooPay_Button_Handler( self::$account, self::get_gateway(), self::$woopay_util );
+			$payment_request_button_handler = new WC_Payments_Payment_Request_Button_Handler( self::$account, self::get_gateway() );
+			$woopay_button_handler          = new WC_Payments_WooPay_Button_Handler( self::$account, self::get_gateway(), self::$woopay_util );
+
 			$express_checkout_button_display_handler = new WC_Payments_Express_Checkout_Button_Display_Handler( self::get_gateway(), $payment_request_button_handler, $woopay_button_handler );
+			$express_checkout_button_display_handler->init_hooks();
 		}
 	}
 
@@ -1723,7 +1729,8 @@ class WC_Payments {
 
 			include_once __DIR__ . '/woopay-user/class-woopay-save-user.php';
 
-			new WooPay_Save_User();
+			$woopay_save_user = new WooPay_Save_User();
+			$woopay_save_user->init_hooks();
 		}
 	}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1490,7 +1490,7 @@ class WC_Payments {
 			$woopay_button_handler          = new WC_Payments_WooPay_Button_Handler( self::$account, self::get_gateway(), self::$woopay_util );
 
 			$express_checkout_button_display_handler = new WC_Payments_Express_Checkout_Button_Display_Handler( self::get_gateway(), $payment_request_button_handler, $woopay_button_handler );
-			$express_checkout_button_display_handler->init_hooks();
+			$express_checkout_button_display_handler->init();
 		}
 	}
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -622,7 +622,7 @@ class WC_Payments {
 		}
 
 		if ( is_admin() && current_user_can( 'manage_woocommerce' ) ) {
-			new WC_Payments_Admin(
+			$wcpay_admin = new WC_Payments_Admin(
 				self::$api_client,
 				self::get_gateway(),
 				self::$account,
@@ -631,18 +631,23 @@ class WC_Payments {
 				self::$incentives_service,
 				self::$database_cache
 			);
+			$wcpay_admin->init_hooks();
 
-			new WC_Payments_Admin_Settings( self::get_gateway() );
+			$admin_settings = new WC_Payments_Admin_Settings( self::get_gateway() );
+			$admin_settings->init_hooks();
 
 			// Use tracks loader only in admin screens because it relies on WC_Tracks loaded by WC_Admin.
 			include_once WCPAY_ABSPATH . 'includes/admin/tracks/tracks-loader.php';
 
 			include_once __DIR__ . '/admin/class-wc-payments-admin-sections-overwrite.php';
-			new WC_Payments_Admin_Sections_Overwrite( self::get_account_service() );
+			$admin_sections_overwrite = new WC_Payments_Admin_Sections_Overwrite( self::get_account_service() );
+			$admin_sections_overwrite->init_hooks();
 
-			new WC_Payments_Status( self::get_wc_payments_http(), self::get_account_service() );
+			$wcpay_status = new WC_Payments_Status( self::get_wc_payments_http(), self::get_account_service() );
+			$wcpay_status->init_hooks();
 
-			new WCPay\Fraud_Prevention\Order_Fraud_And_Risk_Meta_Box( self::$order_service );
+			$order_fraud_meta_box = new WCPay\Fraud_Prevention\Order_Fraud_And_Risk_Meta_Box( self::$order_service );
+			$order_fraud_meta_box->init_hooks();
 		}
 
 		// Load WCPay Subscriptions.

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -48,9 +48,15 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 * @param \WC_Payments_Http_Interface $http    A class implementing WC_Payments_Http_Interface.
 	 */
 	public function __construct( $http ) {
-
 		$this->http = $http;
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_action( 'wp_ajax_platform_tracks', [ $this, 'ajax_tracks' ] );
 		add_action( 'wp_ajax_nopriv_platform_tracks', [ $this, 'ajax_tracks' ] );
 

--- a/includes/fraud-prevention/class-fraud-risk-tools.php
+++ b/includes/fraud-prevention/class-fraud-risk-tools.php
@@ -48,6 +48,7 @@ class Fraud_Risk_Tools {
 	public static function instance() {
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new self( WC_Payments::get_account_service() );
+			self::$instance->init_hooks();
 		}
 		return self::$instance;
 	}
@@ -66,6 +67,14 @@ class Fraud_Risk_Tools {
 	 */
 	public function __construct( WC_Payments_Account $payments_account ) {
 		$this->payments_account = $payments_account;
+	}
+
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		if ( is_admin() && current_user_can( 'manage_woocommerce' ) ) {
 			add_action( 'admin_menu', [ $this, 'init_advanced_settings_page' ] );
 		}

--- a/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
+++ b/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
@@ -30,9 +30,16 @@ class Order_Fraud_And_Risk_Meta_Box {
 	 * @param WC_Payments_Order_Service $order_service The order service.
 	 */
 	public function __construct( WC_Payments_Order_Service $order_service ) {
-		add_action( 'add_meta_boxes', [ $this, 'maybe_add_meta_box' ] );
-
 		$this->order_service = $order_service;
+	}
+
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
+		add_action( 'add_meta_boxes', [ $this, 'maybe_add_meta_box' ] );
 	}
 
 	/**

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -68,7 +68,14 @@ class WC_Payments_Invoice_Service {
 		$this->payments_api_client = $payments_api_client;
 		$this->product_service     = $product_service;
 		$this->order_service       = $order_service;
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		/**
 		 * When a store is in staging mode we don't want any order status chagnes to fire off corrisponding invoice requests to the server.
 		 *

--- a/includes/wc-payment-api/class-wc-payments-http.php
+++ b/includes/wc-payment-api/class-wc-payments-http.php
@@ -32,7 +32,14 @@ class WC_Payments_Http implements WC_Payments_Http_Interface {
 	 */
 	public function __construct( $connection_manager ) {
 		$this->connection_manager = $connection_manager;
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_filter( 'allowed_redirect_hosts', [ $this, 'allowed_redirect_hosts' ] );
 	}
 

--- a/includes/woopay-user/class-woopay-save-user.php
+++ b/includes/woopay-user/class-woopay-save-user.php
@@ -26,7 +26,14 @@ class WooPay_Save_User {
 	 */
 	public function __construct() {
 		$this->woopay_util = new WooPay_Utilities();
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_action( 'wp_enqueue_scripts', [ $this, 'register_checkout_page_scripts' ] );
 		add_filter( 'wcpay_metadata_from_order', [ $this, 'maybe_add_userdata_to_metadata' ], 10, 2 );
 		add_action( 'woocommerce_payment_complete', [ $this, 'maybe_clear_session_key' ], 10, 2 );

--- a/includes/woopay/class-woopay-order-status-sync.php
+++ b/includes/woopay/class-woopay-order-status-sync.php
@@ -36,7 +36,14 @@ class WooPay_Order_Status_Sync {
 	public function __construct( WC_Payments_API_Client $payments_api_client ) {
 
 		$this->payments_api_client = $payments_api_client;
+	}
 
+	/**
+	 * Initializes this class's WP hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
 		add_filter( 'woocommerce_webhook_topic_hooks', [ __CLASS__, 'add_topics' ], 20, 2 );
 		add_filter( 'woocommerce_webhook_payload', [ __CLASS__, 'create_payload' ], 10, 4 );
 		add_filter( 'woocommerce_valid_webhook_resources', [ __CLASS__, 'add_resource' ], 10, 1 );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,6 +7,7 @@
 	<arg name="extensions" value="php"/>
 
     <!-- Exclude paths -->
+	<exclude-pattern>./dev/*</exclude-pattern>
 	<exclude-pattern>./dist/*</exclude-pattern>
 	<exclude-pattern>./release/*</exclude-pattern>
 	<exclude-pattern>./docker/*</exclude-pattern>
@@ -68,4 +69,7 @@
 	</rule>
 
 	<rule ref="PEAR.WhiteSpace.ObjectOperatorIndent" />
+
+	<!-- Custom WCPay rules -->
+	<rule ref="./dev/phpcs/ruleset.xml"/>
 </ruleset>

--- a/tests/unit/admin/test-class-wc-payments-admin-sections-overwrite.php
+++ b/tests/unit/admin/test-class-wc-payments-admin-sections-overwrite.php
@@ -47,7 +47,8 @@ class WC_Payments_Admin_Sections_Overwrite_Test extends WCPAY_UnitTestCase {
 			->expects( $this->any() )
 			->method( 'get_cached_account_data' )
 			->willReturn( [ 'is_live' => true ] );
-		new WC_Payments_Admin_Sections_Overwrite( $this->account_service );
+		$admin_sections_overwrite = new WC_Payments_Admin_Sections_Overwrite( $this->account_service );
+		$admin_sections_overwrite->init_hooks();
 
 		$this->assertEquals(
 			$expected_sections,

--- a/tests/unit/test-class-wc-payments-account-capital.php
+++ b/tests/unit/test-class-wc-payments-account-capital.php
@@ -88,8 +88,11 @@ class WC_Payments_Account_Capital_Test extends WCPAY_UnitTestCase {
 
 	public function test_maybe_redirect_to_capital_offer_will_run() {
 		$wcpay_account = $this->getMockBuilder( WC_Payments_Account::class )
+			->setMethodsExcept( [ 'init_hooks' ] )
 			->setConstructorArgs( [ $this->mock_api_client, $this->mock_database_cache, $this->mock_action_scheduler_service ] )
 			->getMock();
+
+		$wcpay_account->init_hooks();
 
 		$this->assertNotFalse(
 			has_action( 'admin_init', [ $wcpay_account, 'maybe_redirect_to_capital_offer' ] )

--- a/tests/unit/test-class-wc-payments-account-link.php
+++ b/tests/unit/test-class-wc-payments-account-link.php
@@ -71,6 +71,7 @@ class WC_Payments_Account_Server_Links_Test extends WCPAY_UnitTestCase {
 			->setMethods( [ 'redirect_to' ] )
 			->setConstructorArgs( [ $this->mock_api_client, $this->mock_database_cache, $this->mock_action_scheduler_service ] )
 			->getMock();
+		$this->wcpay_account->init_hooks();
 	}
 
 	public function tear_down() {

--- a/tests/unit/test-class-wc-payments-apple-pay-registration.php
+++ b/tests/unit/test-class-wc-payments-apple-pay-registration.php
@@ -64,6 +64,7 @@ class WC_Payments_Apple_Pay_Registration_Test extends WCPAY_UnitTestCase {
 			->getMock();
 
 		$this->wc_apple_pay_registration = new WC_Payments_Apple_Pay_Registration( $this->mock_api_client, $this->mock_account, $mock_gateway );
+		$this->wc_apple_pay_registration->init_hooks();
 
 		$this->file_name             = 'apple-developer-merchantid-domain-association';
 		$this->initial_file_contents = file_get_contents( WCPAY_ABSPATH . '/' . $this->file_name ); // @codingStandardsIgnoreLine

--- a/tests/unit/test-class-wc-payments-fraud-service.php
+++ b/tests/unit/test-class-wc-payments-fraud-service.php
@@ -51,6 +51,7 @@ class WC_Payments_Fraud_Service_Test extends WCPAY_UnitTestCase {
 		$this->mock_account          = $this->createMock( WC_Payments_Account::class );
 
 		$this->fraud_service = new WC_Payments_Fraud_Service( $this->mock_api_client, $this->mock_customer_service, $this->mock_account );
+		$this->fraud_service->init_hooks();
 	}
 
 	public function test_registers_filters_and_actions_properly() {

--- a/tests/unit/test-class-wc-payments-incentives-service.php
+++ b/tests/unit/test-class-wc-payments-incentives-service.php
@@ -34,6 +34,7 @@ class WC_Payments_Incentives_Service_Test extends WCPAY_UnitTestCase {
 
 		$this->mock_database_cache = $this->createMock( Database_Cache::class );
 		$this->incentives_service  = new WC_Payments_Incentives_Service( $this->mock_database_cache );
+		$this->incentives_service->init_hooks();
 
 		global $menu;
 		// phpcs:ignore: WordPress.WP.GlobalVariablesOverride.Prohibited

--- a/tests/unit/test-class-wc-payments-localization-service.php
+++ b/tests/unit/test-class-wc-payments-localization-service.php
@@ -23,6 +23,7 @@ class WC_Payments_Localization_Service_Test extends WCPAY_UnitTestCase {
 		parent::set_up();
 
 		$this->localization_service = new WC_Payments_Localization_Service();
+		$this->localization_service->load_locale_data();
 	}
 
 	public function tear_down() {

--- a/tests/unit/test-class-wc-payments-onboarding-service.php
+++ b/tests/unit/test-class-wc-payments-onboarding-service.php
@@ -132,6 +132,7 @@ class WC_Payments_Onboarding_Service_Test extends WCPAY_UnitTestCase {
 		$this->mock_database_cache = $this->createMock( Database_Cache::class );
 
 		$this->onboarding_service = new WC_Payments_Onboarding_Service( $this->mock_api_client, $this->mock_database_cache );
+		$this->onboarding_service->init_hooks();
 	}
 
 	public function test_filters_registered_properly() {

--- a/tests/unit/test-class-wc-payments-webhook-reliability-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-reliability-service.php
@@ -70,7 +70,7 @@ class WC_Payments_Webhook_Reliability_Service_Test extends WCPAY_UnitTestCase {
 			$this->mock_action_scheduler_service,
 			$this->mock_webhook_processing_service
 		);
-
+		$this->webhook_reliability_service->init_hooks();
 	}
 	/**
 	 * Test that necessary filters are added when the WC_Payments_Webhook_Reliability_Service instance is created.


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/woocommerce-payments/pull/6326

Partial fix for https://github.com/Automattic/woocommerce-payments/issues/2769 and https://github.com/Automattic/woocommerce-payments/issues/5698

#### Changes proposed in this Pull Request

Similar to https://github.com/Automattic/woocommerce-payments/pull/6326, this PR moves the hooks initialization to a separate function. No change in functionality is expected.

#### Testing instructions

* Unit tests should pass
* Light smoke testing - make a transaction, refund, authorize a charge, make sure everything in the admin panel looks good

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
