### PR TITLE
Prefill Business Name and Country Fields

### DIFF
--- a/changelog/dev-6878-prefill-po-fields
+++ b/changelog/dev-6878-prefill-po-fields
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Prefill the Business Name and Country fields during WooPayments KYC.

--- a/client/onboarding/index.tsx
+++ b/client/onboarding/index.tsx
@@ -60,6 +60,8 @@ const OnboardingPage: React.FC = () => {
 	const businessUrl = isLocalhost
 		? 'https://wcpay.test'
 		: wcSettings?.homeUrl ?? '';
+	const businessName = wcSettings?.siteTitle ?? '';
+	const country = wcpaySettings?.connect?.country ?? '';
 
 	useEffect( () => {
 		trackStarted();
@@ -80,7 +82,13 @@ const OnboardingPage: React.FC = () => {
 
 	return (
 		<div className="wcpay-onboarding-prototype">
-			<OnboardingContextProvider initialData={ { url: businessUrl } }>
+			<OnboardingContextProvider
+				initialData={ {
+					business_name: businessName,
+					url: businessUrl,
+					country: country,
+				} }
+			>
 				<OnboardingStepper />
 			</OnboardingContextProvider>
 		</div>


### PR DESCRIPTION
Fixes #6878 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

* Prefill the business name field with the store title.
* Prefill the country field with the store country.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Disconnect any accounts linked with your store (you can do this by going to `localhost:8087` and updating the `account_type` field for any active accounts in the `wcpay_accounts` table to something other than `wcpay`. 
* Start an onboarding with the `Progressive Onboarding` flag enabled in the dev tools.
* On the third page of the form (business details), you should see the business name field filled out with the store title, and the country prefilled with the WooCommerce store country.
* Ensure the values of the `company type` question are correct for your country.
* Complete an onboarding and ensure the account is created correctly.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
