### PR TITLE
Fix account details  active discounts T&C link

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,64 @@
 *** WooPayments Changelog ***
 
+= 6.3.0 - 2023-08-09 =
+* Add - Add constant flag to use the new payment service (project reengineering payment process).
+* Add - Add JCB payment method coming soon notice
+* Add - Add payment service class (project reengineering payment process).
+* Add - Adds integration for Stripe Link while using split UPE with deferred intent creation.
+* Add - Add support for Japan
+* Add - Add support for the Enabled status from Stripe (will replace Restricted Soon in the case where there is no active deadline).
+* Add - Add support for United Arab Emirates
+* Add - Add Tracks events around account connect when promo is active.
+* Add - Add warning to the advanced settings page for WooPay incompatible extensions
+* Add - Add WooPay Gift Cards support.
+* Add - Add WooPay on onboarding payment methods.
+* Add - Add WooPay Points and Rewards support
+* Add - Allow WooPay verified email requests
+* Add - Ensure WooPay compatibility with the split UPE that has deferred intent creation implementation.
+* Add - Include WooPay merchant terms on WooCommerce Payment Methods settings.
+* Add - Prefill the Business Name and Country fields during WooPayments KYC.
+* Fix - Adding more descriptive error messages in gradual signup
+* Fix - Allow card gateway to load properly with WooPay enabled and subscription item in the cart.
+* Fix - Allow only domestic payments for BNPL payment methods
+* Fix - Allow only Japanese phone numbers for Japanese accounts
+* Fix - Avoid creating duplicate paid orders from a single payment intent.
+* Fix - Disputes listing column renamed to Respond by and will show empty when dispute does not need response or if respond by date has passed.
+* Fix - Enable customers who have migrated a WCPay subscription to a tokenised subscription to pay for existing failed orders.
+* Fix - Fatal error when using latest MailPoet with WooPay
+* Fix - Fixed the creation of the nonce that is sent to WooPay
+* Fix - Fix error while selecting product variations. Make the stripe payment messaging element load only if at least one BNPL method is active.
+* Fix - Fix extra requests when clicking WooPay express checkout button.
+* Fix - Fix Fraud and Risk Tools welcome tour to only show if Fraud and Risk banner learn more button is clicked and tour not previously dismissed.
+* Fix - Get WooPay adapted extensions from server
+* Fix - Highlight menu item when transaction details, deposit details, and disputes details page are opened.
+* Fix - Improve split UPE support of WooPay with multiple payment methods enabled.
+* Fix - Minor copy changes on the Set Up Real Payments modal.
+* Fix - Remove daily deposits for JP merchants as it's not permitted by our payment processor
+* Fix - Reverting change to the plugin name because of compatibility with iOS app.
+* Fix - Send correct shipping address to Afterpay in Classic Checkout
+* Fix - Send shipping address correctly to Afterpay in block checkout, when separate billing address is provided.
+* Fix - Update excerpt in readme.txt to improve ranking
+* Fix - Visual fixes for the Connect page hero.
+* Update - Allows nulls in min/max payment ranges definitions for UPE payment methods
+* Update - Minor copy fixes on the onboarding form.
+* Update - Modify 'Contact WooCommerce Support' badge located on the 'Payments accepted on checkout' section of Payments > Settings.
+* Update - Only show the post-onboarding congratulations message if user did not onboard in test mode.
+* Update - Unify payment method icon design
+* Dev - Add a dependency container for the new src directory.
+* Dev - Add generic Get_Request class, and migrate current simple requests to use it
+* Dev - Add PSR-4 autoloading for the src directory.
+* Dev - Add unit tests to cover WooPay button eligibility.
+* Dev - Add webpack script to generate RTL .css files and enqueue it for RTL languages
+* Dev - Adjust coding standards to align with WC Core.
+* Dev - Avoiding product-service exceptions during checkout, making debugging easier.
+* Dev - Fix Husky post-merge script to conform to `sh` syntax
+* Dev - Introduce model class WC_Payments_API_Setup_Intention for setup intents
+* Dev - Migrate certain WCPay shopper tracks to use wcpay prefix
+* Dev - Migrate Chip component to TypeScript to improve code quality.
+* Dev - Migrate DisputeStatusChip comp to TypeScript to improve code quality.
+* Dev - Pass tracks identity to WooPay iframe
+* Dev - Pass Tracks identity to WooPay to improve telemetry
+
 = 6.2.2 - 2023-08-01 =
 * Fix - Move the email title hook from the UPE class to the parent legacy gateway class, to avoid multiple callback invocations for the split UPE
 

