### PR TITLE
Enables deferred intent UPE for existing split UPE stores and newly onboarded stores

### DIFF
--- a/changelog/add-7003-deferred-intent-rollout-phase-1
+++ b/changelog/add-7003-deferred-intent-rollout-phase-1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Enables deferred intent UPE for existing split UPE stores and newly onboarded stores.

--- a/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
@@ -119,13 +119,13 @@ class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
 		$is_upe_enabled = $request->get_param( 'is_upe_enabled' );
 
 		if ( $is_upe_enabled ) {
-			update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
+			update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, '1' );
 
 			// WooCommerce core only includes Tracks in admin, not the REST API, so we need to use this wc_admin method
 			// that includes WC_Tracks in case it's not loaded.
 			if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
 				wc_admin_record_tracks_event(
-					Track_Events::SPLIT_UPE_ENABLED,
+					Track_Events::DEFERRED_INTENT_UPE_ENABLED,
 					[
 						'is_bnpl_affirm_afterpay_enabled' => WC_Payments_Features::is_bnpl_affirm_afterpay_enabled(),
 					]
@@ -147,13 +147,25 @@ class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
 					]
 				);
 			}
-		} else {
-			// marking the flag as "disabled", so that we can keep track that the merchant explicitly disabled it.
+		} elseif ( '1' === get_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME ) ) {
+			// marking the flag as "disabled", so that we can keep track that the merchant explicitly disabled split UPE.
 			update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, 'disabled' );
 
 			if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
 				wc_admin_record_tracks_event(
 					Track_Events::SPLIT_UPE_DISABLED,
+					[
+						'is_bnpl_affirm_afterpay_enabled' => WC_Payments_Features::is_bnpl_affirm_afterpay_enabled(),
+					]
+				);
+			}
+		} elseif ( '1' === get_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME ) ) {
+			// marking the flag as "disabled", so that we can keep track that the merchant explicitly disabled deferred intent UPE.
+			update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, 'disabled' );
+
+			if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
+				wc_admin_record_tracks_event(
+					Track_Events::DEFERRED_INTENT_UPE_DISABLED,
 					[
 						'is_bnpl_affirm_afterpay_enabled' => WC_Payments_Features::is_bnpl_affirm_afterpay_enabled(),
 					]

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1905,10 +1905,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				WooPay_Order_Status_Sync::remove_webhook();
 			} elseif ( WC_Payments_Features::is_upe_legacy_enabled() ) {
 				update_option( WC_Payments_Features::UPE_FLAG_NAME, '0' );
-				update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
+				update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, '1' );
 
 				if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
