### PR TITLE
Improved design of express checkout settings Page in mobile view - WooPay

### DIFF
--- a/changelog/imp-6428-improve-settings-mobile-view-express-checkouts-woopay
+++ b/changelog/imp-6428-improve-settings-mobile-view-express-checkouts-woopay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Improved design of express checkout settings Page in mobile view - WooPay

--- a/client/settings/express-checkout/woopay-item.js
+++ b/client/settings/express-checkout/woopay-item.js
@@ -84,71 +84,97 @@ const WooPayExpressCheckoutItem = () => {
 								/>
 							) }
 						</div>
-						<div className="express-checkout__icon">
-							<img src={ WooIcon } alt="WooPay" />
-						</div>
-						<div className="express-checkout__label-container">
-							<div className="express-checkout__label">
-								{ __( 'WooPay', 'woocommerce-payments' ) }
-							</div>
-							<div className="express-checkout__description">
-								{
-									/* eslint-disable jsx-a11y/anchor-has-content */
-									isWooPayEnabled
-										? __(
-												'Boost conversion and customer loyalty by offering a single click, secure way to pay.',
+						<div className="express-checkout__text-container">
+							<div>
+								<div className="express-checkout__subgroup">
+									<div className="express-checkout__icon">
+										<img src={ WooIcon } alt="WooPay" />
+									</div>
+									<div className="express-checkout__label express-checkout__label-mobile">
+										{ __(
+											'WooPay',
+											'woocommerce-payments'
+										) }
+									</div>
+									<div className="express-checkout__label-container">
+										<div className="express-checkout__label express-checkout__label-desktop">
+											{ __(
+												'WooPay',
 												'woocommerce-payments'
-										  )
-										: interpolateComponents( {
-												mixedString: __(
-													/* eslint-disable-next-line max-len */
-													'Boost conversion and customer loyalty by offering a single click, secure way to pay. ' +
-														'In order to use {{wooPayLink}}WooPay{{/wooPayLink}}, you must agree to our ' +
-														'{{tosLink}}WooCommerce Terms of Service{{/tosLink}} ' +
-														'and {{privacyLink}}Privacy Policy{{/privacyLink}}. ' +
-														'{{trackingLink}}Click here{{/trackingLink}} to learn more about the ' +
-														'data you will be sharing and opt-out options.',
-													'woocommerce-payments'
-												),
-												components: {
-													wooPayLink: (
-														<a
-															target="_blank"
-															rel="noreferrer"
-															href="https://woocommerce.com/document/woopay-merchant-documentation/"
-														/>
-													),
-													tosLink: (
-														<a
-															target="_blank"
-															rel="noreferrer"
-															href="https://wordpress.com/tos/"
-														/>
-													),
-													privacyLink: (
-														<a
-															target="_blank"
-															rel="noreferrer"
-															href="https://automattic.com/privacy/"
-														/>
-													),
-													trackingLink: (
-														<a
-															target="_blank"
-															rel="noreferrer"
-															href="https://woocommerce.com/usage-tracking/"
-														/>
-													),
-												},
-										  } )
-									/* eslint-enable jsx-a11y/anchor-has-content */
-								}
+											) }
+										</div>
+										<div className="express-checkout__description">
+											{
+												/* eslint-disable jsx-a11y/anchor-has-content */
+												isWooPayEnabled
+													? __(
+															'Boost conversion and customer loyalty by' +
+																' offering a single click, secure way to pay.',
+															'woocommerce-payments'
+													  )
+													: interpolateComponents( {
+															mixedString: __(
+																/* eslint-disable-next-line max-len */
+																'Boost conversion and customer loyalty by offering a single click, secure way to pay. ' +
+																	'In order to use {{wooPayLink}}WooPay{{/wooPayLink}},' +
+																	' you must agree to our ' +
+																	'{{tosLink}}WooCommerce Terms of Service{{/tosLink}} ' +
+																	'and {{privacyLink}}Privacy Policy{{/privacyLink}}. ' +
+																	'{{trackingLink}}Click here{{/trackingLink}} to learn more about the ' +
+																	'data you will be sharing and opt-out options.',
+																'woocommerce-payments'
+															),
+															components: {
+																wooPayLink: (
+																	<a
+																		target="_blank"
+																		rel="noreferrer"
+																		// eslint-disable-next-line max-len
+																		href="https://woocommerce.com/document/woopay-merchant-documentation/"
+																	/>
+																),
+																tosLink: (
+																	<a
+																		target="_blank"
+																		rel="noreferrer"
+																		href="https://wordpress.com/tos/"
+																	/>
+																),
+																privacyLink: (
+																	<a
+																		target="_blank"
+																		rel="noreferrer"
+																		href="https://automattic.com/privacy/"
+																	/>
+																),
+																trackingLink: (
+																	<a
+																		target="_blank"
+																		rel="noreferrer"
+																		href="https://woocommerce.com/usage-tracking/"
+																	/>
+																),
+															},
+													  } )
+												/* eslint-enable jsx-a11y/anchor-has-content */
+											}
+										</div>
+									</div>
+								</div>
 							</div>
-						</div>
-						<div className="express-checkout__link">
-							<a href={ getPaymentMethodSettingsUrl( 'woopay' ) }>
-								{ __( 'Customize', 'woocommerce-payments' ) }
-							</a>
+
+							<div className="express-checkout__link">
+								<a
+									href={ getPaymentMethodSettingsUrl(
+										'woopay'
+									) }
+								>
+									{ __(
+										'Customize',
+										'woocommerce-payments'
+									) }
+								</a>
+							</div>
 						</div>
 					</div>
 					{ showIncompatibilityNotice && (


### PR DESCRIPTION
Fixes #6428 

#### Changes proposed in this Pull Request

- Aligned mobile view for express checkouts - WooPay

Please refer to [this design](C1r0Vzxh1mhbDJJnbjHp5q-fi-2135_82787) for expected design

### Layout 1
| Before | After |
|--------|--------|
| ![image](https://github.com/Automattic/woocommerce-payments/assets/15019298/1a34336b-0283-4984-8aa6-26f962b4a802) | ![image](https://github.com/Automattic/woocommerce-payments/assets/15019298/105a4128-c35b-4d0f-8e5a-d94dba71b427) |



<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Goto Payment > Settings
- Enable Multiple payment methods by switching store currency to EUR
- Open the browser dev tools and switch to the mobile view
- Check mobile responsiveness as expected
- Make sure the desktop version UI doesn't change and is as expected.
- Check the dropdown position in both mobile and desktop versions.
- Check if the functionality is intact and doesn't change on either desktop or mobile.


![image](https://github.com/Automattic/woocommerce-payments/assets/15019298/f09d4286-8431-4db2-bfdc-c7860df04c57)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