--- a/changelog/add-6391-implement-stripe-link-with-deferred-intent
+++ b/changelog/add-6391-implement-stripe-link-with-deferred-intent
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Adds integration for Stripe Link while using split UPE with deferred intent creation.

--- a/changelog/add-6479-japan-fees
+++ b/changelog/add-6479-japan-fees
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add support for Japan

--- a/changelog/add-6480-uae-fees
+++ b/changelog/add-6480-uae-fees
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add support for United Arab Emirates

--- a/changelog/add-6859-tracks-account-connect-events
+++ b/changelog/add-6859-tracks-account-connect-events
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add Tracks events around account connect when promo is active.

--- a/changelog/add-add-single-woopay-compatibility-endpoint
+++ b/changelog/add-add-single-woopay-compatibility-endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Get WooPay adapted extensions from server

--- a/changelog/add-add-woopay-onboarding-payment-methods
+++ b/changelog/add-add-woopay-onboarding-payment-methods
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add WooPay on onboarding payment methods.

--- a/changelog/add-affirm-afterpay-ranges-flexible
+++ b/changelog/add-affirm-afterpay-ranges-flexible
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Allows nulls in min/max payment ranges definitions for UPE payment methods

--- a/changelog/add-allow-woopay-verified-email-requests
+++ b/changelog/add-allow-woopay-verified-email-requests
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Allow WooPay verified email requests

--- a/changelog/add-include-woopay-terms-on-payment-methods
+++ b/changelog/add-include-woopay-terms-on-payment-methods
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Include WooPay merchant terms on WooCommerce Payment Methods settings.

--- a/changelog/add-jcb-payment-method
+++ b/changelog/add-jcb-payment-method
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add JCB payment method coming soon notice

--- a/changelog/add-pass-tracks-identity-to-woopay-iframe
+++ b/changelog/add-pass-tracks-identity-to-woopay-iframe
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Pass tracks identity to WooPay iframe

--- a/changelog/add-pass-tracks-user-data-to-woopay
+++ b/changelog/add-pass-tracks-user-data-to-woopay
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Pass Tracks identity to WooPay to improve telemetry

--- a/changelog/add-rtl-support
+++ b/changelog/add-rtl-support
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Add webpack script to generate RTL .css files and enqueue it for RTL languages

--- a/changelog/add-track-wcpay-shopper-events
+++ b/changelog/add-track-wcpay-shopper-events
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Migrate certain WCPay shopper tracks to use wcpay prefix

--- a/changelog/add-warning-to-advanced-settings
+++ b/changelog/add-warning-to-advanced-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add warning to the advanced settings page for WooPay incompatible extensions

--- a/changelog/add-wcs_stripe_billing_migration_log
+++ b/changelog/add-wcs_stripe_billing_migration_log
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: This long living log file will form part of a wider set of changes and a changelog entry for it is not needed.
-
-

--- a/changelog/add-woopay-gift-cards-support
+++ b/changelog/add-woopay-gift-cards-support
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add WooPay Gift Cards support.

--- a/changelog/add-woopay-points-and-rewards-support
+++ b/changelog/add-woopay-points-and-rewards-support
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add WooPay Points and Rewards support

