### PR TITLE
Add woocommerce-payments-dev-tools for generated links in Jurassic Ninja integration

### DIFF
--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -122,7 +122,7 @@ jobs:
           
           #### Option 2. Jurassic Ninja - available for logged-in A12s
          
-          :rocket: [Launch a JN site with this branch](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&branches.woocommerce-payments=${PR_HEAD_REF}) :rocket:
+          :rocket: [Launch a JN site with this branch](https://jurassic.ninja/create/?jetpack-beta&shortlived&nojetpack&woocommerce&woocommerce-payments-dev-tools&branches.woocommerce-payments=${PR_HEAD_REF}) :rocket:
           
           :information_source: Install this [Tampermonkey script](https://github.com/Automattic/woocommerce-payments/tree/develop/bin/wcpay-live-branches) to get more options.
           

--- a/bin/wcpay-live-branches/wcpay-live-branches.user.js
+++ b/bin/wcpay-live-branches/wcpay-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         WCPay Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.1
+// @version      1.2
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @grant        GM_xmlhttpRequest
 // @connect      jurassic.ninja
@@ -186,6 +186,7 @@
 								{
 									label: 'WooCommerce Payments Dev Tools',
 									name: 'woocommerce-payments-dev-tools',
+									checked: true,
 								},
 								{
 									label: 'WooCommerce Smooth Generator',

--- a/changelog/dev-add-dev-tools-for-jn
+++ b/changelog/dev-add-dev-tools-for-jn
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Add woocommerce-payments-dev-tools for generated links in Jurassic Ninja integration.
+
+


### PR DESCRIPTION
Fixes #
Feedback from @tpaksu. 

#### Changes proposed in this Pull Request
Add woocommerce-payments-dev-tools for generated links in Jurassic Ninja integration, for both: 

- botwoo message 
- and TamperMonkey script.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- Check the message added by botwoo regarding JN integration below. Ensure it includes `woocommerce-payments-dev-tools`. Click it and see the new JN site. 
- Try https://github.com/Automattic/woocommerce-payments/raw/fd977fbb7e7b8c9a6786ade27f17dbf41db1c480/bin/wcpay-live-branches/wcpay-live-branches.user.js and confirm that the link also includes `woocommerce-payments-dev-tools`.

![Markup on 2023-08-11 at 14:54:16](https://github.com/Automattic/woocommerce-payments/assets/10045087/0452d564-c7ec-4049-9b76-0bfbe931dd16)


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
