### PR TITLE
Fix deprecation warnings on blocks checkout

### DIFF
--- a/changelog/fix-deprecation-warning-on-blocks-checkout
+++ b/changelog/fix-deprecation-warning-on-blocks-checkout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix deprecation warnings on blocks checkout.

--- a/client/checkout/blocks/fields.js
+++ b/client/checkout/blocks/fields.js
@@ -23,10 +23,7 @@ const WCPayFields = ( {
 	stripe,
 	elements,
 	billing: { billingData },
-	eventRegistration: {
-		onPaymentProcessing,
-		onCheckoutAfterProcessingWithSuccess,
-	},
+	eventRegistration: { onPaymentProcessing, onCheckoutSuccess },
 	emitResponse,
 	shouldSavePayment,
 } ) => {
@@ -87,7 +84,7 @@ const WCPayFields = ( {
 		api,
 		stripe,
 		elements,
-		onCheckoutAfterProcessingWithSuccess,
+		onCheckoutSuccess,
 		emitResponse,
 		shouldSavePayment
 	);

--- a/client/checkout/blocks/hooks.js
+++ b/client/checkout/blocks/hooks.js
@@ -16,21 +16,20 @@ export const usePaymentCompleteHandler = (
 	api,
 	stripe,
 	elements,
-	onCheckoutAfterProcessingWithSuccess,
+	onCheckoutSuccess,
 	emitResponse,
 	shouldSavePayment
 ) => {
 	// Once the server has completed payment processing, confirm the intent of necessary.
 	useEffect(
 		() =>
-			onCheckoutAfterProcessingWithSuccess(
-				( { processingResponse: { paymentDetails } } ) =>
-					confirmCardPayment(
-						api,
-						paymentDetails,
-						emitResponse,
-						shouldSavePayment
-					)
+			onCheckoutSuccess( ( { processingResponse: { paymentDetails } } ) =>
+				confirmCardPayment(
+					api,
+					paymentDetails,
+					emitResponse,
+					shouldSavePayment
+				)
 			),
 		// not sure if we need to disable this, but kept it as-is to ensure nothing breaks. Please consider passing all the deps.
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/checkout/blocks/saved-token-handler.js
+++ b/client/checkout/blocks/saved-token-handler.js
@@ -7,7 +7,7 @@ export const SavedTokenHandler = ( {
 	api,
 	stripe,
 	elements,
-	eventRegistration: { onCheckoutAfterProcessingWithSuccess },
+	eventRegistration: { onCheckoutSuccess },
 	emitResponse,
 } ) => {
 	// Once the server has completed payment processing, confirm the intent of necessary.
@@ -15,7 +15,7 @@ export const SavedTokenHandler = ( {
 		api,
 		stripe,
 		elements,
-		onCheckoutAfterProcessingWithSuccess,
+		onCheckoutSuccess,
 		emitResponse,
 		false // No need to save a payment that has already been saved.
 	);

--- a/client/checkout/blocks/upe-deferred-intent-creation/payment-processor.js
+++ b/client/checkout/blocks/upe-deferred-intent-creation/payment-processor.js
@@ -59,7 +59,7 @@ const PaymentProcessor = ( {
 	api,
 	activePaymentMethod,
 	testingInstructions,
-	eventRegistration: { onPaymentSetup, onCheckoutAfterProcessingWithSuccess },
+	eventRegistration: { onPaymentSetup, onCheckoutSuccess },
 	emitResponse,
 	paymentMethodId,
 	upeMethods,
@@ -228,7 +228,7 @@ const PaymentProcessor = ( {
 		api,
 		stripe,
 		elements,
-		onCheckoutAfterProcessingWithSuccess,
+		onCheckoutSuccess,
 		emitResponse,
 		shouldSavePayment
 	);

--- a/client/checkout/blocks/upe-fields.js
+++ b/client/checkout/blocks/upe-fields.js
@@ -41,10 +41,7 @@ const WCPayUPEFields = ( {
 	activePaymentMethod,
 	billing: { billingData },
 	shippingData,
-	eventRegistration: {
-		onPaymentProcessing,
-		onCheckoutAfterProcessingWithSuccess,
-	},
+	eventRegistration: { onPaymentProcessing, onCheckoutSuccess },
 	emitResponse,
 	paymentIntentId,
 	paymentIntentSecret,
@@ -206,7 +203,7 @@ const WCPayUPEFields = ( {
 	// Once the server has completed payment processing, confirm the intent if necessary.
 	useEffect(
 		() =>
-			onCheckoutAfterProcessingWithSuccess(
+			onCheckoutSuccess(
 				( { orderId, processingResponse: { paymentDetails } } ) => {
 					async function updateIntent() {
 						if ( api.handleDuplicatePayments( paymentDetails ) ) {

--- a/client/checkout/blocks/upe-split-fields.js
+++ b/client/checkout/blocks/upe-split-fields.js
@@ -45,10 +45,7 @@ const WCPayUPEFields = ( {
 	testingInstructions,
 	billing: { billingData },
 	shippingData,
-	eventRegistration: {
-		onPaymentProcessing,
-		onCheckoutAfterProcessingWithSuccess,
-	},
+	eventRegistration: { onPaymentProcessing, onCheckoutSuccess },
 	emitResponse,
 	paymentMethodId,
 	upeMethods,
@@ -204,7 +201,7 @@ const WCPayUPEFields = ( {
 	// Once the server has completed payment processing, confirm the intent if necessary.
 	useEffect(
 		() =>
-			onCheckoutAfterProcessingWithSuccess(
+			onCheckoutSuccess(
 				( { orderId, processingResponse: { paymentDetails } } ) => {
 					async function updateIntent() {
 						if ( api.handleDuplicatePayments( paymentDetails ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
Update the deprecated `onCheckoutAfterProcessingWithSuccess` to `onCheckoutSuccess` to prevent console warnings on blocks checkout.

<img width="487" alt="Screenshot 2023-08-25 at 21 58 47" src="https://github.com/Automattic/woocommerce-payments/assets/1693223/3f84d376-9b77-45dd-a337-f6ae86213200">


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

With UPE enabled and disabled:

* Add an item to the cart.
* Access blocks checkout.
* Access DevTools console.
* The `onCheckoutAfterProcessingWithSuccess` warning should not appear.
* Place order.
* The order should be processed as usual.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
