### PR TITLE
Fix phone number input on checkout

### DIFF
--- a/changelog/fix-6952-fix-phonenumberinput
+++ b/changelog/fix-6952-fix-phonenumberinput
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix phone number input widget on checkout page

--- a/client/settings/phone-input/index.tsx
+++ b/client/settings/phone-input/index.tsx
@@ -75,16 +75,18 @@ const PhoneNumberInput = ( {
 			onlyCountries: [],
 		};
 
-		const accountCountry = wcpaySettings?.accountStatus?.country ?? '';
-
-		// Special case for Japan: Only Japanese phone numbers are accepted by Stripe
-		if ( accountCountry === 'JP' ) {
-			phoneCountries = {
-				initialCountry: 'JP',
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore
-				onlyCountries: [ 'JP' ],
-			};
+		//if in admin panel
+		if ( 'undefined' !== typeof wcpaySettings ) {
+			const accountCountry = wcpaySettings?.accountStatus?.country ?? '';
+			// Special case for Japan: Only Japanese phone numbers are accepted by Stripe
+			if ( accountCountry === 'JP' ) {
+				phoneCountries = {
+					initialCountry: 'JP',
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-ignore
+					onlyCountries: [ 'JP' ],
+				};
+			}
 		}
 
 		if ( currentRef ) {


### PR DESCRIPTION
Fixes #6952 

#### Changes proposed in this Pull Request
Fix `PhoneNumberInput` on checkout when using WooPay
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to WcPay Dev and enable WooPay
* go to payment settings and enable WooPay from Express checkouts section
* add a product in cart and go to checkout
* complete a random email address and when after completing the credit card fields tick the woopay checkbox

<img width="390" alt="Screenshot 2023-08-09 at 12 17 59" src="https://github.com/Automattic/woocommerce-payments/assets/82826872/a9bec972-41da-44bd-b3d6-3a4d22544e74">

* no JS errors should occur, and the phone input should be shown

<img width="370" alt="Screenshot 2023-08-09 at 12 19 18" src="https://github.com/Automattic/woocommerce-payments/assets/82826872/57397030-0480-4c2c-9149-e88acbfc6412">

Test for admin panel https://github.com/Automattic/woocommerce-payments/pull/6912
* Use a Japanese account.
* Navigate to Payments -> Settings.
* Verify only Japan is available on the Support phone input field.
* Enter a non-Japanese phone, e.g. '+359878111111'.
* Verify an error is triggered on Save settings.
-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.