### PR TITLE
Update multi currency documentation links

### DIFF
--- a/changelog/update-6186-mc-settings-links
+++ b/changelog/update-6186-mc-settings-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update Multi-currency documentation links.

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/index.js
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/index.js
@@ -25,7 +25,7 @@ import SettingsSection from 'wcpay/settings/settings-section';
 
 const EnabledCurrenciesSettingsDescription = () => {
 	const LEARN_MORE_URL =
-		'https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/';
+		'https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#enabled-currencies';
 
 	return (
 		<>

--- a/client/multi-currency/multi-currency-settings/enabled-currencies-list/test/__snapshots__/index.js.snap
+++ b/client/multi-currency/multi-currency-settings/enabled-currencies-list/test/__snapshots__/index.js.snap
@@ -14,7 +14,7 @@ exports[`Multi-Currency enabled currencies list Enabled currencies list renders 
       <p>
         Accept payments in multiple currencies. Prices are converted based on exchange rates and rounding rules. 
         <a
-          href="https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/"
+          href="https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#enabled-currencies"
           rel="noreferrer"
           target="_blank"
         >

--- a/client/multi-currency/multi-currency-settings/store-settings/index.js
+++ b/client/multi-currency/multi-currency-settings/store-settings/index.js
@@ -18,7 +18,7 @@ import PreviewModal from 'wcpay/multi-currency/preview-modal';
 
 const StoreSettingsDescription = () => {
 	const LEARN_MORE_URL =
-		'https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/';
+		'https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#store-settings';
 
 	return (
 		<>

--- a/client/multi-currency/multi-currency-settings/store-settings/test/__snapshots__/index.test.js.snap
+++ b/client/multi-currency/multi-currency-settings/store-settings/test/__snapshots__/index.test.js.snap
@@ -14,7 +14,7 @@ exports[`Multi-Currency store settings store settings task renders correctly: sn
       <p>
         Store settings allow your customers to choose which currency they would like to use when shopping at your store. 
         <a
-          href="https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/"
+          href="https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#store-settings"
           rel="noreferrer"
           target="_blank"
         >

--- a/client/multi-currency/single-currency-settings/index.js
+++ b/client/multi-currency/single-currency-settings/index.js
@@ -412,7 +412,7 @@ const SingleCurrencySettings = () => {
 													onClick={ () => {
 														open(
 															/* eslint-disable-next-line max-len */
-															'https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/#price-rounding',
+															'https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#price-rounding',
 															'_blank'
 														);
 													} }
@@ -477,7 +477,7 @@ const SingleCurrencySettings = () => {
 													onClick={ () => {
 														open(
 															/* eslint-disable-next-line max-len */
-															'https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/#charm-pricing',
+															'https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#charm-pricing',
 															'_blank'
 														);
 													} }

--- a/includes/multi-currency/SettingsOnboardCta.php
+++ b/includes/multi-currency/SettingsOnboardCta.php
@@ -18,7 +18,7 @@ class SettingsOnboardCta extends \WC_Settings_Page {
 	 *
 	 * @var string
 	 */
-	const LEARN_MORE_URL = 'https://woocommerce.com/document/woocommerce-payments/currencies/multi-currency-setup/';
+	const LEARN_MORE_URL = 'https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/';
 
 	/**
 	 * MultiCurrency instance.


### PR DESCRIPTION
Fixes #6186 

#### Changes proposed in this Pull Request

This PR aims to update the Multi-currency documentation on the settings page. All links were updated to redirect to the latest `/woopayments` URL and the URI fragment was also added to improve the navigation.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout to this branch
* Run `npm run build:client`
* Unit tests should be passing
* Check the updated URLs
  * Open the Multi-currency settings page (`/wp-admin/admin.php?page=wc-settings&tab=wcpay_multi_currency`)
    * The **Enabled currencies** learn more link should redirect to the [Enabled currencies header from the docs](https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#enabled-currencies)
    * The **Store settings** learn more link should redirect to the [Store settings header from the docs](https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#store-settings)
    * Add a currency – and then click on the "manage" button
      ![image](https://github.com/Automattic/woocommerce-payments/assets/16882226/754504dc-a160-4f27-a4c2-a126e3de787f)
    * The **Price rounding** learn more link should redirect to the [Price rounding header from the docs](https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#price-rounding)
    * The **Charm pricing** learn more link should redirect to the [Charm pricing header from the docs](https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#charm-pricing)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
