### PR TITLE
Migrate WCPay shopper tracks to wcpay prefix

### DIFF
--- a/changelog/add-track-wcpay-shopper-events
+++ b/changelog/add-track-wcpay-shopper-events
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Migrate certain WCPay shopper tracks to use wcpay prefix

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -189,7 +189,11 @@ export const handleWooPayEmailInput = async (
 		window.addEventListener( 'resize', setPopoverPosition );
 
 		iframe.classList.add( 'open' );
-		wcpayTracks.recordUserEvent( wcpayTracks.events.WOOPAY_OTP_START );
+		wcpayTracks.recordUserEvent(
+			wcpayTracks.events.WOOPAY_OTP_START,
+			[],
+			true
+		);
 	} );
 
 	// Add the iframe and iframe arrow to the wrapper.
@@ -369,7 +373,9 @@ export const handleWooPayEmailInput = async (
 					openIframe( email );
 				} else if ( data.code !== 'rest_invalid_param' ) {
 					wcpayTracks.recordUserEvent(
-						wcpayTracks.events.WOOPAY_OFFERED
+						wcpayTracks.events.WOOPAY_OFFERED,
+						[],
+						true
 					);
 				}
 			} )
@@ -503,7 +509,9 @@ export const handleWooPayEmailInput = async (
 			case 'redirect_to_platform_checkout':
 			case 'redirect_to_woopay':
 				wcpayTracks.recordUserEvent(
-					wcpayTracks.events.WOOPAY_OTP_COMPLETE
+					wcpayTracks.events.WOOPAY_OTP_COMPLETE,
+					[],
+					true
 				);
 				api.initWooPay(
 					woopayEmailInput.value,
@@ -530,7 +538,9 @@ export const handleWooPayEmailInput = async (
 				break;
 			case 'otp_validation_failed':
 				wcpayTracks.recordUserEvent(
-					wcpayTracks.events.WOOPAY_OTP_FAILED
+					wcpayTracks.events.WOOPAY_OTP_FAILED,
+					[],
+					true
 				);
 				break;
 			case 'close_modal':
@@ -589,7 +599,11 @@ export const handleWooPayEmailInput = async (
 			dispatchUserExistEvent( true );
 		}, 2000 );
 
-		wcpayTracks.recordUserEvent( wcpayTracks.events.WOOPAY_SKIPPED );
+		wcpayTracks.recordUserEvent(
+			wcpayTracks.events.WOOPAY_SKIPPED,
+			[],
+			true
+		);
 
 		searchParams.delete( 'skip_woopay' );
 

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -93,7 +93,11 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 		window.addEventListener( 'resize', setPopoverPosition );
 
 		iframe.classList.add( 'open' );
-		wcpayTracks.recordUserEvent( wcpayTracks.events.WOOPAY_OTP_START );
+		wcpayTracks.recordUserEvent(
+			wcpayTracks.events.WOOPAY_OTP_START,
+			[],
+			true
+		);
 	} );
 
 	// Add the iframe to the wrapper.
