### PR TITLE
Track checkout view event on non WooPay stores

### DIFF
--- a/changelog/fix-track-checkout-view-on-non-woopay-stores
+++ b/changelog/fix-track-checkout-view-on-non-woopay-stores
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix Tracks to record checkout view on all stores

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -108,7 +108,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	}
 
 	/**
-	 * Generic method to track user events.
+	 * Generic method to track user events on WooPay enabled stores.
 	 *
 	 * @param string  $event name of the event.
 	 * @param array   $data array of event properties.
@@ -126,6 +126,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 
 	/**
 	 * Track shopper events with the wcpay_prefix.
+	 * This method will track the event on all WCPay stores.
 	 *
 	 * @param string $event name of the event.
 	 * @param array  $data array of event properties.
@@ -143,7 +144,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	}
 
 	/**
-	 * Generic method to track admin events.
+	 * Generic method to track admin events on all WCPay stores.
 	 *
 	 * @param string $event name of the event.
 	 * @param array  $data array of event properties.

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -216,10 +216,11 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	 * @param string $event_name             The name of the event.
 	 * @param array  $properties             Custom properties to send with the event.
 	 * @param bool   $is_admin_event         Indicate whether the event is emitted from admin area.
+	 * @param bool   $track_on_all_stores    Indicate whether the event is tracked on all WCPay stores.
 	 *
 	 * @return bool|array|\WP_Error|\Jetpack_Tracks_Event
 	 */
-	public function tracks_record_event( $event_name, $properties = [], $is_admin_event = false ) {
+	public function tracks_record_event( $event_name, $properties = [], $is_admin_event = false, $track_on_all_stores = false ) {
 
 		$user = wp_get_current_user();
 
@@ -228,7 +229,7 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 			return false;
 		}
 
-		if ( ! $this->should_enable_tracking( $is_admin_event ) ) {
+		if ( ! $this->should_enable_tracking( $is_admin_event, $track_on_all_stores ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
Fixes a bug where `wcpay_checkout_page_view` event was only tracked in WooPay-enabled stores when it was meant to be tracked on all stores.

Context: paJDYF-9HR-p2
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Regression Test
* Make sure WooPay is disabled on the store
* As a non-admin user, add a product to the cart and go to the classic checkout page.
* Then view the Blocks checkout page.
* In ~5 minutes, search MC live view for `wcpay_checkout_page_view` two events.
* Make sure one event has `woopay_enabled: true` and `theme_type: short_code` properties.
* The other event has `woopay_enabled: true` and `theme_type: blocks` properties.

Test the fix
* Disable WooPay.
* Repeat the steps from 2nd step.
* Ensure that `woopay_enabled: false` property is present in the two events.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.