### PR TITLE
Update Base_Constant to return the singleton object for same static calls

### DIFF
--- a/changelog/update-base-constant-return-same-object-static-call
+++ b/changelog/update-base-constant-return-same-object-static-call
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update Base_Constant to return the singleton object for same static calls.

--- a/includes/constants/class-base-constant.php
+++ b/includes/constants/class-base-constant.php
@@ -27,12 +27,19 @@ abstract class Base_Constant implements \JsonSerializable {
 	protected $value;
 
 	/**
-	 * Class constructor.
+	 * Static objects cache.
 	 *
-	 * @param mixed $value Constant from class.
+	 * @var array
+	 */
+	protected static $object_cache = [];
+
+	/**
+	 * Class constructor. Keep it private to only allow initializing from __callStatic()
+	 *
+	 * @param string $value Constant from class.
 	 * @throws \InvalidArgumentException
 	 */
-	public function __construct( $value ) {
+	private function __construct( string $value ) {
 		if ( $value instanceof static ) {
 			$value = $value->get_value();
 		} else {
@@ -61,7 +68,7 @@ abstract class Base_Constant implements \JsonSerializable {
 	 * @return bool
 	 */
 	final public function equals( $variable = null ): bool {
-		return $variable instanceof Base_Constant && $this->get_value() === $variable->get_value() && static::class === \get_class( $variable );
+		return $this === $variable;
 	}
 
 	/**
@@ -92,7 +99,10 @@ abstract class Base_Constant implements \JsonSerializable {
 	 * @throws \InvalidArgumentException
 	 */
 	public static function __callStatic( $name, $arguments ) {
-		return new static( $name );
+		if ( ! isset( static::$object_cache[ $name ] ) ) {
+			static::$object_cache[ $name ] = new static( $name );
+		}
+		return static::$object_cache[ $name ];
 	}
 
 	/**

--- a/tests/unit/test-class-base-constant.php
+++ b/tests/unit/test-class-base-constant.php
@@ -12,6 +12,11 @@ use WCPay\Constants\Payment_Method;
  */
 class Base_Constant_Test extends WCPAY_UnitTestCase {
 
+	public function test_base_constant_retun_single_object_for_multiple_same_static_calls() {
+		$instance_1 = Payment_Method::BASC();
+		$instance_2 = Payment_Method::BASC();
+		$this->assertTrue( $instance_1 === $instance_2 );
+	}
 	public function test_base_constant_will_create_constant() {
 		$class = Payment_Method::BASC();
 		$this->assertInstanceOf( Payment_Method::class, $class );
@@ -52,4 +57,5 @@ class Base_Constant_Test extends WCPAY_UnitTestCase {
 		$this->expectException( \InvalidArgumentException::class );
 		Payment_Method::search( 'foo' );
 	}
+
 }


### PR DESCRIPTION
Fixes #
See context in https://github.com/Automattic/woocommerce-payments/pull/7035#discussion_r1305308840

## I will merge this PR next Tuesday after the code freeze for verion 6.4 scheduled releasing next week.  

#### Changes proposed in this Pull Request

- Update Base_Constant to return the singleton object for same static calls
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* All tests are passed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] NO NEED Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
