### PR TITLE
Revert "BNPLs: updated methods copy on settings page (#6880)"

### DIFF
--- a/changelog/revert-6799-bnpl-methods-copy-in-settings-page
+++ b/changelog/revert-6799-bnpl-methods-copy-in-settings-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Revert changes to BNPL payment methods copy.

--- a/changelog/update-6799-bnpl-methods-copy-in-settings-page
+++ b/changelog/update-6799-bnpl-methods-copy-in-settings-page
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-BNPLs: updated methods copy on settings page

--- a/client/additional-methods-setup/upe-preview-methods-selector/test/add-payment-methods-task.test.js
+++ b/client/additional-methods-setup/upe-preview-methods-selector/test/add-payment-methods-task.test.js
@@ -19,7 +19,6 @@ import {
 	useCurrencies,
 	useEnabledCurrencies,
 	useManualCapture,
-	useAccountDefaultCurrency,
 } from '../../../data';
 import WCPaySettingsContext from '../../../settings/wcpay-settings-context';
 import { upeCapabilityStatuses } from 'wcpay/additional-methods-setup/constants';
@@ -32,7 +31,6 @@ jest.mock( '../../../data', () => ( {
 	useEnabledCurrencies: jest.fn(),
 	useGetPaymentMethodStatuses: jest.fn(),
 	useManualCapture: jest.fn(),
-	useAccountDefaultCurrency: jest.fn(),
 } ) );
 
 jest.mock( '@wordpress/a11y', () => ( {
@@ -118,7 +116,6 @@ describe( 'AddPaymentMethodsTask', () => {
 			},
 		} );
 		useManualCapture.mockReturnValue( [ false, jest.fn() ] );
-		useAccountDefaultCurrency.mockReturnValue( 'USD' );
 		global.wcpaySettings = {
 			accountEmail: 'admin@example.com',
 		};

--- a/client/components/payment-methods-checkboxes/payment-method-checkbox.tsx
+++ b/client/components/payment-methods-checkboxes/payment-method-checkbox.tsx
@@ -14,7 +14,7 @@ import React, { useContext, useEffect } from 'react';
 import LoadableCheckboxControl from 'components/loadable-checkbox';
 import { HoverTooltip } from 'components/tooltip';
 import { upeCapabilityStatuses } from 'wcpay/additional-methods-setup/constants';
-import { useManualCapture, useAccountDefaultCurrency } from 'wcpay/data';
+import { useManualCapture } from 'wcpay/data';
 import { FeeStructure } from 'wcpay/types/fees';
 import PaymentMethodsMap from '../../payment-methods-map';
 import WCPaySettingsContext from '../../settings/wcpay-settings-context';
@@ -26,33 +26,8 @@ import PaymentMethodDisabledTooltip from '../payment-method-disabled-tooltip';
 import Pill from '../pill';
 import './payment-method-checkbox.scss';
 
-type PaymentMethodProps = {
-	name: string;
-};
-
-const getDescription = ( name: string, currency: string ) => {
-	let { description, allows_pay_later: allowsPayLater } = PaymentMethodsMap[
-		name
-	];
-
-	if ( ! description ) return null;
-
-	if ( allowsPayLater ) {
-		description = sprintf( description, currency.toUpperCase() );
-	}
-
-	return description;
-};
-
-const PaymentMethodDescription: React.FC< PaymentMethodProps > = ( {
-	name,
-} ) => {
-	const [ stripeAccountDefaultCurrency ] = useAccountDefaultCurrency();
-	const description = getDescription(
-		name,
-		stripeAccountDefaultCurrency as string
-	);
-
+const PaymentMethodDescription = ( { name }: { name: string } ) => {
+	const description = PaymentMethodsMap[ name ]?.description;
 	if ( ! description ) return null;
 
 	return (
@@ -70,17 +45,7 @@ const PaymentMethodDescription: React.FC< PaymentMethodProps > = ( {
 	);
 };
 
-type PaymentMethodCheckboxProps = {
-	onChange: ( name: string, enabled: boolean ) => void;
-	name: string;
-	checked: boolean;
-	fees: string;
-	status: string;
-	required: boolean;
-	locked: boolean;
-};
-
-const PaymentMethodCheckbox: React.FC< PaymentMethodCheckboxProps > = ( {
+const PaymentMethodCheckbox = ( {
 	onChange,
 	name,
 	checked,
@@ -88,7 +53,15 @@ const PaymentMethodCheckbox: React.FC< PaymentMethodCheckboxProps > = ( {
 	status,
 	required,
 	locked,
-} ) => {
+}: {
+	onChange: ( name: string, enabled: boolean ) => void;
+	name: string;
+	checked: boolean;
+	fees: string;
+	status: string;
+	required: boolean;
+	locked: boolean;
+} ): React.ReactElement => {
 	const {
 		accountFees,
 	}: { accountFees: Record< string, FeeStructure > } = useContext(
@@ -131,7 +104,7 @@ const PaymentMethodCheckbox: React.FC< PaymentMethodCheckboxProps > = ( {
 				label={ paymentMethod.label }
 				checked={ checked }
 				disabled={ disabled || locked }
-				onChange={ ( state: boolean ) => {
+				onChange={ ( state: string ) => {
 					handleChange( state );
 				} }
 				delayMsOnCheck={ 1500 }

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -59,14 +59,6 @@ export const useEnabledPaymentMethodIds = () => {
 	);
 };
 
-export const useAccountDefaultCurrency = () => {
-	return useSelect( ( select ) => {
-		const { getAccountDefaultCurrency } = select( STORE_NAME );
-
-		return [ getAccountDefaultCurrency() ];
-	}, [] );
-};
-
 export const useSelectedPaymentMethod = () => {
 	const { updateSelectedPaymentMethod } = useDispatch( STORE_NAME );
 

--- a/client/data/settings/selectors.js
+++ b/client/data/settings/selectors.js
@@ -56,10 +56,6 @@ export const getAccountBusinessName = ( state ) => {
 	return getSettings( state ).account_business_name || '';
 };
 
-export const getAccountDefaultCurrency = ( state ) => {
-	return getSettings( state ).account_default_currency || '';
-};
-
 export const getAccountBusinessURL = ( state ) => {
 	return getSettings( state ).account_business_url || '';
 };

--- a/client/payment-methods-map.tsx
+++ b/client/payment-methods-map.tsx
@@ -196,8 +196,7 @@ const PaymentMethodInformationObject: Record<
 			affirm: __( 'Affirm', 'woocommerce-payments' ),
 		},
 		description: __(
-			// translators: %s is the store currency.
-			'Allow customers to pay over time with Affirm. Available to all customers paying in %s.',
+			'Expand your business with Affirm',
 			'woocommerce-payments'
 		),
 		icon: iconComponent( AffirmIcon, 'Affirm' ),
@@ -213,8 +212,7 @@ const PaymentMethodInformationObject: Record<
 			afterpay_clearpay: __( 'Afterpay', 'woocommerce-payments' ),
 		},
 		description: __(
-			// translators: %s is the store currency.
-			'Allow customers to pay over time with Afterpay. Available to all customers paying in %s.',
+			'Expand your business with Afterpay',
 			'woocommerce-payments'
 		),
 		icon: iconComponent( AfterpayIcon, 'Afterpay' ),

--- a/client/payment-methods/index.js
+++ b/client/payment-methods/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { useContext, useState } from 'react';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	Button,
 	Card,
@@ -26,7 +26,6 @@ import {
 	useGetPaymentMethodStatuses,
 	useSelectedPaymentMethod,
 	useUnselectedPaymentMethod,
-	useAccountDefaultCurrency,
 } from 'wcpay/data';
 
 import useIsUpeEnabled from '../settings/wcpay-upe-toggle/hook.js';
@@ -160,8 +159,6 @@ const PaymentMethods = () => {
 
 	const [ , updateSelectedPaymentMethod ] = useSelectedPaymentMethod();
 
-	const [ stripeAccountDefaultCurrency ] = useAccountDefaultCurrency();
-
 	const completeActivation = ( itemId ) => {
 		updateSelectedPaymentMethod( itemId );
 		handleActivationModalOpen( null );
@@ -286,20 +283,12 @@ const PaymentMethods = () => {
 								description,
 								icon: Icon,
 								allows_manual_capture: isAllowingManualCapture,
-								allows_pay_later: isAllowingPayLater,
 							} ) => (
 								<PaymentMethod
 									id={ id }
 									key={ id }
 									label={ label }
-									description={
-										isAllowingPayLater
-											? sprintf(
-													description,
-													stripeAccountDefaultCurrency.toUpperCase()
-											  )
-											: description
-									}
+									description={ description }
 									checked={
 										enabledMethodIds.includes( id ) &&
 										upeCapabilityStatuses.INACTIVE !==

--- a/client/payment-methods/test/index.js
+++ b/client/payment-methods/test/index.js
@@ -12,7 +12,6 @@ import user from '@testing-library/user-event';
  */
 import PaymentMethods from '..';
 import {
-	useAccountDefaultCurrency,
 	useEnabledPaymentMethodIds,
 	useGetAvailablePaymentMethodIds,
 	useGetPaymentMethodStatuses,
@@ -42,7 +41,6 @@ jest.mock( '../../data', () => ( {
 	useManualCapture: jest.fn(),
 	useSelectedPaymentMethod: jest.fn(),
 	useUnselectedPaymentMethod: jest.fn(),
-	useAccountDefaultCurrency: jest.fn(),
 } ) );
 
 jest.mock( '@wordpress/data', () => ( {
@@ -82,7 +80,6 @@ describe( 'PaymentMethods', () => {
 		global.wcpaySettings = {
 			accountEmail: 'admin@example.com',
 		};
-		useAccountDefaultCurrency.mockReturnValue( 'USD' );
 	} );
 
 	test( 'payment methods are rendered correctly', () => {

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -399,7 +399,6 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 				'is_wcpay_subscriptions_enabled'      => WC_Payments_Features::is_wcpay_subscriptions_enabled(),
 				'is_wcpay_subscriptions_eligible'     => WC_Payments_Features::is_wcpay_subscriptions_eligible(),
 				'is_subscriptions_plugin_active'      => $this->wcpay_gateway->is_subscriptions_plugin_active(),
-				'account_default_currency'            => $this->wcpay_gateway->get_option( 'account_default_currency' ),
 				'account_statement_descriptor'        => $this->wcpay_gateway->get_option( 'account_statement_descriptor' ),
 				'account_business_name'               => $this->wcpay_gateway->get_option( 'account_business_name' ),
 				'account_business_url'                => $this->wcpay_gateway->get_option( 'account_business_url' ),

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1742,8 +1742,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				return $this->get_account_statement_descriptor();
 			case 'account_business_name':
 				return $this->get_account_business_name();
-			case 'account_default_currency':
-				return $this->get_account_default_currency();
 			case 'account_business_url':
 				return $this->get_account_business_url();
 			case 'account_business_support_address':

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -205,12 +205,6 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 			->expects( $this->any() )
 			->method( 'get_is_live' )
 			->willReturn( true );
-
-		$this->mock_wcpay_account
-			->expects( $this->any() )
-			->method( 'get_account_default_currency' )
-			->willReturn( 'usd' );
-
 	}
 
 	public function tear_down() {


### PR DESCRIPTION
This reverts commit c2b69c94f4e30d44354501df7db8705b4e62a974. We identified that the implementation was wrong after the [original PR](https://github.com/Automattic/woocommerce-payments/pull/6880) was merged.

