### PR TITLE
Display onboarding MCC field validation error

### DIFF
--- a/changelog/fix-6813-mcc-field-validation
+++ b/changelog/fix-6813-mcc-field-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Display onboarding MCC field validation error

--- a/client/components/form/fields.tsx
+++ b/client/components/form/fields.tsx
@@ -9,26 +9,40 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import CustomSelectControl, {
-	ControlProps,
-	Item,
-} from 'components/custom-select-control';
+	ControlProps as SelectControlProps,
+	Item as SelectItem,
+} from '../custom-select-control';
 import PhoneNumberControl, {
 	PhoneNumberControlProps,
 } from '../phone-number-control';
+import GroupedSelectControl, {
+	GroupedSelectControlProps,
+	ListItem as GroupedSelectItem,
+} from '../grouped-select-control';
 import './style.scss';
 
 interface CommonProps {
 	error?: string;
 }
 
+type Item = SelectItem | GroupedSelectItem;
 export type TextFieldProps = TextControl.Props & CommonProps;
-export type SelectFieldProps< ItemType > = ControlProps< ItemType > &
+export type SelectFieldProps< ItemType > = SelectControlProps< ItemType > &
 	CommonProps;
 export type PhoneNumberFieldProps = PhoneNumberControlProps & CommonProps;
