### PR TITLE
Track WooPay Save My Info checkbox usage

### DIFF
--- a/changelog/add-track-save-my-info-click
+++ b/changelog/add-track-save-my-info-click
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Track WooPay Save My Info checkbox usage

--- a/client/components/woopay/save-user/checkout-page-save-user.js
+++ b/client/components/woopay/save-user/checkout-page-save-user.js
@@ -23,6 +23,7 @@ import useWooPayUser from '../hooks/use-woopay-user';
 import useSelectedPaymentMethod from '../hooks/use-selected-payment-method';
 import { WC_STORE_CART } from '../../../checkout/constants';
 import WooPayIcon from 'assets/images/woopay.svg?asset';
+import wcpayTracks from 'tracks';
 import './style.scss';
 
 const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
@@ -122,6 +123,13 @@ const CheckoutPageSaveUser = ( { isBlocksCheckout } ) => {
 			}
 		}
 		setIsSaveDetailsChecked( isChecked );
+
+		wcpayTracks.recordUserEvent(
+			wcpayTracks.events.WOOPAY_SAVE_MY_INFO_CLICK,
+			{
+				status: isChecked ? 'checked' : 'unchecked',
+			}
+		);
 	};
 
 	useEffect( () => {

--- a/client/components/woopay/save-user/test/checkout-page-save-user.test.js
+++ b/client/components/woopay/save-user/test/checkout-page-save-user.test.js
@@ -6,6 +6,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 // eslint-disable-next-line import/no-unresolved
 import { extensionCartUpdate } from '@woocommerce/blocks-checkout';
+import wcpayTracks from 'tracks';
 
 /**
  * Internal dependencies
@@ -34,6 +35,10 @@ jest.mock( '@wordpress/data', () => ( {
 	} ),
 } ) );
 
+jest.mock( 'tracks', () => ( {
+	recordUserEvent: jest.fn(),
+} ) );
+
 describe( 'CheckoutPageSaveUser', () => {
 	beforeEach( () => {
 		useWooPayUser.mockImplementation( () => false );
@@ -46,6 +51,11 @@ describe( 'CheckoutPageSaveUser', () => {
 		getConfig.mockImplementation(
 			( setting ) => setting === 'forceNetworkSavedCards'
 		);
+
+		wcpayTracks.recordUserEvent.mockReturnValue( true );
+		wcpayTracks.events = {
+			WOOPAY_SAVE_MY_INFO_CLICK: 'woopay_express_button_offered',
+		};
 
 		window.wcpaySettings = {
 			accountStatus: {

--- a/client/tracks/index.js
+++ b/client/tracks/index.js
@@ -101,6 +101,7 @@ const events = {
 	WOOPAY_SKIPPED: 'woopay_skipped',
 	WOOPAY_BUTTON_LOAD: 'woopay_button_load',
 	WOOPAY_BUTTON_CLICK: 'woopay_button_click',
+	WOOPAY_SAVE_MY_INFO_CLICK: 'checkout_save_my_info_click',
 	// Onboarding flow.
 	ONBOARDING_FLOW_STARTED: 'wcpay_onboarding_flow_started',
 	ONBOARDING_FLOW_MODE_SELECTED: 'wcpay_onboarding_flow_mode_selected',


### PR DESCRIPTION


#### Changes proposed in this Pull Request

Record a Tracks event when clicking on WooPay's Save My Info checkbox, with a `status` property indicating whether the checkbox was selected or not selected. 

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a product to the cart 
* Go to classic checkout page
* Enter a WooPay unregistered email 
* Click on the WooPay's "Save My Info..." checkbox
* In ~5 minutes check MC Tracks Live view for a `wcpay_checkout_save_my_info_click` event with `status: checked` property.
* Uncheck the Save My Info checkbox and notice the same event appearing in Tracks Live view with `status: unchecked`
* Repeat the above steps for Blocks checkout. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
