### PR TITLE
Fixed issue in extending requests class when request class was already extended.

### DIFF
--- a/changelog/fix-7007-extend-request-class-bugfix
+++ b/changelog/fix-7007-extend-request-class-bugfix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed issue with validation of extended request class

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -675,17 +675,27 @@ abstract class Request {
 	 */
 	public function validate_extended_class( $child_class, string $parent_class ) {
 
-		if ( ! is_subclass_of( $child_class, $parent_class ) ) {
-			throw new Extend_Request_Exception(
-				sprintf(
-					'Failed to extend request. %s is not a subclass of %s',
-					is_string( $child_class ) ? $child_class : get_class( $child_class ),
-					$parent_class
-				),
-				'wcpay_core_extend_class_not_subclass'
-			);
+		// Check if the child class directly extends the parent class.
+		if ( is_subclass_of( $child_class, $parent_class ) ) {
+			return;
 		}
 
+		// Retrieve the immediate parent (grandparent) of the specified parent class.
+		$grandparent_class = get_parent_class( $parent_class );
+
+		// Check if the child class extends the grandparent class, ensuring that the grandparent class exists
+		// and is not the same as the class where this method is defined.
+		if ( $grandparent_class && self::class !== $grandparent_class && is_subclass_of( $child_class, $grandparent_class ) ) {
+			return;
+		}
+		throw new Extend_Request_Exception(
+			sprintf(
+				'Failed to extend request. %s is not a subclass of %s',
+				is_string( $child_class ) ? $child_class : get_class( $child_class ),
+				$parent_class
+			),
+			'wcpay_core_extend_class_not_subclass'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7007 

#### Fixed issue when request class is extended from the request class that was already extended.

In our codebase, we've enhanced the `Create_And_Confirm` request class with filters. During payment processing, we employ a [filter](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/woopay/services/class-checkout-service.php#L30) to modify certain parameters of the original `Create_And_Confirm` request class. 

If you try to create a new request class using the `extend` or `apply_filters` function based on a class that has already been extended similarly with those functions, you'll be met with an error. Refer to the https://github.com/Automattic/woocommerce-payments/issues/7007 for more details. 

This PR addresses the issue by verifying if the extended request class is a subclass of the class it's extended from or if they share a common parent. Simply put, the class you pass in the `extend()` function needs to be the parent class or grandfather class (parent of parent, but not base default Request abstract class) of the new class you wish to create.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure to run all cases described in the GitHub issue description.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.