--- a/changelog/add-woopay-util-tests
+++ b/changelog/add-woopay-util-tests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Add unit tests to cover WooPay button eligibility.

--- a/changelog/dev-5966-restricted-soon-fix
+++ b/changelog/dev-5966-restricted-soon-fix
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add support for the Enabled status from Stripe (will replace Restricted Soon in the case where there is no active deadline).

--- a/changelog/dev-6217-generic-get-request-class
+++ b/changelog/dev-6217-generic-get-request-class
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Add generic Get_Request class, and migrate current simple requests to use it

--- a/changelog/dev-6741-po-copy-tweaks
+++ b/changelog/dev-6741-po-copy-tweaks
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Minor copy fixes on the onboarding form.

--- a/changelog/dev-6778-fix-copy-test-mode
+++ b/changelog/dev-6778-fix-copy-test-mode
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Minor copy changes on the Set Up Real Payments modal.

--- a/changelog/dev-6799-remove-changelog-after-revert
+++ b/changelog/dev-6799-remove-changelog-after-revert
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Remove wrong changelog file introduced in previous revert commit.
-
-

--- a/changelog/dev-6878-prefill-po-fields
+++ b/changelog/dev-6878-prefill-po-fields
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Prefill the Business Name and Country fields during WooPayments KYC.

--- a/changelog/dev-add-stub-WP_UnitTestCase
+++ b/changelog/dev-add-stub-WP_UnitTestCase
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Add WP_UnitTestCase stub to support IDEs.
-
-

--- a/changelog/dev-remove-yoda-conditions
+++ b/changelog/dev-remove-yoda-conditions
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Adjust coding standards to align with WC Core.

--- a/changelog/dev-test-mode-update
+++ b/changelog/dev-test-mode-update
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Only show the post-onboarding congratulations message if user did not onboard in test mode.

--- a/changelog/dev-ts-refactor-chip-component
+++ b/changelog/dev-ts-refactor-chip-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Migrate Chip component to TypeScript to improve code quality.

--- a/changelog/dev-ts-refactor-dispute-status-chip
+++ b/changelog/dev-ts-refactor-dispute-status-chip
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Migrate DisputeStatusChip comp to TypeScript to improve code quality.

--- a/changelog/feature-deferred-intent-woopay
+++ b/changelog/feature-deferred-intent-woopay
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Ensure WooPay compatibility with the split UPE that has deferred intent creation implementation.

--- a/changelog/fix-5786-avoid-multiple-order-upe-flow
+++ b/changelog/fix-5786-avoid-multiple-order-upe-flow
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Avoid creating duplicate paid orders from a single payment intent.

--- a/changelog/fix-6394-highlight-menu-for-details-pages
+++ b/changelog/fix-6394-highlight-menu-for-details-pages
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Highlight menu item when transaction details, deposit details, and disputes details page are opened.

--- a/changelog/fix-6517-restrict-bnpl-to-domestic-country
+++ b/changelog/fix-6517-restrict-bnpl-to-domestic-country
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Allow only domestic payments for BNPL payment methods

--- a/changelog/fix-6620-unify-payment-method-icon-design
+++ b/changelog/fix-6620-unify-payment-method-icon-design
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Unify payment method icon design

--- a/changelog/fix-6780-connect-page-illustration
+++ b/changelog/fix-6780-connect-page-illustration
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Visual fixes for the Connect page hero.

--- a/changelog/fix-6783-specific-validation-text-po
+++ b/changelog/fix-6783-specific-validation-text-po
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Adding more descriptive error messages in gradual signup

--- a/changelog/fix-6792-1-afterpay-shipping-data-block-checkout
+++ b/changelog/fix-6792-1-afterpay-shipping-data-block-checkout
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Send shipping address correctly to Afterpay in block checkout, when separate billing address is provided.

--- a/changelog/fix-6792-afterpay-shipping-data
+++ b/changelog/fix-6792-afterpay-shipping-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Send correct shipping address to Afterpay in Classic Checkout

