### PR TITLE
Fix improperly rendered payment method brand images on Transaction screens

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -36,108 +36,96 @@
 	height: 1.25rem;
 	width: 32px;
 	width: 2rem;
+	background-size: contain;
+	background-repeat: no-repeat;
 }
 
 .payment-method__brand--amex {
-	background: no-repeat url( '../images/cards/amex.svg' );
+	background-image: url( '../images/cards/amex.svg' );
 }
 
 .payment-method__brand--diners {
-	background: no-repeat url( '../images/cards/diners.svg' );
+	background-image: url( '../images/cards/diners.svg' );
 }
 
 .payment-method__brand--discover {
-	background: no-repeat url( '../images/cards/discover.svg' );
+	background-image: url( '../images/cards/discover.svg' );
 }
 
 .payment-method__brand--jcb {
-	background: no-repeat url( '../images/cards/jcb.svg' );
+	background-image: url( '../images/cards/jcb.svg' );
 }
 
 .payment-method__brand--mastercard {
-	background: no-repeat url( '../images/cards/mastercard.svg' );
+	background-image: url( '../images/cards/mastercard.svg' );
 }
 
 .payment-method__brand--unionpay {
-	background: no-repeat url( '../images/cards/unionpay.svg' );
+	background-image: url( '../images/cards/unionpay.svg' );
 }
 
 .payment-method__brand--visa {
-	background: no-repeat url( '../images/cards/visa.svg' );
+	background-image: url( '../images/cards/visa.svg' );
 }
 
 .payment-method__brand--unknown {
-	background: no-repeat url( '../images/cards/unknown.svg' );
+	background-image: url( '../images/cards/unknown.svg' );
 }
 
 .payment-method__brand--giropay {
-	background: no-repeat url( '../images/payment-methods/giropay.svg' );
-	background-size: contain;
+	background-image: url( '../images/payment-methods/giropay.svg' );
 }
 
 .payment-method__brand--eps {
-	background: no-repeat url( '../images/payment-methods/eps.svg' );
-	background-size: contain;
+	background-image: url( '../images/payment-methods/eps.svg' );
 }
 
 .payment-method__brand--p24 {
-	background: no-repeat url( '../images/payment-methods/p24.svg' );
-	background-size: contain;
+	background-image: url( '../images/payment-methods/p24.svg' );
 }
 
 .payment-method__brand--sepa_debit {
-	background: no-repeat url( '../images/cards/sepa.svg' );
-	background-size: contain;
+	background-image: url( '../images/cards/sepa.svg' );
 }
 
 .payment-method__brand--sofort {
-	background: no-repeat url( '../images/payment-methods/sofort.svg' );
-	background-size: contain;
+	background-image: url( '../images/payment-methods/sofort.svg' );
 }
 
 .payment-method__brand--ideal {
-	background: no-repeat url( '../images/payment-methods/ideal.svg' );
-	background-size: contain;
+	background-image: url( '../images/payment-methods/ideal.svg' );
 }
 
 .payment-method__brand--google-pay {
-	background: no-repeat url( '../images/cards/google-pay.svg' );
-	background-size: contain;
+	background-image: url( '../images/cards/google-pay.svg' );
 }
 
 .payment-method__brand--apple-pay {
-	background: no-repeat url( '../images/cards/apple-pay.svg' );
-	background-size: contain;
+	background-image: url( '../images/cards/apple-pay.svg' );
 }
 
 .payment-method__brand--bancontact {
-	background: no-repeat url( '../images/payment-methods/bancontact.svg' );
-	background-size: contain;
+	background-image: url( '../images/payment-methods/bancontact.svg' );
 }
 
 .payment-method__brand--sepa_debit {
-	background: no-repeat url( '../images/payment-methods/sepa-debit.svg' );
-	background-size: contain;
+	background-image: url( '../images/payment-methods/sepa-debit.svg' );
 }
 
 .payment-method__brand--au_becs_debit {
-	background: no-repeat url( '../images/payment-methods/bank-debit.svg' );
-	background-size: contain;
+	background-image: url( '../images/payment-methods/bank-debit.svg' );
 }
 
 .payment-method__brand--link {
-	background: no-repeat url( '../images/payment-methods/link.svg' );
-	background-size: contain;
+	background-image: url( '../images/payment-methods/link.svg' );
 }
 
 .payment-method__brand--afterpay_clearpay {
-	background: no-repeat url( '../images/payment-methods/afterpay-icon.svg' );
-	background-size: contain;
+	background-image: url( '../images/payment-methods/afterpay-icon.svg' );
 }
 
 .payment-method__brand--affirm {
-	background: no-repeat url( '../images/payment-methods/affirm-icon.svg' );
-	background-size: contain;
+	background-image: url( '../images/payment-methods/affirm-icon.svg' );
 }
 
 .wc_gateways tr[data-gateway_id='woocommerce_payments'] .payment-method__icon {

--- a/changelog/fix-payment-method-brand-images
+++ b/changelog/fix-payment-method-brand-images
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fix for unreleased UI bug – no need for changelog entry.
+
+


### PR DESCRIPTION
This PR fixes a UI bug affecting the payment method image/logo on the Transaction Details screen and Transactions List screen.

<img width="944" alt="visa-bug" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/719324c5-7a6f-4628-b0c7-986c57b4065e">

<img width="1048" alt="Screenshot 2023-08-10 at 12 06 00" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/898985a9-99c1-4de7-9849-b69f2a91e46a">


A mock of each payment method image before this PR:
<img width="631" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/41778205-b0e0-491a-8d7e-e9c82648dd26">



#### Changes proposed in this Pull Request

* Changes the `background-size` for all `.payment-method__brand` variants to `contain`
* Changes the `background-repeat` for all `.payment-method__brand` variants to `no-repeat`
* Replaced each individual `.payment-method__brand--XXX` `background` declaration with `background-image` in order to use the shared `.payment-method__brand` styles.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check Payments → Transactions and confirm each payment method image is properly rendered.
* Check an individual Transaction Details screen and confirm the payment method image is properly rendered.
* Check other locations where `.payment-method__brand` may be used.
	* Dispute list screen

Here is a mock of how each payment method image will render with this PR:
<img width="634" alt="image" src="https://github.com/Automattic/woocommerce-payments/assets/3147296/0555c249-af56-4e58-83ed-c5381ebb8127">

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) Tested on Safari iOS 16.6 iPhone SE MHGV3X/A

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