+export type GroupedSelectFieldProps< ItemType > = GroupedSelectControlProps<
+	ItemType
+> &
+	CommonProps;
 
 type FieldProps< ItemType > = {
-	component: 'text' | 'select' | 'phone';
-} & ( TextFieldProps | SelectFieldProps< ItemType > | PhoneNumberFieldProps );
+	component: 'text' | 'select' | 'phone' | 'grouped-select';
+} & (
+	| TextFieldProps
+	| SelectFieldProps< ItemType >
+	| PhoneNumberFieldProps
+	| GroupedSelectFieldProps< ItemType >
+ );
 
 const Field = < ItemType extends Item >( {
 	component,
@@ -46,12 +60,16 @@ const Field = < ItemType extends Item >( {
 			field = <TextControl { ...props } />;
 			break;
 		case 'select':
-			props = rest as SelectFieldProps< ItemType >;
+			props = rest as SelectFieldProps< SelectItem >;
 			field = <CustomSelectControl { ...props } />;
 			break;
 		case 'phone':
 			props = rest as PhoneNumberFieldProps;
 			field = <PhoneNumberControl { ...props } />;
+			break;
+		case 'grouped-select':
+			props = rest as GroupedSelectFieldProps< GroupedSelectItem >;
+			field = <GroupedSelectControl { ...props } />;
 			break;
 	}
 
@@ -69,12 +87,16 @@ export const TextField: React.FC< TextFieldProps > = ( props ) => (
 	<Field component={ 'text' } { ...props } />
 );
 
-export const SelectField = < ItemType extends Item >(
+export const SelectField = < ItemType extends SelectItem >(
 	props: SelectFieldProps< ItemType >
 ): JSX.Element => <Field component={ 'select' } { ...props } />;
 
 export const PhoneNumberField: React.FC< PhoneNumberControlProps > = (
 	props
 ) => <Field component={ 'phone' } { ...props } />;
+
+export const GroupedSelectField = < ItemType extends GroupedSelectItem >(
+	props: GroupedSelectControlProps< ItemType >
+): JSX.Element => <Field component={ 'grouped-select' } { ...props } />;
 
 export default Field;

--- a/client/components/form/style.scss
+++ b/client/components/form/style.scss
@@ -4,11 +4,12 @@
 	}
 }
 
-.components-custom-select-control.has-error {
+.components-custom-select-control.has-error,
+.wcpay-component-grouped-select-control.has-error {
 	margin-bottom: $gap-smaller;
 
 	button {
-		border-color: $alert-red;
+		border-color: $alert-red !important;
 	}
 }
 

--- a/client/components/form/test/fields.tsx
+++ b/client/components/form/test/fields.tsx
@@ -7,7 +7,12 @@ import { render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import { TextField, SelectField, PhoneNumberField } from '../fields';
+import {
+	TextField,
+	SelectField,
+	PhoneNumberField,
+	GroupedSelectField,
+} from '../fields';
 
 describe( 'Form fields components', () => {
 	it( 'renders TextField component with provided props', () => {
@@ -43,6 +48,21 @@ describe( 'Form fields components', () => {
 			<PhoneNumberField
 				label="Test Label"
 				value="123"
+				onChange={ jest.fn() }
+			/>
+		);
+		expect( screen.getByText( 'Test Label' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders GroupedSelectField component with provided props', () => {
+		const options = [
+			{ key: 'option-1', name: 'Option 1', group: 'a' },
+			{ key: 'option-2', name: 'Option 2', group: 'b' },
+		];
+		render(
+			<GroupedSelectField
+				label="Test Label"
+				options={ options }
 				onChange={ jest.fn() }
 			/>
 		);

--- a/client/onboarding/form.tsx
+++ b/client/onboarding/form.tsx
@@ -9,8 +9,11 @@ import { isEmpty, mapValues } from 'lodash';
  * Internal dependencies
  */
 import { useStepperContext } from 'components/stepper';
-import { Item } from 'components/custom-select-control';
+import { Item as SelectItem } from 'components/custom-select-control';
+import { ListItem as GroupedSelectItem } from 'components/grouped-select-control';
 import {
+	GroupedSelectField,
+	GroupedSelectFieldProps,
 	PhoneNumberField,
 	PhoneNumberFieldProps,
 	SelectField,
@@ -23,9 +26,6 @@ import { OnboardingFields } from './types';
 import { useValidation } from './validation';
 import { trackStepCompleted } from './tracking';
 import strings from './strings';
-import GroupedSelectControl, {
-	ListItem,
-} from 'components/grouped-select-control';
 
 export const OnboardingForm: React.FC = ( { children } ) => {
 	const { errors, touched, setTouched } = useOnboardingContext();
@@ -121,7 +121,7 @@ interface OnboardingSelectFieldProps< ItemType >
 	onChange?: ( name: keyof OnboardingFields, item?: ItemType | null ) => void;
 }
 
-export const OnboardingSelectField = < ItemType extends Item >( {
+export const OnboardingSelectField = < ItemType extends SelectItem >( {
 	name,
 	onChange,
 	...rest
@@ -154,11 +154,14 @@ export const OnboardingSelectField = < ItemType extends Item >( {
 };
 
 interface OnboardingGroupedSelectFieldProps< ItemType >
-	extends OnboardingSelectFieldProps< ItemType > {
-	searchable?: boolean;
+	extends Partial< Omit< GroupedSelectFieldProps< ItemType >, 'onChange' > > {
+	name: keyof OnboardingFields;
+	onChange?: ( name: keyof OnboardingFields, item?: ItemType | null ) => void;
 }
 
-export const OnboardingGroupedSelectField = < ListItemType extends ListItem >( {
+export const OnboardingGroupedSelectField = <
+	ListItemType extends GroupedSelectItem
+>( {
 	name,
 	onChange,
 	...rest
@@ -167,7 +170,7 @@ export const OnboardingGroupedSelectField = < ListItemType extends ListItem >( {
 	const { validate, error } = useValidation( name );
 
 	return (
-		<GroupedSelectControl
+		<GroupedSelectField
 			label={ strings.fields[ name ] }
 			value={ rest.options?.find(
 				( item ) => item.key === data[ name ]

--- a/client/onboarding/style.scss
+++ b/client/onboarding/style.scss
@@ -111,7 +111,8 @@ body.wcpay-onboarding__body {
 		}
 
 		.components-base-control,
-		.components-custom-select-control {
+		.components-custom-select-control,
+		.wcpay-component-grouped-select-control {
 			margin-bottom: $gap-large;
 		}
 


### PR DESCRIPTION
Fixes #6813 

#### Changes proposed in this Pull Request
- Create `GroupedSelectedField` to wrap `GroupedSelectControl` and display the validation error message.
- Ensure that the error style is accordingly applied to both `CustomSelectControl` and `GroupedSelectControl`, including the `border-color`.

#### Testing instructions
- Go to the business details step on the onboarding process.
- Click on **Continue** without filling anything.
- MCC field should display the error message `Please provide a type of goods or services`.

### Screenshot
<img width="411" alt="Screenshot 2023-08-16 at 12 08 17" src="https://github.com/Automattic/woocommerce-payments/assets/7670276/e334570f-809c-4b4e-be64-15c22f4fd3c2">


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
