### PR TITLE
Add the lib folder to release build

### DIFF
--- a/changelog/add-lib-folder-to-release-build
+++ b/changelog/add-lib-folder-to-release-build
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Add the lib folder is missed in PR #6862
+
+

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -18,6 +18,7 @@ const filesToCopy = [
 	'i18n',
 	'languages',
 	'src',
+	'lib',
 	'templates',
 	'vendor',
 	'woocommerce-payments.php',


### PR DESCRIPTION
This folder is is missed in PR #6862

Fixes #

#### Changes proposed in this Pull Request

This change is similar to https://github.com/Automattic/woocommerce-payments/pull/6805/files#diff-ec35879e287f47fffad31c52de53a3fec88aaeb6fc94261f87f897a8a113b08fR20

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

- Check the build that can be found on https://jurassic.ninja/wp-json/jurassic.ninja/jetpack-beta/plugins/woocommerce-payments/branches - searching for the branch of this PR `add/lib-folder-to-release-build`.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