-					wc_admin_record_tracks_event( 'wcpay_split_upe_enabled' );
+					wc_admin_record_tracks_event( 'wcpay_deferred_intent_upe_enabled' );
 				}
 			}
 		}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -691,7 +691,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * $return bool - true if UPE is incompatible with WooPay, false otherwise.
 	 */
 	private function is_upe_incompatible_with_woopay() {
-		return WC_Payments_Features::is_upe_legacy_enabled() && ! ( WC_Payments_Features::is_upe_split_enabled() || WC_Payments_Features::is_upe_deferred_intent_enabled() );
+		return WC_Payments_Features::is_upe_legacy_enabled() && ! WC_Payments_Features::is_upe_deferred_intent_enabled();
 	}
 
 	/**
@@ -1425,7 +1425,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// Otherwise $gateway_id must be `woocommerce_payments`.
 		if ( substr( $gateway_id, 0, strlen( $split_upe_gateway_prefix ) ) === $split_upe_gateway_prefix ) {
 			$payment_methods = [ str_replace( $split_upe_gateway_prefix, '', $gateway_id ) ];
-		} elseif ( WC_Payments_Features::is_upe_deferred_intent_enabled() || WC_Payments_Features::is_upe_split_enabled() ) {
+		} elseif ( WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
 			// If split or deferred intent UPE is enabled and $gateway_id is `woocommerce_payments`, this must be the CC gateway.
 			// We only need to return single `card` payment method, adding `link` since deferred intent UPE gateway is compatible with Link.
 			$payment_methods = [ Payment_Method::CARD ];

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -761,9 +761,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				];
 			}
 
-			if ( WC_Payments_Features::is_upe_split_enabled() ) {
-				UPE_Split_Payment_Gateway::remove_upe_payment_intent_from_session();
-			} else {
+			if ( WC_Payments_Features::is_upe_legacy_enabled() ) {
 				UPE_Payment_Gateway::remove_upe_payment_intent_from_session();
 			}
 
@@ -867,9 +865,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$order->add_order_note( $note );
 			}
 
-			if ( WC_Payments_Features::is_upe_split_enabled() ) {
-				UPE_Split_Payment_Gateway::remove_upe_payment_intent_from_session();
-			} else {
+			if ( WC_Payments_Features::is_upe_legacy_enabled() ) {
 				UPE_Payment_Gateway::remove_upe_payment_intent_from_session();
 			}
 
@@ -1429,15 +1425,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// Otherwise $gateway_id must be `woocommerce_payments`.
 		if ( substr( $gateway_id, 0, strlen( $split_upe_gateway_prefix ) ) === $split_upe_gateway_prefix ) {
 			$payment_methods = [ str_replace( $split_upe_gateway_prefix, '', $gateway_id ) ];
-		} elseif ( WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
+		} elseif ( WC_Payments_Features::is_upe_deferred_intent_enabled() || WC_Payments_Features::is_upe_split_enabled() ) {
 			// If split or deferred intent UPE is enabled and $gateway_id is `woocommerce_payments`, this must be the CC gateway.
 			// We only need to return single `card` payment method, adding `link` since deferred intent UPE gateway is compatible with Link.
 			$payment_methods = [ Payment_Method::CARD ];
 			if ( in_array( Payment_Method::LINK, $this->get_upe_enabled_payment_method_ids(), true ) ) {
 				$payment_methods[] = Payment_Method::LINK;
 			}
-		} elseif ( WC_Payments_Features::is_upe_split_enabled() ) {
-			$payment_methods = [ Payment_Method::CARD ];
 		} else {
 			// $gateway_id must be `woocommerce_payments` and gateway is either legacy UPE or legacy card.
 			// Find the relevant gateway and return all available payment methods.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1296,7 +1296,7 @@ class WC_Payments_Account {
 		// user might not have agreed to TOS yet.
 		update_option( '_wcpay_onboarding_stripe_connected', [ 'is_existing_stripe_account' => false ] );
 
-		// Automatically enable split UPE for new stores.
+		// Automatically enable deferred intent UPE for new stores.
 		update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, '1' );
 
 		// Track account connection finish.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -1265,7 +1265,7 @@ class WC_Payments_Account {
 		update_option( '_wcpay_onboarding_stripe_connected', [ 'is_existing_stripe_account' => false ] );
 
 		// Automatically enable split UPE for new stores.
-		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
+		update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, '1' );
 
 		// Track account connection finish.
 		$incentive        = ! empty( $_GET['promo'] ) ? sanitize_text_field( wp_unslash( $_GET['promo'] ) ) : '';

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -137,7 +137,7 @@ class WC_Payments_Checkout {
 			WC_Payments::get_gateway()->tokenization_script();
 			$script_handle = 'WCPAY_CHECKOUT';
 			$js_object     = 'wcpayConfig';
-			if ( WC_Payments_Features::is_upe_split_enabled() || WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
+			if ( WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
 				$script_handle = 'wcpay-upe-checkout';
 				$js_object     = 'wcpay_upe_config';
 			} elseif ( WC_Payments_Features::is_upe_legacy_enabled() ) {

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -78,7 +78,7 @@ class WC_Payments_Features {
 	 * Checks whether the Split UPE with deferred intent is enabled
 	 */
 	public static function is_upe_deferred_intent_enabled() {
-		return '1' === get_option( self::UPE_DEFERRED_INTENT_FLAG_NAME, '0' ) && self::is_upe_split_eligible();
+		return ( '1' === get_option( self::UPE_DEFERRED_INTENT_FLAG_NAME, '0' ) && self::is_upe_split_eligible() ) || self::is_upe_split_enabled();
 	}
 
 	/**

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -71,7 +71,7 @@ class WC_Payments_Token_Service {
 		switch ( $payment_method['type'] ) {
 			case Payment_Method::SEPA:
 				$token      = new WC_Payment_Token_WCPay_SEPA();
-				$gateway_id = WC_Payments_Features::is_upe_split_enabled() || WC_Payments_Features::is_upe_deferred_intent_enabled() ?
+				$gateway_id = WC_Payments_Features::is_upe_deferred_intent_enabled() ?
 					WC_Payment_Gateway_WCPay::GATEWAY_ID . '_' . Payment_Method::SEPA :
 					CC_Payment_Gateway::GATEWAY_ID;
 				$token->set_gateway_id( $gateway_id );
@@ -119,7 +119,7 @@ class WC_Payments_Token_Service {
 	 * @return bool                       True, if payment method type matches gateway, false if otherwise.
 	 */
 	public function is_valid_payment_method_type_for_gateway( $payment_method_type, $gateway_id ) {
-		if ( WC_Payments_Features::is_upe_split_enabled() || WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
+		if ( WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
 			return self::REUSABLE_GATEWAYS_BY_PAYMENT_METHOD[ $payment_method_type ] === $gateway_id;
 		} else {
 			return WC_Payments::get_gateway()->id === $gateway_id;

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -124,10 +124,8 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 			$script_dependencies[] = 'woocommerce-tokenization-form';
 		}
 
-		if ( WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
+		if ( WC_Payments_Features::is_upe_deferred_intent_enabled() || WC_Payments_Features::is_upe_split_enabled() ) {
 			$script = 'dist/upe_with_deferred_intent_creation_checkout';
-		} elseif ( WC_Payments_Features::is_upe_split_enabled() ) {
-			$script = 'dist/upe_split_checkout';
 		} else {
 			$script = 'dist/upe_checkout';
 		}
@@ -231,9 +229,6 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 		$enabled_payment_methods = $this->gateway->get_payment_method_ids_enabled_at_checkout();
 
 		foreach ( $enabled_payment_methods as $payment_method_id ) {
-			if ( 'card' === $payment_method_id && WC_Payments_Features::is_upe_split_enabled() && $this->is_woopay_enabled() ) {
-				continue;
-			}
 			// Link by Stripe should be validated with available fees.
 			if ( Payment_Method::LINK === $payment_method_id ) {
 				if ( ! in_array( Payment_Method::LINK, array_keys( $this->account->get_fees() ), true ) ) {

--- a/includes/class-wc-payments-upe-checkout.php
+++ b/includes/class-wc-payments-upe-checkout.php
@@ -124,7 +124,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 			$script_dependencies[] = 'woocommerce-tokenization-form';
 		}
 
-		if ( WC_Payments_Features::is_upe_deferred_intent_enabled() || WC_Payments_Features::is_upe_split_enabled() ) {
+		if ( WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
 			$script = 'dist/upe_with_deferred_intent_creation_checkout';
 		} else {
 			$script = 'dist/upe_checkout';
@@ -245,7 +245,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 				'countries'      => $payment_method->get_countries(),
 			];
 
-			if ( WC_Payments_Features::is_upe_split_enabled() || WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
+			if ( WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
 				$gateway_for_payment_method                             = $this->gateway->wc_payments_get_payment_gateway_by_id( $payment_method_id );
 				$settings[ $payment_method_id ]['upePaymentIntentData'] = $this->gateway->get_payment_intent_data_from_session( $payment_method_id );
 				$settings[ $payment_method_id ]['upeSetupIntentData']   = $this->gateway->get_setup_intent_data_from_session( $payment_method_id );
@@ -292,7 +292,7 @@ class WC_Payments_UPE_Checkout extends WC_Payments_Checkout {
 			 * before `$this->saved_payment_methods()`.
 			 */
 			$payment_fields  = $this->get_payment_fields_js_config();
-			$upe_object_name = ( WC_Payments_Features::is_upe_split_enabled() || WC_Payments_Features::is_upe_deferred_intent_enabled() ) ? 'wcpay_upe_config' : 'wcpayConfig';
+			$upe_object_name = WC_Payments_Features::is_upe_deferred_intent_enabled() ? 'wcpay_upe_config' : 'wcpayConfig';
 			wp_enqueue_script( 'wcpay-upe-checkout' );
 			add_action(
 				'wp_footer',

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -524,11 +524,7 @@ class WC_Payments {
 				self::$upe_payment_gateway_map[ $payment_method->get_id() ] = $split_gateway;
 			}
 
-			self::$card_gateway = self::get_payment_gateway_by_id( 'card' );
-
-			$card_payments_checkout = new WC_Payments_Checkout( self::$legacy_card_gateway, self::$woopay_util, self::$account, self::$customer_service );
-			$card_payments_checkout->init_hooks();
-
+			self::$card_gateway         = self::get_payment_gateway_by_id( 'card' );
 			self::$wc_payments_checkout = new WC_Payments_UPE_Checkout( self::get_gateway(), self::$woopay_util, self::$account, self::$customer_service );
 		} elseif ( WC_Payments_Features::is_upe_legacy_enabled() ) {
 			$payment_methods = [];

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -505,7 +505,7 @@ class WC_Payments {
 			Afterpay_Payment_Method::class,
 			JCB_Payment_Method::class,
 		];
-		if ( WC_Payments_Features::is_upe_split_enabled() || WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
+		if ( WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
 			$payment_methods = [];
 			foreach ( $payment_method_classes as $payment_method_class ) {
 				$payment_method                               = new $payment_method_class( self::$token_service );
@@ -728,7 +728,7 @@ class WC_Payments {
 	 * @return array The list of payment gateways that will be available, including WooPayments' Gateway class.
 	 */
 	public static function register_gateway( $gateways ) {
-		if ( WC_Payments_Features::is_upe_split_enabled() || WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
+		if ( WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
 
 			$payment_methods = self::$card_gateway->get_payment_method_ids_enabled_at_checkout();
 
@@ -740,11 +740,8 @@ class WC_Payments {
 				self::get_gateway()->update_option( 'upe_enabled_payment_method_ids', $payment_methods );
 			}
 
-			if ( ! WC_Payments_Features::is_upe_deferred_intent_enabled() && WC_Payments_Features::is_woopay_enabled() ) {
-				self::$registered_card_gateway = self::$legacy_card_gateway;
-			} else {
-				self::$registered_card_gateway = self::$card_gateway;
-			}
+			self::$registered_card_gateway = self::$card_gateway;
+
 			$gateways[]       = self::$registered_card_gateway;
 			$all_upe_gateways = [];
 			$reusable_methods = [];
@@ -1287,7 +1284,7 @@ class WC_Payments {
 	 */
 	public static function register_checkout_gateway( $payment_method_registry ) {
 		require_once __DIR__ . '/class-wc-payments-blocks-payment-method.php';
-		if ( WC_Payments_Features::is_upe_split_enabled() || WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
+		if ( WC_Payments_Features::is_upe_deferred_intent_enabled() ) {
 			require_once __DIR__ . '/class-wc-payments-upe-split-blocks-payment-method.php';
 			$payment_method_registry->register( new WC_Payments_UPE_Split_Blocks_Payment_Method() );
 		} elseif ( WC_Payments_Features::is_upe_legacy_enabled() ) {

--- a/includes/constants/class-track-events.php
+++ b/includes/constants/class-track-events.php
@@ -18,10 +18,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Track_Events extends Base_Constant {
 	// UPE toggle events.
-	public const UPE_ENABLED        = 'wcpay_upe_enabled';
-	public const UPE_DISABLED       = 'wcpay_upe_disabled';
-	public const SPLIT_UPE_ENABLED  = 'wcpay_split_upe_enabled';
-	public const SPLIT_UPE_DISABLED = 'wcpay_split_upe_disabled';
+	public const UPE_ENABLED                  = 'wcpay_upe_enabled';
+	public const UPE_DISABLED                 = 'wcpay_upe_disabled';
+	public const SPLIT_UPE_ENABLED            = 'wcpay_split_upe_enabled';
+	public const SPLIT_UPE_DISABLED           = 'wcpay_split_upe_disabled';
+	public const DEFERRED_INTENT_UPE_ENABLED  = 'wcpay_deferred_intent_upe_enabled';
+	public const DEFERRED_INTENT_UPE_DISABLED = 'wcpay_deferred_intent_upe_disabled';
 
 	// Payment method events.
 	public const PAYMENT_METHOD_ENABLED  = 'wcpay_payment_method_enabled';

--- a/includes/migrations/class-track-upe-status.php
+++ b/includes/migrations/class-track-upe-status.php
@@ -31,10 +31,12 @@ class Track_Upe_Status {
 			return;
 		}
 
-		$upe_value = get_option( \WC_Payments_Features::UPE_SPLIT_FLAG_NAME, 'not-set' );
+		$upe_value                 = get_option( \WC_Payments_Features::UPE_FLAG_NAME, 'not-set' );
+		$upe_split_value           = get_option( \WC_Payments_Features::UPE_SPLIT_FLAG_NAME, 'not-set' );
+		$upe_deferred_intent_value = get_option( \WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, 'not-set' );
 
-		// Don't trigger the track event when the flag isn't set.
-		if ( 'not-set' !== $upe_value ) {
+		// Don't trigger the track event when no UPE flags are set.
+		if ( 'not-set' !== $upe_value || 'not-set' !== $upe_split_value || 'not-set' !== $upe_deferred_intent_value ) {
 			self::trigger_track_event();
 		}
 

--- a/includes/notes/class-wc-payments-notes-additional-payment-methods.php
+++ b/includes/notes/class-wc-payments-notes-additional-payment-methods.php
@@ -131,7 +131,7 @@ class WC_Payments_Notes_Additional_Payment_Methods {
 		}
 
 		// Enable UPE, deletes the note and redirect to onboarding task.
-		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
+		update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, '1' );
 		self::possibly_delete_note();
 
 		$wcpay_settings_url = admin_url( 'admin.php?page=wc-admin&path=/payments/additional-payment-methods' );

--- a/includes/payment-methods/class-upe-payment-gateway.php
+++ b/includes/payment-methods/class-upe-payment-gateway.php
@@ -1147,7 +1147,7 @@ class UPE_Payment_Gateway extends WC_Payment_Gateway_WCPay {
 	 * @return string Filtered gateway title.
 	 */
 	public function maybe_filter_gateway_title( $title, $id ) {
-		if ( ! ( WC_Payments_Features::is_upe_split_enabled() || WC_Payments_Features::is_upe_deferred_intent_enabled() ) && self::GATEWAY_ID === $id && $this->title === $title ) {
+		if ( ! WC_Payments_Features::is_upe_deferred_intent_enabled() && self::GATEWAY_ID === $id && $this->title === $title ) {
 			$title                   = $this->checkout_title;
 			$enabled_payment_methods = $this->get_payment_method_ids_enabled_at_checkout();
 

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -220,7 +220,9 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 
 	public function tear_down() {
 		parent::tear_down();
-
+		update_option( WC_Payments_Features::UPE_FLAG_NAME, '0' );
+		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '0' );
+		update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, '0' );
 		WC_Blocks_REST_API_Registration_Preventer::stop_preventing();
 	}
 
@@ -652,8 +654,9 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_enable_woopay_converts_upe_flag() {
-		update_option( '_wcpay_feature_upe', '1' );
-		update_option( '_wcpay_feature_upe_split', '0' );
+		update_option( WC_Payments_Features::UPE_FLAG_NAME, '1' );
+		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '0' );
+		update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, '0' );
 		$this->gateway->update_option( 'platform_checkout', 'no' );
 
 		$request = new WP_REST_Request();
@@ -661,8 +664,9 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 
 		$this->controller->update_settings( $request );
 
-		$this->assertEquals( '0', get_option( '_wcpay_feature_upe' ) );
-		$this->assertEquals( '1', get_option( '_wcpay_feature_upe_split' ) );
+		$this->assertEquals( '0', get_option( WC_Payments_Features::UPE_FLAG_NAME ) );
+		$this->assertEquals( '0', get_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME ) );
+		$this->assertEquals( '1', get_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME ) );
 	}
 
 	public function deposit_schedules_data_provider() {

--- a/tests/unit/admin/test-class-wc-rest-upe-flag-toggle-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-upe-flag-toggle-controller.php
@@ -67,6 +67,16 @@ class WC_REST_UPE_Flag_Toggle_Controller_Test extends WCPAY_UnitTestCase {
 			$this->createMock( WC_Payments_Localization_Service::class )
 		);
 		$this->controller = new WC_REST_UPE_Flag_Toggle_Controller( $this->gateway );
+		update_option( WC_Payments_Features::UPE_FLAG_NAME, '0' );
+		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '0' );
+		update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, '0' );
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+		update_option( WC_Payments_Features::UPE_FLAG_NAME, '0' );
+		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '0' );
+		update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, '0' );
 	}
 
 	public function test_get_flag_fails_if_user_cannot_manage_woocommerce() {
@@ -93,28 +103,38 @@ class WC_REST_UPE_Flag_Toggle_Controller_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_set_flag_without_param_returns_status_code_200() {
-		$request = new WP_REST_Request( 'POST', self::ROUTE );
-		update_option( '_wcpay_feature_upe', '0' );
-		update_option( '_wcpay_feature_upe_split', '0' );
-
+		$request  = new WP_REST_Request( 'POST', self::ROUTE );
 		$response = $this->controller->set_flag( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
 		// no change from the initial flag value.
-		$this->assertEquals( '0', get_option( '_wcpay_feature_upe' ) );
-		$this->assertEquals( '0', get_option( '_wcpay_feature_upe_split' ) );
+		$this->assertEquals( '0', get_option( WC_Payments_Features::UPE_FLAG_NAME ) );
+		$this->assertEquals( '0', get_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME ) );
+		$this->assertEquals( '0', get_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME ) );
 	}
 
 	public function test_set_flag_disabled_with_split_returns_status_code_200() {
-		update_option( '_wcpay_feature_upe', '0' );
+		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
 		$request = new WP_REST_Request( 'POST', self::ROUTE );
 		$request->set_param( 'is_upe_enabled', false );
 
 		$response = $this->controller->set_flag( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( '0', get_option( '_wcpay_feature_upe' ) );
-		$this->assertEquals( 'disabled', get_option( '_wcpay_feature_upe_split' ) );
+		$this->assertEquals( '0', get_option( WC_Payments_Features::UPE_FLAG_NAME ) );
+		$this->assertEquals( 'disabled', get_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME ) );
+	}
+
+	public function test_set_flag_disabled_with_deferred_intent_returns_status_code_200() {
+		update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, '1' );
+		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_param( 'is_upe_enabled', false );
+
+		$response = $this->controller->set_flag( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( '0', get_option( WC_Payments_Features::UPE_FLAG_NAME ) );
+		$this->assertEquals( 'disabled', get_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME ) );
 	}
 
 	public function test_set_flag_enabled_request_returns_status_code_200() {
@@ -124,7 +144,7 @@ class WC_REST_UPE_Flag_Toggle_Controller_Test extends WCPAY_UnitTestCase {
 		$response = $this->controller->set_flag( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( '1', get_option( '_wcpay_feature_upe_split' ) );
+		$this->assertEquals( '1', get_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME ) );
 	}
 
 	public function test_set_flag_disabled_request_returns_status_code_200() {
@@ -135,8 +155,8 @@ class WC_REST_UPE_Flag_Toggle_Controller_Test extends WCPAY_UnitTestCase {
 				'giropay',
 			]
 		);
-		update_option( '_wcpay_feature_upe', '1' );
-		$this->assertEquals( '1', get_option( '_wcpay_feature_upe' ) );
+		update_option( WC_Payments_Features::UPE_FLAG_NAME, '1' );
+		$this->assertEquals( '1', get_option( WC_Payments_Features::UPE_FLAG_NAME ) );
 
 		$request = new WP_REST_Request( 'POST', self::ROUTE );
 		$request->set_param( 'is_upe_enabled', false );
@@ -144,7 +164,7 @@ class WC_REST_UPE_Flag_Toggle_Controller_Test extends WCPAY_UnitTestCase {
 		$response = $this->controller->set_flag( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'disabled', get_option( '_wcpay_feature_upe', null ) );
+		$this->assertEquals( 'disabled', get_option( WC_Payments_Features::UPE_FLAG_NAME, null ) );
 		$this->assertEquals(
 			[
 				'card',

--- a/tests/unit/migrations/test-class-track-upe-status.php
+++ b/tests/unit/migrations/test-class-track-upe-status.php
@@ -25,6 +25,7 @@ class Track_Upe_Status_Test extends WCPAY_UnitTestCase {
 		delete_option( Track_Upe_Status::IS_TRACKED_OPTION );
 		delete_option( WC_Payments_Features::UPE_FLAG_NAME );
 		delete_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME );
+		delete_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME );
 	}
 
 	/**
@@ -35,25 +36,18 @@ class Track_Upe_Status_Test extends WCPAY_UnitTestCase {
 
 		Tracker::remove_admin_event( 'wcpay_upe_enabled' );
 		Tracker::remove_admin_event( 'wcpay_upe_disabled' );
-	}
 
-	/**
-	 * Cleanup after all tests.
-	 *
-	 * @return void
-	 */
-	public static function tear_down_after_class() {
 		delete_option( Track_Upe_Status::IS_TRACKED_OPTION );
 		delete_option( WC_Payments_Features::UPE_FLAG_NAME );
 		delete_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME );
-		parent::tear_down_after_class();
+		delete_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME );
 	}
 
 	/**
 	 * Make sure the 'wcpay_upe_enabled' event is registered when upe is enabled.
 	 */
 	public function test_track_enabled_on_upgrade() {
-		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '1' );
+		update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, '1' );
 
 		Track_Upe_Status::maybe_track();
 
@@ -68,7 +62,7 @@ class Track_Upe_Status_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_track_disabled_on_upgrade() {
-		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, 'disabled' );
+		update_option( WC_Payments_Features::UPE_DEFERRED_INTENT_FLAG_NAME, 'disabled' );
 
 		Track_Upe_Status::maybe_track();
 
@@ -83,8 +77,6 @@ class Track_Upe_Status_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_do_nothing_default_on_upgrade() {
-		delete_option( WC_Payments_Features::UPE_FLAG_NAME );
-
 		Track_Upe_Status::maybe_track();
 
 		$this->assertEquals( [], Tracker::get_admin_events() );

--- a/tests/unit/migrations/test-class-track-upe-status.php
+++ b/tests/unit/migrations/test-class-track-upe-status.php
@@ -38,6 +38,18 @@ class Track_Upe_Status_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Cleanup after all tests.
+	 *
+	 * @return void
+	 */
+	public static function tear_down_after_class() {
+		delete_option( Track_Upe_Status::IS_TRACKED_OPTION );
+		delete_option( WC_Payments_Features::UPE_FLAG_NAME );
+		delete_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME );
+		parent::tear_down_after_class();
+	}
+
+	/**
 	 * Make sure the 'wcpay_upe_enabled' event is registered when upe is enabled.
 	 */
 	public function test_track_enabled_on_upgrade() {

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -295,6 +295,17 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		];
 	}
 
+	/**
+	 * Cleanup after tests.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		update_option( '_wcpay_feature_upe', '0' );
+		update_option( '_wcpay_feature_upe_split', '0' );
+	}
+
 	public function test_payment_fields_outputs_fields() {
 		$this->set_cart_contains_subscription_items( false );
 		$this->set_get_upe_enabled_payment_method_statuses_return_value();

--- a/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-split-payment-gateway.php
@@ -331,6 +331,17 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Cleanup after tests.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		update_option( '_wcpay_feature_upe_split', '0' );
+		update_option( '_wcpay_feature_upe_deferred_intent', '0' );
+	}
+
+	/**
 	 * Test the UI <div> container that will hold the payment method.
 	 *
 	 * @return void
@@ -2406,21 +2417,21 @@ class UPE_Split_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$gateway = WC_Payments::get_gateway();
 		WC_Payments::set_gateway( $mock_upe_gateway );
 
+		$mock_upe_gateway->expects( $this->any() )
+			->method( 'get_upe_enabled_payment_method_ids' )
+			->will(
+				$this->returnValue( [ Payment_Method::CARD, Payment_Method::LINK ] )
+			);
+
 		$payment_methods = $mock_upe_gateway->get_payment_methods_from_gateway_id( UPE_Split_Payment_Gateway::GATEWAY_ID );
 
-		$this->assertSame( [ Payment_Method::CARD ], $payment_methods );
+		$this->assertSame( [ Payment_Method::CARD, Payment_Method::LINK ], $payment_methods );
 
 		$payment_methods = $mock_upe_gateway->get_payment_methods_from_gateway_id( UPE_Split_Payment_Gateway::GATEWAY_ID . '_' . Payment_Method::BANCONTACT );
 
 		$this->assertSame( [ Payment_Method::BANCONTACT ], $payment_methods );
 
 		update_option( '_wcpay_feature_upe_deferred_intent', '1' );
-
-		$mock_upe_gateway->expects( $this->once() )
-			->method( 'get_upe_enabled_payment_method_ids' )
-			->will(
-				$this->returnValue( [ Payment_Method::CARD, Payment_Method::LINK ] )
-			);
 
 		$payment_methods = $mock_upe_gateway->get_payment_methods_from_gateway_id( UPE_Split_Payment_Gateway::GATEWAY_ID );
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -18,6 +18,7 @@ use WCPay\Duplicate_Payment_Prevention_Service;
 use WCPay\Exceptions\API_Exception;
 use WCPay\Exceptions\Connection_Exception;
 use WCPay\Session_Rate_Limiter;
+use WCPay\Constants\Payment_Method;
 // Need to use WC_Mock_Data_Store.
 require_once dirname( __FILE__ ) . '/helpers/class-wc-mock-wc-data-store.php';
 
@@ -26,6 +27,13 @@ require_once dirname( __FILE__ ) . '/helpers/class-wc-mock-wc-data-store.php';
  */
 class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 	const CUSTOMER_ID = 'cus_mock';
+
+	/**
+	 * Original WCPay gateway.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private $wcpay_gateway;
 
 	/**
 	 * System under test.
@@ -165,6 +173,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 					'mark_payment_complete_for_order',
 					'get_level3_data_from_order', // To avoid needing to mock the order items.
 					'should_use_stripe_platform_on_checkout_page',
+					'get_payment_method_ids_enabled_at_checkout',
 				]
 			)
 			->getMock();
@@ -177,12 +186,30 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 				$this->returnValue( $this->return_url )
 			);
 
+		$this->mock_wcpay_gateway
+			->expects( $this->any() )
+			->method( 'get_payment_method_ids_enabled_at_checkout' )
+			->willReturn( [ Payment_Method::CARD ] );
+
+		$this->wcpay_gateway = WC_Payments::get_gateway();
+		WC_Payments::set_gateway( $this->mock_wcpay_gateway );
+
 		// Arrange: Define a $_POST array which includes the payment method,
 		// so that get_payment_method_from_request() does not throw error.
 		$_POST = [
 			'wcpay-payment-method' => 'pm_mock',
 			'payment_method'       => WC_Payment_Gateway_WCPay::GATEWAY_ID,
 		];
+	}
+
+	/**
+	 * Cleanup after each test.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		WC_Payments::set_gateway( $this->wcpay_gateway );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -142,6 +142,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 		WC_Subscriptions::set_wcs_get_subscriptions_for_order( null );
 		WC_Subscriptions::set_wcs_is_subscription( null );
 		WC_Subscriptions::set_wcs_get_subscriptions_for_renewal_order( null );
+		parent::tear_down_after_class();
 	}
 
 	public function test_add_token_to_order_should_add_token_to_subscriptions() {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2191,6 +2191,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'should_use_stripe_platform_on_checkout_page' )
 			->willReturn( true );
 
+		$registered_card_gateway = WC_Payments::get_registered_card_gateway();
 		WC_Payments::set_registered_card_gateway( $mock_wcpay_gateway );
 
 		$payments_checkout = new WC_Payments_Checkout(
@@ -2201,6 +2202,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		);
 
 		$this->assertTrue( $payments_checkout->get_payment_fields_js_config()['forceNetworkSavedCards'] );
+		WC_Payments::set_registered_card_gateway( $registered_card_gateway );
 	}
 
 	public function test_force_network_saved_cards_is_returned_as_false_if_should_not_use_stripe_platform() {
@@ -2211,6 +2213,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			->method( 'should_use_stripe_platform_on_checkout_page' )
 			->willReturn( false );
 
+		$registered_card_gateway = WC_Payments::get_registered_card_gateway();
 		WC_Payments::set_registered_card_gateway( $mock_wcpay_gateway );
 
 		$payments_checkout = new WC_Payments_Checkout(
@@ -2221,6 +2224,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		);
 
 		$this->assertFalse( $payments_checkout->get_payment_fields_js_config()['forceNetworkSavedCards'] );
+		WC_Payments::set_registered_card_gateway( $registered_card_gateway );
 	}
 
 	public function test_is_woopay_enabled_returns_false_if_ineligible() {

--- a/tests/unit/test-class-wc-payments.php
+++ b/tests/unit/test-class-wc-payments.php
@@ -102,6 +102,8 @@ class WC_Payments_Test extends WCPAY_UnitTestCase {
 		$this->assertCount( 1, $registered_gateways );
 		$this->assertInstanceOf( UPE_Split_Payment_Gateway::class, $registered_gateways[0] );
 		$this->assertEquals( $registered_gateways[0]->get_stripe_id(), 'card' );
+
+		update_option( WC_Payments_Features::UPE_SPLIT_FLAG_NAME, '0' );
 	}
 
 	public function test_rest_endpoints_validate_nonce() {


### PR DESCRIPTION
Fixes #7003 

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
This PR will initiate the first phase of our deferred intent rollout. Please see #6023 for more details on this rollout plan.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
With this PR stores that currently have the split UPE enabled will effectively be upgraded to the deferred intent UPE; additionally newly onboarded stores will also begin operating with the deferred intent UPE enabled. 

Effectively the split UPE flag (`_wcpay_feature_upe_split` or `WC_Payments_Features::UPE_SPLIT_FLAG_NAME`) is now made redundant and there should be no way for stores to use this feature: whenever this flag is enabled, stores will be using the deferred intent UPE. (This flag can probably be removed once our rollout is complete.) Consequently, in situations where the split UPE would be enabled, the deferred intent UPE will now be served in its place. If non-UPE users enabled the "new checkout experience", previously this would enable the split UPE; now this will enable the deferred intent UPE instead. If legacy UPE users enabled WooPay--which is incompatible with legacy UPE--previously the split UPE would also be enabled; now the deferred intent UPE will also be enabled.

This PR contains many changes to our unit tests to ensure they are now compatible with these scenarios. There are also a few fixes to unreliable unit tests to ensure that they are completely atomic when setting feature flags or setting global class constants (e.g. functions like `WC_Payments::set_gateway()`) to ensure that tests function as expected without affecting other tests. Additionally, there are some amends to our Tracks implementation to ensure that our analytics also reflect these new scenarios as well.
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
We need to ensure that the deferred intent is enabled when it should be. In most cases you can confirm this easily by checking whether the deferred intent flag (`_wcpay_feature_upe_deferred_intent`) is enabled using the dev tools. However, when the split UPE flag (`_wcpay_feature_upe_split`) is enabled, the deferred intent will be served, though it's flag will not automatically be updated. The deferred intent UPE differs from the split UPE by having a new preloading state and also by presenting the CC gateway with the UPE instead of the legacy card element. These two GIFs should show the difference between the split and deferred intent UPE CC gateways--also, note the preloading state on the deferred intent UPE element that will not be present on any of the split UPE LPM gateways either. 

![Split UPE CC card element](https://cdn-std.droplr.net/files/acc_1104206/Yb0Q0C)
_Split UPE CC card element at checkout_

![Deferred intent UPE CC card element](https://cdn-std.droplr.net/files/acc_1104206/oCzsMG)
_Deferred intent UPE CC card element at checkout_
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Here are the scenarios that we will need to confirm...

1. Newly onboarded store will use deferred intent UPE. _(Deferred intent UPE flag should be enabled.)_
2. Store with deferred intent UPE flag enabled will use deferred intent UPE.
3. Store without deferred intent UPE flag, but with split UPE flag will use deferred intent UPE.
4. With all flags disabled (legacy card), enable the "new checkout experience" from WooPayments settings. Store should now use deferred intent UPE. _(Deferred intent UPE flag should be enabled.)_
5. With _only_ legacy UPE enabled (`_wcpay_feature_upe`), enable WooPay from WooPayments settings. Store should now use deferred intent UPE. _(Deferred intent UPE flag should be enabled.)_
6. With _only_ legacy UPE enabled, disable "new checkout experience" from WooPayments settings. Now re-enable "new checkout experience" from WooPayments settings. Store should now use deferred intent UPE. _(Deferred intent UPE flag should be enabled.)_
7. With deferred intent UPE enabled, disabling "new checkout experience" should return you to the basic legacy card gateway.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
