### PR TITLE
Add a notice that Apple Pay and Google Pay are not available in all contries

### DIFF
--- a/changelog/add-6389-notification-not-available
+++ b/changelog/add-6389-notification-not-available
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add notice that Apple Pay and Google Pay are not available in all countries.

--- a/client/settings/express-checkout-settings/payment-request-settings.js
+++ b/client/settings/express-checkout-settings/payment-request-settings.js
@@ -11,6 +11,7 @@ import { Card, CheckboxControl } from '@wordpress/components';
  */
 import CardBody from '../card-body';
 import GeneralPaymentRequestButtonSettings from './general-payment-request-button-settings';
+import ExpressCheckoutIncompatibilityNotice from '../settings-warnings/express-checkout-incompatibility-notice';
 import {
 	usePaymentRequestEnabledSettings,
 	usePaymentRequestLocations,
@@ -44,6 +45,7 @@ const PaymentRequestSettings = ( { section } ) => {
 		<Card>
 			{ 'enable' === section && (
 				<CardBody>
+					<ExpressCheckoutIncompatibilityNotice />
 					<CheckboxControl
 						checked={ isPaymentRequestEnabled }
 						onChange={ updateIsPaymentRequestEnabled }

--- a/client/settings/express-checkout/apple-google-pay-item.js
+++ b/client/settings/express-checkout/apple-google-pay-item.js
@@ -11,6 +11,7 @@ import interpolateComponents from '@automattic/interpolate-components';
 import { getPaymentMethodSettingsUrl } from '../../utils';
 import ApplePay from 'assets/images/cards/apple-pay.svg?asset';
 import GooglePay from 'assets/images/cards/google-pay.svg?asset';
+import ExpressCheckoutIncompatibilityNotice from '../settings-warnings/express-checkout-incompatibility-notice';
 import { usePaymentRequestEnabledSettings } from 'wcpay/data';
 
 const AppleGooglePayExpressCheckoutItem = () => {
@@ -144,6 +145,8 @@ const AppleGooglePayExpressCheckoutItem = () => {
 					</a>
 				</div>
 			</div>
+
+			<ExpressCheckoutIncompatibilityNotice />
 		</li>
 	);
 };

--- a/client/settings/settings-warnings/express-checkout-incompatibility-notice.js
+++ b/client/settings/settings-warnings/express-checkout-incompatibility-notice.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import interpolateComponents from '@automattic/interpolate-components';
+
+/**
+ * Internal dependencies
+ */
+import { Notice } from '@wordpress/components';
+import NoticeOutlineIcon from 'gridicons/dist/notice-outline';
+import './style.scss';
+
+const ExpressCheckoutIncompatibilityNotice = () => (
+	<Notice
+		status="warning"
+		isDismissible={ false }
+		className="express-checkout__notice express-checkout__apple-google-incompatibility-warning"
+	>
+		<span>
+			<NoticeOutlineIcon
+				style={ {
+					color: '#F0B849',
+					fill: 'currentColor',
+					marginBottom: '-5px',
+					marginRight: '10px',
+				} }
+				size={ 20 }
+			/>
+		</span>
+		<span>
+			{ interpolateComponents( {
+				mixedString: __(
+					/* eslint-disable-next-line max-len */
+					'Apple Pay and Google Pay are not available in all countries and may not work for you. ' +
+						/* eslint-disable-next-line max-len */
+						"Please check {{appleLink}}Apple's{{/appleLink}} or {{googleLink}}Google's{{/googleLink}} website for more details.",
+					'woocommerce-payments'
+				),
+				components: {
+					googleLink: (
+						// eslint-disable-next-line jsx-a11y/anchor-has-content
+						<a
+							target="_blank"
+							rel="noreferrer"
+							href="https://support.google.com/googlepay/answer/12429287"
+						/>
+					),
+					appleLink: (
+						// eslint-disable-next-line jsx-a11y/anchor-has-content
+						<a
+							target="_blank"
+							rel="noreferrer"
+							/* eslint-disable-next-line max-len */
+							href="https://support.apple.com/en-us/HT207957"
+						/>
+					),
+				},
+			} ) }
+		</span>
+	</Notice>
+);
+
+export default ExpressCheckoutIncompatibilityNotice;


### PR DESCRIPTION
Fixes #6389

#### Changes proposed in this Pull Request
This PR adds a warning notice on the `Express Checkout` section and `Apple Pay and Google Pay Customize` page that Apple Pay and Google Pay are unavailable in all countries.

**Express Checkout** section
<img width="1042" alt="Screenshot 2023-07-21 at 18 56 53" src="https://github.com/Automattic/woocommerce-payments/assets/8667118/2e489c49-2f39-4b31-aa73-9954e7c057fe">

**Apple Pay and Google Pay** Customize button
<img width="1039" alt="Screenshot 2023-07-21 at 18 57 26" src="https://github.com/Automattic/woocommerce-payments/assets/8667118/f6288734-ad66-46d2-bf9f-ffcce6f04e69">

**Mobile**
<img width="343" alt="Screenshot 2023-07-21 at 18 57 43" src="https://github.com/Automattic/woocommerce-payments/assets/8667118/02ffe74e-029b-4266-8f67-32d164ac018f">



#### Testing instructions
**Test case 1**
- Navigate to `Payments` -> `Settings`.
- Scroll down to the `Express Checkout` section.
- Verify the text `Apple Pay and Google Pay are not available in all countries and may not work for you. Please check [Apple's](https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/) or [Google's](https://stripe.com/apple-pay/legal) website for more details.` is displayed under Apple Pay and Google Pay checkbox.

**Test case 2**
- Navigate to `Payments` -> `Settings`.
- Scroll down to the `Express Checkout` section.
- Click on `Customize` button next to `Apple Pay and Google Pay` checkbox.
- Verify the text `Apple Pay and Google Pay are not available in all countries and may not work for you. Please check [Apple's](https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/) or [Google's](https://stripe.com/apple-pay/legal) website for more details.` is displayed above `Enable` checkbox.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**
- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