@@ -218,7 +222,9 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 			case 'redirect_to_platform_checkout':
 			case 'redirect_to_woopay':
 				wcpayTracks.recordUserEvent(
-					wcpayTracks.events.WOOPAY_OTP_COMPLETE
+					wcpayTracks.events.WOOPAY_OTP_COMPLETE,
+					[],
+					true
 				);
 				api.initWooPay(
 					userEmail,
@@ -238,7 +244,9 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 				break;
 			case 'otp_validation_failed':
 				wcpayTracks.recordUserEvent(
-					wcpayTracks.events.WOOPAY_OTP_FAILED
+					wcpayTracks.events.WOOPAY_OTP_FAILED,
+					[],
+					true
 				);
 				break;
 			case 'close_modal':

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -39,9 +39,9 @@ export const WoopayExpressCheckoutButton = ( {
 	useEffect( () => {
 		if ( ! isPreview ) {
 			wcpayTracks.recordUserEvent(
-				wcpayTracks.events.WOOPAY_EXPRESS_BUTTON_OFFERED,
+				wcpayTracks.events.WOOPAY_BUTTON_LOAD,
 				{
-					context,
+					source: context,
 				}
 			);
 		}
@@ -54,12 +54,9 @@ export const WoopayExpressCheckoutButton = ( {
 			return; // eslint-disable-line no-useless-return
 		}
 
-		wcpayTracks.recordUserEvent(
-			wcpayTracks.events.WOOPAY_EXPRESS_BUTTON_CLICKED,
-			{
-				context: context,
-			}
-		);
+		wcpayTracks.recordUserEvent( wcpayTracks.events.WOOPAY_BUTTON_CLICK, {
+			source: context,
+		} );
 
 		if ( isProductPage ) {
 			addToCart()

--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -35,8 +35,9 @@ function recordEvent( eventName, eventProperties ) {
  *
  * @param {string}  eventName         Name of the event.
  * @param {Object}  [eventProperties] Event properties (optional).
+ * @param {boolean} isLegacy Event properties (optional).
  */
-function recordUserEvent( eventName, eventProperties ) {
+function recordUserEvent( eventName, eventProperties, isLegacy = false ) {
 	const nonce =
 		getConfig( 'platformTrackerNonce' ) ??
 		getPaymentRequestData( 'nonce' )?.platform_tracker;
@@ -48,6 +49,7 @@ function recordUserEvent( eventName, eventProperties ) {
 	body.append( 'action', 'platform_tracks' );
 	body.append( 'tracksEventName', eventName );
 	body.append( 'tracksEventProp', JSON.stringify( eventProperties ) );
+	body.append( 'isLegacy', isLegacy );
 	fetch( ajaxUrl, {
 		method: 'post',
 		body,
@@ -95,10 +97,10 @@ const events = {
 	WOOPAY_OTP_START: 'woopay_otp_prompt_start',
 	WOOPAY_OTP_COMPLETE: 'woopay_otp_prompt_complete',
 	WOOPAY_OTP_FAILED: 'woopay_otp_prompt_failed',
-	WOOPAY_AUTO_REDIRECT: 'woopay_auto_redirect',
+	WOOPAY_AUTO_REDIRECT: 'checkout_woopay_auto_redirect',
 	WOOPAY_SKIPPED: 'woopay_skipped',
-	WOOPAY_EXPRESS_BUTTON_OFFERED: 'woopay_express_button_offered',
-	WOOPAY_EXPRESS_BUTTON_CLICKED: 'woopay_express_button_clicked',
+	WOOPAY_BUTTON_LOAD: 'woopay_button_load',
+	WOOPAY_BUTTON_CLICK: 'woopay_button_click',
 	// Onboarding flow.
 	ONBOARDING_FLOW_STARTED: 'wcpay_onboarding_flow_started',
 	ONBOARDING_FLOW_MODE_SELECTED: 'wcpay_onboarding_flow_mode_selected',

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -194,7 +194,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 			return false;
 		}
 
-		// Track without checking for .
+		// Track all events without checking for WooPay availability.
 		if ( $track_on_all_stores ) {
 			return true;
 		}

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -12,6 +12,7 @@ use Jetpack_Tracks_Event;
 use WC_Payments;
 use WC_Payments_Features;
 use WP_Error;
+use WCPay\Logger;
 
 defined( 'ABSPATH' ) || exit; // block direct access.
 
@@ -21,11 +22,18 @@ defined( 'ABSPATH' ) || exit; // block direct access.
 class WooPay_Tracker extends Jetpack_Tracks_Client {
 
 	/**
-	 * WooPay user event prefix
+	 * Legacy prefix used for WooPay user events
 	 *
 	 * @var string
 	 */
-	private static $user_prefix = 'woocommerceanalytics';
+	private static $legacy_user_prefix = 'woocommerceanalytics';
+
+	/**
+	 * WCPay user event prefix
+	 *
+	 * @var string
+	 */
+	private static $user_prefix = 'wcpay';
 
 	/**
 	 * WooPay admin event prefix
@@ -55,8 +63,8 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		add_action( 'wp_ajax_nopriv_platform_tracks', [ $this, 'ajax_tracks' ] );
 
 		// Actions that should result in recorded Tracks events.
-		add_action( 'woocommerce_after_checkout_form', [ $this, 'checkout_start' ] );
-		add_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after', [ $this, 'checkout_start' ] );
+		add_action( 'woocommerce_after_checkout_form', [ $this, 'classic_checkout_start' ] );
+		add_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after', [ $this, 'blocks_checkout_start' ] );
 		add_action( 'woocommerce_checkout_order_processed', [ $this, 'checkout_order_processed' ] );
 		add_action( 'woocommerce_blocks_checkout_order_processed', [ $this, 'checkout_order_processed' ] );
 		add_action( 'woocommerce_payments_save_user_in_woopay', [ $this, 'must_save_payment_method_to_platform' ] );
@@ -92,8 +100,10 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 				$tracks_data = $event_prop;
 			}
 		}
-
-		$this->maybe_record_event( sanitize_text_field( wp_unslash( $_REQUEST['tracksEventName'] ) ), $tracks_data );
+		// Legacy events are shopper events that still use the woocommerceanalytics prefix.
+		// These need to be migrated to the wcpay prefix.
+		$is_legacy_event = isset( $_REQUEST['isLegacy'] ) ? rest_sanitize_boolean( wc_clean( wp_unslash( $_REQUEST['isLegacy'] ) ) ) : false;
+		$this->maybe_record_event( sanitize_text_field( wp_unslash( $_REQUEST['tracksEventName'] ) ), $tracks_data, $is_legacy_event );
 
 		wp_send_json_success();
 	}
@@ -101,16 +111,36 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	/**
 	 * Generic method to track user events.
 	 *
+	 * @param string  $event name of the event.
+	 * @param array   $data array of event properties.
+	 * @param boolean $is_legacy indicate whether this is a legacy event.
+	 */
+	public function maybe_record_event( $event, $data = [], $is_legacy = true ) {
+		// Top level events should not be namespaced.
+		if ( '_aliasUser' !== $event ) {
+			$prefix = $is_legacy ? self::$legacy_user_prefix : self::$user_prefix;
+			$event  = $prefix . '_' . $event;
+		}
+
+		return $this->tracks_record_event( $event, $data );
+	}
+
+	/**
+	 * Track shopper events with the wcpay_prefix.
+	 *
 	 * @param string $event name of the event.
 	 * @param array  $data array of event properties.
 	 */
-	public function maybe_record_event( $event, $data = [] ) {
+	public function maybe_record_wcpay_shopper_event( $event, $data = [] ) {
 		// Top level events should not be namespaced.
 		if ( '_aliasUser' !== $event ) {
 			$event = self::$user_prefix . '_' . $event;
 		}
 
-		return $this->tracks_record_event( $event, $data );
+		$is_admin_event      = false;
+		$track_on_all_stores = true;
+
+		return $this->tracks_record_event( $event, $data, $is_admin_event, $track_on_all_stores );
 	}
 
 	/**
@@ -134,10 +164,11 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 * Override parent method to omit the jetpack TOS check.
 	 *
 	 * @param bool $is_admin_event Indicate whether the event is emitted from admin area.
+	 * @param bool $track_on_all_stores Indicate whether the event is tracked on all WCPay stores.
 	 *
 	 * @return bool
 	 */
-	public function should_enable_tracking( $is_admin_event = false ) {
+	public function should_enable_tracking( $is_admin_event = false, $track_on_all_stores = false ) {
 		// Always respect the user specific opt-out cookie.
 		if ( ! empty( $_COOKIE['tk_opt-out'] ) ) {
 			return false;
@@ -151,7 +182,8 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 		// For all other events ensure:
 		// 1. Only site pages are tracked.
 		// 2. Site Admin activity in site pages are not tracked.
-		// 3. Site page tracking is only enabled when WooPay is active.
+		// 3. If track_on_all_stores is enabled, track all events.
+		// 4. Otherwise, track only when WooPay is active.
 
 		// Track only site pages.
 		if ( is_admin() && ! wp_doing_ajax() ) {
@@ -163,7 +195,12 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 			return false;
 		}
 
-		// Don't track when woopay is disabled.
+		// Track without checking for .
+		if ( $track_on_all_stores ) {
+			return true;
+		}
+
+		// For the remaining events, don't track when woopay is disabled.
 		$gateway            = \WC_Payments::get_gateway();
 		$is_woopay_eligible = WC_Payments_Features::is_woopay_eligible(); // Feature flag.
 		$is_woopay_enabled  = 'yes' === $gateway->get_option( 'platform_checkout', 'no' );
@@ -307,22 +344,42 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 
 
 	/**
-	 * Record a Tracks event that the checkout has started.
+	 * Record a Tracks event that the classic checkout page has loaded.
 	 */
-	public function checkout_start() {
-		$this->maybe_record_event( 'order_checkout_start' );
+	public function classic_checkout_start() {
+		$is_woopay_enabled = WC_Payments_Features::is_woopay_enabled();
+		$this->maybe_record_wcpay_shopper_event(
+			'checkout_page_view',
+			[
+				'theme_type'     => 'short_code',
+				'woopay_enabled' => $is_woopay_enabled,
+			]
+		);
+	}
+
+	/**
+	 * Record a Tracks event that the blocks checkout page has loaded.
+	 */
+	public function blocks_checkout_start() {
+		$is_woopay_enabled = WC_Payments_Features::is_woopay_enabled();
+		$this->maybe_record_wcpay_shopper_event(
+			'checkout_page_view',
+			[
+				'theme_type'     => 'blocks',
+				'woopay_enabled' => $is_woopay_enabled,
+			]
+		);
 	}
 
 	/**
 	 * Record a Tracks event that the order has been processed.
 	 */
 	public function checkout_order_processed() {
-		$this->maybe_record_event(
-			'order_checkout_complete',
-			[
-				'source' => ( isset( $_SERVER['HTTP_USER_AGENT'] ) && 'WooPay' === $_SERVER['HTTP_USER_AGENT'] ) ? 'platform' : 'standard',
-			]
-		);
+		$is_woopay_order = ( isset( $_SERVER['HTTP_USER_AGENT'] ) && 'WooPay' === $_SERVER['HTTP_USER_AGENT'] );
+		// Don't track WooPay orders. They will be tracked on WooPay side with more flow specific details.
+		if ( ! $is_woopay_order ) {
+			$this->maybe_record_wcpay_shopper_event( 'checkout_order_placed' );
+		}
 	}
 
 	/**

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -12,7 +12,6 @@ use Jetpack_Tracks_Event;
 use WC_Payments;
 use WC_Payments_Features;
 use WP_Error;
-use WCPay\Logger;
 
 defined( 'ABSPATH' ) || exit; // block direct access.
 


### PR DESCRIPTION
Related p2: paJDYF-9HR-p2
Related WooPay issue: 1907-gh-Automattic/woopay

#### Changes proposed in this Pull Request
- Rename some shopper-originated Tracks events and migrate them to `wcpay` prefix.
- Track `wcpay_checkout_page_view` and `wcpay_checkout_order_placed` on all WCPay stores.
- Make sure `checkout_order_placed` is only tracked on non WooPay checkouts.
- Introduce `theme_type` and `woopay_enabled` props to `wcpay_checkout_page_view` event.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**wcpay_woopay_button_click**
* Make sure WooPay Express Button is enabled in the cart, product, and checkout pages.
* As a non-admin user, add a product to the chart, visit the checkout page, and click the WooPay button.
* In ~5 minutes, search MC's Tracks live for the `wcpay_woopay_button_click` event.
* Ensure "Filter for only rejected events" checkbox is selected. Because `wcpay` prefix is still unregistered, these events are currently rejected. 
* Make sure there's an event from your test blog containing the `source: checkout` property.
* Redo the test for button in cart and product pages and ensure the `source` property contains the correct value.

**wcpay_checkout_order_placed**
* Place a standard checkout order (without using WooPay)
* In ~5 minutes, search MC live view for `wcpay_checkout_order_placed` and ensure an event exists.
* Place a WooPay order
* In ~5 minutes, search MC live view for `wcpay_checkout_order_placed` and ensure an event does not appear.

**wcpay_checkout_page_view**
* Make sure WooPay is enabled on the store
* As a non-admin user, add a product to the cart, and go to the classic checkout page.
* Then view the Blocks checkout page.
* In ~5 minutes, search MC live view for `wcpay_checkout_page_view` two events.
* Make sure one event has `woopay_enabled: true` and `theme_type: short_code` properties.
* The other event has `woopay_enabled: true` and `theme_type: blocks` properties.
* Disable WooPay.
* Repeat the steps from 2nd step.
* Ensure that `woopay_enabled: false` property is present in the two events.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.