### PR TITLE
Fix extra requests when clicking WooPay express checkout button

### DIFF
--- a/changelog/fix-woopay-express-button-extra-requests
+++ b/changelog/fix-woopay-express-button-extra-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix extra requests when clicking WooPay express checkout button.

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -148,6 +148,9 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 	const closeIframe = () => {
 		window.removeEventListener( 'resize', getWindowSize );
 		window.removeEventListener( 'resize', setPopoverPosition );
+		window.removeEventListener( 'pageshow', onPageShow );
+		window.removeEventListener( 'message', onMessage );
+		document.removeEventListener( 'keyup', onKeyUp );
 
 		iframeWrapper.remove();
 		iframe.classList.remove( 'open' );
@@ -162,6 +165,10 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 		if ( document.querySelector( '.woopay-otp-iframe' ) ) {
 			return;
 		}
+
+		window.addEventListener( 'pageshow', onPageShow );
+		window.addEventListener( 'message', onMessage );
+		document.addEventListener( 'keyup', onKeyUp );
 
 		const viewportWidth = window.document.documentElement.clientWidth;
 		const viewportHeight = window.document.documentElement.clientHeight;
@@ -200,13 +207,7 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 		iframe.focus();
 	};
 
-	document.addEventListener( 'keyup', ( event ) => {
-		if ( event.key === 'Escape' && closeIframe() ) {
-			event.stopPropagation();
-		}
-	} );
-
-	window.addEventListener( 'message', ( e ) => {
+	function onMessage( e ) {
 		if ( ! getConfig( 'woopayHost' ).startsWith( e.origin ) ) {
 			return;
 		}
@@ -264,14 +265,20 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 			default:
 			// do nothing, only respond to expected actions.
 		}
-	} );
+	}
 
-	window.addEventListener( 'pageshow', function ( event ) {
+	function onPageShow( event ) {
 		if ( event.persisted ) {
 			// Safari needs to close iframe with this.
 			closeIframe( false );
 		}
-	} );
+	}
+
+	function onKeyUp( event ) {
+		if ( event.key === 'Escape' && closeIframe() ) {
+			event.stopPropagation();
+		}
+	}
 
 	openIframe( woopayEmailInput?.value );
 };


### PR DESCRIPTION
Fixes #6866

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
Currently WCPay adds some listeners to `window` and `document` when opening the WooPay express button iframe and does not remove these listeners when we close the iframe, this way the events are executed one more time every time we open this iframe, this PR fixes that by removing the events when the iframe is closed.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable express checkout button on WooPay settings.
* Add a product to the cart.
* Go to a page with the WooPay express checkout.
* Open the DevTools network tab.
* Click the WooPay express checkout button.
* Wait one request to `/?wc-ajax=wcpay_init_woopay`.
* There should only one request to this endpoint.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
