### PR TITLE
Add `is_user_connected()` and `get_connected_user_data()` methods to `WC_Payments_Http_Interface`

### DIFF
--- a/changelog/6997-public-methods-of-wc_payments_http-class-being-used-without-being-a-part-of-the-wc_payments_http_interface
+++ b/changelog/6997-public-methods-of-wc_payments_http-class-being-used-without-being-a-part-of-the-wc_payments_http_interface
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add `is_user_connected()` and `get_connected_user_data()` methods to `WC_Payments_Http_Interface`

--- a/includes/wc-payment-api/class-wc-payments-http-interface.php
+++ b/includes/wc-payment-api/class-wc-payments-http-interface.php
@@ -46,6 +46,20 @@ interface WC_Payments_Http_Interface {
 	public function has_connection_owner();
 
 	/**
+	 * Checks if the current user is connected to WordPress.com.
+	 *
+	 * @return bool true if the current user is connected.
+	 */
+	public function is_user_connected();
+
+	/**
+	 * Get the wpcom user data of the current connected user.
+	 *
+	 * @return bool|array An array with the WPCOM user data on success, false otherwise.
+	 */
+	public function get_connected_user_data();
+
+	/**
 	 * Gets the current WP.com blog ID.
 	 *
 	 * @return integer Current WPCOM blog ID.


### PR DESCRIPTION
Fixes #6997 

#### Changes proposed in this Pull Request

Add `is_user_connected()` and `get_connected_user_data()` methods to `WC_Payments_Http_Interface`.  

These methods are used by `WC_Payments::woopay_tracker()->tracks_get_identity()`, but because the interface doesn't require these methods to be implemented, a custom implementation may not have them, causing a fatal error at runtime.

##### How can this code break?

If a custom implementation already exists, this code will break the site immediately as static analysis of the PHP will result in an immediate error rather than one that only occurs during checkout.

An alternative approach would be for the calling code to always check if the `WC_Payments_Http_Interface` implementation has the methods needed.  However, I think it is pretty unlikely that a site outside of WordPress.com would have a custom `WC_Payments_Http_Interface` implementation.
