### PR TITLE
Check if store is connected to Stripe account before fetching disputes for WooCommerce home task

### DIFF
--- a/changelog/fix-check-if-conneced-wc-home-disputes-task
+++ b/changelog/fix-check-if-conneced-wc-home-disputes-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fetching disputes on WooCommerce home task when store is not connected to a WooPayments account.

--- a/includes/class-wc-payments-tasks.php
+++ b/includes/class-wc-payments-tasks.php
@@ -30,6 +30,10 @@ class WC_Payments_Tasks {
 	 * Adds a task to the WC 'Things to do next' task list the if disputes awaiting response.
 	 */
 	public static function add_task_disputes_need_response() {
+		if ( ! WC_Payments::get_account_service()->is_stripe_account_valid() ) {
+			return;
+		}
+
 		// 'extended' = 'Things to do next' task list on WooCommerce > Home.
 		TaskLists::add_task( 'extended', new WC_Payments_Task_Disputes() );
 	}


### PR DESCRIPTION
Context: p1692193369706759-slack-C03V0SP07SL

#### Changes proposed in this Pull Request

Check if store is connected to a WooPayments account before fetching disputes to be displayed as one of the tasks on WooCommerce home.

#### Testing instructions

* Install WooCommerce.
* Install WooPayments.
* Do not onboard or if you're already onboarded, disconnect from WooPayments account. I did so by changing the blog id in the WooPayments server's database. I think 'Force the WCPay plugin to act as disconnected from the WCPay Server' in the WCPay Dev tool works too.
* Confirm that we're no longer fetching disputes data. It's hard to test this without doing any local modification to the code. I put some logging in [this line](https://github.com/Automattic/woocommerce-payments/blob/85c37066e1d2f4895c60cd60f8788fcb07e59aba/includes/class-database-cache.php#L106C1-L106C1) and remove option named `wcpay_active_dispute_cache` from `wp_options` table.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.