### PR TITLE
Determine the proper setting for split UPE to work with WooPay

### DIFF
--- a/changelog/fix-split-upe-with-woopay-and-multiple-pms
+++ b/changelog/fix-split-upe-with-woopay-and-multiple-pms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve split UPE support of WooPay with multiple payment methods enabled.

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -176,7 +176,7 @@ class WC_Payments_Checkout {
 			'genericErrorMessage'            => __( 'There was a problem processing the payment. Please check your email inbox and refresh the page to try again.', 'woocommerce-payments' ),
 			'fraudServices'                  => $this->account->get_fraud_services_config(),
 			'features'                       => $this->gateway->supports,
-			'forceNetworkSavedCards'         => WC_Payments::is_network_saved_cards_enabled() || $this->gateway->should_use_stripe_platform_on_checkout_page(),
+			'forceNetworkSavedCards'         => WC_Payments::is_network_saved_cards_enabled() || WC_Payments::get_registered_card_gateway()->should_use_stripe_platform_on_checkout_page(),
 			'locale'                         => WC_Payments_Utils::convert_to_stripe_locale( get_locale() ),
 			'isPreview'                      => is_preview(),
 			'isUPEEnabled'                   => WC_Payments_Features::is_upe_enabled(),

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -770,6 +770,15 @@ class WC_Payments {
 	}
 
 	/**
+	 * Sets registered card gateway instance.
+	 *
+	 * @param WC_Payment_Gateway_WCPay|UPE_Payment_Gateway|UPE_Split_Payment_Gateway $gateway Gateway instance.
+	 */
+	public static function set_registered_card_gateway( $gateway ) {
+		self::$registered_card_gateway = $gateway;
+	}
+
+	/**
 	 * Called on Payments setting page.
 	 *
 	 * Remove all WCPay gateways except CC one.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2172,6 +2172,8 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'should_use_stripe_platform_on_checkout_page' )
 			->willReturn( true );
 
+		WC_Payments::set_registered_card_gateway( $mock_wcpay_gateway );
+
 		$payments_checkout = new WC_Payments_Checkout(
 			$mock_wcpay_gateway,
 			$this->woopay_utilities,
@@ -2180,6 +2182,26 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		);
 
 		$this->assertTrue( $payments_checkout->get_payment_fields_js_config()['forceNetworkSavedCards'] );
+	}
+
+	public function test_force_network_saved_cards_is_returned_as_false_if_should_not_use_stripe_platform() {
+		$mock_wcpay_gateway = $this->get_partial_mock_for_gateway( [ 'should_use_stripe_platform_on_checkout_page' ] );
+
+		$mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'should_use_stripe_platform_on_checkout_page' )
+			->willReturn( false );
+
+		WC_Payments::set_registered_card_gateway( $mock_wcpay_gateway );
+
+		$payments_checkout = new WC_Payments_Checkout(
+			$mock_wcpay_gateway,
+			$this->woopay_utilities,
+			$this->mock_wcpay_account,
+			$this->mock_customer_service
+		);
+
+		$this->assertFalse( $payments_checkout->get_payment_fields_js_config()['forceNetworkSavedCards'] );
 	}
 
 	public function test_is_woopay_enabled_returns_false_if_ineligible() {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/6730

#### Changes proposed in this Pull Request
This PR ensures that for the legacy card gateway in the split UPE, the correct flag is provided to the client side so that the proper Stripe account is used, depending on whether the WooPay is enabled or disabled. Due to the nature of rolling out scripts, we ended up overriding the proper `forceNetworkSavedCards` value with the UPE gateway, which was rolled out as the second and could never use WooPay, leading the flag having the value of `false` always.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable split UPE
2. Enable WooPay
3. Enable any number of additional payment methods other than the card
4. Attempt to purchase a product on the shortcode checkout while paying with card
5. Confirm that the payment went successfully and you were redirected to the _Order received_ page
6. Purchase a product with any other payment method like `giropay` or similar and confirm the successful purchase

Checkout to `develop`, perform steps 1-4 from above and confirm that instead of the fifth successful step, a user is seeing `Error: No such PaymentMethod: 'pm_${ID}'`.

Blocks checkout isn't affected, but making a single purchase and confirming it works will be appreciated.

Perform steps 1-5 for the legacy card gateway and steps 1-6 for the deferred intent creation UPE gateway. Also, sanity checks the legacy UPE checkout by performing steps 1-6 excluding step 2.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