--- a/changelog/fix-6812
+++ b/changelog/fix-6812
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Enable customers who have migrated a WCPay subscription to a tokenised subscription to pay for existing failed orders.

--- a/changelog/fix-6819-afterpay-variable-product-messaging-on-flatsome
+++ b/changelog/fix-6819-afterpay-variable-product-messaging-on-flatsome
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix error while selecting product variations. Make the stripe payment messaging element load only if at least one BNPL method is active.

--- a/changelog/fix-6872-disputes-response-column
+++ b/changelog/fix-6872-disputes-response-column
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Disputes listing column renamed to Respond by and will show empty when dispute does not need response or if respond by date has passed.

--- a/changelog/fix-6887-only-show-frt-tour-from-learn-more-button-click
+++ b/changelog/fix-6887-only-show-frt-tour-from-learn-more-button-click
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Fix Fraud and Risk Tools welcome tour to only show if Fraud and Risk banner learn more button is clicked and tour not previously dismissed.

--- a/changelog/fix-6948-account-details-discounts-link
+++ b/changelog/fix-6948-account-details-discounts-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Provide per active discount Terms and Conditions link in the Account details card.

--- a/changelog/fix-card-gateway-with-woopay-and-subscriptions
+++ b/changelog/fix-card-gateway-with-woopay-and-subscriptions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Allow card gateway to load properly with WooPay enabled and subscription item in the cart.

--- a/changelog/fix-checkout-product-not-found-exceptions
+++ b/changelog/fix-checkout-product-not-found-exceptions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Avoiding product-service exceptions during checkout, making debugging easier.

--- a/changelog/fix-husky-post-merge-checks
+++ b/changelog/fix-husky-post-merge-checks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix Husky post-merge script to conform to `sh` syntax

--- a/changelog/fix-japan-phone-validation
+++ b/changelog/fix-japan-phone-validation
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Allow only Japanese phone numbers for Japanese accounts

--- a/changelog/fix-multiple-payment-methods-fetching
+++ b/changelog/fix-multiple-payment-methods-fetching
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Move the email title hook from the UPE class to the parent legacy gateway class, to avoid multiple callback invocations for the split UPE

--- a/changelog/fix-only-send-woopay-verified-user-nonce-when-has-adapted-extension
+++ b/changelog/fix-only-send-woopay-verified-user-nonce-when-has-adapted-extension
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-

--- a/changelog/fix-send-valid-nonce-to-woopay
+++ b/changelog/fix-send-valid-nonce-to-woopay
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixed the creation of the nonce that is sent to WooPay

--- a/changelog/fix-split-upe-with-woopay-and-multiple-pms
+++ b/changelog/fix-split-upe-with-woopay-and-multiple-pms
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Improve split UPE support of WooPay with multiple payment methods enabled.

--- a/changelog/fix-wcpay-display-string
+++ b/changelog/fix-wcpay-display-string
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Reverting change to the plugin name because of compatibility with iOS app.

--- a/changelog/fix-woopay-express-button-extra-requests
+++ b/changelog/fix-woopay-express-button-extra-requests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix extra requests when clicking WooPay express checkout button.

--- a/changelog/fix-woopay-mailpoet-integration
+++ b/changelog/fix-woopay-mailpoet-integration
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fatal error when using latest MailPoet with WooPay

--- a/changelog/fix-woopay-points-and-rewards-unit-tests
+++ b/changelog/fix-woopay-points-and-rewards-unit-tests
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Unit tests fix.
-
-

--- a/changelog/issue-5987-refactor-accountOverview-namespace
+++ b/changelog/issue-5987-refactor-accountOverview-namespace
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: NA. This is a purely dev related change and no need for changelog.
-
-

--- a/changelog/issue-6524-migrate-wcpay-subscriptions-init
+++ b/changelog/issue-6524-migrate-wcpay-subscriptions-init
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Changelog N/A. This PR is one part of a much bigger wcpay subscriptions migration changes coming to the next version.
-
-

