### PR TITLE
Don't show the congratulations modal if user is in test mode.

### DIFF
--- a/changelog/dev-test-mode-update
+++ b/changelog/dev-test-mode-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Only show the post-onboarding congratulations message if user did not onboard in test mode.

--- a/client/overview/connection-sucess-notice.tsx
+++ b/client/overview/connection-sucess-notice.tsx
@@ -17,6 +17,7 @@ const ConnectionSuccessNotice: React.FC = () => {
 		accountStatus: {
 			progressiveOnboarding: { isComplete, isEnabled },
 		},
+		onboardingTestMode,
 	} = wcpaySettings;
 
 	const DismissMenu = () => {
@@ -36,7 +37,7 @@ const ConnectionSuccessNotice: React.FC = () => {
 		);
 	};
 
-	return ! isDismissed ? (
+	return ! isDismissed && ! onboardingTestMode ? (
 		<Card className="wcpay-connection-success">
 			{ /* Show dismiss button only at the end of Progressive Onboarding //
 			or at the end of the full KYC flow. */ }


### PR DESCRIPTION
Fixes #6893 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

* Update to only show the congratulations message post-onboarding if a live account has been onboarded.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

**Note**: Because of some inconsistencies with how test/live onboardings work on local environment, it's better to test this in Jurassic Ninja. 

* Spin up a JN site using this branch.
*  Install the dev tools, set `Progressive Onboarding enabled`. Do _not_ enable WCPay Dev Mode.
* Perform an onboarding using the new UX, select the test/builder flow. Complete the onboarding.
* After onboarding, you'll be redirected to the `Account > Overview` Page. Verify that you **cannot** see the "Congratulations" message shown in the screenshot below.

<img width="273" alt="Screenshot 2023-08-01 at 14 30 13" src="https://github.com/Automattic/woocommerce-payments/assets/11770181/76753127-5886-4d92-9b54-77d24ed04822">


* Now, use the `Setup Live Payments on your store` notice on the overview page to re-enter the onboarding.
* Complete the onboarding, this time as a live account. (Note that you can use a `US` account with `individual`, `sole trader` and the lowest TPV estimate to trigger the progressive flow so you don't have to complete a full onboarding with real details).
* After the onboarding, you should now see the `Congratulations` message.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
