### PR TITLE
Fix disputes related wording.

### DIFF
--- a/changelog/fix-6803-disputes-wording
+++ b/changelog/fix-6803-disputes-wording
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Minor text changes
+
+

--- a/client/disputes/utils.ts
+++ b/client/disputes/utils.ts
@@ -7,7 +7,11 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
-import type { CachedDispute, EvidenceDetails } from 'wcpay/types/disputes';
+import type {
+	CachedDispute,
+	Dispute,
+	EvidenceDetails,
+} from 'wcpay/types/disputes';
 
 interface IsDueWithinProps {
 	dueBy: CachedDispute[ 'due_by' ] | EvidenceDetails[ 'due_by' ];
@@ -44,4 +48,8 @@ export const isDueWithin = ( { dueBy, days }: IsDueWithinProps ): boolean => {
 	const isWithinDays = dueByMoment.diff( now, 'days', true ) <= days;
 	const isPastDue = now.isAfter( dueByMoment );
 	return isWithinDays && ! isPastDue;
+};
+
+export const isInquiry = ( dispute: Dispute | CachedDispute ): boolean => {
+	return dispute.status.indexOf( 'warning' ) === 0;
 };

--- a/client/disputes/utils.ts
+++ b/client/disputes/utils.ts
@@ -51,5 +51,6 @@ export const isDueWithin = ( { dueBy, days }: IsDueWithinProps ): boolean => {
 };
 
 export const isInquiry = ( dispute: Dispute | CachedDispute ): boolean => {
+	// Inquiry disputes statuses are one of `warning_needs_response`, `warning_under_review` or `warning_closed`.
 	return dispute.status.indexOf( 'warning' ) === 0;
 };

--- a/client/disputes/utils.ts
+++ b/client/disputes/utils.ts
@@ -51,6 +51,6 @@ export const isDueWithin = ( { dueBy, days }: IsDueWithinProps ): boolean => {
 };
 
 export const isInquiry = ( dispute: Dispute | CachedDispute ): boolean => {
-	// Inquiry disputes statuses are one of `warning_needs_response`, `warning_under_review` or `warning_closed`.
-	return dispute.status.indexOf( 'warning' ) === 0;
+	// Inquiry dispute statuses are one of `warning_needs_response`, `warning_under_review` or `warning_closed`.
+	return dispute.status.startsWith( 'warning' );
 };

--- a/client/order/index.js
+++ b/client/order/index.js
@@ -157,8 +157,8 @@ const DisputeNotice = ( { chargeId } ) => {
 			'This order has been disputed in the amount of %1$s. The customer provided the following reason: %2$s. Please respond to this dispute before %3$s.',
 			'woocommerce-payments'
 		),
-    // Translators: %1$s is the formatted dispute amount, %2$s is the dispute reason, %3$s is the due date.
-	  inquiry_default: __(
+		// Translators: %1$s is the formatted dispute amount, %2$s is the dispute reason, %3$s is the due date.
+		inquiry_default: __(
 			// eslint-disable-next-line max-len
 			'The card network involved in this order has opened an inquiry into the transaction with the following reason: %2$s. Please respond to this inquiry before %3$s, just like you would for a formal dispute.',
 			'woocommerce-payments'

--- a/client/order/index.js
+++ b/client/order/index.js
@@ -157,7 +157,8 @@ const DisputeNotice = ( { chargeId } ) => {
 			'This order has been disputed in the amount of %1$s. The customer provided the following reason: %2$s. Please respond to this dispute before %3$s.',
 			'woocommerce-payments'
 		),
-		inquiry_default: __(
+    // Translators: %1$s is the formatted dispute amount, %2$s is the dispute reason, %3$s is the due date.
+	  inquiry_default: __(
 			// eslint-disable-next-line max-len
 			'The card network involved in this order has opened an inquiry into the transaction with the following reason: %2$s. Please respond to this inquiry before %3$s, just like you would for a formal dispute.',
 			'woocommerce-payments'

--- a/client/order/index.js
+++ b/client/order/index.js
@@ -17,6 +17,7 @@ import { formatExplicitCurrency } from 'utils/currency';
 import { reasons } from 'wcpay/disputes/strings';
 import { getDetailsURL } from 'wcpay/components/details-link';
 import { disputeAwaitingResponseStatuses } from 'wcpay/disputes/filters/config';
+import { isInquiry } from 'wcpay/disputes/utils';
 import { useCharge } from 'wcpay/data';
 import wcpayTracks from 'tracks';
 import './style.scss';
@@ -149,6 +150,29 @@ const DisputeNotice = ( { chargeId } ) => {
 		return;
 	}
 
+	const titleStrings = {
+		// Translators: %1$s is the formatted dispute amount, %2$s is the dispute reason, %3$s is the due date.
+		dispute_default: __(
+			// eslint-disable-next-line max-len
+			'This order has been disputed in the amount of %1$s. The customer provided the following reason: %2$s. Please respond to this dispute before %3$s.',
+			'woocommerce-payments'
+		),
+		inquiry_default: __(
+			// eslint-disable-next-line max-len
+			'The card network involved in this order has opened an inquiry into the transaction with the following reason: %2$s. Please respond to this inquiry before %3$s, just like you would for a formal dispute.',
+			'woocommerce-payments'
+		),
+		// Translators: %1$s is the formatted dispute amount, %2$s is the dispute reason, %3$s is the due date.
+		dispute_urgent: __(
+			'Please resolve the dispute on this order for %1$s labeled "%2$s" by %3$s.',
+			'woocommerce-payments'
+		),
+		// Translators: %1$s is the formatted dispute amount, %2$s is the dispute reason, %3$s is the due date.
+		inquiry_urgent: __(
+			'Please resolve the inquiry on this order for %1$s labeled "%2$s" by %3$s.',
+			'woocommerce-payments'
+		),
+	};
 	const amountFormatted = formatExplicitCurrency(
 		dispute.amount,
 		dispute.currency
@@ -156,30 +180,18 @@ const DisputeNotice = ( { chargeId } ) => {
 
 	let urgency = 'warning';
 	let buttonLabel = __( 'Respond now', 'woocommerce-payments' );
-	let title = sprintf(
-		// Translators: %1$s is the formatted dispute amount, %2$s is the dispute reason, %3$s is the due date.
-		__(
-			'This order has a chargeback dispute of %1$s labeled as "%2$s". Please respond to this dispute before %3$s.',
-			'woocommerce-payments'
-		),
-		amountFormatted,
-		reasons[ dispute.reason ].display,
-		dateI18n( 'M j, Y', dueBy.local().toISOString() )
-	);
 	let suffix = '';
+
+	let titleText = isInquiry( dispute )
+		? titleStrings.inquiry_default
+		: titleStrings.dispute_default;
 
 	// If the dispute is due within 7 days, use different wording.
 	if ( countdownDays < 7 ) {
-		title = sprintf(
-			// Translators: %1$s is the formatted dispute amount, %2$s is the dispute reason, %3$s is the due date.
-			__(
-				'Please resolve the dispute on this order for %1$s labeled "%2$s" by %3$s.',
-				'woocommerce-payments'
-			),
-			amountFormatted,
-			reasons[ dispute.reason ].display,
-			dateI18n( 'M j, Y', dueBy.local().toISOString() )
-		);
+		titleText = isInquiry( dispute )
+			? titleStrings.inquiry_urgent
+			: titleStrings.dispute_urgent;
+
 		suffix = sprintf(
 			// Translators: %s is the number of days left to respond to the dispute.
 			_n(
@@ -192,13 +204,19 @@ const DisputeNotice = ( { chargeId } ) => {
 		);
 	}
 
+	const title = sprintf(
+		titleText,
+		amountFormatted,
+		reasons[ dispute.reason ].display,
+		dateI18n( 'M j, Y', dueBy.local().toISOString() )
+	);
+
 	// If the dispute is due within 72 hours, we want to highlight it as urgent/red.
 	if ( countdownDays < 3 ) {
 		urgency = 'error';
 	}
 
 	if ( countdownDays < 1 ) {
-		urgency = 'error';
 		buttonLabel = __( 'Respond today', 'woocommerce-payments' );
 		suffix = __( '(Last day today)', 'woocommerce-payments' );
 	}

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -120,7 +120,7 @@ const FraudProtectionDescription = () => {
 			<h2>{ __( 'Fraud protection', 'woocommerce-payments' ) }</h2>
 			<p>
 				{ __(
-					'Help avoid chargebacks by setting your security and fraud protection risk level.',
+					'Help avoid unauthorized transactions and disputes by setting your fraud protection level.',
 					'woocommerce-payments'
 				) }
 			</p>


### PR DESCRIPTION
Fixes #6803
Fixes #6802 
Fixes #6801 

#### Changes proposed in this Pull Request

Dispute order notices wording has been updated for all inquiries. Previously the notices incorrectly referred to inquiries as disputes. Dispute notices also included the word `chargeback` which is a synonym for dispute that we are not using in WooPayments. 

The wording and color of these notices change based on how much time is left to respond to the dispute. Screenshots are provided below to show the different states of both dispute and inquiry notices.

| | **Dispute** | **Inquiry** |
|--------|--------|--------|
| **7+ days left** | ![Screenshot 2023-08-10 at 4 43 28 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/e6249370-2f55-4f47-a401-d66795fdc703)  | ![Screenshot 2023-08-10 at 4 43 05 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/64b1bb2c-2cf5-461a-8746-07be901af0e8) |
| **3-6 days left** | ![Screenshot 2023-08-10 at 4 43 51 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/1280216d-6c78-44ac-bf33-9eb3b3df0792) | ![Screenshot 2023-08-10 at 4 42 42 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/e90637db-0c64-465d-9cd2-ff1951df2dd3) |
| **1-2 days left** | ![Screenshot 2023-08-10 at 4 44 20 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/2d5ce5bb-9583-4540-9e95-c4c3ce11dd6f) | ![Screenshot 2023-08-10 at 4 42 10 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/7059c407-8621-4f63-9795-673de5bfe386) |
| **Last day** | ![Screenshot 2023-08-10 at 4 44 38 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/2a70c4a6-088b-41e6-9965-693771627038) | ![Screenshot 2023-08-10 at 4 41 09 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/05df3c02-1bf9-40ed-84eb-07db68f66c21) | 

The "Fraud Protection" section in `Payments > Settings` also mentioned `chargebacks` which has now been removed.

![Screenshot 2023-08-10 at 4 46 37 PM](https://github.com/Automattic/woocommerce-payments/assets/57298/29dd9b35-dff5-4d8c-b978-c69e427970a0)


<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

**Fraud Protection Settings**
1. Visit `Payments > Settings`
2. Scroll down to "Fraud Protection Settings" 
3. See that the helper text does not mention "chargebacks"

**Inquiry**
1. Create a new order with an inquiry test card `4000000000001976`
2. Visit the order screen in WC Admin.
3. Verify the correct wording is visible in the dispute order notice. It should clearly state that there is an "Inquiry".

**Dispute**
1. Create a new order with an dispute test card `4000000000000259`
2. Visit the order screen in WC Admin.
3. Verify the correct wording is visible in the dispute order notice. There should be no mention of "chargeback".



-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