--- a/changelog/refactor-2422-object-support-setup-intents
+++ b/changelog/refactor-2422-object-support-setup-intents
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Introduce model class WC_Payments_API_Setup_Intention for setup intents

--- a/changelog/remove-daily-deposits-for-jp-merchants
+++ b/changelog/remove-daily-deposits-for-jp-merchants
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Remove daily deposits for JP merchants as it's not permitted by our payment processor

--- a/changelog/rpp-6674-create-payment-service-class
+++ b/changelog/rpp-6674-create-payment-service-class
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add payment service class (project reengineering payment process).

--- a/changelog/rpp-6675-use-payment-service
+++ b/changelog/rpp-6675-use-payment-service
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add constant flag to use the new payment service (project reengineering payment process).

--- a/changelog/rpp-6677-psr-autoloader
+++ b/changelog/rpp-6677-psr-autoloader
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Add PSR-4 autoloading for the src directory.

--- a/changelog/rpp-6678-dependency-container
+++ b/changelog/rpp-6678-dependency-container
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Add a dependency container for the new src directory.

--- a/changelog/tweak-update-readme-for-wp-org
+++ b/changelog/tweak-update-readme-for-wp-org
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Update excerpt in readme.txt to improve ranking

--- a/changelog/update-6839-modify-contact-support-badge
+++ b/changelog/update-6839-modify-contact-support-badge
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Modify 'Contact WooCommerce Support' badge located on the 'Payments accepted on checkout' section of Payments > Settings.

--- a/client/components/account-status/account-fees/index.js
+++ b/client/components/account-status/account-fees/index.js
@@ -17,19 +17,6 @@ import {
 	getTransactionsPaymentMethodName,
 } from 'utils/account-fees';
 
-const LearnMoreLink = () => {
-	return (
-		<p>
-			<a
-				href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"
-				target="_blank"
-				rel="noopener noreferrer"
-			>
-				{ __( 'Learn more', 'woocommerce-payments' ) }
-			</a>
-		</p>
-	);
-};
 const AccountFee = ( props ) => {
 	const { accountFee, paymentMethod } = props;
 	const baseFee = accountFee.base;
@@ -75,7 +62,6 @@ const AccountFees = ( props ) => {
 				<h4>{ __( 'Active discounts', 'woocommerce-payments' ) }</h4>
 			) }
 			{ activeDiscounts }
-			{ haveDiscounts && <LearnMoreLink /> }
 		</>
 	);
 };

--- a/client/components/account-status/account-fees/test/__snapshots__/index.js.snap
+++ b/client/components/account-status/account-fees/test/__snapshots__/index.js.snap
@@ -42,15 +42,6 @@ exports[`AccountFees renders discounted base fee 1`] = `
   >
     Discounted base fee expires after the first $1,000,000.00 of total payment volume.
   </p>
-  <p>
-    <a
-      href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Learn more
-    </a>
-  </p>
 </div>
 `;
 
