### PR TITLE
Add payment gateway mode to account Tracks events

### DIFF
--- a/changelog/fix-add-mode-to-account-tracks-events
+++ b/changelog/fix-add-mode-to-account-tracks-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: It is a very minor addition to the Tracks events props.
+
+

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -790,10 +790,12 @@ class WC_Payments_Account {
 			// Track connection start.
 			if ( ! isset( $_GET['wcpay-connect-jetpack-success'] ) ) {
 
+				$test_mode        = isset( $_GET['test_mode'] ) ? boolval( wc_clean( wp_unslash( $_GET['test_mode'] ) ) ) : false;
 				$event_properties = [
 					'incentive'              => $incentive,
 					'is_new_onboarding_flow' => $progressive,
 					'woo_country_code'       => WC()->countries->get_base_country(),
+					'mode'                   => $test_mode || WC_Payments::mode()->is_test() ? 'test' : 'live',
 				];
 				$this->tracks_event(
 					self::TRACKS_EVENT_ACCOUNT_CONNECT_START,
@@ -832,10 +834,12 @@ class WC_Payments_Account {
 				}
 
 				// Track successful Jetpack connection.
+				$test_mode        = isset( $_GET['test_mode'] ) ? boolval( wc_clean( wp_unslash( $_GET['test_mode'] ) ) ) : false;
 				$event_properties = [
 					'incentive'              => $incentive,
 					'is_new_onboarding_flow' => $progressive,
 					'woo_country_code'       => WC()->countries->get_base_country(),
+					'mode'                   => $test_mode || WC_Payments::mode()->is_test() ? 'test' : 'live',
 				];
 				$this->tracks_event(
 					self::TRACKS_EVENT_ACCOUNT_CONNECT_WPCOM_CONNECTION_SUCCESS,
@@ -1253,6 +1257,7 @@ class WC_Payments_Account {
 			'incentive'              => $incentive,
 			'is_new_onboarding_flow' => $progressive,
 			'woo_country_code'       => WC()->countries->get_base_country(),
+			'mode'                   => 'test' === $mode ? 'test' : 'live',
 		];
 		$this->tracks_event(
 			self::TRACKS_EVENT_ACCOUNT_CONNECT_FINISHED,


### PR DESCRIPTION
Related to https://github.com/Automattic/woocommerce-payments/issues/6859

#### Changes proposed in this Pull Request

Add the payment gateway mode (`live` or `test`) to the server-side account Tracks events to better discern between live and test accounts in funnels.

#### Testing instructions

* The code changes should make sense

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
