### PR TITLE
Hide "Fraud Protection" menu when the user is not fully onboarded

### DIFF
--- a/changelog/fix-6907-fraud-protection-menu-item-accessible-if-not-onboarded
+++ b/changelog/fix-6907-fraud-protection-menu-item-accessible-if-not-onboarded
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent displaying "Fraud protection" menu on half-onboarded stores

--- a/includes/fraud-prevention/class-fraud-risk-tools.php
+++ b/includes/fraud-prevention/class-fraud-risk-tools.php
@@ -82,7 +82,7 @@ class Fraud_Risk_Tools {
 			return;
 		}
 
-		if ( ! $this->payments_account->is_stripe_connected() || ! $this->payments_account->is_stripe_account_valid() ) {
+		if ( ! $this->payments_account->is_stripe_account_valid() ) {
 			return;
 		}
 

--- a/includes/fraud-prevention/class-fraud-risk-tools.php
+++ b/includes/fraud-prevention/class-fraud-risk-tools.php
@@ -82,7 +82,7 @@ class Fraud_Risk_Tools {
 			return;
 		}
 
-		if ( ! $this->payments_account->is_stripe_connected() ) {
+		if ( ! $this->payments_account->is_stripe_connected() || ! $this->payments_account->is_stripe_account_valid() ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #6907

### Changes proposed in this Pull Request

This PR adds an extra clause to the Stripe account connection check before adding the menu item. The problem is when the user starts onboarding, the Stripe account ID is created and attached to the blog, which makes `Account::is_stripe_connected()` return `true`, but the account is not fully onboarded. To fix it, we also need to test if `Account::is_stripe_account_valid` returns `true`.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

### Testing instructions

#### Reproducing

* Create a JN site with the latest version of WooPayments
* Start onboarding to a new Stripe account, but click `Return to WooPayments` link before finishing it
* Check if the `Fraud Protection` menu is visible under `Payments`.

#### Testing the fix
* Create a new release ZIP from this branch, and upload it a new JN site (or directly click [this link](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&branches.woocommerce-payments=fix/6907-fraud-protection-menu-item-accessible-if-not-onboarded&woocommerce-payments-dev-tools) to create a new JN site using this branch code. 
* Test the above scenario again.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
