### PR TITLE
Fix empty cart WooPay error on WoA (WordPress.com on Atomic) environments

### DIFF
--- a/changelog/fix-atomic-sites-woopay-enabled-check
+++ b/changelog/fix-atomic-sites-woopay-enabled-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix empty cart WooPay error on WoA (WordPress.com on Atomic) environments.

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -13,7 +13,6 @@ use WCPay\Logger;
 use WC_Payments;
 use WC_Payments_Features;
 use WCPay\Platform_Checkout\SessionHandler;
-use WP_REST_Request;
 
 /**
  * Class responsible for handling woopay sessions.
@@ -326,6 +325,11 @@ class WooPay_Session {
 	 * @return bool True if WooPay is enabled, false otherwise.
 	 */
 	private static function is_woopay_enabled(): bool {
+		// This method might be called too early in certain environments, so it's important to check if these are available.
+		if ( ! class_exists( WC_Payments_Features::class ) || ! class_exists( WC_Payments::class ) || is_null( WC_Payments::get_gateway() ) ) {
+			return false;
+		}
+
 		return WC_Payments_Features::is_woopay_eligible() && 'yes' === WC_Payments::get_gateway()->get_option( 'platform_checkout', 'no' );
 	}
 }


### PR DESCRIPTION
Context: p1692118875495869-slack-C022WMN88KG

#### Changes proposed in this Pull Request

Before #6331, we had [this condition](https://github.com/Automattic/woocommerce-payments/commit/5f74b01c692567ebda122802b8fcefb99116125b#diff-b92b064836d1d92a6b3e17be46f62e1faeb72b6ac6c4debdb87d56414adfc415L298) which unexpectedly prevented a race condition problem in Atomic environments.

This PR adds a similar, but more focused condition under `is_woopay_enabled`.

#### Testing instructions

1. Since this can only be tested on Atomic environments, upload a build from this branch into https://woopaytestmerchant.wpcomstaging.com.
   a. Switch to this branch and run `npm run build`.
   b. Create a zip file from the generated build under the `release` folder.
   c. Upload the zip into an Atomic WooPay test site.
   d. When prompted, replace the existing plugin with the uploaded one.
2. Test the WooPay checkout. Ensure everything works as expected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.