### PR TITLE
Release branch for 6.2.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 *** WooPayments Changelog ***
 
+= 6.2.1 - 2023-07-25 =
+
 = 6.2.0 - 2023-07-19 =
 * Add - Add Android option in Device type advanced filter
 * Add - Add dispute notice to the WooCommerce order screen to highlight disputes awaiting a response.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooPayments Changelog ***
 
 = 6.2.1 - 2023-07-25 =
+* Fix - Move the email title hook from the UPE class to the parent legacy gateway class, to avoid multiple callback invocations for the split UPE
 
 = 6.2.0 - 2023-07-19 =
 * Add - Add Android option in Device type advanced filter

--- a/changelog/fix-e2e-test-workflow
+++ b/changelog/fix-e2e-test-workflow
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Fix the server E2E tests workflow by not deleting the dependencies if a specific env variable is not true
-
-

--- a/changelog/fix-multiple-payment-methods-fetching
+++ b/changelog/fix-multiple-payment-methods-fetching
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Move the email title hook from the UPE class to the parent legacy gateway class, to avoid multiple callback invocations for the split UPE

--- a/changelog/fix-multiple-payment-methods-fetching
+++ b/changelog/fix-multiple-payment-methods-fetching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Move the email title hook from the UPE class to the parent legacy gateway class, to avoid multiple callback invocations for the split UPE

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -97,6 +97,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 
 		add_action( 'wp_enqueue_scripts', [ $this, 'register_scripts' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'register_scripts_for_zero_order_total' ], 11 );
+		add_action( 'woocommerce_email_before_order_table', [ $this->gateway, 'set_payment_method_title_for_email' ], 10, 3 );
 	}
 
 	/**

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -114,10 +114,10 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	 * @return void
 	 */
 	public function init_hooks() {
+		// Initializing a hook within this function increases the probability of multiple calls for each split UPE gateway. Consider adding the hook in the parent hook initialization.
 		if ( ! is_admin() ) {
 			add_filter( 'woocommerce_gateway_title', [ $this, 'maybe_filter_gateway_title' ], 10, 2 );
 		}
-		add_action( 'woocommerce_email_before_order_table', [ $this, 'set_payment_method_title_for_email' ], 10, 3 );
 		parent::init_hooks();
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "woocommerce-payments",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "woocommerce-payments",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-payments",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "main": "webpack.config.js",
   "author": "Automattic",
   "license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: payment gateway, payment, apple pay, credit card, google pay
 Requires at least: 6.0
 Tested up to: 6.2
 Requires PHP: 7.3
-Stable tag: 6.2.0
+Stable tag: 6.2.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,9 @@ Please note that our support for the checkout block is still experimental and th
 4. Manage Disputes
 
 == Changelog ==
+
+= 6.2.1 - 2023-07-25 =
+
 
 = 6.2.0 - 2023-07-19 =
 * Add - Add Android option in Device type advanced filter

--- a/readme.txt
+++ b/readme.txt
@@ -95,6 +95,7 @@ Please note that our support for the checkout block is still experimental and th
 == Changelog ==
 
 = 6.2.1 - 2023-07-25 =
+* Fix - Move the email title hook from the UPE class to the parent legacy gateway class, to avoid multiple callback invocations for the split UPE
 
 
 = 6.2.0 - 2023-07-19 =

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -12,7 +12,7 @@
  * WC tested up to: 7.8.0
  * Requires at least: 6.0
  * Requires PHP: 7.3
- * Version: 6.2.0
+ * Version: 6.2.1
  *
  * @package WooCommerce\Payments
  */


### PR DESCRIPTION
:warning: Please do not merge the PR from the GitHub interface. :warning:

 Instead, you can use the following command:
```
 git checkout release/6.2.1 && git pull 
 git checkout trunk && git pull 
 git merge --no-ff release/6.2.1 -m 'Merge release/6.2.1 into trunk' 
 git push origin trunk 
``` 
 Changelog: 
```
Fix - Move the email title hook from the UPE class to the parent legacy gateway class, to avoid multiple callback invocations for the split UPE
```