### PR TITLE
Improvement: Query optimisation for get_all_customer_currencies method

### DIFF
--- a/changelog/6852-get_all_customer_currencies_improvement
+++ b/changelog/6852-get_all_customer_currencies_improvement
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Improved `get_all_customer_currencies` method to retrieve existing order currencies faster.

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -1455,18 +1455,19 @@ class MultiCurrency {
 		if ( class_exists( 'Automattic\WooCommerce\Utilities\OrderUtil' ) &&
 					\Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			foreach ( $currencies as $currency ) {
-				$query_union[] = sprintf(
-					'SELECT "%1$s" AS currency_code, EXISTS(SELECT currency FROM %2$s WHERE currency="%1$s" LIMIT 1) AS exists_in_orders',
+				$query_union[] = $wpdb->prepare(
+					"SELECT %s AS currency_code, EXISTS(SELECT currency FROM {$wpdb->prefix}wc_orders WHERE currency=%s LIMIT 1) AS exists_in_orders",
 					$currency->code,
-					$wpdb->prefix . 'wc_orders'
+					$currency->code
 				);
 			}
 		} else {
 			foreach ( $currencies as $currency ) {
-				$query_union[] = sprintf(
-					'SELECT "%1$s" AS currency_code, EXISTS(SELECT meta_value FROM %2$s WHERE meta_key="_order_currency" AND meta_value="%1$s" LIMIT 1) AS exists_in_orders',
+				$query_union[] = $wpdb->prepare(
+					"SELECT %s AS currency_code, EXISTS(SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key=%s AND meta_value=%s LIMIT 1) AS exists_in_orders",
 					$currency->code,
-					$wpdb->postmeta
+					'_order_currency',
+					$currency->code
 				);
 			}
 		}

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -1480,6 +1480,7 @@ class MultiCurrency {
 			'updated'    => time(),
 		];
 	}
+	
 	/**
 	 * Get all the currencies that have been used in the store.
 	 *

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -1480,7 +1480,7 @@ class MultiCurrency {
 			'updated'    => time(),
 		];
 	}
-	
+
 	/**
 	 * Get all the currencies that have been used in the store.
 	 *

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -978,7 +978,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 
 		$result = $this->multi_currency->get_all_customer_currencies();
 
-		$this->assertEquals( [ 'GBP', 'EUR', 'USD' ], $result );
+		$this->assertEquals( [ 'EUR', 'GBP', 'USD' ], $result );
 
 		foreach ( $mock_orders as $order_id ) {
 			wp_delete_post( $order_id, true );


### PR DESCRIPTION
Fixes #6852

#### Changes proposed in this Pull Request

Response time optimisation for the `MultiCurrency->get_all_customer_currencies` method.

This PR will try and optimise the response time of the `MultiCurrency->get_all_customer_currencies` , which, on sites with high amount of orders, it seems to generate a slow response time up to the point where, on one of the sites tested, it gets into a timeout being stopped from the server after 60s.

Since this query is enabled on all `wp-admin` pages, it can affect the backend browsing experience by introducing an undesired load wait time . 

The changed proposed here is, instead of scanning the whole orders table to get all distinct currencies, to simply create a UNION ALL query based on all existing currencies, which will scan the orders table until one record is found for each currency, then return the found currencies as with the original query.

One additional change I've added is a default sort ASC order, and modified the `test_get_all_customer_currencies` currencies order test to fit this change.

I've also exported that callable function to a non-anonymous method for easier debugging.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

The code only modifies the underlying method query to be more efficient, the end result being the same.

Existing unit tests in `test_get_all_customer_currencies` are passing.

The size of the generated SQL query seems to be around `Size : 22.26 KB, 22005 Characters`,  which should be well below the `max_allowed_packet` setting setup for most servers, not sure if there is any further concern here.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
Union query used to generate the available customer currencies taking 0.02 seconds to execute

<img width="1453" alt="Screenshot 2023-08-02 at 13 18 37" src="https://github.com/Automattic/woocommerce-payments/assets/537751/74e2faa6-73cd-49f2-b9fb-3ebafd609e69">



Original query using DISTINCT taking over 60s to load

<img width="1447" alt="Screenshot 2023-08-02 at 13 18 07 1" src="https://github.com/Automattic/woocommerce-payments/assets/537751/475e7de6-ca79-4456-8400-dec22d78f6a2">


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
1. Load the site with over 1M orders
2. Try and access the wp-admin/ backend
3. Notice the UNION ALL query displayed in Query Monitor on any admin page
4. Go to the Transactions page /wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced and check the Customer Currency filter

<img width="800" alt="Screenshot 2023-08-02 at 13 30 29" src="https://github.com/Automattic/woocommerce-payments/assets/537751/f1163b7c-9006-480c-ac3b-51de86ef9840">

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
