### PR TITLE
Fix Currency Switcher Block flag rendering on Windows platform

### DIFF
--- a/changelog/fix-6192-currency-switcher-block-on-windows
+++ b/changelog/fix-6192-currency-switcher-block-on-windows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Currency Switcher Block flag rendering on Windows platform.

--- a/client/multi-currency/blocks/currency-switcher.js
+++ b/client/multi-currency/blocks/currency-switcher.js
@@ -130,6 +130,16 @@ registerBlockType( 'woocommerce-payments/multi-currency-switcher', {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const blockProps = useBlockProps();
 
+		/**
+		 * WP Emoji replaces the flag emoji with an image if it's not natively
+		 * supported by the browser. This behavior is problematic on Windows
+		 * because it renders an <img> tag inside the <option>, which can lead to crashes.
+		 * We need to guarantee that the OS supports flag emojis before rendering it.
+		 */
+		const supportsFlagEmoji = window._wpemojiSettings
+			? window._wpemojiSettings.supports?.flag
+			: true;
+
 		const onChangeFlag = ( newFlag ) => {
 			setAttributes( { flag: newFlag } );
 		};
@@ -310,7 +320,7 @@ registerBlockType( 'woocommerce-payments/multi-currency-switcher', {
 									key={ enabledCurrencies[ code ].id }
 									value={ enabledCurrencies[ code ].code }
 								>
-									{ flag
+									{ supportsFlagEmoji && flag
 										? enabledCurrencies[ code ].flag + ' '
 										: '' }
 									{ symbol &&


### PR DESCRIPTION
Fixes #6192

WP Emoji replaces the flag emoji with an image if it's not natively supported by the browser. This behavior is problematic on Windows because it renders an `<img>` tag inside the `<option>`, which can lead to crashes.

> List of country flag emojis. 🇯🇵 🇰🇷 🇩🇪 🇨🇳 🇺🇸 🇫🇷 🇪🇸 🇮🇹 🇷🇺 🇬🇧 Emoji flags are supported on all major platforms **except [Windows](https://emojipedia.org/microsoft/),** which displays two-letter country codes instead of emoji flag images.
>
> Emojipedia - https://emojipedia.org/flags/

##### Exception
```
Uncaught DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
    at removeChild (wp-includes/js/dist/vendor/react-dom.js?ver=18.2.0:11109:20)
    at commitDeletionEffectsOnFiber (wp-includes/js/dist/vendor/react-dom.js?ver=18.2.0:24038:17)
    at commitDeletionEffects (wp-includes/js/dist/vendor/react-dom.js?ver=18.2.0:23986:7)
    at recursivelyTraverseMutationEffects (wp-includes/js/dist/vendor/react-dom.js?ver=18.2.0:24269:11)
    at commitMutationEffectsOnFiber (wp-includes/js/dist/vendor/react-dom.js?ver=18.2.0:24356:11)
    at recursivelyTraverseMutationEffects (wp-includes/js/dist/vendor/react-dom.js?ver=18.2.0:24283:9)
    at commitMutationEffectsOnFiber (wp-includes/js/dist/vendor/react-dom.js?ver=18.2.0:24586:11)
    at recursivelyTraverseMutationEffects (wp-includes/js/dist/vendor/react-dom.js?ver=18.2.0:24283:9)
    at commitMutationEffectsOnFiber (wp-includes/js/dist/vendor/react-dom.js?ver=18.2.0:24356:11)
    at recursivelyTraverseMutationEffects (wp-includes/js/dist/vendor/react-dom.js?ver=18.2.0:24283:9)
```

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

* Checks if the OS supports emoji flags before rendering it.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing requirement

- Windows 10 platform

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Before checking out to this branch
* Setup jurassic tube by running `npm run tube:setup`
* Start the jurassic tube `npm run tube:start`
* Open your test site on your jurassic tube domain
* Go to **Appearance > Widgets**
* On the sidebar, add the block "Currency Switcher Block"
* Click on the block and check "Display flags" on the side panel
* Unfocus the block by clicking anywhere, click on the block again, and uncheck "Display flags"
* The block should crash

![#6192](https://user-images.githubusercontent.com/41110392/235696573-fa5326c1-df57-4d05-9e73-c9e60ea6c4dc.gif)

##### Checkout to this branch
* Repeat the steps above
* The block shouldn't crash anymore
* I tested it on different environments and browsers, but feel free to test on the ones you have access
* Stop the jurassic tube `npm run tube:stop`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