@@ -96,15 +87,6 @@ exports[`AccountFees renders discounted fee with USD volume currency and non-USD
   >
     Discounted base fee expires after the first $1,000,000.00 of total payment volume.
   </p>
-  <p>
-    <a
-      href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Learn more
-    </a>
-  </p>
 </div>
 `;
 
@@ -127,15 +109,6 @@ exports[`AccountFees renders discounted fee with end date 1`] = `
     class="description"
   >
     Discounted base fee expires on March 31, 2025.
-  </p>
-  <p>
-    <a
-      href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Learn more
-    </a>
   </p>
 </div>
 `;
@@ -182,15 +155,6 @@ exports[`AccountFees renders discounted fee with volume limit 1`] = `
   >
     Discounted base fee expires after the first $25,000.00 of total payment volume.
   </p>
-  <p>
-    <a
-      href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Learn more
-    </a>
-  </p>
 </div>
 `;
 
@@ -236,15 +200,6 @@ exports[`AccountFees renders discounted fee with volume limit and end date 1`] =
   >
     Discounted base fee expires after the first $25,000.00 of total payment volume or on March 31, 2025.
   </p>
-  <p>
-    <a
-      href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Learn more
-    </a>
-  </p>
 </div>
 `;
 
@@ -263,15 +218,6 @@ exports[`AccountFees renders discounted fee without volume limit 1`] = `
     2.9% + $0.30 per transaction
   </s>
    2.03% + $0.21 per transaction (30% discount)
-  <p>
-    <a
-      href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Learn more
-    </a>
-  </p>
 </div>
 `;
 
@@ -317,15 +263,6 @@ exports[`AccountFees renders discounted non-USD base fee 1`] = `
   >
     Discounted base fee expires after the first £1,000,000.00 of total payment volume.
   </p>
-  <p>
-    <a
-      href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Learn more
-    </a>
-  </p>
 </div>
 `;
 
@@ -364,15 +301,6 @@ exports[`AccountFees renders discounts multiple payment methods 1`] = `
     1.4% + $0.30 per transaction
   </s>
    1.4% + $0.25 per transaction
-  <p>
-    <a
-      href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Learn more
-    </a>
-  </p>
 </div>
 `;
 
@@ -391,15 +319,6 @@ exports[`AccountFees renders first discounted fee ignoring the rest 1`] = `
     2.9% + $0.30 per transaction
   </s>
    2.32% + $0.24 per transaction (20% discount)
-  <p>
-    <a
-      href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Learn more
-    </a>
-  </p>
 </div>
 `;
 
@@ -418,15 +337,6 @@ exports[`AccountFees renders non-USD base fee 1`] = `
     2.9% + 0,25 € per transaction
   </s>
    2.9% + 0,30 € per transaction
-  <p>
-    <a
-      href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Learn more
-    </a>
-  </p>
 </div>
 `;
 
@@ -445,15 +355,6 @@ exports[`AccountFees renders normal base fee 1`] = `
     2.9% + $0.30 per transaction
   </s>
    2.9% + $0.30 per transaction
-  <p>
-    <a
-      href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Learn more
-    </a>
-  </p>
 </div>
 `;
 

--- a/client/components/account-status/test/__snapshots__/index.js.snap
+++ b/client/components/account-status/test/__snapshots__/index.js.snap
@@ -179,15 +179,6 @@ exports[`AccountStatus renders normal status 1`] = `
           2.9% + 0,00 € per transaction
         </s>
          2.9% + 0,30 € per transaction
-        <p>
-          <a
-            href="https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Learn more
-          </a>
-        </p>
       </div>
     </div>
     <div

--- a/client/types/fees.d.ts
+++ b/client/types/fees.d.ts
@@ -18,6 +18,7 @@ export interface DiscountFee extends BaseFee {
 	volume_currency: string | null;
 	current_volume: number | null;
 	discount?: number;
+	tc_url?: string;
 }
 
 export interface FeeStructure {

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -253,6 +253,10 @@ export const formatAccountFeesDescription = (
 		fee: __( '%1$f%% + %2$s per transaction', 'woocommerce-payments' ),
 		/* translators: %f percentage discount to apply */
 		discount: __( '(%f%% discount)', 'woocommerce-payments' ),
+		tc_link: __(
+			' — see <tclink>Terms and Conditions</tclink>',
+			'woocommerce-payments'
+		),
 		displayBaseFeeIfDifferent: true,
 		...customFormats,
 	};
@@ -311,9 +315,27 @@ export const formatAccountFeesDescription = (
 				sprintf( formats.discount, formatFee( discountFee.discount ) );
 		}
 
-		return createInterpolateElement( currentBaseFeeDescription, {
+		const conversionMap: Record< string, any > = {
 			s: <s />,
-		} );
+		};
+
+		if ( discountFee.tc_url && 0 < formats.tc_link.length ) {
+			currentBaseFeeDescription += ' ' + formats.tc_link;
+
+			conversionMap.tclink = (
+				// eslint-disable-next-line jsx-a11y/anchor-has-content
+				<a
+					href={ discountFee.tc_url }
+					target="_blank"
+					rel="noreferrer"
+				/>
+			);
+		}
+
+		return createInterpolateElement(
+			currentBaseFeeDescription,
+			conversionMap
+		);
 	}
 
 	return feeDescription;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "woocommerce-payments",
-  "version": "6.2.2",
+  "version": "6.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "woocommerce-payments",
-      "version": "6.2.2",
+      "version": "6.3.0",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-payments",
-  "version": "6.2.2",
+  "version": "6.3.0",
   "main": "webpack.config.js",
   "author": "Automattic",
   "license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: payment gateway, payment, apple pay, credit card, google pay, woocommerce 
 Requires at least: 6.0
 Tested up to: 6.2
 Requires PHP: 7.3
-Stable tag: 6.2.2
+Stable tag: 6.3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,65 @@ Please note that our support for the checkout block is still experimental and th
 4. Manage Disputes
 
 == Changelog ==
+
+= 6.3.0 - 2023-08-09 =
+* Add - Add constant flag to use the new payment service (project reengineering payment process).
+* Add - Add JCB payment method coming soon notice
+* Add - Add payment service class (project reengineering payment process).
+* Add - Adds integration for Stripe Link while using split UPE with deferred intent creation.
+* Add - Add support for Japan
+* Add - Add support for the Enabled status from Stripe (will replace Restricted Soon in the case where there is no active deadline).
+* Add - Add support for United Arab Emirates
+* Add - Add Tracks events around account connect when promo is active.
+* Add - Add warning to the advanced settings page for WooPay incompatible extensions
+* Add - Add WooPay Gift Cards support.
+* Add - Add WooPay on onboarding payment methods.
+* Add - Add WooPay Points and Rewards support
+* Add - Allow WooPay verified email requests
+* Add - Ensure WooPay compatibility with the split UPE that has deferred intent creation implementation.
+* Add - Include WooPay merchant terms on WooCommerce Payment Methods settings.
+* Add - Prefill the Business Name and Country fields during WooPayments KYC.
+* Fix - Adding more descriptive error messages in gradual signup
+* Fix - Allow card gateway to load properly with WooPay enabled and subscription item in the cart.
+* Fix - Allow only domestic payments for BNPL payment methods
+* Fix - Allow only Japanese phone numbers for Japanese accounts
+* Fix - Avoid creating duplicate paid orders from a single payment intent.
+* Fix - Disputes listing column renamed to Respond by and will show empty when dispute does not need response or if respond by date has passed.
+* Fix - Enable customers who have migrated a WCPay subscription to a tokenised subscription to pay for existing failed orders.
+* Fix - Fatal error when using latest MailPoet with WooPay
+* Fix - Fixed the creation of the nonce that is sent to WooPay
+* Fix - Fix error while selecting product variations. Make the stripe payment messaging element load only if at least one BNPL method is active.
+* Fix - Fix extra requests when clicking WooPay express checkout button.
+* Fix - Fix Fraud and Risk Tools welcome tour to only show if Fraud and Risk banner learn more button is clicked and tour not previously dismissed.
+* Fix - Get WooPay adapted extensions from server
+* Fix - Highlight menu item when transaction details, deposit details, and disputes details page are opened.
+* Fix - Improve split UPE support of WooPay with multiple payment methods enabled.
+* Fix - Minor copy changes on the Set Up Real Payments modal.
+* Fix - Remove daily deposits for JP merchants as it's not permitted by our payment processor
+* Fix - Reverting change to the plugin name because of compatibility with iOS app.
+* Fix - Send correct shipping address to Afterpay in Classic Checkout
+* Fix - Send shipping address correctly to Afterpay in block checkout, when separate billing address is provided.
+* Fix - Update excerpt in readme.txt to improve ranking
+* Fix - Visual fixes for the Connect page hero.
+* Update - Allows nulls in min/max payment ranges definitions for UPE payment methods
+* Update - Minor copy fixes on the onboarding form.
+* Update - Modify 'Contact WooCommerce Support' badge located on the 'Payments accepted on checkout' section of Payments > Settings.
+* Update - Only show the post-onboarding congratulations message if user did not onboard in test mode.
+* Update - Unify payment method icon design
+* Dev - Add a dependency container for the new src directory.
+* Dev - Add generic Get_Request class, and migrate current simple requests to use it
+* Dev - Add PSR-4 autoloading for the src directory.
+* Dev - Add unit tests to cover WooPay button eligibility.
+* Dev - Add webpack script to generate RTL .css files and enqueue it for RTL languages
+* Dev - Adjust coding standards to align with WC Core.
+* Dev - Avoiding product-service exceptions during checkout, making debugging easier.
+* Dev - Fix Husky post-merge script to conform to `sh` syntax
+* Dev - Introduce model class WC_Payments_API_Setup_Intention for setup intents
+* Dev - Migrate certain WCPay shopper tracks to use wcpay prefix
+* Dev - Migrate Chip component to TypeScript to improve code quality.
+* Dev - Migrate DisputeStatusChip comp to TypeScript to improve code quality.
+* Dev - Pass tracks identity to WooPay iframe
+* Dev - Pass Tracks identity to WooPay to improve telemetry
 
 = 6.2.2 - 2023-08-01 =
 * Fix - Move the email title hook from the UPE class to the parent legacy gateway class, to avoid multiple callback invocations for the split UPE

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -12,7 +12,7 @@
  * WC tested up to: 7.8.0
  * Requires at least: 6.0
  * Requires PHP: 7.3
- * Version: 6.2.2
+ * Version: 6.3.0
  *
  * @package WooCommerce\Payments
  */


### PR DESCRIPTION
Fixes #6948 

#### Changes proposed in this Pull Request

The initial Switch Incentive T&C [link](https://woocommerce.com/terms-conditions/woocommerce-payments-promotion/) is removed as it is no longer active.

Instead, **we added support for an additional entry for the active discount fees called `tc_url`.** This entry will be provided via the account details by our server. If a Terms and Conditions URL is provided, we will display a per-discount fee link to it. This way, we can have multiple links, specific to the promotion that a certain discount fee is part of.

Before:

![Screenshot 2023-08-08 at 11 23 37](https://github.com/Automattic/woocommerce-payments/assets/8830539/4c9468b1-08a2-437d-9f62-aedae96915fa)


After:

![Screenshot 2023-08-08 at 11 18 12](https://github.com/Automattic/woocommerce-payments/assets/8830539/00ad12f2-9e03-4299-813d-788ddb788735)


#### Testing instructions

* Checkout the PR branch on your local client installation
* Build the client assets by running `npm run build:client`
* Make sure you are sandboxed
* On your local server installation, make sure you have the Switch Incentive discount fees in your server DB (see this PR description for instructions: https://github.com/Automattic/woocommerce-payments-server/pull/3603)
* Make sure your local account has an active discount fee applied to it, one for the Switch or the Action incentive. You can manually assign it a fee from your local server MC (switch your local hosts file to sandbox before trying).
* Clear your client account cache from the WCPay Dev Tools and check the Payments > Overview page. You should have details about the discount and NO link to them (Learn More or otherwise).
* On your local server, checkout the matching server PR branch https://github.com/Automattic/woocommerce-payments-server/pull/3760
* Refresh your client account cache from the WCPay Dev Tools and check the Payments > Overview page. You should have details about the discount and a Terms and Conditions link to it, like in the screenshot above.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.