### PR TITLE
Add Tracks account connect events

### DIFF
--- a/changelog/add-6859-tracks-account-connect-events
+++ b/changelog/add-6859-tracks-account-connect-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add Tracks events around account connect when promo is active.

--- a/client/connect-account-page/index.tsx
+++ b/client/connect-account-page/index.tsx
@@ -52,6 +52,11 @@ const ConnectAccountPage: React.FC = () => {
 			...( incentive && {
 				incentive_id: incentive.id,
 			} ),
+			woo_country_code:
+				wcSettings?.preloadSettings?.general
+					?.woocommerce_default_country ||
+				wcSettings?.admin?.preloadSettings?.general
+					?.woocommerce_default_country,
 		} );
 		// We only want to run this once.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -96,6 +101,11 @@ const ConnectAccountPage: React.FC = () => {
 			...( incentive && {
 				incentive_id: incentive.id,
 			} ),
+			woo_country_code:
+				wcSettings?.preloadSettings?.general
+					?.woocommerce_default_country ||
+				wcSettings?.admin?.preloadSettings?.general
+					?.woocommerce_default_country,
 		} );
 
 		// If there is an incentive available, request promo activation before redirecting.

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -765,13 +765,21 @@ class WC_Payments_Admin {
 			Logger::log( sprintf( 'WCPay JS settings: Could not determine if WCPay should be in test mode! Message: %s', $e->getMessage() ), 'warning' );
 		}
 
