### PR TITLE
Fix WooPay compatibility for MailPoet versions above v4.18.0

### DIFF
--- a/changelog/fix-woopay-mailpoet-integration
+++ b/changelog/fix-woopay-mailpoet-integration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fatal error when using latest MailPoet with WooPay

--- a/includes/compat/blocks/class-blocks-data-extractor.php
+++ b/includes/compat/blocks/class-blocks-data-extractor.php
@@ -104,12 +104,13 @@ class Blocks_Data_Extractor {
 		 */
 		$settings_instance = \MailPoet\Settings\SettingsController::getInstance();
 		$settings          = [
-			'defaultText'  => $settings_instance->get( 'woocommerce.optin_on_checkout.message', '' ),
-			'optinEnabled' => $settings_instance->get( 'woocommerce.optin_on_checkout.enabled', false ),
+			'defaultText'   => $settings_instance->get( 'woocommerce.optin_on_checkout.message', '' ),
+			'optinEnabled'  => $settings_instance->get( 'woocommerce.optin_on_checkout.enabled', false ),
+			'defaultStatus' => false,
 		];
 
 		if ( version_compare( \MAILPOET_VERSION, '4.18.0', '<=' ) ) {
-			array_push( $settings, [ 'defaultStatus' => $mailpoet_wc_subscription->isCurrentUserSubscribed() ] );
+			$settings['defaultStatus'] = $mailpoet_wc_subscription->isCurrentUserSubscribed();
 		}
 		return $settings;
 	}

--- a/includes/compat/blocks/class-blocks-data-extractor.php
+++ b/includes/compat/blocks/class-blocks-data-extractor.php
@@ -104,10 +104,13 @@ class Blocks_Data_Extractor {
 		 */
 		$settings_instance = \MailPoet\Settings\SettingsController::getInstance();
 		$settings          = [
-			'defaultText'   => $settings_instance->get( 'woocommerce.optin_on_checkout.message', '' ),
-			'optinEnabled'  => $settings_instance->get( 'woocommerce.optin_on_checkout.enabled', false ),
-			'defaultStatus' => $mailpoet_wc_subscription->isCurrentUserSubscribed(),
+			'defaultText'  => $settings_instance->get( 'woocommerce.optin_on_checkout.message', '' ),
+			'optinEnabled' => $settings_instance->get( 'woocommerce.optin_on_checkout.enabled', false ),
 		];
+
+		if ( version_compare( \MAILPOET_VERSION, '4.18.0', '<=' ) ) {
+			array_push( $settings, [ 'defaultStatus' => $mailpoet_wc_subscription->isCurrentUserSubscribed() ] );
+		}
 		return $settings;
 	}
 


### PR DESCRIPTION
This fixes a Fatal error when attempting to checkout using WooPay on stores having the latest Mailpoet version (v4.22.0).

Reported in Slack: p1690398779835349-slack-C022WMN88KG

#### Changes proposed in this Pull Request

Mailpoet versions above v4.18.0 no longer pass `defaultStatus` setting to its Newsletter block integration. This change updates WooPay's Mailpoet integration so that `defaultStatus` setting is set accordingly.



<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install [MailPoet v4.17.1](https://github.com/mailpoet/mailpoet/releases/tag/4.17.1)
* Add a product to the cart and go through WooPay checkout.
* Make sure you're able to get to WooPay checkout screen.
* Upgrade MailPoet to [v4.22.0](https://github.com/mailpoet/mailpoet/releases/tag/4.22.0)
* Make sure you're able to get to WooPay checkout screen.
* Deactivate MailPoet and make sure WooPay checkout still works.

Optional
Go through the test instructions in this [PR](https://github.com/Automattic/woopay/pull/1643)


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.