### PR TITLE
Euro is displayed as zero-decimal currency for Japanese accounts

### DIFF
--- a/changelog/fix-euro-displayed-as-zerodecimal-currency-for-japan
+++ b/changelog/fix-euro-displayed-as-zerodecimal-currency-for-japan
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Ignore updating currency precision if the country is Japan

--- a/client/utils/currency/index.js
+++ b/client/utils/currency/index.js
@@ -60,6 +60,8 @@ export const getCurrency = ( currencyCode, baseCurrencyCode = null ) => {
 				currency.decimalSeparator = baseCurrency.decimalSeparator;
 				currency.thousandSeparator = baseCurrency.thousandSeparator;
 				currency.symbolPosition = baseCurrency.symbolPosition;
+				// If the country is Japan we should skip overwriting the precission
+				// as overwriting it would cause non-zero decimal currencies to act as zero-decimal.
 				if ( currency.precision !== 0 && country !== 'JP' ) {
 					currency.precision = baseCurrency.precision;
 				}

--- a/client/utils/currency/index.js
+++ b/client/utils/currency/index.js
@@ -60,7 +60,7 @@ export const getCurrency = ( currencyCode, baseCurrencyCode = null ) => {
 				currency.decimalSeparator = baseCurrency.decimalSeparator;
 				currency.thousandSeparator = baseCurrency.thousandSeparator;
 				currency.symbolPosition = baseCurrency.symbolPosition;
-				if ( currency.precision !== 0 ) {
+				if ( currency.precision !== 0 && country !== 'JP' ) {
 					currency.precision = baseCurrency.precision;
 				}
 			}

--- a/client/utils/currency/index.js
+++ b/client/utils/currency/index.js
@@ -62,6 +62,7 @@ export const getCurrency = ( currencyCode, baseCurrencyCode = null ) => {
 				currency.symbolPosition = baseCurrency.symbolPosition;
 				// If the country is Japan we should skip overwriting the precission
 				// as overwriting it would cause non-zero decimal currencies to act as zero-decimal.
+				// This is a temporary fix.
 				if ( currency.precision !== 0 && country !== 'JP' ) {
 					currency.precision = baseCurrency.precision;
 				}


### PR DESCRIPTION
Fixes #6944

#### Changes proposed in this Pull Request
A temporary way of fixing a bug where the Euro currency is displayed as a zero-decimal country for Japanese merchants. 

Before the fix:
<img width="436" alt="Screenshot 2023-08-07 at 15 46 23" src="https://github.com/Automattic/woocommerce-payments/assets/8667118/f38f3d50-3eeb-43fb-8b98-60c9d1618ea9">

After the fix:
<img width="426" alt="Screenshot 2023-08-07 at 15 45 31" src="https://github.com/Automattic/woocommerce-payments/assets/8667118/9468b73f-66cf-49fd-b8f6-bbbb6deedb14">

#### Testing instructions
- Connect a Japanese account and enable multi-currency.
- Set the currency from the multi-currency widget to EUR.
- Create an order with EPS.
- Navigate to `Payments` -> `Transactions` and open `Transaction details` for the recent order.
- Verify the fixed Base fee is displayed as 0,28 EUR instead of 0 EUR.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
