### PR TITLE
pass tracks identity to woopay iframe

### DIFF
--- a/changelog/add-pass-tracks-identity-to-woopay-iframe
+++ b/changelog/add-pass-tracks-identity-to-woopay-iframe
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Pass tracks identity to WooPay iframe

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -234,6 +234,7 @@ export const handleWooPayEmailInput = async (
 		const viewportHeight = window.document.documentElement.clientHeight;
 
 		const urlParams = new URLSearchParams();
+
 		urlParams.append( 'email', email );
 		urlParams.append( 'testMode', getConfig( 'testMode' ) );
 		urlParams.append(
@@ -246,6 +247,10 @@ export const handleWooPayEmailInput = async (
 		urlParams.append(
 			'viewport',
 			`${ viewportWidth }x${ viewportHeight }`
+		);
+		urlParams.append(
+			'tracksUserIdentity',
+			JSON.stringify( getConfig( 'tracksUserIdentity' ) )
 		);
 
 		iframe.src = `${ getConfig(

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -234,7 +234,6 @@ export const handleWooPayEmailInput = async (
 		const viewportHeight = window.document.documentElement.clientHeight;
 
 		const urlParams = new URLSearchParams();
-
 		urlParams.append( 'email', email );
 		urlParams.append( 'testMode', getConfig( 'testMode' ) );
 		urlParams.append(

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -190,6 +190,10 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 			'viewport',
 			`${ viewportWidth }x${ viewportHeight }`
 		);
+		urlParams.append(
+			'tracksUserIdentity',
+			JSON.stringify( getConfig( 'tracksUserIdentity' ) )
+		);
 
 		iframe.src = `${ getConfig(
 			'woopayHost'

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -193,6 +193,7 @@ class WC_Payments_Checkout {
 			'woopaySignatureNonce'           => wp_create_nonce( 'woopay_signature_nonce' ),
 			'woopayMerchantId'               => Jetpack_Options::get_option( 'id' ),
 			'icon'                           => $this->gateway->get_icon_url(),
+			'tracksUserIdentity'             => WC_Payments::woopay_tracker()->tracks_get_identity( get_current_user_id() ),
 		];
 
 		/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Pass Tracks identity to WooPay iframe as a URL parameter so that a Tracks user can be identified across WCPay and WooPay
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

See the instructions in https://github.com/Automattic/woopay/pull/2057

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
