### PR TITLE
Improved and updated copy for credit card payment method in settings

### DIFF
--- a/changelog/imp-6428-improve-settings-mobile-view-credit-card
+++ b/changelog/imp-6428-improve-settings-mobile-view-credit-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Updated copy for credit and debit card in settings

--- a/client/components/payment-methods-checkboxes/test/index.test.tsx
+++ b/client/components/payment-methods-checkboxes/test/index.test.tsx
@@ -195,7 +195,7 @@ describe( 'PaymentMethodsCheckboxes', () => {
 			</PaymentMethodsCheckboxes>
 		);
 		const cardCheckbox = screen.getByRole( 'checkbox', {
-			name: 'Credit card / debit card',
+			name: 'Credit / Debit card',
 		} );
 		expect( cardCheckbox ).not.toBeChecked();
 		userEvent.click( cardCheckbox );

--- a/client/payment-methods-map.tsx
+++ b/client/payment-methods-map.tsx
@@ -44,7 +44,7 @@ const PaymentMethodInformationObject: Record<
 > = {
 	card: {
 		id: 'card',
-		label: __( 'Credit card / debit card', 'woocommerce-payments' ),
+		label: __( 'Credit / Debit card', 'woocommerce-payments' ),
 		brandTitles: {
 			amex: __( 'American Express', 'woocommerce-payments' ),
 			diners: __( 'Diners Club', 'woocommerce-payments' ),

--- a/client/payment-methods/test/__snapshots__/activation-modal.test.js.snap
+++ b/client/payment-methods/test/__snapshots__/activation-modal.test.js.snap
@@ -55,7 +55,7 @@ exports[`Activation Modal matches the snapshot 1`] = `
               class="components-modal__header-heading"
               id="components-modal-header-0"
             >
-              One more step to enable Credit card / debit card
+              One more step to enable Credit / Debit card
             </h1>
           </div>
           <button
@@ -104,7 +104,7 @@ exports[`Activation Modal matches the snapshot 1`] = `
           </div>
         </div>
         <p>
-          You need to provide more information to enable Credit card / debit card on your checkout:
+          You need to provide more information to enable Credit / Debit card on your checkout:
         </p>
         <ul
           class="payment-method-requirements-list"

--- a/client/payment-methods/test/__snapshots__/delete-modal.test.js.snap
+++ b/client/payment-methods/test/__snapshots__/delete-modal.test.js.snap
@@ -55,7 +55,7 @@ exports[`Activation Modal matches the snapshot 1`] = `
               class="components-modal__header-heading"
               id="components-modal-header-0"
             >
-              Remove Credit card / debit card from checkout
+              Remove Credit / Debit card from checkout
             </h1>
           </div>
           <button
@@ -106,9 +106,9 @@ exports[`Activation Modal matches the snapshot 1`] = `
         <p>
           Are you sure you want to remove 
           <strong>
-            Credit card / debit card
+            Credit / Debit card
           </strong>
-          ? Your customers will no longer be able to pay using Credit card / debit card.
+          ? Your customers will no longer be able to pay using Credit / Debit card.
         </p>
         <p>
           You can add it again at any time in 

--- a/client/payment-methods/test/index.js
+++ b/client/payment-methods/test/index.js
@@ -97,7 +97,7 @@ describe( 'PaymentMethods', () => {
 		);
 
 		const cc = screen.getByRole( 'checkbox', {
-			name: 'Credit card / debit card',
+			name: 'Credit / Debit card',
 		} );
 		const becs = screen.getByRole( 'checkbox', {
 			name: 'BECS Direct Debit',
@@ -148,7 +148,7 @@ describe( 'PaymentMethods', () => {
 		const updateEnabledMethodsMock = jest.fn( () => {} );
 		useSelectedPaymentMethod.mockReturnValue( [
 			[
-				'Credit card / debit card',
+				'Credit / Debit card',
 				'BECS Direct Debit',
 				'Bancontact',
 				'EPS',


### PR DESCRIPTION
Improvement extended from: https://github.com/Automattic/woocommerce-payments/pull/6903#issuecomment-1677913019

#### Changes proposed in this Pull Request

Change the copy for Credit and debit card. 
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
| Before | After |
|--------|--------|
| ![image](https://github.com/Automattic/woocommerce-payments/assets/15019298/052d9957-fe70-49b5-8ae9-bb6c9414f401) | ![image](https://github.com/Automattic/woocommerce-payments/assets/15019298/c19ea59e-79ff-4b4c-acdd-3c97c24287f2) |

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 - Goto `Payments > Settings` page
 - Observe the text change in the desktop and mobile version

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
