### PR TITLE
Add constant flag to use the new payment service

### DIFF
--- a/changelog/rpp-6675-use-payment-service
+++ b/changelog/rpp-6675-use-payment-service
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add constant flag to use the new payment service (project reengineering payment process).

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -718,8 +718,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public function process_payment( $order_id ) {
 
 		if ( defined( 'WCPAY_NEW_PROCESS' ) && true === WCPAY_NEW_PROCESS ) {
-			$new_payment_processing_service = new PaymentProcessingService();
-			return $new_payment_processing_service->process_payment( $order_id );
+			$new_process = new PaymentProcessingService();
+			return $new_process->process_payment( $order_id );
 		}
 
 		$order = wc_get_order( $order_id );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -40,6 +40,7 @@ use WCPay\WooPay\WooPay_Order_Status_Sync;
 use WCPay\WooPay\WooPay_Utilities;
 use WCPay\Session_Rate_Limiter;
 use WCPay\Tracker;
+use WCPay\Internal\Service\PaymentProcessingService;
 
 /**
  * Gateway class for WooPayments
@@ -715,6 +716,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @throws Exception Error processing the payment.
 	 */
 	public function process_payment( $order_id ) {
+
+		if ( defined( 'WCPAY_NEW_PROCESS' ) && true === WCPAY_NEW_PROCESS ) {
+			$new_payment_processing_service = new PaymentProcessingService();
+			return $new_payment_processing_service->process_payment( $order_id );
+		}
+
 		$order = wc_get_order( $order_id );
 
 		try {

--- a/src/Internal/Service/PaymentProcessingService.php
+++ b/src/Internal/Service/PaymentProcessingService.php
@@ -7,7 +7,7 @@
 
 namespace WCPay\Internal\Service;
 
-use Exception;
+use Exception; // Temporary exception! This service would have its own exception when more business logics are added.
 
 /**
  *  Payment Processing Service.

--- a/src/Internal/Service/PaymentProcessingService.php
+++ b/src/Internal/Service/PaymentProcessingService.php
@@ -7,9 +7,21 @@
 
 namespace WCPay\Internal\Service;
 
+use Exception;
+
 /**
  *  Payment Processing Service.
  */
 class PaymentProcessingService {
 
+	/**
+	 * Process payment.
+	 *
+	 * @param  int $order_id Order ID provided by WooCommerce core.
+	 *
+	 * @throws Exception
+	 */
+	public function process_payment( int $order_id ) {
+		throw new Exception( 'Re-engineering payment process is in-progress. Sit tight, and wait more!' );
+	}
 }


### PR DESCRIPTION
Fixes #6675

#### Changes proposed in this Pull Request

- Add constant flag to conditionally use the new payment service in `WC_Payment_Gateway_WCPay::process_payment()`.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- Test the legacy card flow (no UPE at all), everything is still the same.
- Add `define( 'WCPAY_NEW_PROCESS', true );` to the main file of plugin `woocommerce-payments.php` or `wp-config.php`, and try to check out. See this error:  
![Markup on 2023-08-02 at 12:13:22](https://github.com/Automattic/woocommerce-payments/assets/10045087/2727c13f-0523-4e3a-bdb6-a09e6ebad5fc)

- Ideally, test both classic and block checkouts. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
