### PR TITLE
Fix onboarding text fields autofill validation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -137,7 +137,10 @@
 				"wpcalypso/jsx-classname-namespace": "off",
 				"react/react-in-jsx-scope": "error",
 				"no-shadow": "off",
-				"@typescript-eslint/no-shadow": "error"
+				"@typescript-eslint/no-shadow": "error",
+				"jsdoc/require-param-type": 0,
+				"jsdoc/require-returns-type": 0,
+				"valid-jsdoc": "off"
 			}
 		}
 	]

--- a/changelog/fix-text-fields-autofill-validation
+++ b/changelog/fix-text-fields-autofill-validation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Tiny fix to avoid showing a validation error when fields are filled using autofill
+
+

--- a/client/onboarding/form.tsx
+++ b/client/onboarding/form.tsx
@@ -64,14 +64,21 @@ export const OnboardingTextField: React.FC< OnboardingTextFieldProps > = ( {
 } ) => {
 	const { data, setData, touched } = useOnboardingContext();
 	const { validate, error } = useValidation( name );
+	const inputRef = React.useRef< HTMLInputElement >( null );
 
 	return (
 		<TextField
+			ref={ inputRef as any }
 			label={ strings.fields[ name ] }
 			value={ data[ name ] || '' }
 			onChange={ ( value: string ) => {
 				setData( { [ name ]: value } );
-				if ( touched[ name ] ) validate( value );
+				if (
+					touched[ name ] ||
+					inputRef.current !==
+						inputRef.current?.ownerDocument.activeElement
+				)
+					validate( value );
 			} }
 			onBlur={ () => validate() }
 			onKeyDown={ ( event: React.KeyboardEvent< HTMLInputElement > ) => {

--- a/client/onboarding/test/form.tsx
+++ b/client/onboarding/test/form.tsx
@@ -130,6 +130,7 @@ describe( 'Onboarding Form', () => {
 			render( <OnboardingTextField name="individual.first_name" /> );
 
 			const textField = screen.getByLabelText( 'First name' );
+			textField.focus(); // Workaround for `type` not triggering focus.
 			userEvent.type( textField, 'John' );
 
 			expect( setData ).toHaveBeenCalledWith( {
@@ -139,8 +140,17 @@ describe( 'Onboarding Form', () => {
 			expect( validate ).not.toHaveBeenCalled();
 		} );
 
-		it( 'only calls validate on change if touched', () => {
+		it( 'calls validate on change if touched', () => {
 			touched = { 'individual.first_name': true };
+			render( <OnboardingTextField name="individual.first_name" /> );
+
+			const textField = screen.getByLabelText( 'First name' );
+			userEvent.type( textField, 'John' );
+
+			expect( validate ).toHaveBeenCalledWith( 'John' );
+		} );
+
+		it( 'calls validate on change if not focused', () => {
 			render( <OnboardingTextField name="individual.first_name" /> );
 
 			const textField = screen.getByLabelText( 'First name' );


### PR DESCRIPTION
While working on #7010 I've noticed that when form fields are filled using browser autofill feature, you need to focus and blur on text fields to be able to proceed, due to our current implementation checking if the field is touched.

#### Changes proposed in this Pull Request
- Update ESLint TypeScript config to switch off `valid-jsdoc` which is deprecated, and disable `jsdoc/require-param-type` and `jsdoc/require-returns-type` which are redundant, as TS already includes param and return types.
- Refactor form/fields code to use a simpler approach. Using `makeField` function to decorate controls with errors rather than having a switch-based component, which makes type definitions a bit more cumbersome. Allowing also to pass an optional React reference, required for the next change.
- Update `<OnboardingTextField/>` to include `useRef` and also check for the input not being focused to run validation. This also allows us to validate data when it has been filled using the browser autofill feature.

#### Testing instructions
>[!Note]
> It's required to have autofill enabled in your browser, and some data already there to be able to test it.

##### Without this PR
- Go to the personal step on the onboarding process.
- Click on **First name** field a pick an autofill entry.
- Click on **Continue** without touching anything else.
- **Last name** and **Email** fields should display validation errors. Required you to focus & blur on each of them before proceeding.

##### With this PR
- Go to the personal step on the onboarding process.
- Click on **First name** field a pick an autofill entry.
- Click on **Continue** without touching anything else.
- The flow should move forward to the business step without any issue.

#### Issue screencast

https://github.com/Automattic/woocommerce-payments/assets/7670276/f70698d6-e0a6-447e-810e-81163696ecef

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
