### PR TITLE
Revert #6331 fix multi currency switcher

### DIFF
--- a/changelog/fix-invalid-currency-from-store-api-request
+++ b/changelog/fix-invalid-currency-from-store-api-request
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Fix WooPay Session Handler in Store API requests.

--- a/changelog/revert-6331-fix-multi-currency-switcher
+++ b/changelog/revert-6331-fix-multi-currency-switcher
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Revert fix WooPay Session Handler in Store API requests.

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -45,7 +45,7 @@ class WooPay_Session {
 	 */
 	public static function init() {
 		add_filter( 'determine_current_user', [ __CLASS__, 'determine_current_user_for_woopay' ], 20 );
-		add_filter( 'woocommerce_session_handler', [ __CLASS__, 'add_woopay_store_api_session_handler' ], 20 );
+		add_filter( 'rest_request_before_callbacks', [ __CLASS__, 'add_woopay_store_api_session_handler' ], 10, 3 );
 		add_action( 'woocommerce_order_payment_status_changed', [ __CLASS__, 'remove_order_customer_id_on_requests_with_verified_email' ] );
 		add_action( 'woopay_restore_order_customer_id', [ __CLASS__, 'restore_order_customer_id_from_requests_with_verified_email' ] );
 
@@ -56,24 +56,31 @@ class WooPay_Session {
 	 * This filter is used to add a custom session handler before processing Store API request callbacks.
 	 * This is only necessary because the Store API SessionHandler currently doesn't provide an `init_session_cookie` method.
 	 *
-	 * @param string $default_session_handler The default session handler class name.
+	 * @param mixed           $response The response object.
+	 * @param mixed           $handler The handler used for the response.
+	 * @param WP_REST_Request $request The request used to generate the response.
 	 *
-	 * @return string The session handler class name.
+	 * @return mixed
 	 */
-	public static function add_woopay_store_api_session_handler( $default_session_handler ) {
-		$cart_token = wc_clean( wp_unslash( $_SERVER['HTTP_CART_TOKEN'] ?? null ) );
+	public static function add_woopay_store_api_session_handler( $response, $handler, WP_REST_Request $request ) {
+		$cart_token = $request->get_header( 'Cart-Token' );
 
 		if (
 			$cart_token &&
-			self::is_request_from_woopay() &&
 			self::is_store_api_request() &&
 			class_exists( JsonWebToken::class ) &&
 			JsonWebToken::validate( $cart_token, '@' . wp_salt() )
 		) {
-			return SessionHandler::class;
+			add_filter(
+				'woocommerce_session_handler',
+				function ( $session_handler ) {
+					return SessionHandler::class;
+				},
+				20
+			);
 		}
 
-		return $default_session_handler;
+		return $response;
 	}
 
 	/**
@@ -288,6 +295,10 @@ class WooPay_Session {
 	 * @return bool True if request is a Store API request, false otherwise.
 	 */
 	private static function is_store_api_request(): bool {
+		if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+			return false;
+		}
+
 		$url_parts    = wp_parse_url( esc_url_raw( $_SERVER['REQUEST_URI'] ?? '' ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		$request_path = rtrim( $url_parts['path'], '/' );
 		$rest_route   = str_replace( trailingslashit( rest_get_url_prefix() ), '', $request_path );


### PR DESCRIPTION
Context: p1692214009207459/1692118875.495869-slack-C022WMN88KG

#### Changes proposed in this Pull Request

This PR reverts https://github.com/Automattic/woocommerce-payments/pull/6331.

#### Testing instructions

* Please test this against the staging environment by uploading a build generated from this branch.
* Ensure the WooPay checkout works as expected.
* Ensure the diff looks correct.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.