### PR TITLE
Use botwoo for pushing the release changelog changes using the related GitHub workflow

### DIFF
--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -37,7 +37,9 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
-        
+        with:
+          token: ${{ SECRETS.BOTWOO_TOKEN }}
+      
       - name: "Format the release date"
         id: format_date
         run: |
@@ -54,8 +56,8 @@ jobs:
                     
       - name: "Commit and push the changes"
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "botwoo"
+          git config user.email "botwoo@users.noreply.github.com"
           if ${{ env.CHANGELOG_ACTION == 'amend' }}; then
             git commit -am "Amend changelog entries for release $RELEASE_VERSION"
           else

--- a/changelog/add-use-botwoo-for-release-changelog
+++ b/changelog/add-use-botwoo-for-release-changelog
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Use botwoo for the release changelog GitHub actions to avoid having PR checks stuck on the release branch when running the workflow.
+
+


### PR DESCRIPTION
Fixes #6956 

#### Changes proposed in this Pull Request

- Checkout the branch using botwoo's secret token
- Configure the git username and email as botwoo before pushing

When running the [Release - Changelog](https://github.com/Automattic/woocommerce-payments/blob/develop/.github/workflows/release-changelog.yml) workflow, the commit will now be authored by `botwoo`. The immediate impact is that, if a PR was opened for the branch where the push happens, the PR checks should no longer be stuck.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a branch based on `add/use-botwoo-for-release-changelog`
* Open a PR
* Run the [Release - Changelog](https://github.com/Automattic/woocommerce-payments/blob/develop/.github/workflows/release-changelog.yml) workflow on that new branch
* Confirm that new PR checks were triggered and are running as expected, instead of being stuck

FYI: tested via PR #6960 and after botwoo's push, checks were triggered again successfully, without getting stuck

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