+		$connect_url       = WC_Payments_Account::get_connect_url();
+		$connect_incentive = $this->incentives_service->get_cached_connect_incentive();
+		// If we have an incentive ID, attach it to the connect URL.
+		if ( ! empty( $connect_incentive['id'] ) ) {
+			$connect_url = add_query_arg( [ 'promo' => sanitize_text_field( $connect_incentive['id'] ) ], $connect_url );
+		}
+
 		$this->wcpay_js_settings = [
-			'connectUrl'                  => WC_Payments_Account::get_connect_url(),
+			'connectUrl'                  => $connect_url,
 			'connect'                     => [
 				'country'            => WC()->countries->get_base_country(),
 				'availableCountries' => WC_Payments_Utils::supported_countries(),
 				'availableStates'    => WC()->countries->get_states(),
 			],
+			'connectIncentive'            => $connect_incentive,
 			'testMode'                    => $test_mode,
 			'onboardingTestMode'          => WC_Payments_Onboarding_Service::is_test_mode_enabled(),
 			// Set this flag for use in the front-end to alter messages and notices if on-boarding has been disabled.
@@ -820,7 +828,6 @@ class WC_Payments_Admin {
 			'frtDiscoverBannerSettings'   => get_option( 'wcpay_frt_discover_banner_settings', '' ),
 			'storeCurrency'               => get_option( 'woocommerce_currency' ),
 			'isBnplAffirmAfterpayEnabled' => WC_Payments_Features::is_bnpl_affirm_afterpay_enabled(),
-			'connectIncentive'            => $this->incentives_service->get_cached_connect_incentive(),
 		];
 
 		return apply_filters( 'wcpay_js_settings', $this->wcpay_js_settings );

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -34,6 +34,7 @@ class WC_Payments_Account {
 	const TRACKS_EVENT_ACCOUNT_CONNECT_START                    = 'wcpay_account_connect_start';
 	const TRACKS_EVENT_ACCOUNT_CONNECT_WPCOM_CONNECTION_SUCCESS = 'wcpay_account_connect_wpcom_connection_success';
 	const TRACKS_EVENT_ACCOUNT_CONNECT_FINISHED                 = 'wcpay_account_connect_finished';
+	const TRACKS_EVENT_KYC_REMINDER_MERCHANT_RETURNED           = 'wcpay_kyc_reminder_merchant_returned';
 
 	/**
 	 * Client for making requests to the WooCommerce Payments API
@@ -724,7 +725,7 @@ class WC_Payments_Account {
 			'offset'      => $offset,
 			'description' => $description,
 		];
-		wc_admin_record_tracks_event( 'wcpay_kyc_reminder_merchant_returned', $track_props );
+		$this->tracks_event( self::TRACKS_EVENT_KYC_REMINDER_MERCHANT_RETURNED, $track_props );
 
 		// Take the user to the 'wcpay-connect' URL.
 		// We handle creating and redirecting to the account link there.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -26,11 +26,14 @@ use WCPay\Database_Cache;
 class WC_Payments_Account {
 
 	// ACCOUNT_OPTION is only used in the supporting dev tools plugin, it can be removed once everyone has upgraded.
-	const ACCOUNT_OPTION                   = 'wcpay_account_data';
-	const ON_BOARDING_DISABLED_TRANSIENT   = 'wcpay_on_boarding_disabled';
-	const ON_BOARDING_STARTED_TRANSIENT    = 'wcpay_on_boarding_started';
-	const ERROR_MESSAGE_TRANSIENT          = 'wcpay_error_message';
-	const INSTANT_DEPOSITS_REMINDER_ACTION = 'wcpay_instant_deposit_reminder';
+	const ACCOUNT_OPTION                                        = 'wcpay_account_data';
+	const ON_BOARDING_DISABLED_TRANSIENT                        = 'wcpay_on_boarding_disabled';
+	const ON_BOARDING_STARTED_TRANSIENT                         = 'wcpay_on_boarding_started';
+	const ERROR_MESSAGE_TRANSIENT                               = 'wcpay_error_message';
+	const INSTANT_DEPOSITS_REMINDER_ACTION                      = 'wcpay_instant_deposit_reminder';
+	const TRACKS_EVENT_ACCOUNT_CONNECT_START                    = 'wcpay_account_connect_start';
+	const TRACKS_EVENT_ACCOUNT_CONNECT_WPCOM_CONNECTION_SUCCESS = 'wcpay_account_connect_wpcom_connection_success';
+	const TRACKS_EVENT_ACCOUNT_CONNECT_FINISHED                 = 'wcpay_account_connect_finished';
 
 	/**
 	 * Client for making requests to the WooCommerce Payments API
@@ -780,6 +783,22 @@ class WC_Payments_Account {
 		}
 
 		if ( isset( $_GET['wcpay-connect'] ) && check_admin_referer( 'wcpay-connect' ) ) {
+			$incentive = ! empty( $_GET['promo'] ) ? sanitize_text_field( wp_unslash( $_GET['promo'] ) ) : '';
+
+			// Track connection start with promo incentive.
+			if ( ! isset( $_GET['wcpay-connect-jetpack-success'] )
+				&& ! empty( $incentive ) ) {
+
+				$event_properties = [
+					'incentive'        => $incentive,
+					'woo_country_code' => WC()->countries->get_base_country(),
+				];
+				$this->tracks_event(
+					self::TRACKS_EVENT_ACCOUNT_CONNECT_START,
+					$event_properties
+				);
+			}
+
 			$wcpay_connect_param = sanitize_text_field( wp_unslash( $_GET['wcpay-connect'] ) );
 
 			$from_wc_admin_task       = 'WCADMIN_PAYMENT_TASK' === $wcpay_connect_param;
@@ -797,19 +816,34 @@ class WC_Payments_Account {
 			// Hide menu notification badge upon starting setup.
 			update_option( 'wcpay_menu_badge_hidden', 'yes' );
 
-			if ( isset( $_GET['wcpay-connect-jetpack-success'] ) && ! $this->payments_api_client->is_server_connected() ) {
-				$this->redirect_to_onboarding_welcome_page(
-					sprintf(
+			if ( isset( $_GET['wcpay-connect-jetpack-success'] ) ) {
+				if ( ! $this->payments_api_client->is_server_connected() ) {
+					$this->redirect_to_onboarding_welcome_page(
+						sprintf(
 						/* translators: %s: WooPayments */
-						__( 'Connection to WordPress.com failed. Please connect to WordPress.com to start using %s.', 'woocommerce-payments' ),
-						'WooPayments'
-					)
-				);
-				return;
+							__( 'Connection to WordPress.com failed. Please connect to WordPress.com to start using %s.', 'woocommerce-payments' ),
+							'WooPayments'
+						)
+					);
+
+					return;
+				}
+
+				// Track successful Jetpack connection with promo incentive.
+				if ( ! empty( $incentive ) ) {
+					$event_properties = [
+						'incentive'        => $incentive,
+						'woo_country_code' => WC()->countries->get_base_country(),
+					];
+					$this->tracks_event(
+						self::TRACKS_EVENT_ACCOUNT_CONNECT_WPCOM_CONNECTION_SUCCESS,
+						$event_properties
+					);
+				}
 			}
 
 			try {
-				$this->maybe_init_jetpack_connection( $wcpay_connect_param );
+				$this->maybe_init_jetpack_connection( $wcpay_connect_param, [ 'promo' => $incentive ] );
 			} catch ( Exception $e ) {
 				$this->redirect_to_onboarding_welcome_page(
 				/* translators: error message. */
@@ -819,7 +853,7 @@ class WC_Payments_Account {
 			}
 
 			try {
-				$this->init_stripe_onboarding( $wcpay_connect_param );
+				$this->init_stripe_onboarding( $wcpay_connect_param, [ 'promo' => $incentive ] );
 			} catch ( Exception $e ) {
 				Logger::error( 'Init Stripe onboarding flow failed. ' . $e );
 				$this->redirect_to_onboarding_welcome_page(
@@ -951,21 +985,25 @@ class WC_Payments_Account {
 	 * Starts the Jetpack connection flow if it's not already fully connected.
 	 *
 	 * @param string $wcpay_connect_from - where the user should be returned to after connecting.
+	 * @param array  $additional_args    - additional query args to add to the return URL.
 	 *
 	 * @throws API_Exception If there was an error when registering the site on WP.com.
 	 */
-	private function maybe_init_jetpack_connection( $wcpay_connect_from ) {
+	private function maybe_init_jetpack_connection( $wcpay_connect_from, $additional_args = [] ) {
 		$is_jetpack_fully_connected = $this->payments_api_client->is_server_connected() && $this->payments_api_client->has_server_connection_owner();
 		if ( $is_jetpack_fully_connected ) {
 			return;
 		}
 
 		$redirect = add_query_arg(
-			[
-				'wcpay-connect'                 => $wcpay_connect_from,
-				'wcpay-connect-jetpack-success' => '1',
-				'_wpnonce'                      => wp_create_nonce( 'wcpay-connect' ),
-			],
+			array_merge(
+				[
+					'wcpay-connect'                 => $wcpay_connect_from,
+					'wcpay-connect-jetpack-success' => '1',
+					'_wpnonce'                      => wp_create_nonce( 'wcpay-connect' ),
+				],
+				$additional_args
+			),
 			$this->get_onboarding_return_url( $wcpay_connect_from )
 		);
 		$this->payments_api_client->start_server_connection( $redirect );
@@ -1024,8 +1062,9 @@ class WC_Payments_Account {
 	 * Initializes the onboarding flow by fetching the URL from the API and redirecting to it.
 	 *
 	 * @param string $wcpay_connect_from - where the user should be returned to after connecting.
+	 * @param array  $additional_args    - additional query args to add to the return URL.
 	 */
-	private function init_stripe_onboarding( $wcpay_connect_from ) {
+	private function init_stripe_onboarding( $wcpay_connect_from, $additional_args = [] ) {
 		if ( get_transient( self::ON_BOARDING_STARTED_TRANSIENT ) ) {
 			$this->redirect_to_onboarding_welcome_page(
 				__( 'There was a duplicate attempt to initiate account setup. Please wait a few seconds and try again.', 'woocommerce-payments' )
@@ -1047,6 +1086,9 @@ class WC_Payments_Account {
 
 		$current_user = wp_get_current_user();
 		$return_url   = $this->get_onboarding_return_url( $wcpay_connect_from );
+		if ( ! empty( $additional_args ) ) {
+			$return_url = add_query_arg( $additional_args, $return_url );
+		}
 
 		// Flags to enable progressive onboarding and collect payout requirements.
 		$progressive                 = isset( $_GET['progressive'] ) && 'true' === $_GET['progressive'];
@@ -1190,6 +1232,19 @@ class WC_Payments_Account {
 
 		// Automatically enable split UPE for new stores.
 		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
+
+		// Track account connection finish with promo incentive.
+		$incentive = ! empty( $_GET['promo'] ) ? sanitize_text_field( wp_unslash( $_GET['promo'] ) ) : '';
+		if ( ! empty( $incentive ) ) {
+			$event_properties = [
+				'incentive'        => $incentive,
+				'woo_country_code' => WC()->countries->get_base_country(),
+			];
+			$this->tracks_event(
+				self::TRACKS_EVENT_ACCOUNT_CONNECT_FINISHED,
+				$event_properties
+			);
+		}
 
 		wp_safe_redirect(
 			add_query_arg(
@@ -1607,7 +1662,7 @@ class WC_Payments_Account {
 
 	/**
 	 * Redirects to the onboarding flow page if the Progressive Onboarding feature flag is enabled or in the experiment treatment mode.
-	 * Also checks if the server is connect and try to connect it otherwise.
+	 * Also checks if the server is connected and try to connect it otherwise.
 	 *
 	 * @return void
 	 */
@@ -1623,5 +1678,25 @@ class WC_Payments_Account {
 		} else {
 			$this->redirect_to( $onboarding_url );
 		}
+	}
+
+	/**
+	 * Send a Tracks event.
+	 *
+	 * @param string $name       The event name.
+	 * @param array  $properties Optional. The event custom properties.
+	 *
+	 * @return void
+	 */
+	private function tracks_event( string $name, array $properties = [] ) {
+		if ( ! function_exists( 'wc_admin_record_tracks_event' ) ) {
+			return;
+		}
+
+		// We're not using Tracker::track_admin() here because
+		// WC_Pay\record_tracker_events() is never triggered due to the redirects.
+		wc_admin_record_tracks_event( $name, $properties );
+
+		Logger::info( 'Tracks event: ' . $name . ' with data: ' . wp_json_encode( WC_Payments_Utils::redact_array( $properties, [ 'woo_country_code' ] ) ) );
 	}
 }


### PR DESCRIPTION
Fixes #6859 
Related https://github.com/Automattic/woocommerce-payments-server/issues/3706
Related https://github.com/Automattic/woocommerce-payments-server/issues/3492

### Changes proposed in this Pull Request

- Add `wcadmin_wcpay_account_connect_start` server-side Tracks event at the beginning of WCPay onboarding (aka connection)
- Add `wcadmin_wcpay_account_connect_wpcom_connection_success` server-side Tracks event once the Jetpack (aka WPCOM) connection is established
- Add `wcadmin_wcpay_account_connect_finished` server-side Tracks event at the end of WCPay onboarding (aka connection)
- Attach the Woo store country code to JS Tracks sent for the Connect page (view and click).

### Testing instructions

#### Local testing

* Checkout the PR branch on your local client
* Make sure you delete any WCPay accounts from your local server
* Make sure you don't have any orders or payment gateways active
* Make sure your store's install timestamp is not older than 90 days (edit the `woocommerce_admin_install_timestamp` option value in your client's `wp_options` [table](http://localhost:8083/index.php?route=/table/search&db=wordpress&table=wp_options))
* Make sure you [enable Tracking for WooCommerce](http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com)
* Clear the account cache from the WCPay Dev Tools and you should see the Action Incentive active on the Connect page.
* Go through onboarding
* In your client's [WooCommerce Tracks logs](http://localhost:8082/wp-admin/admin.php?page=wc-status&tab=logs) you should see the `wcadmin_wcpay_account_connect_start` and `wcadmin_wcpay_account_connect_finished` events with the promo ID attached to them.

#### JN testing

For the `wcadmin_wcpay_account_connect_wpcom_connection_success` Tracks event you need to use a JN site that is not connected. 
Go through the same steps, and you should see the Tracks events beside the other two.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
