### PR TITLE
Stripe Link and SEPA Debit tokens always stored to correct payment gateway

### DIFF
--- a/changelog/fix-get-stripe-link-payment-tokens-split-upe
+++ b/changelog/fix-get-stripe-link-payment-tokens-split-upe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensures that Stripe Link and SEPA Debit saved payment tokens are stored and validated with correct gateway IDs for relevant feature flags enabled.

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -21,7 +21,7 @@ class WC_Payments_Token_Service {
 	const REUSABLE_GATEWAYS_BY_PAYMENT_METHOD = [
 		Payment_Method::CARD => WC_Payment_Gateway_WCPay::GATEWAY_ID,
 		Payment_Method::SEPA => WC_Payment_Gateway_WCPay::GATEWAY_ID . '_' . Payment_Method::SEPA,
-		Payment_Method::LINK => WC_Payment_Gateway_WCPay::GATEWAY_ID . '_' . Payment_Method::LINK,
+		Payment_Method::LINK => WC_Payment_Gateway_WCPay::GATEWAY_ID,
 	];
 
 	/**
@@ -71,7 +71,7 @@ class WC_Payments_Token_Service {
 		switch ( $payment_method['type'] ) {
 			case Payment_Method::SEPA:
 				$token      = new WC_Payment_Token_WCPay_SEPA();
-				$gateway_id = WC_Payments_Features::is_upe_split_enabled() ?
+				$gateway_id = WC_Payments_Features::is_upe_split_enabled() || WC_Payments_Features::is_upe_deferred_intent_enabled() ?
 					WC_Payment_Gateway_WCPay::GATEWAY_ID . '_' . Payment_Method::SEPA :
 					CC_Payment_Gateway::GATEWAY_ID;
 				$token->set_gateway_id( $gateway_id );
@@ -79,9 +79,7 @@ class WC_Payments_Token_Service {
 				break;
 			case Payment_Method::LINK:
 				$token      = new WC_Payment_Token_WCPay_Link();
-				$gateway_id = WC_Payments_Features::is_upe_split_enabled() ?
-					WC_Payment_Gateway_WCPay::GATEWAY_ID . '_' . Payment_Method::LINK :
-					CC_Payment_Gateway::GATEWAY_ID;
+				$gateway_id = CC_Payment_Gateway::GATEWAY_ID;
 				$token->set_gateway_id( $gateway_id );
 				$token->set_email( $payment_method[ Payment_Method::LINK ]['email'] );
 				break;
@@ -121,7 +119,7 @@ class WC_Payments_Token_Service {
 	 * @return bool                       True, if payment method type matches gateway, false if otherwise.
 	 */
 	public function is_valid_payment_method_type_for_gateway( $payment_method_type, $gateway_id ) {
-		if ( WC_Payments_Features::is_upe_split_enabled() ) {
+		if ( WC_Payments_Features::is_upe_split_enabled() || WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
 			return self::REUSABLE_GATEWAYS_BY_PAYMENT_METHOD[ $payment_method_type ] === $gateway_id;
 		} else {
 			return WC_Payments::get_gateway()->id === $gateway_id;

--- a/tests/unit/test-class-wc-payments-token-service.php
+++ b/tests/unit/test-class-wc-payments-token-service.php
@@ -111,6 +111,54 @@ class WC_Payments_Token_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Test add SEPA token to user with split UPE.
+	 */
+	public function test_add_token_to_user_for_sepa_split_upe() {
+		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
+		$mock_payment_method = [
+			'id'         => 'pm_mock',
+			'sepa_debit' => [
+				'last4' => '3000',
+			],
+			'type'       => Payment_Method::SEPA,
+		];
+
+		$token = $this->token_service->add_token_to_user( $mock_payment_method, wp_get_current_user() );
+
+		$this->assertEquals( 'woocommerce_payments_sepa_debit', $token->get_gateway_id() );
+		$this->assertEquals( 1, $token->get_user_id() );
+		$this->assertEquals( 'pm_mock', $token->get_token() );
+		$this->assertEquals( '3000', $token->get_last4() );
+		$this->assertInstanceOf( WC_Payment_Token_WCPay_SEPA::class, $token );
+		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '0' );
+
+	}
+
+	/**
+	 * Test add SEPA token to user with deferred intent UPE.
+	 */
+	public function test_add_token_to_user_for_sepa_deferred_upe() {
+		update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, '1' );
+		$mock_payment_method = [
+			'id'         => 'pm_mock',
+			'sepa_debit' => [
+				'last4' => '3000',
+			],
+			'type'       => Payment_Method::SEPA,
+		];
+
+		$token = $this->token_service->add_token_to_user( $mock_payment_method, wp_get_current_user() );
+
+		$this->assertEquals( 'woocommerce_payments_sepa_debit', $token->get_gateway_id() );
+		$this->assertEquals( 1, $token->get_user_id() );
+		$this->assertEquals( 'pm_mock', $token->get_token() );
+		$this->assertEquals( '3000', $token->get_last4() );
+		$this->assertInstanceOf( WC_Payment_Token_WCPay_SEPA::class, $token );
+		update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, '0' );
+
+	}
+
+	/**
 	 * Test add Link token to user.
 	 */
 	public function test_add_token_to_user_for_link() {
@@ -130,6 +178,54 @@ class WC_Payments_Token_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 'test@test.com', $token->get_email() );
 		$this->assertSame( '***test@test.com', $token->get_redacted_email() );
 		$this->assertInstanceOf( WC_Payment_Token_WCPay_Link::class, $token );
+	}
+
+	/**
+	 * Test add Link token to user with split UPE.
+	 */
+	public function test_add_token_to_user_for_link_split_upe() {
+		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
+		$mock_payment_method = [
+			'id'   => 'pm_mock',
+			'link' => [
+				'email' => 'test@test.com',
+			],
+			'type' => Payment_Method::LINK,
+		];
+
+		$token = $this->token_service->add_token_to_user( $mock_payment_method, wp_get_current_user() );
+
+		$this->assertSame( 'woocommerce_payments', $token->get_gateway_id() );
+		$this->assertSame( 1, $token->get_user_id() );
+		$this->assertSame( 'pm_mock', $token->get_token() );
+		$this->assertSame( 'test@test.com', $token->get_email() );
+		$this->assertSame( '***test@test.com', $token->get_redacted_email() );
+		$this->assertInstanceOf( WC_Payment_Token_WCPay_Link::class, $token );
+		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '0' );
+	}
+
+	/**
+	 * Test add Link token to user with deferred intent UPE.
+	 */
+	public function test_add_token_to_user_for_link_deferred_upe() {
+		update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, '1' );
+		$mock_payment_method = [
+			'id'   => 'pm_mock',
+			'link' => [
+				'email' => 'test@test.com',
+			],
+			'type' => Payment_Method::LINK,
+		];
+
+		$token = $this->token_service->add_token_to_user( $mock_payment_method, wp_get_current_user() );
+
+		$this->assertSame( 'woocommerce_payments', $token->get_gateway_id() );
+		$this->assertSame( 1, $token->get_user_id() );
+		$this->assertSame( 'pm_mock', $token->get_token() );
+		$this->assertSame( 'test@test.com', $token->get_email() );
+		$this->assertSame( '***test@test.com', $token->get_redacted_email() );
+		$this->assertInstanceOf( WC_Payment_Token_WCPay_Link::class, $token );
+		update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, '0' );
 	}
 
 	public function test_add_payment_method_to_user() {


### PR DESCRIPTION
Fixes #6261

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
# Stripe Link and SEPA Debit payment token trauma terminated at last
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
## Stripe Link

When the split UPE is enabled--not legacy UPE and not deferred intent UPE--is enabled, Stripe Link saved payment tokens are bestowed with an incorrect gateway ID. [Here](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payments-token-service.php#L83) we can see that they will be stored with the gateway ID of `woocommerce_payments_link`. This is incorrect, as they should always be associated with the card gateway and have a gateway ID of `woocommerce_payments`. 

Peculiarly if you save a Stripe Link payment method with the split UPE enabled, it will appear on the My accounts dashboard (*My account > Payment methods*), but not at checkout. This is because when payment methods are [recalled by the `woocommerce_get_customer_payment_tokens` function](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payments-token-service.php#L139), `is_valid_payment_method_type_for_gateway` will always return `false` in [this conditional](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payments-token-service.php#L196C72-L196C112), since the gateway ID indicated [here](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payments-token-service.php#L24) is incorrect. However, when this function is called on the My accounts Payment methods page, `$gateway_id` is `null`, so the check is ignored. 

Consequently, Stripe Link tokens are not presented at checkout, but are present on the My accounts dashboard (and are otherwise fully functional in renewals).

## SEPA Debit

When the deferred intent UPE is enabled--and split UPE is disabled--SEPA Debit payment methods can be saved, but the tokens will appear in the CC gateway instead of the SEPA Debit gateway. 

This is because the logic [here](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payments-token-service.php#L74) is incorrect, since this conditional does not include deferred intent UPE. So when the deferred intent UPE is enabled, SEPA Debit tokens will erroneously be saved with the CC gateway's ID.

In short, this PR addresses all of the above, sets the score straight, and ensures that gateway IDs and validation for Stripe Link and SEPA Debit tokens is now correct for whichever feature flag is enabled. 

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

## Stripe Link

1. Enable *only* the split UPE, remove SEPA Debit from your store (so that the legacy UPE is not used as a fallback), and make sure you are on the `develop` branch first.
2. Save a Link payment token, by either opting to do so during a regular checkout or purchasing a subscription product using Stripe Link.
3. Visit a new checkout and notice that your saved Link token is not visible.
4. Visit the My accounts dashboard (*My account > Payment methods*) and notice that your Link token *is* visible.
5. Switch to this PR branch, repeat the above steps, and you should find that your Link token is present on any checkout page (shortcode/blocks) and the My accounts dashboard, as expected.
6. Purchase a subscription product using Link. You should be able to change the payment method from Link and process a renewal payment on the subscription using Link.
7. Lucky number seven.

## SEPA Debit

1. Enable *only* the deferred intent UPE, add SEPA Debit to your store, and make sure you are on the `develop`  branch first. Edit [the `WC_Payments_Features::is_upe_split_eligible()` function](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payments-features.php#L87) to always return `true`.
2. Save a SEPA Debit payment token, by either opting to do so during a regular checkout or purchasing a subscription product using Stripe Link.
3. Visit any new checkout and notice that your SEPA Debit token appears under the CC gateway, instead of the SEPA Debit gateway.
4. Switch to this PR branch, repeat the above steps, and you should find your SEPA Debit token stored under the correct gateway this time.


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
