### PR TITLE
Fix Multi-currency exchange rate date formatting when using custom date or time settings

### DIFF
--- a/changelog/fix-6183-exchange-date
+++ b/changelog/fix-6183-exchange-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Multi-currency exchange rate date format when using custom date or time settings.

--- a/client/multi-currency/single-currency-settings/index.js
+++ b/client/multi-currency/single-currency-settings/index.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React, { useContext, useEffect, useState } from 'react';
+import { dateI18n } from '@wordpress/date';
 import { sprintf, __ } from '@wordpress/i18n';
 import SettingsLayout from 'wcpay/settings/settings-layout';
 import SettingsSection from 'wcpay/settings/settings-section';
@@ -20,7 +21,6 @@ import {
 	decimalCurrencyRoundingOptions,
 	zeroDecimalCurrencyCharmOptions,
 	zeroDecimalCurrencyRoundingOptions,
-	toMoment,
 } from './constants';
 import {
 	useCurrencies,
@@ -101,14 +101,14 @@ const SingleCurrencySettings = () => {
 		}
 	}, [ currencySettings, currency, initialPriceRoundingType ] );
 
+	const dateFormat = storeSettings.date_format ?? 'M j, Y';
+	const timeFormat = storeSettings.time_format ?? 'g:iA';
+
 	const formattedLastUpdatedDateTime = targetCurrency
-		? moment
-				.unix( targetCurrency.last_updated )
-				.format(
-					toMoment( storeSettings.date_format ?? 'F j, Y' ) +
-						' ' +
-						toMoment( storeSettings.time_format ?? 'HH:mm' )
-				)
+		? dateI18n(
+				`${ dateFormat } ${ timeFormat }`,
+				moment.unix( targetCurrency.last_updated ).toISOString()
+		  )
 		: '';
 
 	const CurrencySettingsDescription = () => (

--- a/client/multi-currency/single-currency-settings/test/__snapshots__/index.test.js.snap
+++ b/client/multi-currency/single-currency-settings/test/__snapshots__/index.test.js.snap
@@ -82,7 +82,7 @@ exports[`Single currency settings screen Page renders correctly 1`] = `
                         <p
                           class="single-currency-settings-description single-currency-settings-description-inset"
                         >
-                          Current rate: 1 USD = 0.826381 EUR (Last updated: September 24, 2021 01:14)
+                          Current rate: 1 USD = 0.826381 EUR (Last updated: Sep 24, 2021 1:14AM)
                         </p>
                       </label>
                     </li>


### PR DESCRIPTION
Fixes #6183 

#### Changes proposed in this Pull Request

This PR aims to fix the inconsistencies between WordPress' and momentjs' APIs by replacing `moment` with `dateI18n` from `@wordpress/date`. The default date format was also updated to be `M j, Y g:iA` as it's widely used around the codebase.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

From the issue:
- WC Pay test site with multi-currency enabled.
- Go to core's Settings page and set time format to Custom using `g:ia`.
- Save Changes.
- Go **WooCommerce > Settings > Multi-currency** tab.
- Add a currency.
- Click the "manage" link for that currency.
- Notice the timestamp displayed with i for the minutes.

<img src="https://user-images.githubusercontent.com/5512652/235515775-fa95cf89-e038-4a38-9846-21dad4291d28.png" alt="" />

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
