### PR TITLE
Only send WooPay verified user nonce when there is an adapted extension

### DIFF
--- a/changelog/fix-only-send-woopay-verified-user-nonce-when-has-adapted-extension
+++ b/changelog/fix-only-send-woopay-verified-user-nonce-when-has-adapted-extension
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1564,7 +1564,7 @@ class WC_Payments {
 			$woopay_adapted_extensions  = new WooPay_Adapted_Extensions();
 			$body['adapted_extensions'] = $woopay_adapted_extensions->get_adapted_extensions_data( $email );
 
-			if ( ! is_user_logged_in() ) {
+			if ( ! is_user_logged_in() && count( $body['adapted_extensions'] ) > 0 ) {
 				$store_user_email_registered = get_user_by( 'email', $email );
 
 				if ( $store_user_email_registered ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
This PR fixes an invalid nonce error when a verified user on WooPay requests the Store API without adapted extensions installed.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Without Points & Rewards or Gift Cards installed, checkout with WooPay with a verified user that has an account on the merchant store.
* No errors should be shown.
* Install Points & Rewards or Gift Cards, then checkout with WooPay with the same user.
* No errors should be shown.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
